### PR TITLE
tikz-uml: init at 2.0a

### DIFF
--- a/pkgs/by-name/ti/tikz-uml/package.nix
+++ b/pkgs/by-name/ti/tikz-uml/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitLab,
+  callPackage,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "tikz-uml";
+  version = "2.0a";
+  outputs = [
+    "tex"
+    "texdoc"
+  ];
+  src = fetchFromGitLab {
+    domain = "plmlab.math.cnrs.fr";
+    owner = "tikzuml";
+    repo = "tikzuml";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-eSD5wbL7jWCt4Pv8XBXcPqBPFmwdRIeIaZ0iex18sZo=";
+  };
+
+  # https://tikzuml.pages.math.cnrs.fr/userguide/requirements.html
+  passthru.tlDeps =
+    ps: with ps; [
+      pgf # for tikz
+      #ifthen is part of LaTeX
+      xstring
+      tools # for calc
+      pgfopts
+    ];
+
+  # multiple-outputs.sh fails if $out is not defined
+  preHook = ''
+    out="''${tex-}"
+  '';
+  dontConfigure = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 $src/*.sty -t "$tex/tex/latex/${finalAttrs.pname}"
+    install -Dm644 $src/doc/*.pdf -t "$texdoc/doc/tex/latex/${finalAttrs.pname}"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "TikZ extension to manage common UML diagrams";
+    license = lib.licenses.lppl13c;
+    homepage = "https://tikzuml.pages.math.cnrs.fr/";
+    maintainers = [ lib.maintainers.haansn08 ];
+  };
+
+  passthru.tests.umlseqdiag = callPackage ./test.nix { tikz-uml = finalAttrs.finalPackage; };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+})

--- a/pkgs/by-name/ti/tikz-uml/test.nix
+++ b/pkgs/by-name/ti/tikz-uml/test.nix
@@ -1,0 +1,80 @@
+{
+  runCommand,
+  tikz-uml,
+  texliveSmall,
+}:
+runCommand "test.pdf"
+  {
+    nativeBuildInputs = [ (texliveSmall.withPackages (_: [ tikz-uml ])) ];
+    strictDeps = true;
+  }
+  ''
+    cat >test.tex <<EOF
+    \documentclass[a4paper,11pt, svgnames]{article}
+    \usepackage{tikz-uml}
+
+    \textwidth 18.5cm
+    \textheight 25.5cm
+    \hoffset=-2.9cm
+    \voffset=-2.9cm
+
+    \sloppy
+    \hyphenpenalty 10000000
+
+    \date{}
+    \title{}
+    \author{}
+
+
+    \begin{document}
+
+    \begin{center}
+    \begin{tikzpicture}
+    \begin{umlseqdiag}
+    \umlactor[class=A]{a}
+    \umldatabase[class=B, fill=blue!20]{b}
+    \umlmulti[class=C]{c}
+    \umlobject[class=D]{d}
+    \begin{umlcall}[op=opa(), type=synchron, return=0]{a}{b}
+    \begin{umlfragment}
+    \begin{umlcall}[op=opb(), type=synchron, return=1]{b}{c}
+    \begin{umlfragment}[type=alt, label=condition, inner xsep=8, fill=green!10]
+    \begin{umlcall}[op=opc(), type=asynchron, fill=red!10]{c}{d}
+    \end{umlcall}
+    \begin{umlcall}[type=return]{c}{b}
+    \end{umlcall}
+    \umlfpart[default]
+    \begin{umlcall}[op=opd(), type=synchron, return=3]{c}{d}
+    \end{umlcall}
+    \end{umlfragment}
+    \end{umlcall}
+    \end{umlfragment}
+    \begin{umlfragment}
+    \begin{umlcallself}[op=ope(), type=synchron, return=4]{b}
+    \begin{umlfragment}[type=assert]
+    \begin{umlcall}[op=opf(), type=synchron, return=5]{b}{c}
+    \end{umlcall}
+    \end{umlfragment}
+    \end{umlcallself}
+    \end{umlfragment}
+    \end{umlcall}
+    \umlcreatecall[class=E,x=8]{a}{e}
+    \begin{umlfragment}
+    \begin{umlcall}[op=opg(), name=test, type=synchron, return=6, dt=7, fill=red!10]{a}{e}
+    \umlcreatecall[class=F, stereo=boundary, x=12]{e}{f}
+    \end{umlcall}
+    \begin{umlcall}[op=oph(), type=synchron, return=7]{a}{e}
+    \end{umlcall}
+    \end{umlfragment}
+    \end{umlseqdiag}
+    \end{tikzpicture}
+
+    \begin{tikzpicture}
+    \end{tikzpicture}
+    \end{center}
+    \end{document}
+    EOF
+
+    pdflatex test.tex
+    cp test.pdf $out
+  ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds [TikZ-UML](https://tikzuml.pages.math.cnrs.fr/index.html) to nixpkgs.
Unfortunately this TeX package is not part of TeX Live, but I found it quite useful.
I tried to follow the [TeX Custom packages](https://nixos.org/manual/nixpkgs/stable/#sec-language-texlive-custom-packages) section of the nixpkgs manual.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
