### PR TITLE
wizer: 10.0.0 -> 11.0.3

### DIFF
--- a/pkgs/by-name/wi/wizer/package.nix
+++ b/pkgs/by-name/wi/wizer/package.nix
@@ -8,7 +8,7 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "wizer";
-  version = "10.0.0";
+  version = "11.0.3";
 
   # the crate does not contain files which are necessary for the tests
   # see https://github.com/bytecodealliance/wizer/commit/3a95e27ce42f1fdaef07b52988e4699eaa221e04
@@ -16,10 +16,10 @@ rustPlatform.buildRustPackage rec {
     owner = "bytecodealliance";
     repo = "wizer";
     tag = "v${version}";
-    hash = "sha256-Vo6oD0UXGm4QtA3S5Qsc/DDfyfj9gJj01nnXXHw/+bM=";
+    hash = "sha256-gGO09/aHkSN8Q7EcKc7FO761YOkliHt9t7iXP4EB1Fc=";
   };
 
-  cargoHash = "sha256-WocaIib0IXlAWGVyRygOmHl1LBkrahbcCIHffRMX+J0=";
+  cargoHash = "sha256-4pH8bCTYaydgVRw6+hRN3326VGlRRMH9/5GhdPsr5Ok=";
 
   cargoBuildFlags = [
     "--bin"
@@ -27,8 +27,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   buildFeatures = [
-    "env_logger"
-    "structopt"
+    "cli"
   ];
 
   # Setting $HOME to a temporary directory is necessary to prevent checks from failing, as
@@ -36,10 +35,6 @@ rustPlatform.buildRustPackage rec {
   preCheck = ''
     export HOME=$(mktemp -d)
   '';
-
-  passthru.tests = {
-    version = testers.testVersion { package = wizer; };
-  };
 
   meta = {
     description = "WebAssembly pre-initializer";


### PR DESCRIPTION
update to 11.0.3

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
