### PR TITLE
caffeine-ng: 4.2.0 -> 4.3.2

### DIFF
--- a/pkgs/by-name/ca/caffeine-ng/fix-build.patch
+++ b/pkgs/by-name/ca/caffeine-ng/fix-build.patch
@@ -13,12 +13,3 @@ index 3e4f9ea..5b82861 100644
  )
  
  dependency('pygobject-3.0')
-@@ -82,7 +78,7 @@ configure_file(
- 
- install_data(
-   'share/applications/caffeine.desktop',
--  install_dir: '/etc/xdg/autostart',
-+  install_dir: join_paths(get_option('sysconfdir'), 'xdg/autostart'),
- )
- 
- install_data(

--- a/pkgs/by-name/ca/caffeine-ng/package.nix
+++ b/pkgs/by-name/ca/caffeine-ng/package.nix
@@ -19,14 +19,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "caffeine-ng";
-  version = "4.2.0";
+  version = "4.3.2";
   pyproject = false;
 
   src = fetchFromCodeberg {
     owner = "WhyNotHugo";
     repo = "caffeine-ng";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-uYzLRZ+6ZgIwhSuJWRBpLYHgonX7sFXgUZid0V26V0Q=";
+    hash = "sha256-eJ/0lzE5X1WFhgTAgI/SOmtxPbK7ppTk90RWobPZk2o=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Tag: https://codeberg.org/WhyNotHugo/caffeine-ng/releases/tag/v4.3.2
Diff: https://codeberg.org/WhyNotHugo/caffeine-ng/compare/v4.2.0...v4.3.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
