### PR TITLE
extism-js-core: fix missing `iconv` on darwin

### DIFF
--- a/pkgs/by-name/ex/extism-js-core/package.nix
+++ b/pkgs/by-name/ex/extism-js-core/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   fetchNpmDeps,
   lib,
+  libiconv,
   lld,
   nodejs,
   npmHooks,
@@ -55,6 +56,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     nodejs
     npmHooks.npmConfigHook
     rustPlatform.bindgenHook
+  ];
+  buildInputs = lib.optionals stdenv.buildPlatform.isDarwin [
+    libiconv
   ];
 
   # io-extras v0.18.4 uses #![feature]


### PR DESCRIPTION
Due to https://github.com/NixOS/nixpkgs/pull/500048 the darwin build started failing, as it was not tested at the time.

Hydra failures:
- `aarch64-darwin`: https://hydra.nixos.org/build/329276099
- `x86_64-darwin`: https://hydra.nixos.org/build/329276085

Since I do not have access to a darwin machine, I'll attempt to test this using github runners.

EDIT: Did not manage to get this working. Further PRs/comments are very welcome!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
