### PR TITLE
peertube: 8.1.5 -> 8.1.8

### DIFF
--- a/pkgs/by-name/pe/peertube/package.nix
+++ b/pkgs/by-name/pe/peertube/package.nix
@@ -21,13 +21,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "peertube";
-  version = "8.1.5";
+  version = "8.1.8";
 
   src = fetchFromGitHub {
     owner = "Chocobozzz";
     repo = "PeerTube";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vLKjTn8tdHb/DUHj/w3ovXmRNzD8CMSKCaPleW+i7Tc=";
+    hash = "sha256-Ei7MgEyHDJyLXnjI8mT7S7pLno+pTmFWZHc6oEZaTcM=";
   };
 
   outputs = [
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
     fetcherVersion = 3;
-    hash = "sha256-gvjk4OmKR6W/nllUCSaiX/lVXJSac9r04xr7fNiBftI=";
+    hash = "sha256-fQ0FyBPZ3v3lCSoWYz1ccbOSrfgnzwQvOyE7Dp3ZGRY=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
This contains an important security fix!

v7 (nixos stable) is affected too, but there is no patch release for v7. I asked for one: https://github.com/Chocobozzz/PeerTube/issues/7622 but I don't know if upstream will provide one.

I think we should mark the v7 package on stable as insecure rather than backport it. What do you think?

I did not build the package because I don't have enough resources on my laptop, but it's only a patch version bump so it should be fine.

@immae @Izorkin @stevenroose 