### PR TITLE
linuxKernel.kernels.linux_zen: 7.0.9-zen2 -> 7.0.10-zen1

### DIFF
--- a/pkgs/os-specific/linux/kernel/zen-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/zen-kernels.nix
@@ -12,13 +12,13 @@ let
   # override options if they need using lib.mkForce (that has 50 priority)
   mkKernelOverride = lib.mkOverride 90;
 
-  suffix = "zen2";
+  suffix = "zen1";
 in
 
 buildLinux (
   args
   // rec {
-    version = "7.0.9";
+    version = "7.0.10";
     pname = "linux-zen";
     modDirVersion = lib.versions.pad 3 "${version}-${suffix}";
     isZen = true;
@@ -27,7 +27,7 @@ buildLinux (
       owner = "zen-kernel";
       repo = "zen-kernel";
       rev = "v${version}-${suffix}";
-      sha256 = "1x2s9pv8frq77fish833mnwrrdglxssbqrsjnnizj3ayylw41qkd";
+      sha256 = "1xh7bbis9v7yq2s1zwdnmsx54zz9kcmyn1cnrqqlsassk7fzl7nx";
     };
 
     # This is based on the following source:


### PR DESCRIPTION
Update to latest release

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `619e382a1dd35bfef1cfe03bd8d2c2e3708de75e`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 25 packages marked as broken and skipped:</summary>
  <ul>
    <li>linuxKernel.packages.linux_zen.ax99100</li>
    <li>linuxKernel.packages.linux_zen.can-isotp</li>
    <li>linuxKernel.packages.linux_zen.dddvb</li>
    <li>linuxKernel.packages.linux_zen.intel-speed-select</li>
    <li>linuxKernel.packages.linux_zen.isgx</li>
    <li>linuxKernel.packages.linux_zen.ithc</li>
    <li>linuxKernel.packages.linux_zen.ivsc-driver</li>
    <li>linuxKernel.packages.linux_zen.ixgbevf</li>
    <li>linuxKernel.packages.linux_zen.mba6x_bl</li>
    <li>linuxKernel.packages.linux_zen.morse-driver</li>
    <li>linuxKernel.packages.linux_zen.mwprocapture</li>
    <li>linuxKernel.packages.linux_zen.mxu11x0</li>
    <li>linuxKernel.packages.linux_zen.ndiswrapper</li>
    <li>linuxKernel.packages.linux_zen.nvidiabl</li>
    <li>linuxKernel.packages.linux_zen.rtl8188eus-aircrack</li>
    <li>linuxKernel.packages.linux_zen.rtl8192eu</li>
    <li>linuxKernel.packages.linux_zen.rtl8723ds</li>
    <li>linuxKernel.packages.linux_zen.rtl8812au</li>
    <li>linuxKernel.packages.linux_zen.rtl8814au</li>
    <li>linuxKernel.packages.linux_zen.rtl8821au</li>
    <li>linuxKernel.packages.linux_zen.rtl8852au</li>
    <li>linuxKernel.packages.linux_zen.rtl8852bu</li>
    <li>linuxKernel.packages.linux_zen.rtl88xxau-aircrack</li>
    <li>linuxKernel.packages.linux_zen.sysdig</li>
    <li>linuxKernel.packages.linux_zen.tbs</li>
  </ul>
</details>
<details>
  <summary>:x: 9 packages failed to build:</summary>
  <ul>
    <li>linuxKernel.packages.linux_zen.drbd</li>
    <li>linuxKernel.packages.linux_zen.facetimehd</li>
    <li>linuxKernel.packages.linux_zen.lkrg</li>
    <li>linuxKernel.packages.linux_zen.lttng-modules</li>
    <li>linuxKernel.packages.linux_zen.mbp2018-bridge-drv</li>
    <li>linuxKernel.packages.linux_zen.openrazer</li>
    <li>linuxKernel.packages.linux_zen.tsme-test</li>
    <li>linuxKernel.packages.linux_zen.vhba</li>
    <li>linuxKernel.packages.linux_zen.vmm_clock</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 100 packages built:</summary>
  <ul>
    <li>linuxKernel.kernels.linux_zen</li>
    <li>linuxKernel.packages.linux_zen.acer-wmi-battery</li>
    <li>linuxKernel.packages.linux_zen.acpi_call</li>
    <li>linuxKernel.packages.linux_zen.ajantv2</li>
    <li>linuxKernel.packages.linux_zen.akvcam</li>
    <li>linuxKernel.packages.linux_zen.amdgpu-i2c</li>
    <li>linuxKernel.packages.linux_zen.amneziawg</li>
    <li>linuxKernel.packages.linux_zen.apfs</li>
    <li>linuxKernel.packages.linux_zen.asus-ec-sensors</li>
    <li>linuxKernel.packages.linux_zen.batman_adv</li>
    <li>linuxKernel.packages.linux_zen.bbswitch</li>
    <li>linuxKernel.packages.linux_zen.bcachefs</li>
    <li>linuxKernel.packages.linux_zen.ch9344</li>
    <li>linuxKernel.packages.linux_zen.chipsec</li>
    <li>linuxKernel.packages.linux_zen.corefreq</li>
    <li>linuxKernel.packages.linux_zen.cpupower</li>
    <li>linuxKernel.packages.linux_zen.cryptodev</li>
    <li>linuxKernel.packages.linux_zen.ddcci-driver</li>
    <li>linuxKernel.packages.linux_zen.decklink</li>
    <li>linuxKernel.packages.linux_zen.digimend</li>
    <li>linuxKernel.packages.linux_zen.dpdk-kmods</li>
    <li>linuxKernel.packages.linux_zen.ecapture</li>
    <li>linuxKernel.packages.linux_zen.ena</li>
    <li>linuxKernel.packages.linux_zen.evdi</li>
    <li>linuxKernel.packages.linux_zen.fanout</li>
    <li>linuxKernel.packages.linux_zen.framework-laptop-kmod</li>
    <li>linuxKernel.packages.linux_zen.fwts-efi-runtime</li>
    <li>linuxKernel.packages.linux_zen.gasket</li>
    <li>linuxKernel.packages.linux_zen.gcadapter-oc-kmod</li>
    <li>linuxKernel.packages.linux_zen.hid-fanatecff</li>
    <li>linuxKernel.packages.linux_zen.hid-ite8291r3</li>
    <li>linuxKernel.packages.linux_zen.hid-t150</li>
    <li>linuxKernel.packages.linux_zen.hid-tmff2</li>
    <li>linuxKernel.packages.linux_zen.hpuefi-mod</li>
    <li>linuxKernel.packages.linux_zen.hyperv-daemons</li>
    <li>linuxKernel.packages.linux_zen.iio-utils</li>
    <li>linuxKernel.packages.linux_zen.ipu6-drivers</li>
    <li>linuxKernel.packages.linux_zen.it87</li>
    <li>linuxKernel.packages.linux_zen.jool</li>
    <li>linuxKernel.packages.linux_zen.kvmfr</li>
    <li>linuxKernel.packages.linux_zen.lenovo-legion-module</li>
    <li>linuxKernel.packages.linux_zen.linux-gpib</li>
    <li>linuxKernel.packages.linux_zen.liquidtux</li>
    <li>linuxKernel.packages.linux_zen.mdio-netlink</li>
    <li>linuxKernel.packages.linux_zen.msi-ec</li>
    <li>linuxKernel.packages.linux_zen.mstflint_access</li>
    <li>linuxKernel.packages.linux_zen.nct6687d</li>
    <li>linuxKernel.packages.linux_zen.netatop</li>
    <li>linuxKernel.packages.linux_zen.new-lg4ff</li>
    <li>linuxKernel.packages.linux_zen.nullfsvfs</li>
    <li>linuxKernel.packages.linux_zen.nvidia_x11_beta_open</li>
    <li>linuxKernel.packages.linux_zen.nvidia_x11_latest_open</li>
    <li>linuxKernel.packages.linux_zen.nvidia_x11_vulkan_beta_open</li>
    <li>linuxKernel.packages.linux_zen.nxp-pn5xx</li>
    <li>linuxKernel.packages.linux_zen.openafs</li>
    <li>linuxKernel.packages.linux_zen.opensnitch-ebpf</li>
    <li>linuxKernel.packages.linux_zen.ply</li>
    <li>linuxKernel.packages.linux_zen.qc71_laptop</li>
    <li>linuxKernel.packages.linux_zen.r8125</li>
    <li>linuxKernel.packages.linux_zen.r8168</li>
    <li>linuxKernel.packages.linux_zen.rr-zen_workaround</li>
    <li>linuxKernel.packages.linux_zen.rtl8189es</li>
    <li>linuxKernel.packages.linux_zen.rtl8189fs</li>
    <li>linuxKernel.packages.linux_zen.rtl8821ce</li>
    <li>linuxKernel.packages.linux_zen.rtl8821cu</li>
    <li>linuxKernel.packages.linux_zen.rtl88x2bu</li>
    <li>linuxKernel.packages.linux_zen.rtw88</li>
    <li>linuxKernel.packages.linux_zen.rust-out-of-tree-module</li>
    <li>linuxKernel.packages.linux_zen.ryzen-smu</li>
    <li>linuxKernel.packages.linux_zen.sheep-net</li>
    <li>linuxKernel.packages.linux_zen.shufflecake</li>
    <li>linuxKernel.packages.linux_zen.system76</li>
    <li>linuxKernel.packages.linux_zen.system76-acpi</li>
    <li>linuxKernel.packages.linux_zen.system76-io</li>
    <li>linuxKernel.packages.linux_zen.systemtap</li>
    <li>linuxKernel.packages.linux_zen.tmon</li>
    <li>linuxKernel.packages.linux_zen.tp_smapi</li>
    <li>linuxKernel.packages.linux_zen.trelay</li>
    <li>linuxKernel.packages.linux_zen.tt-kmd</li>
    <li>linuxKernel.packages.linux_zen.turbostat</li>
    <li>linuxKernel.packages.linux_zen.tuxedo-drivers</li>
    <li>linuxKernel.packages.linux_zen.universal-pidff</li>
    <li>linuxKernel.packages.linux_zen.usbip</li>
    <li>linuxKernel.packages.linux_zen.v4l2loopback</li>
    <li>linuxKernel.packages.linux_zen.v86d</li>
    <li>linuxKernel.packages.linux_zen.veikk-linux-driver</li>
    <li>linuxKernel.packages.linux_zen.vendor-reset</li>
    <li>linuxKernel.packages.linux_zen.virtio_vmmci</li>
    <li>linuxKernel.packages.linux_zen.virtualbox</li>
    <li>linuxKernel.packages.linux_zen.virtualboxGuestAdditions</li>
    <li>linuxKernel.packages.linux_zen.vmware</li>
    <li>linuxKernel.packages.linux_zen.x86_energy_perf_policy</li>
    <li>linuxKernel.packages.linux_zen.xone</li>
    <li>linuxKernel.packages.linux_zen.xpad-noone</li>
    <li>linuxKernel.packages.linux_zen.xpadneo</li>
    <li>linuxKernel.packages.linux_zen.yt6801</li>
    <li>linuxKernel.packages.linux_zen.zenergy</li>
    <li>linuxKernel.packages.linux_zen.zenpower</li>
    <li>linuxKernel.packages.linux_zen.zfs_2_3</li>
    <li>linuxKernel.packages.linux_zen.zfs_2_4 (linuxKernel.packages.linux_zen.zfs_unstable)</li>
  </ul>
</details>