### PR TITLE
fossil: refactor install phase

### DIFF
--- a/pkgs/applications/version-management/fossil/default.nix
+++ b/pkgs/applications/version-management/fossil/default.nix
@@ -55,10 +55,9 @@ stdenv.mkDerivation (finalAttrs: {
     export USER=nonexistent-but-specified-user
   '';
 
-  installPhase = ''
-    mkdir -p $out/bin
-    INSTALLDIR=$out/bin make install
+  installFlags = [ "INSTALLDIR=$(out)/bin" ];
 
+  postInstall = ''
     installManPage fossil.1
     installShellCompletion --name fossil.bash tools/fossil-autocomplete.bash
   '';

--- a/pkgs/applications/version-management/fossil/default.nix
+++ b/pkgs/applications/version-management/fossil/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postInstall = ''
     installManPage fossil.1
-    installShellCompletion --name fossil.bash tools/fossil-autocomplete.bash
+    installShellCompletion --cmd fossil tools/fossil-autocomplete.{bash,zsh}
   '';
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

this returns the `installPhase` into its default form:
```sh
runHook preInstall
make $installFlags $installTargets 
runHook postInstall
```
while moving the non-`make` installations to the hooks

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
