### PR TITLE
krita: add gapps wrapper

### DIFF
--- a/pkgs/by-name/kr/krita/package.nix
+++ b/pkgs/by-name/kr/krita/package.nix
@@ -6,20 +6,26 @@
     krita-plugin-gmic
   ],
   krita-unwrapped,
+  wrapGAppsHook3,
 }:
 symlinkJoin {
   pname = "krita";
   inherit (krita-unwrapped)
     version
     buildInputs
-    nativeBuildInputs
     meta
     ;
+
+  nativeBuildInputs = krita-unwrapped.nativeBuildInputs ++ [
+    wrapGAppsHook3
+  ];
 
   paths = [ krita-unwrapped ] ++ binaryPlugins;
 
   postBuild = ''
+    gappsWrapperArgsHook
     wrapQtApp "$out/bin/krita" \
+      "''${gappsWrapperArgs[@]}" \
       --prefix PYTHONPATH : "$PYTHONPATH" \
       --set KRITA_PLUGIN_PATH "$out/lib/kritaplugins"
   '';


### PR DESCRIPTION
This fixes #509315. The `gappsWrapperArgsHook` has to be invoked explicitly as it is normally invoked in `preFixupPhase`, which is not present in `symlinkJoin`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
