### PR TITLE
python3Packages.markitdown: update to 0.1.5

### DIFF
--- a/pkgs/development/python-modules/markitdown/default.nix
+++ b/pkgs/development/python-modules/markitdown/default.nix
@@ -42,14 +42,14 @@ let
 in
 buildPythonPackage (finalAttrs: {
   pname = "markitdown";
-  version = "0.1.4";
+  version = "0.1.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "markitdown";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-WKA2eY8wY3SM9xZ7Cek5eUcJbO5q6eMDx2aTKfQnFvE=";
+    hash = "sha256-sqWfft/yaI/0FavhIbAHqltgVfTNk0GJk/phyvdn7Ck=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/packages/markitdown";


### PR DESCRIPTION
## Summary
- Bump `python3Packages.markitdown` from 0.1.4 to 0.1.5.
- Refresh the GitHub source hash for the `v0.1.5` release tarball.

## Validation
- `nix build .#python3Packages.markitdown.src --no-link --print-out-paths`
- `nix eval --raw .#python3Packages.markitdown.version`
- Attempted `nix build .#python3Packages.markitdown -L`, but it exceeded the 10 minute tool limit while building the dependency-heavy onnxruntime chain.

## Risk
- Low. This is a version/hash bump only; the source layout remains `packages/markitdown`.
