### PR TITLE
git-gamble: 2.14.2 -> 2.14.4

### DIFF
--- a/pkgs/by-name/gi/git-gamble/package.nix
+++ b/pkgs/by-name/gi/git-gamble/package.nix
@@ -31,11 +31,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   nativeBuildInputs = [
-    installShellFiles
     makeWrapper
+    installShellFiles
   ];
   postInstall = ''
     wrapProgram $out/bin/git-gamble \
+      --prefix PATH : "${lib.makeBinPath [ gitMinimal ]}"
+
+    wrapProgram $out/bin/git-time-keeper \
       --prefix PATH : "${lib.makeBinPath [ gitMinimal ]}"
 
     export PATH="$PATH:$out/bin/"

--- a/pkgs/by-name/gi/git-gamble/package.nix
+++ b/pkgs/by-name/gi/git-gamble/package.nix
@@ -63,7 +63,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Tool that blends TDD (Test Driven Development) + TCR (`test && commit || revert`)";
     homepage = "https://git-gamble.is-cool.dev";
-    changelog = "https://gitlab.com/pinage404/git-gamble/-/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    changelog = "https://git-gamble.is-cool.dev/changelog/${finalAttrs.version}.html";
     license = lib.licenses.isc;
     sourceProvenance = [ lib.sourceTypes.fromSource ];
     maintainers = [ lib.maintainers.pinage404 ];

--- a/pkgs/by-name/gi/git-gamble/package.nix
+++ b/pkgs/by-name/gi/git-gamble/package.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
   checkFlags = [
     # this test can be flaky ; help is needed to stabilize it in upstream
-    "--skip=git_time_keeper::white_box::lock_file::create_as_many_as_lock_files_when_starting_several_times"
+    "--skip=git_gamble::cancel_command_with_signal::fail_when_git_is_killed"
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gi/git-gamble/package.nix
+++ b/pkgs/by-name/gi/git-gamble/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "git-gamble";
-  version = "2.14.2";
+  version = "2.14.4";
 
   src = fetchFromGitLab {
     owner = "pinage404";
     repo = "git-gamble";
-    rev = "version/${finalAttrs.version}";
-    hash = "sha256-UPiktBeMPZf9vrKz5XFyMzBJtxCe0ojJabeIwhyo9/g=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-DjwdoM9/W1UeD/XqVMXTyzjdcJLfHiAqRA3r//rkn1U=";
   };
 
-  cargoHash = "sha256-yMlb3c2V3NUFw/GDPyCqTCSz+YLn3F9wmeP12jTySCI=";
+  cargoHash = "sha256-X3kJT0pscCH9sQxV3NkX0hL2sccTJHgMj0UeIpJOWJ4=";
 
   nativeCheckInputs = [ gitMinimal ];
   preCheck = ''
@@ -56,7 +56,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru.updateScript = nix-update-script {
     extraArgs = [
       "--version-regex"
-      "version/(.*)"
+      "v(.*)"
     ];
   };
 


### PR DESCRIPTION
* wrap the other binary, in order to include dependency
* add test dependency required to update
* flaky test has been ignored upstream, remove the dirty fix
* changed the changelog URL to use the website instead of the generated file in the forge
* update 2.14.2 -> 2.14.4
	* [changelog 2.14.3](https://git-gamble.is-cool.dev/changelog/2.14.3.html)
	* [changelog 2.14.4](https://git-gamble.is-cool.dev/changelog/2.14.4.html)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy]. ~~didn't read yet, just `nix-build` used, no other tools~~ i read

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
