### PR TITLE
reredirect: fix build (again)

### DIFF
--- a/pkgs/by-name/re/reredirect/package.nix
+++ b/pkgs/by-name/re/reredirect/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch2,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -15,14 +14,6 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "b85df395e18d09b54e1fb73dfe344f8f04224a83";
     sha256 = "sha256-lLhF8taK6PqWo4u6pMZDN2PZavnWwsz4NbEUT7EtULo=";
   };
-
-  patches = [
-    # Fixes gcc-15 build.
-    (fetchpatch2 {
-      url = "https://github.com/jerome-pouiller/reredirect/commit/b85df395e18d09b54e1fb73dfe344f8f04224a83.patch";
-      hash = "sha256-RTzJrgiJGmUf0iVaSvXw/NLwWRTch1aLdDdLp50sAD8=";
-    })
-  ];
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
 


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/516381

## Things done

- https://nfd.1l.is/?selected=reredirect

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
