### PR TITLE
ocm-cli: init at 0.42.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10398,6 +10398,12 @@
     github = "GZGavinZhao";
     githubId = 74938940;
   };
+  h0nIg = {
+    name = "Hans-Joachim Kliemeck";
+    email = "git@kliemeck.de";
+    github = "h0nIg";
+    githubId = 2757302;
+  };
   h3cth0r = {
     name = "Hector Miranda";
     email = "hector.miranda@tec.mx";

--- a/pkgs/by-name/oc/ocm-cli/package.nix
+++ b/pkgs/by-name/oc/ocm-cli/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  stdenv,
+}:
+
+buildGoModule (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "ocm-cli";
+  version = "0.42.0";
+
+  src = fetchFromGitHub {
+    owner = "open-component-model";
+    repo = "ocm";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-c0xQB/OhVcRM2nY4M6NQrfIZPuPKoTClMs0sZ64s2iY=";
+  };
+
+  vendorHash = "sha256-zKIuued0MwEkQoOsRC98frEsEsFd+WCiz0fGRvH00lQ=";
+
+  subPackages = [
+    "cmds/ocm"
+    "cmds/cliplugin"
+    "cmds/demoplugin"
+    "cmds/ecrplugin"
+    "cmds/subcmdplugin"
+    "cmds/jfrogplugin"
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/open-component-model/ocm/pkg/version.version=${finalAttrs.version}"
+  ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd ocm \
+      --bash <($out/bin/ocm completion bash) \
+      --zsh <($out/bin/ocm completion zsh) \
+      --fish <($out/bin/ocm completion fish)
+  '';
+
+  meta = {
+    description = "Open Component Model (OCM) is an open standard to describe software bills of delivery (SBOD)";
+    longDescription = ''
+      OCM is a technology-agnostic and machine-readable format focused on the software artifacts that must be delivered for software products.
+      The specification is also used to express metadata needed for security, compliance, and certification purpose.
+    '';
+    homepage = "https://ocm.software";
+    changelog = "https://github.com/open-component-model/ocm/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ h0nIg ];
+    mainProgram = "ocm";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
The ocm cli is very useful for software bills of delivery

Open Component Model is an open standard to describe software bills of delivery (SBOD)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
