### PR TITLE
ivpn-service: support quantum resistance

### DIFF
--- a/pkgs/by-name/iv/ivpn-service/package.nix
+++ b/pkgs/by-name/iv/ivpn-service/package.nix
@@ -13,13 +13,17 @@
   iptables,
   gawk,
   util-linux,
+  liboqs,
   nix-update-script,
 }:
 buildGoModule (finalAttrs: {
   pname = "ivpn-service";
   version = "3.15.6";
 
-  buildInputs = [ wirelesstools ];
+  buildInputs = [
+    wirelesstools
+    liboqs
+  ];
   nativeBuildInputs = [ makeWrapper ];
 
   src = fetchFromGitHub {
@@ -62,7 +66,9 @@ buildGoModule (finalAttrs: {
       --replace-fail 'dnscryptproxyBinPath = path.Join(installDir, "dnscrypt-proxy/dnscrypt-proxy")' \
       'dnscryptproxyBinPath = "${dnscrypt-proxy}/bin/dnscrypt-proxy"' \
       --replace-fail 'v2rayBinaryPath = path.Join(installDir, "v2ray/v2ray")' \
-      'v2rayBinaryPath = "${v2ray}/bin/v2ray"'
+      'v2rayBinaryPath = "${v2ray}/bin/v2ray"' \
+      --replace-fail 'kemHelperBinaryPath = path.Join(installDir, "kem/kem-helper")' \
+      'kemHelperBinaryPath = "${placeholder "out"}/bin/kem-helper"'
   '';
 
   ldflags = [
@@ -72,8 +78,17 @@ buildGoModule (finalAttrs: {
     "-X github.com/ivpn/desktop-app/daemon/version._time=1970-01-01"
   ];
 
+  postBuild = ''
+    $CC -O2 -pthread \
+        References/common/kem-helper/main.c \
+        References/common/kem-helper/base64.c \
+        -loqs -Wl,-z,stack-size=5242880 \
+        -o kem-helper
+  '';
+
   postInstall = ''
     mv $out/bin/{daemon,ivpn-service}
+    install -Dm755 kem-helper $out/bin/kem-helper
   '';
 
   postFixup = ''

--- a/pkgs/by-name/iv/ivpn-service/package.nix
+++ b/pkgs/by-name/iv/ivpn-service/package.nix
@@ -21,7 +21,7 @@ buildGoModule (finalAttrs: {
 
   buildInputs = [
     wirelesstools
-    liboqs
+    (finalAttrs.passthru.liboqs)
   ];
   nativeBuildInputs = [ makeWrapper ];
 
@@ -107,6 +107,35 @@ buildGoModule (finalAttrs: {
         ]
       }
   '';
+
+  # IVPN pins this to an older incompatible version, so we vendor it at that
+  # Lives in passthru so end-users can override it
+  passthru.liboqs = liboqs.overrideAttrs (
+    final: prev: {
+      version = "0.10.0";
+      src = fetchFromGitHub {
+        owner = "open-quantum-safe";
+        repo = "liboqs";
+        tag = "${final.version}";
+        hash = "sha256-BFDa5NUr02lFPcT4Hnb2rjGAi+2cXvh1SHLfqX/zLlI=";
+      };
+      # the main derivations patches don't apply onto the older version
+      patches = [ ];
+      # manually do what the main derivations pkg-config patch does (unbreak invalid path)
+      postPatch = ''
+        substituteInPlace src/liboqs.pc.in \
+          --replace-fail 'libdir=''${prefix}/@CMAKE_INSTALL_LIBDIR@' \
+          'libdir=@CMAKE_INSTALL_FULL_LIBDIR@' \
+          --replace-fail 'includedir=''${prefix}/@CMAKE_INSTALL_INCLUDEDIR@' \
+          'includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@'
+      '';
+      # This matches IVPNs build script at $src/daemon/References/common/kem-helper/build.sh
+      cmakeFlags = (prev.cmakeFlags or [ ]) ++ [
+        "-DOQS_USE_OPENSSL=OFF"
+        "-DOQS_MINIMAL_BUILD=KEM_kyber_1024;KEM_classic_mceliece_348864"
+      ];
+    }
+  );
 
   meta = {
     description = "Official IVPN Desktop app service daemon";

--- a/pkgs/by-name/iv/ivpn-service/package.nix
+++ b/pkgs/by-name/iv/ivpn-service/package.nix
@@ -14,7 +14,6 @@
   gawk,
   util-linux,
   liboqs,
-  nix-update-script,
 }:
 buildGoModule (finalAttrs: {
   pname = "ivpn-service";
@@ -108,8 +107,6 @@ buildGoModule (finalAttrs: {
         ]
       }
   '';
-
-  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Official IVPN Desktop app service daemon";


### PR DESCRIPTION
Adds support for quantum resistant encryption in IVPN.

Just compiles in a small helper that was previously missing

Closes https://github.com/NixOS/nixpkgs/issues/523386

cc @Arcterus

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
