### PR TITLE
scx-loader: init at 1.1.1, add nixos module and test

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -12,6 +12,8 @@
 
 - [tranquil](https://tangled.org/tranquil.farm/tranquil-pds) is an ATProto PDS (personal data server) implementation in Rust. A featureful, spec conscious and community driven alternative to the Bluesky reference implementation PDS. Available as [services.tranquil-pds](#opt-services.tranquil-pds.enable).
 
+- [scx_loader](https://github.com/sched-ext/scx-loader), a system daemon and DBus-based loader for sched_ext schedulers. `scxctl` is the command-line client for interacting with the loader, allowing users to switch schedulers, modes, and arguments dynamically. Available as [services.scx-loader](#opt-services.scx-loader.enable)
+
 - [FlapAlerted](https://github.com/Kioubit/FlapAlerted), detects BGP flapping events and provides statistics based on BGP update messages. Available as [services.flap-alerted](#opt-services.flap-alerted.enable).
 
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1483,6 +1483,7 @@
   ./services/scheduling/cron.nix
   ./services/scheduling/fcron.nix
   ./services/scheduling/prefect.nix
+  ./services/scheduling/scx-loader.nix
   ./services/scheduling/scx.nix
   ./services/search/elasticsearch-curator.nix
   ./services/search/elasticsearch.nix

--- a/nixos/modules/services/scheduling/scx-loader.nix
+++ b/nixos/modules/services/scheduling/scx-loader.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.services.scx-loader;
+  settingsFormat = pkgs.formats.toml { };
+  configFile = settingsFormat.generate "scx_loader.toml" (
+    lib.filterAttrsRecursive (_: v: v != null) cfg.config
+  );
+
+  schedulers = builtins.concatMap (
+    x: x.passthru.schedulers or (throw "Scheduler not found in package ${x.name}")
+  ) cfg.schedsPackages;
+in
+{
+  options.services.scx-loader = {
+    enable = lib.mkEnableOption "SCX Loader service, a daemon to run schedulers from userspace using dbus. This requires kernel version 6.12 and later.";
+
+    package = lib.mkPackageOption pkgs "scx-loader" { };
+
+    schedsPackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ pkgs.scx.rustscheds ];
+      defaultText = lib.literalExpression "[ pkgs.scx.rustscheds ]";
+      example = lib.literalExpression "[ pkgs.scx.full ]";
+      description = ''
+        `scx` package to use. Defaults to `scx.rustscheds`, which includes all currently by `scx_loader` supported schedulers.
+      '';
+    };
+
+    config = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
+
+        options = {
+          default_sched = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            example = "scx_bpfland";
+            description = ''
+              Default scheduler that will be started automatically when `scx_loader` starts.
+              If not set or set to an empty string, `scx_loader` will not start any scheduler by default.
+            '';
+          };
+        };
+      };
+      default = { };
+      description = ''
+        Configuration for `scx_loader`.
+
+        See <https://github.com/sched-ext/scx-loader/blob/main/crates/scx_loader/configuration.md> for the full list of options.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.12";
+        message = "SCX is only supported on kernel version 6.12 and above.";
+      }
+      {
+        assertion = !config.services.scx.enable;
+        message = "services.scx and services.scx_loader cannot be enabled simultaneously. Please enable only one of them.";
+      }
+      {
+        assertion =
+          cfg.config.default_sched == null || lib.elem cfg.config.default_sched ([ "" ] ++ schedulers);
+        message = ''
+          Invalid default scheduler: ${cfg.config.default_sched}. It must be one of: ${lib.concatStringsSep ", " schedulers}.
+        '';
+      }
+    ];
+
+    environment.systemPackages = [ cfg.package ] ++ cfg.schedsPackages;
+    systemd.packages = [ cfg.package ];
+    services.dbus.packages = [ cfg.package ];
+
+    security.polkit.enable = true;
+
+    systemd.services.scx_loader = {
+      path = cfg.schedsPackages;
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        TemporaryFileSystem = [ "/etc" ];
+        BindReadOnlyPaths = [ "${configFile.outPath}:/etc/scx_loader.toml" ];
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ ccicnce113424 ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1493,6 +1493,7 @@ in
   scion-freestanding-deployment = runTest ./scion/freestanding-deployment;
   scrutiny = runTest ./scrutiny.nix;
   scx = runTest ./scx/default.nix;
+  scx-loader = runTest ./scx/loader.nix;
   sddm = import ./sddm.nix { inherit runTest; };
   sdl3 = runTest ./sdl3.nix;
   searx = runTest ./searx.nix;

--- a/nixos/tests/scx/loader.nix
+++ b/nixos/tests/scx/loader.nix
@@ -1,0 +1,20 @@
+{ pkgs, lib, ... }:
+
+{
+  name = "scx-loader";
+  meta.maintainers = with lib.maintainers; [ ccicnce113424 ];
+
+  nodes.machine = {
+    boot.kernelPackages = pkgs.linuxPackages_latest;
+    services.scx-loader = {
+      enable = true;
+      config.default_sched = "scx_bpfland";
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+    output = machine.succeed("scxctl get").strip()
+    assert output == "running Bpfland in Auto mode", f"Unexpected scxctl output: {output!r}"
+  '';
+}

--- a/pkgs/by-name/sc/scx-loader/package.nix
+++ b/pkgs/by-name/sc/scx-loader/package.nix
@@ -3,6 +3,7 @@
   rustPlatform,
   lib,
   nix-update-script,
+  nixosTests,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "scx-loader";
@@ -36,7 +37,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail "/usr/bin/scx_loader" "$out/bin/scx_loader"
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = { inherit (nixosTests) scx-loader; };
+  };
 
   meta = {
     mainProgram = "scxctl";

--- a/pkgs/by-name/sc/scx-loader/package.nix
+++ b/pkgs/by-name/sc/scx-loader/package.nix
@@ -1,0 +1,53 @@
+{
+  fetchFromGitHub,
+  rustPlatform,
+  lib,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "scx-loader";
+  version = "1.1.1";
+
+  cargoHash = "sha256-uX2lCVDa8eAKWi/bj94+JQHoOLll0OjKRHT0EPZELNc=";
+
+  src = fetchFromGitHub {
+    owner = "sched-ext";
+    repo = "scx-loader";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5OvdtW/Li+ubHDBSKe2ssE9ZyNSCcxNFSJffzxQ9WMk=";
+  };
+
+  __structuredAttrs = true;
+
+  env = {
+    VENDOR_PREFIX = "";
+    VENDOR_DATADIR = "/share";
+  };
+
+  postInstall = ''
+    cargo xtask install --destdir $out
+    rm $out/bin/xtask
+  '';
+
+  postFixup = ''
+    substituteInPlace $out/lib/systemd/system/scx_loader.service \
+      --replace-fail "/usr/bin/scx_loader" "$out/bin/scx_loader"
+    substituteInPlace $out/share/dbus-1/system-services/org.scx.Loader.service \
+      --replace-fail "/usr/bin/scx_loader" "$out/bin/scx_loader"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "scxctl";
+    homepage = "https://github.com/sched-ext/scx-loader";
+    changelog = "https://github.com/sched-ext/scx-loader/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      Gliczy
+      michaelBelsanti
+      ccicnce113424
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Inspired by #483360, but the module has been completely rewritten.
`scx_loader` is a system daemon and DBus-based loader for [sched_ext](https://github.com/sched-ext/scx) schedulers.
https://github.com/sched-ext/scx-loader
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
