### PR TITLE
ivpn-service: fix quantum encryption

### DIFF
--- a/pkgs/by-name/iv/ivpn-service/package.nix
+++ b/pkgs/by-name/iv/ivpn-service/package.nix
@@ -14,12 +14,16 @@
   gawk,
   util-linux,
   nix-update-script,
+  liboqs,
 }:
 buildGoModule (finalAttrs: {
   pname = "ivpn-service";
   version = "3.15.0";
 
-  buildInputs = [ wirelesstools ];
+  buildInputs = [
+    wirelesstools
+    liboqs
+  ];
   nativeBuildInputs = [ makeWrapper ];
 
   src = fetchFromGitHub {
@@ -59,6 +63,10 @@ buildGoModule (finalAttrs: {
       'dnscryptproxyBinPath = "${dnscrypt-proxy}/bin/dnscrypt-proxy"' \
       --replace-fail 'v2rayBinaryPath = path.Join(installDir, "v2ray/v2ray")' \
       'v2rayBinaryPath = "${v2ray}/bin/v2ray"'
+
+    substituteInPlace daemon/service/wgkeys/manager.go \
+      --replace-fail 'kemKeys.KemLibraryVersion = kemHelper.GetPublicKeyLiboqsVersion()' \
+      'kemKeys.KemLibraryVersion = "0.10.0"'
   '';
 
   ldflags = [
@@ -68,8 +76,17 @@ buildGoModule (finalAttrs: {
     "-X github.com/ivpn/desktop-app/daemon/version._time=1970-01-01"
   ];
 
+  postBuild = ''
+    $CC -Wall -O2 -pthread \
+        References/common/kem-helper/main.c \
+        References/common/kem-helper/base64.c \
+        -loqs -Wl,-z,stack-size=5242880 \
+        -o kem-helper
+  '';
+
   postInstall = ''
     mv $out/bin/{daemon,ivpn-service}
+    install -Dm755 kem-helper $out/kem/kem-helper
   '';
 
   postFixup = ''


### PR DESCRIPTION
### Automation/AI Disclosure

This was written with Gemini 3.5 flash

## Things done

This commit fixes `ivpn wgkeys -regenerate` so it's able to generate quantum resistant encryption keys.

Tested and working.

The patch for `kemKeys.KemLibraryVersion` to 0.10.0 is the only way that the server would give a quantum resistant key.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
