### PR TITLE
Blahtexml fixes

### DIFF
--- a/pkgs/by-name/bl/blahtexml/package.nix
+++ b/pkgs/by-name/bl/blahtexml/package.nix
@@ -22,13 +22,13 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch =
     lib.optionalString stdenv.cc.isClang ''
       substituteInPlace makefile \
-        --replace "\$(CXX)" "\$(CXX) -std=c++98"
+        --replace-fail "\$(CXX)" "\$(CXX) -std=c++98"
     ''
     +
     # fix the doc build on TeX Live 2023
     ''
       substituteInPlace Documentation/manual.tex \
-        --replace '\usepackage[utf8x]{inputenc}' '\usepackage[utf8]{inputenc}'
+        --replace-fail '\usepackage[utf8x]{inputenc}' '\usepackage[utf8]{inputenc}'
     '';
 
   outputs = [

--- a/pkgs/by-name/bl/blahtexml/package.nix
+++ b/pkgs/by-name/bl/blahtexml/package.nix
@@ -4,7 +4,7 @@
   stdenv,
   libiconv,
   libxslt,
-  texliveFull,
+  texliveBasic,
   xercesc,
 }:
 
@@ -38,7 +38,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     libxslt
-    texliveFull # scheme-full needed for ucs package
+    (texliveBasic.withPackages (ps: [
+      ps.cm-super
+      ps.ucs
+    ]))
   ];
   buildInputs = [ xercesc ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
 

--- a/pkgs/by-name/bl/blahtexml/package.nix
+++ b/pkgs/by-name/bl/blahtexml/package.nix
@@ -3,6 +3,7 @@
   lib,
   stdenv,
   libiconv,
+  libxslt,
   texliveFull,
   xercesc,
 }:
@@ -35,7 +36,10 @@ stdenv.mkDerivation (finalAttrs: {
     "doc"
   ];
 
-  nativeBuildInputs = [ texliveFull ]; # scheme-full needed for ucs package
+  nativeBuildInputs = [
+    libxslt
+    texliveFull # scheme-full needed for ucs package
+  ];
   buildInputs = [ xercesc ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
 
   buildFlags = [


### PR DESCRIPTION
It turns out that blahtexml *may* fail to build on Darwin when xsltproc is missing. Somehow this is not an issue on Hydra.

I have added a couple of minor improvements to the package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
