### PR TITLE
hexapoda: init at 0.2.3

### DIFF
--- a/pkgs/by-name/he/hexapoda/package.nix
+++ b/pkgs/by-name/he/hexapoda/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "hexapoda";
+  version = "0.2.3";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "simonomi";
+    repo = "hexapoda";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-ZIZVioyo/1U7sy6rWLcuABRsHO6rU69keQpfH6tfcD0=";
+  };
+
+  cargoHash = "sha256-4MeStfLWv/M3rycdTULuqAli7bUQXQ0WDZvYHWpOd1A=";
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  # Build.rs script checks if these exist to actually create the completions and manpage
+  env = {
+    HEXAPODA_COMPLETIONS = "completions";
+    HEXAPODA_MANPAGE = "man";
+  };
+
+  preBuild = ''
+    mkdir -p "$HEXAPODA_COMPLETIONS" "$HEXAPODA_MANPAGE"
+  '';
+
+  postInstall = ''
+    installShellCompletion --bash completions/hexapoda.bash
+    installShellCompletion --fish completions/hexapoda.fish
+    installShellCompletion --zsh completions/_hexapoda
+    installShellCompletion --nushell completions/hexapoda.nu
+
+    installManPage man/hexapoda.1
+  '';
+
+  meta = {
+    description = "A colorful modal hex editor";
+    homepage = "https://simonomi.dev/hexapoda";
+    license = lib.licenses.gpl3Only;
+    changelog = "https://github.com/simonomi/hexapoda/releases/tag/v${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ philocalyst ];
+    mainProgram = "hexapoda";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- model hex editor is hype

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
