### PR TITLE
direvent: Fix on Darwin

### DIFF
--- a/pkgs/by-name/di/direvent/fix-darwin.patch
+++ b/pkgs/by-name/di/direvent/fix-darwin.patch
@@ -1,0 +1,12 @@
+diff --git i/src/direvent.h w/src/direvent.h
+index 18ab4c8..3c49500 100644
+--- i/src/direvent.h
++++ w/src/direvent.h
+@@ -313,6 +313,7 @@ int sigv_set_all(void (*handler)(int), int sigc, int *sigv,
+ 		 struct sigaction *retsa);
+ int sigv_set_tab(int sigc, struct sigtab *sigtab, struct sigaction *retsa);
+ int sigv_set_action_tab(int sigc, struct sigtab *sigtab, struct sigaction *sa);
++int sigv_restore_tab(int sigc, struct sigtab *sigtab, struct sigaction *sa);
+ 
+ struct grecs_locus;
+ int filpatlist_add(filpatlist_t *fptr, char const *arg,

--- a/pkgs/by-name/di/direvent/package.nix
+++ b/pkgs/by-name/di/direvent/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  autoreconfHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -12,6 +13,17 @@ stdenv.mkDerivation (finalAttrs: {
     url = "mirror://gnu/direvent/direvent-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-DhbAtLPm92c+m08x2BqwEjatIvg1OFEvOy9Y+flv3Lc=";
   };
+
+  patches = [
+    ./fix-darwin.patch
+    ./use-nonosleep-if-clock-nanosleep-not-available.patch
+  ];
+
+  nativeBuildInputs = [
+    # The nanosleep patch about modifies configure.ac so we use autoreconfHook.
+    # We should be able to remove this when we drop the nanosleep patch.
+    autoreconfHook
+  ];
 
   meta = {
     description = "Directory event monitoring daemon";

--- a/pkgs/by-name/di/direvent/use-nonosleep-if-clock-nanosleep-not-available.patch
+++ b/pkgs/by-name/di/direvent/use-nonosleep-if-clock-nanosleep-not-available.patch
@@ -1,0 +1,89 @@
+commit f6042ca2e240a27a20e405de49755f350ca95e7b
+Author: Sergey Poznyakoff <gray@gnu.org>
+Date:   Sat Jul 25 22:15:56 2026 +0300
+
+    Use nanosleep on systems lacking clock_nanosleep.
+    
+    * configure.ac: Check for clock_nanosleep.
+    * src/progman.c (abswait): New function.
+    (process_drain): Use it to wait till the specified absolute timestamp.
+
+diff --git a/configure.ac b/configure.ac
+index 336aa2a..a4fcedc 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -41,7 +41,7 @@ AC_CHECK_HEADERS([sys/inotify.h sys/event.h])
+ # Checks for typedefs, structures, and compiler characteristics.
+ 
+ # Checks for library functions.
+-AC_CHECK_FUNCS([inotify_init kqueue rfork getgrouplist])
++AC_CHECK_FUNCS([inotify_init kqueue rfork getgrouplist clock_nanosleep])
+ 
+ if test "$ac_cv_header_sys_inotify_h/$ac_cv_func_inotify_init" = yes/yes; then
+   iface=inotify
+diff --git a/src/progman.c b/src/progman.c
+index 86c3edf..743b97f 100644
+--- a/src/progman.c
++++ b/src/progman.c
+@@ -244,12 +244,40 @@ timespec_add(struct timespec *a, struct timespec *b)
+ 	}
+ }
+ 
++static inline void
++timespec_sub(struct timespec *a, struct timespec const *b)
++{
++	struct timespec d;
++
++	a->tv_sec -= b->tv_sec;
++	a->tv_nsec -= b->tv_nsec;
++	if (a->tv_nsec < 0) {
++		--a->tv_sec;
++		a->tv_nsec += NANOSEC;
++	}
++}
++
++static int
++abswait(struct timespec const *ts)
++{
++#if HAVE_CLOCK_NANOSLEEP
++	return clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, ts, NULL);
++#else
++	struct timespec now, t = *ts;
++	clock_gettime(CLOCK_MONOTONIC, &now);
++	timespec_sub(&t, &now);
++	if (t.tv_sec < 0)
++		return 0;
++	return nanosleep(&t, NULL);
++#endif
++}
++
+ void
+ process_drain(void)
+ {
+ 	struct process *p;
+ 	struct timespec ts;
+-	
++
+ 	/* Send all processes the TERM signal. */
+ 	for (p = proc_list; p; p = p->next) {
+ 		if (p->type == PROC_HANDLER)
+@@ -257,15 +285,13 @@ process_drain(void)
+ 	}
+ 	/* Wait for all processes to terminate. */
+ 	diag(LOG_INFO, _("waiting for processes to terminate"));
+-		     
++
+ 	clock_gettime (CLOCK_MONOTONIC, &ts);
+ 	timespec_add (&ts, &shutdown_timeout);
+-	
+-	do {		
+-		process_cleanup(1);
+-	} while (proc_list &&
+-		 clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &ts, NULL));
+ 
++	do {
++		process_cleanup(1);
++	} while (proc_list && abswait(&ts));
+ 
+ 	if (proc_list) {
+ 		diag(LOG_INFO,


### PR DESCRIPTION
The problem is that there is an implicit definition of a function, which is by default an error with the compiler that is used on Darwin.

There is an upstream submitted patch
(https://puszcza.gnu.org.ua/bugs/?256) to fix this issue, but its from 2015 and thus doesn't seem likely to be applied anytime soon. Since its just a comment, we can't retrieve it with fetchpatch or similar. The patch is very simple and so we can just vendor it here.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
