### PR TITLE
lsplug: init at 7

### DIFF
--- a/pkgs/by-name/ls/lsplug/package.nix
+++ b/pkgs/by-name/ls/lsplug/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  python3Packages,
+  fetchFromSourcehut,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "lsplug";
+  version = "7";
+  pyproject = true;
+
+  src = fetchFromSourcehut {
+    owner = "~martijnbraam";
+    repo = "lsplug";
+    tag = finalAttrs.version;
+    hash = "sha256-eY9XNEdJfQREKroxsuPlv3CKqNX/XiMEnN8TdGYGa+g=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  pythonImportsCheck = [
+    "lsplug"
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Replacement for lsusb that shows more useful info and less useless info";
+    homepage = "https://git.sr.ht/~martijnbraam/lsplug";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      Luflosi
+    ];
+    mainProgram = "lsplug";
+  };
+})


### PR DESCRIPTION
Replacement for lsusb that shows more useful info and less useless info.

https://youtu.be/nAYND-fDETc
https://git.sr.ht/~martijnbraam/lsplug

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test