### PR TITLE
low_latency_layer: init at 0.2.0

### DIFF
--- a/pkgs/by-name/lo/low_latency_layer/package.nix
+++ b/pkgs/by-name/lo/low_latency_layer/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  vulkan-headers,
+  vulkan-loader,
+  vulkan-utility-libraries,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "low_latency_layer";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "Korthos-Software";
+    repo = "low_latency_layer";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-mnGAH0m19wOkWEowpcPRHXQSc6HGYW+CFYxjPF2onk4=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    vulkan-headers
+    vulkan-loader
+    vulkan-utility-libraries
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  meta = {
+    description = "A Vulkan layer that reduces latency by implementing both AMD and NVIDIA's latency reduction technologies.";
+    longDescription = ''
+      A C++23 implicit Vulkan layer that reduces click-to-photon latency by implementing both AMD and NVIDIA's latency reduction technologies.
+      By providing hardware-agnostic implementations of the VK_NV_low_latency2 and VK_AMD_anti_lag device extensions, this layer brings Reflex and Anti-Lag capabilities to AMD and Intel GPUs. When paired with dxvk-nvapi to forward the relevant calls, it bypasses the need for official driver-level support.
+      The layer also eliminates a hardware support disparity as considerably more applications support NVIDIA's Reflex than AMD's Anti-Lag.
+      To use this in NixOS add this package to hardware.graphics.extraPackages.
+    '';
+    homepage = "https://github.com/Korthos-Software/low_latency_layer";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      returntoreality
+    ];
+  };
+})


### PR DESCRIPTION
Adds https://github.com/Korthos-Software/low_latency_layer
Description:
A C++23 implicit Vulkan layer that reduces click-to-photon latency by implementing both AMD and NVIDIA's latency reduction technologies.

By providing hardware-agnostic implementations of the VK_NV_low_latency2 and VK_AMD_anti_lag device extensions, this layer brings Reflex and Anti-Lag capabilities to AMD and Intel GPUs. When paired with dxvk-nvapi to forward the relevant calls, it bypasses the need for official driver-level support.

The layer also eliminates a hardware support disparity as considerably more applications support NVIDIA's Reflex than AMD's Anti-Lag.

To use this in NixOS add this package to hardware.graphics.extraPackages.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
