### PR TITLE
uncover: 1.1.0 -> 1.2.1

### DIFF
--- a/pkgs/by-name/un/uncover/package.nix
+++ b/pkgs/by-name/un/uncover/package.nix
@@ -7,16 +7,18 @@
 
 buildGoModule (finalAttrs: {
   pname = "uncover";
-  version = "1.1.0";
+  version = "1.2.1";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "projectdiscovery";
     repo = "uncover";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-BRh25lvk3Zut5M6dedLuSET4514R9j0fUHmamw4rp5U=";
+    hash = "sha256-LFKCUBBgG7dTQhJF9iciyU7GTnQsO+ZdVCtaOnl+Et0=";
   };
 
-  vendorHash = "sha256-6TvPKp/P0v/ZJRGRICp77C/8FHupyr9Hy2+zlYc2HIU=";
+  vendorHash = "sha256-Pkpp2D3b3A5TQ8eXaOf6qKUY/bamdytmuqOVAozK9k0=";
 
   subPackages = [ "cmd/uncover" ];
 
@@ -29,8 +31,6 @@ buildGoModule (finalAttrs: {
 
   doInstallCheck = true;
 
-  versionCheckProgramArg = "-version";
-
   meta = {
     description = "API wrapper to search for exposed hosts";
     longDescription = ''
@@ -40,7 +40,7 @@ buildGoModule (finalAttrs: {
       Currently, it supports shodan,shodan-internetdb, censys, and fofa search API.
     '';
     homepage = "https://github.com/projectdiscovery/uncover";
-    changelog = "https://github.com/projectdiscovery/uncover/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/projectdiscovery/uncover/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "uncover";


### PR DESCRIPTION
Diff: https://github.com/projectdiscovery/uncover/compare/v1.1.0...v1.2.1

Changelog:

- https://github.com/projectdiscovery/uncover/releases/tag/v1.2.0
- https://github.com/projectdiscovery/uncover/releases/tag/v1.2.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
