### PR TITLE
authentik: 2025.12.6 -> 2026.5.3

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -30,6 +30,11 @@
 
 - `boot.vesa` has been removed. It was deprecated in 2020 because Xorg now works better with kernel modesetting. If you still need the legacy VESA 800x600 fallback, set `boot.kernelParams = [ "vga=0x317" "nomodeset" ];` directly.
 
+- `authentik` has been updated to 2026.5.3, which changes the default listen address from `0.0.0.0` to `[::]`.
+  IPv4-only deployments might need to adjust their listen settings.
+  Deployments running the server and worker in the same network namespace must also set at least the worker
+  `AUTHENTIK_LISTEN__HTTP` address so that the server and worker do not bind to the same address.
+
 - Support for the legacy U‐Boot image format has been removed from the initrd generators, as it is deprecated upstream and no longer used by any platform in Nixpkgs.
 
 - Rustical migrates from `settings.http.host` and `settings.http.port` to `settings.http.bind` to support UNIX domain sockets as well as TCP sockets in one setting.

--- a/pkgs/by-name/au/authentik/client-go-config.patch
+++ b/pkgs/by-name/au/authentik/client-go-config.patch
@@ -1,9 +1,0 @@
-diff --git a/config.yaml b/config.yaml
-index 2f07ea7..0f90432 100644
---- a/config.yaml
-+++ b/config.yaml
-@@ -4,3 +4,4 @@ additionalProperties:
-   packageName: api
-   enumClassPrefix: true
-   useOneOfDiscriminatorLookup: true
-+  disallowAdditionalPropertiesIfNotPresent: false

--- a/pkgs/by-name/au/authentik/package.nix
+++ b/pkgs/by-name/au/authentik/package.nix
@@ -3,14 +3,19 @@
   stdenvNoCC,
   callPackages,
   cacert,
+  clangStdenv,
+  cmake,
   fetchFromGitHub,
   buildGoModule,
+  buildNpmPackage,
   bash,
   chromedriver,
   nodejs_24,
-  python3,
+  python314,
   makeWrapper,
   openapi-generator-cli,
+  perl,
+  rustPlatform,
   go,
   typescript,
   makeSetupHook,
@@ -20,13 +25,18 @@
 let
   nodejs = nodejs_24;
 
-  version = "2025.12.6";
+  version = "2026.5.3";
+
+  cargoPackageFlags = [
+    "--package"
+    "authentik"
+  ];
 
   src = fetchFromGitHub {
     owner = "goauthentik";
     repo = "authentik";
     tag = "version/${version}";
-    hash = "sha256-uIg47z4LaCawF/5ir4mKE6DpDnEpQ8DuObCNaq6TcYk=";
+    hash = "sha256-nmAX8nwZpdDcFAPvC9hAEp0x43RnFtGLUTAm7NcvNZo=";
   };
 
   meta = {
@@ -46,24 +56,9 @@ let
 
   client-go = stdenvNoCC.mkDerivation {
     pname = "authentik-client-go";
-    version = "3.${version}";
-    inherit meta;
+    inherit version src meta;
 
-    src = fetchFromGitHub {
-      owner = "goauthentik";
-      repo = "client-go";
-      tag = "v3.2025.12.4";
-      hash = "sha256-+/CfOE2HkBU+ZddvdXGenB/z8xNFk8cujpZpMXyh3cY=";
-    };
-
-    patches = [
-      ./client-go-config.patch
-    ];
-
-    postPatch = ''
-      substituteInPlace ./config.yaml \
-        --replace-fail '/local' "$(pwd)"
-    '';
+    sourceRoot = "${src.name}/packages/client-go";
 
     nativeBuildInputs = [
       openapi-generator-cli
@@ -86,10 +81,9 @@ let
     installPhase = ''
       runHook preInstall
 
-      cp go.mod go.sum $out
-
       cd $out
       rm -rf test
+      rm -f go.mod go.sum
       rm -f .travis.yml git_push.sh
 
       runHook postInstall
@@ -101,8 +95,8 @@ let
     inherit version src meta;
 
     postPatch = ''
-      substituteInPlace ./scripts/api/ts-config.yaml \
-        --replace-fail '/local' "$(pwd)"
+      substituteInPlace ./packages/client-ts/config.yaml \
+        --replace-fail '/local' "$(pwd)/packages/client-ts"
     '';
 
     nativeBuildInputs = [
@@ -117,7 +111,7 @@ let
       openapi-generator-cli generate \
         -i ./schema.yml -o $out \
         -g typescript-fetch \
-        -c ./scripts/api/ts-config.yaml \
+        -c ./packages/client-ts/config.yaml \
         --additional-properties=npmVersion=${version} \
         --git-repo-id authentik --git-user-id goauthentik
 
@@ -128,32 +122,19 @@ let
     '';
   };
 
-  # prefetch-npm-deps does not save all dependencies even though the lockfile is fine
-  website-deps = stdenvNoCC.mkDerivation {
+  website-deps = buildNpmPackage {
     pname = "authentik-website-deps";
     inherit src version meta;
 
     sourceRoot = "${src.name}/website";
 
-    outputHash =
-      {
-        "aarch64-linux" = "sha256-EbLneRDCyLLLBOZ2DUDpf2TbZoTL8QMXP4WlAZEzS90=";
-        "x86_64-linux" = "sha256-yDjwN/+lX2i9WYDXq4yWwf9o8nA4342iHDDQH4Jt7eQ=";
-      }
-      .${stdenvNoCC.hostPlatform.system} or (throw "authentik-website-deps: unsupported host platform");
-
-    outputHashMode = "recursive";
-
-    nativeBuildInputs = [
-      nodejs
-      cacert
-    ];
-
-    buildPhase = ''
-      npm ci --cache ./cache
-
-      rm -r ./cache node_modules/.package-lock.json
-    '';
+    inherit nodejs;
+    npmDepsHash = "sha256-SkIZF+wQPgoZOGJc0YR8Ot07KCsAdA1985SLQaoibfA=";
+    npmDepsFetcherVersion = 2;
+    makeCacheWritable = true;
+    npmInstallFlags = [ "--legacy-peer-deps" ];
+    npmRebuildFlags = [ "--ignore-scripts" ];
+    dontNpmBuild = true;
 
     # dependencies of workspace projects are installed into separate node_modules folders with
     # symlinks between them, so we have to copy all of them
@@ -208,8 +189,8 @@ let
 
     outputHash =
       {
-        "aarch64-linux" = "sha256-J9wGQe7iMfKznNk3woqi0VNVNA/dE6TGi2f44DOlG1c=";
-        "x86_64-linux" = "sha256-9Q590Rw0mk3q5osxOKGWU7+XtKwkTyA+CLC2LxAA/3g=";
+        "aarch64-linux" = "sha256-41xZEfLul92vJATZqyVnd7Pp++NzLL/u8NeJJPHpXrw=";
+        "x86_64-linux" = "sha256-FpfOl6wNCgXLg86+vbjnYkcOnpaOZBCNxJiFDRT5W3s=";
       }
       .${stdenvNoCC.hostPlatform.system} or (throw "authentik-webui-deps: unsupported host platform");
     outputHashMode = "recursive";
@@ -220,6 +201,7 @@ let
     ];
 
     buildPhase = ''
+      chmod -R +w . ../packages/client-ts
       npm ci --cache ./cache --ignore-scripts
 
       rm -r ./cache node_modules/.package-lock.json
@@ -295,7 +277,7 @@ let
     ];
   };
 
-  python = python3.override {
+  python = python314.override {
     self = python;
     packageOverrides = final: prev: {
       # https://github.com/goauthentik/authentik/pull/16324
@@ -375,62 +357,6 @@ let
           django-postgres-extra
         ];
       };
-
-      # Running authentik currently requires a custom version.
-      # Look in `pyproject.toml` for changes to the rev in the `[tool.uv.sources]` section.
-      # See https://github.com/goauthentik/authentik/pull/14057 for latest version bump.
-      djangorestframework = final.buildPythonPackage {
-        pname = "djangorestframework";
-        version = "3.16.0";
-        format = "setuptools";
-
-        src = fetchFromGitHub {
-          owner = "authentik-community";
-          repo = "django-rest-framework";
-          rev = "896722bab969fabc74a08b827da59409cf9f1a4e";
-          hash = "sha256-YrEDEU3qtw/iyQM3CoB8wYx57zuPNXiJx6ZjrIwnCNU=";
-        };
-
-        propagatedBuildInputs = with final; [
-          django
-          pytz
-        ];
-
-        nativeCheckInputs = with final; [
-          pytest-django
-          pytest7CheckHook
-
-          # optional tests
-          coreapi
-          django-guardian
-          inflection
-          pyyaml
-          uritemplate
-        ];
-
-        disabledTests = [
-          "test_ignore_validation_for_unchanged_fields"
-          "test_invalid_inputs"
-          "test_shell_code_example_rendering"
-          "test_unique_together_condition"
-          "test_unique_together_with_source"
-        ];
-
-        pythonImportsCheck = [ "rest_framework" ];
-      };
-
-      # authentik is currently not compatible with v1.18 and fails with the following error:
-      # > AttributeError: 'Namespace' object has no attribute 'worker_fork_timeout'. Did you mean: 'worker_shutdown_timeout'?
-      dramatiq = prev.dramatiq.overrideAttrs (_: rec {
-        version = "1.17.1";
-
-        src = fetchFromGitHub {
-          owner = "Bogdanp";
-          repo = "dramatiq";
-          tag = "v${version}";
-          hash = "sha256-NeUGhG+H6r+JGd2qnJxRUbQ61G7n+3tsuDugTin3iJ4=";
-        };
-      });
 
       authentik-django = final.buildPythonPackage {
         pname = "authentik-django";
@@ -548,7 +474,32 @@ let
 
   inherit (python.pkgs) authentik-django;
 
-  # Provide a setup-hook to configure the Go vendor directory with up-to-date API bindings.
+  worker = (rustPlatform.buildRustPackage.override { stdenv = clangStdenv; }) {
+    pname = "authentik-worker";
+    inherit version src meta;
+
+    cargoHash = "sha256-KExlNyT9G3R5rnt99beT2pYrWxezMLhGw+Q9T1X2kj4=";
+
+    nativeBuildInputs = [
+      cmake
+      go
+      perl
+    ];
+
+    buildInputs = [ python ];
+
+    env = {
+      PYO3_PYTHON = lib.getExe python;
+      RUSTFLAGS = "--cfg tokio_unstable";
+    };
+
+    cargoBuildFlags = cargoPackageFlags;
+
+    # Upstream currently has no Rust tests in this package.
+    doCheck = false;
+  };
+
+  # Provide a setup-hook to configure the Go source tree with up-to-date API bindings.
   # This is done to avoid the `vendorHash` depending on anything in the `client-go` build (e.g.
   # openapi-generator-cli version updates changing the produced content) and invalidating the hash.
   apiGoVendorHook =
@@ -559,9 +510,10 @@ let
       (
         writeShellScript "authentik-api-go-vendor-hook" ''
           authentikApiGoVendorHook() {
-            chmod -R +w vendor/goauthentik.io/api
-            rm -rf vendor/goauthentik.io/api/v3
-            cp -r ${client-go} vendor/goauthentik.io/api/v3
+            chmod -R +w packages/client-go
+            rm -rf packages/client-go
+            cp -r ${client-go} packages/client-go
+            chmod -R +w packages/client-go
 
             echo "Finished authentikApiGoVendorHook"
           }
@@ -593,10 +545,11 @@ let
     # calculate the vendorHash without other dependencies, so it is only based on the `go.sum` file
     overrideModAttrs.postPatch = "";
 
-    vendorHash = "sha256-pdQg02f1K4nOhsnadoplQYOhEybqZxn+yDQRN5RNygM=";
+    vendorHash = "sha256-EVDOZ4USaJoIBDB8mM4ZSBfsSc1d/NOm1Qv/hUJ+8f4=";
 
     postInstall = ''
-      mv $out/bin/server $out/bin/authentik
+      mv $out/bin/server $out/bin/authentik-server
+      ln -s authentik-server $out/bin/authentik
     '';
 
     subPackages = [ "cmd/server" ];
@@ -612,11 +565,6 @@ stdenvNoCC.mkDerivation {
   postPatch = ''
     rm Makefile
     patchShebangs lifecycle/ak
-
-    # This causes issues in systemd services
-    substituteInPlace lifecycle/ak \
-      --replace-fail 'printf' '>&2 printf' \
-      --replace-fail '>/dev/stderr' ""
   '';
 
   installPhase = ''
@@ -627,8 +575,9 @@ stdenvNoCC.mkDerivation {
     wrapProgram $out/bin/ak \
       --prefix PATH : ${
         lib.makeBinPath [
-          (python.withPackages (ps: [ ps.authentik-django ]))
+          worker
           proxy
+          (python.withPackages (ps: [ ps.authentik-django ]))
         ]
       } \
       --set TMPDIR /dev/shm \
@@ -638,7 +587,7 @@ stdenvNoCC.mkDerivation {
   '';
 
   passthru = {
-    inherit proxy apiGoVendorHook;
+    inherit proxy worker apiGoVendorHook;
     outposts = callPackages ./outposts.nix {
       inherit (proxy) vendorHash;
       inherit apiGoVendorHook;


### PR DESCRIPTION
Update authentik to 2026.5.3.

Changelog: https://docs.goauthentik.io/releases/2026.5
GitHub release: https://github.com/goauthentik/authentik/releases/tag/version%2F2026.5.3

Notable packaging changes:
- switch authentik to Python 3.14, matching upstream's requirement
- build the new Rust `authentik` worker/all-in-one binary and include it in the `ak` wrapper runtime path
- build the Go server as `authentik-server`, matching upstream's `lifecycle/ak` lookup, while keeping an `authentik -> authentik-server` compatibility symlink in the proxy output
- use a clang stdenv for the Rust worker because `aws-lc-fips-sys` fails its FIPS delocation step with the default GCC stdenv
- use the generated Go client from the authentik monorepo under `packages/client-go`
- update the generated Go and TypeScript clients and hashes
- remove the obsolete client-go patch now included upstream
- remove local Python dependency overrides; nixpkgs now has the required `djangorestframework`, `twilio`, and `dramatiq` versions
- add a release note for the upstream breaking listen-address default change

Automation disclosure: this PR was prepared with assistance from OpenAI Codex, with manual review and validation before submission.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Notes:
- Previously built `.#authentik` and `.#authentik.outposts.{ldap,proxy,radius}` on both x86_64-linux and aarch64-linux.
- Previously ran `nixpkgs-review pr 523484 --package authentik --package authentik.outposts.ldap --package authentik.outposts.proxy --package authentik.outposts.radius` on x86_64-linux and aarch64-linux; 4 packages built on each platform.
- After the Rust worker and server-wrapper changes, built `authentik.worker`, `authentik.proxy`, and `authentik` with `NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1 nix-build ... --system x86_64-linux --max-jobs 0`.
- Checked the generated `ak` wrapper includes the worker path before the proxy path, so `ak worker` resolves the Rust `authentik` binary while direct users of `authentik.proxy/bin/authentik` keep working.
- Verified that plain `rustPlatform.buildRustPackage` with the default GCC stdenv fails in `aws-lc-fips-sys`; the clang stdenv override builds successfully.
- Ran `git diff --check`.
- Evaluated `pkgs.authentik.version` as `2026.5.3`.
- Evaluated dependency versions from nixpkgs: `djangorestframework 3.17.1`, `twilio 9.10.9`, `dramatiq 2.1.0`.
- Built `authentik.proxy.goModules` with `NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1 nix-build -A authentik.proxy.goModules --no-out-link`.
- I did not find an existing authentik NixOS test in `nixos/tests`.
- `ak --help` starts the wrapper, but authentik bootstrap requires runtime configuration/PostgreSQL, so I am not marking binary functionality as fully tested.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
