### PR TITLE
libglycin{,-gtk4}: fix cross compilation, enable strictDeps

### DIFF
--- a/pkgs/by-name/li/libglycin-gtk4/package.nix
+++ b/pkgs/by-name/li/libglycin-gtk4/package.nix
@@ -91,6 +91,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   env.CARGO_BUILD_TARGET = stdenv.hostPlatform.rust.rustcTargetSpec;
 
+  strictDeps = true;
+
   meta = {
     description = "C-Bindings to convert glycin frames to GDK Textures";
     homepage = "https://gitlab.gnome.org/GNOME/glycin";

--- a/pkgs/by-name/li/libglycin-gtk4/package.nix
+++ b/pkgs/by-name/li/libglycin-gtk4/package.nix
@@ -79,12 +79,17 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     patchShebangs \
       build-aux/crates-version.py
+    substituteInPlace libglycin/meson.build --replace-fail \
+      "cargo_output = cargo_target_dir / rust_target" \
+      "cargo_output = cargo_target_dir / '${stdenv.hostPlatform.rust.cargoShortTarget}' / rust_target"
   '';
 
   postFixup = ''
     # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
     moveToOutput "share/doc" "$devdoc"
   '';
+
+  env.CARGO_BUILD_TARGET = stdenv.hostPlatform.rust.rustcTargetSpec;
 
   meta = {
     description = "C-Bindings to convert glycin frames to GDK Textures";

--- a/pkgs/by-name/li/libglycin/package.nix
+++ b/pkgs/by-name/li/libglycin/package.nix
@@ -94,12 +94,17 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     patchShebangs \
       build-aux/crates-version.py
+    substituteInPlace libglycin/meson.build --replace-fail \
+      "cargo_output = cargo_target_dir / rust_target" \
+      "cargo_output = cargo_target_dir / '${stdenv.hostPlatform.rust.cargoShortTarget}' / rust_target"
   '';
 
   postFixup = ''
     # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
     moveToOutput "share/doc" "$devdoc"
   '';
+
+  env.CARGO_BUILD_TARGET = stdenv.hostPlatform.rust.rustcTargetSpec;
 
   passthru = {
     updateScript =

--- a/pkgs/by-name/li/libglycin/package.nix
+++ b/pkgs/by-name/li/libglycin/package.nix
@@ -106,6 +106,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   env.CARGO_BUILD_TARGET = stdenv.hostPlatform.rust.rustcTargetSpec;
 
+  strictDeps = true;
+
   passthru = {
     updateScript =
       let


### PR DESCRIPTION
fixes `nix-build -A pkgsCross.aarch64-multiplatform.libglycin` and `nix-build -A pkgsCross.aarch64-multiplatform.libglycin-gtk4`.

populate `CARGO_BUILD_TARGET` to make cargo build for the desired platform, and then patch the build script on account that explicitly specifying the target causes cargo to place outputs into a `target/$PLATFORM/` subdirectory instead of the toplevel `target/`. this is the same pattern we use for `glycin-loaders`, `fractal`, `papers`, `snapshot`, etc.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
