### PR TITLE
lensfun: update lens database

### DIFF
--- a/pkgs/by-name/le/lensfun/package.nix
+++ b/pkgs/by-name/le/lensfun/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  stdenvNoCC,
   fetchFromGitHub,
   pkg-config,
   glib,
@@ -9,20 +10,54 @@
   cmake,
   python3,
   python3Packages,
+
+  # optionally specify a derivation containing the lens data as generated from the `generate_db.py` script
+  lensfunDatabases ? null,
 }:
 
 let
   version = "0.3.4";
   pname = "lensfun";
 
-  # Fetch a more recent version of the repo containing a more recent lens
-  # database
-  lensfunDatabase = fetchFromGitHub {
-    owner = "lensfun";
-    repo = "lensfun";
-    rev = "a1510e6f33ce9bc8b5056a823c6d5bc6b8cba033";
-    sha256 = "sha256-qdONyKk873Tq11M33JmznhJMAGd4dqp5KdXdVhfy/Ak=";
-  };
+  lensData =
+    if lensfunDatabases != null then
+      lensfunDatabases
+    else
+      # fetch a more recent version of the lens database
+      stdenvNoCC.mkDerivation {
+        name = "lensfun-databases";
+
+        src = fetchFromGitHub {
+          owner = "lensfun";
+          repo = "lensfun";
+          rev = "201da1a7433626a2a1ecd67e1f21a42fb17aa4a5";
+          sha256 = "sha256-64ZcupHA4oClPRCnG8KofGC46M/mZFermugzQ15B6k4=";
+
+          leaveDotGit = true;
+          # generate timestamp based on the most recent commit
+          postFetch = ''
+            cd $out
+            git log -1 --format=%at > $out/timestamp.txt
+            rm -R .git
+          '';
+        };
+
+        nativeBuildInputs = [
+          python3
+          python3Packages.setuptools
+          python3Packages.lxml
+        ];
+
+        # generates versioned tarballs of lens data
+        # patch applied so that we read the previously generated `timestamp.txt` instead
+        # of trying to read from `.git` (which is deleted during `postFetch`)
+        buildPhase = ''
+          substituteInPlace tools/update_database/generate_db.py \
+            --replace-fail '"git", "log", "-1", "--format=%ad", "--date=raw", "--", "*.xml"' '"cat", "timestamp.txt"'
+          python3 tools/update_database/generate_db.py --input data/db --output $out
+          cp timestamp.txt $out/timestamp.txt
+        '';
+      };
 
 in
 stdenv.mkDerivation {
@@ -36,15 +71,13 @@ stdenv.mkDerivation {
   };
 
   # replace database with a more recent snapshot
-  # the master branch uses version 2 profiles, while 0.3.3 requires version 1 profiles,
-  # so we run the conversion tool the project provides,
-  # then untar the version 1 profiles into the source dir before we build
+  # the master branch uses version 2 profiles, while this version requires version 1 profiles
+  # also copies in the required `timestamp.txt` file
   prePatch = ''
     rm -R data/db
-    python3 ${lensfunDatabase}/tools/lensfun_convert_db_v2_to_v1.py $TMPDIR ${lensfunDatabase}/data/db
     mkdir -p data/db
-    tar xvf $TMPDIR/db/version_1.tar -C data/db
-    date +%s > data/db/timestamp.txt
+    tar xvfj ${lensData}/version_1.tar.bz2 -C data/db
+    cp ${lensData}/timestamp.txt data/db/timestamp.txt
   ''
   # Backport CMake 4 support
   # This is already on master, but not yet in a stable release:
@@ -60,9 +93,6 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     cmake
     pkg-config
-    python3
-    python3Packages.setuptools
-    python3Packages.lxml # For the db converison
   ];
 
   buildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Change Summary

- bumps the lens database to the latest version as of time of authoring
- switches to the new `generate_db.py` script
  - the previously used `lensfun_convert_db_v2_to_v1.py` script has been removed upstream and this is the new preferred method
- adds new optional `lensfunDatabases` argument which overrides the lens databases used when building the package
- changes the method used to generate the `timestamp.txt` file
  - was previously generated using `date +%s` (which is not reproducible)
  - now generated based off most recent commit timestamp

## Additional Testing Performed
- tested by using my branch as an overlay for the `lensfun` package and running darktable `5.2.1` using a lens that was not previously included in the databases packaged in `nixos-25.11`
  - the lens is now recognized by darktable and the lens correction module correctly accounted for distortion and vignetting on the lens
- running `nix-build -A lensfun --check --keep-failed` now passes successfully (it currently does not pass on `master` due to the aforementioned timestamp generation method)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
