### PR TITLE
kdePackages.{kfilemetadata,kio-extras,kio-extras-kf5}: add dev output to stop propagating libappimage dev outputs

### DIFF
--- a/pkgs/kde/frameworks/kfilemetadata/default.nix
+++ b/pkgs/kde/frameworks/kfilemetadata/default.nix
@@ -12,6 +12,8 @@
 mkKdeDerivation {
   pname = "kfilemetadata";
 
+  outputs = [ "out" "dev" ];
+
   # Fix installing cmake files into wrong directory
   # FIXME(later): upstream
   patches = [ ./cmake-install-paths.patch ];

--- a/pkgs/kde/gear/kio-extras/default.nix
+++ b/pkgs/kde/gear/kio-extras/default.nix
@@ -19,6 +19,8 @@
 mkKdeDerivation {
   pname = "kio-extras";
 
+  outputs = [ "out" "dev" ];
+
   extraNativeBuildInputs = [
     pkg-config
     gperf

--- a/pkgs/kde/misc/kio-extras-kf5/default.nix
+++ b/pkgs/kde/misc/kio-extras-kf5/default.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation rec {
   pname = "kio-extras-kf5";
   version = "24.02.2";
 
+  outputs = [ "out" "dev" ];
+
   src = fetchurl {
     url = "mirror://kde/stable/release-service/${version}/src/kio-extras-kf5-${version}.tar.xz";
     hash = "sha256-qar1jzuALINBu6HOuVBU+RUFnqRH9Z/8e5M8ynGxKsk=";


### PR DESCRIPTION

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
