### PR TITLE
bmake: restore missing bsd.*.mk symlinks on Darwin

### DIFF
--- a/pkgs/by-name/bm/bmake/package.nix
+++ b/pkgs/by-name/bm/bmake/package.nix
@@ -67,6 +67,8 @@ stdenv.mkDerivation (finalAttrs: {
     ) "export"
   );
 
+  __structuredAttrs = true;
+
   strictDeps = true;
 
   doCheck = true;

--- a/pkgs/by-name/bm/bmake/package.nix
+++ b/pkgs/by-name/bm/bmake/package.nix
@@ -96,8 +96,8 @@ stdenv.mkDerivation (finalAttrs: {
     # `boot-strap op=install` runs the built bmake, which breaks cross builds.
     install -Dm755 bmake $out/bin/bmake
     install -Dm644 bmake.1 $man/share/man/man1/bmake.1
-    mkdir -p $out/share
-    cp -r mk $out/share
+    install -Dm755 -d $out/share/mk
+    sh mk/install-mk -v -m 444 $out/share/mk
 
     runHook postInstall
   '';


### PR DESCRIPTION
bmake's `installPhase` was updated in #462500 to manually install the binaries and share Makefiles for bmake as the boot-strap script invokes bmake (breaking cross builds). This caused the darwin.locale build to regress as bmake could no longer find [bsd.prog.mk][1]. The install-sh script (which is invoked by the install-mk target used by the boot-strap script) creates bsd.-prefixed symlinks to the Makefiles under share on BSD systems, including Darwin. Update bmake's `installPhase` to invoke install-mk to ensure that the symlinks are created. install-mk does not invoke bmake so this should not break cross builds.

[1]: https://github.com/apple-oss-distributions/adv_cmds/blob/2bdd0b49a2d51a3249eecdb04277da034f54eca6/locale/BSDmakefile#L9

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test