### PR TITLE
wild-unwrapped: 0.8.0 -> 0.9.0

### DIFF
--- a/pkgs/by-name/wi/wild-unwrapped/adapterTest.nix
+++ b/pkgs/by-name/wi/wild-unwrapped/adapterTest.nix
@@ -14,6 +14,7 @@
   clang-tools,
   useWildLinker,
   hello,
+  taplo,
 }:
 let
   # These wrappers are REQUIRED for the Wild test suite to pass
@@ -101,6 +102,10 @@ in
     checkInputs = [
       stdenv.cc.libc.out
       stdenv.cc.libc.static
+    ];
+
+    nativeCheckInputs = [
+      taplo
     ];
 
     # https://github.com/davidlattimore/wild/discussions/832#discussioncomment-14482948

--- a/pkgs/by-name/wi/wild-unwrapped/package.nix
+++ b/pkgs/by-name/wi/wild-unwrapped/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   callPackage,
   versionCheckHook,
@@ -10,20 +11,24 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "wild-unwrapped";
-  version = "0.8.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "wild-linker";
     repo = "wild";
     tag = finalAttrs.version;
-    hash = "sha256-E5cmZuOtF+MNTPyalKjnguhin70zqtDDB0D71ZpeE48=";
+    hash = "sha256-v4lPgZDPvRTAekkU9Vku9llgpOsaVtKt91VFUGrEeKw=";
   };
 
-  cargoHash = "sha256-r0r7sN1SW5TIybHORfzJkN51Y0REEC2/h7q71GxUgAM=";
+  __structuredAttrs = true;
 
-  cargoBuildFlags = [ "-p wild-linker" ];
+  cargoHash = "sha256-ADJLtTRXcVWcbvgwXvCs0wxcGp2XP1LZJUJ4hpuzVHQ=";
 
-  strictDeps = true;
+  cargoBuildFlags = [
+    "-p"
+    "wild-linker"
+  ];
+
   nativeBuildInputs = [
     pkg-config
   ];
@@ -54,6 +59,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     ];
     mainProgram = "wild";
     maintainers = with lib.maintainers; [ RossSmyth ];
-    platforms = lib.platforms.linux;
+    # Wild can run on Linux and Darwin, but can only target ELF platforms.
+    # On linux this is native, on Darwin this is cross (or emulated)
+    platforms = with lib.platforms; lib.optionals (stdenv.targetPlatform.isElf) (linux ++ darwin);
   };
 })

--- a/pkgs/by-name/wi/wild-unwrapped/package.nix
+++ b/pkgs/by-name/wi/wild-unwrapped/package.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.8.0";
 
   src = fetchFromGitHub {
-    owner = "davidlattimore";
+    owner = "wild-linker";
     repo = "wild";
     tag = finalAttrs.version;
     hash = "sha256-E5cmZuOtF+MNTPyalKjnguhin70zqtDDB0D71ZpeE48=";
@@ -46,8 +46,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Very fast linker for Linux";
-    homepage = "https://github.com/davidlattimore/wild";
-    changelog = "https://github.com/davidlattimore/wild/blob/${finalAttrs.version}/CHANGELOG.md";
+    homepage = "https://github.com/wild-linker/wild";
+    changelog = "https://github.com/wild-linker/wild/blob/${finalAttrs.version}/CHANGELOG.md";
     license = [
       lib.licenses.asl20 # or
       lib.licenses.mit


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Requires a manual update.

1. Rename the github owner to the Wild org
2. Update the package hashes
3. Fix the tests
4. Enable `__structuredAttrs`
5. Enable Darwin (I think this is experimental upstream, but they are working on it and it is tested in CI now)

I also removed strictDeps as it is redundant (buildRustPackage already unconditionally enables this).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
