### PR TITLE
fop: use finalAttrs

### DIFF
--- a/pkgs/by-name/fo/fop/package.nix
+++ b/pkgs/by-name/fo/fop/package.nix
@@ -7,12 +7,12 @@
   stripJavaArchivesHook,
 }:
 
-maven.buildMavenPackage rec {
+maven.buildMavenPackage (finalAttrs: {
   pname = "fop";
   version = "2.11";
 
   src = fetchurl {
-    url = "https://dlcdn.apache.org/xmlgraphics/fop/source/fop-${version}-src.tar.gz";
+    url = "https://dlcdn.apache.org/xmlgraphics/fop/source/fop-${finalAttrs.version}-src.tar.gz";
     hash = "sha256-uY6cUjmyuenfK3jAWvugsYa5qg8rbnvRZZ6qA/g2fZM=";
   };
 
@@ -75,4 +75,4 @@ maven.buildMavenPackage rec {
       binaryBytecode # source bundles dependencies as jars
     ];
   };
-}
+})


### PR DESCRIPTION
Use `finalAttrs` rather than `rec` for the parameter to `buildMavenPackage`.

I was under the impression that `finalAttrs`  was the preferred way to do it, but now I can't find clear documentation that says so. I'll let the `fop` maintainer(s) decide whether they prefer this approach or not.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
