### PR TITLE
python3Packages.dramatiq-abort: fix tests with dramatiq 2.0

### DIFF
--- a/pkgs/development/python-modules/dramatiq-abort/default.nix
+++ b/pkgs/development/python-modules/dramatiq-abort/default.nix
@@ -22,6 +22,11 @@ buildPythonPackage rec {
     hash = "sha256-i5vL9yjQQambG8m6RDByr7/j8+PhDdLsai3pDrH1A4Q=";
   };
 
+  patches = [
+    # https://github.com/Flared/dramatiq-abort/pull/38
+    ./dramatiq-2.0-stub-broker-fail-fast.patch
+  ];
+
   build-system = [ setuptools ];
 
   dependencies = [

--- a/pkgs/development/python-modules/dramatiq-abort/dramatiq-2.0-stub-broker-fail-fast.patch
+++ b/pkgs/development/python-modules/dramatiq-abort/dramatiq-2.0-stub-broker-fail-fast.patch
@@ -1,0 +1,11 @@
+--- a/tests/conftest.py
++++ b/tests/conftest.py
+@@ -32,7 +32,7 @@ def check_redis(client: Any) -> None:
+
+ @pytest.fixture()
+ def stub_broker() -> Generator[dramatiq.Broker, None, None]:
+-    broker = StubBroker()
++    broker = StubBroker(fail_fast_default=False)
+     broker.emit_after("process_boot")
+     dramatiq.set_broker(broker)
+     yield broker


### PR DESCRIPTION
ZHF: #516381 (Part of)

Hydra Failure (Click the banner to go to Hydra build report):
[![](https://hydra-banner.harinn.dev/build/329440559)](https://hydra.nixos.org/build/329440559)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

