### PR TITLE
secp256k1-jdk: init at 0.3

### DIFF
--- a/pkgs/by-name/se/secp256k1-jdk/package.nix
+++ b/pkgs/by-name/se/secp256k1-jdk/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  fetchFromGitHub,
+  maven,
+  jdk25,
+}:
+
+maven.buildMavenPackage (finalAttrs: {
+  pname = "secp256k1-jdk";
+  version = "0.3";
+
+  src = fetchFromGitHub {
+    owner = "bitcoinj";
+    repo = "secp256k1-jdk";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-kIWBgJ9OueNNDRKf1HHaxt6PFxK2iCuO0TFr8swbiL0=";
+  };
+
+  mvnJdk = jdk25;
+  mvnGoal = "deploy"; # The secp256k1-jdk POM targets a `local-staging` repository using a file URL
+  mvnOffline = false; # We need actions not allowed in Maven offline mode, but Nix sandboxing will still be enforced
+  mvnParameters = "-Drevision=${finalAttrs.version}"; # make snapshot builds reproducible
+  mvnHash = "sha256-87iDewdy/7lSyvROf1YyrsgvVUJtaivdHdSLig3Ea1Y=";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+  buildOffline = true;
+  doCheck = false;
+
+  installPhase = ''
+    runHook preInstall
+
+    # copy the full output in a maven repository directory structure
+    mkdir -p "$out/share/maven-repo"
+    cp -r target/repo/. "$out/share/maven-repo"
+
+    # create symlinks for the binaries in $out/share/java
+    mkdir -p "$out/share/java"
+    ln -s "$out/share/maven-repo/org/bitcoinj/secp/secp-api/${finalAttrs.version}/secp-api-${finalAttrs.version}.jar" "$out/share/java"
+    ln -s "$out/share/maven-repo/org/bitcoinj/secp/secp-bouncy/${finalAttrs.version}/secp-bouncy-${finalAttrs.version}.jar" "$out/share/java"
+    ln -s "$out/share/maven-repo/org/bitcoinj/secp/secp-ffm/${finalAttrs.version}/secp-ffm-${finalAttrs.version}.jar" "$out/share/java"
+    ln -s "$out/share/maven-repo/org/bitcoinj/secp/secp-graalvm/${finalAttrs.version}/secp-graalvm-${finalAttrs.version}.jar" "$out/share/java"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    changelog = "https://github.com/bitcoinj/secp256k1-jdk/blob/master/CHANGELOG.adoc";
+    description = "Java library providing Elliptic Curve Cryptography on curve secp256k1";
+    longDescription = ''
+      secp256k1-jdk is a Java library providing Elliptic Curve Cryptography using the SECG curve secp256k1.
+      It provides ECDSA and Schnorr message signing, verification, and other functions.
+    '';
+    homepage = "https://github.com/bitcoinj/secp256k1-jdk";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      msgilligan
+    ];
+    platforms = jdk25.meta.platforms;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode # dependencies pulled via FOD from Maven Central
+    ];
+  };
+})


### PR DESCRIPTION


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
