### PR TITLE
mkvtoolnix: drop unused dependencies from buildInputs

### DIFF
--- a/pkgs/by-name/mk/mkvtoolnix/package.nix
+++ b/pkgs/by-name/mk/mkvtoolnix/package.nix
@@ -64,6 +64,8 @@ stdenv.mkDerivation (finalAttrs: {
     };
   };
 
+  __structuredAttrs = true;
+
   nativeBuildInputs = [
     autoreconfHook
     docbook_xsl

--- a/pkgs/by-name/mk/mkvtoolnix/package.nix
+++ b/pkgs/by-name/mk/mkvtoolnix/package.nix
@@ -8,8 +8,6 @@
   boost,
   cmark,
   docbook_xsl,
-  expat,
-  file,
   flac,
   fmt,
   gettext,
@@ -26,7 +24,6 @@
   pugixml,
   qt6,
   utf8cpp,
-  xdg-utils,
   zlib,
   nix-update-script,
   withGUI ? true,
@@ -81,8 +78,6 @@ stdenv.mkDerivation (finalAttrs: {
   # qtbase and qtmultimedia are needed without the GUI
   buildInputs = [
     boost
-    expat
-    file
     flac
     fmt
     gmp
@@ -96,7 +91,6 @@ stdenv.mkDerivation (finalAttrs: {
     qt6.qtbase
     qt6.qtmultimedia
     utf8cpp
-    xdg-utils
     zlib
   ]
   ++ optionals withGUI [ cmark ]


### PR DESCRIPTION
- [expat was replaced with pugixml for XML parsing in 5.5.0][1]
- [libmagic was replaced with Qt for MIME type detection in 59.0.0][2]
- xdg-utils does not appear to be used by MKVToolNix itself, though /usr/bin/xdg-open is listed as an example command for the "Execute a program" option in the MKVToolnixGUI preferences.

[1]: https://codeberg.org/mbunkus/mkvtoolnix/src/branch/main/NEWS.md#other-changes-29
[2]: https://codeberg.org/mbunkus/mkvtoolnix/src/branch/main/NEWS.md#version-59-0-0-shining-star-2021-07-10


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
