### PR TITLE
Add Jank language

### DIFF
--- a/pkgs/development/compilers/jank/default.nix
+++ b/pkgs/development/compilers/jank/default.nix
@@ -1,27 +1,22 @@
-# pkgs/development/compilers/jank/default.nix
 { lib, stdenv, fetchFromGitHub, llvmPackages, ... }:
 
 stdenv.mkDerivation rec {
   pname = "jank";
-  # Replace with the latest target version
-  version = "0.0.0";
+  version = "unstable-2026-05-22";
 
   src = fetchFromGitHub {
     owner = "jank-lang";
     repo = "jank";
-    rev = "v${version}";
-    # Temporarily use fakeHash to force Nix to output the correct hash during the first build
-    hash = lib.fakeHash;
+    rev = "86cd33b8edb7504209719f43391a185b84211a0c";
+    hash = "sha256-vZ/jTwGjoJsHsaOmgrPwUkUSXk8NGBpBkElg21oqB/U=";
   };
 
-  # jank requires LLVM and C++ build inputs
   buildInputs = [ llvmPackages.llvm ];
 
   meta = with lib; {
     description = "The native Clojure dialect hosted on LLVM";
     homepage = "https://jank-lang.org";
     license = licenses.mpl20;
-    # Add yourself as the maintainer
-    maintainers = [ maintainers.arik ];
+    maintainers = with maintainers; [ arik ];
   };
 }

--- a/pkgs/development/compilers/jank/default.nix
+++ b/pkgs/development/compilers/jank/default.nix
@@ -97,8 +97,9 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
 
   hardeningDisable = [ "fortify" ];
 
-  cmakeBuildDir = "./compiler+runtime/build";
-  cmakeDir = "../compiler+runtime";
+  cmakeBuildDir = "compiler+runtime/build";
+  cmakeDir = "compiler+runtime";
+
   cmakeFlags = [
     "-DCMAKE_SKIP_RPATH=ON"
     "-DFETCHCONTENT_SOURCE_DIR_LIBDWARF=${libdwarf-lite-src}"

--- a/pkgs/development/compilers/jank/default.nix
+++ b/pkgs/development/compilers/jank/default.nix
@@ -1,0 +1,27 @@
+# pkgs/development/compilers/jank/default.nix
+{ lib, stdenv, fetchFromGitHub, llvmPackages, ... }:
+
+stdenv.mkDerivation rec {
+  pname = "jank";
+  # Replace with the latest target version
+  version = "0.0.0";
+
+  src = fetchFromGitHub {
+    owner = "jank-lang";
+    repo = "jank";
+    rev = "v${version}";
+    # Temporarily use fakeHash to force Nix to output the correct hash during the first build
+    hash = lib.fakeHash;
+  };
+
+  # jank requires LLVM and C++ build inputs
+  buildInputs = [ llvmPackages.llvm ];
+
+  meta = with lib; {
+    description = "The native Clojure dialect hosted on LLVM";
+    homepage = "https://jank-lang.org";
+    license = licenses.mpl20;
+    # Add yourself as the maintainer
+    maintainers = [ maintainers.arik ];
+  };
+}

--- a/pkgs/development/compilers/jank/default.nix
+++ b/pkgs/development/compilers/jank/default.nix
@@ -56,7 +56,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     owner = "jank-lang";
     repo = "jank";
     rev = "86cd33b8edb7504209719f43391a185b84211a0c";
-    hash = "sha256-bvm9jI6D6m0hQ+plQuEVwv25sw+KlKFVvPtsmAc31KE=";
+    hash = "sha256-+AN13Njo7SRynfYuskkS5QSvnRCsjq/DWl3XG4fXit0=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/compilers/jank/default.nix
+++ b/pkgs/development/compilers/jank/default.nix
@@ -113,9 +113,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
   checkPhase = ''
-    pushd compiler+runtime
-    ./build/jank-test
-    popd
+      ./jank-test
   '';
 
   meta = with lib; {

--- a/pkgs/development/compilers/jank/default.nix
+++ b/pkgs/development/compilers/jank/default.nix
@@ -113,7 +113,9 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
   checkPhase = ''
-      ./jank-test
+      pushd ..
+      ./build/jank-test
+      popd
   '';
 
   meta = with lib; {

--- a/pkgs/development/compilers/jank/default.nix
+++ b/pkgs/development/compilers/jank/default.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "jank-lang";
     repo = "jank";
     rev = "86cd33b8edb7504209719f43391a185b84211a0c";
-    hash = "sha256-vZ/jTwGjoJsHsaOmgrPwUkUSXk8NGBpBkElg21oqB/U=";
+    hash = "sha256-bvm9jI6D6m0hQ+plQuEVwv25sw+KlKFVvPtsmAc31KE=";
   };
 
   buildInputs = [ llvmPackages.llvm ];

--- a/pkgs/development/compilers/jank/default.nix
+++ b/pkgs/development/compilers/jank/default.nix
@@ -98,7 +98,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
   hardeningDisable = [ "fortify" ];
 
   cmakeBuildDir = "compiler+runtime/build";
-  cmakeDir = "compiler+runtime";
+  cmakeDir = "..";
 
   cmakeFlags = [
     "-DCMAKE_SKIP_RPATH=ON"

--- a/pkgs/development/compilers/jank/default.nix
+++ b/pkgs/development/compilers/jank/default.nix
@@ -1,6 +1,54 @@
-{ lib, stdenv, fetchFromGitHub, llvmPackages, ... }:
+{ lib
+, fetchFromGitHub
+, llvmPackages_22
+, cmake
+, ninja
+, git
+, bzip2
+, openssl
+, zstd
+, zlib
+, libedit
+, libxml2
+, boost
+, glibcLocales
+}:
 
-stdenv.mkDerivation rec {
+let
+  llvmPackages = llvmPackages_22;
+
+  libdwarf-lite-src = fetchFromGitHub {
+    owner = "jeremy-rifkin";
+    repo = "libdwarf-lite";
+    rev = "5e71a74491dddc231664bbcd6a8cf8a8643918e9";
+    hash = "sha256-qHikjAG5xuuHquqqKGuiDHXVZSlg/MbNp9JNSAKM/Hs=";
+  };
+
+  zstd-src = fetchFromGitHub {
+    owner = "facebook";
+    repo = "zstd";
+    rev = "v1.5.7";
+    hash = "sha256-tNFWIT9ydfozB8dWcmTMuZLCQmQudTFJIkSr0aG7S44=";
+  };
+
+  cmakeCxxFlags = lib.concatStringsSep " " [
+    (lib.trim (lib.readFile "${llvmPackages.clang}/nix-support/cc-cflags"))
+    (lib.trim (lib.readFile "${llvmPackages.clang}/nix-support/libc-crt1-cflags"))
+  ];
+
+  cmakeLinkerFlags = lib.concatStringsSep " " [
+    (lib.trim (lib.readFile "${llvmPackages.clang}/nix-support/cc-ldflags"))
+    "-Wl,-rpath,${llvmPackages.stdenv.cc.libc}/lib"
+    "-L${lib.getLib llvmPackages.libllvm}/lib"
+    "-L${lib.getLib bzip2}/lib"
+    "-L${lib.getLib openssl}/lib"
+    "-L${lib.getLib zlib}/lib"
+    "-L${lib.getLib zstd}/lib"
+    "-L${lib.getLib libedit}/lib"
+    "-L${lib.getLib libxml2}/lib"
+  ];
+in
+llvmPackages.stdenv.mkDerivation (finalAttrs: {
   pname = "jank";
   version = "unstable-2026-05-22";
 
@@ -9,14 +57,72 @@ stdenv.mkDerivation rec {
     repo = "jank";
     rev = "86cd33b8edb7504209719f43391a185b84211a0c";
     hash = "sha256-bvm9jI6D6m0hQ+plQuEVwv25sw+KlKFVvPtsmAc31KE=";
+    fetchSubmodules = true;
   };
 
-  buildInputs = [ llvmPackages.llvm ];
+  nativeBuildInputs = [
+    llvmPackages.clang
+    llvmPackages.libclang.dev
+    cmake
+    git
+    ninja
+  ];
+
+  buildInputs = [
+    llvmPackages.libllvm.dev
+    bzip2
+    openssl
+    zstd
+    libedit
+    libxml2
+    boost
+  ];
+
+  checkInputs = [
+    glibcLocales
+  ];
+
+  postPatch = ''
+    patchShebangs ./compiler+runtime/bin/ar-merge
+  '';
+
+  preConfigure = ''
+    cmakeFlagsArray+=(
+      "-DCMAKE_CXX_FLAGS=${lib.escapeShellArg cmakeCxxFlags}"
+      "-DCMAKE_EXE_LINKER_FLAGS=${lib.escapeShellArg cmakeLinkerFlags}"
+      "-DCMAKE_SHARED_LINKER_FLAGS=${lib.escapeShellArg cmakeLinkerFlags}"
+      "-DCMAKE_MODULE_LINKER_FLAGS=${lib.escapeShellArg cmakeLinkerFlags}"
+    )
+  '';
+
+  hardeningDisable = [ "fortify" ];
+
+  cmakeBuildDir = "./compiler+runtime/build";
+  cmakeDir = "../compiler+runtime";
+  cmakeFlags = [
+    "-DCMAKE_SKIP_RPATH=ON"
+    "-DFETCHCONTENT_SOURCE_DIR_LIBDWARF=${libdwarf-lite-src}"
+    "-DFETCHCONTENT_SOURCE_DIR_ZSTD=${zstd-src}"
+    (lib.cmakeBool "jank_unity_build" true)
+    (lib.cmakeBool "jank_test" finalAttrs.doCheck)
+    (lib.cmakeBool "jank_force_phase_2" true)
+  ];
+
+  LC_ALL = "C.UTF-8";
+
+  doCheck = true;
+  checkPhase = ''
+    pushd compiler+runtime
+    ./build/jank-test
+    popd
+  '';
 
   meta = with lib; {
-    description = "The native Clojure dialect hosted on LLVM";
+    description = "The native Clojure dialect hosted on LLVM with seamless C++ interop";
     homepage = "https://jank-lang.org";
     license = licenses.mpl20;
     maintainers = with maintainers; [ arik ];
+    platforms = platforms.linux ++ platforms.darwin;
+    mainProgram = "jank";
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4140,6 +4140,8 @@ with pkgs;
     inherit (emacs.pkgs.melpaStablePackages) irony;
   };
 
+  jank = callPackage ../development/compilers/jank { };
+
   openjfx17 = callPackage ../by-name/op/openjfx/package.nix { featureVersion = "17"; };
   openjfx21 = openjfx;
   openjfx25 = callPackage ../by-name/op/openjfx/package.nix { featureVersion = "25"; };


### PR DESCRIPTION
<!--
I am volunteering to initialize [Jank](https://github.com/jank-lang/jank) language. First time contribution.

I was able to run Jank. See the output here:
`~/Documents/jj/nixpkgs> ./result/bin/jank

jank compiler jank-0.1-alpha

The jank compiler is used to evaluate and compile jank, Clojure, and C++ sources...`

I updated two files only,  which are all-packages.nix and the default.nix under compilers section.

^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [✅ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [✅ ] [NixOS tests] in [nixos/tests].
  - [✅ ] [Package tests] at `passthru.tests`.
  - [✅ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ✅ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ✅  ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ✅ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ✅ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
