### PR TITLE
heroic: set Electron window class

### DIFF
--- a/pkgs/by-name/he/heroic-unwrapped/package.nix
+++ b/pkgs/by-name/he/heroic-unwrapped/package.nix
@@ -108,6 +108,8 @@ stdenv.mkDerivation (finalAttrs: {
       "${epic-integration}/EpicGamesLauncher.exe" \
       "$bin_dir/x64/win32/"
 
+    # Match StartupWMClass in the desktop file so taskbars can associate the
+    # running Electron window with Heroic's icon.
     makeWrapper "${lib.getExe electron}" "$out/bin/heroic" \
       --inherit-argv0 \
       --set ELECTRON_FORCE_IS_PACKAGED 1 \
@@ -118,6 +120,7 @@ stdenv.mkDerivation (finalAttrs: {
           ]
         )
       }" \
+      --add-flags --class=heroic \
       --add-flags --disable-gpu-compositing \
       --add-flags $out/opt/heroic/resources/app.asar \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"


### PR DESCRIPTION
Heroic's desktop file uses `StartupWMClass=heroic`, but the nixpkgs wrapper launches the system Electron binary without setting the window class. On Wayland this can leave panels/taskbars matching the running window as generic `electron`, which shows the Electron icon instead of Heroic's icon.

This passes `--class=heroic` to Electron so the window class matches the desktop file.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] `nix build .#heroic`
  - [x] Inspected the generated wrapper and verified it includes `--class=heroic`.