### PR TITLE
element-desktop: set Electron window class

### DIFF
--- a/pkgs/by-name/el/element-desktop/package.nix
+++ b/pkgs/by-name/el/element-desktop/package.nix
@@ -139,6 +139,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # executable wrapper
     makeWrapper '${lib.getExe electron}' "$out/bin/element-desktop" \
+      --add-flags --class=Element \
       --add-flags "$out/share/element/app.asar" \
       --set LD_PRELOAD ${sqlcipher}/lib/libsqlcipher.so \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \


### PR DESCRIPTION
Element Desktop's desktop item uses `StartupWMClass=Element`, but the nixpkgs Linux wrapper launches the system Electron binary without setting the window class. On Wayland this can leave panels/taskbars matching the running window as generic `electron`, which shows the Electron icon instead of Element's icon.

This passes `--class=Element` to Electron before the app path so the window class matches the desktop file.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] `nix build --no-link --print-out-paths --option cores 1 --option max-jobs 1 .#element-desktop`
  - [x] Inspected the generated wrapper and verified it includes `--class=Element` before `app.asar`.
  - [x] Inspected the generated desktop file and verified `StartupWMClass=Element`.