### PR TITLE
mystmd: 1.9.0 -> 1.9.1

### DIFF
--- a/pkgs/by-name/my/mystmd/package.nix
+++ b/pkgs/by-name/my/mystmd/package.nix
@@ -7,11 +7,12 @@
   stdenv,
   testers,
   nix-update-script,
+  makeWrapper,
   writableTmpDirAsHomeHook,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "mystmd";
-  version = "1.9.0";
+  version = "1.9.1";
 
   strictDeps = true;
   __structuredAttrs = true;
@@ -20,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "jupyter-book";
     repo = "mystmd";
     tag = "mystmd@${finalAttrs.version}";
-    hash = "sha256-gAUfL2sTdTmslPuOnkeTwv/GmarM5nWpxjg3KPL+1fs=";
+    hash = "sha256-SopL2yIFWWCMm7afjkMrG4Z7Ohxxb5gfCrKNRX5tyo8=";
   };
 
   node_modules = stdenv.mkDerivation {
@@ -31,6 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
       bun
       nodejs
       writableTmpDirAsHomeHook
+      makeWrapper
     ];
 
     dontConfigure = true;
@@ -69,6 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     bun
     nodejs
+    makeWrapper
   ];
 
   buildInputs = [
@@ -92,7 +95,7 @@ stdenv.mkDerivation (finalAttrs: {
     cp -r node_modules $out/lib/
     cp -r packages $out/lib/
     install -D packages/mystmd/dist/myst.cjs $out/bin/myst
-
+    wrapProgram $out/bin/myst --prefix PATH : ${lib.makeBinPath [ nodejs ]}
     runHook postInstall
   '';
 


### PR DESCRIPTION
Update to 1.9.1

add missing runtime dependency

pbsds edit: closes https://github.com/NixOS/nixpkgs/pull/523547

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
