### PR TITLE
vimPlugins.blink-pairs: 0.4.1 -> 0.5.0

### DIFF
--- a/pkgs/applications/editors/vim/plugins/non-generated/blink-pairs/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/blink-pairs/default.nix
@@ -8,13 +8,13 @@
   nix-update-script,
 }:
 let
-  version = "0.4.1";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "Saghen";
     repo = "blink.pairs";
     tag = "v${version}";
-    hash = "sha256-IfnFSusQMm6LujE1AmihK9wEF2RSGfKYwpV2fedg0fc=";
+    hash = "sha256-PTbj6jlXNRUOmwFSplvRDDiyyGqkBzUKtuBrvZm9kzM=";
   };
 
   blink-pairs-lib = rustPlatform.buildRustPackage {
@@ -50,6 +50,12 @@ vimUtils.buildVimPlugin {
       mkdir -p target/release
       ln -s ${blink-pairs-lib}/lib/libblink_pairs${ext} target/release/
     '';
+
+  nvimSkipModules = [
+    # a module to quickly setup a minimal reproduction environment for testing
+    # bugs. therefore mostly useless from a consumer side
+    "repro"
+  ];
 
   passthru = {
     updateScript = nix-update-script {


### PR DESCRIPTION
Diff: https://github.com/Saghen/blink.pairs/compare/v0.4.1...v0.5.0
Changelog: https://github.com/Saghen/blink.pairs/blob/v0.5.0/CHANGELOG.md

closes https://github.com/NixOS/nixpkgs/issues/510620

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
