### PR TITLE
calc: fix usage file generation

### DIFF
--- a/pkgs/by-name/ca/calc/fix-usage-generation.patch
+++ b/pkgs/by-name/ca/calc/fix-usage-generation.patch
@@ -1,0 +1,11 @@
+diff --git a/Makefile b/Makefile
+index b12766d..abc2c95 100644
+--- a/Makefile
++++ b/Makefile
+@@ -536,7 +536,7 @@ calc.usage: calc.1 ${MK_SET}
+ 	    LESSCHARSET=iso8859 ${CALCPAGER} calc.1; \
+ 	else \
+ 	    ${NROFF} -man calc.1; \
+-	fi 2>&1 | ${GREP} -E -v 'cannot adjust line' | ${COL} -b > $@
++	fi 2>&1 | ${GREP} -E -v 'cannot adjust line' > $@
+ 	${Q} echo calc.usage formed

--- a/pkgs/by-name/ca/calc/package.nix
+++ b/pkgs/by-name/ca/calc/package.nix
@@ -6,6 +6,7 @@
   ncurses,
   readline,
   unixtools,
+  groff,
   enableReadline ? true,
 }:
 
@@ -20,6 +21,10 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     hash = "sha256-dPEj32SiR7RhI9fBa9ny9+EEuuiXS2WswRcDVuOMJXc=";
   };
+
+  patches = [
+    ./fix-usage-generation.patch
+  ];
 
   postPatch = ''
     substituteInPlace Makefile.target \
@@ -39,6 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   makeFlags = [
     "T=$(out)"
+    "NROFF=${lib.getExe' groff "nroff"}"
     "INCDIR="
     "BINDIR=/bin"
     "LIBDIR=/lib"


### PR DESCRIPTION
 - add `nroff` to generate the usage file
 - patch out `col -b` so that the escape sequences are interpreted properly

As a result, the file is not plain text anymore, which may not be desired(?).

fixes #373512

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
