### PR TITLE
rtl_fm_streamer: unstable-2021-06-08 -> 0-unstable-2026-05-23

### DIFF
--- a/pkgs/by-name/rt/rtl_fm_streamer/package.nix
+++ b/pkgs/by-name/rt/rtl_fm_streamer/package.nix
@@ -6,33 +6,19 @@
   pkg-config,
   libusb1,
   libev,
+  rtl-sdr,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rtl_fm_streamer";
-  version = "unstable-2021-06-08";
+  version = "0-unstable-2026-05-23";
 
   src = fetchFromGitHub {
     owner = "AlbrechtL";
     repo = "rtl_fm_streamer";
-    rev = "ceb2bf06883f986ed01aa57c84989ba35b6b9a27";
-    hash = "sha256-9M7GS6AC7HEJge04vl7V6ZdtwWvbMu/Rhaf9fwQa9WA=";
+    rev = "7d98bcee154be86b772ab9440bc65361ac2cad67";
+    hash = "sha256-IlZcxu9JMaiqY+Vu6Bv14JxpQeJqytugW4mAvS0qIKY=";
   };
-
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace '/etc/udev/rules.d' "$out/etc/udev/rules.d"
-
-    substituteInPlace rtl-sdr.rules \
-      --replace 'MODE:="0666"' 'ENV{ID_SOFTWARE_RADIO}="1", MODE="0660", GROUP="plugdev"'
-
-    substituteInPlace CMakeLists.txt \
-      --replace-fail "cmake_minimum_required(VERSION 2.6)" "cmake_minimum_required(VERSION 3.10)"
-  '';
-
-  patches = [
-    ./use-stdbool.patch
-  ];
 
   nativeBuildInputs = [
     cmake
@@ -42,6 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     libusb1
     libev
+    rtl-sdr
   ];
 
   cmakeFlags = [
@@ -55,6 +42,5 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/AlbrechtL/rtl_fm_streamer";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ doronbehar ];
-    broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64;
   };
 })


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test