### PR TITLE
waves: 0.1.44 -> 0.1.45

### DIFF
--- a/pkgs/by-name/wa/waves/package.nix
+++ b/pkgs/by-name/wa/waves/package.nix
@@ -10,13 +10,13 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "waves";
-  version = "0.1.44";
+  version = "0.1.45";
 
   src = fetchFromGitHub {
     owner = "llehouerou";
     repo = "waves";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-uyTstoF3rhqMmhG5hwyyq1fGBa6mJjw3/NEjTIMYxi4=";
+    hash = "sha256-dIewVRPw4ZR9bG+z0v1Vim1Mhi+Buoy0pMzF5THNccU=";
   };
 
   vendorHash = "sha256-lps0OdY8KoILJh/roY78iC+bYHPeENioQoIsL6v/N0A=";


### PR DESCRIPTION
[Changelog](https://github.com/llehouerou/waves/releases/tag/v0.1.45)

  ## Things done

  - Built on platform:
    - [x] x86_64-linux
    - [ ] aarch64-linux
    - [ ] x86_64-darwin
    - [ ] aarch64-darwin
  - Tested, as applicable:
    - [ ] [NixOS tests] in [nixos/tests].
    - [ ] [Package tests] at `passthru.tests`.
    - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Nixpkgs Release Notes
    - [ ] Package update: when the change is major or breaking.
  - NixOS Release Notes
    - [ ] Module addition: when adding a new NixOS module.
    - [ ] Module update: when the change is significant.
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
  - [x] Follows the [automation/AI policy].

  [NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
  [Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
  [nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

  [CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
  [automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
  [lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
  [maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
  [nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
  [pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
  [pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test