### PR TITLE
Migrate variouis test to nspawn container

### DIFF
--- a/nixos/tests/evcc.nix
+++ b/nixos/tests/evcc.nix
@@ -7,7 +7,7 @@ in
   name = "evcc";
   meta.maintainers = with lib.maintainers; [ hexa ];
 
-  nodes = {
+  containers = {
     machine = {
       services.evcc = {
         enable = true;

--- a/nixos/tests/pinnwand.nix
+++ b/nixos/tests/pinnwand.nix
@@ -12,7 +12,7 @@ in
     maintainers = [ hexa ];
   };
 
-  nodes = {
+  containers = {
     server =
       { config, ... }:
       {

--- a/nixos/tests/postfix-tlspol.nix
+++ b/nixos/tests/postfix-tlspol.nix
@@ -7,7 +7,7 @@
 
   meta.maintainers = with lib.maintainers; [ hexa ];
 
-  nodes.machine = {
+  containers.machine = {
     services.postfix.enable = true;
     services.postfix-tlspol.enable = true;
 

--- a/nixos/tests/zigbee2mqtt.nix
+++ b/nixos/tests/zigbee2mqtt.nix
@@ -6,7 +6,7 @@
 
 {
   name = "zigbee2mqtt";
-  nodes.machine = {
+  containers.machine = {
     systemd.services.dummy-serial = {
       wantedBy = [
         "multi-user.target"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
