### PR TITLE
nixos/boot.tmp: also clean /var/tmp on boot when cleanOnBoot is set

### DIFF
--- a/nixos/modules/system/boot/tmp.nix
+++ b/nixos/modules/system/boot/tmp.nix
@@ -82,6 +82,9 @@ in
       }
     ];
 
-    systemd.tmpfiles.rules = lib.optional cfg.cleanOnBoot "D! /tmp 1777 root root";
+    systemd.tmpfiles.rules = lib.optionals cfg.cleanOnBoot [
+      "D! /tmp 1777 root root"
+      "D! /var/tmp 1777 root root"
+    ];
   };
 }


### PR DESCRIPTION
## Description

When `boot.tmp.cleanOnBoot = true`, NixOS adds a `D! /tmp 1777 root root` rule that overrides systemd's upstream `tmpfiles.d/tmp.conf` on boot. However `/var/tmp` was left with systemd's default rule:

```
q /var/tmp 1777 root root 30d
```

which only cleans `/var/tmp` based on age (30 days), not on boot. This is inconsistent with the `cleanOnBoot` promise.

Following @r-vdp's suggestion, this adds a matching `D!` rule for `/var/tmp` in the same way `/tmp` is already handled, instead of vendoring systemd's `tmp.conf`. This keeps the upstream file intact (so future upstream rule changes are picked up automatically) and relies on the existing lexicographic override mechanism described in the `tmpfiles.d` manpage.

**Before** (`cleanOnBoot = true`):
```
D! /tmp 1777 root root        # NixOS, overrides upstream
q /var/tmp 1777 root root 30d # systemd default, age-based
```

**After:**
```
D! /tmp 1777 root root        # cleared on boot
D! /var/tmp 1777 root root    # cleared on boot
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test