### PR TITLE
quickwit.tests: drop deleted test reference

### DIFF
--- a/pkgs/by-name/qu/quickwit/package.nix
+++ b/pkgs/by-name/qu/quickwit/package.nix
@@ -109,7 +109,6 @@ rustPlatform.buildRustPackage rec {
   passthru = {
     tests = {
       inherit (nixosTests) quickwit;
-      inherit (nixosTests.vector) syslog-quickwit;
     };
     updateScript = nix-update-script { };
   };


### PR DESCRIPTION
Without the change the eval fails as:

```
$ nix-instantiate -A quickwit.tests
error:
       … while evaluating the attribute 'syslog-quickwit'
         at pkgs/by-name/qu/quickwit/package.nix:112:35:
          111|       inherit (nixosTests) quickwit;
          112|       inherit (nixosTests.vector) syslog-quickwit;
             |                                   ^
          113|     };

       error: attribute 'syslog-quickwit' missing
       at pkgs/by-name/qu/quickwit/package.nix:112:35:
          111|       inherit (nixosTests) quickwit;
          112|       inherit (nixosTests.vector) syslog-quickwit;
             |                                   ^
          113|     };
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
