### PR TITLE
n8n: 2.20.6 -> 2.22.5

### DIFF
--- a/pkgs/by-name/n8/n8n/package.nix
+++ b/pkgs/by-name/n8/n8n/package.nix
@@ -26,20 +26,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "n8n";
-  version = "2.20.6";
+  version = "2.22.5";
 
   src = fetchFromGitHub {
     owner = "n8n-io";
     repo = "n8n";
     tag = "n8n@${finalAttrs.version}";
-    hash = "sha256-c0O6tC+QDhHN3nmzXqNwhAM4+NoFYVO1mtO3V348hDs=";
+    hash = "sha256-YF6VJLA+y8pcAE3RwTub1XjPVfeh8cR+3TQqb3VvV5U=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
     fetcherVersion = 3;
-    hash = "sha256-ft7n3J7L+u2hwEiR32Jw2k0ZsHCfI5yIB+IfmtB8xMY=";
+    hash = "sha256-lAe3GuZRdzEwOXWmpBtF7YfGvA4XJumLf80uDYS6j30=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/n8/n8n/update.sh
+++ b/pkgs/by-name/n8/n8n/update.sh
@@ -2,9 +2,7 @@
 #!nix-shell --pure -i bash -p bash curl jq nix-update cacert git
 set -euo pipefail
 
-new_version="$(curl -s 'https://api.github.com/repos/n8n-io/n8n/releases?per_page=30' | \
-  jq -r '
-    map(select(.prerelease | not) | .tag_name | select(startswith("n8n@")) | sub("^n8n@"; ""))
-    | sort_by(split(".") | map(tonumber)) | last
-    ')"
+new_version="$(curl -s ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} \
+  'https://api.github.com/repos/n8n-io/n8n/releases/latest' |
+  jq -r '.tag_name | sub("^n8n@"; "")')"
 nix-update n8n --version "$new_version"


### PR DESCRIPTION
Fixes https://nixpkgs-update-logs.nix-community.org/n8n/2026-05-20.log.

Release: https://github.com/n8n-io/n8n/releases/tag/n8n%402.22.5


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
