### PR TITLE
ddcutil: 2.2.6 -> 2.2.7

### DIFF
--- a/pkgs/by-name/dd/ddcutil/package.nix
+++ b/pkgs/by-name/dd/ddcutil/package.nix
@@ -12,15 +12,17 @@
   libdrm,
   libxrandr,
   libxext,
+  acl,
+  dbus,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ddcutil";
-  version = "2.2.6";
+  version = "2.2.7";
 
   src = fetchurl {
     url = "https://www.ddcutil.com/tarballs/ddcutil-${finalAttrs.version}.tar.gz";
-    hash = "sha256-5LaRkcC0UK6iOjSlks88WPAn/hRiAgF5BwzJLV7K7Yg=";
+    hash = "sha256-GaxmBM8Rd7pWZm+KaCWB5x6Jc70Gx8jc8DNnTkqqpkg=";
   };
 
   nativeBuildInputs = [
@@ -29,14 +31,16 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    acl
+    dbus
     glib
     jansson
     libdrm
     libgudev
     libusb1
-    udev
     libxext
     libxrandr
+    udev
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Bumps `ddcutil` from 2.2.6 to 2.2.7. 

This release fixes a bug where certain i2c connector errors were printed to `stdout` instead of `stderr`, breaking some scripts.

### Upstream Release Notes Summary

- Contains extensive changes to `libddcutil` for detecting display connection/disconnection.
- Fixes several bugs triggered by KDE PowerDevil.
- Addresses transient `EACCES` errors some users have experienced.

### Build Fixes
* Upstream commit [`93f07cc`](https://github.com/rockowitz/ddcutil/commit/93f07cc1addd2c52d4691aed29d470dc15ad407d) ("link libacl") introduced a hard requirement for `libacl`. Added `acl` to `buildInputs` to resolve the configuration phase failure.
* Upstream commit [`b6a6bee`](https://github.com/rockowitz/ddcutil/commit/b6a6bee1171bea4c3314dbf3d22248eadd951403) ("new source file src/util/dbus_util.c/h") introduced a new `dbus_util` component to track system sleep resumes via `systemd-logind`. Added `dbus` to `buildInputs` to prevent downstream linkage failures (e.g., `clightd`, `powerdevil`), which were failing with:

```text
/nix/store/...-ddcutil-2.2.7/lib/libddcutil.so: undefined reference to `ldbus_start_sleep_watch_thread'
```

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 523616`
Commit: `ccf5b48c1f1f4c74033b3af9a4949cb4b73bbae4`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 17 packages built:</summary>
  <ul>
    <li>clight</li>
    <li>clightd</li>
    <li>ddcui</li>
    <li>ddcutil</li>
    <li>ddcutil-service</li>
    <li>enlightenment.enlightenment</li>
    <li>fastfetch</li>
    <li>gnomeExtensions.brightness-control-using-ddcutil</li>
    <li>gummy</li>
    <li>kdePackages.kdeplasma-addons</li>
    <li>kdePackages.plasma-desktop</li>
    <li>kdePackages.plasma-setup</li>
    <li>kdePackages.powerdevil</li>
    <li>luminance</li>
    <li>noctalia-shell</li>
    <li>plasma-panel-colorizer</li>
    <li>plasma-panel-spacer-extended</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
