### PR TITLE
treewide: remove usage of CSC_IDENTITY_AUTO_DISCOVERY

### DIFF
--- a/pkgs/by-name/bi/bitwarden-desktop/package.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/package.nix
@@ -95,9 +95,6 @@ buildNpmPackage rec {
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
-  # make electron-builder not attempt to codesign the app on darwin
-  env.CSC_IDENTITY_AUTO_DISCOVERY = "false";
-
   nativeBuildInputs = [
     cargo
     dart-sass

--- a/pkgs/by-name/dr/drawio/package.nix
+++ b/pkgs/by-name/dr/drawio/package.nix
@@ -64,19 +64,18 @@ stdenv.mkDerivation (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    cp -R ${electron.dist}/Electron.app Electron.app
-    chmod -R u+w Electron.app
-    export CSC_IDENTITY_AUTO_DISCOVERY=false
+    electron_dist="$(mktemp -d)"
+    cp -r ${electron.dist}/. "$electron_dist"
+    chmod -R u+w "$electron_dist"
+
     sed -i "/afterSign/d" electron-builder-linux-mac.json
-  ''
-  + ''
+
     npm exec electron-builder -- \
       --dir \
-      ${lib.optionalString stdenv.hostPlatform.isDarwin "--config electron-builder-linux-mac.json --config.mac.identity=null"} \
-      -c.electronDist=${if stdenv.hostPlatform.isDarwin then "." else electron.dist} \
-      -c.electronVersion=${electron.version}
+      --config electron-builder-linux-mac.json \
+      -c.electronDist="$electron_dist" \
+      -c.electronVersion=${electron.version} \
+      -c.mac.identity=null
 
     runHook postBuild
   '';

--- a/pkgs/by-name/gr/gridtracker2/package.nix
+++ b/pkgs/by-name/gr/gridtracker2/package.nix
@@ -50,28 +50,20 @@ buildNpmPackage (finalAttrs: {
 
   buildPhase = ''
     runHook preBuild
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    # electronDist needs to be modifiable on Darwin
-    cp -r ${electron.dist} electron-dist
-    chmod -R u+w electron-dist
 
-    # Disable code signing during build on macOS.
-    # https://github.com/electron-userland/electron-builder/blob/fa6fc16/docs/code-signing.md#how-to-disable-code-signing-during-the-build-process-on-macos
-    export CSC_IDENTITY_AUTO_DISCOVERY=false
+    # the electronDist directory needs to be outside of the working directory
+    # otherwise the electron-builder config accidentally includes it inside the .asar file
+    electron_dist="$(mktemp -d)"
+    cp -r ${electron.dist}/. "$electron_dist"
+    chmod -R u+w "$electron_dist"
 
     npm exec electron-builder -- \
       --dir \
-      -c.electronDist=electron-dist \
-      -c.electronVersion=${electron.version}
-  ''
-  + lib.optionalString stdenv.hostPlatform.isLinux ''
-    npm exec electron-builder -- \
-      --dir \
-      -c.electronDist=${electron.dist} \
-      -c.electronVersion=${electron.version}
-  ''
-  + ''
+      -c.electronDist="$electron_dist" \
+      -c.electronVersion=${electron.version} \
+      -c.mac.identity=null
+    # ^ disable codesigning on Darwin
+
     runHook postBuild
   '';
 

--- a/pkgs/by-name/ka/kando/package.nix
+++ b/pkgs/by-name/ka/kando/package.nix
@@ -69,8 +69,6 @@ buildNpmPackage.override { inherit nodejs; } rec {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
     # use our own node headers since we skip downloading them
     NIX_CFLAGS_COMPILE = "-I${nodejs}/include/node";
-    # disable code signing on Darwin
-    CSC_IDENTITY_AUTO_DISCOVERY = lib.optionalString stdenv.hostPlatform.isDarwin "false";
   };
 
   postConfigure = ''

--- a/pkgs/by-name/mq/mqtt-explorer/package.nix
+++ b/pkgs/by-name/mq/mqtt-explorer/package.nix
@@ -56,12 +56,6 @@ stdenv.mkDerivation rec {
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
-  # disable code signing on macos
-  # https://github.com/electron-userland/electron-builder/blob/77f977435c99247d5db395895618b150f5006e8f/docs/code-signing.md#how-to-disable-code-signing-during-the-build-process-on-macos
-  postConfigure = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    export CSC_IDENTITY_AUTO_DISCOVERY=false
-  '';
-
   configurePhase = ''
     runHook preConfigure
 
@@ -100,7 +94,9 @@ stdenv.mkDerivation rec {
 
     yarn --offline run electron-builder --dir \
       -c.electronDist="$electron_dist" \
-      -c.electronVersion=${electron.version}
+      -c.electronVersion=${electron.version} \
+      -c.mac.identity=null
+    # ^ disable code signing on macos
 
     runHook postBuild
   '';

--- a/pkgs/by-name/op/opencode-desktop/package.nix
+++ b/pkgs/by-name/op/opencode-desktop/package.nix
@@ -54,12 +54,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     OPENCODE_CHANNEL = "prod";
     MODELS_DEV_API_JSON = "${models-dev}/dist/_api.json";
     OPENCODE_DISABLE_MODELS_FETCH = true;
-  }
-  # Disable code signing on macOS. Public build hosts don't have Apple Developer
-  # certificates, so electron-builder's `security find-identity` spawns produce
-  # EPERM inside the nix sandbox.
-  // lib.optionalAttrs stdenvNoCC.hostPlatform.isDarwin {
-    CSC_IDENTITY_AUTO_DISCOVERY = "false";
   };
 
   postPatch = ''

--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -181,10 +181,6 @@ stdenv.mkDerivation (finalAttrs: {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
     SIGNAL_ENV = "production";
     SOURCE_DATE_EPOCH = 1780508208;
-  }
-  // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
-    # Disable code signing during local macOS builds.
-    CSC_IDENTITY_AUTO_DISCOVERY = "false";
   };
 
   preBuild = ''

--- a/pkgs/by-name/su/super-productivity/package.nix
+++ b/pkgs/by-name/su/super-productivity/package.nix
@@ -78,7 +78,6 @@ buildNpmPackage rec {
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
     CHROMEDRIVER_SKIP_DOWNLOAD = "true";
-    CSC_IDENTITY_AUTO_DISCOVERY = "false";
   };
 
   nativeBuildInputs = [ copyDesktopItems ];

--- a/pkgs/by-name/te/teams-for-linux/package.nix
+++ b/pkgs/by-name/te/teams-for-linux/package.nix
@@ -37,11 +37,7 @@ buildNpmPackage rec {
 
   doInstallCheck = stdenv.hostPlatform.isLinux;
 
-  env = {
-    # disable code signing on Darwin
-    CSC_IDENTITY_AUTO_DISCOVERY = "false";
-    ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
-  };
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
   makeCacheWritable = true;
 

--- a/pkgs/by-name/vo/voicevox/package.nix
+++ b/pkgs/by-name/vo/voicevox/package.nix
@@ -86,9 +86,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
-  # disable code signing on Darwin
-  env.CSC_IDENTITY_AUTO_DISCOVERY = "false";
-
   buildPhase = ''
     runHook preBuild
 
@@ -106,7 +103,9 @@ stdenv.mkDerivation (finalAttrs: {
       --dir \
       --config ./build/electronBuilderConfigLoader.cjs \
       -c.electronDist=electron-dist \
-      -c.electronVersion=${electron.version}
+      -c.electronVersion=${electron.version} \
+      -c.mac.identity=null
+    # ^ disable codesigning on Darwin
 
     runHook postBuild
   '';


### PR DESCRIPTION
As per the [docs](https://github.com/electron-userland/electron-builder/blob/5dbba8c4aa7becc357f9b5439c55641aedf2e18b/website/docs/features/code-signing/code-signing-mac.md#how-to-disable-code-signing-during-the-build-process-on-macos) we can use both `CSC_IDENTITY_AUTO_DISCOVERY="false"` and `-c.mac.identity=null` to disable signing.
IMO we should only use one of them and `-c.mac.identity=null` is the more robust of the two.

In some packages both methods were being used.

If anyone is against me changing their package, leave a review.

For `gridtracker2` and `drawio` I also fixed the issue where the `electron-dist` directory would be included inside the `.asar` file.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
