### PR TITLE
yaziPlugins: update on 2026-05-24

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/clipboard/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/clipboard/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "clipboard.yazi";
-  version = "0-unstable-2026-05-20";
+  version = "0-unstable-2026-05-22";
 
   src = fetchFromGitHub {
     owner = "XYenon";
     repo = "clipboard.yazi";
-    rev = "a125df07ba69c893df0e22592e55c1130ce16fe4";
-    hash = "sha256-Q+8MGfeP7reX3nDl5V/HFxRYIayPKEQT5w0b+n73b5k=";
+    rev = "0ac03203a88a6ca85539378fbb1b73b75fe8521e";
+    hash = "sha256-Ug0lEL+lR3xH1ps4fNljbs2DyExz0P5M2waWR9XTcEQ=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/close-and-restore-tab/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/close-and-restore-tab/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "close-and-restore-tab.yazi";
-  version = "0-unstable-2025-05-29";
+  version = "0-unstable-2026-05-23";
 
   src = fetchFromGitHub {
     owner = "MasouShizuka";
     repo = "close-and-restore-tab.yazi";
-    rev = "5047217e59f9c2f4aa5ae15baa92df7b3f724e67";
-    hash = "sha256-bsx6HVdB2CcKXQG+tGxY2T8Ys8TluIe6xWHhOhv4L4I=";
+    rev = "d7638aadf1f6c4ca5ed2dbff2d3b07c6f86d9804";
+    hash = "sha256-s9VOheYlUw7uqxZnd0+mN6lFghOi1shxf0DVIfn6unQ=";
   };
 
   meta = {


### PR DESCRIPTION
- clipboard: 0-unstable-2026-05-20 → 0-unstable-2026-05-22
  Compare: https://github.com/XYenon/clipboard.yazi/compare/a125df07ba69c893df0e22592e55c1130ce16fe4...0ac03203a88a6ca85539378fbb1b73b75fe8521e
- close-and-restore-tab: 0-unstable-2025-05-29 → 0-unstable-2026-05-23
  Compare: https://github.com/MasouShizuka/close-and-restore-tab.yazi/compare/5047217e59f9c2f4aa5ae15baa92df7b3f724e67...d7638aadf1f6c4ca5ed2dbff2d3b07c6f86d9804


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
