### PR TITLE
hyphen: 2.8.8 -> 2.8.9, switch to github

### DIFF
--- a/pkgs/development/libraries/hyphen/default.nix
+++ b/pkgs/development/libraries/hyphen/default.nix
@@ -1,32 +1,30 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  autoreconfHook,
   perl,
 }:
 
-let
-  version = "2.8.8";
-  folder =
-    with builtins;
-    let
-      parts = splitVersion version;
-    in
-    concatStringsSep "." [
-      (elemAt parts 0)
-      (elemAt parts 1)
-    ];
-in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "hyphen";
-  inherit version;
+  version = "2.8.9";
 
-  nativeBuildInputs = [ perl ];
+  nativeBuildInputs = [
+    autoreconfHook
+    perl
+  ];
 
-  src = fetchurl {
-    url = "https://sourceforge.net/projects/hunspell/files/Hyphen/${folder}/${pname}-${version}.tar.gz";
-    sha256 = "01ap9pr6zzzbp4ky0vy7i1983fwyqy27pl0ld55s30fdxka3ciih";
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "hunspell";
+    repo = "hyphen";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-F7PJQjEiE5t5i1gi5B8wzrwAJQl8FWzopRA8uDsaZBc=";
   };
+
+  enableParallelBuilding = true;
 
   # Do not install the en_US dictionary.
   installPhase = ''
@@ -36,14 +34,15 @@ stdenv.mkDerivation rec {
     make install-includeHEADERS
 
     # license
-    install -D -m644 COPYING "$out/share/licenses/${pname}/LICENSE"
+    install -D -m644 COPYING "$out/share/licenses/hyphen/LICENSE"
     runHook postInstall
   '';
 
   meta = {
+    changelog = "https://github.com/hunspell/hyphen/blob/${finalAttrs.src.tag}/NEWS";
     description = "Text hyphenation library";
     mainProgram = "substrings.pl";
-    homepage = "https://sourceforge.net/projects/hunspell/files/Hyphen/";
+    homepage = "https://github.com/hunspell/hyphen";
     platforms = lib.platforms.all;
     license = with lib.licenses; [
       gpl2
@@ -51,4 +50,4 @@ stdenv.mkDerivation rec {
       mpl11
     ];
   };
-}
+})


### PR DESCRIPTION
`hyphen` moved releases and repository to `github`. Switch source fetch there and slightly refresh the derivation.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
