### PR TITLE
gnome2.gtksourceview: resolve missing AM_GNU_GETTEXT_VERSION build failure

### DIFF
--- a/pkgs/desktops/gnome-2/desktop/gtksourceview/default.nix
+++ b/pkgs/desktops/gnome-2/desktop/gtksourceview/default.nix
@@ -73,6 +73,11 @@ stdenv.mkDerivation (finalAttrs: {
     gtk-mac-integration-gtk2
   ];
 
+  # where to find the AM_GNU_GETTEXT_VERSION macro
+  preHook = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    addToSearchPath ACLOCAL_PATH ${gettext}/share/gettext/m4
+  '';
+
   doCheck = false; # requires X11 daemon
 
   passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;


### PR DESCRIPTION
Resolve a Darwin build failure due to gettext m4 macros not being picked up.

The normal fix would be to add automake as build input, but gettext puts those files in a nonstandard folder anyway (`share/gettext/m4` rather than `share/aclocal`), so we have to modify `ACLOCAL_PATH` manually.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
