### PR TITLE
nixos/music-assistant: disable MemoryDenyWriteExecute

### DIFF
--- a/nixos/modules/services/audio/music-assistant.nix
+++ b/nixos/modules/services/audio/music-assistant.nix
@@ -155,7 +155,8 @@ in
         CapabilityBoundingSet = [ "" ];
         DevicePolicy = "closed";
         LockPersonality = true;
-        MemoryDenyWriteExecute = !useYTMusic;
+        # breaks pyopenssl's cffi calls, used in remote access feature
+        MemoryDenyWriteExecute = false;
         ProcSubset = "pid";
         ProtectClock = true;
         ProtectControlGroups = true;


### PR DESCRIPTION
MemoryDenyWriteExecute=true breaks the remote access functionality.

```
2026-05-24 17:32:58.344 ERROR (MainThread) [music_assistant] Error doing task: Task exception was never retrieved
Traceback (most recent call last):
  File "/nix/store/mmv9717wjskv3q5v4768dq0fq5hf4jry-python3.13-aiortc-1.14.0/lib/python3.13/site-packages/aiortc/rtcpeerconnection.py", line 1084, in __connect
    await dtlsTransport.start(self.__remoteDtls[self.__sctp])
  File "/nix/store/mmv9717wjskv3q5v4768dq0fq5hf4jry-python3.13-aiortc-1.14.0/lib/python3.13/site-packages/aiortc/rtcdtlstransport.py", line 518, in start
    self.__local_certificate._create_ssl_context(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        srtp_profiles=self._srtp_profiles
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/nix/store/mmv9717wjskv3q5v4768dq0fq5hf4jry-python3.13-aiortc-1.14.0/lib/python3.13/site-packages/aiortc/rtcdtlstransport.py", line 198, in _create_ssl_context
    ctx.set_verify(
    ~~~~~~~~~~~~~~^
        SSL.VERIFY_PEER | SSL.VERIFY_FAIL_IF_NO_PEER_CERT, lambda *args: True
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/nix/store/5kwsndvbzfj3dv4fwpdlgin42mgbd4xk-python3.13-pyopenssl-26.0.0/lib/python3.13/site-packages/OpenSSL/SSL.py", line 867, in inner
    return f(self, *args, **kwargs)
  File "/nix/store/5kwsndvbzfj3dv4fwpdlgin42mgbd4xk-python3.13-pyopenssl-26.0.0/lib/python3.13/site-packages/OpenSSL/SSL.py", line 1390, in set_verify
    self._verify_helper = _VerifyHelper(callback)
                          ~~~~~~~~~~~~~^^^^^^^^^^
  File "/nix/store/5kwsndvbzfj3dv4fwpdlgin42mgbd4xk-python3.13-pyopenssl-26.0.0/lib/python3.13/site-packages/OpenSSL/SSL.py", line 527, in __init__
    self.callback = _ffi.callback(
                    ~~~~~~~~~~~~~^
        "int (*)(int, X509_STORE_CTX *)", wrapper
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
MemoryError: Cannot allocate write+execute memory for ffi.callback(). You might be running on a system that prevents this. For more information, see https://cffi.readthedocs.io/en/latest/using.html#callbacks
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
