### PR TITLE
cmux: init at 0.64.10

### DIFF
--- a/pkgs/by-name/cm/cmux/package.nix
+++ b/pkgs/by-name/cm/cmux/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  _7zz,
+  makeBinaryWrapper,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "cmux";
+  version = "0.64.10";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchurl {
+    url = "https://github.com/manaflow-ai/cmux/releases/download/v${finalAttrs.version}/cmux-macos.dmg";
+    hash = "sha256-+MKcMChZTFiDF482mVIh6mzeyKghDMV9gLA+6BjamXw=";
+  };
+
+  # -snld prevents "ERROR: Dangerous symbolic link path was ignored"
+  # -xr'!*:com.apple.*' avoids extended attributes being extracted as files
+  # from the APFS image, which would corrupt the .app bundle.
+  unpackCmd = "7zz x -snld -xr'!*:com.apple.*' $curSrc";
+
+  nativeBuildInputs = [
+    _7zz
+    makeBinaryWrapper
+  ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -R cmux.app $out/Applications/
+
+    mkdir -p $out/bin
+    makeBinaryWrapper \
+      "$out/Applications/cmux.app/Contents/MacOS/cmux" \
+      "$out/bin/cmux"
+
+    runHook postInstall
+  '';
+
+  # Preserve the notarized signature of the bundled binaries and resources.
+  dontFixup = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Native macOS terminal built on Ghostty, designed for AI coding agents";
+    longDescription = ''
+      cmux is a macOS-native terminal application built on Ghostty that
+      provides vertical tabs, notification rings, an in-app browser, and
+      first-class support for AI coding agents such as Claude Code.
+      It exposes scriptable CLI and socket APIs.
+    '';
+    homepage = "https://cmux.com";
+    changelog = "https://github.com/manaflow-ai/cmux/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "cmux";
+    maintainers = with lib.maintainers; [ imcvampire ];
+    platforms = lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
