### PR TITLE
python3Packages.urllib3: 2.6.3 -> 2.7.0

### DIFF
--- a/pkgs/development/python-modules/urllib3/default.nix
+++ b/pkgs/development/python-modules/urllib3/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   isPyPy,
 
   # build-system
@@ -31,23 +31,20 @@
 let
   self = buildPythonPackage rec {
     pname = "urllib3";
-    version = "2.6.3";
+    version = "2.7.0";
     pyproject = true;
 
-    src = fetchPypi {
-      inherit pname version;
-      hash = "sha256-G2K2iElEpX2+MhUJq5T9TTswcHXgwurpkaxx7hWtOO0=";
+    src = fetchFromGitHub {
+      owner = "urllib3";
+      repo = "urllib3";
+      tag = version;
+      hash = "sha256-iN59MS5gKgDxe2v4ILrZ/1y7wV4yB1tFs4ATKppYAAk=";
     };
 
     build-system = [
       hatchling
       hatch-vcs
     ];
-
-    postPatch = ''
-      substituteInPlace pyproject.toml \
-        --replace-fail ', "setuptools-scm>=8,<10"' ""
-    '';
 
     optional-dependencies = {
       brotli = if isPyPy then [ brotlicffi ] else [ brotli ];

--- a/pkgs/development/python-modules/urllib3/default.nix
+++ b/pkgs/development/python-modules/urllib3/default.nix
@@ -28,79 +28,76 @@
   trustme,
 }:
 
-let
-  self = buildPythonPackage rec {
-    pname = "urllib3";
-    version = "2.7.0";
-    pyproject = true;
+buildPythonPackage (finalAttrs: {
+  pname = "urllib3";
+  version = "2.7.0";
+  pyproject = true;
 
-    src = fetchFromGitHub {
-      owner = "urllib3";
-      repo = "urllib3";
-      tag = version;
-      hash = "sha256-iN59MS5gKgDxe2v4ILrZ/1y7wV4yB1tFs4ATKppYAAk=";
-    };
-
-    build-system = [
-      hatchling
-      hatch-vcs
-    ];
-
-    optional-dependencies = {
-      brotli = if isPyPy then [ brotlicffi ] else [ brotli ];
-      h2 = [ h2 ];
-      socks = [ pysocks ];
-      zstd = [ backports-zstd ];
-    };
-
-    nativeCheckInputs = [
-      httpx
-      pyopenssl
-      pytest-socket
-      pytest-timeout
-      pytestCheckHook
-      quart
-      quart-trio
-      tornado
-      trio
-      trustme
-    ]
-    ++ lib.concatAttrValues optional-dependencies;
-
-    disabledTestMarks = [
-      "requires_network"
-    ];
-
-    # Tests in urllib3 are mostly timeout-based instead of event-based and
-    # are therefore inherently flaky. On your own machine, the tests will
-    # typically build fine, but on a loaded cluster such as Hydra random
-    # timeouts will occur.
-    #
-    # The urllib3 test suite has two different timeouts in their test suite
-    # (see `test/__init__.py`):
-    # - SHORT_TIMEOUT
-    # - LONG_TIMEOUT
-    # When CI is in the env, LONG_TIMEOUT will be significantly increased.
-    # Still, failures can occur and for that reason tests are disabled.
-    doCheck = false;
-
-    passthru.tests.pytest = self.overridePythonAttrs (_: {
-      doCheck = true;
-    });
-
-    preCheck = ''
-      export CI # Increases LONG_TIMEOUT
-    '';
-
-    pythonImportsCheck = [ "urllib3" ];
-
-    meta = {
-      description = "Powerful, user-friendly HTTP client for Python";
-      homepage = "https://github.com/urllib3/urllib3";
-      changelog = "https://github.com/urllib3/urllib3/blob/${version}/CHANGES.rst";
-      license = lib.licenses.mit;
-      maintainers = with lib.maintainers; [ fab ];
-    };
+  src = fetchFromGitHub {
+    owner = "urllib3";
+    repo = "urllib3";
+    tag = finalAttrs.version;
+    hash = "sha256-iN59MS5gKgDxe2v4ILrZ/1y7wV4yB1tFs4ATKppYAAk=";
   };
-in
-self
+
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
+
+  optional-dependencies = {
+    brotli = if isPyPy then [ brotlicffi ] else [ brotli ];
+    h2 = [ h2 ];
+    socks = [ pysocks ];
+    zstd = [ backports-zstd ];
+  };
+
+  nativeCheckInputs = [
+    httpx
+    pyopenssl
+    pytest-socket
+    pytest-timeout
+    pytestCheckHook
+    quart
+    quart-trio
+    tornado
+    trio
+    trustme
+  ]
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
+
+  disabledTestMarks = [
+    "requires_network"
+  ];
+
+  # Tests in urllib3 are mostly timeout-based instead of event-based and
+  # are therefore inherently flaky. On your own machine, the tests will
+  # typically build fine, but on a loaded cluster such as Hydra random
+  # timeouts will occur.
+  #
+  # The urllib3 test suite has two different timeouts in their test suite
+  # (see `test/__init__.py`):
+  # - SHORT_TIMEOUT
+  # - LONG_TIMEOUT
+  # When CI is in the env, LONG_TIMEOUT will be significantly increased.
+  # Still, failures can occur and for that reason tests are disabled.
+  doCheck = false;
+
+  passthru.tests.pytest = finalAttrs.finalPackage.overrideAttrs (_: {
+    doInstallCheck = true;
+  });
+
+  preCheck = ''
+    export CI # Increases LONG_TIMEOUT
+  '';
+
+  pythonImportsCheck = [ "urllib3" ];
+
+  meta = {
+    description = "Powerful, user-friendly HTTP client for Python";
+    homepage = "https://github.com/urllib3/urllib3";
+    changelog = "https://github.com/urllib3/urllib3/blob/${finalAttrs.src.tag}/CHANGES.rst";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+})


### PR DESCRIPTION
Diff: https://github.com/urllib3/urllib3/compare/2.6.3...2.7.0

Changelog: https://github.com/urllib3/urllib3/blob/2.7.0/CHANGES.rst

fixes https://github.com/NixOS/nixpkgs/issues/520500
fixes https://github.com/NixOS/nixpkgs/issues/520501

The bump is also in https://github.com/NixOS/nixpkgs/pull/521373 but this PR allows cherry-picking the correct commit.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
