### PR TITLE
doc: add section for writableTmpDirAsHomeHook

### DIFF
--- a/doc/hooks/index.md
+++ b/doc/hooks/index.md
@@ -48,6 +48,7 @@ unzip.section.md
 validatePkgConfig.section.md
 versionCheckHook.section.md
 waf.section.md
+writable-tmpdir-as-home-hook.section.md
 zig.section.md
 xcbuild.section.md
 xfce4-dev-tools.section.md

--- a/doc/hooks/writable-tmpdir-as-home-hook.section.md
+++ b/doc/hooks/writable-tmpdir-as-home-hook.section.md
@@ -1,0 +1,5 @@
+# writableTmpDirAsHomeHook {#writableTmpDirAsHomeHook}
+
+This setup hook provides a writable home directory for packages that require it.
+
+To use, just add the hook to the `nativeBuildInputs` of the package.

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -1016,6 +1016,9 @@
   "tar-files": [
     "index.html#tar-files"
   ],
+  "writableTmpDirAsHomeHook": [
+    "index.html#writableTmpDirAsHomeHook"
+  ],
   "x86_64-darwin-26.05": [
     "release-notes.html#x86_64-darwin-26.05"
   ],


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Added the above section. No AI was used.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
