### PR TITLE
python3Packages.paramiko: 4.0.0 -> 5.0.0

### DIFF
--- a/pkgs/by-name/tu/tunnelgraf/package.nix
+++ b/pkgs/by-name/tu/tunnelgraf/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   fetchFromGitHub,
-  fetchPypi,
   python3,
 }:
 
@@ -12,12 +11,18 @@ let
       # Doesn't work with latest paramiko
       paramiko = super.paramiko.overridePythonAttrs (oldAttrs: rec {
         version = "3.4.0";
-        src = fetchPypi {
-          pname = "paramiko";
-          inherit version;
-          hash = "sha256-qsCPJqMdxN/9koIVJ9FoLZnVL572hRloEUqHKPPCdNM=";
+        src = fetchFromGitHub {
+          owner = "paramiko";
+          repo = "paramiko";
+          tag = version;
+          hash = "sha256-V0s9IoRmqXvzYQzzBsWmovYWwXnNC0x1phyiyjbejGA=";
         };
         doCheck = false;
+        meta = oldAttrs.meta // {
+          knownVulnerabilities = [
+            "CVE-2026-44405"
+          ];
+        };
       });
     };
   };

--- a/pkgs/development/python-modules/paramiko/default.nix
+++ b/pkgs/development/python-modules/paramiko/default.nix
@@ -3,12 +3,9 @@
   bcrypt,
   buildPythonPackage,
   cryptography,
-  fetchPypi,
-  gssapi,
+  fetchFromGitHub,
   icecream,
   invoke,
-  mock,
-  pyasn1,
   pynacl,
   pytest-relaxed,
   pytestCheckHook,
@@ -17,12 +14,14 @@
 
 buildPythonPackage rec {
   pname = "paramiko";
-  version = "4.0.0";
+  version = "5.0.0";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-aiXwezgMycmojSuSCtNxZ6xGZ/jZiGzOvY+Q9lS11p8=";
+  src = fetchFromGitHub {
+    owner = "paramiko";
+    repo = "paramiko";
+    tag = version;
+    hash = "sha256-zzbM2oGaZ5jkIN7LyDGuMAKSpSmUwpBbup6MBVdTaXA=";
   };
 
   build-system = [ setuptools ];
@@ -34,21 +33,11 @@ buildPythonPackage rec {
     pynacl
   ];
 
-  optional-dependencies = {
-    gssapi = [
-      pyasn1
-      gssapi
-    ];
-    ed25519 = [ ];
-  };
-
   nativeCheckInputs = [
     icecream
-    mock
     pytestCheckHook
     pytest-relaxed
-  ]
-  ++ lib.concatAttrValues optional-dependencies;
+  ];
 
   pythonImportsCheck = [ "paramiko" ];
 
@@ -56,7 +45,7 @@ buildPythonPackage rec {
 
   meta = {
     homepage = "https://github.com/paramiko/paramiko/";
-    changelog = "https://github.com/paramiko/paramiko/blob/${version}/sites/www/changelog.rst";
+    changelog = "https://github.com/paramiko/paramiko/blob/${src.tag}/sites/www/changelog.rst";
     description = "Native Python SSHv2 protocol library";
     license = lib.licenses.lgpl21Plus;
     longDescription = ''

--- a/pkgs/development/python-modules/paramiko/default.nix
+++ b/pkgs/development/python-modules/paramiko/default.nix
@@ -12,7 +12,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "paramiko";
   version = "5.0.0";
   pyproject = true;
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "paramiko";
     repo = "paramiko";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-zzbM2oGaZ5jkIN7LyDGuMAKSpSmUwpBbup6MBVdTaXA=";
   };
 
@@ -45,7 +45,7 @@ buildPythonPackage rec {
 
   meta = {
     homepage = "https://github.com/paramiko/paramiko/";
-    changelog = "https://github.com/paramiko/paramiko/blob/${src.tag}/sites/www/changelog.rst";
+    changelog = "https://github.com/paramiko/paramiko/blob/${finalAttrs.src.tag}/sites/www/changelog.rst";
     description = "Native Python SSHv2 protocol library";
     license = lib.licenses.lgpl21Plus;
     longDescription = ''
@@ -55,4 +55,4 @@ buildPythonPackage rec {
       supported. SFTP client and server mode are both supported too.
     '';
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/paramiko/paramiko/compare/4.0.0...5.0.0

Changelog: https://github.com/paramiko/paramiko/blob/5.0.0/sites/www/changelog.rst

fixes CVE-2026-44405
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
