### PR TITLE
authentik: 2025.12.4 -> 2025.12.5

### DIFF
--- a/pkgs/by-name/au/authentik/package.nix
+++ b/pkgs/by-name/au/authentik/package.nix
@@ -20,13 +20,13 @@
 let
   nodejs = nodejs_24;
 
-  version = "2025.12.4";
+  version = "2025.12.5";
 
   src = fetchFromGitHub {
     owner = "goauthentik";
     repo = "authentik";
     tag = "version/${version}";
-    hash = "sha256-alTyrMBbjZbw4jhEna8saabf93sqSrZCu+Z5xH3pZ7M=";
+    hash = "sha256-LPGAhbtmuztDQ4CVhUXb+vBU5HjvNZ7JicI5r3lr1QQ=";
   };
 
   meta = {
@@ -52,7 +52,7 @@ let
     src = fetchFromGitHub {
       owner = "goauthentik";
       repo = "client-go";
-      tag = "v3.${version}";
+      tag = "v3.2025.12.4";
       hash = "sha256-+/CfOE2HkBU+ZddvdXGenB/z8xNFk8cujpZpMXyh3cY=";
     };
 
@@ -137,8 +137,8 @@ let
 
     outputHash =
       {
-        "aarch64-linux" = "sha256-GL5FPIBnoEXYtw8DPJpRPe3tT3qioN4AdoeOmCoiYsM=";
-        "x86_64-linux" = "sha256-AnceTipq6uUvTbOAZanVshAbAJ9LS1kwImbttTOcWxc=";
+        "aarch64-linux" = "sha256-smm9x29z7gOI7Wq0NvP45KHtBbT6p1lH6IjEf9LRuGs=";
+        "x86_64-linux" = "sha256-K86wnn50svP+QG3i0mggH8RQgfoIqEmyQTouz35xzw8=";
       }
       .${stdenvNoCC.hostPlatform.system} or (throw "authentik-website-deps: unsupported host platform");
 
@@ -208,8 +208,8 @@ let
 
     outputHash =
       {
-        "aarch64-linux" = "sha256-eZZ5Ynj81KwFsU5emPtYZ2CxO8MFvWbJnCHs+L88KQQ=";
-        "x86_64-linux" = "sha256-yUAyyO1NFav1EptrRYGSzC8dxCxYVj0FmzHk8IckFZM=";
+        "aarch64-linux" = "sha256-J9wGQe7iMfKznNk3woqi0VNVNA/dE6TGi2f44DOlG1c=";
+        "x86_64-linux" = "sha256-9Q590Rw0mk3q5osxOKGWU7+XtKwkTyA+CLC2LxAA/3g=";
       }
       .${stdenvNoCC.hostPlatform.system} or (throw "authentik-webui-deps: unsupported host platform");
     outputHashMode = "recursive";


### PR DESCRIPTION
Diff: https://github.com/goauthentik/authentik/compare/version/2025.12.4...version/2025.12.5

Changelog: https://github.com/goauthentik/authentik/releases/tag/version%2F2025.12.5

fixes https://github.com/NixOS/nixpkgs/issues/522568 ([CVE-2026-40165](https://github.com/goauthentik/authentik/security/advisories/GHSA-9wj8-xv4r-qwrp))

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
