### PR TITLE
invidious: unpin crystal version

### DIFF
--- a/pkgs/by-name/in/invidious/package.nix
+++ b/pkgs/by-name/in/invidious/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   callPackage,
-  crystal_1_16,
+  crystal,
   fetchFromGitHub,
   librsvg,
   pkg-config,
@@ -27,7 +27,6 @@
 let
   # normally video.js is downloaded at build time
   videojs = callPackage ./videojs.nix { inherit versions; };
-  crystal = crystal_1_16;
 in
 crystal.buildCrystalPackage rec {
   pname = "invidious";
@@ -69,7 +68,7 @@ crystal.buildCrystalPackage rec {
 
       # Patch the assets and locales paths to be absolute
       substituteInPlace src/invidious.cr \
-          --replace-fail 'public_folder "assets"' 'public_folder "${placeholder "out"}/share/invidious/assets"'
+          --replace-fail 'StaticAssetsHandler.new("assets"' 'StaticAssetsHandler.new("${placeholder "out"}/share/invidious/assets"'
       substituteInPlace src/invidious/helpers/i18n.cr \
           --replace-fail 'File.read("locales/' 'File.read("${placeholder "out"}/share/invidious/locales/'
 


### PR DESCRIPTION
I think this fixed the following issue I was running into on my homeserver:
```
invidious-start[114324]: Invalid memory access (signal 11) at address 0x0
invidious-start[114324]: [0x5df980647c56] ?? +103326182308950 in /nix/store/jg0jw2bbxr3wcnirg512p65xbcwjszcl-invidious-2.20260207.0/bin/invidious
invidious-start[114324]: [0x5df9806472fb] ?? +103326182306555 in /nix/store/jg0jw2bbxr3wcnirg512p65xbcwjszcl-invidious-2.20260207.0/bin/invidious
invidious-start[114324]: [0x73cd582419c0] ?? +127325784250816 in /nix/store/7nbi22pcc92y2fqbkyp7h3srvvklmckb-glibc-2.40-224/lib/libc.so.6
invidious-start[114324]: [0x73cd58cf5ea6] GC_generic_malloc_many +742 in /nix/store/1ngdf6ag33bs7wfiszghah0yvkl5rnyd-boehm-gc-8.2.8/lib/libgc.so.1
invidious-start[114324]: [0x73cd58cf6549] GC_malloc_kind +313 in /nix/store/1ngdf6ag33bs7wfiszghah0yvkl5rnyd-boehm-gc-8.2.8/lib/libgc.so.1
invidious-start[114324]: [0x5df980761074] ?? +103326183460980 in /nix/store/jg0jw2bbxr3wcnirg512p65xbcwjszcl-invidious-2.20260207.0/bin/invidious
invidious-start[114324]: [0x5df98075dccb] ?? +103326183447755 in /nix/store/jg0jw2bbxr3wcnirg512p65xbcwjszcl-invidious-2.20260207.0/bin/invidious
invidious-start[114324]: [0x5df98075d336] ?? +103326183445302 in /nix/store/jg0jw2bbxr3wcnirg512p65xbcwjszcl-invidious-2.20260207.0/bin/invidious
invidious-start[114324]: [0x5df98064577d] ?? +103326182299517 in /nix/store/jg0jw2bbxr3wcnirg512p65xbcwjszcl-invidious-2.20260207.0/bin/invidious
invidious-start[114324]: [0x0] ???
systemd[1]: invidious.service: Main process exited, code=exited, status=11/n/a
```

It happened only occasionally but would cause Invidious to crash around 10s after startup when it did.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
