### PR TITLE
WIP: boot.initrd.luks.devices.<name>: add skipIfMissing option

### DIFF
--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -168,10 +168,20 @@ let
     ''
       # Wait for luksRoot (and optionally keyFile and/or header) to appear, e.g.
       # if on a USB drive.
-      wait_target "device" ${dev.device} || die "${dev.device} is unavailable"
+      wait_target "device" ${dev.device} || ${
+        if dev.skipIfMissing then
+          ''echo "WARNING: ${dev.device} is unavailable, skipping LUKS device ${dev.name}"; true''
+        else
+          ''die "${dev.device} is unavailable"''
+      }
 
       ${optionalString (dev.header != null) ''
-        wait_target "header" ${dev.header} || die "${dev.header} is unavailable"
+        wait_target "header" ${dev.header} || ${
+          if dev.skipIfMissing then
+            ''echo "WARNING: header ${dev.header} is unavailable, skipping LUKS device ${dev.name}"; true''
+          else
+            ''die "${dev.header} is unavailable"''
+        }
       ''}
 
       try_empty_passphrase() {
@@ -829,6 +839,21 @@ in
                     Whether to fallback to interactive passphrase prompt if the keyfile
                     cannot be found. This will prevent unattended boot should the keyfile
                     go missing.
+                  '';
+                };
+
+                skipIfMissing = mkOption {
+                  default = false;
+                  type = types.bool;
+                  description = ''
+                    If the device (or its detached header) is not available after
+                    the wait period, skip it and continue booting instead of
+                    aborting. Useful for optional or removable encrypted devices
+                    that should not block the boot process when absent.
+
+                    Note: enabling this means the device will silently remain
+                    locked if it is missing; make sure your system can boot
+                    without it.
                   '';
                 };
 


### PR DESCRIPTION
Add option to kkip optional/removable LUKS devices that are absent at boot instead of aborting.

This adds a per-device `skipIfMissing` option (default `false`) that replaces the fatal `die` with a warning when the device or its detached header is not found after the wait period.

I personally have a server with two LUKS devices and ontop an btrfs raid1, the raid1 is mounted so if one is missing it still can go on, but when i needed it, i had an outage due to luks not skipping the missing drive.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
