### PR TITLE
oshu: init at 2.0.3

### DIFF
--- a/pkgs/by-name/os/oshu/package.nix
+++ b/pkgs/by-name/os/oshu/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  SDL2,
+  SDL2_image,
+  ffmpeg,
+  cairo,
+  pango,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "oshu";
+  version = "2.0.3";
+
+  src = fetchFromGitHub {
+    owner = "fmang";
+    repo = "oshu";
+    tag = finalAttrs.version;
+    hash = "sha256-bVMEhaSaLtlxkPnu3rtue6Ov5m+8ymteBRLnWVv0YEI=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    versionCheckHook
+  ];
+
+  buildInputs = [
+    SDL2
+    SDL2_image
+    ffmpeg
+    cairo
+    pango
+  ];
+
+  cmakeFlag = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DOSHU_DEFAULT_SKIN=minimal"
+  ];
+
+  doCheck = true;
+  checkTarget = "check";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Lightweight osu! client for Linux and low-end systems";
+    homepage = "https://github.com/fmang/oshu";
+    mainProgram = "oshu";
+    changelog = "https://github.com/fmang/oshu/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ castorNova2 ];
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Part of #380688

Add a package of [Oshu](https://github.com/fmang/oshu) which is a rhythm game inspired by osu!.

- The package build the main executable alongside <mark>oshu-library</mark>
- SDL2 accelerated renderer and ffmpeg based audio playback
- Only "Mode:0" beatmaps are currently supported
- Beatmaps must be launched from a .osu file:
```terminal
oshu path/to/beatmap.osu
```
- The game also need referenced assets (audio and background) to exist alongside beatmap file.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
