### PR TITLE
luarocks-packages-updater: commit updates separately

### DIFF
--- a/pkgs/by-name/lu/luarocks-packages-updater/updater.py
+++ b/pkgs/by-name/lu/luarocks-packages-updater/updater.py
@@ -105,6 +105,26 @@ def extract_rev(nix_expr: str) -> str | None:
     return None
 
 
+def commit_files(repo, message: str, files: list[Path]) -> None:
+    worktree = repo.working_tree_dir
+    paths = [str(path) for path in files]
+
+    subprocess.run(["git", "add", "--", *paths], cwd=worktree, check=True)
+    diff_result = subprocess.run(
+        ["git", "diff", "--cached", "--quiet", "--", *paths],
+        cwd=worktree,
+        check=False,
+    )
+    if diff_result.returncode == 0:
+        print("no changes in working tree to commit")
+        return
+    if diff_result.returncode != 1:
+        raise RuntimeError("Could not inspect staged changes")
+
+    print(f'committing to nixpkgs "{message}"')
+    subprocess.run(["git", "commit", "-m", message, "--", *paths], cwd=worktree, check=True)
+
+
 # rename Editor to LangUpdate/ EcosystemUpdater
 class LuaEditor(nixpkgs_plugin_update.Editor):
     def create_parser(self):
@@ -131,7 +151,42 @@ class LuaEditor(nixpkgs_plugin_update.Editor):
         return luaPackages
 
     def update(self, args):
-        update_plugins(self, args)
+        if args.no_commit:
+            update_plugins(self, args)
+            return
+
+        fetch_config = FetchConfig(args.proc, args.github_token)
+        specs = self.load_plugin_spec(fetch_config, args.input_file)
+        specs = sorted(specs, key=lambda v: v.name.lower())
+
+        if args.update_only:
+            specs = [
+                p
+                for p in specs
+                if p.normalized_name in args.update_only or p.name in args.update_only
+            ]
+
+        if not specs:
+            log.error("No matching Lua packages to update")
+            return
+
+        assert self.nixpkgs_repo is not None
+        for spec in specs:
+            update = self.get_update(
+                str(args.input_file),
+                str(args.outfile),
+                fetch_config,
+                to_update=[spec.name],
+            )
+            _redirects, updated_plugins = update()
+
+            for name, old_ver, new_ver in updated_plugins:
+                if old_ver == "init":
+                    msg = f"{self.attr_path}.{name}: init at {new_ver}"
+                else:
+                    msg = f"{self.attr_path}.{name}: {old_ver} -> {new_ver}"
+
+                commit_files(self.nixpkgs_repo, msg, [args.outfile])
 
     def generate_nix(self, results: list[tuple[LuaPlugin, str]], outfilename: str):
         with tempfile.NamedTemporaryFile("w+") as f:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Same concept as https://github.com/NixOS/nixpkgs/pull/523689 since we don't have many packages updating at once with release versions. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
