### PR TITLE
steam-haptics-singer: init at 1.11.3

### DIFF
--- a/pkgs/by-name/st/steam-haptics-singer/package.nix
+++ b/pkgs/by-name/st/steam-haptics-singer/package.nix
@@ -1,0 +1,42 @@
+{
+  fetchFromGitHub,
+  hidapi,
+  lib,
+  libusb1,
+  pkg-config,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "steam-haptics-singer";
+  version = "1.11.3";
+
+  src = fetchFromGitHub {
+    owner = "CrazyCritic89";
+    repo = "SteamHapticsSinger";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5BhhPgQd36OHMuRsQstPR5Az4uH0uaZ6wyP2PlNWQ70=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    hidapi
+    libusb1
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 steam-haptics-singer $out/bin/steam-haptics-singer
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Program to play MIDI files using haptics from Steam hardware";
+    homepage = "https://github.com/CrazyCritic89/SteamHapticsSinger";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ PopeRigby ];
+    mainProgram = "steam-haptics-singer";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
https://github.com/CrazyCritic89/SteamHapticsSinger

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
