### PR TITLE
python3Packages.twisted: 25.5.0 -> 26.4.0

### DIFF
--- a/pkgs/development/python-modules/scrapy/default.nix
+++ b/pkgs/development/python-modules/scrapy/default.nix
@@ -9,6 +9,7 @@
   fetchFromGitHub,
   glibcLocales,
   hatchling,
+  httpx,
   installShellFiles,
   itemadapter,
   itemloaders,
@@ -40,14 +41,14 @@
 
 buildPythonPackage rec {
   pname = "scrapy";
-  version = "2.14.1";
+  version = "2.16.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "scrapy";
     repo = "scrapy";
     tag = version;
-    hash = "sha256-KDci1Z5TZ+3svotYXkEG1s+bPWtxzIfQQwOgvI0k8w0=";
+    hash = "sha256-s72COXzDuTtRNGenZEZG8QCeq+9LBu6fuT5NOjpVYaY=";
   };
 
   pythonRelaxDeps = [
@@ -86,6 +87,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     botocore
     glibcLocales
+    httpx
     jmespath
     pexpect
     pytest-asyncio
@@ -106,7 +108,6 @@ buildPythonPackage rec {
   ];
 
   disabledTestPaths = [
-    "tests/test_proxy_connect.py"
     "tests/test_utils_display.py"
     "tests/test_command_check.py"
 
@@ -133,9 +134,12 @@ buildPythonPackage rec {
     "AnonymousFTPTestCase"
     "FTPFeedStorageTest"
     "FeedExportTest"
+    "TestRealWebsite"
     "test_custom_asyncio_loop_enabled_true"
     "test_custom_loop_asyncio"
     "test_custom_loop_asyncio_deferred_signal"
+    "test_pos_string"
+    "test_key_resp_or_url"
     # "FileFeedStoragePreFeedOptionsTest" # https://github.com/scrapy/scrapy/issues/5157
     "test_persist"
     "test_timeout_download_from_spider_nodata_rcvd"

--- a/pkgs/development/python-modules/twisted/default.nix
+++ b/pkgs/development/python-modules/twisted/default.nix
@@ -4,8 +4,7 @@
   buildPythonPackage,
   pythonAtLeast,
   pythonOlder,
-  fetchPypi,
-  fetchpatch,
+  fetchFromGitHub,
   python,
 
   # build-system
@@ -56,29 +55,15 @@
 
 buildPythonPackage rec {
   pname = "twisted";
-  version = "25.5.0";
+  version = "26.4.0";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    extension = "tar.gz";
-    hash = "sha256-HesnI1jLa+Hj6PxvnIs2946w+nwiM9Lb4R7G/uBOoxY=";
+  src = fetchFromGitHub {
+    owner = "twisted";
+    repo = "twisted";
+    tag = "twisted-${version}";
+    hash = "sha256-D6vDa+8qwjryKnElPBZgXCNokMX2l3i2bMdtk4FhEp4=";
   };
-
-  patches = [
-    (fetchpatch {
-      # https://github.com/twisted/twisted/pull/12508
-      url = "https://github.com/twisted/twisted/commit/ef6160aa2595adfba0c71da6db65b7a7252f23e9.patch";
-      hash = "sha256-zHkEWT0lvWf86RlkzU5Wx6R5ear04cfpxB7wjgdpw5c=";
-    })
-    # https://github.com/twisted/twisted/pull/12511
-    ./python314-urljoin-compat.patch
-    (fetchpatch {
-      # https://github.com/twisted/twisted/pull/12551
-      url = "https://github.com/twisted/twisted/commit/b1173fa307a9752eedd63890113eb610c3cca4a0.patch";
-      hash = "sha256-DWEygdo1b8uQOeFLy0/zcRNuuKJdSsF7cQM7RH04Puw=";
-    })
-  ];
 
   __darwinAllowLocalNetworking = true;
 


### PR DESCRIPTION
Changelog: https://github.com/twisted/twisted/blob/twisted-26.4.0/NEWS.rst

fixes CVE-2026-42304
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
