### PR TITLE
Game/solvitaire

### DIFF
--- a/pkgs/by-name/so/solvitaire/package.nix
+++ b/pkgs/by-name/so/solvitaire/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  ncurses,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "solvitaire";
+  version = "0-unstable-2022-05-19";
+
+  src = fetchgit {
+    url = "https://git.gir.st/solVItaire.git";
+    rev = "1883ee0c67f3e5f7807f7a886333360e31f804be";
+    hash = "sha256-truPFMojxdUlFzSmcdgt+WurKHKej9/0ETN8YmnmH/c=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  buildInputs = [ ncurses ];
+
+  # makeFlags = [
+  #   "CC=${stdenv.cc.targetPrefix}cc"
+  # ];
+
+  buildFlags = [
+    "all"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 sol $out/bin/sol
+    install -Dm755 spider $out/bin/spider
+    install -Dm755 freecell $out/bin/freecell
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Terminal solitaire games like Klondlike, Spider and FreeCell";
+    homepage = "https://gir.st/sol.html";
+    mainProgram = "sol";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ castorNova2 ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Part of #380688

Add a package of [solvitaire](https://gir.st/sol.html) which is a termianl game of klondline, freecell and spider.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
