### PR TITLE
maintainers: remove shlok

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25303,12 +25303,6 @@
     githubId = 487050;
     name = "Shea Levy";
   };
-  shlok = {
-    email = "sd-nix-maintainer@quant.is";
-    github = "shlok";
-    githubId = 3000933;
-    name = "Shlok Datye";
-  };
   shmish111 = {
     email = "shmish111@gmail.com";
     github = "shmish111";

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -453,9 +453,6 @@ package-maintainers:
     - massiv
     - massiv-io
     - massiv-test
-  shlok:
-    - streamly-archive
-    - streamly-lmdb
   slotThe:
     - X11
     - X11-xft


### PR DESCRIPTION
## Reasons

- Last commented in [June 2023](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Ashlok)
- Hasn't created any PRs / Issues since [June 2023](https://github.com/NixOS/nixpkgs/issues?q=author%3Ashlok)
- About 2 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Ashlok%20-commenter%3Ashlok%20-author%3Ashlok%20-reviewed-by%3Ashlok) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] haskellPackages.streamly-archive
- [ ] haskellPackages.streamly-lmdb