### PR TITLE
resync-rs: init at v0.3.0

### DIFF
--- a/pkgs/by-name/re/resync-rs/package.nix
+++ b/pkgs/by-name/re/resync-rs/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  zstd,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "resync-rs";
+  version = "0.3.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "vedLinuxian";
+    repo = "resync-rs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ssh2yt9d5QGyhrm03C5txD1WpU2D+hVZBqOsnO5n3PI=";
+  };
+
+  cargoHash = "sha256-rpNDEdzClqIGippLW5bnSVE+VOuT9vwfZ7NGvTMapZY=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    zstd
+  ];
+
+  env = {
+    ZSTD_SYS_USE_PKG_CONFIG = true;
+  };
+
+  passthru.updateScript = nix-update-script { };
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  meta = {
+    description = "Next-generation parallel delta-sync engine — rsync reimagined in Rust";
+    homepage = "https://github.com/vedLinuxian/resync-rs";
+    changelog = "https://github.com/vedLinuxian/resync-rs/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ paepcke ];
+    mainProgram = "resync";
+  };
+})


### PR DESCRIPTION
- modern rsync re-implementation with valid major improvements over classic rsync
  => mmap + copy_file_range(2), FastCDC (Gear hash), BLAKE3 (256-bit, SIMD), TLS, ...
  => https://vedlinuxian.github.io/resync-rs/
- valid codebase, just stiching some well known popular libs together
- project check into github are fresh and single (visible) developer only, but seems mostly ai-free code and stable
- pls verify, 2nd opinion are welcome: https://github.com/vedLinuxian/resync-rs

Would like to give it a try and a push. The advantages over classic rsync are real. 
With positive feedback would like to integrate backend as server into services.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
