### PR TITLE
irpf: 2026-1.2 -> 2026-1.3

### DIFF
--- a/pkgs/by-name/ir/irpf/package.nix
+++ b/pkgs/by-name/ir/irpf/package.nix
@@ -17,7 +17,7 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "irpf";
-  version = "2026-1.2";
+  version = "2026-1.3";
 
   # https://www.gov.br/receitafederal/pt-br/centrais-de-conteudo/download/pgd/dirpf
   # Para outros sistemas operacionais -> Multi
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     in
     fetchzip {
       url = "https://downloadirpf.receita.fazenda.gov.br/irpf/${year}/irpf/arquivos/IRPF${finalAttrs.version}.zip";
-      hash = "sha256-Zw/QtmbINCV1VPz52KCxam+WFgkh8Kjz1v0e7oVeZCs=";
+      hash = "sha256-5CX+HaIfQRoeWQHvXTGBhqRAaCM7UH2Duq8+6+3Ai7o=";
     };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!-- Nixpkgs PR template -->

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For new packages: please use `nix-shell -p nixpkgs-review --run "nixpkgs-review pr"` (n/a — version bump, but local `nix-build -A irpf` succeeded and the resulting binary launches normally)
- [x] Tested, as applicable:
  - [x] `nix-build -A irpf` from this branch (builds and installs cleanly)
  - [x] Launched the resulting `irpf` binary
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"` (n/a — leaf package, no reverse dependencies)
- [x] Determined the impact on package closure size (no meaningful change — same upstream layout, just a newer zip)
- [x] Ensured that relevant documentation is up to date
- [x] Fits CONTRIBUTING.md

## Summary

Atualiza o pacote `irpf` (Imposto de Renda Pessoa Física, da Receita Federal do Brasil) da versão `2026-1.2` para `2026-1.3`, a versão mais recente publicada em https://www.gov.br/receitafederal/pt-br/centrais-de-conteudo/download/pgd/dirpf.

Apenas mudaram `version` e o `hash` do `fetchzip` — nenhuma outra alteração no derivation foi necessária.

cc @rafaelrc (maintainer)