### PR TITLE
limine: 12.3.1 -> 12.3.2

### DIFF
--- a/pkgs/by-name/li/limine/package.nix
+++ b/pkgs/by-name/li/limine/package.nix
@@ -101,15 +101,19 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.unix;
     badPlatforms = lib.platforms.darwin;
     # Caution. Some submodules have different licenses.
-    license = with lib.licenses; [
-      asl20 # cc-runtime
-      bsd0 # freestanding-headers, freestanding-toolchain, limine-protocol, pdgzip
-      bsd2 # limine, flanterm, libfdt, PicoEFI
-      bsd2Patent # PicoEFI
-      bsd3 # PicoEFI
-      bsdAxisNoDisclaimerUnmodified # PicoEFI
-      mit # PicoEFI, stb_image
-    ];
+    license =
+      with lib.licenses;
+      AND [
+        asl20 # cc-runtime
+        bsd0 # freestanding-headers, freestanding-toolchain, limine-protocol, pdgzip
+        bsd2 # limine, flanterm, libfdt, PicoEFI
+        (OR [
+          bsd2Patent # PicoEFI
+          bsd3 # PicoEFI
+          bsdAxisNoDisclaimerUnmodified # PicoEFI
+        ])
+        mit # PicoEFI, stb_image
+      ];
     maintainers = with lib.maintainers; [
       johnrtitor
       lzcunt

--- a/pkgs/by-name/li/limine/package.nix
+++ b/pkgs/by-name/li/limine/package.nix
@@ -47,14 +47,14 @@ in
 # as bootloader for various platforms and corresponding binary and helper files.
 stdenv.mkDerivation (finalAttrs: {
   pname = "limine";
-  version = "12.3.1";
+  version = "12.3.2";
 
   # We don't use the Git source but the release tarball, as the source has a
   # `./bootstrap` script performing network access to download resources.
   # Packaging that in Nix is very cumbersome.
   src = fetchurl {
     url = "https://github.com/Limine-Bootloader/Limine/releases/download/v${finalAttrs.version}/limine-${finalAttrs.version}.tar.gz";
-    hash = "sha256-orkotxbusV4giozDLkUZuLZAHNS4GZnfj+EXi5tSRWU=";
+    hash = "sha256-xQUoMQbq3fpbvFbYwbHPMz0SZU3LN/gOaF01duhwKGU=";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
https://github.com/Limine-Bootloader/Limine/releases/tag/v12.3.2
Diff: https://github.com/Limine-Bootloader/Limine/compare/v12.3.1...v12.3.2

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
