### PR TITLE
postgresql: 17 -> 18

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -4,7 +4,7 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Create the first release note entry in this section!
+- The default PostgreSQL version for new NixOS installations (i.e. with `system.stateVersion >= 26.11`) is v18.
 
 ## New Modules {#sec-release-26.11-new-modules}
 

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -204,7 +204,9 @@ in
         type = types.package;
         example = literalExpression "pkgs.postgresql_15";
         defaultText = literalExpression ''
-          if versionAtLeast config.system.stateVersion "25.11" then
+          if versionAtLeast config.system.stateVersion "26.11" then
+            pkgs.postgresql_18
+          else if versionAtLeast config.system.stateVersion "25.11" then
             pkgs.postgresql_17
           else if versionAtLeast config.system.stateVersion "24.11" then
             pkgs.postgresql_16
@@ -657,7 +659,9 @@ in
           '';
         base =
           # XXX Don't forget to keep `defaultText` of `services.postgresql.package` up to date!
-          if versionAtLeast config.system.stateVersion "25.11" then
+          if versionAtLeast config.system.stateVersion "26.11" then
+            pkgs.postgresql_18
+          else if versionAtLeast config.system.stateVersion "25.11" then
             pkgs.postgresql_17
           else if versionAtLeast config.system.stateVersion "24.11" then
             pkgs.postgresql_16

--- a/pkgs/by-name/pg/pgcopydb/package.nix
+++ b/pkgs/by-name/pg/pgcopydb/package.nix
@@ -17,13 +17,13 @@
 
 clangStdenv.mkDerivation (finalAttrs: {
   pname = "pgcopydb";
-  version = "0.17";
+  version = "0.17-unstable-2026-05-21";
 
   src = fetchFromGitHub {
     owner = "dimitri";
     repo = "pgcopydb";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-g5MC4F0BYgTimpJZDX+PepFLXv1QuH7XGlzV66xM11M=";
+    rev = "984269274ccdaf0d297ed82db635e6746be55b75";
+    hash = "sha256-qTtziRdsge4YtQTTfWQ5KD8SQn2HYnj3rDMcrbI56SY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pg/pgcopydb/package.nix
+++ b/pkgs/by-name/pg/pgcopydb/package.nix
@@ -31,18 +31,11 @@ clangStdenv.mkDerivation (finalAttrs: {
     postgresql.pg_config
   ];
 
-  buildInputs = [
+  buildInputs = postgresql.buildInputs ++ [
     boehmgc
-    libkrb5
-    openssl
     postgresql
-    readline
     sqlite
-    zlib
     python3Packages.sphinxHook
-  ]
-  ++ lib.optionals clangStdenv.hostPlatform.isLinux [
-    pam
   ];
 
   hardeningDisable = [ "format" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8096,8 +8096,8 @@ with pkgs;
     postgresql_17_jit
     postgresql_18_jit
     ;
-  postgresql = postgresql_17;
-  postgresql_jit = postgresql_17_jit;
+  postgresql = postgresql_18;
+  postgresql_jit = postgresql_18_jit;
   postgresqlPackages = recurseIntoAttrs postgresql.pkgs;
   postgresql14Packages = recurseIntoAttrs postgresql_14.pkgs;
   postgresql15Packages = recurseIntoAttrs postgresql_15.pkgs;


### PR DESCRIPTION
Now that 26.05 is branched off, we should bump PostgreSQL's default version to v18.

## Things done

- Built on platform:
  - [x] aarch64-linux
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- NixOS Release Notes
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
