### PR TITLE
python3Packages.ziglang: init at 0.16.0, python3Packages.scrapli: init at 2.0.0-rc.7, python3Packages.scrapli-netconf: init at 2026.01.12, python3Packages.dimi: init at 1.5.0, netboxPlugins.netbox-validity: init at 3.5.0

### DIFF
--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-validity/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-validity/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  netbox,
+  python,
+
+  boto3,
+  deepdiff,
+  dimi,
+  django-bootstrap5,
+  dulwich,
+  jq,
+  netmiko,
+  pydantic,
+  scrapli-netconf,
+  simpleeval,
+  textfsm,
+  ttp,
+  xmltodict,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "netbox-validity";
+  version = "3.5.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "amyasnikov";
+    repo = "validity";
+    tag = finalAttrs.version;
+    hash = "sha256-LKuyzO1CXAHCspT4AhHkK0NH3RelL/kGBXFOdaKHlOU=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonRelaxDeps = [
+    "django-bootstrap5"
+    "simpleeval"
+    "textfsm"
+    "xmltodict"
+  ];
+
+  dependencies = [
+    boto3
+    deepdiff
+    dimi
+    django-bootstrap5
+    dulwich
+    jq
+    netmiko
+    pydantic
+    simpleeval
+    scrapli-netconf
+    textfsm
+    ttp
+    xmltodict
+  ];
+
+  nativeCheckInputs = [ netbox ];
+
+  preFixup = ''
+    export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH
+  '';
+
+  dontUsePythonImportsCheck = python.pythonVersion != netbox.python.pythonVersion;
+
+  pythonImportsCheck = [ "validity" ];
+
+  passthru.pluginName = "validity";
+
+  meta = {
+    description = "NetBox plugin to validate network devices";
+    homepage = "https://github.com/amyasnikov/validity";
+    changelog = "https://github.com/amyasnikov/validity/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/development/python-modules/dimi/default.nix
+++ b/pkgs/development/python-modules/dimi/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  pytestCheckHook,
+  anyio,
+  pytest-asyncio,
+  pytest-tornasync,
+  pytest-trio,
+  pytest-twisted,
+  twisted,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "dimi";
+  version = "1.5.0";
+  format = "pyproject";
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-eJ9y1gGx3aCqJ1Q5+/7PPvJ9oiUYB6HyggK63bK/DTw=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "dimi" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    anyio
+    pytest-asyncio
+    pytest-tornasync
+    pytest-trio
+    pytest-twisted
+    twisted
+  ];
+
+  # TODO investigate, seams to require some fixtures, not sure where to get them from
+  disabledTestPaths = [
+    "tests/test_di.py"
+    "tests/test_integrations.py"
+    "tests/test_use_cases.py"
+    "tests/test_utils.py"
+  ];
+
+  meta = {
+    description = "Minimalistic Dependency Injection for Python";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/development/python-modules/scrapli-netconf/default.nix
+++ b/pkgs/development/python-modules/scrapli-netconf/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+  lxml,
+  scrapli,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "scrapli-netconf";
+  version = "2026.01.12";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "scrapli";
+    repo = "scrapli_netconf";
+    tag = finalAttrs.version;
+    hash = "sha256-ob4CBNF5gIJsSdMRosNA7temkPNVQRT7winFq3ghejo";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonRemoveDeps = [ "scrapli" ];
+
+  dependencies = [
+    scrapli
+    lxml
+  ];
+
+  pythonImportCheck = [ "scrapli_netconf" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  # TODO investigate
+  doCheck = false;
+
+  meta = {
+    description = "Fast and flexible Python 3.7+ netconf client specifically for network devices";
+    homepage = "https://scrapli.github.io/scrapli_netconf/";
+    changelog = "https://github.com/scrapli/scrapli_netconf/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/development/python-modules/scrapli/default.nix
+++ b/pkgs/development/python-modules/scrapli/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+  ziglang,
+  pytest-asyncio,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "scrapli";
+  version = "2.0.0-rc.7";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "carlmontanari";
+    repo = "scrapli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Yq06QxeFxr1A2cqetmIw/MRVvcwM6h7BBKr4ehzVk9o=";
+  };
+
+  preBuild = ''
+    substituteInPlace setup.py --replace-fail '"bdist_wheel": LibscrapliBdist,' ""
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [ ziglang ];
+
+  pythonImportCheck = "scrapli";
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+  ];
+
+  # TODO investigate
+  doCheck = false;
+
+  meta = {
+    description = "Fast, flexible, sync/async, Python 3.10+ screen scraping client specifically for network devices";
+    homepage = "https://github.com/carlmontanari/scrapli";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/development/python-modules/ziglang/default.nix
+++ b/pkgs/development/python-modules/ziglang/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "ziglang";
+  version = "0.16.0";
+  format = "wheel";
+  __structuredAttrs = true;
+
+  # not sure how to build this from source: https://codeberg.org/ziglang/zig https://codeberg.org/ziglang/zig-pypi
+  src = fetchPypi {
+    inherit pname version format;
+    hash = "sha256-n82nP2K4Ud1ypUtxCtQKIJiW2xTPsTZJ5iGRJDVWNCs=";
+    dist = "py3";
+    python = "py3";
+    platform = "manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64";
+  };
+
+  build-system = [ setuptools ];
+
+  meta = {
+    description = "Zig is a general-purpose programming language and toolchain for maintaining robust, optimal, and reusable software";
+    homepage = "https://ziglang.org/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3958,6 +3958,8 @@ self: super: with self; {
 
   dill = callPackage ../development/python-modules/dill { };
 
+  dimi = callPackage ../development/python-modules/dimi { };
+
   dinghy = callPackage ../development/python-modules/dinghy { };
 
   dingz = callPackage ../development/python-modules/dingz { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17637,6 +17637,8 @@ self: super: with self; {
 
   scrapli = callPackage ../development/python-modules/scrapli { };
 
+  scrapli-netconf = callPackage ../development/python-modules/scrapli-netconf { };
+
   scrapy = callPackage ../development/python-modules/scrapy { };
 
   scrapy-deltafetch = callPackage ../development/python-modules/scrapy-deltafetch { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17635,6 +17635,8 @@ self: super: with self; {
 
   scrap-engine = callPackage ../development/python-modules/scrap-engine { };
 
+  scrapli = callPackage ../development/python-modules/scrapli { };
+
   scrapy = callPackage ../development/python-modules/scrapy { };
 
   scrapy-deltafetch = callPackage ../development/python-modules/scrapy-deltafetch { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21912,6 +21912,8 @@ self: super: with self; {
 
   zict = callPackage ../development/python-modules/zict { };
 
+  ziglang = callPackage ../development/python-modules/ziglang { };
+
   ziggo-mediabox-xl = callPackage ../development/python-modules/ziggo-mediabox-xl { };
 
   zigpy = callPackage ../development/python-modules/zigpy { };


### PR DESCRIPTION
Work in progress, not sure how to handle ziglang... Building this from source seams to be too complicated, just to get the python mappings, but I think we can't have multi architecture support without it :(

Also for scrapli* I cannot get the tests running, I'm not even sure this works as intended.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
