### PR TITLE
python3Packages.geoarrow-rust: fix the failing tests

### DIFF
--- a/pkgs/development/python-modules/geoarrow-rust/default.nix
+++ b/pkgs/development/python-modules/geoarrow-rust/default.nix
@@ -8,18 +8,18 @@
   obstore,
 
   # tests
-  pyarrow,
-  pyproj,
+  arro3-compute,
+  arro3-io,
+  geoarrow-types,
+  geodatasets,
+  geopandas,
   numpy,
   pandas,
-  geoarrow-types,
-  geopandas,
-  geodatasets,
-  shapely,
+  pyarrow,
   pyogrio,
+  pyproj,
   pytest-asyncio,
-  arro3-io,
-  arro3-compute,
+  shapely,
 }:
 let
   version = "0.6.1";
@@ -110,8 +110,8 @@ let
     pythonImportsCheck = [ "geoarrow.rust.io" ];
     dependencies = [
       arro3-core
-      pyproj
       obstore
+      pyproj
     ];
   };
 
@@ -124,21 +124,21 @@ let
     dontInstall = true;
 
     nativeCheckInputs = [
-      pytestCheckHook
-      pytest-asyncio
-      geoarrow-types
-      pandas
-      pyarrow
-      numpy
-      geopandas
-      geodatasets
-      shapely
-      pyogrio
-      obstore
-      arro3-io
       arro3-compute
+      arro3-io
       geoarrow-rust-core
       geoarrow-rust-io
+      geoarrow-types
+      geodatasets
+      geopandas
+      numpy
+      obstore
+      pandas
+      pyarrow
+      pyogrio
+      pytest-asyncio
+      pytestCheckHook
+      shapely
     ];
 
     # use the latest test folder (skips the tests_old folder)

--- a/pkgs/development/python-modules/geoarrow-rust/default.nix
+++ b/pkgs/development/python-modules/geoarrow-rust/default.nix
@@ -5,11 +5,21 @@
   rustPlatform,
   pytestCheckHook,
   arro3-core,
+  obstore,
+
+  # tests
   pyarrow,
   pyproj,
   numpy,
   pandas,
   geoarrow-types,
+  geopandas,
+  geodatasets,
+  shapely,
+  pyogrio,
+  pytest-asyncio,
+  arro3-io,
+  arro3-compute,
 }:
 let
   version = "0.6.1";
@@ -101,6 +111,7 @@ let
     dependencies = [
       arro3-core
       pyproj
+      obstore
     ];
   };
 
@@ -114,15 +125,39 @@ let
 
     nativeCheckInputs = [
       pytestCheckHook
+      pytest-asyncio
       geoarrow-types
       pandas
       pyarrow
       numpy
+      geopandas
+      geodatasets
+      shapely
+      pyogrio
+      obstore
+      arro3-io
+      arro3-compute
       geoarrow-rust-core
       geoarrow-rust-io
     ];
 
-    pytestFlags = [ "python" ];
+    # use the latest test folder (skips the tests_old folder)
+    pytestFlags = [ "python/tests" ];
+
+    disabledTests = [
+      # require internet access to download datasets
+      "test_parse_nybb"
+      "test_parse_nybb_chunked"
+      "test_getitem"
+      "test_geo_interface_polygon"
+      "test_parquet_file"
+    ];
+
+    # fix the directory name, as it is named as source for nix build
+    postPatch = ''
+      substituteInPlace python/tests/utils.py \
+        --replace-fail 'while current_dir.stem != "geoarrow-rs":' 'while current_dir.stem != "source":'
+    '';
   };
 in
 {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

The `passthru.tests` seemed to be failing. https://github.com/NixOS/nixpkgs/pull/522234#issuecomment-4530681755
- Add the missing dependencies for the tests
- Also added obstore as a runtime dependency as it was missing 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
