### PR TITLE
luaPackages.lgi: Backport fix for GLib 2.88

### DIFF
--- a/pkgs/development/lua-modules/lgi/glib-2.88.patch
+++ b/pkgs/development/lua-modules/lgi/glib-2.88.patch
@@ -1,0 +1,146 @@
+At time of writing this is equivalent to https://github.com/lgi-devs/lgi/pull/361.patch?full_index=1
+The only difference is that this diff does not include the *tests/progress.lua* changes since that file does not exist in the source used by *nixpkgs*.
+
+--- a/lgi/ffi.lua
++++ b/lgi/ffi.lua
+@@ -74,19 +74,39 @@
+ end
+ 
+ -- Creates new enum/flags table with all values from specified gtype.
++--
++-- Fixes https://github.com/lgi-devs/lgi/issues/358
++--
++-- Implementation for the fix was mirrored from the LGI fork:
++--   https://github.com/vtrlx/LuaGObject/blob/0.10.5/LuaGObject/ffi.lua#L74-L104
+ function ffi.load_enum(gtype, name)
+-   local GObject = core.repo.GObject
++   local GLib, GObject = core.repo.GLib, core.repo.GObject
+    local is_flags = GObject.Type.is_a(gtype, GObject.Type.FLAGS)
+    local enum_component = component.create(
+       gtype, is_flags and enum.bitflags_mt or enum.enum_mt, name)
+-   local type_class = GObject.TypeClass.ref(gtype)
++   local type_class
++   -- GLib >= 2.86 deprecates GObject.TypeClass.ref() in favour of .get()
++   if GLib.check_version(2, 86, 0) then
++      type_class = GObject.TypeClass.ref(gtype)
++   else
++      type_class = GObject.TypeClass.get(gtype)
++   end
+    local enum_class = core.record.cast(
+       type_class, is_flags and GObject.FlagsClass or GObject.EnumClass)
+-   for i = 0, enum_class.n_values - 1 do
+-      local val = core.record.fromarray(enum_class.values, i)
+-      enum_component[core.upcase(val.value_nick):gsub('%-', '_')] = val.value
++   if GLib.check_version(2, 87, 0) then
++      for i = 0, enum_class.n_values - 1 do
++         local val = core.record.fromarray(enum_class.values, i)
++         enum_component[core.upcase(val.value_nick):gsub('%-', '_')] = val.value
++      end
++   else
++      for _, val in ipairs(enum_class.values) do
++         enum_component[core.upcase(val.value_nick):gsub('%-', '_')] = val.value
++      end
++   end
++   -- For GLib versions below 2.86, type_class was ref'd and needs to be unref'd
++   if GLib.check_version(2, 86, 0) then
++      type_class:unref()
+    end
+-   type_class:unref()
+    return enum_component
+ end
+ 
+--- a/lgi/ffi.lua
++++ b/lgi/ffi.lua
+@@ -74,18 +74,12 @@
+ end
+ 
+ -- Creates new enum/flags table with all values from specified gtype.
+---
+--- Fixes https://github.com/lgi-devs/lgi/issues/358
+---
+--- Implementation for the fix was mirrored from the LGI fork:
+---   https://github.com/vtrlx/LuaGObject/blob/0.10.5/LuaGObject/ffi.lua#L74-L104
+ function ffi.load_enum(gtype, name)
+    local GLib, GObject = core.repo.GLib, core.repo.GObject
+    local is_flags = GObject.Type.is_a(gtype, GObject.Type.FLAGS)
+    local enum_component = component.create(
+       gtype, is_flags and enum.bitflags_mt or enum.enum_mt, name)
+    local type_class
+-   -- GLib >= 2.86 deprecates GObject.TypeClass.ref() in favour of .get()
+    if GLib.check_version(2, 86, 0) then
+       type_class = GObject.TypeClass.ref(gtype)
+    else
+@@ -103,7 +97,6 @@
+          enum_component[core.upcase(val.value_nick):gsub('%-', '_')] = val.value
+       end
+    end
+-   -- For GLib versions below 2.86, type_class was ref'd and needs to be unref'd
+    if GLib.check_version(2, 86, 0) then
+       type_class:unref()
+    end
+--- a/lgi/ffi.lua
++++ b/lgi/ffi.lua
+@@ -80,6 +80,7 @@
+    local enum_component = component.create(
+       gtype, is_flags and enum.bitflags_mt or enum.enum_mt, name)
+    local type_class
++   -- GLib >= 2.86 deprecates GObject.TypeClass.ref() in favour of .get()
+    if GLib.check_version(2, 86, 0) then
+       type_class = GObject.TypeClass.ref(gtype)
+    else
+@@ -97,6 +98,7 @@
+          enum_component[core.upcase(val.value_nick):gsub('%-', '_')] = val.value
+       end
+    end
++   -- For GLib versions below 2.86, type_class was ref'd and needs to be unref'd
+    if GLib.check_version(2, 86, 0) then
+       type_class:unref()
+    end
+--- a/tests/pango.lua
++++ b/tests/pango.lua
+@@ -35,8 +35,24 @@
+       local offset = items[i].offset
+       local length = items[i].length
+       local analysis = items[i].analysis
+-      local pgs = Pango.GlyphString()
+-      Pango.shape(string.sub(s,1+offset), length, analysis, pgs)
++      --
++      -- Fixes https://github.com/lgi-devs/lgi/issues/336
++      --
++      -- Implementation for the fix was a combination
++      -- of ideas from:
++      --
++      -- 1) my own investigation plus trial-error
++      -- 2) the comment: https://github.com/lgi-devs/lgi/issues/336#issuecomment-2888361271
++      -- 3) the LGI fork: https://github.com/vtrlx/LuaGObject/blob/0.10.5/tests/pango.lua#L38-L39
++      --
++      local pgs
++      if Pango.version_check(1, 56, 2) then
++         pgs = Pango.GlyphString()
++         Pango.shape(string.sub(s,1+offset), length, analysis, pgs)
++      else
++         pgs = Pango.shape(string.sub(s,1+offset), length, analysis)
++      end
++
+       -- Pull out individual glyphs with pgs.glyphs
+       local glyphs = pgs.glyphs
+       check(type(glyphs) == 'table')
+--- a/tests/pango.lua
++++ b/tests/pango.lua
+@@ -35,16 +35,6 @@
+       local offset = items[i].offset
+       local length = items[i].length
+       local analysis = items[i].analysis
+-      --
+-      -- Fixes https://github.com/lgi-devs/lgi/issues/336
+-      --
+-      -- Implementation for the fix was a combination
+-      -- of ideas from:
+-      --
+-      -- 1) my own investigation plus trial-error
+-      -- 2) the comment: https://github.com/lgi-devs/lgi/issues/336#issuecomment-2888361271
+-      -- 3) the LGI fork: https://github.com/vtrlx/LuaGObject/blob/0.10.5/tests/pango.lua#L38-L39
+-      --
+       local pgs
+       if Pango.version_check(1, 56, 2) then
+          pgs = Pango.GlyphString()

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -303,13 +303,10 @@ in
         sha256 = "0gfvvbri9kyzhvq3bvdbj2l6mwvlz040dk4mrd5m9gz79f7w109c";
       })
 
-      # https://github.com/lgi-devs/lgi/issues/346
-      # https://gitlab.archlinux.org/archlinux/packaging/packages/lgi/-/issues/1
-      (fetchpatch {
-        name = "glib-2.86.0.patch";
-        url = "https://gitlab.archlinux.org/archlinux/packaging/packages/lgi/-/raw/05a0c9df75883da235bacd4379b769e7d7713fb9/0001-Use-TypeClass.get-instead-of-.ref.patch";
-        hash = "sha256-Z1rNv0VzVrK41rV73KiPXq9yLaNxbTOFiSd6eLZyrbY=";
-      })
+      # https://github.com/lgi-devs/lgi/issues/362
+      # https://github.com/lgi-devs/lgi/pull/361
+      # https://github.com/NixOS/nixpkgs/issues/523345
+      ./lgi/glib-2.88.patch
     ];
 
     # https://github.com/lgi-devs/lgi/pull/300


### PR DESCRIPTION
This replaces the earlier 2.86 patch.
One may consider bumping the source to something newer than the 8 year old release, but that's out of scope for this fix.

---

Links:

- Fixes #523345 
- https://github.com/lgi-devs/lgi/issues/362
- https://github.com/lgi-devs/lgi/pull/361
- ZHF: #516381

Vendored because the PR isn't merged yet (at time of writing).
Tested by cherry-picking on top of current *nixos-unstable* and running *awesome* (the window manager), so it should work in practice, anyone running *nixpkgs-review* would be appreciated tho.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
