### PR TITLE
karere: 2.5.5 -> 3.1.1

### DIFF
--- a/pkgs/by-name/ka/karere/package.nix
+++ b/pkgs/by-name/ka/karere/package.nix
@@ -2,57 +2,72 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  rustPlatform,
+  cargo,
   meson,
   ninja,
   pkg-config,
-  cargo,
+  rustPlatform,
   rustc,
   wrapGAppsHook4,
   blueprint-compiler,
   desktop-file-utils,
-  appstream,
-  gtk4,
   libadwaita,
   webkitgtk_6_0,
   glib-networking,
+  gst_all_1,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "karere";
-  version = "2.5.5";
+  version = "3.1.1";
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "tobagin";
     repo = "karere";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-cR4+nZvz7ELy9/POX9yZiryVcCcpC63mFhZ6kvR33i8=";
+    hash = "sha256-VJGTpkMkYKvU/I/DoyBMD9deciLzmrs48If1wQutvnE=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-h51B8iGiMWHbHogJSAKdm27QDBPzlrkCxlYOj9T4SuI=";
+    hash = "sha256-48ai2Jf/Uo+sXsT78v4usVEAn1zV/YVz4FZZs2ZZDa8=";
   };
 
   nativeBuildInputs = [
+    cargo
     meson
     ninja
     pkg-config
-    cargo
-    rustc
     rustPlatform.cargoSetupHook
+    rustc
     wrapGAppsHook4
     blueprint-compiler
     desktop-file-utils
-    appstream
   ];
 
   buildInputs = [
-    gtk4
     libadwaita
     webkitgtk_6_0
     glib-networking
-  ];
+  ]
+  ++ (with gst_all_1; [
+    gstreamer
+    gst-plugins-base
+    gst-plugins-good
+    gst-plugins-bad
+    gst-libav
+  ]);
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --set FLATPAK_ID io.github.tobagin.karere
+    )
+  '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Gtk4 Whatsapp client";


### PR DESCRIPTION
Diff: https://github.com/tobagin/karere/compare/v2.5.5...v3.1.1

Changelog: https://github.com/tobagin/karere/blob/refs/tags/v3.1.1/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
