### PR TITLE
microsandbox: init at 0.4.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5467,6 +5467,11 @@
     githubId = 6487079;
     name = "Dane Rieber";
   };
+  conao3 = {
+    github = "conao3";
+    githubId = 4703128;
+    name = "Naoya Yamashita";
+  };
   conduktorbot = {
     email = "automation@conduktor.io";
     github = "conduktorbot";

--- a/pkgs/by-name/mi/microsandbox/package.nix
+++ b/pkgs/by-name/mi/microsandbox/package.nix
@@ -1,0 +1,86 @@
+{
+  autoPatchelfHook,
+  fetchurl,
+  lib,
+  libcap_ng,
+  stdenv,
+  versionCheckHook,
+}:
+
+let
+  sources = {
+    "x86_64-linux" = {
+      url = "https://github.com/superradcompany/microsandbox/releases/download/v0.4.6/microsandbox-linux-x86_64.tar.gz";
+      hash = "sha256-gCb8yykJBNJ8Y0v19hhdOPu+UVyUEoHkZ2fQ93Jvbac=";
+    };
+    "aarch64-linux" = {
+      url = "https://github.com/superradcompany/microsandbox/releases/download/v0.4.6/microsandbox-linux-aarch64.tar.gz";
+      hash = "sha256-5LFHqCfSlbGJVPMJQkjaNLSdf+8neguahElpUkHNRtM=";
+    };
+  };
+
+  source =
+    sources.${stdenv.hostPlatform.system}
+      or (throw "microsandbox: unsupported platform ${stdenv.hostPlatform.system}");
+
+  libkrunfwVersion = "5.2.1";
+  libkrunfwAbi = "5";
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "microsandbox";
+  version = "0.4.6";
+
+  src = fetchurl {
+    inherit (source) url hash;
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  buildInputs = [
+    libcap_ng
+    stdenv.cc.cc.lib
+  ];
+
+  sourceRoot = ".";
+
+  appendRunpaths = [ "${placeholder "out"}/lib" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 msb -t $out/bin
+    ln -s msb $out/bin/microsandbox
+
+    install -Dm644 libkrunfw.so.${libkrunfwVersion} -t $out/lib
+    ln -s libkrunfw.so.${libkrunfwVersion} $out/lib/libkrunfw.so.${libkrunfwAbi}
+    ln -s libkrunfw.so.${libkrunfwAbi} $out/lib/libkrunfw.so
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/msb";
+  versionCheckProgramArg = "--version";
+
+  meta = {
+    description = "Self-hostable sandbox for running untrusted code in microVMs";
+    longDescription = ''
+      Microsandbox launches OCI-compatible images inside microVMs backed by
+      libkrun, providing kernel-level isolation while keeping startup times
+      comparable to containers. It exposes a JSON-RPC API and a Model
+      Context Protocol server so AI agents and other automation can spin
+      up sandboxed environments on demand.
+    '';
+    homepage = "https://microsandbox.dev/";
+    changelog = "https://github.com/superradcompany/microsandbox/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    mainProgram = "msb";
+    maintainers = with lib.maintainers; [ conao3 ];
+    platforms = lib.attrNames sources;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION

[microsandbox](https://microsandbox.dev/) is a self-hostable sandbox runtime that boots OCI-compatible images inside [libkrun](https://github.com/containers/libkrun) microVMs. It targets workloads where container isolation is insufficient — running AI-agent-generated code, executing untrusted user submissions, providing interactive code interpreters — by giving each sandbox its own guest kernel rather than sharing the host's, while keeping startup latency in the same order of magnitude as containers. The daemon (`microsandbox-server`) exposes both a JSON-RPC 2.0 API and a Model Context Protocol server, so MCP clients can drive sandbox lifecycle directly.

The upstream project distributes prebuilt release tarballs at <https://github.com/superradcompany/microsandbox/releases>, each containing the `msb` CLI and a versioned `libkrunfw.so` (Linux) or `.dylib` (Darwin). This package installs the `x86_64-linux` and `aarch64-linux` tarballs, runs `autoPatchelfHook` to bind the ELF against the nixpkgs glibc / libcap-ng / libgcc, and appends `$out/lib` to the runpath so `msb` finds the bundled `libkrunfw`. `aarch64-darwin` ships in the upstream releases as well; that platform is left out of this initial PR until a Darwin maintainer can verify the `install_name_tool` path.

License: Apache-2.0. Upstream is currently beta (rapid breaking changes), which is reflected by the source tag in `meta.sourceProvenance = [ binaryNativeCode ]` and the lack of a NixOS module.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] `versionCheckHook` (`msb --version`) wired up via `doInstallCheck`. Passes during `nix-build`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## Functional verification (x86_64-linux)

Beyond `versionCheckHook`, the binary was exercised end-to-end on NixOS 26.05 (KVM enabled):

- Booted a Nix-built rootfs (busybox + a `hello` shell script, generated via `dockerTools.buildLayeredImage` + layer extraction) with `msb run --no-net ./rootfs -- /bin/hello`.
- Guest `uname` reported Linux 6.12.68 (libkrun's bundled kernel), distinct from the host's 6.18.31, confirming the microVM boundary.
- `/etc/os-release` from the Nix-built rootfs surfaced correctly inside the guest.

## aarch64-linux note

The tarball hash is included and the file structure matches `x86_64-linux` (same `msb` + `libkrunfw.so.5.2.1` layout), so the same derivation logic should apply. I do not have aarch64-linux hardware to verify, so the platform checkbox above is intentionally left unchecked; a reviewer with such a machine — or `nixpkgs-review` — is encouraged to confirm before merge.

---
Assisted-by: Claude Code:claude-opus-4-7[1m]