### PR TITLE
treewide: don't accidentally package electron-dist into .asar file

### DIFF
--- a/pkgs/by-name/ca/caprine/package.nix
+++ b/pkgs/by-name/ca/caprine/package.nix
@@ -27,14 +27,15 @@ buildNpmPackage rec {
   nativeBuildInputs = [ copyDesktopItems ];
 
   postBuild = ''
-    cp -r ${electron.dist} electron-dist
-    chmod -R u+w electron-dist
+    electron_dist="$(mktemp -d)"
+    cp -r ${electron.dist}/. "$electron_dist"
+    chmod -R u+w "$electron_dist"
 
     npm exec electron-builder -- \
         --dir \
         -c.npmRebuild=true \
         -c.asarUnpack="**/*.node" \
-        -c.electronDist=electron-dist \
+        -c.electronDist="$electron_dist" \
         -c.electronVersion=${electron.version}
   '';
 

--- a/pkgs/by-name/iv/ivpn-ui/package.nix
+++ b/pkgs/by-name/iv/ivpn-ui/package.nix
@@ -34,12 +34,13 @@ buildNpmPackage (finalAttrs: {
   };
 
   postBuild = ''
-    cp -r ${electron.dist} electron-dist
-    chmod -R u+w electron-dist
+    electron_dist="$(mktemp -d)"
+    cp -r ${electron.dist}/. "$electron_dist"
+    chmod -R u+w "$electron_dist"
 
     npm exec electron-builder -- \
       --dir \
-      -c.electronDist=electron-dist \
+      -c.electronDist="$electron_dist" \
       -c.electronVersion=${electron.version} \
       --config electron-builder.config.js
   '';

--- a/pkgs/by-name/mq/mqtt-explorer/package.nix
+++ b/pkgs/by-name/mq/mqtt-explorer/package.nix
@@ -86,8 +86,9 @@ stdenv.mkDerivation rec {
 
     patchShebangs {node_modules,app/node_modules,backend/node_modules}
 
-    cp -r ${electron.dist} electron-dist
-    chmod -R u+w electron-dist
+    electron_dist="$(mktemp -d)"
+    cp -r ${electron.dist}/. "$electron_dist"
+    chmod -R u+w "$electron_dist"
 
     runHook postConfigure
   '';
@@ -98,7 +99,7 @@ stdenv.mkDerivation rec {
     tsc && cd app && yarn --offline run build && cd ..
 
     yarn --offline run electron-builder --dir \
-      -c.electronDist=electron-dist \
+      -c.electronDist="$electron_dist" \
       -c.electronVersion=${electron.version}
 
     runHook postBuild
@@ -143,7 +144,7 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   checkPhase = ''
-    export ELECTRON_OVERRIDE_DIST_PATH=electron-dist/
+    export ELECTRON_OVERRIDE_DIST_PATH="$electron_dist"
 
     yarn test:app --offline
     yarn test:backend --offline

--- a/pkgs/by-name/re/repath-studio/package.nix
+++ b/pkgs/by-name/re/repath-studio/package.nix
@@ -16,8 +16,6 @@
   makeWrapper,
   replaceVars,
 
-  vulkan-loader,
-
   nixosTests,
 }:
 buildNpmPackage (finalAttrs: {
@@ -72,19 +70,13 @@ buildNpmPackage (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
-    # electronDist needs to be modifiable
-    cp -r ${electron.dist} electron-dist
-    chmod -R u+w electron-dist
-  ''
-  # Electron builder complains about symlink in electron-dist
-  + lib.optionalString stdenv.hostPlatform.isLinux ''
-    rm electron-dist/libvulkan.so.1
-    cp ${lib.getLib vulkan-loader}/lib/libvulkan.so.1 electron-dist
-  ''
-  + ''
+    electron_dist="$(mktemp -d)"
+    cp -r ${electron.dist}/. "$electron_dist"
+    chmod -R u+w "$electron_dist"
+
     npm run build
     npm exec electron-builder -- --dir \
-      -c.electronDist=electron-dist \
+      -c.electronDist="$electron_dist" \
       -c.electronVersion=${electron.version}
 
     runHook postBuild
@@ -123,7 +115,7 @@ buildNpmPackage (finalAttrs: {
   doCheck = stdenv.hostPlatform.isLinux;
   checkPhase = ''
     runHook preCheck
-    export ELECTRON_OVERRIDE_DIST_PATH=electron-dist/
+    export ELECTRON_OVERRIDE_DIST_PATH="$electron_dist"
     export PUPPETEER_EXECUTABLE_PATH=${chromium}/bin/chromium
     export CHROME_BIN=${chromium}/bin/chromium
     npm run test

--- a/pkgs/by-name/sh/shogihome/package.nix
+++ b/pkgs/by-name/sh/shogihome/package.nix
@@ -5,7 +5,6 @@
   fetchFromGitHub,
   makeWrapper,
   electron_40,
-  vulkan-loader,
   makeDesktopItem,
   copyDesktopItems,
   commandLineArgs ? [ ],
@@ -67,16 +66,11 @@ buildNpmPackage (finalAttrs: {
 
     cp -r ${electron.dist} electron-dist
     chmod -R u+w electron-dist
-  ''
-  # Electron builder complains about symlink in electron-dist
-  + lib.optionalString stdenv.hostPlatform.isLinux ''
-    rm electron-dist/libvulkan.so.1
-    cp '${lib.getLib vulkan-loader}/lib/libvulkan.so.1' electron-dist
-  ''
-  # Explicitly set identity to null to avoid signing on arm64 macs with newer electron-builder.
-  # See: https://github.com/electron-userland/electron-builder/pull/9007
-  + ''
+
     npm run electron:pack
+
+    # Explicitly set identity to null to avoid signing on arm64 macs with newer electron-builder.
+    # See: https://github.com/electron-userland/electron-builder/pull/9007
 
     ./node_modules/.bin/electron-builder \
         --dir \

--- a/pkgs/by-name/te/teams-for-linux/package.nix
+++ b/pkgs/by-name/te/teams-for-linux/package.nix
@@ -10,7 +10,6 @@
   makeWrapper,
   nix-update-script,
   versionCheckHook,
-  vulkan-loader,
   which,
 }:
 
@@ -46,21 +45,15 @@ buildNpmPackage rec {
   buildPhase = ''
     runHook preBuild
 
-    cp -r ${electron_41.dist} electron-dist
-    chmod -R u+w electron-dist
-  ''
-  # Electron builder complains about symlink in electron-dist
-  + lib.optionalString stdenv.hostPlatform.isLinux ''
-    rm electron-dist/libvulkan.so.1
-    cp ${lib.getLib vulkan-loader}/lib/libvulkan.so.1 electron-dist
-  ''
-  + ''
+    electron_dist="$(mktemp -d)"
+    cp -r ${electron_41.dist}/. "$electron_dist"
+    chmod -R u+w "$electron_dist"
 
     npm exec electron-builder -- \
         --dir \
         -c.npmRebuild=true \
         -c.asarUnpack="**/*.node" \
-        -c.electronDist=electron-dist \
+        -c.electronDist="$electron_dist" \
         -c.electronVersion=${electron_41.version} \
         -c.mac.identity=null
 


### PR DESCRIPTION
Packages using `electron-builder` with an config where the `file` option is empty or only consists of blacklists will accidentally include the electron-dist directory that's created in the working directory.

Some packages already discovered this because `electron-builder` complains if the .asar file includes symlinks.
They handled it (wrongly) by just replacing the symlink with the original.

Instead, the better solution would have been to just create the directory passed to -c.electronDist to be outside of the working directory.

A few packages already do this, they put the `.electron-dist` directory inside `$HOME`, but this requires the `writableTmpDirAsHomeHook`, which is overkill IMO.

So instead I opted to use `mktemp -d` directly.

In packages where the symlink workaround was no longer needed, I removed it.

---

In the future, I was thinking of creating some helper scripts for e.g. creating an unpacked, writable electron.dist, or creating a zipped writable electron.dist so that the repetition can be reduced.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
