### PR TITLE
warzone2100: for darwin :)

### DIFF
--- a/pkgs/by-name/wa/warzone2100/package.nix
+++ b/pkgs/by-name/wa/warzone2100/package.nix
@@ -224,6 +224,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
       fgaz
+      philocalyst
     ];
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/wa/warzone2100/package.nix
+++ b/pkgs/by-name/wa/warzone2100/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  fetchFromGitHub,
   fetchurl,
   cmake,
   ninja,
@@ -23,7 +24,6 @@
   freetype,
   harfbuzz,
   sqlite,
-  which,
   vulkan-headers,
   vulkan-loader,
   shaderc,
@@ -40,8 +40,6 @@
 }:
 
 let
-  pname = "warzone2100";
-
   sequences = fetchurl {
     url = "mirror://sourceforge/warzone2100/warzone2100/Videos/high-quality-en/sequences.wz";
     hash = "sha256-kP9VLKSnDiU34CfiLFCY6k7RvBG7f8lBOMbJQac9Kfo=";
@@ -49,12 +47,15 @@ let
 in
 
 stdenv.mkDerivation (finalAttrs: {
-  inherit pname;
+  pname = "warzone2100";
   version = "4.7.0";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/project/warzone2100/releases/${finalAttrs.version}/warzone2100_src.tar.xz";
-    hash = "sha256-le5NW4hoDqGxzyMLZ+qEAo4IokWLhGBayff7nrl8Tjc=";
+  src = fetchFromGitHub {
+    owner = "Warzone2100";
+    repo = "warzone2100";
+    rev = finalAttrs.version;
+    fetchSubmodules = true;
+    hash = "sha256-GZiBs+aUeRCFixSWJscG47W7Ypgz3mLPHtkNKr4nnvs=";
   };
 
   buildInputs = [
@@ -74,8 +75,6 @@ stdenv.mkDerivation (finalAttrs: {
     sqlite
     protobuf
     libzip
-  ]
-  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     vulkan-headers
     vulkan-loader
   ];
@@ -90,14 +89,37 @@ stdenv.mkDerivation (finalAttrs: {
     shaderc
   ];
 
-  postPatch = ''
-    substituteInPlace lib/exceptionhandler/dumpinfo.cpp \
-                      --replace '"which "' '"${which}/bin/which "'
-    substituteInPlace lib/exceptionhandler/exceptionhandler.cpp \
-                      --replace "which %s" "${which}/bin/which %s"
-    substituteInPlace CMakeLists.txt \
-      --replace-fail "CONFIGURE_WZ_COMPILER_WARNINGS()" ""
-  '';
+  postPatch =
+    let
+      cacheContent = lib.generators.toKeyValue { } {
+        VCS_TYPE = "git";
+        VCS_BASENAME = "warzone2100";
+        VCS_TAG = finalAttrs.version;
+        VCS_TAG_TAG_COUNT = 1;
+        VCS_FULL_HASH = "0000000000000000000000000000000000000000";
+        VCS_SHORT_HASH = "0000000";
+        VCS_WC_MODIFIED = 0;
+        VCS_REPO_IS_SHALLOW = 0;
+        VCS_COMMIT_COUNT = 0;
+        VCS_MOST_RECENT_TAGGED_VERSION = finalAttrs.version;
+        VCS_MOST_RECENT_TAGGED_VERSION_TAG_COUNT = 0;
+        VCS_COMMIT_COUNT_SINCE_MOST_RECENT_TAGGED_VERSION = 0;
+        VCS_COMMIT_COUNT_ON_MASTER_UNTIL_BRANCH = 0;
+        VCS_BRANCH_COMMIT_COUNT = 0;
+        VCS_MOST_RECENT_COMMIT_DATE = "2024-01-01";
+        VCS_MOST_RECENT_COMMIT_YEAR = "2024";
+      };
+    in
+    ''
+      printf '%s' '${cacheContent}' > build_tools/autorevision.cache
+
+      substituteInPlace CMakeLists.txt \
+        --replace-fail "CONFIGURE_WZ_COMPILER_WARNINGS()" ""
+
+      DOLLAR='$'
+      substituteInPlace 3rdparty/basis_universal_host_build/CMakeLists.txt \
+        --replace-fail "''${DOLLAR}{CMAKE_COMMAND} chdir" "''${DOLLAR}{CMAKE_COMMAND} -E chdir"
+    '';
 
   cmakeFlags = [
     "-DWZ_DISTRIBUTOR=NixOS"
@@ -111,8 +133,7 @@ stdenv.mkDerivation (finalAttrs: {
     #
     # Alternatively, we could have set CMAKE_INSTALL_BINDIR to "bin".
     "-DCMAKE_INSTALL_DATAROOTDIR=${placeholder "out"}/share"
-  ]
-  ++ lib.optional stdenv.hostPlatform.isDarwin "-P../configure_mac.cmake";
+  ];
 
   postInstall = lib.optionalString withVideos ''
     ln -sn ${sequences} $out/share/warzone2100/sequences.wz
@@ -132,6 +153,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
+    changelog = "https://github.com/Warzone2100/warzone2100/blob/${finalAttrs.version}/ChangeLog";
     description = "Free RTS game, originally developed by Pumpkin Studios";
     mainProgram = "warzone2100";
     longDescription = ''
@@ -151,8 +173,5 @@ stdenv.mkDerivation (finalAttrs: {
       fgaz
     ];
     platforms = lib.platforms.all;
-    # configure_mac.cmake tries to download stuff
-    # https://github.com/Warzone2100/warzone2100/blob/master/macosx/README.md
-    broken = stdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/by-name/wa/warzone2100/package.nix
+++ b/pkgs/by-name/wa/warzone2100/package.nix
@@ -24,11 +24,16 @@
   freetype,
   harfbuzz,
   sqlite,
+  which,
   vulkan-headers,
   vulkan-loader,
   shaderc,
   protobuf,
   libzip,
+
+  makeBinaryWrapper,
+
+  makeWrapper,
 
   testers,
   warzone2100,
@@ -86,8 +91,14 @@ stdenv.mkDerivation (finalAttrs: {
     p7zip
     asciidoctor
     gettext
+    makeBinaryWrapper
     shaderc
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    makeWrapper
   ];
+
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-fobjc-arc";
 
   postPatch =
     let
@@ -119,6 +130,10 @@ stdenv.mkDerivation (finalAttrs: {
       DOLLAR='$'
       substituteInPlace 3rdparty/basis_universal_host_build/CMakeLists.txt \
         --replace-fail "''${DOLLAR}{CMAKE_COMMAND} chdir" "''${DOLLAR}{CMAKE_COMMAND} -E chdir"
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      substituteInPlace src/CMakeLists.txt \
+        --replace-fail 'if(CMAKE_SYSTEM_NAME MATCHES "Darwin")' 'if(FALSE)'
     '';
 
   cmakeFlags = [
@@ -133,11 +148,49 @@ stdenv.mkDerivation (finalAttrs: {
     #
     # Alternatively, we could have set CMAKE_INSTALL_BINDIR to "bin".
     "-DCMAKE_INSTALL_DATAROOTDIR=${placeholder "out"}/share"
-  ];
-
-  postInstall = lib.optionalString withVideos ''
-    ln -sn ${sequences} $out/share/warzone2100/sequences.wz
+  ]
+  ++ lib.optional stdenv.hostPlatform.isDarwin ''
+    -DWZ_ENABLE_BACKEND_VULKAN=OFF
   '';
+
+  postInstall =
+    (lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+      wrapProgram $out/bin/warzone2100 \
+        --prefix PATH : ${lib.makeBinPath [ which ]}
+    '')
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      appBundle="$out/Applications/Warzone 2100.app"
+      mkdir -p "$appBundle/Contents/MacOS"
+      mkdir -p "$appBundle/Contents/Resources"
+
+      mv "$out/bin/warzone2100" "$appBundle/Contents/MacOS/Warzone 2100"
+
+      ln -s "$out/share/warzone2100" "$appBundle/Contents/Resources/data"
+      ln -s "$out/share/locale" "$appBundle/Contents/Resources/locale"
+      ln -s "$out/share/doc/warzone2100" "$appBundle/Contents/Resources/docs"
+      cp "$NIX_BUILD_TOP/$sourceRoot/platforms/macos/Resources/Warzone.icns" \
+        "$appBundle/Contents/Resources/Warzone.icns"
+
+      plist="$appBundle/Contents/Info.plist"
+      cp "$NIX_BUILD_TOP/$sourceRoot/platforms/macos/Resources/Warzone-Info.plist.in" "$plist"
+      substituteInPlace "$plist" \
+        --replace-fail '$(EXECUTABLE_NAME)' 'Warzone 2100' \
+        --replace-fail '$(PRODUCT_BUNDLE_IDENTIFIER)' 'net.wz2100.Warzone2100' \
+        --replace-fail '$(MACOSX_DEPLOYMENT_TARGET)' '14' \
+        --replace-fail '@WZINFO_CFBundleGetInfoString@' 'Warzone 2100 ${finalAttrs.version}' \
+        --replace-fail '@MAC_VERSION_NUMBER@' '${finalAttrs.version}' \
+        --replace-fail '@MAC_BUILD_NUMBER@' '${finalAttrs.version}' \
+        --replace-fail '@WZINFO_NSHumanReadableCopyright@' 'Copyright The Warzone 2100 Project' \
+        --replace-fail '@VCS_FULL_HASH@' '0000000000000000000000000000000000000000' \
+        --replace-fail '@VCS_SHORT_HASH@' '0000000'
+
+      makeBinaryWrapper \
+        "$appBundle/Contents/MacOS/Warzone 2100" \
+        "$out/bin/warzone2100"
+    ''
+    + lib.optionalString withVideos ''
+      ln -sn ${sequences} $out/share/warzone2100/sequences.wz
+    '';
 
   passthru.tests = {
     version = testers.testVersion {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- Got warzone working for Darwin!
- Switched to from source building
- Using the github remote
- Replaced the which calls with a wrap program (Don't even know if this is needed because it's not activated on Darwin and all is swell?)
- Working app bundle !
- Changelog improvements

Also!
```console
(°◡◦)⊃━━ (./warzone2100 --version| complete ).exit_code
0
```
I do think the version check wouldn't pass anymore because it does give a 0 exit code these days.

@fgaz Thoughts?

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
