### PR TITLE
accountsservice: 23.13.9 -> 26.13.3

### DIFF
--- a/pkgs/by-name/ac/accountsservice/fix-paths.patch
+++ b/pkgs/by-name/ac/accountsservice/fix-paths.patch
@@ -1,39 +1,39 @@
 diff --git a/src/daemon.c b/src/daemon.c
-index aa9d050..861430f 100644
+index 48c310e..cd36e60 100644
 --- a/src/daemon.c
 +++ b/src/daemon.c
-@@ -1319,7 +1319,7 @@ daemon_create_user_authorized_cb (Daemon                *daemon,
+@@ -1806,7 +1806,7 @@ daemon_create_user_backend (Daemon         *daemon,
+         const gchar *argv[9] = { NULL };
+         int i = 0;
  
-         sys_log (context, "create user '%s'", cd->user_name);
- 
--        argv[0] = "/usr/sbin/useradd";
-+        argv[0] = "@shadow@/bin/useradd";
-         argv[1] = "-m";
-         argv[2] = "-c";
-         argv[3] = cd->real_name;
-@@ -1552,7 +1552,7 @@ daemon_delete_user_authorized_cb (Daemon                *daemon,
+-        argv[i++] = "/usr/sbin/useradd";
++        argv[i++] = "@shadow@/bin/useradd";
+         argv[i++] = "-m";
+         argv[i++] = "-c";
+         argv[i++] = cd->real_name;
+@@ -2040,7 +2040,7 @@ daemon_delete_shadow_user (Daemon                *daemon,
          }
          free (resolved_homedir);
  
--        argv[0] = "/usr/sbin/userdel";
-+        argv[0] = "@shadow@/bin/userdel";
-         if (ud->remove_files) {
-                 argv[1] = "-f";
-                 argv[2] = "-r";
+-        argv[i++] = "/usr/sbin/userdel";
++        argv[i++] = "@shadow@/bin/userdel";
+         argv[i++] = "-f";
+ 
+         if (rm_files)
 diff --git a/src/user.c b/src/user.c
-index 917d427..28170db 100644
+index da6428c..682842d 100644
 --- a/src/user.c
 +++ b/src/user.c
-@@ -1193,7 +1193,7 @@ user_change_real_name_authorized_cb (Daemon                *daemon,
-                         new_gecos = g_strdup (name);
-                 }
+@@ -1947,7 +1947,7 @@ user_change_real_name_authorized_cb (Daemon                *daemon,
+                                 new_gecos = g_strdup (name);
+                         }
  
--                argv[0] = "/usr/sbin/usermod";
-+                argv[0] = "@shadow@/bin/usermod";
-                 argv[1] = "-c";
-                 argv[2] = new_gecos;
-                 argv[3] = "--";
-@@ -1267,7 +1267,7 @@ user_change_user_name_authorized_cb (Daemon                *daemon,
+-                        argv[0] = "/usr/sbin/usermod";
++                        argv[0] = "@shadow@/bin/usermod";
+                         argv[1] = "-c";
+                         argv[2] = new_gecos;
+                         argv[3] = "--";
+@@ -2022,7 +2022,7 @@ user_change_user_name_authorized_cb (Daemon                *daemon,
                           accounts_user_get_uid (ACCOUNTS_USER (user)),
                           name);
  
@@ -42,25 +42,25 @@ index 917d427..28170db 100644
                  argv[1] = "-l";
                  argv[2] = name;
                  argv[3] = "--";
-@@ -1718,7 +1718,7 @@ user_set_password_expiration_policy_authorized_cb (Daemon                *daemon
-                  accounts_user_get_uid (ACCOUNTS_USER (user)));
+@@ -2609,7 +2609,7 @@ user_set_password_expiration_policy_authorized_cb (Daemon                *daemon
+                 days_to_warn = g_strdup_printf ("%ld", pwd_expiration->days_to_warn);
+                 days_after_exp_until_lock = g_strdup_printf ("%ld", pwd_expiration->days_after_expiration_until_lock);
  
-         g_object_freeze_notify (G_OBJECT (user));
--        argv[0] = "/usr/bin/chage";
-+        argv[0] = "@shadow@/bin/chage";
-         argv[1] = "-m";
-         argv[2] = pwd_expiration->min_days_between_changes;
-         argv[3] = "-M";
-@@ -1806,7 +1806,7 @@ user_set_user_expiration_policy_authorized_cb (Daemon                *daemon,
-         } else {
-                 expiration_time = g_strdup ("-1");
-         }
--        argv[0] = "/usr/bin/chage";
-+        argv[0] = "@shadow@/bin/chage";
-         argv[1] = "-E";
-         argv[2] = expiration_time;
-         argv[3] = accounts_user_get_user_name (ACCOUNTS_USER (user));
-@@ -1919,7 +1919,7 @@ user_change_home_dir_authorized_cb (Daemon                *daemon,
+-                argv[0] = "/usr/bin/chage";
++                argv[0] = "@shadow@/bin/chage";
+                 argv[1] = "-m";
+                 argv[2] = min_days_bt_changes;
+                 argv[3] = "-M";
+@@ -2735,7 +2735,7 @@ user_set_user_expiration_policy_authorized_cb (Daemon                *daemon,
+                         expiration_time = g_strdup ("-1");
+                 }
+ 
+-                argv[0] = "/usr/bin/chage";
++                argv[0] = "@shadow@/bin/chage";
+                 argv[1] = "-E";
+                 argv[2] = expiration_time;
+                 argv[3] = accounts_user_get_user_name (ACCOUNTS_USER (user));
+@@ -2861,7 +2861,7 @@ user_change_home_dir_authorized_cb (Daemon                *daemon,
                           accounts_user_get_uid (ACCOUNTS_USER (user)),
                           home_dir);
  
@@ -69,16 +69,16 @@ index 917d427..28170db 100644
                  argv[1] = "-m";
                  argv[2] = "-d";
                  argv[3] = home_dir;
-@@ -1977,7 +1977,7 @@ user_change_shell_authorized_cb (Daemon                *daemon,
-                          accounts_user_get_uid (ACCOUNTS_USER (user)),
-                          shell);
+@@ -2957,7 +2957,7 @@ user_change_shell_authorized_cb (Daemon                *daemon,
+                 } else {
+                         const gchar *argv[6];
  
--                argv[0] = "/usr/sbin/usermod";
-+                argv[0] = "@shadow@/bin/usermod";
-                 argv[1] = "-s";
-                 argv[2] = shell;
-                 argv[3] = "--";
-@@ -2120,7 +2120,7 @@ user_change_icon_file_authorized_cb (Daemon                *daemon,
+-                        argv[0] = "/usr/sbin/usermod";
++                        argv[0] = "@shadow@/bin/usermod";
+                         argv[1] = "-s";
+                         argv[2] = shell;
+                         argv[3] = "--";
+@@ -3163,7 +3163,7 @@ user_change_icon_file_classic_authorized_cb (Daemon                *daemon,
                          return;
                  }
  
@@ -87,34 +87,34 @@ index 917d427..28170db 100644
                  argv[1] = filename;
                  argv[2] = NULL;
  
-@@ -2201,7 +2201,7 @@ user_change_locked_authorized_cb (Daemon                *daemon,
-                          locked ? "locking" : "unlocking",
-                          accounts_user_get_user_name (ACCOUNTS_USER (user)),
-                          accounts_user_get_uid (ACCOUNTS_USER (user)));
--                argv[0] = "/usr/sbin/usermod";
-+                argv[0] = "@shadow@/bin/usermod";
-                 argv[1] = locked ? "-L" : "-U";
-                 argv[2] = "--";
-                 argv[3] = accounts_user_get_user_name (ACCOUNTS_USER (user));
-@@ -2328,7 +2328,7 @@ user_change_account_type_authorized_cb (Daemon                *daemon,
+@@ -3279,7 +3279,7 @@ user_change_locked_authorized_cb (Daemon                *daemon,
+                 } else {
+                         const gchar *argv[5];
  
-                 g_free (groups);
+-                        argv[0] = "/usr/sbin/usermod";
++                        argv[0] = "@shadow@/bin/usermod";
+                         argv[1] = locked ? "-L" : "-U";
+                         argv[2] = "--";
+                         argv[3] = accounts_user_get_user_name (ACCOUNTS_USER (user));
+@@ -3471,7 +3471,7 @@ user_change_account_type_shadow (GDBusMethodInvocation *context,
  
--                argv[0] = "/usr/sbin/usermod";
-+                argv[0] = "@shadow@/bin/usermod";
-                 argv[1] = "-G";
-                 argv[2] = str->str;
-                 argv[3] = "--";
-@@ -2396,7 +2396,7 @@ user_change_password_mode_authorized_cb (Daemon                *daemon,
+         g_free (groups);
  
-                 if (mode == PASSWORD_MODE_SET_AT_LOGIN ||
-                     mode == PASSWORD_MODE_NONE) {
+-        argv[0] = "/usr/sbin/usermod";
++        argv[0] = "@shadow@/bin/usermod";
+         argv[1] = "-G";
+         argv[2] = str->str;
+         argv[3] = "--";
+@@ -3604,7 +3604,7 @@ user_change_password_mode_authorized_cb (Daemon                *daemon,
+                         }
+                 } else if (mode == PASSWORD_MODE_SET_AT_LOGIN ||
+                            mode == PASSWORD_MODE_NONE) {
 -                        argv[0] = "/usr/bin/passwd";
 +                        argv[0] = "/run/wrappers/bin/passwd";
                          argv[1] = "-d";
                          argv[2] = "--";
                          argv[3] = accounts_user_get_user_name (ACCOUNTS_USER (user));
-@@ -2408,7 +2408,7 @@ user_change_password_mode_authorized_cb (Daemon                *daemon,
+@@ -3616,7 +3616,7 @@ user_change_password_mode_authorized_cb (Daemon                *daemon,
                          }
  
                          if (mode == PASSWORD_MODE_SET_AT_LOGIN) {
@@ -123,7 +123,7 @@ index 917d427..28170db 100644
                                  argv[1] = "-d";
                                  argv[2] = "0";
                                  argv[3] = "--";
-@@ -2428,7 +2428,7 @@ user_change_password_mode_authorized_cb (Daemon                *daemon,
+@@ -3637,7 +3637,7 @@ user_change_password_mode_authorized_cb (Daemon                *daemon,
                           */
                          accounts_user_set_locked (ACCOUNTS_USER (user), FALSE);
                  } else if (accounts_user_get_locked (ACCOUNTS_USER (user))) {
@@ -132,7 +132,7 @@ index 917d427..28170db 100644
                          argv[1] = "-U";
                          argv[2] = "--";
                          argv[3] = accounts_user_get_user_name (ACCOUNTS_USER (user));
-@@ -2505,7 +2505,7 @@ user_change_password_authorized_cb (Daemon                *daemon,
+@@ -3717,7 +3717,7 @@ user_change_password_authorized_cb (Daemon                *daemon,
  
          g_autoptr (GError) error = NULL;
          g_autoptr (GSubprocess) process = NULL;

--- a/pkgs/by-name/ac/accountsservice/package.nix
+++ b/pkgs/by-name/ac/accountsservice/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitLab,
   replaceVars,
   pkg-config,
   glib,
@@ -13,6 +13,7 @@
   meson,
   mesonEmulatorHook,
   dbus,
+  json_c,
   ninja,
   python3,
   vala,
@@ -22,16 +23,19 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "accountsservice";
-  version = "23.13.9";
+  version = "26.13.3";
 
   outputs = [
     "out"
     "dev"
   ];
 
-  src = fetchurl {
-    url = "https://www.freedesktop.org/software/accountsservice/accountsservice-${finalAttrs.version}.tar.xz";
-    sha256 = "rdpM3q4k+gmS598///nv+nCQvjrCM6Pt/fadWpybkk8=";
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "accountsservice";
+    repo = "accountsservice";
+    tag = finalAttrs.version;
+    hash = "sha256-ZIfkBlEaITX2rDcV5al4e2IFP238MXOlWeGoh+3+DoQ=";
   };
 
   patches = [
@@ -73,6 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
     dbus
     gettext
     glib
+    json_c
     polkit
     systemdLibs
     libxcrypt
@@ -97,9 +102,13 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     chmod +x meson_post_install.py
     patchShebangs meson_post_install.py
+
+    substituteInPlace meson.build \
+      --replace-fail "run_command(['./generate-version.sh'], check: true).stdout().strip()" "'${finalAttrs.version}'"
   '';
 
   meta = {
+    changelog = "https://gitlab.freedesktop.org/accountsservice/accountsservice/-/releases/${finalAttrs.src.tag}";
     description = "D-Bus interface for user account query and manipulation";
     homepage = "https://www.freedesktop.org/wiki/Software/AccountsService";
     license = lib.licenses.gpl3Plus;


### PR DESCRIPTION
Diff: https://gitlab.freedesktop.org/accountsservice/accountsservice/-/compare/23.13.9...26.13.3

Changelog: https://gitlab.freedesktop.org/accountsservice/accountsservice/-/releases/26.13.3


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
