### PR TITLE
asio: 1.36.0 -> 1.38.0

### DIFF
--- a/pkgs/by-name/as/asio/package.nix
+++ b/pkgs/by-name/as/asio/package.nix
@@ -7,7 +7,7 @@
   openssl,
   boost,
   testers,
-  asioVersion ? "1.36.0",
+  asioVersion ? "1.38.0",
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -23,11 +23,13 @@ stdenv.mkDerivation (finalAttrs: {
         # Preserve 1.32.0 because some project depends on asio/io_service.hpp
         "1.32.0" = "sha256-PBoa4OAOOmHas9wCutjz80rWXc3zGONntb9vTQk3FNY=";
         "1.36.0" = "sha256-BhJpE5+t0WXsuQ5CtncU0P8Kf483uFoV+OGlFLc7TpQ=";
+        "1.38.0" = "sha256-pkSu8XMibmRPMoS3v5hO34oJb077bYc9KWELj3t8D6M=";
       }
       .${asioVersion} or (throw "Unsupported asio version. Please use overrideAttrs directly");
   };
 
-  sourceRoot = "${finalAttrs.src.name}/asio";
+  sourceRoot =
+    finalAttrs.src.name + lib.optionalString (lib.versionOlder finalAttrs.version "1.38.0") "/asio";
 
   patches = [
     # Linking against `boost_system` fails because the stub compiled library


### PR DESCRIPTION
Diff: https://github.com/chriskohlhoff/asio/compare/asio-1-36-0...asio-1-38-0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
