### PR TITLE
stdenv/check-meta: route warnings through handleEvalIssue

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -675,7 +675,10 @@ let
             "Package '${getNameWithVersion attrs}' in ${pos_str meta} ${warning.msg}"
             + lib.optionalString (!inHydra && warning.remediation != "") " ${warning.remediation}";
         in
-        warn msg acc;
+        if config ? handleEvalIssue then
+          builtins.seq (config.handleEvalIssue warning.kind msg) acc
+        else
+          warn msg acc;
     in
     # Give all warnings first, then error if any
     builtins.seq (foldl' giveWarning null warnings) withError;

--- a/pkgs/stdenv/generic/problems.nix
+++ b/pkgs/stdenv/generic/problems.nix
@@ -500,6 +500,7 @@ rec {
 
       warnings = map (x: {
         reason = "problem";
+        inherit (x) kind;
         msg = "has the following problem: ${fullMessage x}";
         remediation = "See https://nixos.org/manual/nixpkgs/unstable#sec-problems"; # TODO: Add remediation, maybe just link to docs to keep it small
       }) warnProblems;

--- a/pkgs/test/problems/cases/handleEvalIssue-warning/default.nix
+++ b/pkgs/test/problems/cases/handleEvalIssue-warning/default.nix
@@ -1,0 +1,19 @@
+{
+  nixpkgs ? ../../../../..,
+}:
+let
+  pkgs = import nixpkgs {
+    system = "x86_64-linux";
+    overlays = [ ];
+    config = {
+      checkMeta = true;
+      handleEvalIssue = reason: msg: builtins.trace "reason: ${reason}, msg: ${msg}" true;
+    };
+  };
+in
+pkgs.stdenvNoCC.mkDerivation {
+  pname = "a";
+  version = "0";
+  meta.description = "Some package";
+  meta.problems.removal.message = "To be removed.";
+}

--- a/pkgs/test/problems/cases/handleEvalIssue-warning/expected-stderr
+++ b/pkgs/test/problems/cases/handleEvalIssue-warning/expected-stderr
@@ -1,0 +1,2 @@
+trace: reason: removal, msg: Package 'a-0' in /nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-default.nix:17 has the following problem: removal: To be removed. See https://nixos.org/manual/nixpkgs/unstable#sec-problems
+warning: you did not specify '--add-root'; the result might be removed by the garbage collector


### PR DESCRIPTION
## Summary

Fixes #523712.

`meta.problems` (from #494416) currently can't be used on any package: the moment a maintainer adds e.g. `meta.problems.removal.message = "..."`, the Eval CI job aborts on every system. The eval driver in `ci/eval/default.nix` treats any stderr output as a chunk failure, and `meta.problems` warnings are emitted via `lib.warn`, which writes to stderr. That's blocking #522364 (gemini-cli deprecation notice).

## The change

`giveWarning` in `pkgs/stdenv/generic/check-meta.nix` now routes through the existing `config.handleEvalIssue` hook (the same one the error path already uses), falling back to `lib.warn` when no handler is set:

```nix
if config ? handleEvalIssue then
  builtins.seq (config.handleEvalIssue warning.kind msg) acc
else
  warn msg acc;
```

To pass the problem's kind (matching how the error path calls `handleEvalIssue problem.kind ...`), the warning record in `pkgs/stdenv/generic/problems.nix` now carries `kind` alongside the existing fields.

CI's existing `handleEvalIssue` in `ci/eval/outpaths.nix` already returns `true` for these kinds (it only aborts/throws for `unknown-meta`, `broken-outputs`, `broken`, `unfree`, `unsupported`), so no change to `outpaths.nix` is needed: the warning simply stops reaching stderr during CI eval. Interactive users (no `handleEvalIssue` set) still get the warning via `lib.warn`.

This reuses the existing eval hook rather than adding a new `config.handleEvalWarning` attribute (the first version of this PR) or overriding `problems.matchers`.

This follows @infinisil's suggestion to reuse `config.handleEvalIssue` rather than add a new hook.

## Issue linkage

Fixes #523712.
Unblocks #522364.

> Note: ChatGPT was used to enhance translations and scaffolding tests.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
