### PR TITLE
python3Packages.pygreat: 2024.0.5 -> 2026.0.0

### DIFF
--- a/pkgs/development/python-modules/cynthion/default.nix
+++ b/pkgs/development/python-modules/cynthion/default.nix
@@ -51,6 +51,8 @@ buildPythonPackage rec {
     setuptools
   ];
 
+  pythonRelaxDeps = [ "pygreat" ];
+
   pythonRemoveDeps = [ "future" ];
 
   dependencies = [

--- a/pkgs/development/python-modules/pygreat/default.nix
+++ b/pkgs/development/python-modules/pygreat/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "pygreat";
-  version = "2024.0.5";
+  version = "2026.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "greatscottgadgets";
     repo = "libgreat";
     tag = "v${version}";
-    hash = "sha256-2PFeCG7m8qiK3eBX2838P6ZsLoQxcJBG+/TppUMT6dE=";
+    hash = "sha256-m+s2TAJK7UhKWbuSd5ec1O40WeMXxJyTD9yqPOr0LEM=";
   };
 
   sourceRoot = "${src.name}/host";
@@ -25,8 +25,6 @@ buildPythonPackage rec {
       --replace-fail '"setuptools-git-versioning<2"' "" \
       --replace-fail 'dynamic = ["version"]' 'version = "${version}"'
   '';
-
-  pythonRemoveDeps = [ "backports.functools_lru_cache" ];
 
   build-system = [ setuptools ];
 


### PR DESCRIPTION
https://github.com/greatscottgadgets/libgreat/releases/tag/v2026.0.0

Also relaxes cynthion's constraint for it. (it's compatible)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
