### PR TITLE
gradle: allow nixpkgs derivations to substitute maven deps at build time

### DIFF
--- a/pkgs/by-name/mi/mitm-cache/fetch.nix
+++ b/pkgs/by-name/mi/mitm-cache/fetch.nix
@@ -9,10 +9,78 @@
   name ? "deps",
   data,
   dontFixup ? true,
+  # Overrides: attrset keyed by "groupId:artifactId:version" ->
+  #   { "artifactId-version.jar" = originalDrv: replacementDrv; }
+  # Allows substituting fetched Maven artifacts with local nixpkgs derivations.
+  # Build this with gradle.mkGradleLocalOverrides or gradle.mkVersionChainUpgrade.
+  overrides ? { },
   ...
 }@attrs:
 
 let
+  # Known Maven repository URL prefixes for GAV coordinate extraction.
+  mavenRepoPrefixes = [
+    "https://repo.maven.apache.org/maven2/"
+    "https://repo1.maven.org/maven2/"
+    "https://plugins.gradle.org/m2/"
+    "https://jcenter.bintray.com/"
+    "https://dl.google.com/dl/android/maven2/"
+    "https://maven.google.com/"
+    "https://oss.sonatype.org/content/repositories/releases/"
+    "https://s01.oss.sonatype.org/content/repositories/releases/"
+    "https://jitpack.io/"
+    "https://repo.clojars.org/"
+  ];
+
+  # Extract "groupId:artifactId:version" from a Maven artifact URL, or null if
+  # the URL is not from a recognized Maven repository.
+  mavenUrlToGav =
+    url:
+    let
+      prefix = lib.findFirst (p: lib.hasPrefix p url) null mavenRepoPrefixes;
+    in
+    if prefix == null then
+      null
+    else
+      let
+        rel = lib.removePrefix prefix url;
+        parts = lib.splitString "/" rel;
+        n = builtins.length parts;
+      in
+      if n < 4 then
+        null
+      else
+        let
+          filename = builtins.elemAt parts (n - 1);
+          version = builtins.elemAt parts (n - 2);
+          artifactId = builtins.elemAt parts (n - 3);
+          groupParts = lib.take (n - 3) parts;
+          groupId = builtins.concatStringsSep "." groupParts;
+        in
+        if groupId == "" || artifactId == "" || version == "" then
+          null
+        else if !lib.hasPrefix "${artifactId}-${version}" filename then
+          null
+        else
+          "${groupId}:${artifactId}:${version}";
+
+  hasOverrides = overrides != { };
+
+  # Return the override for this URL if one exists, otherwise return the
+  # original binary unchanged. Only applied to `hash` entries (downloaded files).
+  doOverride =
+    binary: url:
+    if !hasOverrides then
+      binary
+    else
+      let
+        gav = mavenUrlToGav url;
+        # Attribute lookup requires a string key; guard against non-Maven URLs.
+        gavOverrides = if gav != null then overrides.${gav} or { } else { };
+        filename = baseNameOf url;
+      in
+      if gavOverrides ? ${filename} then gavOverrides.${filename} binary else binary;
+
   data' = removeAttrs (if builtins.isPath data then lib.importJSON data else data) [
     "!version"
   ];
@@ -28,6 +96,7 @@ let
       )
     else
       builtins.replaceStrings [ "://" ] [ "/" ] url;
+
   code = ''
     mkdir -p "$out"
     cd "$out"
@@ -40,7 +109,8 @@ let
         val = info.${key};
         path = urlToPath url;
         name = baseNameOf path;
-        source =
+        isHash = key == "hash";
+        source0 =
           {
             redirect = "$out/${urlToPath val}";
             hash = fetchurl {
@@ -50,6 +120,7 @@ let
             text = writeText name val;
           }
           .${key} or (throw "Unknown key: ${url}");
+        source = if isHash then doOverride source0 url else source0;
       in
       ''
         mkdir -p "${dirOf path}"
@@ -62,6 +133,7 @@ runCommand name (
   removeAttrs attrs [
     "name"
     "data"
+    "overrides"
   ]
   // {
     passthru = (attrs.passthru or { }) // {

--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -22,6 +22,7 @@ let
     }@args:
     let
       gradle = gradle-unwrapped.override args;
+      localDepsLib = callPackage ./local-deps.nix { };
     in
     symlinkJoin {
       pname = "gradle";
@@ -44,7 +45,10 @@ let
       ];
 
       passthru = {
-        fetchDeps = callPackage ./fetch-deps.nix { inherit mitm-cache; };
+        fetchDeps = callPackage ./fetch-deps.nix { inherit mitm-cache localDepsLib; };
+        # Build an overrides attrset from nixpkgs derivations for use with
+        # the `localDeps` or `overrides` parameter of fetchDeps.
+        inherit (localDepsLib) mkGradleLocalOverrides mkVersionChainUpgrade;
         inherit (gradle) jdk;
         unwrapped = gradle;
         tests = {

--- a/pkgs/development/tools/build-managers/gradle/fetch-deps.nix
+++ b/pkgs/development/tools/build-managers/gradle/fetch-deps.nix
@@ -1,13 +1,19 @@
 {
   mitm-cache,
+  localDepsLib,
   lib,
   pkgs,
   stdenv,
   callPackage,
+  fetchurl,
+  writeText,
 }:
 
 let
   getPkg = attrPath: lib.getAttrFromPath (lib.splitString "." (toString attrPath)) pkgs;
+  securityOverrides = callPackage ./security-overrides.nix {
+    inherit (localDepsLib) mkVersionChainUpgrade;
+  };
 in
 # the derivation to fetch/update deps for
 {
@@ -19,6 +25,15 @@ in
   bwrapFlags ? "--ro-bind \"$PWD\" \"$PWD\"",
   # deps path (relative to the package directory, or absolute)
   data,
+  # List of nixpkgs-backed Maven artifact specs. Each element is an attrset
+  # accepted by gradle.mkGradleLocalOverrides:
+  #   { drv, groupId, artifactId, version, jarPath?, pom? }
+  # The MITM proxy will serve the nixpkgs derivation instead of the fetched
+  # artifact for every matching (groupId, artifactId, version) triple.
+  localDeps ? [ ],
+  # Additional raw overrides attrset (merged after localDeps and security
+  # overrides; highest priority). Keyed by "groupId:artifactId:version".
+  overrides ? { },
   # redirect stdout to stderr to allow the update script to be used with update script combinators
   silent ? true,
   useBwrap ? stdenv.hostPlatform.isLinux,
@@ -255,12 +270,49 @@ let
       };
 
   finalData = visitAttrs { } [ ] data';
+
+  # Validate that every localDeps entry's GAV appears in deps.json, so typos
+  # are caught at eval time rather than silently ignored at build time.
+  checkLocalDeps =
+    let
+      gavToUrlFragment =
+        groupId: artifactId: version:
+        let
+          groupPath = builtins.replaceStrings [ "." ] [ "/" ] groupId;
+        in
+        "${groupPath}/${artifactId}/${version}/${artifactId}-${version}";
+      entryInData =
+        {
+          groupId,
+          artifactId,
+          version,
+          ...
+        }:
+        let
+          fragment = gavToUrlFragment groupId artifactId version;
+        in
+        if builtins.any (url: lib.hasInfix fragment url) (builtins.attrNames finalData) then
+          true
+        else
+          throw "gradle.fetchDeps: localDeps entry ${groupId}:${artifactId}:${version} not found in deps.json. Check spelling and verify the artifact was fetched by Gradle.";
+    in
+    builtins.all entryInData localDeps;
+
+  # Merge priority (highest last): security upgrades < localDeps < caller overrides.
+  allOverrides =
+    assert checkLocalDeps;
+    lib.foldl' lib.recursiveUpdate { } [
+      securityOverrides
+      (localDepsLib.mkGradleLocalOverrides localDeps)
+      overrides
+    ];
 in
 mitm-cache.fetch {
   name = "${pkg.pname or pkg.name}-deps";
   data = finalData // {
     "!version" = 1;
   };
+  overrides = allOverrides;
   passthru = lib.optionalAttrs (!builtins.isAttrs data) {
     updateScript = callPackage ./update-deps.nix { } {
       inherit

--- a/pkgs/development/tools/build-managers/gradle/local-deps.nix
+++ b/pkgs/development/tools/build-managers/gradle/local-deps.nix
@@ -1,0 +1,115 @@
+{
+  lib,
+  writeText,
+}:
+
+let
+  minimalPom =
+    {
+      groupId,
+      artifactId,
+      version,
+    }:
+    ''
+      <?xml version="1.0" encoding="UTF-8"?>
+      <project>
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>${groupId}</groupId>
+        <artifactId>${artifactId}</artifactId>
+        <version>${version}</version>
+        <packaging>jar</packaging>
+      </project>
+    '';
+
+  # Shared builder: produce a single GAV override entry given resolved inputs.
+  mkEntry =
+    {
+      groupId,
+      artifactId,
+      version,
+      jarSource,
+      pom ? null,
+    }:
+    let
+      base = "${artifactId}-${version}";
+      pomDrv = writeText "${base}.pom" (
+        if pom != null then pom else minimalPom { inherit groupId artifactId version; }
+      );
+    in
+    {
+      "${groupId}:${artifactId}:${version}" = {
+        "${base}.jar" = _: jarSource;
+        "${base}.pom" = _: pomDrv;
+      };
+    };
+
+  mkArtifactEntry =
+    {
+      # nixpkgs derivation providing the JAR.
+      drv,
+      groupId,
+      artifactId,
+      version,
+      # Subpath within drv to the JAR file (e.g. "share/java/foo-1.0.jar").
+      # If null, drv itself is treated as the JAR (only correct when drv is a
+      # single-file fetchurl result).
+      jarPath ? null,
+      # Full POM XML string. If null a minimal four-field POM is generated,
+      # which is sufficient for Gradle's offline resolver.
+      pom ? null,
+    }:
+    mkEntry {
+      inherit
+        groupId
+        artifactId
+        version
+        pom
+        ;
+      jarSource = if jarPath != null then "${drv}/${jarPath}" else "${drv}";
+    };
+
+in
+{
+  # Build an overrides attrset from a list of nixpkgs-backed artifact specs.
+  # Each spec is an attrset with: drv, groupId, artifactId, version, jarPath?, pom?
+  mkGradleLocalOverrides = artifacts: lib.mergeAttrsList (map mkArtifactEntry artifacts);
+
+  # Build override entries that transparently redirect requests for old
+  # (potentially vulnerable) artifact versions to a safe replacement.
+  # The MITM proxy will serve `jar` whenever Gradle requests any of the
+  # `oldVersions`, without any changes to the package's deps.json.
+  #
+  # Example:
+  #   gradle.mkVersionChainUpgrade {
+  #     groupId    = "commons-codec";
+  #     artifactId = "commons-codec";
+  #     oldVersions = [ "1.0" "1.1" "1.2" "1.3" "1.4" "1.5" "1.6"
+  #                     "1.7" "1.8" "1.9" "1.10" "1.11" "1.12" ];
+  #     jar = fetchurl {
+  #       url  = "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.13/commons-codec-1.13.jar";
+  #       hash = "sha256-...";
+  #     };
+  #   }
+  mkVersionChainUpgrade =
+    {
+      groupId,
+      artifactId,
+      oldVersions,
+      # Derivation or store path of the replacement JAR.
+      jar,
+      # Optional full POM XML for the replacement. If null a minimal POM is
+      # generated bearing the *old* version coordinate so Gradle's resolver
+      # does not notice the substitution.
+      pom ? null,
+    }:
+    lib.mergeAttrsList (
+      map (
+        oldVer:
+        mkEntry {
+          inherit groupId artifactId pom;
+          version = oldVer;
+          jarSource = jar;
+        }
+      ) oldVersions
+    );
+}

--- a/pkgs/development/tools/build-managers/gradle/security-overrides.nix
+++ b/pkgs/development/tools/build-managers/gradle/security-overrides.nix
@@ -1,0 +1,42 @@
+# Transparent security upgrades for known-vulnerable Maven artifact versions.
+#
+# Every entry here is merged into the overrides passed to mitm-cache.fetch for
+# ALL Gradle builds that use gradle.fetchDeps. When Gradle requests a listed
+# vulnerable version the MITM proxy silently serves the patched jar instead,
+# with no changes required to the consuming package.
+#
+# HOW TO ADD AN ENTRY
+# -------------------
+# Use mkVersionChainUpgrade (re-exported as gradle.mkVersionChainUpgrade):
+#
+#   (mkVersionChainUpgrade {
+#     groupId     = "commons-codec";
+#     artifactId  = "commons-codec";
+#     oldVersions = [ "1.0" "1.1" "1.2" "1.3" "1.4" "1.5" "1.6"
+#                     "1.7" "1.8" "1.9" "1.10" "1.11" "1.12" ];
+#     jar = fetchurl {
+#       url  = "https://repo.maven.apache.org/maven2/commons-codec/commons-codec/1.13/commons-codec-1.13.jar";
+#       hash = "sha256-<run: nix-prefetch-url --type sha256 <url>>";
+#     };
+#   })
+#
+# Add the entry to the list below and open a PR that includes:
+#   - the CVE / advisory reference
+#   - the first safe version
+#   - the hash of the replacement jar (verified with nix-prefetch-url)
+#
+# KNOWN CANDIDATES (hashes still need to be pinned before adding)
+# ---------------------------------------------------------------
+#   commons-codec < 1.13      WS-2019-0379
+#   gson < 2.8.9              CVE-2022-25647  (com.google.code.gson:gson)
+#   slf4j-api 1.x < 1.7.36   several low-severity issues
+#
+{
+  lib,
+  fetchurl,
+  mkVersionChainUpgrade,
+}:
+
+lib.mergeAttrsList [
+  # Add entries here, one mkVersionChainUpgrade call per vulnerable artifact.
+]


### PR DESCRIPTION
Closes #521882

This implementation is largely based on @mio-19's [work](https://github.com/mio-19/repo/blob/3eaa2f92541d951e2f6b875503c85a746163bbf1/libs/mitm-cache-fetch/package.nix). I tried something else before making this PR, but her implementation is way properer than what I started with.

> The `overrides` design came from gradle2nix v2 by @tadfisher : [tadfisher/gradle2nix#62](https://github.com/tadfisher/gradle2nix/pull/62)


## Changes

### Override hook in `mitm-cache/fetch.nix`

`mitm-cache.fetch` now accepts an `overrides` attrset keyed by "groupId:artifactId:version":

```nix
overrides = {
  "commons-logging:commons-logging:1.2" = {
    "commons-logging-1.2.jar" = originalDrv: replacementPath;
    "commons-logging-1.2.pom" = originalDrv: replacementPomDrv;
  };
};
```

When building the symlink tree, `mavenUrlToGav` parses each URL against a list of known Maven repository prefixes to extract the GAV. If an entry exists in `overrides` for that GAV + filename, the override function is called with the original fetchurl derivation and its return value becomes the symlink target. If the override ignores its argument (as `_: something` always does), the original `fetchurl` is never added to the derivation's input closure. It is never downloaded.

Only `hash`-type entries (downloaded files) are intercepted. `text` entries (synthesized maven-metadata XML) and redirect entries (shell-variable symlinks) are left unchanged.

### `local-deps.nix`'s two helper functions

`mkGradleLocalOverrides` - takes a list of artifact specs and returns an overrides attrset:

```nix
gradle.mkGradleLocalOverrides [
  {
    drv = pkgs.commons-logging; # nixpkgs derivation
    groupId = "commons-logging";
    artifactId = "commons-logging";
    version = "1.2"; # version Gradle requests
    jarPath = "share/java/commons-logging-1.3.6.jar";
  }
]
```

Generates a minimal four-field POM bearing the requested version coordinate (so Gradle's resolver doesn't notice the substitution), and points the `.jar` symlink to the nixpkgs store path.

`mkVersionChainUpgrade` - maps a list of old versions to a single replacement jar, designed for security patch chains:

```nix
gradle.mkVersionChainUpgrade {
  groupId = "commons-codec"; artifactId = "commons-codec";
  oldVersions = [ "1.0" "1.1" "1.2" ... "1.12" ];
  newVersion = "1.13";  # informational
  jar = fetchurl { url = "..."; hash = "sha256-..."; };
}
```

Each old version gets its own `.jar` and `.pom` symlink pointing to the replacement content.

### `security-overrides.nix` for CVE baseline

Built from `mkVersionChainUpgrade` calls, merged into every `gradle.fetchDeps` invocation automatically (lowest priority in the merge order). Currently empty pending hash verification, but the structure is complete. Three candidates are promising: `commons-codec < 1.13` (WS-2019-0379), `gson < 2.8.9` (CVE-2022-25647), `slf4j-api 1.x < 1.7.36`.

Merge order in `fetch-deps.nix` is
```
security-overrides  <  localDeps  <  caller overrides (highest wins)
```

## How to use it

**As a package author replacing a Maven dep with a nixpkgs package**:

```nix
mitmCache = gradle.fetchDeps {
  inherit (finalAttrs) pname;
  data = ./deps.json;
  localDeps = [
    {
      drv = pkgs.commons-logging;
      groupId = "commons-logging";
      artifactId = "commons-logging";
      version = "1.2"; # must match what's in deps.json
      jarPath = "share/java/commons-logging-1.3.6.jar";
    }
  ];
};
```

No other changes should be needed. The `deps.json` stays identical; the substitution only happens at build time when the MITM proxy serves the cache.

**As a security maintainer adding a CVE upgrade chain**:

Add one `mkVersionChainUpgrade` call to `security-overrides.nix` with a pinned `fetchurl` hash. It applies to all packages automatically on next rebuild.

**As an advanced user needing full control**:

Pass a raw `overrides` attrset (built manually or with the helpers).
It (should) win over everything else.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Issues

- Mio's implementation scans `./lib/*.mavenProvides` automatically, this one doesn't. Users have to specify coords explicitly.
- Commits have been heavily written using AI. I understand it, but just letting you know. The `Assisted-by:` footer is set.
- (probably more that I didn't think about)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
