### PR TITLE
libffi_3_3: fix `gcc-15` build

### DIFF
--- a/pkgs/by-name/li/libffi_3_3/package.nix
+++ b/pkgs/by-name/li/libffi_3_3/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
 
   doCheck ? true, # test suite depends on dejagnu which cannot be used during bootstrapping
   dejagnu,
@@ -16,7 +17,15 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-cvunkicD3fp6Ao1ROsFahcjVTI1n9V+lpIAohdxlIFY=";
   };
 
-  patches = [ ];
+  patches = [
+    # Backport gcc-15 fix:
+    #   https://github.com/libffi/libffi/pull/861
+    (fetchpatch {
+      name = "gcc-15.patch";
+      url = "https://github.com/libffi/libffi/commit/0859f8431242d5adff21420b9cab538d2af527b5.patch";
+      hash = "sha256-Py4ZAhVyXsfLxr4pnYAH7/lcsQOmpToFgvjQvLg9XVc=";
+    })
+  ];
 
   outputs = [
     "out"


### PR DESCRIPTION
Without the chnage the build fails in `master` as
https://hydra.nixos.org/build/329329821:

```
FAIL: libffi.call/va_struct2.c -W -Wall -Wno-psabi -O0 (test for excess errors)
FAIL: libffi.call/va_struct2.c -W -Wall -Wno-psabi -O2 (test for excess errors)
FAIL: libffi.call/va_struct3.c -W -Wall -Wno-psabi -O0 (test for excess errors)
FAIL: libffi.call/va_struct3.c -W -Wall -Wno-psabi -O2 (test for excess errors)
```

ZHF: #516381


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
