### PR TITLE
ci/eval/compare: show performance comparison even when package sets differ

### DIFF
--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -238,33 +238,32 @@ runCommand "compare"
       jq -r -f ${./generate-step-summary.jq} < ${changed-paths}
     } >> $out/step-summary.md
 
-    if jq -e '(.attrdiff.added | length == 0) and (.attrdiff.removed | length == 0)' "${changed-paths}" > /dev/null; then
-      # Chunks have changed between revisions
-      # We cannot generate a performance comparison
-      {
-        echo
-        echo "# Performance comparison"
-        echo
-        echo "This compares the performance of this branch against its pull request base branch (e.g., 'master')"
-        echo
-        echo "For further help please refer to: [ci/README.md](https://github.com/NixOS/nixpkgs/blob/master/ci/README.md)"
-        echo
-      } >> $out/step-summary.md
+    {
+      echo
+      echo "# Performance comparison"
+      echo
+      echo "This compares the performance of this branch against its pull request base branch (e.g., 'master')"
+      echo
+    } >> $out/step-summary.md
 
-      cmp-stats --explain ${combined}/before/stats ${combined}/after/stats >> $out/step-summary.md
-
-    else
-      # Package chunks are the same in both revisions
-      # We can use the to generate a performance comparison
+    # cmp-stats only compares the stats chunks present in both revisions, so the
+    # comparison is still produced when packages were added/removed. The paired
+    # chunks may cover different attrs in that case, so caveat the figures.
+    if ! jq -e '(.attrdiff.added | length == 0) and (.attrdiff.removed | length == 0)' "${changed-paths}" > /dev/null; then
       {
+        echo "> [!NOTE]"
+        echo "> The package sets differ between the two revisions. This comparison only"
+        echo "> covers packages evaluated in both, so treat the figures as approximate."
         echo
-        echo "# Performance Comparison"
-        echo
-        echo "Performance stats were skipped because the package sets differ between the two revisions."
-        echo
-        echo "For further help please refer to: [ci/README.md](https://github.com/NixOS/nixpkgs/blob/master/ci/README.md)"
       } >> $out/step-summary.md
     fi
+
+    {
+      echo "For further help please refer to: [ci/README.md](https://github.com/NixOS/nixpkgs/blob/master/ci/README.md)"
+      echo
+    } >> $out/step-summary.md
+
+    cmp-stats --explain ${combined}/before/stats ${combined}/after/stats >> $out/step-summary.md
 
     jq -r '.[]' "${touchedFilesJson}" > ./touched-files
     readarray -t touchedFiles < ./touched-files


### PR DESCRIPTION
The eval comparison CI step (`ci/eval/compare`) previously skipped the performance comparison entirely whenever packages were added or removed between the two revisions, emitting only a "Performance stats were skipped because the package sets differ" message.

However, `cmp-stats` already restricts its pairwise comparison to the stats chunks present in *both* revisions (`common_files = set(before_metrics) & set(after_metrics)`), so a meaningful comparison can still be produced when the package sets differ — it simply ignores the attrs unique to one side.

This change always runs the comparison and, when the package sets differ, prepends a GitHub note caveating that the figures only cover packages evaluated in both revisions and should be treated as approximate (chunk contents can shift as attrs are added/removed).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Assisted-by: claude-code with claude-opus-4-7[1m]-xhigh
