### PR TITLE
kicad: Fix rebuild when `compressStep = false`

### DIFF
--- a/pkgs/by-name/ki/kicad/base.nix
+++ b/pkgs/by-name/ki/kicad/base.nix
@@ -62,7 +62,6 @@
   debug,
   sanitizeAddress,
   sanitizeThreads,
-  templateDir ? null,
 }:
 
 assert lib.assertMsg (
@@ -207,14 +206,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   dontStrip = debug;
-
-  # KiCad looks for the stock library tables at
-  # KICAD_LIBRARY_DATA/template/{sym,fp}-lib-table, where KICAD_LIBRARY_DATA is
-  # compiled in as $out/share/kicad. Those files live in separate library packages.
-  postInstall = optionalString (templateDir != null) ''
-    rm -rf $out/share/kicad/template
-    ln -s ${templateDir} $out/share/kicad/template
-  '';
 
   meta = {
     description = "Just the built source without the libraries";

--- a/pkgs/by-name/ki/kicad/package.nix
+++ b/pkgs/by-name/ki/kicad/package.nix
@@ -186,7 +186,6 @@ stdenv.mkDerivation rec {
     inherit wxGTK python wxPython;
     inherit withNgspice withScripting withI18n;
     inherit debug sanitizeAddress sanitizeThreads;
-    templateDir = template_dir;
   };
 
   inherit pname;
@@ -221,6 +220,36 @@ stdenv.mkDerivation rec {
       "${symbols}/share/kicad/template"
     ];
   };
+
+  # KiCad looks up its stock library tables relative to GetStockDataPath(),
+  # which our runtime_stock_data_path.patch lets us override via
+  # NIX_KICAD10_STOCK_DATA_PATH. We synthesise a directory that mirrors
+  # ${base}/share/kicad but replaces the upstream-installed (incomplete)
+  # template/ with the merged template_dir from the library packages.
+  # Doing this in the wrapper instead of in base.nix keeps the heavy
+  # kicad-base compile independent of the (cheap) library packages, so
+  # toggling overrides like compressStep doesn't force a base rebuild.
+  baseWithTemplate = runCommand "kicad-stock-data" { } ''
+    mkdir -p $out
+    for d in ${base}/share/kicad/*; do
+      name=$(basename "$d")
+      [ "$name" = template ] || ln -s "$d" "$out/$name"
+    done
+    ln -s ${template_dir} $out/template
+  '';
+
+  stockDataPath =
+    if addons == [ ] then
+      baseWithTemplate
+    else
+      symlinkJoin {
+        name = "kicad_stock_data_path";
+        paths = [
+          baseWithTemplate
+          "${addonsJoined}/share/kicad"
+        ];
+      };
+
   # We are emulating wrapGAppsHook3, along with other variables to the wrapper
   makeWrapperArgs =
     with passthru.libraries;
@@ -238,19 +267,8 @@ stdenv.mkDerivation rec {
       "--set-default KICAD10_FOOTPRINT_DIR ${footprints}/share/kicad/footprints"
       "--set-default KICAD10_SYMBOL_DIR ${symbols}/share/kicad/symbols"
       "--set-default KICAD10_TEMPLATE_DIR ${template_dir}"
+      "--set-default NIX_KICAD10_STOCK_DATA_PATH ${stockDataPath}"
     ]
-    ++ optionals (addons != [ ]) (
-      let
-        stockDataPath = symlinkJoin {
-          name = "kicad_stock_data_path";
-          paths = [
-            "${base}/share/kicad"
-            "${addonsJoined}/share/kicad"
-          ];
-        };
-      in
-      [ "--set-default NIX_KICAD10_STOCK_DATA_PATH ${stockDataPath}" ]
-    )
     ++ optionals with3d [
       "--set-default KICAD10_3DMODEL_DIR ${packages3d}/share/kicad/3dmodels"
     ]

--- a/pkgs/by-name/ki/kicad/runtime_stock_data_path.patch
+++ b/pkgs/by-name/ki/kicad/runtime_stock_data_path.patch
@@ -1,5 +1,4 @@
 diff --git a/common/paths.cpp b/common/paths.cpp
-index a74cdd9..790cc58 100644
 --- a/common/paths.cpp
 +++ b/common/paths.cpp
 @@ -151,6 +151,10 @@ wxString PATHS::GetStockDataPath( bool aRespectRunFromBuildDir )
@@ -13,3 +12,14 @@ index a74cdd9..790cc58 100644
      if( aRespectRunFromBuildDir && wxGetEnv( wxT( "KICAD_RUN_FROM_BUILD_DIR" ), nullptr ) )
      {
          // Allow debugging from build dir by placing relevant files/folders in the build root
+@@ -198,6 +202,10 @@ wxString PATHS::GetStockEDALibraryPath()
+ {
+     wxString path;
+
++    if( wxGetEnv( wxT( "NIX_KICAD10_STOCK_DATA_PATH" ), &path ) ) {
++        return path;
++    }
++
+ #if defined( __WXMAC__ )
+     path = GetOSXKicadMachineDataDir();
+ #elif defined( __WXMSW__ )


### PR DESCRIPTION
It does no longer rebuild, as expected:

> nix-instantiate --eval -E 'with import ./. {}; kicad.base.drvPath'
"/nix/store/8b0wimhxyr3vlbxsr8xybnzaz06161k5-kicad-base-10.0.3.drv"

> nix-instantiate --eval -E 'with import ./. {}; (kicad.override { compressStep = false; }).base.drvPath'
"/nix/store/8b0wimhxyr3vlbxsr8xybnzaz06161k5-kicad-base-10.0.3.drv"

@dmitmel can you test as well?

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
