### PR TITLE
nixos/kmscon: RFC42 treatment

### DIFF
--- a/nixos/modules/services/ttys/kmscon.nix
+++ b/nixos/modules/services/ttys/kmscon.nix
@@ -19,10 +19,21 @@ let
 
   gettyCfg = config.services.getty;
 
+  mkKeyValue =
+    k: v:
+    if true == v then
+      k + "\n"
+    else if false == v then
+      "no-" + k + "\n"
+    else
+      lib.generators.mkKeyValueDefault { } "=" k v + "\n";
+
   configDir = pkgs.writeTextFile {
     name = "kmscon-config";
     destination = "/kmscon.conf";
-    text = cfg.extraConfig;
+    text = lib.concatStrings (
+      lib.mapAttrsToList mkKeyValue (lib.filterAttrsRecursive (_: v: v != null) cfg.config)
+    );
   };
 
   baseLoginOptions = "-p";
@@ -55,6 +66,10 @@ in
 
       Check `services.getty.autologinUser` instead.
     '')
+
+    (lib.mkRenamedOptionModule [ "services" "kmscon" "extraConfig" ] [ "services" "kmscon" "config" ])
+
+    (lib.mkRenamedOptionModule [ "services" "kmscon" "term" ] [ "services" "kmscon" "config" "term" ])
   ];
 
   options = {
@@ -95,18 +110,117 @@ in
 
       useXkbConfig = mkEnableOption "configure keymap from xserver keyboard settings.";
 
-      term = mkOption {
-        description = "Value for the TERM environment variable.";
-        type = types.nullOr types.str;
-        default = null;
-        example = "xterm-256color";
-      };
+      config = mkOption {
+        description = ''
+          Configuration for kmscon. See {manpage}`kmscon.conf(5)`
+          for available options.
+        '';
+        default = { };
+        type = types.submodule {
+          freeformType =
+            with types;
+            attrsOf (oneOf [
+              bool
+              int
+              str
+            ]);
 
-      extraConfig = mkOption {
-        description = "Extra contents of the kmscon.conf file.";
-        type = types.lines;
-        default = "";
-        example = "font-size=14";
+          options = {
+            font-name = mkOption {
+              type = types.nullOr types.str;
+              default = if cfg.fonts != null then lib.concatMapStringsSep ", " (f: f.name) cfg.fonts else null;
+              defaultText = lib.literalExpression ''
+                if config.services.kmscon.fonts != null then
+                  lib.concatMapStringsSep ", " (f: f.name) config.services.kmscon.fonts
+                else
+                  null
+              '';
+              description = "Font name to use.";
+            };
+
+            hwaccel = mkOption {
+              type = types.nullOr types.bool;
+              default = if cfg.hwRender then true else null;
+              defaultText = lib.literalExpression ''
+                if config.services.kmscon.hwRender then true else null
+              '';
+              description = "Use 3D hardware-acceleration if available.";
+            };
+
+            drm = mkOption {
+              type = types.nullOr types.bool;
+              default = if cfg.hwRender then true else null;
+              defaultText = lib.literalExpression ''
+                if config.services.kmscon.hwRender then true else null
+              '';
+              description = "Use DRM if available.";
+            };
+
+            xkb-layout = mkOption {
+              type = types.nullOr types.str;
+              default =
+                if cfg.useXkbConfig && config.services.xserver.xkb.layout != "" then
+                  config.services.xserver.xkb.layout
+                else
+                  null;
+              defaultText = lib.literalExpression ''
+                if config.services.kmscon.useXkbConfig && config.services.xserver.xkb.layout != "" then
+                  config.services.xserver.xkb.layout
+                else
+                  null
+              '';
+              description = "Set XkbLayout for input devices.";
+            };
+
+            xkb-model = mkOption {
+              type = types.nullOr types.str;
+              default =
+                if cfg.useXkbConfig && config.services.xserver.xkb.model != "" then
+                  config.services.xserver.xkb.model
+                else
+                  null;
+              defaultText = lib.literalExpression ''
+                if config.services.kmscon.useXkbConfig && config.services.xserver.xkb.model != "" then
+                  config.services.xserver.xkb.model
+                else
+                  null
+              '';
+              description = "Set XkbModel for input devices.";
+            };
+
+            xkb-options = mkOption {
+              type = types.nullOr types.str;
+              default =
+                if cfg.useXkbConfig && config.services.xserver.xkb.options != "" then
+                  config.services.xserver.xkb.options
+                else
+                  null;
+              defaultText = lib.literalExpression ''
+                if config.services.kmscon.useXkbConfig && config.services.xserver.xkb.options != "" then
+                  config.services.xserver.xkb.options
+                else
+                  null
+              '';
+              description = "Set XkbOptions for input devices.";
+            };
+
+            xkb-variant = mkOption {
+              type = types.nullOr types.str;
+              default =
+                if cfg.useXkbConfig && config.services.xserver.xkb.variant != "" then
+                  config.services.xserver.xkb.variant
+                else
+                  null;
+              defaultText = lib.literalExpression ''
+                if config.services.kmscon.useXkbConfig && config.services.xserver.xkb.variant != "" then
+                  config.services.xserver.xkb.variant
+                else
+                  null
+              '';
+              description = "Set XkbVariant for input devices.";
+            };
+          };
+        };
       };
 
       extraOptions = mkOption {
@@ -161,29 +275,6 @@ in
     ];
 
     systemd.suppressedSystemUnits = [ "getty@.service" ];
-
-    services.kmscon.extraConfig = lib.concatLines (
-      optionals cfg.useXkbConfig (
-        lib.mapAttrsToList (n: v: "xkb-${n}=${v}") (
-          lib.filterAttrs (
-            n: v:
-            builtins.elem n [
-              "layout"
-              "model"
-              "options"
-              "variant"
-            ]
-            && v != ""
-          ) config.services.xserver.xkb
-        )
-      )
-      ++ optionals cfg.hwRender [
-        "drm"
-        "hwaccel"
-      ]
-      ++ optional (cfg.fonts != null) "font-name=${lib.concatMapStringsSep ", " (f: f.name) cfg.fonts}"
-      ++ optional (cfg.term != null) "term=${cfg.term}"
-    );
 
     hardware.graphics.enable = mkIf cfg.hwRender true;
 

--- a/nixos/tests/kmscon.nix
+++ b/nixos/tests/kmscon.nix
@@ -23,7 +23,7 @@
             package = pkgs.nerd-fonts.jetbrains-mono;
           }
         ];
-        term = "xterm-256color";
+        config.term = "xterm-256color";
         package = pkgs.kmscon;
       };
     };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
