### PR TITLE
python3Packages.ziglang: init at 0.16.0, python3Packages.scrapli: init at 2.0.0-rc.7, python3Packages.scrapli-community: init at 2025.01.30, python3Packages.scrapli-cfg: init at 2025.01.30, netboxPlugins.netbox-config-diff: init at 2.14.3

### DIFF
--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-config-diff/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-config-diff/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  netbox,
+  python,
+  hier-config,
+  netutils,
+  scrapli,
+  scrapli-cfg,
+  scrapli-community,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "netbox-config-diff";
+  version = "2.14.3";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "miaow2";
+    repo = "netbox-config-diff";
+    tag = finalAttrs.version;
+    hash = "sha256-OREnrxfEJoAXpklYPkNYHruFWgK0WflpWQxoO7MIf2g=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonRemoveDeps = [ "scrapli" ];
+
+  pythonRelaxDeps = [
+    "hier-config"
+    "netutils"
+  ];
+
+  dependencies = [
+    hier-config
+    netutils
+    scrapli
+    scrapli-cfg
+    scrapli-community
+  ];
+
+  nativeCheckInputs = [ netbox ];
+
+  preFixup = ''
+    export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH
+  '';
+
+  dontUsePythonImportsCheck = python.pythonVersion != netbox.python.pythonVersion;
+
+  pythonImportsCheck = [ "netbox_config_diff" ];
+
+  passthru.pluginName = "netbox_config_diff";
+
+  meta = {
+    description = "NetBox plugin to find diff, push rendered device configurations to devices and apply them";
+    homepage = "https://miaow2.github.io/netbox-config-diff/";
+    changelog = "https://github.com/miaow2/netbox-config-diff/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/development/python-modules/scrapli-cfg/default.nix
+++ b/pkgs/development/python-modules/scrapli-cfg/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+  scrapli,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "scrapli-cfg";
+  version = "2025.01.30";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "scrapli";
+    repo = "scrapli_cfg";
+    tag = finalAttrs.version;
+    hash = "sha256-OpS0Yp/INqyDDIPyOxLRTr2XOk3fw428qT2eCrasNVc=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonRemoveDeps = [ "scrapli" ];
+
+  dependencies = [ scrapli ];
+
+  pythonImportCheck = [ "scrapli_cfg" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  # TODO investigate: ModuleNotFoundError: No module named 'scrapli.driver'
+  doCheck = false;
+
+  meta = {
+    description = "Scrapli community platforms";
+    homepage = "https://scrapli.github.io/scrapli_cfg/";
+    changelog = "https://github.com/scrapli/scrapli_cfg/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/development/python-modules/scrapli-community/default.nix
+++ b/pkgs/development/python-modules/scrapli-community/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+  scrapli,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "scrapli-community";
+  version = "2025.01.30";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "scrapli";
+    repo = "scrapli_community";
+    tag = finalAttrs.version;
+    hash = "sha256-RvwMHLXk+sJs6G7qbBoesNNCJmi1y8HsEGp6Fdl/RAY=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ scrapli ];
+
+  pythonRemoveDeps = [ "scrapli" ];
+
+  pythonImportCheck = [ "scrapli_community" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  # TODO investigate: ModuleNotFoundError: No module named 'scrapli.driver'
+  doCheck = false;
+
+  meta = {
+    description = "Scrapli community platforms";
+    homepage = "https://scrapli.github.io/scrapli_community/";
+    changelog = "https://github.com/scrapli/scrapli_community/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/development/python-modules/scrapli/default.nix
+++ b/pkgs/development/python-modules/scrapli/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+  ziglang,
+  pytest-asyncio,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "scrapli";
+  version = "2.0.0-rc.7";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "carlmontanari";
+    repo = "scrapli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Yq06QxeFxr1A2cqetmIw/MRVvcwM6h7BBKr4ehzVk9o=";
+  };
+
+  preBuild = ''
+    substituteInPlace setup.py --replace-fail '"bdist_wheel": LibscrapliBdist,' ""
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [ ziglang ];
+
+  pythonImportCheck = "scrapli";
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+  ];
+
+  # TODO investigate
+  doCheck = false;
+
+  meta = {
+    description = "Fast, flexible, sync/async, Python 3.10+ screen scraping client specifically for network devices";
+    homepage = "https://github.com/carlmontanari/scrapli";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/development/python-modules/ziglang/default.nix
+++ b/pkgs/development/python-modules/ziglang/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "ziglang";
+  version = "0.16.0";
+  format = "wheel";
+  __structuredAttrs = true;
+
+  # not sure how to build this from source: https://codeberg.org/ziglang/zig https://codeberg.org/ziglang/zig-pypi
+  src = fetchPypi {
+    inherit pname version format;
+    hash = "sha256-n82nP2K4Ud1ypUtxCtQKIJiW2xTPsTZJ5iGRJDVWNCs=";
+    dist = "py3";
+    python = "py3";
+    platform = "manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64";
+  };
+
+  build-system = [ setuptools ];
+
+  meta = {
+    description = "Zig is a general-purpose programming language and toolchain for maintaining robust, optimal, and reusable software";
+    homepage = "https://ziglang.org/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17637,6 +17637,8 @@ self: super: with self; {
 
   scrapli = callPackage ../development/python-modules/scrapli { };
 
+  scrapli-community = callPackage ../development/python-modules/scrapli-community { };
+
   scrapy = callPackage ../development/python-modules/scrapy { };
 
   scrapy-deltafetch = callPackage ../development/python-modules/scrapy-deltafetch { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17635,6 +17635,8 @@ self: super: with self; {
 
   scrap-engine = callPackage ../development/python-modules/scrap-engine { };
 
+  scrapli = callPackage ../development/python-modules/scrapli { };
+
   scrapy = callPackage ../development/python-modules/scrapy { };
 
   scrapy-deltafetch = callPackage ../development/python-modules/scrapy-deltafetch { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21912,6 +21912,8 @@ self: super: with self; {
 
   zict = callPackage ../development/python-modules/zict { };
 
+  ziglang = callPackage ../development/python-modules/ziglang { };
+
   ziggo-mediabox-xl = callPackage ../development/python-modules/ziggo-mediabox-xl { };
 
   zigpy = callPackage ../development/python-modules/zigpy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17637,6 +17637,8 @@ self: super: with self; {
 
   scrapli = callPackage ../development/python-modules/scrapli { };
 
+  scrapli-cfg = callPackage ../development/python-modules/scrapli-cfg { };
+
   scrapli-community = callPackage ../development/python-modules/scrapli-community { };
 
   scrapy = callPackage ../development/python-modules/scrapy { };


### PR DESCRIPTION
ziglang and scrapli are also being used in https://github.com/NixOS/nixpkgs/pull/523812, I will remove the commits from the pr that gets merged after 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
