### PR TITLE
lyricspot: init at 2.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30263,6 +30263,12 @@
     github = "yarektyshchenko";
     githubId = 185304;
   };
+  yarn = {
+    name = "yarncat";
+    github = "yaaaarn";
+    githubId = 30006414;
+    email = "nix@yarncat.moe";
+  };
   yarny = {
     github = "Yarny0";
     githubId = 41838844;

--- a/pkgs/by-name/ly/lyricspot/package.nix
+++ b/pkgs/by-name/ly/lyricspot/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenvNoCC,
+  makeWrapper,
+  python3,
+  playerctl,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "lyricspot";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "vlensys";
+    repo = "lyricspot";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qDXTcTlpMWW7vAQuOFBEnM26DvIdy/fvkGTL/TdDa2A=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp lyricspot.py $out/bin/lyricspot
+    chmod +x $out/bin/lyricspot
+    wrapProgram $out/bin/lyricspot \
+      --prefix PATH ":" ${
+        lib.makeBinPath [
+          python3
+          playerctl
+        ]
+      }
+  '';
+
+  meta = {
+    homepage = "https://github.com/vlensys/lyricspot";
+    description = "Good old live synced lyrics in your terminal";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "lyricspot";
+    maintainers = with lib.maintainers; [
+      yarn
+    ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
https://github.com/vlensys/lyricspot
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
