### PR TITLE
logind: re-enable service restarts when xserver is not present

### DIFF
--- a/nixos/modules/system/boot/systemd/logind.nix
+++ b/nixos/modules/system/boot/systemd/logind.nix
@@ -44,38 +44,40 @@
     };
   };
 
-  config = lib.mkIf config.services.logind.enable {
-    systemd.additionalUpstreamSystemUnits = [
-      "systemd-logind.service"
-      "systemd-user-sessions.service"
-    ]
-    ++ lib.optionals config.systemd.package.withImportd [
-      "dbus-org.freedesktop.import1.service"
-    ]
-    ++ lib.optionals config.systemd.package.withMachined [
-      "dbus-org.freedesktop.machine1.service"
-    ]
-    ++ [
-      "dbus-org.freedesktop.login1.service"
-      "user@.service"
-      "user-runtime-dir@.service"
-    ];
+  config = lib.mkIf config.services.logind.enable (
+    lib.mkMerge [
+      {
+        systemd.additionalUpstreamSystemUnits = [
+          "systemd-logind.service"
+          "systemd-user-sessions.service"
+        ]
+        ++ lib.optionals config.systemd.package.withImportd [ "dbus-org.freedesktop.import1.service" ]
+        ++ lib.optionals config.systemd.package.withMachined [ "dbus-org.freedesktop.machine1.service" ]
+        ++ [
+          "dbus-org.freedesktop.login1.service"
+          "user@.service"
+          "user-runtime-dir@.service"
+        ];
 
-    environment.etc."systemd/logind.conf".text =
-      utils.systemdUtils.lib.settingsToSections config.services.logind.settings;
+        environment.etc."systemd/logind.conf".text =
+          utils.systemdUtils.lib.settingsToSections config.services.logind.settings;
 
-    # Restarting systemd-logind breaks X11
-    # - upstream commit: https://cgit.freedesktop.org/xorg/xserver/commit/?id=dc48bd653c7e101
-    # - systemd announcement: https://github.com/systemd/systemd/blob/22043e4317ecd2bc7834b48a6d364de76bb26d91/NEWS#L103-L112
-    # - this might be addressed in the future by xorg
-    #systemd.services.systemd-logind.restartTriggers = [ config.environment.etc."systemd/logind.conf".source ];
-    systemd.services.systemd-logind.restartIfChanged = false;
-    systemd.services.systemd-logind.stopIfChanged = false;
+        # The user-runtime-dir@ service is managed by systemd-logind we should not touch it or else we break the users' sessions.
+        systemd.services."user-runtime-dir@".stopIfChanged = false;
+        systemd.services."user-runtime-dir@".restartIfChanged = false;
+      }
 
-    # The user-runtime-dir@ service is managed by systemd-logind we should not touch it or else we break the users' sessions.
-    systemd.services."user-runtime-dir@".stopIfChanged = false;
-    systemd.services."user-runtime-dir@".restartIfChanged = false;
-  };
+      (lib.mkIf config.config.services.xserver.enable {
+        # Restarting systemd-logind breaks X11
+        # - upstream commit: https://cgit.freedesktop.org/xorg/xserver/commit/?id=dc48bd653c7e101
+        # - systemd announcement: https://github.com/systemd/systemd/blob/22043e4317ecd2bc7834b48a6d364de76bb26d91/NEWS#L103-L112
+        # - this might be addressed in the future by xorg
+        #systemd.services.systemd-logind.restartTriggers = [ config.environment.etc."systemd/logind.conf".source ];
+        systemd.services.systemd-logind.restartIfChanged = false;
+        systemd.services.systemd-logind.stopIfChanged = false;
+      })
+    ]
+  );
 
   imports =
     let


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Currently, logind services are not restarted due to comment https://github.com/NixOS/nixpkgs/blob/687f05a9184cad4eaf905c48b63649e3a86f5433/nixos/modules/system/boot/systemd/logind.nix#L67

It brings confusion to users when nothing is changed on system switch, i.e. closing the laptop lid still makes their laptop go to sleep. This PR currently checks whether `services.xserver.enable` (is this enough?) is set to `true` to avoid breaking X11 as per comment.

Also it might be a good idea to print eval warning about that? I need another opinion on this. Thanks!

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test