### PR TITLE
alliance: unbreak

### DIFF
--- a/pkgs/by-name/al/alliance/package.nix
+++ b/pkgs/by-name/al/alliance/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # To avoid compiler error in LoadDataBase.c:366:27
-  env.NIX_CFLAGS_COMPILE = "-Wno-incompatible-pointer-types";
+  env.NIX_CFLAGS_COMPILE = "-std=gnu99 -Wno-incompatible-pointer-types";
 
   postPatch = ''
     # texlive for docs seems extreme
@@ -77,6 +77,5 @@ stdenv.mkDerivation (finalAttrs: {
     license = with lib.licenses; gpl2Plus;
     maintainers = [ ];
     platforms = with lib.platforms; linux;
-    broken = true;
   };
 })


### PR DESCRIPTION
add -std=gnu99 to fix compilation. remove broken flag.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
