### PR TITLE
dfhack: move env variables into env for structuredAttrs

### DIFF
--- a/pkgs/games/dwarf-fortress/df.lock.json
+++ b/pkgs/games/dwarf-fortress/df.lock.json
@@ -20,7 +20,7 @@
           "git": {
             "url": "https://github.com/DFHack/dfhack.git",
             "revision": "53.14-r2",
-            "outputHash": "sha256-UOmp84VoY/pam99T2ktAYH3N3cFMSIb9v8KOTZCof8U="
+            "outputHash": "sha256-8OvJ8NULgfR+S0kzOSmQvplhPT7wcxw02sRkG450ptE="
           },
           "xmlRev": "01aae95cacd98850e4f477c45a4b75f800bacecc"
         }

--- a/pkgs/games/dwarf-fortress/dfhack/default.nix
+++ b/pkgs/games/dwarf-fortress/dfhack/default.nix
@@ -145,8 +145,19 @@ stdenv.mkDerivation {
     # Use SDL_GetPrefPath since this takes XDG_DATA_HOME into account (which is correct).
     ++ optional (versionAtLeast version "52.02-r2") ./use-df-linux-dir.patch;
 
-  # gcc 11 fix
-  CXXFLAGS = optionalString (versionOlder version "0.47.05-r3") "-fpermissive";
+  env = {
+    # gcc 11 fix
+    CXXFLAGS = optionalString (versionOlder version "0.47.05-r3") "-fpermissive";
+
+    NIX_CFLAGS_COMPILE = toString (
+      [
+        "-Wno-error=deprecated-enum-enum-conversion"
+      ]
+      ++ optionals (versionOlder version "0.47") [
+        "-fpermissive"
+      ]
+    );
+  };
 
   nativeBuildInputs = [
     cmake
@@ -199,11 +210,6 @@ stdenv.mkDerivation {
     "-DFETCHCONTENT_FULLY_DISCONNECTED=ON"
     "-DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=${fetchOverrides}"
   ];
-
-  NIX_CFLAGS_COMPILE = [
-    "-Wno-error=deprecated-enum-enum-conversion"
-  ]
-  ++ optionals (versionOlder version "0.47") [ "-fpermissive" ];
 
   preFixup = ''
     # Wrap dfhack scripts.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
