### PR TITLE
openfoam: init at 2512

### DIFF
--- a/pkgs/by-name/op/openfoam-unwrapped/package.nix
+++ b/pkgs/by-name/op/openfoam-unwrapped/package.nix
@@ -1,0 +1,192 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  cmake,
+  cgal_5,
+  zlib,
+  gmp,
+  gnum4,
+  boost,
+  fftw,
+  flex,
+  openmpi,
+  scotch,
+  symlinkJoin,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "openfoam-unwrapped";
+  version = "2512";
+
+  src = fetchFromGitLab {
+    owner = "OpenFOAM/core";
+    repo = "openfoam";
+    tag = "OpenFOAM-v${finalAttrs.version}";
+    hash = "sha256-uaXA0sFso6W+1jE2/2G0ckQlqRGnP/QBk0aHzP7xTWw=";
+  };
+
+  sourceRoot = ".";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  dontUseCmakeConfigure = true;
+  dontFixup = true;
+
+  buildInputs = [
+    zlib
+    gmp
+    gmp.dev
+    boost
+    flex
+    openmpi
+    openmpi.dev
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    flex
+    gnum4
+    openmpi.dev
+  ];
+
+  patchPhase =
+    let
+      scotchCombined = symlinkJoin {
+        name = "scotch-combined";
+        paths = [
+          scotch.dev
+          scotch.out
+        ];
+      };
+
+      fftwCombined = symlinkJoin {
+        name = "fftw-combined";
+        paths = [
+          fftw.dev
+          fftw.out
+        ];
+      };
+
+      boostCombined = symlinkJoin {
+        name = "boost-combined";
+        paths = [
+          boost.dev
+          boost.out
+        ];
+      };
+    in
+    ''
+      runHook prePatch
+
+      patchShebangs --build .
+
+      substituteInPlace source/etc/config.sh/scotch \
+        --replace-fail \
+          'SCOTCH_VERSION=scotch_6.1.0' \
+          'SCOTCH_VERSION=scotch-system' \
+        --replace-fail \
+          'export SCOTCH_ARCH_PATH=$WM_THIRD_PARTY_DIR/platforms/$WM_ARCH$WM_COMPILER$WM_PRECISION_OPTION$WM_LABEL_OPTION/$SCOTCH_VERSION' \
+          'export SCOTCH_ARCH_PATH=${scotchCombined}'
+
+      substituteInPlace source/etc/config.sh/FFTW \
+        --replace-fail \
+          'fftw_version=fftw-3.3.10' \
+          'fftw_version=fftw-system' \
+        --replace-fail \
+          'export FFTW_ARCH_PATH=$WM_THIRD_PARTY_DIR/platforms/$WM_ARCH$WM_COMPILER/$fftw_version' \
+          'export FFTW_ARCH_PATH=${fftwCombined}'
+
+      substituteInPlace source/etc/config.sh/CGAL \
+        --replace-fail \
+          'cgal_version=CGAL-4.14.3' \
+          'cgal_version=cgal-system' \
+        --replace-fail \
+          'export CGAL_ARCH_PATH="$WM_THIRD_PARTY_DIR/platforms/$WM_ARCH$WM_COMPILER/$cgal_version"' \
+          'export CGAL_ARCH_PATH="${cgal_5}"'
+
+      substituteInPlace source/etc/config.sh/CGAL \
+        --replace-fail \
+          'boost_version=boost_1_74_0' \
+          'boost_version=boost-system' \
+        --replace-fail \
+          'export BOOST_ARCH_PATH="$WM_THIRD_PARTY_DIR/platforms/$WM_ARCH$WM_COMPILER/$boost_version"' \
+          'export BOOST_ARCH_PATH="${boostCombined}"'
+
+      export HOME="$PWD/builduser"
+
+      mkdir -p "$HOME/OpenFOAM"
+      mkdir -p "$HOME/.OpenFOAM"
+
+      mv source "$HOME/OpenFOAM/OpenFOAM-${finalAttrs.version}"
+
+      runHook postPatch
+    '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    cd "$HOME/OpenFOAM/OpenFOAM-${finalAttrs.version}"
+
+    set +eu
+    source ./etc/bashrc
+    set -eu
+
+    ./Allwmake -j "$NIX_BUILD_CORES" -q -s
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    OUT_DIR="$out/opt/OpenFOAM-${finalAttrs.version}"
+
+    mkdir -p "$OUT_DIR"
+    cp -r . "$OUT_DIR"
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    tests.foamInstallation = stdenv.mkDerivation {
+      name = "openfoam-installation-test";
+
+      nativeBuildInputs = [
+        finalAttrs.finalPackage
+        flex
+        openmpi
+      ];
+
+      dontUnpack = true;
+
+      buildPhase = ''
+        set +eu
+        source ${finalAttrs.finalPackage}/opt/OpenFOAM-${finalAttrs.version}/etc/bashrc
+        set -eu
+
+        foamInstallationTest > test.log 2>&1
+        cat test.log
+
+        if grep -q 'fatal error' test.log; then
+          exit 1
+        fi
+      '';
+
+      installPhase = ''
+        touch "$out"
+      '';
+    };
+  };
+
+  meta = {
+    description = "OpenFOAM is an open-source CFD toolkit for solving fluid flow, turbulence, heat transfer, chemical reactions, and multiphysics problems";
+    homepage = "https://openfoam.com";
+    downloadPage = "https://gitlab.com/openfoam/core/openfoam";
+    changelog = "https://www.openfoam.com/news/main-news/openfoam-v${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ Zirconium419122 ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/op/openfoam/package.nix
+++ b/pkgs/by-name/op/openfoam/package.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  stdenv,
+  openfoam-unwrapped,
+  flex,
+  openmpi,
+  paraview,
+  makeWrapper,
+}:
+
+stdenv.mkDerivation {
+  pname = "openfoam";
+  version = openfoam-unwrapped.version;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [
+    flex
+    openmpi
+    makeWrapper
+  ];
+
+  installPhase = ''
+    OUT_DIR="${openfoam-unwrapped}/opt/OpenFOAM-${openfoam-unwrapped.version}"
+
+    wrapDir() {
+      local dir="$1"
+
+      for f in "$dir"/*; do
+        [ -f "$f" ] || continue
+        [ -x "$f" ] || continue
+
+        local name
+        name="$(basename "$f")"
+
+        makeWrapper "$f" "$out/bin/$name" \
+          --run "
+            set +eu
+
+            export PATH="${lib.makeBinPath [ paraview ]}:$PATH"
+
+            source "$OUT_DIR/etc/bashrc"
+          "
+      done
+    }
+
+    set +eu
+    source "$OUT_DIR/etc/bashrc"
+    set -eu
+
+    mkdir -p "$out/bin"
+
+    wrapDir "$OUT_DIR/bin"
+    wrapDir "$OUT_DIR/platforms/$WM_OPTIONS/bin"
+
+    mkdir -p "$out/share/man/man1"
+
+    $OUT_DIR/bin/tools/foamCreateManpage \
+      -dir="$out/bin" \
+      -output="$out/share/man/man1" \
+      -version="v${openfoam-unwrapped.version}"
+
+    mkdir -p "$out/share/openfoam"
+    mkdir -p "$out/share/bash-completion/completions"
+
+    cp "$OUT_DIR/etc/config.sh/bash_completion" "$out/share/openfoam/bash_completion"
+
+    $OUT_DIR/bin/tools/foamCreateCompletionCache \
+      -dir "$out/bin" \
+      -o "$out/share/openfoam/completion_cache"
+
+    cat > "$out/share/bash-completion/completions/openfoam" <<EOF
+      FOAM_APPBIN="$out/bin"
+      source "$out/share/openfoam/completion_cache"
+      source "$out/share/openfoam/bash_completion"
+    EOF
+
+    for f in "$out/bin"/*; do
+      [ -f "$f" ] || continue
+      [ -x "$f" ] || continue
+
+      name="$(basename "$f")"
+
+      ln -s openfoam "$out/share/bash-completion/completions/$name"
+    done
+  '';
+
+  meta = openfoam-unwrapped.meta;
+}


### PR DESCRIPTION
Add [OpenFOAM](https://www.openfoam.com/) to nixpkgs.

Includes a unwrapped derivation as well as a wrapper. The cause for this split is because compiling OpenFOAM takes a significant amount of time (upwards of half a hour), so changes to wrapping can be made easier/quicker.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
