### PR TITLE
nixos/firewalld: add reload triggers for config file changes

### DIFF
--- a/nixos/modules/services/networking/firewalld/default.nix
+++ b/nixos/modules/services/networking/firewalld/default.nix
@@ -57,7 +57,19 @@ in
     systemd.services.firewalld = {
       aliases = [ "dbus-org.fedoraproject.FirewallD1.service" ];
       wantedBy = [ "multi-user.target" ];
-      serviceConfig.ExecReload = "${lib.getExe' pkgs.coreutils "kill"} -HUP $MAINPID";
+      serviceConfig.ExecReload = [
+        ""
+        "${lib.getExe' pkgs.coreutils "kill"} -HUP $MAINPID"
+      ];
+      reloadTriggers = [
+        config.environment.etc."firewalld/firewalld.conf".source
+      ]
+      ++ lib.mapAttrsToList (
+        name: _: config.environment.etc."firewalld/zones/${name}.xml".source
+      ) config.services.firewalld.zones
+      ++ lib.mapAttrsToList (
+        name: _: config.environment.etc."firewalld/services/${name}.xml".source
+      ) config.services.firewalld.services;
       environment.NIX_FIREWALLD_CONFIG_PATH = "${paths}/lib/firewalld";
     };
   };


### PR DESCRIPTION
When firewalld serves as the backend for networking.firewall, changes to allowedTCPPorts, zones, settings etc. rewrite /etc/firewalld/* but firewalld.service was never reloaded. Add reloadTriggers pointing to firewalld.conf, all zone XMLs and service XMLs so switch-to-configuration reloads the daemon on nixos-rebuild switch.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
