### PR TITLE
rapidhash: init at 3

### DIFF
--- a/pkgs/by-name/ra/rapidhash/package.nix
+++ b/pkgs/by-name/ra/rapidhash/package.nix
@@ -1,0 +1,35 @@
+{
+  stdenvNoCC,
+  fetchFromGitHub,
+  lib,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "rapidhash";
+  version = "3";
+  src = fetchFromGitHub {
+    owner = "Nicoshev";
+    repo = "rapidhash";
+    tag = "rapidhash_v${finalAttrs.version}";
+    hash = "sha256-3J5/R3TcIqMkhst6sAxS3X/ZC7C5Jl60nPPMVyaugzc=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm444 *.h -t $out/include/rapidhash
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Very fast, high quality, platform-independent hashing algorithm libraries for C++";
+    homepage = "https://github.com/Nicoshev/rapidhash/";
+    license = [ lib.licenses.mit ];
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.jackr ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

add rapidhash: https://github.com/Nicoshev/rapidhash/tree/master, a dependency of https://github.com/mrizaln/madbfs (which i am working on packaging).

First time packaging c++ headers so feedback very welcome :)



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
