### PR TITLE
clash-verge-rev: 2.4.7 -> 2.5.1

### DIFF
--- a/nixos/modules/programs/clash-verge.nix
+++ b/nixos/modules/programs/clash-verge.nix
@@ -62,6 +62,10 @@
       systemd.services.clash-verge = lib.mkIf cfg.serviceMode {
         enable = true;
         description = "Clash Verge Service Mode";
+        # service-ipc v2.3 persists desired core/logger state below XDG_STATE_HOME.
+        # The upstream module keeps ProtectSystem=strict, so give it an explicit
+        # systemd-managed state directory instead of relying on /var/lib writes.
+        environment.XDG_STATE_HOME = "/var/lib";
         serviceConfig = {
           ExecStart = "${cfg.package}/bin/clash-verge-service";
           Restart = "on-failure";
@@ -81,6 +85,10 @@
           LockPersonality = true;
           RestrictRealtime = true;
           RuntimeDirectory = "clash-verge-rev";
+          # Keep the runtime socket group-scoped, matching programs.clash-verge.group.
+          RuntimeDirectoryMode = "0770";
+          StateDirectory = "clash-verge-service";
+          StateDirectoryMode = "0750";
           ProtectClock = true;
           MemoryDenyWriteExecute = true;
           RestrictSUIDSGID = true;

--- a/pkgs/by-name/cl/clash-verge-rev/package.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/package.nix
@@ -13,17 +13,17 @@
 let
   pname = "clash-verge-rev";
   # Please keep service version in sync
-  version = "2.4.7";
+  version = "2.5.1";
 
   src = fetchFromGitHub {
     owner = "clash-verge-rev";
     repo = "clash-verge-rev";
     tag = "v${version}";
-    hash = "sha256-Jw9GXD0RFFPkqhJuNZaooxIHVDt1ti0a4g863jIwtkY=";
+    hash = "sha256-2X2QlWo12qM7RT0wjf1Xlmh3We2wZR/kJnSxIxVst9Y=";
   };
 
-  pnpm-hash = "sha256-2iGCe9LmH99hVOWEWkDy7/XH4r/Jlr8rzL5FrCRpn3Q=";
-  vendor-hash = "sha256-EHsGCrphP6SRQ04Q0sIh8CmzMwbvqDQeiL44ItBGIaM=";
+  pnpm-hash = "sha256-eO2ir0kQ0blPX6ExER6hhldZaoE4Rwh3NF/1WTHoWRo=";
+  vendor-hash = "sha256-nF9d1OWpn3rf4EPhD4vqQbKEp/J5pc7J7XJDgAjd0DA=";
 
   service = callPackage ./service.nix {
     inherit

--- a/pkgs/by-name/cl/clash-verge-rev/patch-service-directory.patch
+++ b/pkgs/by-name/cl/clash-verge-rev/patch-service-directory.patch
@@ -2,6 +2,15 @@ diff --git a/src/core/server.rs b/src/core/server.rs
 index 45570ea..d459b3e 100644
 --- a/src/core/server.rs
 +++ b/src/core/server.rs
+@@ -67,7 +67,7 @@ pub async fn run_ipc_server() -> Result<JoinHandle<Result<()>>> {
+                 tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+             }
+             if socket_ready {
+-                fs::set_permissions(paths.ipc_path(), Permissions::from_mode(0o777)).await?;
++                fs::set_permissions(paths.ipc_path(), Permissions::from_mode(0o660)).await?;
+             } else {
+                 warn!(
+                     "IPC socket {:?} did not appear before permission update timeout",
 @@ -123,7 +123,7 @@ async fn make_ipc_dir() -> Result<()> {
          // on macOS or the primary group on Linux) to manage the socket's lifecycle. This prevents
          // permission denied errors when the GUI process, running with non-root privileges,
@@ -11,16 +20,25 @@ index 45570ea..d459b3e 100644
      }
      #[cfg(windows)]
      {
+@@ -208,7 +208,7 @@ pub fn spawn_socket_dir_watchdog() {
+                     continue;
+                 }
+                 use std::fs::Permissions;
+                 use std::os::unix::fs::PermissionsExt;
+-                let _ = tokio::fs::set_permissions(dir, Permissions::from_mode(0o777)).await;
++                let _ = tokio::fs::set_permissions(dir, Permissions::from_mode(0o770)).await;
+                 info!("IPC socket directory {:?} recreated", dir);
+             }
+         }
 diff --git a/src/lib.rs b/src/lib.rs
 index a21f89b..81175fc 100644
 --- a/src/lib.rs
 +++ b/src/lib.rs
 @@ -12,7 +12,7 @@ pub use core::{run_ipc_server, stop_ipc_server};
  pub use client::*;
- 
+
  #[cfg(all(unix, not(feature = "test")))]
 -pub static IPC_PATH: &str = "/tmp/verge/clash-verge-service.sock";
 +pub static IPC_PATH: &str = "/run/clash-verge-rev/service.sock";
  #[cfg(all(windows, not(feature = "test")))]
  pub static IPC_PATH: &str = r"\\.\pipe\clash-verge-service";
- 

--- a/pkgs/by-name/cl/clash-verge-rev/service.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/service.nix
@@ -1,4 +1,5 @@
 {
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
   meta,
@@ -7,25 +8,23 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "clash-verge-service-ipc";
-  version = "2.1.3";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "clash-verge-rev";
     repo = "clash-verge-service-ipc";
-    # upstream uses branch
-    rev = "a486e7df6ac3d641014085f43bd08e99ff09b5a2";
-    hash = "sha256-WmQ3s6uED4Q1E2ORtjDqdxaUaPD+RIB5x8bYPOuGUSk=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XavlZWxuZKCTyIYpuXRvXpXCdakWhbLhOMmOrGBgDRo=";
   };
 
   patches = [
-    # 1. Don't SetGID because the path is managed by systemd in NixOS, and we
-    #    use different IPC path for sidecar mode. We can keep RestrictSUIDSGID
-    #    in systemd serviceConfig.
-    # 2. Set IPC socket path
+    # Let the NixOS module's RuntimeDirectory/Group own socket access policy.
+    # Upstream defaults target installer-managed /tmp paths and broad fallback
+    # permissions, which do not fit the hardened systemd service.
     ./patch-service-directory.patch
   ];
 
-  cargoHash = "sha256-xE8ihRlox7qrmLHEGQ76pbisFj+1bqjwr+tllxLRDoA=";
+  cargoHash = "sha256-WhH2o5wN5vYW8jZl+hWbnk1xqHu61ibAr4+/CI3YKHg=";
 
   buildFeatures = [
     "standalone"
@@ -34,9 +33,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeCheckInputs = [
     procps
   ];
-  # build mock_binary for tests
+  # Upstream tests look in target/debug, while Nix builds under the target triple.
   preCheck = ''
-    cargo build --features=test
+    cargo build --features=test --bin mock_binary --bin crash_binary
+    cargo build --features=standalone,test --bin owner_lock_holder
+
+    mkdir -p target/debug
+    for bin in mock_binary crash_binary owner_lock_holder; do
+      ln -sf "../${stdenv.hostPlatform.config}/debug/$bin" "target/debug/$bin"
+    done
   '';
   checkFeatures = [
     "standalone"

--- a/pkgs/by-name/cl/clash-verge-rev/unwrapped.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/unwrapped.nix
@@ -13,7 +13,7 @@
   moreutils,
   nodejs,
   pkg-config,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
 
@@ -37,7 +37,7 @@ rustPlatform.buildRustPackage {
       version
       src
       ;
-    pnpm = pnpm_9;
+    pnpm = pnpm_10;
     fetcherVersion = 3;
     hash = pnpm-hash;
   };
@@ -87,7 +87,7 @@ rustPlatform.buildRustPackage {
     nodejs
     pkg-config
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
   ];
 
   buildInputs = [


### PR DESCRIPTION
Updates clash-verge-rev to 2.5.1 and clash-verge-service-ipc to 2.3.0.

Tested locally:
- nix build --impure --no-link --expr '(import ./. {}).clash-verge-rev.service'
- nix build --impure --no-link --expr '(import ./. {}).clash-verge-rev'
- nix eval module service settings for programs.clash-verge.serviceMode
- git diff --check
- nixfmt-rfc-style --check