### PR TITLE
zod: move env variables into env

### DIFF
--- a/pkgs/by-name/zo/zod/package.nix
+++ b/pkgs/by-name/zo/zod/package.nix
@@ -39,7 +39,9 @@ let
     coreutils
   ];
   hardeningDisable = [ "format" ];
-  NIX_LDFLAGS = "-L${libmysqlclient}/lib/mysql";
+  env = {
+    NIX_LDFLAGS = "-L${libmysqlclient}/lib/mysql";
+  };
   zod_engine = stdenv.mkDerivation {
     inherit
       version
@@ -48,7 +50,7 @@ let
       nativeBuildInputs
       buildInputs
       hardeningDisable
-      NIX_LDFLAGS
+      env
       ;
     pname = "zod-engine-engine";
     enableParallelBuilding = true;
@@ -67,7 +69,7 @@ let
       nativeBuildInputs
       buildInputs
       hardeningDisable
-      NIX_LDFLAGS
+      env
       ;
     pname = "zod-engine-map_editor";
     enableParallelBuilding = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
