### PR TITLE
treewide: follow GitHub redirects for `fetchFromGitHub`

### DIFF
--- a/pkgs/applications/audio/snapcast/default.nix
+++ b/pkgs/applications/audio/snapcast/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.35.0";
 
   src = fetchFromGitHub {
-    owner = "badaix";
+    owner = "snapcast";
     repo = "snapcast";
     rev = "v${finalAttrs.version}";
     hash = "sha256-kUw4yQpCxgjP4hH2Lpxc7l+ufhYSKs7xL80aJuPrqOo=";
@@ -79,7 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Synchronous multi-room audio player";
-    homepage = "https://github.com/badaix/snapcast";
+    homepage = "https://github.com/snapcast/snapcast";
     maintainers = with lib.maintainers; [ fpletz ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     license = lib.licenses.gpl3Plus;

--- a/pkgs/applications/editors/jupyter-kernels/xeus-cling/xeus-cling.nix
+++ b/pkgs/applications/editors/jupyter-kernels/xeus-cling/xeus-cling.nix
@@ -56,7 +56,7 @@ clangStdenv.mkDerivation (finalAttrs: {
   version = "0.15.3";
 
   src = fetchFromGitHub {
-    owner = "QuantStack";
+    owner = "jupyter-xeus";
     repo = "xeus-cling";
     rev = "${finalAttrs.version}";
     hash = "sha256-OfZU+z+p3/a36GntusBfwfFu3ssJW4Fu7SV3SMCoo1I=";

--- a/pkgs/applications/misc/redshift/default.nix
+++ b/pkgs/applications/misc/redshift/default.nix
@@ -138,7 +138,7 @@ rec {
     version = "1.12";
 
     src = fetchFromGitHub {
-      owner = "jonls";
+      owner = "sharpbracket";
       repo = "redshift";
       rev = "v${version}";
       sha256 = "12cb4gaqkybp4bkkns8pam378izr2mwhr2iy04wkprs2v92j7bz6";

--- a/pkgs/applications/networking/sync/lsyncd/default.nix
+++ b/pkgs/applications/networking/sync/lsyncd/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   version = "2.3.1";
 
   src = fetchFromGitHub {
-    owner = "axkibe";
+    owner = "lsyncd";
     repo = "lsyncd";
     rev = "release-${version}";
     hash = "sha256-QBmvS1HGF3VWS+5aLgDr9AmUfEsuSz+DTFIeql2XHH4=";
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   '';
 
   # Special flags needed on Darwin:
-  # https://github.com/axkibe/lsyncd/blob/42413cabbedca429d55a5378f6e830f191f3cc86/INSTALL#L51
+  # https://github.com/lsyncd/lsyncd/blob/42413cabbedca429d55a5378f6e830f191f3cc86/INSTALL#L51
   cmakeFlags = lib.optionals stdenv.hostPlatform.isDarwin [
     "-DWITH_INOTIFY=OFF"
     "-DWITH_FSEVENTS=ON"
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
   ];
 
   meta = {
-    homepage = "https://github.com/axkibe/lsyncd";
+    homepage = "https://github.com/lsyncd/lsyncd";
     description = "Utility that synchronizes local directories with remote targets";
     mainProgram = "lsyncd";
     license = lib.licenses.gpl2Plus;

--- a/pkgs/applications/office/beancount/beancount-ing-diba.nix
+++ b/pkgs/applications/office/beancount/beancount-ing-diba.nix
@@ -12,7 +12,7 @@ python3.pkgs.buildPythonApplication rec {
 
   src = fetchFromGitHub {
     owner = "siddhantgoel";
-    repo = "beancount-ing-diba";
+    repo = "beancount-ing";
     rev = "v${version}";
     sha256 = "sha256-zjwajl+0ix4wnW0bf4MAuO9Lr9F8sBv87TIL5Ghmlxg=";
   };
@@ -29,7 +29,7 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   meta = {
-    homepage = "https://github.com/siddhantgoel/beancount-ing-diba";
+    homepage = "https://github.com/siddhantgoel/beancount-ing";
     description = "Beancount Importers for ING-DiBa (Germany) CSV Exports";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ matthiasbeyer ];

--- a/pkgs/applications/virtualization/krunvm/default.nix
+++ b/pkgs/applications/virtualization/krunvm/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   version = "0.2.4";
 
   src = fetchFromGitHub {
-    owner = "containers";
+    owner = "libkrun";
     repo = "krunvm";
     rev = "v${version}";
     hash = "sha256-YbK4DKw0nh9IO1F7QsJcbOMlHekEdeUBbDHwuQ2x1Ww=";
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "CLI-based utility for creating microVMs from OCI images";
-    homepage = "https://github.com/containers/krunvm";
+    homepage = "https://github.com/libkrun/krunvm";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ nickcao ];
     platforms = libkrun.meta.platforms;

--- a/pkgs/by-name/_4/_4d-minesweeper/package.nix
+++ b/pkgs/by-name/_4/_4d-minesweeper/package.nix
@@ -27,8 +27,8 @@ stdenv.mkDerivation {
   version = "2.0";
 
   src = fetchFromGitHub {
-    owner = "gapophustu";
-    repo = "4D-Minesweeper";
+    owner = "Alzager";
+    repo = "4D-Minesweeper-Archived";
     rev = "db176d8aa5981a597bbae6a1a74aeebf0f376df4";
     hash = "sha256-A5QKqCo9TTdzmK13WRSAfkrkeUqHc4yQCzy4ZZ9uX2M=";
   };
@@ -80,7 +80,7 @@ stdenv.mkDerivation {
   dontStrip = true;
 
   meta = {
-    homepage = "https://github.com/gapophustu/4D-Minesweeper";
+    homepage = "https://github.com/Alzager/4D-Minesweeper-Archived";
     description = "4D Minesweeper game written in Godot";
     license = lib.licenses.mpl20;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/aa/aaa/package.nix
+++ b/pkgs/by-name/aa/aaa/package.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "1.1.1";
 
   src = fetchFromGitHub {
-    owner = "DomesticMoth";
+    owner = "asciimoth";
     repo = "aaa";
     tag = "v${finalAttrs.version}";
     sha256 = "sha256-gIOlPjZOcmVLi9oOn4gBv6F+3Eq6t5b/3fKzoFqxclw=";
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Terminal viewer for 3a format";
-    homepage = "https://github.com/DomesticMoth/aaa";
+    homepage = "https://github.com/asciimoth/aaa";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ asciimoth ];
     mainProgram = "aaa";

--- a/pkgs/by-name/ac/aces-container/package.nix
+++ b/pkgs/by-name/ac/aces-container/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.0.2";
 
   src = fetchFromGitHub {
-    owner = "ampas";
+    owner = "aces-aswf";
     repo = "aces_container";
     tag = "v${finalAttrs.version}";
     hash = "sha256-luMqXqlJ6UzoawEDmbK38lm3GHosaZm/mFJntBF54Y4=";
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Reference Implementation of SMPTE ST2065-4";
-    homepage = "https://github.com/ampas/aces_container";
+    homepage = "https://github.com/aces-aswf/aces_container";
     license = lib.licenses.ampas;
     maintainers = with lib.maintainers; [ paperdigits ];
     mainProgram = "aces-container";

--- a/pkgs/by-name/ae/aeron-cpp/package.nix
+++ b/pkgs/by-name/ae/aeron-cpp/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
   inherit version;
 
   src = fetchFromGitHub {
-    owner = "real-logic";
+    owner = "aeron-io";
     repo = "aeron";
     tag = version;
     hash = "sha256-sROEZVOfScrlqMLbfrPtw3LQCQ5TfMcrLiP6j/Z9rSM=";

--- a/pkgs/by-name/ai/airwave/package.nix
+++ b/pkgs/by-name/ai/airwave/package.nix
@@ -19,7 +19,7 @@ multiStdenv.mkDerivation (finalAttrs: {
   version = "1.3.3";
 
   src = fetchFromGitHub {
-    owner = "phantom-code";
+    owner = "psycha0s";
     repo = "airwave";
     tag = finalAttrs.version;
     hash = "sha256-mvT0b0auKiu1T8cbR9RoBT94hKSnXDamqkIQPnUqVq0=";
@@ -55,7 +55,7 @@ multiStdenv.mkDerivation (finalAttrs: {
   # shrinking.
   dontPatchELF = true;
 
-  # Cf. https://github.com/phantom-code/airwave/issues/57
+  # Cf. https://github.com/psycha0s/airwave/issues/57
   hardeningDisable = [ "format" ];
 
   cmakeFlags = [ "-DVSTSDK_PATH=${vst2-sdk}" ];
@@ -78,7 +78,7 @@ multiStdenv.mkDerivation (finalAttrs: {
       protocol to correctly embed the plugin editor into the host
       window.
     '';
-    homepage = "https://github.com/phantom-code/airwave";
+    homepage = "https://github.com/psycha0s/airwave";
     license = lib.licenses.mit;
     platforms = [ "x86_64-linux" ];
     maintainers = with lib.maintainers; [ michalrus ];

--- a/pkgs/by-name/am/amass/package.nix
+++ b/pkgs/by-name/am/amass/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
   buildInputs = [ libpostalWithData ];
 
   src = fetchFromGitHub {
-    owner = "OWASP";
+    owner = "owasp-amass";
     repo = "Amass";
     tag = "v${finalAttrs.version}";
     hash = "sha256-d4zy64W5cIseOVAaekN5Q4I5WuLz+M/cP7FXQ3CQ+mk=";
@@ -21,7 +21,7 @@ buildGoModule (finalAttrs: {
 
   vendorHash = "sha256-3MpE61ixMps4IRIZkqjzG225zk4fsERkssoNoItUXbQ=";
 
-  # https://github.com/OWASP/Amass/issues/640
+  # https://github.com/owasp-amass/amass/issues/640
   doCheck = false;
 
   meta = {
@@ -35,7 +35,7 @@ buildGoModule (finalAttrs: {
       target networks.
     '';
     homepage = "https://owasp.org/www-project-amass/";
-    changelog = "https://github.com/OWASP/Amass/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/owasp-amass/amass/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       kalbasit

--- a/pkgs/by-name/an/anchor/package.nix
+++ b/pkgs/by-name/an/anchor/package.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "1.0.2";
 
   src = fetchFromGitHub {
-    owner = "solana-foundation";
+    owner = "otter-sec";
     repo = "anchor";
     tag = "v${finalAttrs.version}";
     hash = "sha256-J8q+oNT6x36LlTO/szlkxIcT5oFJ3y8b3YyqwBjDYX8=";
@@ -32,8 +32,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Solana Sealevel Framework";
-    homepage = "https://github.com/solana-foundation/anchor";
-    changelog = "https://github.com/solana-foundation/anchor/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    homepage = "https://github.com/otter-sec/anchor";
+    changelog = "https://github.com/otter-sec/anchor/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       Denommus

--- a/pkgs/by-name/an/anup/package.nix
+++ b/pkgs/by-name/an/anup/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
   version = "0.4.0";
 
   src = fetchFromGitHub {
-    owner = "Acizza";
+    owner = "jonathanlmc";
     repo = "anup";
     tag = version;
     hash = "sha256-4pXF4p4K8+YihVB9NdgT6bOidmQEgWXUbcbvgXJ0IDA=";
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   meta = {
-    homepage = "https://github.com/Acizza/anup";
+    homepage = "https://github.com/jonathanlmc/anup";
     description = "Anime tracker for AniList featuring a TUI";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ natto1784 ];

--- a/pkgs/by-name/ap/apftool-rs/package.nix
+++ b/pkgs/by-name/ap/apftool-rs/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "suyulin";
-    repo = "apftool-rs";
+    repo = "afptool-rs";
     tag = "v${finalAttrs.version}";
     hash = "sha256-bcXZIY0CDyWE3vh04IU3kXRxi/uUm5TD8ifA0jq47rc=";
   };
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "About Tools for Rockchip image unpack tool";
     mainProgram = "apftool-rs";
-    homepage = "https://github.com/suyulin/apftool-rs";
+    homepage = "https://github.com/suyulin/afptool-rs";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ colemickens ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/ap/appindicator-sharp/package.nix
+++ b/pkgs/by-name/ap/appindicator-sharp/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   version = "0-unstable-2016-01-18";
 
   src = fetchFromGitHub {
-    owner = "stsundermann";
+    owner = "sundermann";
     repo = "appindicator-sharp";
     rev = "5a79cde93da6d68a4b1373f1ce5796c3c5fe1b37";
     sha256 = "sha256:1i0vqbp05l29f5v9ygp7flm4s05pcnn5ivl578mxmhb51s7ncw6l";
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Bindings for appindicator using gobject-introspection";
-    homepage = "https://github.com/stsundermann/appindicator-sharp";
+    homepage = "https://github.com/sundermann/appindicator-sharp";
     license = lib.licenses.lgpl3Only;
     maintainers = with lib.maintainers; [ kevincox ];
   };

--- a/pkgs/by-name/ap/apriltag/package.nix
+++ b/pkgs/by-name/ap/apriltag/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "AprilRobotics";
-    repo = "AprilTags";
+    repo = "apriltag";
     tag = "v${finalAttrs.version}";
     hash = "sha256-pBUjRKfP884+bNgV5B4b8TiuhyZ9p/jIluxs+idv/28=";
   };

--- a/pkgs/by-name/ar/art/package.nix
+++ b/pkgs/by-name/ar/art/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.26.4";
 
   src = fetchFromGitHub {
-    owner = "artpixls";
+    owner = "artraweditor";
     repo = "ART";
     tag = finalAttrs.version;
     hash = "sha256-T7ri0fQz3OBLmr3BBQvYgSmAQaV/aMax6SOupAQDg5o=";

--- a/pkgs/by-name/as/assh/package.nix
+++ b/pkgs/by-name/as/assh/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
   version = "2.17.2";
 
   src = fetchFromGitHub {
-    repo = "advanced-ssh-config";
+    repo = "assh";
     owner = "moul";
     tag = "v${finalAttrs.version}";
     hash = "sha256-/w4RluA7py6d75S04czNsgHpmR5rmAUZx8OnZfu9oNg=";

--- a/pkgs/by-name/as/async-profiler/package.nix
+++ b/pkgs/by-name/as/async-profiler/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "4.3";
 
   src = fetchFromGitHub {
-    owner = "jvm-profiling-tools";
+    owner = "async-profiler";
     repo = "async-profiler";
     tag = "v${finalAttrs.version}";
     hash = "sha256-wysOjirCfxm0SmwDW7GS+S73lAT8/0g4avu7T5+qy2Q=";
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Low overhead sampling profiler for Java that does not suffer from Safepoint bias problem";
-    homepage = "https://github.com/jvm-profiling-tools/async-profiler";
+    homepage = "https://github.com/async-profiler/async-profiler";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ mschuwalow ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/au/audiness/package.nix
+++ b/pkgs/by-name/au/audiness/package.nix
@@ -10,7 +10,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "audiusGmbH";
+    owner = "audius";
     repo = "audiness";
     tag = finalAttrs.version;
     hash = "sha256-row372NA8/DJbI6WJyGmKrlfuCsxUa5inhMljRzShT8=";

--- a/pkgs/by-name/au/ausweisapp/package.nix
+++ b/pkgs/by-name/au/ausweisapp/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "Governikus";
-    repo = "AusweisApp2";
+    repo = "AusweisApp";
     rev = finalAttrs.version;
     hash = "sha256-R+2swDzIHlgE0kVonoYQih8r8p38RN7bqkbb+WB1hCc=";
   };
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Official authentication app for German ID card and residence permit";
-    downloadPage = "https://github.com/Governikus/AusweisApp2/releases";
+    downloadPage = "https://github.com/Governikus/AusweisApp/releases";
     homepage = "https://www.ausweisapp.bund.de/open-source-software";
     license = lib.licenses.eupl12;
     mainProgram = "AusweisApp";

--- a/pkgs/by-name/av/avizo/package.nix
+++ b/pkgs/by-name/av/avizo/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
   version = "1.3-unstable-2024-11-03";
 
   src = fetchFromGitHub {
-    owner = "misterdanb";
+    owner = "heyjuvi";
     repo = "avizo";
     rev = "5efaa22968b2cc1a3c15a304cac3f22ec2727b17";
     sha256 = "sha256-KYQPHVxjvqKt4d7BabplnrXP30FuBQ6jQ1NxzR5U7qI=";
@@ -56,7 +56,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Neat notification daemon for Wayland";
-    homepage = "https://github.com/misterdanb/avizo";
+    homepage = "https://github.com/heyjuvi/avizo";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;
     maintainers = [

--- a/pkgs/by-name/aw/aws-rotate-key/package.nix
+++ b/pkgs/by-name/aw/aws-rotate-key/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   version = "1.2.0";
 
   src = fetchFromGitHub {
-    owner = "Fullscreen";
+    owner = "stefansundin";
     repo = "aws-rotate-key";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-fYpgHHOw0k/8WLGhq+uVOvoF4Wff6wzTXuN8r4D+TmU=";
@@ -31,7 +31,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Easily rotate your AWS key";
-    homepage = "https://github.com/Fullscreen/aws-rotate-key";
+    homepage = "https://github.com/stefansundin/aws-rotate-key";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.mbode ];
     mainProgram = "aws-rotate-key";

--- a/pkgs/by-name/ba/bash-my-aws/package.nix
+++ b/pkgs/by-name/ba/bash-my-aws/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
   version = "0-unstable-2025-01-22";
 
   src = fetchFromGitHub {
-    owner = "bash-my-aws";
+    owner = "mbailey";
     repo = "bash-my-aws";
     rev = "d338b43cc215719c1853ec500c946db6b9caaa11";
     sha256 = "sha256-PR52T6XCrakQsBOJXf0PaYpYE5oMcIz5UDA4I9B7C38=";

--- a/pkgs/by-name/ba/batticonplus/package.nix
+++ b/pkgs/by-name/ba/batticonplus/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.0.1";
 
   src = fetchFromGitHub {
-    owner = "artist4xlibre";
+    owner = "artist4artixlinux";
     repo = "batticonplus";
     tag = "v${finalAttrs.version}";
     hash = "sha256-H9ZoiQ5zWMIoWWol2a6f9Z8g4o9DIHYdF+/nEsBfuzc=";
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Lightweight battery status icon for the system tray and notifier (based on cbatticon)";
     mainProgram = "batticonplus";
-    homepage = "https://github.com/artist4xlibre/batticonplus";
+    homepage = "https://github.com/artist4artixlinux/batticonplus";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ yechielw ];

--- a/pkgs/by-name/ba/bazel-gazelle/package.nix
+++ b/pkgs/by-name/ba/bazel-gazelle/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "0.47.0";
 
   src = fetchFromGitHub {
-    owner = "bazelbuild";
+    owner = "bazel-contrib";
     repo = "bazel-gazelle";
     rev = "v${finalAttrs.version}";
     hash = "sha256-rnJ8rht7ccAI8ceOv3B0mlcY0fQg9Nfy+hu+/pmQQqE=";
@@ -22,7 +22,7 @@ buildGoModule (finalAttrs: {
   subPackages = [ "cmd/gazelle" ];
 
   meta = {
-    homepage = "https://github.com/bazelbuild/bazel-gazelle";
+    homepage = "https://github.com/bazel-contrib/bazel-gazelle";
     description = ''
       Gazelle is a Bazel build file generator for Bazel projects. It natively
       supports Go and protobuf, and it may be extended to support new languages

--- a/pkgs/by-name/bi/bibata-cursors-translucent/package.nix
+++ b/pkgs/by-name/bi/bibata-cursors-translucent/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation rec {
   version = "1.1.2";
 
   src = fetchFromGitHub {
-    owner = "Silicasandwhich";
+    owner = "silica-dev";
     repo = "Bibata_Cursor_Translucent";
     rev = "v${version}";
     sha256 = "sha256-RroynJfdFpu+Wl9iw9NrAc9wNZsSxWI+heJXUTwEe7s=";
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation rec {
 
   meta = {
     description = "Translucent Varient of the Material Based Cursor";
-    homepage = "https://github.com/Silicasandwhich/Bibata_Cursor_Translucent";
+    homepage = "https://github.com/silica-dev/Bibata_Cursor_Translucent";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;
     maintainers = [ ];

--- a/pkgs/by-name/bi/biscuit-cli/package.nix
+++ b/pkgs/by-name/bi/biscuit-cli/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.6.0";
 
   src = fetchFromGitHub {
-    owner = "biscuit-auth";
+    owner = "eclipse-biscuit";
     repo = "biscuit-cli";
     tag = finalAttrs.version;
     sha256 = "sha256-s4Y4MhM79Z+4VxB03+56OqRQJaSHj2VQEJcL6CsT+2k=";

--- a/pkgs/by-name/bp/bpftop/package.nix
+++ b/pkgs/by-name/bp/bpftop/package.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage.override { stdenv = clangStdenv; } (finalAttrs: {
   version = "0.9.0";
 
   src = fetchFromGitHub {
-    owner = "Netflix";
+    owner = "jfernandez";
     repo = "bpftop";
     tag = "v${finalAttrs.version}";
     hash = "sha256-QukcBq80tASPSHRg1yRouYiZqvca+ipp6RGzXqP2CwA=";
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage.override { stdenv = clangStdenv; } (finalAttrs: {
 
   meta = {
     description = "Dynamic real-time view of running eBPF programs";
-    homepage = "https://github.com/Netflix/bpftop";
+    homepage = "https://github.com/jfernandez/bpftop";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       _0x4A6F

--- a/pkgs/by-name/bt/btor2tools/package.nix
+++ b/pkgs/by-name/bt/btor2tools/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   version = "0-unstable-2025-09-18";
 
   src = fetchFromGitHub {
-    owner = "boolector";
+    owner = "hwmcc";
     repo = "btor2tools";
     rev = "d33c73ff1d173f1bfac8ba6b1c6d68ba62c55f8e";
     sha256 = "sha256-RVjZ5HM2yQ3eAICFuzwvNeQDXzWzzSiCCslIWMJi6U8=";
@@ -54,7 +54,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Generic parser and tool package for the BTOR2 format";
-    homepage = "https://github.com/Boolector/btor2tools";
+    homepage = "https://github.com/hwmcc/btor2tools";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ thoughtpolice ];

--- a/pkgs/by-name/bw/bws/package.nix
+++ b/pkgs/by-name/bw/bws/package.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "bitwarden";
-    repo = "sdk";
+    repo = "sdk-sm";
     tag = "bws-v${finalAttrs.version}";
     hash = "sha256-NjnLoa4UjPzTejjEwc5LIrHqeqncXoMICJM2eUesoIM=";
   };
@@ -63,7 +63,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Bitwarden Secrets Manager CLI";
     homepage = "https://bitwarden.com/help/secrets-manager-cli/";
-    changelog = "https://github.com/bitwarden/sdk-sm/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/bitwarden/sdk-sm-sm/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.unfree; # BITWARDEN SOFTWARE DEVELOPMENT KIT LICENSE AGREEMENT
     maintainers = with lib.maintainers; [ iamanaws ];
     mainProgram = "bws";

--- a/pkgs/by-name/c2/c2fmzq/package.nix
+++ b/pkgs/by-name/c2/c2fmzq/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "c2FmZQ";
-    repo = "c2FmZQ";
+    repo = "photos";
     rev = "v${finalAttrs.version}";
     hash = "sha256-O4/V8fFiTfqTiJWPwEsdigdeKBmwGGo43ZvJXPcVRlE=";
   };
@@ -34,7 +34,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Securely encrypt, store, and share files, including but not limited to pictures and videos";
-    homepage = "https://github.com/c2FmZQ/c2FmZQ";
+    homepage = "https://github.com/c2FmZQ/photos";
     license = lib.licenses.gpl3Only;
     mainProgram = "c2FmZQ-server";
     maintainers = with lib.maintainers; [ hmenke ];

--- a/pkgs/by-name/ca/cagent/package.nix
+++ b/pkgs/by-name/ca/cagent/package.nix
@@ -12,7 +12,7 @@ buildGoModule (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "docker";
-    repo = "cagent";
+    repo = "docker-agent";
     tag = "v${finalAttrs.version}";
     hash = "sha256-jcJxzdtU0Zzov7EKvJCxgbrfwMcI4k7OgHVrb5S4fs8=";
   };
@@ -44,9 +44,9 @@ buildGoModule (finalAttrs: {
       orchestrates AI agents with specialized capabilities and tools,
       and the interactions between agents.
     '';
-    homepage = "https://github.com/docker/cagent";
-    changelog = "https://github.com/docker/cagent/releases/tag/v${finalAttrs.version}";
-    downloadPage = "https://github.com/docker/cagent/releases";
+    homepage = "https://github.com/docker/docker-agent";
+    changelog = "https://github.com/docker/docker-agent/releases/tag/v${finalAttrs.version}";
+    downloadPage = "https://github.com/docker/docker-agent/releases";
     license = lib.licenses.asl20;
     mainProgram = "cagent";
     maintainers = with lib.maintainers; [ MH0386 ];

--- a/pkgs/by-name/ca/cano/package.nix
+++ b/pkgs/by-name/ca/cano/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.2.0-alpha";
 
   src = fetchFromGitHub {
-    owner = "CobbCoding1";
+    owner = "Cano-Projects";
     repo = "Cano";
     tag = "v${finalAttrs.version}";
     hash = "sha256-OaWj0AKw3+sEhcAbIjgOLfxwCKRG6O1k+zSp0GnnFn8=";
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Text Editor Written In C Using ncurses";
-    homepage = "https://github.com/CobbCoding1/Cano";
+    homepage = "https://github.com/Cano-Projects/Cano";
     license = lib.licenses.asl20;
     mainProgram = "Cano";
     maintainers = with lib.maintainers; [ sigmanificient ];

--- a/pkgs/by-name/ca/cargo-limit/package.nix
+++ b/pkgs/by-name/ca/cargo-limit/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.0.10";
 
   src = fetchFromGitHub {
-    owner = "alopatindev";
+    owner = "cargo-limit";
     repo = "cargo-limit";
     tag = finalAttrs.version;
     sha256 = "sha256-joWDB9fhCsYVZFZdr+Gfm4JaRlm5kj+CHp34Sx5iQYk=";
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Cargo subcommand \"limit\": reduces the noise of compiler messages";
-    homepage = "https://github.com/alopatindev/cargo-limit";
+    homepage = "https://github.com/cargo-limit/cargo-limit";
     license = with lib.licenses; [
       asl20 # or
       mit

--- a/pkgs/by-name/ca/cargo-rr/package.nix
+++ b/pkgs/by-name/ca/cargo-rr/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.3.0";
 
   src = fetchFromGitHub {
-    owner = "danielzfranklin";
+    owner = "dzfranklin";
     repo = "cargo-rr";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-t8pRqeOdaRVG0titQhxezT2aDjljSs//MnRTTsJ73Yo=";
@@ -33,7 +33,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Cargo subcommand \"rr\": a light wrapper around rr, the time-travelling debugger";
     mainProgram = "cargo-rr";
-    homepage = "https://github.com/danielzfranklin/cargo-rr";
+    homepage = "https://github.com/dzfranklin/cargo-rr";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [
       otavio

--- a/pkgs/by-name/ca/cassandra-cpp-driver/package.nix
+++ b/pkgs/by-name/ca/cassandra-cpp-driver/package.nix
@@ -15,8 +15,8 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.17.1";
 
   src = fetchFromGitHub {
-    owner = "datastax";
-    repo = "cpp-driver";
+    owner = "apache";
+    repo = "cassandra-cpp-driver";
     tag = finalAttrs.version;
     sha256 = "sha256-GuvmKHJknudyn7ahrn/8+kKUA4NW5UjCfkYoX3aTE+Q=";
   };

--- a/pkgs/by-name/cd/cdxgen/package.nix
+++ b/pkgs/by-name/cd/cdxgen/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "11.10.0";
 
   src = fetchFromGitHub {
-    owner = "CycloneDX";
+    owner = "cdxgen";
     repo = "cdxgen";
     tag = "v${finalAttrs.version}";
     hash = "sha256-RmgR6OfNrZUYFyn36zTHERIHlzszaFqTX8b4Rf2TF/U=";
@@ -65,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Creates CycloneDX Software Bill-of-Materials (SBOM) for your projects from source and container images";
     mainProgram = "cdxgen";
-    homepage = "https://github.com/CycloneDX/cdxgen";
+    homepage = "https://github.com/cdxgen/cdxgen";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       quincepie

--- a/pkgs/by-name/cf/cfm/package.nix
+++ b/pkgs/by-name/cf/cfm/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.6.6";
 
   src = fetchFromGitHub {
-    owner = "willeccles";
+    owner = "sophec";
     repo = "cfm";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-uXL0RO9P+NYSZ0xCv91KzjHOJJI500YUT8IJkFS86pE=";
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    homepage = "https://github.com/willeccles/cfm";
+    homepage = "https://github.com/sophec/cfm";
     description = "Simple and fast TUI file manager with no dependencies";
     license = lib.licenses.mpl20;
     maintainers = [ ];

--- a/pkgs/by-name/ch/chars/package.nix
+++ b/pkgs/by-name/ch/chars/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.7.0";
 
   src = fetchFromGitHub {
-    owner = "antifuchs";
+    owner = "boinkor-net";
     repo = "chars";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-mBtwdPzIc6RgEFTyReStFlhS4UhhRWjBTKT6gD3tzpQ=";
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Commandline tool to display information about unicode characters";
     mainProgram = "chars";
-    homepage = "https://github.com/antifuchs/chars";
+    homepage = "https://github.com/boinkor-net/chars";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ bbigras ];
   };

--- a/pkgs/by-name/ch/chiri/package.nix
+++ b/pkgs/by-name/ch/chiri/package.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.8.1";
 
   src = fetchFromGitHub {
-    owner = "SapphoSys";
+    owner = "chiriapp";
     repo = "chiri";
     tag = "app-v${finalAttrs.version}";
     hash = "sha256-45a1mmh8dxrWw+UQzJcbPAujFjCYC4ovsGhdAn39LkI=";
@@ -108,8 +108,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Cross-platform CalDAV task management app";
-    homepage = "https://github.com/SapphoSys/chiri";
-    changelog = "https://github.com/SapphoSys/chiri/releases/tag/app-v${finalAttrs.version}";
+    homepage = "https://github.com/chiriapp/chiri";
+    changelog = "https://github.com/chiriapp/chiri/releases/tag/app-v${finalAttrs.version}";
     license = lib.licenses.zlib;
     maintainers = with lib.maintainers; [ SapphoSys ];
     mainProgram = "chiri";

--- a/pkgs/by-name/cj/cjose/package.nix
+++ b/pkgs/by-name/cj/cjose/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.6.2.2";
 
   src = fetchFromGitHub {
-    owner = "zmartzone";
+    owner = "OpenIDC";
     repo = "cjose";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-vDvCxMpgCdteGvNxy2HCNRaxbhxOuTadL0nM2wkFHtk=";
@@ -47,8 +47,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    homepage = "https://github.com/zmartzone/cjose";
-    changelog = "https://github.com/zmartzone/cjose/blob/${finalAttrs.version}/CHANGELOG.md";
+    homepage = "https://github.com/OpenIDC/cjose";
+    changelog = "https://github.com/OpenIDC/cjose/blob/${finalAttrs.version}/CHANGELOG.md";
     description = "C library for Javascript Object Signing and Encryption. This is a maintained fork of the original project";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ midchildan ];

--- a/pkgs/by-name/cl/clarity-city/package.nix
+++ b/pkgs/by-name/cl/clarity-city/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "1.0.0";
 
   src = fetchFromGitHub {
-    owner = "vmware";
+    owner = "vmware-archive";
     repo = "clarity-city";
     rev = "v${finalAttrs.version}";
     hash = "sha256-1POSdd2ICnyNNmGadIujezNK8qvARD0kkLR4yWjs5kA=";
@@ -29,7 +29,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Open source sans-serif typeface";
-    homepage = "https://github.com/vmware/clarity-city";
+    homepage = "https://github.com/vmware-archive/clarity-city";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ sagikazarmark ];

--- a/pkgs/by-name/cl/classicube/package.nix
+++ b/pkgs/by-name/cl/classicube/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.3.8";
 
   src = fetchFromGitHub {
-    owner = "UnknownShadow200";
+    owner = "ClassiCube";
     repo = "ClassiCube";
     tag = finalAttrs.version;
     hash = "sha256-AF4cr3ZXCixwiihS+2ayrzVH5eYShkjlfF0myb2PbHM=";

--- a/pkgs/by-name/cl/clematis/package.nix
+++ b/pkgs/by-name/cl/clematis/package.nix
@@ -9,7 +9,7 @@ buildGoModule {
   version = "2022-04-16";
 
   src = fetchFromGitHub {
-    owner = "TorchedSammy";
+    owner = "sammy-ette";
     repo = "clematis";
     rev = "cbe74da084b9d3f6893f53721c27cd0f3a45fe93";
     sha256 = "sha256-TjoXHbY0vUQ2rhwdCJ/s/taRd9/MG0P9HaEw2BOIy/s=";
@@ -19,7 +19,7 @@ buildGoModule {
 
   meta = {
     description = "Discord rich presence for MPRIS music players";
-    homepage = "https://github.com/TorchedSammy/Clematis";
+    homepage = "https://github.com/sammy-ette/clematis";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ misterio77 ];

--- a/pkgs/by-name/cn/cnquery/package.nix
+++ b/pkgs/by-name/cn/cnquery/package.nix
@@ -10,7 +10,7 @@ buildGoModule rec {
 
   src = fetchFromGitHub {
     owner = "mondoohq";
-    repo = "cnquery";
+    repo = "mql";
     tag = "v${version}";
     hash = "sha256-CTg2jfpCLTYuRx5R+9Si0Ig1NT1ZGXMFbcPPa8CbMKY=";
   };
@@ -32,7 +32,7 @@ buildGoModule rec {
       accounts, Kubernetes, containers, services, VMs, APIs, and more.
     '';
     homepage = "https://mondoo.com/cnquery";
-    changelog = "https://github.com/mondoohq/cnquery/releases/tag/v${version}";
+    changelog = "https://github.com/mondoohq/mql/releases/tag/v${version}";
     license = lib.licenses.bsl11;
     maintainers = with lib.maintainers; [ mariuskimmina ];
   };

--- a/pkgs/by-name/co/cocogitto/package.nix
+++ b/pkgs/by-name/co/cocogitto/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "7.0.0";
 
   src = fetchFromGitHub {
-    owner = "oknozor";
+    owner = "cocogitto";
     repo = "cocogitto";
     tag = finalAttrs.version;
     hash = "sha256-Z+SXB6bDxyR+Bt3Pz6uF9+sZLjbiFNYeECVFZbx40h8=";
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Set of cli tools for the conventional commit and semver specifications";
     mainProgram = "cog";
-    homepage = "https://github.com/oknozor/cocogitto";
+    homepage = "https://github.com/cocogitto/cocogitto";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ gs-101 ];
   };

--- a/pkgs/by-name/co/cointop/package.nix
+++ b/pkgs/by-name/co/cointop/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "1.6.10";
 
   src = fetchFromGitHub {
-    owner = "miguelmota";
+    owner = "cointop-sh";
     repo = "cointop";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-NAw1uoBL/FnNLJ86L9aBCOY65aJn1DDGK0Cd0IO2kr0=";

--- a/pkgs/by-name/co/construct/package.nix
+++ b/pkgs/by-name/co/construct/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.1.0";
 
   src = fetchFromGitHub {
-    owner = "Thomas-de-Bock";
+    owner = "Thomas-995";
     repo = "construct";
     rev = finalAttrs.version;
     hash = "sha256-ENso0y7yEaXzGXzZOnlZ1L7+j/qayJL+f55/NYLz2ew=";
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Abstraction over x86 NASM Assembly";
     longDescription = "Construct adds features such as while loops, if statements, scoped macros and function-call syntax to NASM Assembly.";
-    homepage = "https://github.com/Thomas-de-Bock/construct";
+    homepage = "https://github.com/Thomas-995/construct";
     maintainers = with lib.maintainers; [ rucadi ];
     platforms = lib.platforms.all;
     license = lib.licenses.mit;

--- a/pkgs/by-name/co/cosmic-applibrary/package.nix
+++ b/pkgs/by-name/co/cosmic-applibrary/package.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
-    repo = "cosmic-applibrary";
+    repo = "cosmic-app-library";
     tag = "epoch-${finalAttrs.version}";
     hash = "sha256-IgRKdhs07FK8G4yRb+0d8JFKZv3Zkq/tp2pC4epkxaM=";
   };
@@ -62,7 +62,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   meta = {
-    homepage = "https://github.com/pop-os/cosmic-applibrary";
+    homepage = "https://github.com/pop-os/cosmic-app-library";
     description = "Application Template for the COSMIC Desktop Environment";
     license = lib.licenses.gpl3Only;
     teams = [ lib.teams.cosmic ];

--- a/pkgs/by-name/co/coze/package.nix
+++ b/pkgs/by-name/co/coze/package.nix
@@ -10,7 +10,7 @@ buildGoModule (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "Cyphrme";
-    repo = "Coze_cli";
+    repo = "CozeCLI";
     rev = "v${finalAttrs.version}";
     hash = "sha256-/Cznx5Q0a9vVrC4oAoBmAkejT1505AQzzCW/wi3itv4=";
   };
@@ -24,7 +24,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "CLI client for Coze, a cryptographic JSON messaging specification";
     mainProgram = "coze";
-    homepage = "https://github.com/Cyphrme/coze_cli";
+    homepage = "https://github.com/Cyphrme/CozeCLI";
     license = with lib.licenses; [ bsd3 ];
     maintainers = with lib.maintainers; [ qbit ];
   };

--- a/pkgs/by-name/cp/cppcheck/package.nix
+++ b/pkgs/by-name/cp/cppcheck/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   src = fetchFromGitHub {
-    owner = "danmar";
+    owner = "cppcheck-opensource";
     repo = "cppcheck";
     tag = finalAttrs.version;
     hash = "sha256-c32dNM1tNN+Nqv5GmKHnAhWx8r9RTcv3FQ/+ROGurkw=";

--- a/pkgs/by-name/cp/cpuset/package.nix
+++ b/pkgs/by-name/cp/cpuset/package.nix
@@ -10,7 +10,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "lpechacek";
+    owner = "SUSE";
     repo = "cpuset";
     rev = "v${finalAttrs.version}";
     hash = "sha256-fW0SXNI10pb6FTn/2TOqxP9qlys0KL/H9m//NjslUaY=";

--- a/pkgs/by-name/cr/credhub-cli/package.nix
+++ b/pkgs/by-name/cr/credhub-cli/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "2.9.54";
 
   src = fetchFromGitHub {
-    owner = "cloudfoundry-incubator";
+    owner = "cloudfoundry";
     repo = "credhub-cli";
     rev = finalAttrs.version;
     sha256 = "sha256-qp7Oj207uu2P/Jt9O5tZM0ra9fMx+DfuHPaKr5z+ef0=";
@@ -40,7 +40,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Provides a command line interface to interact with CredHub servers";
-    homepage = "https://github.com/cloudfoundry-incubator/credhub-cli";
+    homepage = "https://github.com/cloudfoundry/credhub-cli";
     maintainers = with lib.maintainers; [ ris ];
     license = lib.licenses.asl20;
   };

--- a/pkgs/by-name/cr/crlfsuite/package.nix
+++ b/pkgs/by-name/cr/crlfsuite/package.nix
@@ -10,7 +10,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "Nefcore";
+    owner = "Raghavd3v";
     repo = "CRLFsuite";
     tag = "v${finalAttrs.version}";
     sha256 = "sha256-mK20PbVGhTEjhY5L6coCzSMIrG/PHHmNq30ZoJEs6uI=";
@@ -35,7 +35,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   meta = {
     description = "CRLF injection (HTTP Response Splitting) scanner";
     mainProgram = "crlfsuite";
-    homepage = "https://github.com/Nefcore/CRLFsuite";
+    homepage = "https://github.com/Raghavd3v/CRLFsuite";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       fab

--- a/pkgs/by-name/ct/ctodo/package.nix
+++ b/pkgs/by-name/ct/ctodo/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.3";
 
   src = fetchFromGitHub {
-    owner = "Acolarh";
+    owner = "nielssp";
     repo = "ctodo";
     rev = "v${finalAttrs.version}";
     sha256 = "0mqy5b35cbdwfpbs91ilsgz3wc4cky38xfz9pnr4q88q1vybigna";

--- a/pkgs/by-name/ct/ctrtool/package.nix
+++ b/pkgs/by-name/ct/ctrtool/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.3.0";
 
   src = fetchFromGitHub {
-    owner = "jakcron";
+    owner = "3DSGuy";
     repo = "Project_CTR";
     rev = "ctrtool-v${finalAttrs.version}";
     sha256 = "GvEzv97DqCsaDWVqDpajQRWYe+WM8xCYmGE0D3UcSrM=";

--- a/pkgs/by-name/cu/cups-printers/package.nix
+++ b/pkgs/by-name/cu/cups-printers/package.nix
@@ -10,7 +10,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "audiusGmbH";
+    owner = "audius";
     repo = "cups-printers";
     tag = finalAttrs.version;
     hash = "sha256-Fne7V9dEZwdV6OsQPg2gzrz/wloAOOuwlx3CqXOyWBc=";

--- a/pkgs/by-name/da/dapper/package.nix
+++ b/pkgs/by-name/da/dapper/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "0.6.0";
 
   src = fetchFromGitHub {
-    owner = "rancher";
+    owner = "rancher-archives";
     repo = "dapper";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-V+lHnOmIWjI1qmoJ7+pp+cGmJAtSeY+r2I9zykswQzM=";
@@ -23,7 +23,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Docker build wrapper";
     mainProgram = "dapper";
-    homepage = "https://github.com/rancher/dapper";
+    homepage = "https://github.com/rancher-archives/dapper";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ kuznero ];

--- a/pkgs/by-name/dd/ddosify/package.nix
+++ b/pkgs/by-name/dd/ddosify/package.nix
@@ -10,8 +10,8 @@ buildGoModule (finalAttrs: {
   version = "2.6.0";
 
   src = fetchFromGitHub {
-    owner = "ddosify";
-    repo = "ddosify";
+    owner = "getanteon";
+    repo = "anteon";
     tag = "selfhosted-${finalAttrs.version}";
     hash = "sha256-EPbpBCSaUVVhxGlj7gRqwHLuj5p6563iiARqkEjA6Rk=";
   };
@@ -41,7 +41,7 @@ buildGoModule (finalAttrs: {
     description = "High-performance load testing tool, written in Golang";
     mainProgram = "ddosify";
     homepage = "https://ddosify.com/";
-    changelog = "https://github.com/ddosify/ddosify/releases/tag/selfhosted-${finalAttrs.version}";
+    changelog = "https://github.com/getanteon/anteon/releases/tag/selfhosted-${finalAttrs.version}";
     license = lib.licenses.agpl3Plus;
     maintainers = [ ];
   };

--- a/pkgs/by-name/de/dehydrated/package.nix
+++ b/pkgs/by-name/de/dehydrated/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.7.2";
 
   src = fetchFromGitHub {
-    owner = "lukas2511";
+    owner = "dehydrated-io";
     repo = "dehydrated";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-xDDYqP6oxJt0NPgHtHV1xQKUxVc8JQxWekXwxezggtE=";

--- a/pkgs/by-name/de/desmume/package.nix
+++ b/pkgs/by-name/de/desmume/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.9.13";
 
   src = fetchFromGitHub {
-    owner = "TASVideos";
+    owner = "TASEmulators";
     repo = "desmume";
     rev = "release_${lib.replaceStrings [ "." ] [ "_" ] finalAttrs.version}";
     hash = "sha256-vmjKXa/iXLTwtqnG+ZUvOnOQPZROeMpfM5J3Jh/Ynfo=";
@@ -87,7 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    homepage = "https://www.github.com/TASVideos/desmume/";
+    homepage = "https://www.github.com/TASEmulators/desmume/";
     description = "Open-source Nintendo DS emulator";
     longDescription = ''
       DeSmuME is a freeware emulator for the NDS roms & Nintendo DS Lite games

--- a/pkgs/by-name/di/digitalbitbox/package.nix
+++ b/pkgs/by-name/di/digitalbitbox/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.0.0";
 
   src = fetchFromGitHub {
-    owner = "digitalbitbox";
+    owner = "BitBoxSwiss";
     repo = "dbb-app";
     tag = "v${finalAttrs.version}";
     hash = "sha256-ig3+TdYv277D9GVnkRSX6nc6D6qruUOw/IQdQCK6FoA=";

--- a/pkgs/by-name/di/discord-rpc/package.nix
+++ b/pkgs/by-name/di/discord-rpc/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.4.0";
 
   src = fetchFromGitHub {
-    owner = "discordapp";
+    owner = "discord";
     repo = "discord-rpc";
     rev = "v${finalAttrs.version}";
     sha256 = "04cxhqdv5r92lrpnhxf8702a8iackdf3sfk1050z7pijbijiql2a";
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Official library to interface with the Discord client";
-    homepage = "https://github.com/discordapp/discord-rpc";
+    homepage = "https://github.com/discord/discord-rpc";
     license = lib.licenses.mit;
     maintainers = [ ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/di/discord-sh/package.nix
+++ b/pkgs/by-name/di/discord-sh/package.nix
@@ -14,7 +14,7 @@ stdenvNoCC.mkDerivation rec {
   version = "2.0.1";
 
   src = fetchFromGitHub {
-    owner = "ChaoticWeg";
+    owner = "fieu";
     repo = "discord.sh";
     rev = "v${version}";
     sha256 = "sha256-z57uMbH6PI68aTMAjA8UIPEefV8sQRR4cS0eK6Ypxuk=";
@@ -61,7 +61,7 @@ stdenvNoCC.mkDerivation rec {
   meta = {
     description = "Write-only command-line Discord webhook integration written in 100% Bash script";
     mainProgram = "discord.sh";
-    homepage = "https://github.com/ChaoticWeg/discord.sh";
+    homepage = "https://github.com/fieu/discord.sh";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ matthewcroughan ];

--- a/pkgs/by-name/di/disktui/package.nix
+++ b/pkgs/by-name/di/disktui/package.nix
@@ -7,7 +7,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "disktui";
   version = "1.3.0";
   src = fetchFromGitHub {
-    owner = "Maciejonos";
+    owner = "mkbula";
     repo = "disktui";
     tag = "v${finalAttrs.version}";
     hash = "sha256-C0skZF7fP7Qx5o+q9bUitgnBB9tBh1J4JdGyn8oQ/Rc=";
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "TUI for disk management on Linux";
-    homepage = "https://github.com/Maciejonos/disktui";
+    homepage = "https://github.com/mkbula/disktui";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ Inarizxc ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/dj/djlint/package.nix
+++ b/pkgs/by-name/dj/djlint/package.nix
@@ -10,7 +10,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "Riverside-Healthcare";
+    owner = "djlint";
     repo = "djlint";
     tag = "v${finalAttrs.version}";
     hash = "sha256-1DXBDVe8Ae8joJOYwwlBZB8MVubDPVhh+TiJBpL2u2M=";
@@ -43,7 +43,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   meta = {
     description = "HTML Template Linter and Formatter. Django - Jinja - Nunjucks - Handlebars - GoLang";
     mainProgram = "djlint";
-    homepage = "https://github.com/Riverside-Healthcare/djlint";
+    homepage = "https://github.com/djlint/djLint";
     license = lib.licenses.gpl3Only;
     changelog = "https://github.com/djlint/djLint/blob/v${finalAttrs.version}/CHANGELOG.md";
     maintainers = with lib.maintainers; [ traxys ];

--- a/pkgs/by-name/dj/djv/package.nix
+++ b/pkgs/by-name/dj/djv/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.1.1";
 
   src = fetchFromGitHub {
-    owner = "darbyjohnston";
+    owner = "grizzlypeak3d";
     repo = "djv";
     tag = finalAttrs.version;
     hash = "sha256-/SakJ23mi/dz8eUt2UtcgfLtFZiCHy1ME+jWdNS8+Fw=";

--- a/pkgs/by-name/dm/dmrconfig/package.nix
+++ b/pkgs/by-name/dm/dmrconfig/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.1";
 
   src = fetchFromGitHub {
-    owner = "sergev";
+    owner = "OpenRTX";
     repo = "dmrconfig";
     rev = finalAttrs.version;
     sha256 = "1qwix75z749628w583fwp7m7kxbj0k3g159sxb7vgqxbadqqz1ab";
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     longDescription = ''
       DMRconfig is a utility for programming digital radios via USB programming cable.
     '';
-    homepage = "https://github.com/sergev/dmrconfig";
+    homepage = "https://github.com/OpenRTX/dmrconfig";
     license = lib.licenses.asl20;
     maintainers = [ ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/do/dogedns/package.nix
+++ b/pkgs/by-name/do/dogedns/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "Dj-Codeman";
-    repo = "doge";
+    repo = "dog_community";
     rev = "v${finalAttrs.version}";
     hash = "sha256-SeC/GZ1AeEqRzxWc4oJ6JOvXfn3/LRcQz9uWXXqdTqU=";
   };
@@ -53,7 +53,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Reviving a command-line DNS client";
-    homepage = "https://github.com/Dj-Codeman/doge";
+    homepage = "https://github.com/Dj-Codeman/dog_community";
     license = lib.licenses.eupl12;
     mainProgram = "doge";
     maintainers = with lib.maintainers; [ aktaboot ];

--- a/pkgs/by-name/do/doom-bcc/package.nix
+++ b/pkgs/by-name/do/doom-bcc/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   version = "unstable-2018-01-04";
 
   src = fetchFromGitHub {
-    owner = "wormt";
+    owner = "positively-charged";
     repo = "bcc";
     rev = "d58b44d9f18b28fd732c27113e5607a454506d19";
     sha256 = "1m83ip40ln61qrvb1fbgaqbld2xip9n3k817lwkk1936pml9zcrq";
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Compiler for Doom/Hexen scripts (ACS, BCS)";
     mainProgram = "bcc";
-    homepage = "https://github.com/wormt/bcc";
+    homepage = "https://github.com/positively-charged/bcc";
     license = lib.licenses.mit;
   };
 }

--- a/pkgs/by-name/dr/droidcam/package.nix
+++ b/pkgs/by-name/dr/droidcam/package.nix
@@ -17,8 +17,8 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.1.5";
 
   src = fetchFromGitHub {
-    owner = "aramg";
-    repo = "droidcam";
+    owner = "dev47apps";
+    repo = "droidcam-linux-client";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-22lRmtXumjR/83Fg1edBisM1GjNZvNUvPs1Yg7Na1xw=";
   };
@@ -62,7 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Linux client for DroidCam app";
-    homepage = "https://github.com/aramg/droidcam";
+    homepage = "https://github.com/dev47apps/droidcam-linux-client";
     license = lib.licenses.gpl2Only;
     maintainers = [ lib.maintainers.suhr ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/dr/drone/package.nix
+++ b/pkgs/by-name/dr/drone/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "harness";
-    repo = "drone";
+    repo = "harness";
     tag = "v${finalAttrs.version}";
     hash = "sha256-jKM+jET6dsMe5+QRDKIHA40OOHb/nZmli3owaDB7IvU=";
   };
@@ -28,7 +28,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Continuous Integration platform built on container technology";
     mainProgram = "drone-server";
-    homepage = "https://github.com/harness/drone";
+    homepage = "https://github.com/harness/harness";
     maintainers = with lib.maintainers; [
       vdemeester
       techknowlogick

--- a/pkgs/by-name/ef/effitask/package.nix
+++ b/pkgs/by-name/ef/effitask/package.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "1.4.2";
 
   src = fetchFromGitHub {
-    owner = "sanpii";
+    owner = "todotxt-rs";
     repo = "effitask";
     rev = finalAttrs.version;
     sha256 = "sha256-6BA/TCCqVh5rtgGkUgk8nIqUzozipC5rrkbXMDWYpdQ=";
@@ -45,7 +45,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       Or use it as standalone program by defining some environment variables
       like described in the projects readme.
     '';
-    homepage = "https://github.com/sanpii/effitask";
+    homepage = "https://github.com/todotxt-rs/effitask";
     maintainers = with lib.maintainers; [ davidak ];
     license = with lib.licenses; [ mit ];
     mainProgram = "effitask";

--- a/pkgs/by-name/ek/eksctl/package.nix
+++ b/pkgs/by-name/ek/eksctl/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   version = "0.226.0";
 
   src = fetchFromGitHub {
-    owner = "weaveworks";
+    owner = "eksctl-io";
     repo = "eksctl";
     rev = finalAttrs.version;
     hash = "sha256-XjiM4o4xJPY+ZFtvWi5K99tQaZwNxiCla/jUeQQo+5E=";
@@ -31,8 +31,8 @@ buildGoModule (finalAttrs: {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/weaveworks/eksctl/pkg/version.gitCommit=${finalAttrs.src.rev}"
-    "-X github.com/weaveworks/eksctl/pkg/version.buildDate=19700101-00:00:00"
+    "-X github.com/eksctl-io/eksctl/pkg/version.gitCommit=${finalAttrs.src.rev}"
+    "-X github.com/eksctl-io/eksctl/pkg/version.buildDate=19700101-00:00:00"
   ];
 
   nativeBuildInputs = [ installShellFiles ];
@@ -46,7 +46,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "CLI for Amazon EKS";
-    homepage = "https://github.com/weaveworks/eksctl";
+    homepage = "https://github.com/eksctl-io/eksctl";
     changelog = "https://github.com/eksctl-io/eksctl/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/el/elfcat/package.nix
+++ b/pkgs/by-name/el/elfcat/package.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.1.10";
 
   src = fetchFromGitHub {
-    owner = "ruslashev";
+    owner = "rbakbashev";
     repo = "elfcat";
     rev = finalAttrs.version;
     sha256 = "sha256-8jyOYV455APlf8F6HmgyvgfNGddMzrcGhj7yFQT6qvg=";
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "ELF visualizer, generates HTML files from ELF binaries";
-    homepage = "https://github.com/ruslashev/elfcat";
+    homepage = "https://github.com/rbakbashev/elfcat";
     license = lib.licenses.zlib;
     maintainers = with lib.maintainers; [ moni ];
     mainProgram = "elfcat";

--- a/pkgs/by-name/em/embree/package.nix
+++ b/pkgs/by-name/em/embree/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "4.4.0";
 
   src = fetchFromGitHub {
-    owner = "embree";
+    owner = "RenderKit";
     repo = "embree";
     tag = "v${finalAttrs.version}";
     hash = "sha256-bHVokEfnTW2cJqx3Zz2x1hIH07WamPAVFY9tiv6nHd0=";

--- a/pkgs/by-name/em/emissary/package.nix
+++ b/pkgs/by-name/em/emissary/package.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.3.1";
 
   src = fetchFromGitHub {
-    owner = "altonen";
+    owner = "eepnet";
     repo = "emissary";
     tag = "v${finalAttrs.version}";
     hash = "sha256-fLhvMzdxXAuEB99NgIfTLxYezIIZVaC8Z6snK9UUEl0=";
@@ -30,10 +30,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   __darwinAllowLocalNetworking = true;
 
   meta = {
-    changelog = "https://github.com/altonen/emissary/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/eepnet/emissary/releases/tag/${finalAttrs.version}";
     description = "Rust implementation of the I2P protocol stack";
     homepage = "https://altonen.github.io/emissary/";
-    license = lib.licenses.mit; # https://github.com/altonen/emissary/blob/master/LICENSE (found an apache2 as well but thats for https://github.com/altonen/emissary/commit/c4a1c849ebfceba892adce53f512f1f099721de2)
+    license = lib.licenses.mit; # https://github.com/eepnet/emissary/blob/master/LICENSE (found an apache2 as well but thats for https://github.com/eepnet/emissary/commit/c4a1c849ebfceba892adce53f512f1f099721de2)
     mainProgram = "emissary-cli";
     maintainers = [ lib.maintainers.N4CH723HR3R ];
   };

--- a/pkgs/by-name/es/esshader/package.nix
+++ b/pkgs/by-name/es/esshader/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   version = "0-unstable-2020-08-09";
 
   src = fetchFromGitHub {
-    owner = "cmcsun";
+    owner = "chrismcfee";
     repo = "esshader";
     rev = "506eb02f3de52d3d1f4d81ac9ee145655216dee5";
     sha256 = "sha256-euxJw7CqOwi6Ndzalps37kDr5oOIL3tZICCfmxsujfk=";
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Offline ShaderToy-compatible GLSL shader viewer using OpenGL ES 2.0";
-    homepage = "https://github.com/cmcsun/esshader";
+    homepage = "https://github.com/chrismcfee/esshader";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ astro ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/et/etherpad-lite/package.nix
+++ b/pkgs/by-name/et/etherpad-lite/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "ether";
-    repo = "etherpad-lite";
+    repo = "etherpad";
     tag = "v${finalAttrs.version}";
     hash = "sha256-8DCgbfp3ttpMTXS9SNkN1R63LZHaklsNHViRhmWVFuk=";
   };
@@ -86,7 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
       It provides full data export capabilities, and runs on your server, under your control.
     '';
     homepage = "https://etherpad.org/";
-    changelog = "https://github.com/ether/etherpad-lite/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/ether/etherpad/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     maintainers = with lib.maintainers; [
       erdnaxe
       f2k1de

--- a/pkgs/by-name/ev/evcxr/package.nix
+++ b/pkgs/by-name/ev/evcxr/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.21.1";
 
   src = fetchFromGitHub {
-    owner = "google";
+    owner = "evcxr";
     repo = "evcxr";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-8dV+NNtU4HFerrgRyc1kO+MSsMTJJItTtJylEIN014g=";
@@ -91,7 +91,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Evaluation context for Rust";
-    homepage = "https://github.com/google/evcxr";
+    homepage = "https://github.com/evcxr/evcxr";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       protoben

--- a/pkgs/by-name/ev/eventstore/package.nix
+++ b/pkgs/by-name/ev/eventstore/package.nix
@@ -19,8 +19,8 @@ buildDotnetModule rec {
   version = "24.10.6";
 
   src = fetchFromGitHub {
-    owner = "EventStore";
-    repo = "EventStore";
+    owner = "kurrent-io";
+    repo = "KurrentDB";
     tag = "v${version}";
     hash = "sha256-8/sagvMyJ1/onGMuJ28QLWI5M8dBDWyGOcZKUv3PJsQ=";
     leaveDotGit = true;

--- a/pkgs/by-name/ex/expected-lite/package.nix
+++ b/pkgs/by-name/ex/expected-lite/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.10.0";
 
   src = fetchFromGitHub {
-    owner = "martinmoene";
+    owner = "nonstd-lite";
     repo = "expected-lite";
     rev = "v${finalAttrs.version}";
     hash = "sha256-nxwdymBNbd+RuL8rKi2Fx2gC68TnJe7WnoN0O01lecQ=";
@@ -28,8 +28,8 @@ stdenv.mkDerivation (finalAttrs: {
     description = ''
       Expected objects in C++11 and later in a single-file header-only library
     '';
-    homepage = "https://github.com/martinmoene/expected-lite";
-    changelog = "https://github.com/martinmoene/expected-lite/blob/${finalAttrs.src.rev}/CHANGES.txt";
+    homepage = "https://github.com/nonstd-lite/expected-lite";
+    changelog = "https://github.com/nonstd-lite/expected-lite/blob/${finalAttrs.src.rev}/CHANGES.txt";
     license = lib.licenses.boost;
     maintainers = with lib.maintainers; [ azahi ];
   };

--- a/pkgs/by-name/fa/faba-icon-theme/package.nix
+++ b/pkgs/by-name/fa/faba-icon-theme/package.nix
@@ -16,7 +16,7 @@ stdenvNoCC.mkDerivation rec {
   version = "4.3";
 
   src = fetchFromGitHub {
-    owner = "moka-project";
+    owner = "snwh";
     repo = "faba-icon-theme";
     rev = "v${version}";
     sha256 = "0xh6ppr73p76z60ym49b4d0liwdc96w41cc5p07d48hxjsa6qd6n";

--- a/pkgs/by-name/fc/fcitx5-tokyonight/package.nix
+++ b/pkgs/by-name/fc/fcitx5-tokyonight/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation {
   version = "0-unstable-2024-01-28";
 
   src = fetchFromGitHub {
-    owner = "ch3n9w";
+    owner = "ch4xer";
     repo = "fcitx5-Tokyonight";
     rev = "f7454ab387d6b071ee12ff7ee819f0c7030fdf2c";
     hash = "sha256-swOy0kDZUdqtC2sPSZEBLnHSs8dpQ/QfFMObI6BARfo=";
@@ -36,7 +36,7 @@ stdenvNoCC.mkDerivation {
 
   meta = {
     description = "Fcitx5 theme based on Tokyo Night color";
-    homepage = "https://github.com/ch3n9w/fcitx5-Tokyonight";
+    homepage = "https://github.com/ch4xer/fcitx5-Tokyonight";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ Guanran928 ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/fc/fcppt/package.nix
+++ b/pkgs/by-name/fc/fcppt/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "5.0.0";
 
   src = fetchFromGitHub {
-    owner = "freundlich";
+    owner = "cpreh";
     repo = "fcppt";
     rev = finalAttrs.version;
     hash = "sha256-8dBG6LdSngsutBboqb3WVVg3ylayoUYDOJV6p/ZFkoE=";

--- a/pkgs/by-name/fe/feather-tk/package.nix
+++ b/pkgs/by-name/fe/feather-tk/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.4.0";
 
   src = fetchFromGitHub {
-    owner = "darbyjohnston";
+    owner = "grizzlypeak3d";
     repo = "feather-tk";
     tag = finalAttrs.version;
     hash = "sha256-hcV99y14o3YFUtKDLEKaR7MxBB3pBdd3sferrYvtvYw=";
@@ -90,12 +90,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Lightweight toolkit for building cross-platform applications";
-    homepage = "https://github.com/darbyjohnston/feather-tk";
+    homepage = "https://github.com/grizzlypeak3d/feather-tk";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ liberodark ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     badPlatforms = [
-      # Broken on darwin with latest SDK, see https://github.com/darbyjohnston/feather-tk/issues/1
+      # Broken on darwin with latest SDK, see https://github.com/grizzlypeak3d/feather-tk/issues/1
       lib.systems.inspect.patterns.isDarwin
     ];
   };

--- a/pkgs/by-name/fe/fence/package.nix
+++ b/pkgs/by-name/fe/fence/package.nix
@@ -17,7 +17,7 @@ buildGoModule (finalAttrs: {
   version = "0.1.58";
 
   src = fetchFromGitHub {
-    owner = "Use-Tusk";
+    owner = "jy-tan";
     repo = "fence";
     tag = "v${finalAttrs.version}";
     hash = "sha256-ACe3N4bXYJW6QDQHtRChFWOTXTZTbEUbZ4d8cuFRqMY=";
@@ -72,7 +72,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Lightweight, container-free sandbox for running commands with network and filesystem restrictions";
-    homepage = "https://github.com/Use-Tusk/fence";
+    homepage = "https://github.com/jy-tan/fence";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ dwt ];
     mainProgram = "fence";

--- a/pkgs/by-name/fe/ferrishot/package.nix
+++ b/pkgs/by-name/fe/ferrishot/package.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "nik-rev";
-    repo = "ferrishot";
+    repo = "peashot";
     tag = "v${finalAttrs.version}";
     hash = "sha256-QnIHLkxqL/4s6jgIbGmzR5tqCjH7yJcfpx0AhdxqVKc=";
   };
@@ -60,8 +60,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Screenshot app written in Rust";
-    homepage = "https://github.com/nik-rev/ferrishot";
-    changelog = "https://github.com/nik-rev/ferrishot/blob/v${finalAttrs.version}/CHANGELOG.md";
+    homepage = "https://github.com/nik-rev/peashot";
+    changelog = "https://github.com/nik-rev/peashot/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ GaetanLepage ];
     mainProgram = "ferrishot";

--- a/pkgs/by-name/fe/fet-sh/package.nix
+++ b/pkgs/by-name/fe/fet-sh/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation rec {
   version = "1.9";
 
   src = fetchFromGitHub {
-    owner = "6gk";
+    owner = "eepykate";
     repo = "fet.sh";
     rev = "v${version}";
     sha256 = "sha256-xhX2nVteC3T3IjQh++mYlm0btDJQbyQa6b8sGualV0E=";
@@ -25,7 +25,7 @@ stdenvNoCC.mkDerivation rec {
 
   meta = {
     description = "Fetch written in posix shell without any external commands";
-    homepage = "https://github.com/6gk/fet.sh";
+    homepage = "https://github.com/eepykate/fet.sh";
     license = lib.licenses.isc;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ elkowar ];

--- a/pkgs/by-name/fi/findup/package.nix
+++ b/pkgs/by-name/fi/findup/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.0.0";
 
   src = fetchFromGitHub {
-    owner = "booniepepper";
+    owner = "so-dang-cool";
     repo = "findup";
     tag = "v${finalAttrs.version}";
     hash = "sha256-6/rQ4xNfzJQwJgrpvFRuirqlx6fVn7sLXfVRFsG3fUw=";
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
 
   meta = {
-    homepage = "https://github.com/booniepepper/findup";
+    homepage = "https://github.com/so-dang-cool/findup";
     description = "Search parent directories for sentinel files";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ booniepepper ];

--- a/pkgs/by-name/fl/flintlock/package.nix
+++ b/pkgs/by-name/fl/flintlock/package.nix
@@ -14,7 +14,7 @@ buildGoModule (finalAttrs: {
   version = "0.8.1";
 
   src = fetchFromGitHub {
-    owner = "weaveworks";
+    owner = "liquidmetal-dev";
     repo = "flintlock";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-Kbk94sqj0aPsVonPsiu8kbjhIOURB1kX9Lt3NURL+jk=";
@@ -30,7 +30,7 @@ buildGoModule (finalAttrs: {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/weaveworks/flintlock/internal/version.Version=v${finalAttrs.version}"
+    "-X github.com/liquidmetal-dev/flintlock/internal/version.Version=v${finalAttrs.version}"
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fl/fluxcd-operator-mcp/package.nix
+++ b/pkgs/by-name/fl/fluxcd-operator-mcp/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "controlplaneio-fluxcd";
-    repo = "fluxcd-operator";
+    repo = "flux-operator";
     tag = "v${finalAttrs.version}";
     hash = "sha256-Ggx38aF9o7dMFcQxYbx5hSXCE2oRRTgvUvXCAJJN6V8=";
   };

--- a/pkgs/by-name/fl/fluxcd-operator/package.nix
+++ b/pkgs/by-name/fl/fluxcd-operator/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "controlplaneio-fluxcd";
-    repo = "fluxcd-operator";
+    repo = "flux-operator";
     tag = "v${finalAttrs.version}";
     hash = "sha256-Ggx38aF9o7dMFcQxYbx5hSXCE2oRRTgvUvXCAJJN6V8=";
   };

--- a/pkgs/by-name/fl/flye/package.nix
+++ b/pkgs/by-name/fl/flye/package.nix
@@ -17,7 +17,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "fenderglass";
+    owner = "mikolmogorov";
     repo = "flye";
     tag = finalAttrs.version;
     hash = "sha256-ZdrAxPKY3+HJ388tGCdpDcvW70mJ5wd4uOUkuufyqK8=";
@@ -56,7 +56,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   meta = {
     description = "De novo assembler for single molecule sequencing reads using repeat graphs";
-    homepage = "https://github.com/fenderglass/Flye";
+    homepage = "https://github.com/mikolmogorov/Flye";
     license = lib.licenses.bsd3;
     mainProgram = "flye";
     maintainers = with lib.maintainers; [ assistant ];

--- a/pkgs/by-name/fo/fooyin/package.nix
+++ b/pkgs/by-name/fo/fooyin/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.9.2";
 
   src = fetchFromGitHub {
-    owner = "ludouzi";
+    owner = "fooyin";
     repo = "fooyin";
     tag = "v" + finalAttrs.version;
     hash = "sha256-sQ1zsQ/6OHGPkofiKhusCrpW2XnO+PpMvH1M2OG5Huw=";

--- a/pkgs/by-name/fo/foxmarks/package.nix
+++ b/pkgs/by-name/fo/foxmarks/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "2.1.1";
 
   src = fetchFromGitHub {
-    owner = "zer0-x";
+    owner = "zefr0x";
     repo = "foxmarks";
     rev = "v${finalAttrs.version}";
     hash = "sha256-6lJ9acVo444RMxc3wUakBz4zT74oNUpwoP69rdf2mmE=";
@@ -22,8 +22,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "CLI read-only interface for Mozilla Firefox's bookmarks";
-    homepage = "https://github.com/zer0-x/foxmarks";
-    changelog = "https://github.com/zer0-x/foxmarks/blob/v${finalAttrs.version}/CHANGELOG.md";
+    homepage = "https://github.com/zefr0x/foxmarks";
+    changelog = "https://github.com/zefr0x/foxmarks/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ loicreynier ];
   };

--- a/pkgs/by-name/fp/fprettify/package.nix
+++ b/pkgs/by-name/fp/fprettify/package.nix
@@ -10,7 +10,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "pseewald";
+    owner = "fortran-lang";
     repo = "fprettify";
     rev = "v${finalAttrs.version}";
     sha256 = "17v52rylmsy3m3j5fcb972flazykz2rvczqfh8mxvikvd6454zyj";

--- a/pkgs/by-name/fr/freebayes/package.nix
+++ b/pkgs/by-name/fr/freebayes/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     name = "freebayes-${finalAttrs.version}-src";
-    owner = "ekg";
+    owner = "freebayes";
     repo = "freebayes";
     tag = "v${finalAttrs.version}";
     sha256 = "035nriknjqq8gvil81vvsmvqwi35v80q8h1cw24vd1gdyn1x7bys";
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Bayesian haplotype-based polymorphism discovery and genotyping";
     license = lib.licenses.mit;
-    homepage = "https://github.com/ekg/freebayes";
+    homepage = "https://github.com/freebayes/freebayes";
     maintainers = with lib.maintainers; [ jdagilliland ];
     platforms = [ "x86_64-linux" ];
   };

--- a/pkgs/by-name/fr/frescobaldi/package.nix
+++ b/pkgs/by-name/fr/frescobaldi/package.nix
@@ -13,7 +13,7 @@ python3Packages.buildPythonApplication rec {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "wbsoft";
+    owner = "frescobaldi";
     repo = "frescobaldi";
     tag = "v${version}";
     hash = "sha256-IgvjKj0+8oNbuZ91n4O16kGXBS7rS63HQUNQnJcOis8=";

--- a/pkgs/by-name/fs/fsql/package.nix
+++ b/pkgs/by-name/fs/fsql/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "0.5.2";
 
   src = fetchFromGitHub {
-    owner = "kshvmdn";
+    owner = "kashav";
     repo = "fsql";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-U6TPszqsZvoz+9GIB0wNYMRJqIDLOp/BZO3/k8FC0Gs=";
@@ -24,7 +24,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Search through your filesystem with SQL-esque queries";
-    homepage = "https://github.com/kshvmdn/fsql";
+    homepage = "https://github.com/kashav/fsql";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ pSub ];
     mainProgram = "fsql";

--- a/pkgs/by-name/fs/fsrx/package.nix
+++ b/pkgs/by-name/fs/fsrx/package.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "1.0.2";
 
   src = fetchFromGitHub {
-    owner = "thatvegandev";
+    owner = "jrnxf";
     repo = "fsrx";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-hzfpjunP20WCt3erYu7AO7A3nz+UMKdFzWUA5jASbVA=";
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Flow state reader in the terminal";
-    homepage = "https://github.com/thatvegandev/fsrx";
+    homepage = "https://github.com/jrnxf/fsrx";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ MoritzBoehme ];
     mainProgram = "fsrx";

--- a/pkgs/by-name/fw/fwup/package.nix
+++ b/pkgs/by-name/fw/fwup/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.15.1";
 
   src = fetchFromGitHub {
-    owner = "fhunleth";
+    owner = "fwup-home";
     repo = "fwup";
     tag = "v${finalAttrs.version}";
     hash = "sha256-SIRDVlC/g+rq5m4Ind7dqPzjdCjAxRK/kAdXt6byL/8=";
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     changelog = "https://github.com/fwup-home/fwup/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "Configurable embedded Linux firmware update creator and runner";
-    homepage = "https://github.com/fhunleth/fwup";
+    homepage = "https://github.com/fwup-home/fwup";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.georgewhewell ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/fz/fzf-preview/package.nix
+++ b/pkgs/by-name/fz/fzf-preview/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
   version = "0-unstable-2026-02-22";
 
   src = fetchFromGitHub {
-    owner = "niksingh710";
+    owner = "semi710";
     repo = "fzf-preview";
     rev = "5e5a5a5c4258fa86300cb56224e31416ff7401b5";
     hash = "sha256-ZjBoTsZ2ymfhmUbMpMWT1MB20kLf0BILnCDu75F6WEQ=";
@@ -79,7 +79,7 @@ stdenv.mkDerivation {
       be simple, fast, and highly compatible, making it a useful tool for anyone
       leveraging fzf for file navigation or search.
     '';
-    homepage = "https://github.com/niksingh710/fzf-preview";
+    homepage = "https://github.com/semi710/fzf-preview";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       niksingh710

--- a/pkgs/by-name/ga/galaxy-buds-client/package.nix
+++ b/pkgs/by-name/ga/galaxy-buds-client/package.nix
@@ -22,7 +22,7 @@ buildDotnetModule rec {
   version = "5.2.0";
 
   src = fetchFromGitHub {
-    owner = "ThePBone";
+    owner = "timschneeb";
     repo = "GalaxyBudsClient";
     tag = version;
     hash = "sha256-rFaI5coTGuWoxM3QZyCBJdvwvR6LeB2jjvcJ3xXw5X8=";
@@ -85,7 +85,7 @@ buildDotnetModule rec {
 
   meta = {
     description = "Unofficial Galaxy Buds Manager";
-    homepage = "https://github.com/ThePBone/GalaxyBudsClient";
+    homepage = "https://github.com/timschneeb/GalaxyBudsClient";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ icy-thought ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/ge/gemget/package.nix
+++ b/pkgs/by-name/ge/gemget/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "1.9.0";
 
   src = fetchFromGitHub {
-    owner = "makeworld-the-better-one";
+    owner = "makew0rld";
     repo = "gemget";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-P5+yRaf2HioKOclJMMm8bJ8/BtBbNEeYU57TceZVqQ8=";
@@ -19,7 +19,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Command line downloader for the Gemini protocol";
-    homepage = "https://github.com/makeworld-the-better-one/gemget";
+    homepage = "https://github.com/makew0rld/gemget";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ amfl ];
     mainProgram = "gemget";

--- a/pkgs/by-name/gh/gh-cherry-pick/package.nix
+++ b/pkgs/by-name/gh/gh-cherry-pick/package.nix
@@ -10,7 +10,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "PerchunPak";
-    repo = "gh-cherry-pick";
+    repo = "ghcherry";
     tag = "v${finalAttrs.version}";
     hash = "sha256-a2vhQ9upJYc+t4Juq+eukNc7dzq6MafNxDUULPZs9sQ=";
   };
@@ -43,7 +43,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   meta = {
     description = "Cherry-pick commits across GitHub repositories using only the GitHub API";
-    homepage = "https://github.com/PerchunPak/gh-cherry-pick";
+    homepage = "https://github.com/PerchunPak/ghcherry";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.PerchunPak ];
     mainProgram = "gh-cherry-pick";

--- a/pkgs/by-name/gi/git-annex-remote-rclone/package.nix
+++ b/pkgs/by-name/gi/git-annex-remote-rclone/package.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation rec {
   version = "0.8";
 
   src = fetchFromGitHub {
-    owner = "DanielDent";
+    owner = "git-annex-remote-rclone";
     repo = "git-annex-remote-rclone";
     rev = "v${version}";
     sha256 = "sha256-B6x67XXE4BHd3x7a8pQlqPPmpy0c62ziDAldB4QpqQ4=";
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "https://github.com/DanielDent/git-annex-remote-rclone";
+    homepage = "https://github.com/git-annex-remote-rclone/git-annex-remote-rclone";
     description = "Use rclone supported cloud storage providers with git-annex";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/gi/git-bug-migration/package.nix
+++ b/pkgs/by-name/gi/git-bug-migration/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "0.3.4";
 
   src = fetchFromGitHub {
-    owner = "MichaelMure";
+    owner = "git-bug";
     repo = "git-bug-migration";
     rev = "v${finalAttrs.version}";
     hash = "sha256-IOBgrU3C0ZHD2wx9LRVgKEJzDlUj6z2UXlHGU3tdTdQ=";
@@ -32,7 +32,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Tool for upgrading repositories using git-bug to new versions";
-    homepage = "https://github.com/MichaelMure/git-bug-migration";
+    homepage = "https://github.com/git-bug/git-bug-migration";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       DeeUnderscore

--- a/pkgs/by-name/gi/git-graph/package.nix
+++ b/pkgs/by-name/gi/git-graph/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.7.0";
 
   src = fetchFromGitHub {
-    owner = "mlange-42";
+    owner = "git-bahn";
     repo = "git-graph";
     tag = "v${finalAttrs.version}";
     hash = "sha256-9GFwxWYDnH3kKDWpxgh7ciSLB1Zr2zExxIrIrhycmZY=";
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Command line tool to show clear git graphs arranged for your branching model";
-    homepage = "https://github.com/mlange-42/git-graph";
+    homepage = "https://github.com/git-bahn/git-graph";
     license = lib.licenses.mit;
     broken = stdenv.hostPlatform.isDarwin;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/gi/git-igitt/package.nix
+++ b/pkgs/by-name/gi/git-igitt/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.1.21";
 
   src = fetchFromGitHub {
-    owner = "mlange-42";
+    owner = "git-bahn";
     repo = "git-igitt";
     rev = "v${finalAttrs.version}";
     hash = "sha256-5AVKBew+HShWFZwm4xRmRSL76N2c84Yi97jgcqsslxM=";
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Interactive, cross-platform Git terminal application with clear git graphs arranged for your branching model";
-    homepage = "https://github.com/mlange-42/git-igitt";
+    homepage = "https://github.com/git-bahn/git-igitt";
     license = lib.licenses.mit;
     sourceProvenance = [ lib.sourceTypes.fromSource ];
     maintainers = [ lib.maintainers.pinage404 ];

--- a/pkgs/by-name/gi/git-quick-stats/package.nix
+++ b/pkgs/by-name/gi/git-quick-stats/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     repo = "git-quick-stats";
-    owner = "arzzen";
+    owner = "git-quick-stats";
     rev = finalAttrs.version;
     sha256 = "sha256-YVvlrlNRDDci7fH9LW4NxZcIkakVgvKe9FhJ2gCfoXg=";
   };
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
 
   meta = {
-    homepage = "https://github.com/arzzen/git-quick-stats";
+    homepage = "https://github.com/git-quick-stats/git-quick-stats";
     description = "Simple and efficient way to access various statistics in git repository";
     platforms = lib.platforms.all;
     maintainers = [ lib.maintainers.kmein ];

--- a/pkgs/by-name/gi/git-repo/package.nix
+++ b/pkgs/by-name/gi/git-repo/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.59";
 
   src = fetchFromGitHub {
-    owner = "android";
+    owner = "aosp-mirror";
     repo = "tools_repo";
     rev = "v${finalAttrs.version}";
     hash = "sha256-5ffk5B4ZA/Wy2bQNahFaXPFRSZdKz5t6TaGbN00mfxo=";

--- a/pkgs/by-name/gi/gitflow/package.nix
+++ b/pkgs/by-name/gi/gitflow/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "petervanderdoes";
-    repo = "gitflow";
+    repo = "gitflow-avh";
     rev = finalAttrs.version;
     sha256 = "sha256-kHirHG/bfsU6tKyQ0khNSTyChhzHfzib+HyA3LOtBI8=";
   };
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://github.com/petervanderdoes/gitflow";
+    homepage = "https://github.com/petervanderdoes/gitflow-avh";
     description = "Extend git with the Gitflow branching model";
     mainProgram = "git-flow";
     longDescription = ''

--- a/pkgs/by-name/gi/gitqlient/package.nix
+++ b/pkgs/by-name/gi/gitqlient/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.6.3-unstable-2025-09-11"; # cmake does not install correctly on tagged release
 
   src = fetchFromGitHub {
-    owner = "francescmm";
+    owner = "francescmaestre";
     repo = "gitqlient";
     rev = "faa3e2c19205123944bb88427a569c6f1b4366a1";
     fetchSubmodules = true;
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
   env.NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations"; # QCheckBox::stateChanged is deprecated
 
   meta = {
-    homepage = "https://github.com/francescmm/GitQlient";
+    homepage = "https://github.com/francescmaestre/GitQlient";
     description = "Multi-platform Git client written with Qt";
     license = lib.licenses.lgpl2Plus;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/gl/glabels-qt/package.nix
+++ b/pkgs/by-name/gl/glabels-qt/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   version = "unstable-2025-12-03";
 
   src = fetchFromGitHub {
-    owner = "jimevins";
+    owner = "j-evins";
     repo = "glabels-qt";
     tag = "3.99-master602";
     hash = "sha256-7MQufoU1GBvmZd8FRn331/PwmwQMuZeuFKQqViRI754=";
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "GLabels Label Designer (Qt/C++)";
-    homepage = "https://github.com/jimevins/glabels-qt";
+    homepage = "https://github.com/j-evins/glabels-qt";
     license = lib.licenses.gpl3Only;
     maintainers = [ lib.maintainers.matthewcroughan ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/gl/glava/package.nix
+++ b/pkgs/by-name/gl/glava/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.6.3";
 
   src = fetchFromGitHub {
-    owner = "wacossusca34";
+    owner = "jarcode-foss";
     repo = "glava";
     rev = "v${finalAttrs.version}";
     sha256 = "0kqkjxmpqkmgby05lsf6c6iwm45n33jk5qy6gi3zvjx4q4yzal1i";
@@ -96,7 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
       OpenGL audio spectrum visualizer
     '';
     mainProgram = "glava";
-    homepage = "https://github.com/wacossusca34/glava";
+    homepage = "https://github.com/jarcode-foss/glava";
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/gm/gmap/package.nix
+++ b/pkgs/by-name/gm/gmap/package.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.3.3";
 
   src = fetchFromGitHub {
-    owner = "seeyebe";
+    owner = "marawny";
     repo = "gmap";
     tag = finalAttrs.version;
     hash = "sha256-+klVySOgI/M57f98Cx3omkEBx/NcaWD4FuIW6cz1aN8=";
@@ -41,8 +41,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
       Built for developers who live in the CLI and want quick,
       powerful insights.
     '';
-    homepage = "https://github.com/seeyebe/gmap";
-    changelog = "https://github.com/seeyebe/gmap/releases/tag/${finalAttrs.src.tag}";
+    homepage = "https://github.com/marawny/gmap";
+    changelog = "https://github.com/marawny/gmap/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ yiyu ];
     mainProgram = "gmap";

--- a/pkgs/by-name/gn/gnome-inform7/package.nix
+++ b/pkgs/by-name/gn/gnome-inform7/package.nix
@@ -104,7 +104,7 @@ stdenv.mkDerivation {
   version = "unstable-2021-04-06";
   src = fetchFromGitHub {
     owner = "ptomato";
-    repo = "gnome-inform7";
+    repo = "inform7-ide";
     # build from revision in the GTK3 branch as mainline requires webkit-1.0
     rev = "c37e045c159692aae2e4e79b917e5f96cfefa66a";
     sha256 = "Q4xoITs3AYXhvpWaABRAvJaUWTtUl8lYQ1k9zX7FrNw=";
@@ -143,7 +143,7 @@ stdenv.mkDerivation {
     longDescription = ''
       This version of Inform 7 for the Gnome platform was created by Philip Chimento, based on a design by Graham Nelson and Andrew Hunter.
     '';
-    homepage = "https://github.com/ptomato/gnome-inform7";
+    homepage = "https://github.com/ptomato/inform7-ide";
     license = lib.licenses.gpl3Only;
     maintainers = [ lib.maintainers.fitzgibbon ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/gn/gnome-pomodoro/package.nix
+++ b/pkgs/by-name/gn/gnome-pomodoro/package.nix
@@ -27,8 +27,8 @@ stdenv.mkDerivation rec {
   version = "0.28.1";
 
   src = fetchFromGitHub {
-    owner = "gnome-pomodoro";
-    repo = "gnome-pomodoro";
+    owner = "focustimerhq";
+    repo = "FocusTimer";
     rev = version;
     hash = "sha256-1G0Sv6uR4rE+/TZqEM57mCdBaXoJNpC0cznY4pnPEa4=";
   };

--- a/pkgs/by-name/go/go-autoconfig/package.nix
+++ b/pkgs/by-name/go/go-autoconfig/package.nix
@@ -9,7 +9,7 @@ buildGoModule {
   version = "unstable-2022-08-03";
 
   src = fetchFromGitHub {
-    owner = "L11R";
+    owner = "savely-krasovsky";
     repo = "go-autoconfig";
     rev = "b1b182202da82cc881dccd715564853395d4f76a";
     sha256 = "sha256-Rbg6Ghp5NdcLSLSIhwwFFMKmZPWsboDyHCG6ePqSSZA=";
@@ -23,7 +23,7 @@ buildGoModule {
 
   meta = {
     description = "IMAP/SMTP autodiscover feature for Thunderbird, Apple Mail and Microsoft Outlook";
-    homepage = "https://github.com/L11R/go-autoconfig";
+    homepage = "https://github.com/savely-krasovsky/go-autoconfig";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ onny ];
     mainProgram = "go-autoconfig";

--- a/pkgs/by-name/go/go-callvis/package.nix
+++ b/pkgs/by-name/go/go-callvis/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "0.7.1";
 
   src = fetchFromGitHub {
-    owner = "ofabry";
+    owner = "ondrajz";
     repo = "go-callvis";
     rev = "v${finalAttrs.version}";
     hash = "sha256-gCQjxJH03QAg6MZx5NJUJR6tKP02ThIa5BGN6A/0ejM=";
@@ -29,7 +29,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Visualize call graph of a Go program using Graphviz";
     mainProgram = "go-callvis";
-    homepage = "https://github.com/ofabry/go-callvis";
+    homepage = "https://github.com/ondrajz/go-callvis";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ meain ];
   };

--- a/pkgs/by-name/go/go-dnscollector/package.nix
+++ b/pkgs/by-name/go/go-dnscollector/package.nix
@@ -10,7 +10,7 @@ buildGoModule (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "dmachard";
-    repo = "go-dnscollector";
+    repo = "DNS-collector";
     tag = "v${finalAttrs.version}";
     hash = "sha256-hqSfL3R0fp7uYBGoD1Wu0ZNLq1VnOvcN0n8zzfRXTfA=";
   };
@@ -21,7 +21,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Ingesting, pipelining, and enhancing your DNS logs with usage indicators, security analysis, and additional metadata";
-    homepage = "https://github.com/dmachard/go-dnscollector";
+    homepage = "https://github.com/dmachard/DNS-collector";
     changelog = "https://github.com/dmachard/DNS-collector/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ shift ];

--- a/pkgs/by-name/go/gogcli/package.nix
+++ b/pkgs/by-name/go/gogcli/package.nix
@@ -10,7 +10,7 @@ buildGoModule (finalAttrs: {
   version = "0.11.0";
 
   src = fetchFromGitHub {
-    owner = "steipete";
+    owner = "openclaw";
     repo = "gogcli";
     tag = "v${finalAttrs.version}";
     hash = "sha256-hJU40ysjRx4p9SWGmbhhpToYCpk3DcMAWCnKqxHRmh0=";
@@ -23,9 +23,9 @@ buildGoModule (finalAttrs: {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/steipete/gogcli/internal/cmd.version=v${finalAttrs.version}"
-    "-X github.com/steipete/gogcli/internal/cmd.commit=${finalAttrs.src.rev}"
-    "-X github.com/steipete/gogcli/internal/cmd.date=1970-01-01T00:00:00Z"
+    "-X github.com/openclaw/gogcli/internal/cmd.version=v${finalAttrs.version}"
+    "-X github.com/openclaw/gogcli/internal/cmd.commit=${finalAttrs.src.rev}"
+    "-X github.com/openclaw/gogcli/internal/cmd.date=1970-01-01T00:00:00Z"
   ];
 
   passthru.tests.version = testers.testVersion {
@@ -36,7 +36,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "CLI tool for interacting with Google APIs (Gmail, Calendar, Drive, and more)";
-    homepage = "https://github.com/steipete/gogcli";
+    homepage = "https://github.com/openclaw/gogcli";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ macalinao ];
     mainProgram = "gog";

--- a/pkgs/by-name/go/gomi/package.nix
+++ b/pkgs/by-name/go/gomi/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "1.6.2";
 
   src = fetchFromGitHub {
-    owner = "b4b4r07";
+    owner = "babarot";
     repo = "gomi";
     tag = "v${finalAttrs.version}";
     hash = "sha256-Ino7jUd9JvX6afvS6ouPHxU42GYfF696m+OS5CSvx5g=";
@@ -40,7 +40,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Replacement for UNIX rm command";
-    homepage = "https://github.com/b4b4r07/gomi";
+    homepage = "https://github.com/babarot/gomi";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       mimame

--- a/pkgs/by-name/go/gomuks/package.nix
+++ b/pkgs/by-name/go/gomuks/package.nix
@@ -16,7 +16,7 @@ buildGoModule rec {
   version = "0.3.1";
 
   src = fetchFromGitHub {
-    owner = "tulir";
+    owner = "gomuks";
     repo = "gomuks";
     rev = "v${version}";
     sha256 = "sha256-bDJXo8d9K5UO599HDaABpfwc9/dJJy+9d24KMVZHyvI=";

--- a/pkgs/by-name/go/goose-cli/package.nix
+++ b/pkgs/by-name/go/goose-cli/package.nix
@@ -51,7 +51,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "1.28.0";
 
   src = fetchFromGitHub {
-    owner = "block";
+    owner = "aaif-goose";
     repo = "goose";
     tag = "v${finalAttrs.version}";
     hash = "sha256-/1TtsnNiLoTkvyeFR282qSpo+Jt3pvFxduJ7lyzsTXI=";
@@ -181,7 +181,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Open-source, extensible AI agent that goes beyond code suggestions - install, execute, edit, and test with any LLM";
-    homepage = "https://github.com/block/goose";
+    homepage = "https://github.com/aaif-goose/goose";
     mainProgram = "goose";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/go/gore/package.nix
+++ b/pkgs/by-name/go/gore/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "0.6.1";
 
   src = fetchFromGitHub {
-    owner = "motemen";
+    owner = "x-motemen";
     repo = "gore";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-EPySMj+mQxTJbGheAtzKvQq23DLljPR6COrmytu1x/Q=";
@@ -22,7 +22,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Yet another Go REPL that works nicely";
     mainProgram = "gore";
-    homepage = "https://github.com/motemen/gore";
+    homepage = "https://github.com/x-motemen/gore";
     license = lib.licenses.mit;
     maintainers = [ ];
   };

--- a/pkgs/by-name/go/goreplay/package.nix
+++ b/pkgs/by-name/go/goreplay/package.nix
@@ -11,16 +11,16 @@ buildGoModule (finalAttrs: {
   version = "1.3.3";
 
   src = fetchFromGitHub {
-    owner = "buger";
+    owner = "probelabs";
     repo = "goreplay";
     rev = finalAttrs.version;
     sha256 = "sha256-FiY9e5FgpPu+K8eoO8TsU3xSaSoPPDxYEu0oi/S8Q1w=";
   };
 
   patches = [
-    # Fix build on arm64-linux, see https://github.com/buger/goreplay/pull/1140
+    # Fix build on arm64-linux, see https://github.com/probelabs/goreplay/pull/1140
     (fetchpatch {
-      url = "https://github.com/buger/goreplay/commit/a01afa1e322ef06f36995abc3fda3297bdaf0140.patch";
+      url = "https://github.com/probelabs/goreplay/commit/a01afa1e322ef06f36995abc3fda3297bdaf0140.patch";
       sha256 = "sha256-w3aVe/Fucwd2OuK5Fu2jJTbmMci8ilWaIjYjsWuLRlo=";
     })
   ];
@@ -37,7 +37,7 @@ buildGoModule (finalAttrs: {
   doCheck = false;
 
   meta = {
-    homepage = "https://github.com/buger/goreplay";
+    homepage = "https://github.com/probelabs/goreplay";
     license = lib.licenses.lgpl3Only;
     description = "Open-source tool for capturing and replaying live HTTP traffic";
     maintainers = [ ];

--- a/pkgs/by-name/gq/gqlgenc/package.nix
+++ b/pkgs/by-name/gq/gqlgenc/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   version = "0.32.1";
 
   src = fetchFromGitHub {
-    owner = "yamashou";
+    owner = "gqlgo";
     repo = "gqlgenc";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-AGbE+R3502Igl4/HaN8yvFVJBsKQ6iVff8IEvddJLEo=";
@@ -20,7 +20,7 @@ buildGoModule (finalAttrs: {
   patches = [
     (fetchpatch2 {
       name = "fix-version.patch";
-      url = "https://github.com/Yamashou/gqlgenc/commit/aad0599a70780696a9530a7adffebfff53538695.patch?full_index=1";
+      url = "https://github.com/gqlgo/gqlgenc/commit/aad0599a70780696a9530a7adffebfff53538695.patch?full_index=1";
       hash = "sha256-moidhkkO/5It8kH1VlwbV+YLlMOTXKH3RyLKGCA2chw=";
     })
   ];
@@ -45,7 +45,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Go tool for building GraphQL client with gqlgen";
     mainProgram = "gqlgenc";
-    homepage = "https://github.com/Yamashou/gqlgenc";
+    homepage = "https://github.com/gqlgo/gqlgenc";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ wattmto ];
   };

--- a/pkgs/by-name/gr/granted/package.nix
+++ b/pkgs/by-name/gr/granted/package.nix
@@ -14,7 +14,7 @@ buildGoModule (finalAttrs: {
   version = "0.38.0";
 
   src = fetchFromGitHub {
-    owner = "common-fate";
+    owner = "fwdcloudsec";
     repo = "granted";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-xHpYtHG0fJ/VvJ/4lJ90ept3yGzJRnmtFQFbYxJtxwY=";
@@ -87,8 +87,8 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Easiest way to access your cloud";
-    homepage = "https://github.com/common-fate/granted";
-    changelog = "https://github.com/common-fate/granted/releases/tag/${finalAttrs.version}";
+    homepage = "https://github.com/fwdcloudsec/granted";
+    changelog = "https://github.com/fwdcloudsec/granted/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       jlbribeiro

--- a/pkgs/by-name/gv/gvolicon/package.nix
+++ b/pkgs/by-name/gv/gvolicon/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   version = "0-unstable-2014-04-28";
 
   src = fetchFromGitHub {
-    owner = "Unia";
+    owner = "Hjdskes";
     repo = "gvolicon";
     rev = "0d65a396ba11f519d5785c37fec3e9a816217a07";
     sha256 = "sha256-lm5OfryV1/1T1RgsVDdp0Jg5rh8AND8M3ighfrznKes=";
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Simple and lightweight volume icon that sits in your system tray";
-    homepage = "https://github.com/Unia/gvolicon";
+    homepage = "https://github.com/Hjdskes/gvolicon";
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl3Plus;
     maintainers = [ lib.maintainers.bennofs ];

--- a/pkgs/by-name/ha/hackertyper/package.nix
+++ b/pkgs/by-name/ha/hackertyper/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   version = "2.1";
 
   src = fetchFromGitHub {
-    owner = "Hurricane996";
+    owner = "hyasynthesized";
     repo = "Hackertyper";
     rev = "8d08e3200c65817bd8c5bd0baa5032919315853b";
     sha256 = "0shri0srihw9fk027k61qkxr9ikwkn28aaamrhps6lg0vpbqpx2w";
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "C rewrite of hackertyper.net";
-    homepage = "https://github.com/Hurricane996/Hackertyper";
+    homepage = "https://github.com/hyasynthesized/Hackertyper";
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.marius851000 ];
     mainProgram = "hackertyper";

--- a/pkgs/by-name/he/helio-workstation/package.nix
+++ b/pkgs/by-name/he/helio-workstation/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "helio-fm";
-    repo = "helio-workstation";
+    repo = "helio-sequencer";
     tag = finalAttrs.version;
     fetchSubmodules = true;
     hash = "sha256-uEo4dxwc1HksYGU5ssYp3rLugszSir2kKo4XxgqvSno=";

--- a/pkgs/by-name/hp/hpx/package.nix
+++ b/pkgs/by-name/hp/hpx/package.nix
@@ -16,14 +16,14 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.11.0";
 
   src = fetchFromGitHub {
-    owner = "STEllAR-GROUP";
+    owner = "TheHPXProject";
     repo = "hpx";
     rev = "v${finalAttrs.version}";
     hash = "sha256-AhByaw1KnEDuRfKiN+/vQMbkG0BJ6Z3+h+QT8scFzAY=";
   };
 
   patches = [
-    # https://github.com/STEllAR-GROUP/hpx/pull/6731
+    # https://github.com/TheHPXProject/hpx/pull/6731
     # Fix build with asio >= 1.34.0
     ./remove_deprecated_asio_features.patch
   ];
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "C++ standard library for concurrency and parallelism";
-    homepage = "https://github.com/STEllAR-GROUP/hpx";
+    homepage = "https://github.com/TheHPXProject/hpx";
     license = lib.licenses.boost;
     platforms = [ "x86_64-linux" ]; # lib.platforms.linux;
     maintainers = with lib.maintainers; [ bobakker ];

--- a/pkgs/by-name/hs/hstr/package.nix
+++ b/pkgs/by-name/hs/hstr/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.1";
 
   src = fetchFromGitHub {
-    owner = "dvorka";
+    owner = "dvorka-oss";
     repo = "hstr";
     rev = finalAttrs.version;
     hash = "sha256-OuLy1aiEwUJDGy3+UXYF1Vx1nNXic46WIZEM1xrIPfA=";
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags = [ "--prefix=$(out)" ];
 
   meta = {
-    homepage = "https://github.com/dvorka/hstr";
+    homepage = "https://github.com/dvorka-oss/hstr";
     description = "Shell history suggest box - easily view, navigate, search and use your command history";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.matthiasbeyer ];

--- a/pkgs/by-name/hu/hub/package.nix
+++ b/pkgs/by-name/hu/hub/package.nix
@@ -16,7 +16,7 @@ buildGoModule (finalAttrs: {
   version = "unstable-2022-12-01";
 
   src = fetchFromGitHub {
-    owner = "github";
+    owner = "mislav";
     repo = "hub";
     rev = "38bcd4ae469e5f53f01901340b715c7658ab417a";
     hash = "sha256-V2GvwKj0m2UXxE42G23OHXyAsTrVRNw1p5CAaJxGYog=";
@@ -24,15 +24,15 @@ buildGoModule (finalAttrs: {
 
   patches = [
     # Fix `fish` completions
-    # https://github.com/github/hub/pull/3036
+    # https://github.com/mislav/hub/pull/3036
     (fetchpatch {
-      url = "https://github.com/github/hub/commit/439b7699e79471fc789929bcdea2f30bd719963e.patch";
+      url = "https://github.com/mislav/hub/commit/439b7699e79471fc789929bcdea2f30bd719963e.patch";
       hash = "sha256-pR/OkGa2ICR4n1pLNx8E2UTtLeDwFtXxeeTB94KFjC4=";
     })
     # Fix `bash` completions
-    # https://github.com/github/hub/pull/2948
+    # https://github.com/mislav/hub/pull/2948
     (fetchpatch {
-      url = "https://github.com/github/hub/commit/64b291006f208fc7db1d5be96ff7db5535f1d853.patch";
+      url = "https://github.com/mislav/hub/commit/64b291006f208fc7db1d5be96ff7db5535f1d853.patch";
       hash = "sha256-jGFFIvSKEIpTQY0Wz63cqciUk25MzPHv5Z1ox8l7wmo=";
     })
   ];

--- a/pkgs/by-name/hy/hyperssh/package.nix
+++ b/pkgs/by-name/hy/hyperssh/package.nix
@@ -17,16 +17,16 @@ buildNpmPackage {
   dontNpmBuild = true;
 
   src = fetchFromGitHub {
-    owner = "mafintosh";
+    owner = "holepunchto";
     repo = "hyperssh";
     rev = "v5.0.3";
     hash = "sha256-vjPSNcQRsqu0ee0hownEE9y8dFf9dqaL7alGRc9WjcI=2";
   };
 
   patches = [
-    # TODO: remove after this is merged: https://github.com/mafintosh/hyperssh/pull/16
+    # TODO: remove after this is merged: https://github.com/holepunchto/hyperssh/pull/16
     (fetchurl {
-      url = "https://github.com/mafintosh/hyperssh/commit/ad1d0e06a133e71c9df9f59dd5f805c49f46ec70.patch";
+      url = "https://github.com/holepunchto/hyperssh/commit/ad1d0e06a133e71c9df9f59dd5f805c49f46ec70.patch";
       hash = "sha256-fUjgHHbZHgqokNg2fVVZCjoDA3LqSJiFzBwgA8Tt1m4=";
     })
   ];
@@ -50,7 +50,7 @@ buildNpmPackage {
 
   meta = {
     description = "Run SSH over hyperswarm";
-    homepage = "https://github.com/mafintosh/hyperssh";
+    homepage = "https://github.com/holepunchto/hyperssh";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ davhau ];
     mainProgram = "hyperssh";

--- a/pkgs/by-name/i3/i3ipc-glib/package.nix
+++ b/pkgs/by-name/i3/i3ipc-glib/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.0.1";
 
   src = fetchFromGitHub {
-    owner = "acrisci";
+    owner = "altdesktop";
     repo = "i3ipc-glib";
     tag = "v${finalAttrs.version}";
     hash = "sha256-F9Tiwc/gB7BFWr/qerS4n/+k/nUvJsH7Bp2zb1fe3wU=";
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "C interface library to i3wm";
-    homepage = "https://github.com/acrisci/i3ipc-glib";
+    homepage = "https://github.com/altdesktop/i3ipc-glib";
     maintainers = with lib.maintainers; [ teto ];
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/ia/iannix/package.nix
+++ b/pkgs/by-name/ia/iannix/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   version = "unstable-2020-12-09";
 
   src = fetchFromGitHub {
-    owner = "iannix";
+    owner = "buzzinglight";
     repo = "IanniX";
     rev = "287b51d9b90b3e16ae206c0c4292599619f7b159";
     sha256 = "AhoP+Ok78Vk8Aee/RP572hJeM8O7v2ZTvFalOZZqRy8=";

--- a/pkgs/by-name/ik/ikill/package.nix
+++ b/pkgs/by-name/ik/ikill/package.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "1.6.0";
 
   src = fetchFromGitHub {
-    owner = "pjmp";
+    owner = "pombadev";
     repo = "ikill";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-hOQBBwxkVnTkAZJi84qArwAo54fMC0zS+IeYMV04kUs=";
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Interactively kill running processes";
-    homepage = "https://github.com/pjmp/ikill";
+    homepage = "https://github.com/pombadev/ikill";
     maintainers = with lib.maintainers; [ zendo ];
     license = [ lib.licenses.mit ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/il/illum/package.nix
+++ b/pkgs/by-name/il/illum/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.5";
 
   src = fetchFromGitHub {
-    owner = "jmesmon";
+    owner = "codyps";
     repo = "illum";
     tag = "v${finalAttrs.version}";
     sha256 = "S4lUBeRnZlRUpIxFdN/bh979xvdS7roF6/6Dk0ZUrnM=";
@@ -24,8 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     (fetchpatch {
-      name = "prevent-unplug-segfault"; # See https://github.com/jmesmon/illum/issues/19
-      url = "https://github.com/jmesmon/illum/commit/47b7cd60ee892379e5d854f79db343a54ae5a3cc.patch";
+      name = "prevent-unplug-segfault"; # See https://github.com/codyps/illum/issues/19
+      url = "https://github.com/codyps/illum/commit/47b7cd60ee892379e5d854f79db343a54ae5a3cc.patch";
       sha256 = "sha256-hIBBCIJXAt8wnZuyKye1RiEfOCelP3+4kcGrM43vFOE=";
     })
   ];
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://github.com/jmesmon/illum";
+    homepage = "https://github.com/codyps/illum";
     description = "Daemon that wires button presses to screen backlight level";
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.dancek ];

--- a/pkgs/by-name/in/inriafonts/package.nix
+++ b/pkgs/by-name/in/inriafonts/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation rec {
   version = "1.200";
 
   src = fetchFromGitHub {
-    owner = "BlackFoundry";
+    owner = "BlackFoundryCom";
     repo = "InriaFonts";
     rev = "v${version}";
     hash = "sha256-CMKkwGuUEVYavnFi15FCk7Xloyk97w+LhAZ6mpIv5xg=";

--- a/pkgs/by-name/io/io/package.nix
+++ b/pkgs/by-name/io/io/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
   version = "2019.05.22-alpha";
 
   src = fetchFromGitHub {
-    owner = "stevedekorte";
+    owner = "IoLanguage";
     repo = "io";
     tag = "2019.05.22-alpha";
     fetchSubmodules = true;

--- a/pkgs/by-name/ip/ip2location-c/package.nix
+++ b/pkgs/by-name/ip/ip2location-c/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "8.7.0";
 
   src = fetchFromGitHub {
-    owner = "chrislim2888";
+    owner = "ip2location";
     repo = "IP2Location-C-Library";
     rev = finalAttrs.version;
     sha256 = "sha256-kp0tNZPP9u2xxFOmBAdivsVLtyF66o38H6eRrs2/S/Y=";

--- a/pkgs/by-name/ir/ircdog/package.nix
+++ b/pkgs/by-name/ir/ircdog/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "0.5.5";
 
   src = fetchFromGitHub {
-    owner = "goshuirc";
+    owner = "ergochat";
     repo = "ircdog";
     tag = "v${finalAttrs.version}";
     hash = "sha256-maF53Z0FHAhGmnOnMsX0dDnmckPNBY4Bcm4OBM/x4hQ=";

--- a/pkgs/by-name/is/isso/package.nix
+++ b/pkgs/by-name/is/isso/package.nix
@@ -14,7 +14,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   format = "setuptools";
 
   src = fetchFromGitHub {
-    owner = "posativ";
+    owner = "isso-comments";
     repo = "isso";
     tag = finalAttrs.version;
     hash = "sha256-8kXqqiMXxF0wCJ+AzYT8j0rjuhlXO3F6UJbump672b4=";
@@ -31,7 +31,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   ];
 
   postPatch = ''
-    # Remove when https://github.com/posativ/isso/pull/973 is available.
+    # Remove when https://github.com/isso-comments/isso/pull/973 is available.
     substituteInPlace isso/tests/test_comments.py \
       --replace "self.client.delete_cookie('localhost.local', '1')" "self.client.delete_cookie(key='1', domain='localhost')"
   '';

--- a/pkgs/by-name/jc/jcal/package.nix
+++ b/pkgs/by-name/jc/jcal/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.5.1";
 
   src = fetchFromGitHub {
-    owner = "fzerorubigd";
+    owner = "persiancal";
     repo = "jcal";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-vJc5uijZlvohEtiS03LYlqtswVE38S9/ejlHrmZ0wqA=";

--- a/pkgs/by-name/jf/jfmt/package.nix
+++ b/pkgs/by-name/jf/jfmt/package.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "1.2.1";
 
   src = fetchFromGitHub {
-    owner = "scruffystuffs";
+    owner = "skilly-lily";
     repo = "jfmt.rs";
     rev = "v${finalAttrs.version}";
     hash = "sha256-X3wk669G07BTPAT5xGbAfIu2Qk90aaJIi1CLmOnSG80=";
@@ -20,8 +20,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "CLI utility to format json files";
     mainProgram = "jfmt";
-    homepage = "https://github.com/scruffystuffs/jfmt.rs";
-    changelog = "https://github.com/scruffystuffs/jfmt.rs/blob/${finalAttrs.version}/CHANGELOG.md";
+    homepage = "https://github.com/skilly-lily/jfmt.rs";
+    changelog = "https://github.com/skilly-lily/jfmt.rs/blob/${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.psibi ];
   };

--- a/pkgs/by-name/jg/jgmenu/package.nix
+++ b/pkgs/by-name/jg/jgmenu/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "4.5.0";
 
   src = fetchFromGitHub {
-    owner = "johanmalm";
+    owner = "jgmenu";
     repo = "jgmenu";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-vuSpiZZYe0l5va9dHM54gaoI9x8qXH1gJORUS5489jQ=";
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 
   meta = {
-    homepage = "https://github.com/johanmalm/jgmenu";
+    homepage = "https://github.com/jgmenu/jgmenu";
     description = "Small X11 menu intended to be used with openbox and tint2";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/jr/jrsonnet/package.nix
+++ b/pkgs/by-name/jr/jrsonnet/package.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.5.0-pre98";
 
   src = fetchFromGitHub {
-    owner = "CertainLach";
+    owner = "deltarocks";
     repo = "jrsonnet";
     tag = "v${finalAttrs.version}";
     hash = "sha256-2dNzxZnvnw8TsKnnIlHGpuixrqe4z0a4faOBPv2N+ws=";
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Purely-functional configuration language that helps you define JSON data";
-    homepage = "https://github.com/CertainLach/jrsonnet";
+    homepage = "https://github.com/deltarocks/jrsonnet";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       lach

--- a/pkgs/by-name/js/jsubfinder/package.nix
+++ b/pkgs/by-name/js/jsubfinder/package.nix
@@ -9,7 +9,7 @@ buildGoModule {
   version = "0-unstable-2022-05-31";
 
   src = fetchFromGitHub {
-    owner = "ThreatUnkown";
+    owner = "ThreatUnknown";
     repo = "jsubfinder";
     rev = "e21de1ebc174bb69485f1c224e8063c77d87e4ad";
     hash = "sha256-QjRYJyk0uFGa6FCCYK9SIJhoyam4ALsQJ26DsmbNk8s=";
@@ -20,7 +20,7 @@ buildGoModule {
   meta = {
     description = "Tool to search for in Javascript hidden subdomains and secrets";
     mainProgram = "jsubfinder";
-    homepage = "https://github.com/ThreatUnkown/jsubfinder";
+    homepage = "https://github.com/ThreatUnknown/jsubfinder";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/by-name/ka/kaniko/package.nix
+++ b/pkgs/by-name/ka/kaniko/package.nix
@@ -4,8 +4,6 @@
   fetchFromGitHub,
   buildGoModule,
   installShellFiles,
-  testers,
-  kaniko,
   versionCheckHook,
 }:
 
@@ -14,7 +12,7 @@ buildGoModule (finalAttrs: {
   version = "1.25.15";
 
   src = fetchFromGitHub {
-    owner = "chainguard-dev";
+    owner = "chainguard-forks";
     repo = "kaniko";
     rev = "v${finalAttrs.version}";
     hash = "sha256-0d0QdNmR7FaybJJEq6bb9WshTg6dX3HtO9oESg1e4S4=";
@@ -52,7 +50,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Tool to build container images from a Dockerfile, inside a container or Kubernetes cluster";
-    homepage = "https://github.com/chainguard-dev/kaniko";
+    homepage = "https://github.com/chainguard-forks/kaniko";
     license = lib.licenses.asl20;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/kb/kbdlight/package.nix
+++ b/pkgs/by-name/kb/kbdlight/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.3";
 
   src = fetchFromGitHub {
-    owner = "hobarrera";
+    owner = "WhyNotHugo";
     repo = "kbdlight";
     rev = "v${finalAttrs.version}";
     sha256 = "1f08aid1xrbl4sb5447gkip9lnvkia1c4ap0v8zih5s9w8v72bny";
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://github.com/hobarrera/kbdlight";
+    homepage = "https://github.com/WhyNotHugo/kbdlight";
     description = "Very simple application that changes MacBooks' keyboard backlight level";
     mainProgram = "kbdlight";
     license = lib.licenses.isc;

--- a/pkgs/by-name/ke/keybinder/package.nix
+++ b/pkgs/by-name/ke/keybinder/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.3.1";
 
   src = fetchFromGitHub {
-    owner = "engla";
+    owner = "kupferlauncher";
     repo = "keybinder";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-elL6DZtzCwAtoyGZYP0jAma6tHPks2KAtrziWtBENGU=";
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
       * Gobject-Introspection (gir)  generated bindings
       * Lua bindings, ``lua-keybinder``
     '';
-    homepage = "https://github.com/engla/keybinder/";
+    homepage = "https://github.com/kupferlauncher/keybinder/";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.bjornfor ];

--- a/pkgs/by-name/ke/keycard-cli/package.nix
+++ b/pkgs/by-name/ke/keycard-cli/package.nix
@@ -12,7 +12,7 @@ buildGoModule (finalAttrs: {
   version = "0.8.2";
 
   src = fetchFromGitHub {
-    owner = "status-im";
+    owner = "keycard-tech";
     repo = "keycard-cli";
     rev = finalAttrs.version;
     hash = "sha256-H9fipHGxINMAXdxUYhyVZusDXA3HW1iQl8iRX6AF7iE=";

--- a/pkgs/by-name/ke/keychain/package.nix
+++ b/pkgs/by-name/ke/keychain/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.9.8";
 
   src = fetchFromGitHub {
-    owner = "funtoo";
+    owner = "danielrobbins";
     repo = "keychain";
     rev = finalAttrs.version;
     sha256 = "sha256-xk3ooFhBkgv93Po5oC4TZRmMhJJXDv7yekoE102FQd8=";

--- a/pkgs/by-name/kj/kjv/package.nix
+++ b/pkgs/by-name/kj/kjv/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
   version = "unstable-2021-03-11";
 
   src = fetchFromGitHub {
-    owner = "bontibon";
+    owner = "layeh";
     repo = "kjv";
     rev = "108595dcbb9bb12d40e0309f029b6fb3ccd81309";
     hash = "sha256-Z6myd9Xn23pYizG+IZVDrP988pYU06QIcpqXtWTcPiw=";
@@ -42,7 +42,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Bible, King James Version";
-    homepage = "https://github.com/bontibon/kjv";
+    homepage = "https://github.com/layeh/kjv";
     license = lib.licenses.unlicense;
     maintainers = with lib.maintainers; [
       jtobin

--- a/pkgs/by-name/ko/koodousfinder/package.nix
+++ b/pkgs/by-name/ko/koodousfinder/package.nix
@@ -10,9 +10,9 @@ python3.pkgs.buildPythonApplication {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "teixeira0xfffff";
+    owner = "HuntDownProject";
     repo = "KoodousFinder";
-    # Not properly tagged, https://github.com/teixeira0xfffff/KoodousFinder/issues/7
+    # Not properly tagged, https://github.com/HuntDownProject/KoodousFinder/issues/7
     #tag = "v${version}";
     rev = "d9dab5572f44e5cd45c04e6fcda38956897855d1";
     hash = "sha256-skCbt2lDKgSyZdHY3WImbr6CF0icrDPTIXNV1736gKk=";
@@ -34,7 +34,7 @@ python3.pkgs.buildPythonApplication {
 
   meta = {
     description = "Tool to allows users to search for and analyze Android apps";
-    homepage = "https://github.com/teixeira0xfffff/KoodousFinder";
+    homepage = "https://github.com/HuntDownProject/KoodousFinder";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/by-name/kr/krillinai/package.nix
+++ b/pkgs/by-name/kr/krillinai/package.nix
@@ -20,7 +20,7 @@ buildGoModule (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "krillinai";
-    repo = "KlicStudio";
+    repo = "KrillinAI";
     tag = "v${finalAttrs.version}";
     hash = "sha256-CMeF24BCJ+wbiXCl0iJm0acNoggVxeOu3Q/cXJY8aQo=";
   };
@@ -51,8 +51,8 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Video translation and dubbing tool";
-    homepage = "https://github.com/krillinai/KlicStudio";
-    changelog = "https://github.com/krillinai/KlicStudio/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/krillinai/KrillinAI";
+    changelog = "https://github.com/krillinai/KrillinAI/releases/tag/v${finalAttrs.version}";
     mainProgram = "krillinai-desktop";
     license = lib.licenses.gpl3Plus;
     maintainers = [ ];

--- a/pkgs/by-name/kr/kristall/package.nix
+++ b/pkgs/by-name/kr/kristall/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
   version = "0.3";
 
   src = fetchFromGitHub {
-    owner = "MasterQ32";
+    owner = "ikskuh";
     repo = "kristall";
     rev = "V${version}";
     sha256 = "07nf7w6ilzs5g6isnvsmhh4qa1zsprgjyf0zy7rhpx4ikkj8c8zq";

--- a/pkgs/by-name/ku/kubie/package.nix
+++ b/pkgs/by-name/ku/kubie/package.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   src = fetchFromGitHub {
     rev = "v${finalAttrs.version}";
-    owner = "sbstp";
+    owner = "kubie-org";
     repo = "kubie";
     sha256 = "sha256-eSzNCH0MiGvLKHrSXFSXQq4lN5tfmr0NcuGaN96Invs=";
   };
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Shell independent context and namespace switcher for kubectl";
     mainProgram = "kubie";
-    homepage = "https://github.com/sbstp/kubie";
+    homepage = "https://github.com/kubie-org/kubie";
     license = with lib.licenses; [ zlib ];
     maintainers = with lib.maintainers; [ illiusdope ];
   };

--- a/pkgs/by-name/le/ledmon/package.nix
+++ b/pkgs/by-name/le/ledmon/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.92";
 
   src = fetchFromGitHub {
-    owner = "intel";
+    owner = "md-raid-utilities";
     repo = "ledmon";
     rev = "v${finalAttrs.version}";
     sha256 = "1lz59606vf2sws5xwijxyffm8kxcf8p9qbdpczsq1b5mm3dk6lvp";
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    homepage = "https://github.com/intel/ledmon";
+    homepage = "https://github.com/md-raid-utilities/ledmon";
     description = "Enclosure LED Utilities";
     platforms = lib.platforms.linux;
     license = with lib.licenses; [ gpl2Only ];

--- a/pkgs/by-name/le/legendary-gl/package.nix
+++ b/pkgs/by-name/le/legendary-gl/package.nix
@@ -11,7 +11,7 @@ python3Packages.buildPythonApplication {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "derrod";
+    owner = "legendary-gl";
     repo = "legendary";
     rev = "56d439ed2d3d9f34e2b08fa23e627c23a487b8d6";
     hash = "sha256-yCHeeEGw+9gtRMGyIhbStxJhmSM/1Fqly7HSRDkZILQ=";
@@ -35,7 +35,7 @@ python3Packages.buildPythonApplication {
 
   meta = {
     description = "Free and open-source Epic Games Launcher alternative";
-    homepage = "https://github.com/derrod/legendary";
+    homepage = "https://github.com/legendary-gl/legendary";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ equirosa ];
     mainProgram = "legendary";

--- a/pkgs/by-name/le/lemminx/package.nix
+++ b/pkgs/by-name/le/lemminx/package.nix
@@ -29,7 +29,7 @@ maven.buildMavenPackage rec {
   version = "0.31.0";
 
   src = fetchFromGitHub {
-    owner = "eclipse";
+    owner = "eclipse-lemminx";
     repo = "lemminx";
     tag = version;
     hash = "sha256-a+9RN1265fsmYAUMuUTxA+VqJv7xPlzuc8HqoZwmR4M=";
@@ -126,7 +126,7 @@ maven.buildMavenPackage rec {
   meta = {
     description = "XML Language Server";
     mainProgram = "lemminx";
-    homepage = "https://github.com/eclipse/lemminx";
+    homepage = "https://github.com/eclipse-lemminx/lemminx";
     license = lib.licenses.epl20;
     maintainers = with lib.maintainers; [ tricktron ];
   };

--- a/pkgs/by-name/li/libcdio-paranoia/package.nix
+++ b/pkgs/by-name/li/libcdio-paranoia/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.0.2";
 
   src = fetchFromGitHub {
-    owner = "rocky";
+    owner = "libcdio";
     repo = "libcdio-paranoia";
     rev = "release-10.2+${finalAttrs.version}";
     hash = "sha256-n05PSVgh6z7BFPq4CjJa5DqCO7Huj8Bsg0x3HQPsbeI=";
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
       This is a port of xiph.org's cdda paranoia to use libcdio for CDROM
       access. By doing this, cdparanoia runs on platforms other than GNU/Linux.
     '';
-    homepage = "https://github.com/rocky/libcdio-paranoia";
+    homepage = "https://github.com/libcdio/libcdio-paranoia";
     license = lib.licenses.gpl3;
     maintainers = [ ];
     mainProgram = "cd-paranoia";

--- a/pkgs/by-name/li/libconfuse/package.nix
+++ b/pkgs/by-name/li/libconfuse/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "1npfk5jv59kk4n8pkyx89fn9s6p8x3gbffs42jaw24frgxfgp8ca";
     rev = "v${finalAttrs.version}";
     repo = "libconfuse";
-    owner = "martinh";
+    owner = "libconfuse";
   };
 
   patches = [

--- a/pkgs/by-name/li/libetpan/package.nix
+++ b/pkgs/by-name/li/libetpan/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.9.4";
 
   src = fetchFromGitHub {
-    owner = "dinhviethoa";
+    owner = "dinhvh";
     repo = "libetpan";
     rev = finalAttrs.version;
     hash = "sha256-lukeWURNsRPTuFk2q2XVnwkKz5Y+PRiPba5GPQCw6jw=";

--- a/pkgs/by-name/li/libfreeaptx/package.nix
+++ b/pkgs/by-name/li/libfreeaptx/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.2.2";
 
   src = fetchFromGitHub {
-    owner = "iamthehorker";
+    owner = "regularhunter";
     repo = "libfreeaptx";
     rev = finalAttrs.version;
     sha256 = "sha256-ntbF0jz/ilOk45xMQxx00WJtJq4Wb7VyKE0eKvghYnY=";
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Free Implementation of Audio Processing Technology codec (aptX)";
     license = lib.licenses.lgpl21Plus;
-    homepage = "https://github.com/iamthehorker/libfreeaptx";
+    homepage = "https://github.com/regularhunter/libfreeaptx";
     platforms = lib.platforms.unix;
     maintainers = [ ];
   };

--- a/pkgs/by-name/li/libgumath/package.nix
+++ b/pkgs/by-name/li/libgumath/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
 
   src = fetchFromGitHub {
     owner = "xnd-project";
-    repo = "gumath";
+    repo = "libgumath";
     rev = "360ed454105ac5615a7cb7d216ad25bc4181b876";
     sha256 = "1wprkxpmjrk369fpw8rbq51r7jvqkcndqs209y7p560cnagmsxc6";
   };

--- a/pkgs/by-name/li/libnabo/package.nix
+++ b/pkgs/by-name/li/libnabo/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "libnabo";
 
   src = fetchFromGitHub {
-    owner = "ethz-asl";
+    owner = "norlab-ulaval";
     repo = "libnabo";
     rev = finalAttrs.version;
     sha256 = "sha256-/XXRwiLLaEvp+Q+c6lBiuWBb9by6o0pDf8wFtBNp7o8=";

--- a/pkgs/by-name/li/libndtypes/package.nix
+++ b/pkgs/by-name/li/libndtypes/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
 
   src = fetchFromGitHub {
     owner = "xnd-project";
-    repo = "ndtypes";
+    repo = "libndtypes";
     rev = "3ce6607c96d8fe67b72cc0c97bf595620cdd274e";
     sha256 = "18303q0jfar1lmi4krp94plczb455zcgw772f9lb8xa5p0bkhx01";
   };

--- a/pkgs/by-name/li/libnet/package.nix
+++ b/pkgs/by-name/li/libnet/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.3";
 
   src = fetchFromGitHub {
-    owner = "sam-github";
+    owner = "libnet";
     repo = "libnet";
     rev = "v${finalAttrs.version}";
     hash = "sha256-P3LaDMMNPyEnA8nO1Bm7H0mW/hVBr0cFdg+p2JmWcGI=";
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://github.com/sam-github/libnet";
+    homepage = "https://github.com/libnet/libnet";
     description = "Portable framework for low-level network packet construction";
     mainProgram = "libnet-config";
     license = lib.licenses.bsd3;

--- a/pkgs/by-name/li/libpsm2/package.nix
+++ b/pkgs/by-name/li/libpsm2/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   src = fetchFromGitHub {
-    owner = "intel";
+    owner = "cornelisnetworks";
     repo = "opa-psm2";
     rev = "PSM2_${finalAttrs.version}";
     sha256 = "sha256-MzocxY+X2a5rJvTo+gFU0U10YzzazR1IxzgEporJyhI=";
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://github.com/intel/opa-psm2";
+    homepage = "https://github.com/cornelisnetworks/opa-psm2";
     description = "PSM2 library supports a number of fabric media and stacks";
     license = with lib.licenses; [
       gpl2Only

--- a/pkgs/by-name/li/librealsense/package.nix
+++ b/pkgs/by-name/li/librealsense/package.nix
@@ -46,7 +46,7 @@ stdenv'.mkDerivation rec {
   ];
 
   src = fetchFromGitHub {
-    owner = "IntelRealSense";
+    owner = "realsenseai";
     repo = "librealsense";
     rev = "v${version}";
     sha256 = "sha256-d/FkvnUa7CqW25ZG8PY9+cd7uRL4zC1Md/JT8B/qAKU=";
@@ -184,7 +184,7 @@ stdenv'.mkDerivation rec {
 
   meta = {
     description = "Cross-platform library for Intel® RealSense™ depth cameras (D400 series and the SR300)";
-    homepage = "https://github.com/IntelRealSense/librealsense";
+    homepage = "https://github.com/realsenseai/librealsense";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       brian-dawn

--- a/pkgs/by-name/li/libremidi/package.nix
+++ b/pkgs/by-name/li/libremidi/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "4.5.0";
 
   src = fetchFromGitHub {
-    owner = "jcelerier";
+    owner = "celtera";
     repo = "libremidi";
     rev = "v${finalAttrs.version}";
     hash = "sha256-JwXOIBq+pmPIR4y/Zv5whEyCfpLHmbllzdH2WLZmWLw=";
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://github.com/jcelerier/libremidi";
+    homepage = "https://github.com/celtera/libremidi";
     description = "Modern C++ MIDI real-time & file I/O library";
     license = lib.licenses.bsd2;
     maintainers = [ ];

--- a/pkgs/by-name/li/libspatialaudio/package.nix
+++ b/pkgs/by-name/li/libspatialaudio/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   version = "0.3.0";
 
   src = fetchFromGitHub {
-    owner = "videolabs";
+    owner = "videolan";
     repo = "libspatialaudio";
     rev = version;
     hash = "sha256-sPnQPD41AceXM4uGqWXMYhuQv0TUkA6TZP8ChxUFIoI=";
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   # Fix the build with CMake 4.
   #
-  # See: <https://github.com/videolabs/libspatialaudio/commit/cec3eeac0984cfd8c1d09fef0dd511c6ccf2a175>
+  # See: <https://github.com/videolan/libspatialaudio/commit/cec3eeac0984cfd8c1d09fef0dd511c6ccf2a175>
   postPatch = ''
     substituteInPlace CMakeLists.txt \
       --replace-fail \
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Ambisonic encoding / decoding and binauralization library in C++";
-    homepage = "https://github.com/videolabs/libspatialaudio";
+    homepage = "https://github.com/videolan/libspatialaudio";
     license = lib.licenses.lgpl21Plus;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ krav ];

--- a/pkgs/by-name/li/libsurvive/package.nix
+++ b/pkgs/by-name/li/libsurvive/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.01";
 
   src = fetchFromGitHub {
-    owner = "cntools";
+    owner = "collabora";
     repo = "libsurvive";
     tag = "v${finalAttrs.version}";
     # Fixes 'Unknown CMake command "cnkalman_generate_code"'
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     eigen
   ];
 
-  # https://github.com/cntools/libsurvive/issues/272
+  # https://github.com/collabora/libsurvive/issues/272
   postPatch = ''
     substituteInPlace survive.pc.in \
       libs/cnkalman/cnkalman.pc.in libs/cnkalman/libs/cnmatrix/cnmatrix.pc.in \
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Open Source Lighthouse Tracking System";
-    homepage = "https://github.com/cntools/libsurvive";
+    homepage = "https://github.com/collabora/libsurvive";
     license = lib.licenses.mit;
     maintainers = [ ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/li/lightdm-tiny-greeter/package.nix
+++ b/pkgs/by-name/li/lightdm-tiny-greeter/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   version = "1.2";
 
   src = fetchFromGitHub {
-    owner = "off-world";
+    owner = "tobiohlala";
     repo = "lightdm-tiny-greeter";
     rev = version;
     sha256 = "08azpj7b5qgac9bgi1xvd6qy6x2nb7iapa0v40ggr3d1fabyhrg6";
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Tiny multi user lightdm greeter";
     mainProgram = "lightdm-tiny-greeter";
-    homepage = "https://github.com/off-world/lightdm-tiny-greeter";
+    homepage = "https://github.com/tobiohlala/lightdm-tiny-greeter";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/li/lightdm/package.nix
+++ b/pkgs/by-name/li/lightdm/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   src = fetchFromGitHub {
-    owner = "canonical";
+    owner = "ubuntu";
     repo = "lightdm";
     tag = finalAttrs.version;
     sha256 = "sha256-ttNlhWD0Ran4d3QvZ+PxbFbSUGMkfrRm+hJdQxIDJvM=";
@@ -129,7 +129,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    homepage = "https://github.com/canonical/lightdm";
+    homepage = "https://github.com/ubuntu/lightdm";
     description = "Cross-desktop display manager";
     platforms = lib.platforms.linux;
     license = with lib.licenses; [

--- a/pkgs/by-name/li/lightgbm/package.nix
+++ b/pkgs/by-name/li/lightgbm/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "4.6.0";
 
   src = fetchFromGitHub {
-    owner = "microsoft";
+    owner = "lightgbm-org";
     repo = "lightgbm";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;

--- a/pkgs/by-name/li/lint-staged/package.nix
+++ b/pkgs/by-name/li/lint-staged/package.nix
@@ -11,7 +11,7 @@ buildNpmPackage rec {
   version = "17.0.5";
 
   src = fetchFromGitHub {
-    owner = "okonet";
+    owner = "lint-staged";
     repo = "lint-staged";
     rev = "v${version}";
     hash = "sha256-W9OW4ylRhgeUq7AlJlSkfN0IKv8Us6IEhmfE08UXzH8=";

--- a/pkgs/by-name/li/linux-exploit-suggester/package.nix
+++ b/pkgs/by-name/li/linux-exploit-suggester/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation {
   version = "unstable-2022-04-01";
 
   src = fetchFromGitHub {
-    owner = "mzet-";
+    owner = "The-Z-Labs";
     repo = "linux-exploit-suggester";
     rev = "54a5c01497d6655be88f6262ccad5bc5a5e4f4ec";
     sha256 = "v0Q8O+aaXEqwWAwGP/u5Nkm4DzM6nM11GI4XbK2PeWM=";
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation {
   meta = {
     description = "Tool designed to assist in detecting security deficiencies for given Linux kernel/Linux-based machine";
     mainProgram = "linux-exploit-suggester";
-    homepage = "https://github.com/mzet-/linux-exploit-suggester";
+    homepage = "https://github.com/The-Z-Labs/linux-exploit-suggester";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ emilytrau ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/li/lix-diff/package.nix
+++ b/pkgs/by-name/li/lix-diff/package.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "1.5.1";
 
   src = fetchFromGitHub {
-    owner = "tgirlcloud";
+    owner = "isabelroses";
     repo = "lix-diff";
     tag = "v${finalAttrs.version}";
     hash = "sha256-mURA7fZ9RAhVtOx+gnEeJI48tyvi+zbKE+xUs5UMPY4=";

--- a/pkgs/by-name/lo/local-ai/package.nix
+++ b/pkgs/by-name/lo/local-ai/package.nix
@@ -337,7 +337,7 @@ let
   pname = "local-ai";
   version = "2.28.0";
   src = fetchFromGitHub {
-    owner = "go-skynet";
+    owner = "mudler";
     repo = "LocalAI";
     tag = "v${version}";
     hash = "sha256-Hpz0dGkgasSY/FGO7mDzqsLjXut0LdQ9PUXGaURUOlY=";

--- a/pkgs/by-name/lo/lora/package.nix
+++ b/pkgs/by-name/lo/lora/package.nix
@@ -17,7 +17,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "cyrealtype";
-    repo = "lora";
+    repo = "Lora-Cyrillic";
     tag = "v${finalAttrs.version}";
     hash = "sha256-v9wE9caI9HTCfO01Yf+s6KajF7WpnL12nu+IuOV7T+w=";
   };
@@ -38,7 +38,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Lora Font: well-balanced contemporary serif with roots in calligraphy";
-    homepage = "https://github.com/cyrealtype/lora";
+    homepage = "https://github.com/cyrealtype/Lora-Cyrillic";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ ofalvai ];

--- a/pkgs/by-name/lr/lr/package.nix
+++ b/pkgs/by-name/lr/lr/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.0.1";
 
   src = fetchFromGitHub {
-    owner = "chneukirchen";
+    owner = "leahneukirchen";
     repo = "lr";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-zpHThIB1FS45RriE214SM9ZQJ1HyuBkBi/+PTeJjEFc=";
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   makeFlags = [ "PREFIX=$(out)" ];
 
   meta = {
-    homepage = "https://github.com/chneukirchen/lr";
+    homepage = "https://github.com/leahneukirchen/lr";
     description = "List files recursively";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/ls/lsh/package.nix
+++ b/pkgs/by-name/ls/lsh/package.nix
@@ -8,16 +8,16 @@ buildGoModule (finalAttrs: {
   version = "1.5.8";
   src = fetchFromGitHub {
     owner = "latitudesh";
-    repo = "lsh";
+    repo = "cli";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-BFhVCrl2LS5s38WBtkTjZ+IYCO9VQgIVmel3xwzaBI8=";
   };
   vendorHash = "sha256-vAZYd4fbXsZRqDvSQ1Y+lk3RVY06PqxdJF9DofTa6sQ=";
   subPackages = [ "." ];
   meta = {
-    changelog = "https://github.com/latitudesh/lsh/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/latitudesh/cli/releases/tag/v${finalAttrs.version}";
     description = "Command-Line Interface for Latitude.sh";
-    homepage = "https://github.com/latitudesh/lsh";
+    homepage = "https://github.com/latitudesh/cli";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.dzmitry-lahoda ];
   };

--- a/pkgs/by-name/lu/lune/package.nix
+++ b/pkgs/by-name/lu/lune/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage rec {
   version = "0.10.4";
 
   src = fetchFromGitHub {
-    owner = "filiptibell";
+    owner = "lune-org";
     repo = "lune";
     tag = "v${version}";
     hash = "sha256-AbviyCy2nn6WHC575JKl/t3bM/4Myb+Wx5/buTvB4MY=";

--- a/pkgs/by-name/lv/lv2bm/package.nix
+++ b/pkgs/by-name/lv/lv2bm/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.1";
 
   src = fetchFromGitHub {
-    owner = "moddevices";
+    owner = "mod-audio";
     repo = "lv2bm";
     rev = "v${finalAttrs.version}";
     sha256 = "0vlppxfb9zbmffazs1kiyb79py66s8x9hihj36m2vz86zsq7ybl0";

--- a/pkgs/by-name/m3/m33-linux/package.nix
+++ b/pkgs/by-name/m3/m33-linux/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
 
   src = fetchFromGitHub {
     owner = "donovan6000";
-    repo = "M3D-Linux";
+    repo = "M33-Linux";
     rev = "5c1b90c13d260771dac970b49fdc9f840fee5f4a";
     sha256 = "1bvbclkyfcv23vxb4s1zssvygklks1nhp4iwi4v90c1fvyz0356f";
   };
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    homepage = "https://github.com/donovan6000/M3D-Linux";
+    homepage = "https://github.com/donovan6000/M33-Linux";
     description = "Linux program that can communicate with the Micro 3D printer";
     mainProgram = "m33-linux";
     license = lib.licenses.gpl2Only;

--- a/pkgs/by-name/ma/mantra/package.nix
+++ b/pkgs/by-name/ma/mantra/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "3.1";
 
   src = fetchFromGitHub {
-    owner = "MrEmpy";
+    owner = "brosck";
     repo = "Mantra";
     tag = "v${finalAttrs.version}";
     hash = "sha256-DnErXuMbCRK3WxhdyPj0dOUtGnCcmynPk/hYmOsOKVU=";
@@ -24,8 +24,8 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Tool used to hunt down API key leaks in JS files and pages";
-    homepage = "https://github.com/MrEmpy/Mantra";
-    changelog = "https://github.com/MrEmpy/Mantra/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/brosck/mantra";
+    changelog = "https://github.com/brosck/mantra/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "mantra";

--- a/pkgs/by-name/ma/mariadb-galera/package.nix
+++ b/pkgs/by-name/ma/mariadb-galera/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "26.4.24";
 
   src = fetchFromGitHub {
-    owner = "codership";
+    owner = "mariadb-corporation";
     repo = "galera";
     tag = "release_${finalAttrs.version}";
     hash = "sha256-mpf+YY0m+UwvemdZt6SfRP9IJlq5IZtlOJMucADc1oM=";

--- a/pkgs/by-name/ma/mastodon-archive/package.nix
+++ b/pkgs/by-name/ma/mastodon-archive/package.nix
@@ -11,7 +11,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "kensanata";
-    repo = "mastodon-backup";
+    repo = "mastodon-archive";
     rev = "v${finalAttrs.version}";
     hash = "sha256-yz17ddcA0U9fq1aDlPmD3OkNL6Epzdp9C7L+31yNLBc=";
   };

--- a/pkgs/by-name/ma/maxfetch/package.nix
+++ b/pkgs/by-name/ma/maxfetch/package.nix
@@ -13,7 +13,7 @@ stdenvNoCC.mkDerivation {
   version = "unstable-2023-07-31";
 
   src = fetchFromGitHub {
-    owner = "jobcmax";
+    owner = "natewhar";
     repo = "maxfetch";
     rev = "17baa4047073e20572403b70703c69696af6b68d";
     hash = "sha256-LzOhrFFjGs9GIDjk1lUFKhlnzJuEUrKjBcv1eT3kaY8=";
@@ -37,7 +37,7 @@ stdenvNoCC.mkDerivation {
 
   meta = {
     description = "Nice fetching program written in sh";
-    homepage = "https://github.com/jobcmax/maxfetch";
+    homepage = "https://github.com/natewhar/maxfetch";
     license = lib.licenses.gpl2Plus;
     mainProgram = "maxfetch";
     maintainers = with lib.maintainers; [ jtbx ];

--- a/pkgs/by-name/mb/mbpfan/package.nix
+++ b/pkgs/by-name/mb/mbpfan/package.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "mbpfan";
   version = "2.4.0";
   src = fetchFromGitHub {
-    owner = "dgraziotin";
+    owner = "linux-on-mac";
     repo = "mbpfan";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-F9IWUcILOuLn5K4zRSU5jn+1Wk1xy0CONSI6JTXU2pA=";
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Daemon that uses input from coretemp module and sets the fan speed using the applesmc module";
     mainProgram = "mbpfan";
-    homepage = "https://github.com/dgraziotin/mbpfan";
+    homepage = "https://github.com/linux-on-mac/mbpfan";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;
     maintainers = [ ];

--- a/pkgs/by-name/mc/mcporter/package.nix
+++ b/pkgs/by-name/mc/mcporter/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.11.1";
 
   src = fetchFromGitHub {
-    owner = "steipete";
+    owner = "openclaw";
     repo = "mcporter";
     tag = "v${finalAttrs.version}";
     hash = "sha256-fhIU5z0H6piHNNHSQ3UQW6IqCdpCTjTxngT7AwQm5S0=";
@@ -58,8 +58,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "TypeScript runtime and CLI for connecting to configured Model Context Protocol servers";
-    homepage = "https://github.com/steipete/mcporter";
-    changelog = "https://github.com/steipete/mcporter/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/openclaw/mcporter";
+    changelog = "https://github.com/openclaw/mcporter/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ mkg20001 ];
     mainProgram = "mcporter";

--- a/pkgs/by-name/me/memtier-benchmark/package.nix
+++ b/pkgs/by-name/me/memtier-benchmark/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.2.2";
 
   src = fetchFromGitHub {
-    owner = "redislabs";
+    owner = "redis";
     repo = "memtier_benchmark";
     tag = finalAttrs.version;
     hash = "sha256-/t7OY3N9VBa9o2amOFb2/MUr5Y4ep4HGUil8OtwKkng=";
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Redis and Memcached traffic generation and benchmarking tool";
-    homepage = "https://github.com/redislabs/memtier_benchmark";
+    homepage = "https://github.com/redis/memtier_benchmark";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ thoughtpolice ];

--- a/pkgs/by-name/mi/minesector/package.nix
+++ b/pkgs/by-name/mi/minesector/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.1.5";
 
   src = fetchFromGitHub {
-    owner = "grassdne";
+    owner = "ruuzia";
     repo = "minesector";
     tag = finalAttrs.version;
     hash = "sha256-VMTXZ4CIk9RpE4R9shHPl0R/T7mJUKY2b8Zi0DPW0/Q=";
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     mainProgram = "minesector";
     description = "Snazzy Minesweeper-based game built with SDL2";
-    homepage = "https://github.com/grassdne/minesector";
+    homepage = "https://github.com/ruuzia/minesector";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     maintainers = [ ];

--- a/pkgs/by-name/mi/mirrorbits/package.nix
+++ b/pkgs/by-name/mi/mirrorbits/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
   version = "0.6.1";
 
   src = fetchFromGitHub {
-    owner = "etix";
+    owner = "videolabs";
     repo = "mirrorbits";
     tag = "v${finalAttrs.version}";
     hash = "sha256-PqPE/PgIyQylbYoABC/saxLF83XjgRAS0QimragJ8P8=";
@@ -46,7 +46,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Geographical download redirector for distributing files efficiently across a set of mirrors";
-    homepage = "https://github.com/etix/mirrorbits";
+    homepage = "https://github.com/videolabs/mirrorbits";
     longDescription = ''
       Mirrorbits is a geographical download redirector written in Go for
       distributing files efficiently across a set of mirrors. It offers

--- a/pkgs/by-name/mo/mod-arpeggiator-lv2/package.nix
+++ b/pkgs/by-name/mo/mod-arpeggiator-lv2/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   version = "0-unstable-2021-11-09";
 
   src = fetchFromGitHub {
-    owner = "moddevices";
+    owner = "mod-audio";
     repo = "mod-arpeggiator-lv2";
     rev = "82f3d9f159ce216454656a8782362c3d5ed48bed";
     sha256 = "sha256-1KiWMTVTTf1/iR4AzJ1Oe0mOrWN5edsZN0tQMidgnRA=";
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "LV2 arpeggiator";
-    homepage = "https://github.com/moddevices/mod-arpeggiator-lv2";
+    homepage = "https://github.com/mod-audio/mod-arpeggiator-lv2";
     license = lib.licenses.gpl2Plus;
     maintainers = [ lib.maintainers.magnetophon ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/mo/mod-distortion/package.nix
+++ b/pkgs/by-name/mo/mod-distortion/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   version = "0-unstable-2016-08-19";
 
   src = fetchFromGitHub {
-    owner = "portalmod";
+    owner = "mod-audio";
     repo = "mod-distortion";
     rev = "e672d5feb9d631798e3d56eb96e8958c3d2c6821";
     sha256 = "005wdkbhn9dgjqv019cwnziqg86yryc5vh7j5qayrzh9v446dw34";
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
   installFlags = [ "INSTALL_PATH=$(out)/lib/lv2" ];
 
   meta = {
-    homepage = "https://github.com/portalmod/mod-distortion";
+    homepage = "https://github.com/mod-audio/mod-distortion";
     description = "Analog distortion emulation lv2 plugins";
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.magnetophon ];

--- a/pkgs/by-name/mo/mono_repo/package.nix
+++ b/pkgs/by-name/mo/mono_repo/package.nix
@@ -15,7 +15,7 @@ buildDartApplication (finalAttrs: {
   # Fetch the whole monorepo
   src = fetchFromGitHub {
     owner = "google";
-    repo = "mono_repo";
+    repo = "mono_repo.dart";
     tag = "mono_repo-v${finalAttrs.version}";
     hash = "sha256-2/YJ2S3I9K5Xzje787HdJ/KxfbiBEGKU8feuHnOizn8=";
   };

--- a/pkgs/by-name/na/nanomq/package.nix
+++ b/pkgs/by-name/na/nanomq/package.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.24.11";
 
   src = fetchFromGitHub {
-    owner = "emqx";
+    owner = "nanomq";
     repo = "nanomq";
     tag = finalAttrs.version;
     hash = "sha256-I2SLc/KbkBvqbbWuLr8ARmmg4DeE7ZbTqcM1tw8WhwQ=";

--- a/pkgs/by-name/nb/nbping/package.nix
+++ b/pkgs/by-name/nb/nbping/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage {
 
   src = fetchFromGitHub {
     owner = "hanshuaikang";
-    repo = "Nping";
+    repo = "NBping";
     tag = "v${version}";
     hash = "sha256-rGWYvYJs6vkG+HQuT4NJGMUUG9QzIhyJThgDWTC6/JI=";
   };
@@ -21,8 +21,8 @@ rustPlatform.buildRustPackage {
 
   meta = {
     description = "Ping Tool in Rust with Real-Time Data and Visualizations";
-    homepage = "https://github.com/hanshuaikang/Nping";
-    changelog = "https://github.com/hanshuaikang/Nping/releases/";
+    homepage = "https://github.com/hanshuaikang/NBping";
+    changelog = "https://github.com/hanshuaikang/NBping/releases/";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ luftmensch-luftmensch ];
     mainProgram = "nbping";

--- a/pkgs/by-name/nb/nbxplorer/package.nix
+++ b/pkgs/by-name/nb/nbxplorer/package.nix
@@ -10,7 +10,7 @@ buildDotnetModule rec {
   version = "2.6.0";
 
   src = fetchFromGitHub {
-    owner = "dgarage";
+    owner = "btcpayserver";
     repo = "NBXplorer";
     tag = "v${version}";
     hash = "sha256-X1+UdsKVOC3QpES22p0MG1Rz1oresilBM+b/4I1nCyI=";

--- a/pkgs/by-name/ne/neocmakelsp/package.nix
+++ b/pkgs/by-name/ne/neocmakelsp/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.10.1";
 
   src = fetchFromGitHub {
-    owner = "Decodetalkers";
+    owner = "neocmakelsp";
     repo = "neocmakelsp";
     rev = "v${finalAttrs.version}";
     hash = "sha256-Zhu3ka4suqvLLZMXC3/sRPW7EBg1YII5T+kVMf/zuH0=";
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "CMake lsp based on tower-lsp and treesitter";
-    homepage = "https://github.com/Decodetalkers/neocmakelsp";
+    homepage = "https://github.com/neocmakelsp/neocmakelsp";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/ne/networkmanager-l2tp/package.nix
+++ b/pkgs/by-name/ne/networkmanager-l2tp/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "nm-l2tp";
-    repo = "network-manager-l2tp";
+    repo = "NetworkManager-l2tp";
     rev = version;
     hash = "sha256-5EIG/5fexhrcOOQE+31+TJKMtINGVL+EI32m9tEhYVo=";
   };
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "L2TP plugin for NetworkManager";
     inherit (networkmanager.meta) platforms;
-    homepage = "https://github.com/nm-l2tp/network-manager-l2tp";
+    homepage = "https://github.com/nm-l2tp/NetworkManager-l2tp";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
       obadz

--- a/pkgs/by-name/ne/new-session-manager/package.nix
+++ b/pkgs/by-name/ne/new-session-manager/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.6.1";
 
   src = fetchFromGitHub {
-    owner = "linuxaudio";
+    owner = "jackaudio";
     repo = "new-session-manager";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-5G2GlBuKjC/r1SMm78JKia7bMA97YcvUR5l6zBucemw=";

--- a/pkgs/by-name/ne/nexa/package.nix
+++ b/pkgs/by-name/ne/nexa/package.nix
@@ -56,7 +56,7 @@ buildGo125Module (finalAttrs: {
   version = "0.2.73";
 
   src = fetchFromGitHub {
-    owner = "NexaAI";
+    owner = "qualcomm";
     repo = "nexa-sdk";
     tag = "v${finalAttrs.version}";
     hash = "sha256-JioUguVO2z37BYxkXBlDEswJIh80bpOONG6EVNlq5OA=";
@@ -199,8 +199,8 @@ buildGo125Module (finalAttrs: {
 
   meta = {
     description = "Nexa AI SDK CLI for model management, inference, and server operations";
-    homepage = "https://github.com/NexaAI/nexa-sdk";
-    changelog = "https://github.com/NexaAI/nexa-sdk/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/qualcomm/nexa-sdk";
+    changelog = "https://github.com/qualcomm/nexa-sdk/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ mkg20001 ];
     mainProgram = "nexa";

--- a/pkgs/by-name/ne/nextinspace/package.nix
+++ b/pkgs/by-name/ne/nextinspace/package.nix
@@ -10,7 +10,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "not-stirred";
+    owner = "gideonshaked";
     repo = "nextinspace";
     tag = "v${finalAttrs.version}";
     hash = "sha256-oEvRxaxx1pIco2+jm/3HUN0a0nqdo2VosCisM0MWTjU=";

--- a/pkgs/by-name/ne/nezha-theme-user/package.nix
+++ b/pkgs/by-name/ne/nezha-theme-user/package.nix
@@ -11,7 +11,7 @@ buildNpmPackage (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "hamster1963";
-    repo = "nezha-dash-v1";
+    repo = "nezha-dash-v2";
     tag = "v${finalAttrs.version}";
     hash = "sha256-3zaA3T4zW18caOQe5DBF8Zsms3cjks3Ywyfkyk6N2N0=";
   };
@@ -46,8 +46,8 @@ buildNpmPackage (finalAttrs: {
 
   meta = {
     description = "Nezha monitoring user frontend based on next.js";
-    changelog = "https://github.com/hamster1963/nezha-dash-v1/releases/tag/v${finalAttrs.version}";
-    homepage = "https://github.com/hamster1963/nezha-dash-v1";
+    changelog = "https://github.com/hamster1963/nezha-dash-v2/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/hamster1963/nezha-dash-v2";
     license = lib.licenses.apsl20;
     maintainers = with lib.maintainers; [ moraxyc ];
   };

--- a/pkgs/by-name/ne/nezha/package.nix
+++ b/pkgs/by-name/ne/nezha/package.nix
@@ -111,9 +111,9 @@ buildGoModule (finalAttrs: {
   versionCheckProgramArg = "-v";
   doInstallCheck = true;
 
-  passthru = {
-    updateScript = nix-update-script { };
-  };
+  __darwinAllowLocalNetworking = true;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Self-hosted, lightweight server and website monitoring and O&M tool";

--- a/pkgs/by-name/ng/ngt/package.nix
+++ b/pkgs/by-name/ng/ngt/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.6.0";
 
   src = fetchFromGitHub {
-    owner = "yahoojapan";
+    owner = "NGT-labs";
     repo = "NGT";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-dAJ8Xz7Cgmajac43G/3JWj1gwlG2z1RaN7R49IsbMnc=";
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    homepage = "https://github.com/yahoojapan/NGT";
+    homepage = "https://github.com/NGT-labs/NGT";
     description = "Nearest Neighbor Search with Neighborhood Graph and Tree for High-dimensional Data";
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     license = lib.licenses.asl20;

--- a/pkgs/by-name/nh/nhentai/package.nix
+++ b/pkgs/by-name/nh/nhentai/package.nix
@@ -31,7 +31,7 @@ python.pkgs.buildPythonApplication rec {
 
   src = fetchFromGitHub {
     owner = "RicterZ";
-    repo = "nhentai";
+    repo = "doujinshi-dl";
     rev = version;
     hash = "sha256-KwcaCeeGeR6qSfraSYyf4VEims9YWB6j3HmpT8XSePo=";
   };
@@ -62,7 +62,7 @@ python.pkgs.buildPythonApplication rec {
   ];
 
   meta = {
-    homepage = "https://github.com/RicterZ/nhentai";
+    homepage = "https://github.com/RicterZ/doujinshi-dl";
     description = "CLI tool for downloading doujinshi from adult site(s)";
     license = lib.licenses.mit;
     maintainers = [ ];

--- a/pkgs/by-name/ni/nix-bundle/package.nix
+++ b/pkgs/by-name/ni/nix-bundle/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.4.1";
 
   src = fetchFromGitHub {
-    owner = "matthewbauer";
+    owner = "nix-community";
     repo = "nix-bundle";
     rev = "v${finalAttrs.version}";
     sha256 = "0js8spwjvw6kjxz1i072scd035fhiyazixvn84ibdnw8dx087gjv";
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://github.com/matthewbauer/nix-bundle";
+    homepage = "https://github.com/nix-community/nix-bundle";
     description = "Create bundles from Nixpkgs attributes";
     longDescription = ''
       nix-bundle is a way to package Nix attributes into single-file

--- a/pkgs/by-name/ni/nixos-facter/package.nix
+++ b/pkgs/by-name/ni/nixos-facter/package.nix
@@ -16,7 +16,7 @@ let
   # We are waiting on some changes to be merged upstream: https://github.com/openSUSE/hwinfo/pulls
   hwinfoOverride = hwinfo.overrideAttrs {
     src = fetchFromGitHub {
-      owner = "numtide";
+      owner = "nix-community";
       repo = "hwinfo";
       rev = "bfeab0b4e38b200c7a62a44d4d01601a86fe1091";
       hash = "sha256-GL3fNCSaU45fNihEksgtPtbuLkc+tVGXtPH05wbrHwI=";
@@ -28,7 +28,7 @@ buildGoModule (finalAttrs: {
   version = "0.4.4";
 
   src = fetchFromGitHub {
-    owner = "numtide";
+    owner = "nix-community";
     repo = "nixos-facter";
     tag = "v${finalAttrs.version}";
     hash = "sha256-w4tFIouJQLf/JeY7wvvSLbxQv73Bbs11a8EAu6iXwKU=";
@@ -60,7 +60,7 @@ buildGoModule (finalAttrs: {
     "-w"
     "-X git.numtide.com/numtide/nixos-facter/build.Name=nixos-facter"
     "-X git.numtide.com/numtide/nixos-facter/build.Version=v${finalAttrs.version}"
-    "-X github.com/numtide/nixos-facter/pkg/build.System=${stdenv.hostPlatform.system}"
+    "-X github.com/nix-community/nixos-facter/pkg/build.System=${stdenv.hostPlatform.system}"
   ];
 
   passthru.tests = {
@@ -71,7 +71,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Declarative hardware configuration for NixOS";
-    homepage = "https://github.com/numtide/nixos-facter";
+    homepage = "https://github.com/nix-community/nixos-facter";
     license = lib.licenses.gpl3Plus;
     maintainers = [ lib.maintainers.brianmcgee ];
     mainProgram = "nixos-facter";

--- a/pkgs/by-name/no/nordzy-icon-theme/package.nix
+++ b/pkgs/by-name/no/nordzy-icon-theme/package.nix
@@ -12,7 +12,7 @@ stdenvNoCC.mkDerivation rec {
   version = "1.8.7";
 
   src = fetchFromGitHub {
-    owner = "alvatip";
+    owner = "MolassesLover";
     repo = "Nordzy-icon";
     rev = version;
     sha256 = "sha256-r/WYGcHRAFX7TennestobjcJhwu3GE8aQXxnaeokQM0=";
@@ -49,7 +49,7 @@ stdenvNoCC.mkDerivation rec {
 
   meta = {
     description = "Icon theme using the Nord color palette, based on WhiteSur and Numix icon themes";
-    homepage = "https://github.com/alvatip/Nordzy-icon";
+    homepage = "https://github.com/MolassesLover/Nordzy-icon";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ alexnortung ];

--- a/pkgs/by-name/no/nototools/package.nix
+++ b/pkgs/by-name/no/nototools/package.nix
@@ -11,7 +11,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "googlefonts";
+    owner = "notofonts";
     repo = "nototools";
     tag = "v${finalAttrs.version}";
     sha256 = "sha256-0se0YcnhDwwMbt2C4hep0T/JEidHfFRUnm2Sy7qr2uk=";
@@ -75,7 +75,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   meta = {
     description = "Noto fonts support tools and scripts plus web site generation";
-    homepage = "https://github.com/googlefonts/nototools";
+    homepage = "https://github.com/notofonts/nototools";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };

--- a/pkgs/by-name/oa/oapi-codegen/package.nix
+++ b/pkgs/by-name/oa/oapi-codegen/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "2.5.1";
 
   src = fetchFromGitHub {
-    owner = "deepmap";
+    owner = "oapi-codegen";
     repo = "oapi-codegen";
     tag = "v${finalAttrs.version}";
     hash = "sha256-1xTWykLH2g4ShznwO3lHvKyb5FC05grWl/WbI/y9648=";

--- a/pkgs/by-name/oa/oauth2c/package.nix
+++ b/pkgs/by-name/oa/oauth2c/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "1.20.0";
 
   src = fetchFromGitHub {
-    owner = "cloudentity";
+    owner = "SecureAuthCorp";
     repo = "oauth2c";
     rev = "v${finalAttrs.version}";
     hash = "sha256-l/fXorXE4+6n7qQM2c2pJssNq3DKaxOjapdfNlXuAWg=";
@@ -20,7 +20,7 @@ buildGoModule (finalAttrs: {
   doCheck = false; # tests want to talk to oauth2c.us.authz.cloudentity.io
 
   meta = {
-    homepage = "https://github.com/cloudentity/oauth2c";
+    homepage = "https://github.com/SecureAuthCorp/oauth2c";
     description = "User-friendly OAuth2 CLI";
     mainProgram = "oauth2c";
     longDescription = ''

--- a/pkgs/by-name/oc/ocsigen-i18n/package.nix
+++ b/pkgs/by-name/oc/ocsigen-i18n/package.nix
@@ -11,14 +11,14 @@ ocamlPackages.buildDunePackage rec {
   buildInputs = with ocamlPackages; [ ppxlib ];
 
   src = fetchFromGitHub {
-    owner = "besport";
+    owner = "ocsigen";
     repo = "ocsigen-i18n";
     rev = version;
     hash = "sha256-NIl1YUTws8Ff4nrqdhU7oS/TN0lxVQgrtyEZtpS1ojM=";
   };
 
   meta = {
-    homepage = "https://github.com/besport/ocsigen-i18n";
+    homepage = "https://github.com/ocsigen/ocsigen-i18n";
     description = "I18n made easy for web sites written with eliom";
     license = lib.licenses.lgpl21;
     maintainers = [ lib.maintainers.gal_bolle ];

--- a/pkgs/by-name/ok/okolors/package.nix
+++ b/pkgs/by-name/ok/okolors/package.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.9.0";
 
   src = fetchFromGitHub {
-    owner = "Ivordir";
+    owner = "IanManske";
     repo = "Okolors";
     rev = "v${finalAttrs.version}";
     hash = "sha256-RSkZUkwCn9uvvT2dIqM2Q4+mRqjUegVuXCms5DBugbk=";
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Generate a color palette from an image using k-means clustering in the Oklab color space";
-    homepage = "https://github.com/Ivordir/Okolors";
+    homepage = "https://github.com/IanManske/Okolors";
     license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "okolors";

--- a/pkgs/by-name/on/onetbb/package.nix
+++ b/pkgs/by-name/on/onetbb/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   src = fetchFromGitHub {
-    owner = "oneapi-src";
+    owner = "uxlfoundation";
     repo = "oneTBB";
     tag = "v${finalAttrs.version}";
     hash = "sha256-HIHF6KHlEI4rgQ9Epe0+DmNe1y95K9iYa4V/wFnJfEU=";

--- a/pkgs/by-name/op/opencorsairlink/package.nix
+++ b/pkgs/by-name/op/opencorsairlink/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
   src = fetchFromGitHub {
-    owner = "audiohacked";
+    owner = "hyperkineticnerd";
     repo = "OpenCorsairLink";
     rev = "46dbf206e19a40d6de6bd73142ed93bdb26c5c1a";
     sha256 = "1nizicl0mc9pslc6065mnrs0fnn8sh7ca8iiw7w9ix57zrhabpld";
@@ -31,14 +31,14 @@ stdenv.mkDerivation {
     # Pull upstream fix for -fno-common toolchain
     (fetchpatch {
       name = "fno-common.patch";
-      url = "https://github.com/audiohacked/OpenCorsairLink/commit/d600c7ff032a3911d30b039844a31f0b3acfe26a.patch";
+      url = "https://github.com/hyperkineticnerd/OpenCorsairLink/commit/d600c7ff032a3911d30b039844a31f0b3acfe26a.patch";
       sha256 = "030rwka5bvf79x6ir18vqb09izhz1crp94x5gqjxwv3b20vvv4kx";
     })
   ];
 
   meta = {
     description = "Linux and Mac OS support for the CorsairLink Devices";
-    homepage = "https://github.com/audiohacked/OpenCorsairLink";
+    homepage = "https://github.com/hyperkineticnerd/OpenCorsairLink";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.all;
     maintainers = [ ];

--- a/pkgs/by-name/op/openlibm/package.nix
+++ b/pkgs/by-name/op/openlibm/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.8.7";
 
   src = fetchFromGitHub {
-    owner = "JuliaLang";
+    owner = "JuliaMath";
     repo = "openlibm";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-fSEszCJ1PXkSydTLk8KAyu7zffUrKf+7a1ZDf3Wl/lE=";

--- a/pkgs/by-name/op/openlierox/package.nix
+++ b/pkgs/by-name/op/openlierox/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.58_rc5";
 
   src = fetchFromGitHub {
-    owner = "albertz";
+    owner = "openlierox";
     repo = "openlierox";
     rev = finalAttrs.version;
     hash = "sha256-4ofjroEHlfrQitc7M+YTNWut0LGgntgQoOeBWU8nscY=";

--- a/pkgs/by-name/op/openspecfun/package.nix
+++ b/pkgs/by-name/op/openspecfun/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "openspecfun";
   version = "0.5.7";
   src = fetchFromGitHub {
-    owner = "JuliaLang";
+    owner = "JuliaMath";
     repo = "openspecfun";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-fx9z6bbU2V4x6Pr7/vmlSxkWxZ6qTYuPxnfqKLv08CA=";
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Collection of special mathematical functions";
-    homepage = "https://github.com/JuliaLang/openspecfun";
+    homepage = "https://github.com/JuliaMath/openspecfun";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.ttuegel ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/op/openttd-ttf/package.nix
+++ b/pkgs/by-name/op/openttd-ttf/package.nix
@@ -10,7 +10,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "0.8";
 
   src = fetchFromGitHub {
-    owner = "zephyris";
+    owner = "OpenTTD";
     repo = "openttd-ttf";
     tag = finalAttrs.version;
     hash = "sha256-ZV74ZQ4Z4jw2tjG3kXj4Vo1J+W3BF0SJIFIae9DWLAc=";
@@ -47,8 +47,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://github.com/zephyris/openttd-ttf";
-    changelog = "https://github.com/zephyris/openttd-ttf/releases/tag/${finalAttrs.version}";
+    homepage = "https://github.com/OpenTTD/OpenTTD-TTF";
+    changelog = "https://github.com/OpenTTD/OpenTTD-TTF/releases/tag/${finalAttrs.version}";
     description = "TrueType typefaces for text in a pixel art style, designed for use in OpenTTD";
     license = [ lib.licenses.gpl2 ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/op/optional-lite/package.nix
+++ b/pkgs/by-name/op/optional-lite/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.6.0";
 
   src = fetchFromGitHub {
-    owner = "martinmoene";
+    owner = "nonstd-lite";
     repo = "optional-lite";
     tag = "v${finalAttrs.version}";
     hash = "sha256-qmKuxYc0cpoOtRRb4okJZ8pYPvzQid1iqBctnhGlz6M=";
@@ -31,8 +31,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "C++17-like optional, a nullable object for C++98, C++11 and later in a single-file header-only library";
-    homepage = "https://github.com/martinmoene/optional-lite";
-    changelog = "https://github.com/martinmoene/optional-lite/blob/v${finalAttrs.version}/CHANGES.txt";
+    homepage = "https://github.com/nonstd-lite/optional-lite";
+    changelog = "https://github.com/nonstd-lite/optional-lite/blob/v${finalAttrs.version}/CHANGES.txt";
     license = lib.licenses.boost;
     maintainers = with lib.maintainers; [ titaniumtown ];
   };

--- a/pkgs/by-name/os/osqp-eigen/package.nix
+++ b/pkgs/by-name/os/osqp-eigen/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.11.0";
 
   src = fetchFromGitHub {
-    owner = "robotology";
+    owner = "gbionics";
     repo = "osqp-eigen";
     rev = "v${finalAttrs.version}";
     hash = "sha256-SrQxRyzbheotCTSF7eBFr6nxJxWdze1hFhP/F06cb7g=";
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Simple Eigen-C++ wrapper for OSQP library";
-    homepage = "https://github.com/robotology/osqp-eigen";
+    homepage = "https://github.com/gbionics/osqp-eigen";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ nim65s ];
   };

--- a/pkgs/by-name/os/osqp/package.nix
+++ b/pkgs/by-name/os/osqp/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.0.0";
 
   src = fetchFromGitHub {
-    owner = "oxfordcontrol";
+    owner = "osqp";
     repo = "osqp";
     tag = "v${finalAttrs.version}";
     hash = "sha256-BOAytzJzHcggncQzeDrXwJOq8B3doWERJ6CKIVg1yJY=";

--- a/pkgs/by-name/ov/oven-media-engine/package.nix
+++ b/pkgs/by-name/ov/oven-media-engine/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
   version = "0.17.1";
 
   src = fetchFromGitHub {
-    owner = "AirenSoft";
+    owner = "OvenMediaLabs";
     repo = "OvenMediaEngine";
     rev = "v${version}";
     sha256 = "sha256-fYvP1mk32lrnYxWdpI1WqEUxAfHsQH3Ng0JLC/GbjrY=";
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     # ffmpeg 7.0 Update: Use new channel layout
-    # https://github.com/AirenSoft/OvenMediaEngine/pull/1626
+    # https://github.com/OvenMediaLabs/OvenMediaEngine/pull/1626
     ./support-ffmpeg-7.patch
   ];
 

--- a/pkgs/by-name/ox/oxipng/package.nix
+++ b/pkgs/by-name/ox/oxipng/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # do not use fetchCrate (only repository includes tests)
   src = fetchFromGitHub {
-    owner = "shssoichiro";
+    owner = "oxipng";
     repo = "oxipng";
     tag = "v${finalAttrs.version}";
     hash = "sha256-G06GAlxEVOqt2xHq+JOLSYbsa++aArbu+sb0ypQn9u4=";
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://github.com/shssoichiro/oxipng";
+    homepage = "https://github.com/oxipng/oxipng";
     description = "Multithreaded lossless PNG compression optimizer";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ dywedir ];

--- a/pkgs/by-name/pa/padbuster/package.nix
+++ b/pkgs/by-name/pa/padbuster/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   version = "0.3.3";
 
   src = fetchFromGitHub {
-    owner = "AonCyberLabs";
+    owner = "strozfriedberg";
     repo = "padbuster";
     rev = "50e4a3e2bf5dfff5699440b3ebc61ed1b5c49bbe";
     sha256 = "VIvZ28MVnTSQru6l8flLVVqIIpxxXD8lCqzH81sPe/U=";

--- a/pkgs/by-name/pa/paho-mqtt-c/package.nix
+++ b/pkgs/by-name/pa/paho-mqtt-c/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.3.16";
 
   src = fetchFromGitHub {
-    owner = "eclipse";
+    owner = "eclipse-paho";
     repo = "paho.mqtt.c";
     tag = "v${finalAttrs.version}";
     hash = "sha256-ETSx3dvGP9Kjf7v8zglnUvMK6nOcgUnryJ5QUVvEgT4=";

--- a/pkgs/by-name/pa/paho-mqtt-cpp/package.nix
+++ b/pkgs/by-name/pa/paho-mqtt-cpp/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.6.0";
 
   src = fetchFromGitHub {
-    owner = "eclipse";
+    owner = "eclipse-paho";
     repo = "paho.mqtt.cpp";
     tag = "v${finalAttrs.version}";
     hash = "sha256-WpuI0BPGPCuV1riviUGy2CLshW0RSVIxcjgFmmH2SqA=";

--- a/pkgs/by-name/pa/patroni/package.nix
+++ b/pkgs/by-name/pa/patroni/package.nix
@@ -27,7 +27,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "zalando";
+    owner = "patroni";
     repo = "patroni";
     tag = "v${finalAttrs.version}";
     hash = "sha256-P64smYmLJyuqMpqYY2lRbZwupfYBsg03FrzUZ6CBGpI=";

--- a/pkgs/by-name/pd/pdf2svg/package.nix
+++ b/pkgs/by-name/pd/pdf2svg/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.2.4";
 
   src = fetchFromGitHub {
-    owner = "db9052";
+    owner = "dawbarton";
     repo = "pdf2svg";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-zME0U+PyENnoLyjo9W2i2MRM00wNmHkYcR2LMEtTbBY=";

--- a/pkgs/by-name/pe/pekwm/package.nix
+++ b/pkgs/by-name/pe/pekwm/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.3.2";
 
   src = fetchFromGitHub {
-    owner = "pekdon";
+    owner = "pekwm";
     repo = "pekwm";
     rev = "release-${finalAttrs.version}";
     hash = "sha256-rwvecE9T+/zZg0rRUDl/DEMGH9ZmuvYj/Rz6vzmMv1I=";

--- a/pkgs/by-name/pg/pgmodeler/package.nix
+++ b/pkgs/by-name/pg/pgmodeler/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.2.3";
 
   src = fetchFromGitHub {
-    owner = "pgmodeler";
+    owner = "nullptrlabs";
     repo = "pgmodeler";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-WA3EOJm9RrKk7DrzdrpiihW+LhJOvvE2uajGwPCsBIk=";

--- a/pkgs/by-name/ph/phpantom-lsp/package.nix
+++ b/pkgs/by-name/ph/phpantom-lsp/package.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
-    owner = "AJenbo";
+    owner = "PHPantom-dev";
     repo = "phpantom_lsp";
     tag = finalAttrs.version;
     hash = "sha256-ZmtOdoxXkwn2IDg7RyQ9KG0RNz5mrGDMcESfcOSR3Ig=";
@@ -57,9 +57,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   meta = {
-    changelog = "https://github.com/AJenbo/phpantom_lsp/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/PHPantom-dev/phpantom_lsp/releases/tag/${finalAttrs.src.tag}";
     description = "Fast, lightweight PHP language server written in Rust";
-    homepage = "https://github.com/AJenbo/phpantom_lsp";
+    homepage = "https://github.com/PHPantom-dev/phpantom_lsp";
     license = lib.licenses.mit;
     mainProgram = "phpantom_lsp";
     maintainers = with lib.maintainers; [ nanoyaki ];

--- a/pkgs/by-name/ph/physlock/package.nix
+++ b/pkgs/by-name/ph/physlock/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "13";
   pname = "physlock";
   src = fetchFromGitHub {
-    owner = "muennich";
+    owner = "xyb3rt";
     repo = "physlock";
     rev = "v${finalAttrs.version}";
     sha256 = "1mz4xxjip5ldiw9jgfq9zvqb6w10bcjfx6939w1appqg8f521a7s";

--- a/pkgs/by-name/pi/pietrasanta-traceroute/package.nix
+++ b/pkgs/by-name/pi/pietrasanta-traceroute/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "catchpoint";
-    repo = "Networking.traceroute";
+    repo = "Pietrasanta-traceroute";
     rev = "e4a5cf94dccd646e03b9b75a762e9b014e3a3128";
     hash = "sha256-5FbuITewgSh6UFUU1vttkokk8uZ2IrzkDwsCuWJPKlM=";
   };
@@ -31,8 +31,8 @@ stdenv.mkDerivation (finalAttrs: {
       - Similar QUIC-based traceroute.
       - Enhanced ToS (DSCP/ECN) field report.
     '';
-    homepage = "https://github.com/catchpoint/Networking.traceroute/";
-    changelog = "https://github.com/catchpoint/Networking.traceroute/blob/${finalAttrs.src.rev}/ChangeLog";
+    homepage = "https://github.com/catchpoint/Pietrasanta-traceroute/";
+    changelog = "https://github.com/catchpoint/Pietrasanta-traceroute/blob/${finalAttrs.src.rev}/ChangeLog";
     license = with lib.licenses; [
       gpl2Only
       lgpl21Only

--- a/pkgs/by-name/pi/pinniped/package.nix
+++ b/pkgs/by-name/pi/pinniped/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   version = "0.46.0";
 
   src = fetchFromGitHub {
-    owner = "vmware-tanzu";
+    owner = "vmware";
     repo = "pinniped";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-C7N6iPD4caTUXR6gB+9sdfBlWyT1tfE8KwE5WaiUdQM=";

--- a/pkgs/by-name/pi/pip-audit/package.nix
+++ b/pkgs/by-name/pi/pip-audit/package.nix
@@ -11,7 +11,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "trailofbits";
+    owner = "pypa";
     repo = "pip-audit";
     tag = "v${finalAttrs.version}";
     hash = "sha256-fnIwtXFswKcfz/8VssL4UVukwkq6CC63NCyqqbqziO8=";
@@ -63,7 +63,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   meta = {
     description = "Tool for scanning Python environments for known vulnerabilities";
-    homepage = "https://github.com/trailofbits/pip-audit";
+    homepage = "https://github.com/pypa/pip-audit";
     changelog = "https://github.com/pypa/pip-audit/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];

--- a/pkgs/by-name/pl/playerctl/package.nix
+++ b/pkgs/by-name/pl/playerctl/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.4.1";
 
   src = fetchFromGitHub {
-    owner = "acrisci";
+    owner = "altdesktop";
     repo = "playerctl";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-OiGKUnsKX0ihDRceZoNkcZcEAnz17h2j2QUOSVcxQEY=";
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Command-line utility and library for controlling media players that implement MPRIS";
-    homepage = "https://github.com/acrisci/playerctl";
+    homepage = "https://github.com/altdesktop/playerctl";
     license = lib.licenses.lgpl3;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ puffnfresh ];

--- a/pkgs/by-name/pl/plecost/package.nix
+++ b/pkgs/by-name/pl/plecost/package.nix
@@ -12,7 +12,7 @@ python3Packages.buildPythonApplication {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "iniqua";
+    owner = "Plecost";
     repo = "plecost";
     # Release is untagged
     rev = "4895e345d71bffe956be43530632e303dd379a5f";
@@ -38,7 +38,7 @@ python3Packages.buildPythonApplication {
   meta = {
     description = "Vulnerability fingerprinting and vulnerability finder for Wordpress blog engine";
     mainProgram = "plecost";
-    homepage = "https://github.com/iniqua/plecost";
+    homepage = "https://github.com/Plecost/plecost";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ emilytrau ];
   };

--- a/pkgs/by-name/pm/pms/package.nix
+++ b/pkgs/by-name/pm/pms/package.nix
@@ -9,7 +9,7 @@ buildGoModule {
   version = "unstable-2022-11-12";
 
   src = fetchFromGitHub {
-    owner = "ambientsound";
+    owner = "kimtore";
     repo = "pms";
     rev = "40d6e37111293187ab4542c7a64bd73d1b13974f";
     sha256 = "sha256-294MiS4c2PO2lFSSRrg8ns7sXzZsEUAqPG3q2z3TRUg=";

--- a/pkgs/by-name/pr/pritunl-client/package.nix
+++ b/pkgs/by-name/pr/pritunl-client/package.nix
@@ -24,7 +24,7 @@ let
   version = "1.3.4275.94";
   src = fetchFromGitHub {
     owner = "pritunl";
-    repo = "pritunl-client-electron";
+    repo = "pritunl-client";
     rev = version;
     sha256 = "sha256-a1arRI4qQy5niKV8JAyusAjheMa/LtEXPZGhngsH+TU=";
   };

--- a/pkgs/by-name/pr/prometheus-nginx-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-nginx-exporter/package.nix
@@ -10,7 +10,7 @@ buildGoModule rec {
   version = "1.5.1";
 
   src = fetchFromGitHub {
-    owner = "nginxinc";
+    owner = "nginx";
     repo = "nginx-prometheus-exporter";
     rev = "v${version}";
     sha256 = "sha256-BJf5gL+bkT6g28OVhGM29IwuLfFz3HPAo/DZzg5Eoqk=";
@@ -36,7 +36,7 @@ buildGoModule rec {
   meta = {
     description = "NGINX Prometheus Exporter for NGINX and NGINX Plus";
     mainProgram = "nginx-prometheus-exporter";
-    homepage = "https://github.com/nginxinc/nginx-prometheus-exporter";
+    homepage = "https://github.com/nginx/nginx-prometheus-exporter";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       benley

--- a/pkgs/by-name/pu/pulseeffects-legacy/package.nix
+++ b/pkgs/by-name/pu/pulseeffects-legacy/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation {
 
   src = fetchFromGitHub {
     owner = "wwmm";
-    repo = "pulseeffects";
+    repo = "easyeffects";
     rev = "fbe0a724c1405cee624802f381476cf003dfcfa";
     hash = "sha256-tyVUWc8w08WUnJRTjJVTIiG/YBWTETNYG+4amwEYezY=";
   };
@@ -109,7 +109,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Limiter, compressor, reverberation, equalizer and auto volume effects for Pulseaudio applications";
     mainProgram = "pulseeffects";
-    homepage = "https://github.com/wwmm/pulseeffects";
+    homepage = "https://github.com/wwmm/easyeffects";
     license = lib.licenses.gpl3Plus;
     maintainers = [ ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/qu/quark-engine/package.nix
+++ b/pkgs/by-name/qu/quark-engine/package.nix
@@ -21,7 +21,7 @@ pythonPackages.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "quark-engine";
+    owner = "ev-flow";
     repo = "quark-engine";
     tag = "v${finalAttrs.version}";
     hash = "sha256-DAD37fzswY3c0d+ubOCYImxs4qyD4fhC3m2l0iD977A=";
@@ -58,7 +58,7 @@ pythonPackages.buildPythonApplication (finalAttrs: {
   meta = {
     description = "Android malware (analysis and scoring) system";
     homepage = "https://quark-engine.readthedocs.io/";
-    changelog = "https://github.com/quark-engine/quark-engine/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/ev-flow/quark-engine/releases/tag/${finalAttrs.src.tag}";
     license = with lib.licenses; [ gpl3Only ];
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/by-name/re/redisinsight/package.nix
+++ b/pkgs/by-name/re/redisinsight/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.70.0";
 
   src = fetchFromGitHub {
-    owner = "RedisInsight";
+    owner = "redis";
     repo = "RedisInsight";
     rev = finalAttrs.version;
     hash = "sha256-b97/hBhXqSFDzcyrQKu5Ebu1Ud3wpWEjyzUehj0PP9w=";
@@ -167,7 +167,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Developer GUI for Redis";
-    homepage = "https://github.com/RedisInsight/RedisInsight";
+    homepage = "https://github.com/redis/RedisInsight";
     license = lib.licenses.sspl;
     maintainers = with lib.maintainers; [
       tomasajt

--- a/pkgs/by-name/re/release-plz/package.nix
+++ b/pkgs/by-name/re/release-plz/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.3.158";
 
   src = fetchFromGitHub {
-    owner = "MarcoIeni";
+    owner = "release-plz";
     repo = "release-plz";
     rev = "release-plz-v${finalAttrs.version}";
     hash = "sha256-AFqSj5utn5PGo7mC1LdZSdw71kDEGg1F+ELNolkBgV0=";
@@ -45,7 +45,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Publish Rust crates from CI with a Release PR";
     homepage = "https://release-plz.ieni.dev";
-    changelog = "https://github.com/MarcoIeni/release-plz/blob/release-plz-v${finalAttrs.version}/CHANGELOG.md";
+    changelog = "https://github.com/release-plz/release-plz/blob/release-plz-v${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [
       asl20
       mit

--- a/pkgs/by-name/re/restish/package.nix
+++ b/pkgs/by-name/re/restish/package.nix
@@ -17,7 +17,7 @@ buildGoModule (finalAttrs: {
   version = "0.21.2";
 
   src = fetchFromGitHub {
-    owner = "danielgtaylor";
+    owner = "rest-sh";
     repo = "restish";
     tag = "v${finalAttrs.version}";
     hash = "sha256-C+fB9UeEq+h6SlBtVPPZWs5fCCsJVe/TJFy4KhhaItU=";
@@ -51,7 +51,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "CLI tool for interacting with REST-ish HTTP APIs";
     homepage = "https://rest.sh/";
-    changelog = "https://github.com/danielgtaylor/restish/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/rest-sh/restish/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "restish";

--- a/pkgs/by-name/re/resvg/package.nix
+++ b/pkgs/by-name/re/resvg/package.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.47.0";
 
   src = fetchFromGitHub {
-    owner = "RazrFalcon";
+    owner = "linebender";
     repo = "resvg";
     rev = "v${finalAttrs.version}";
     hash = "sha256-BCYjVOWFpOZm7ocmfszFpaBxnd96vhf3/yGlvAVRtCw=";
@@ -29,8 +29,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "SVG rendering library";
-    homepage = "https://github.com/RazrFalcon/resvg";
-    changelog = "https://github.com/RazrFalcon/resvg/blob/v${finalAttrs.version}/CHANGELOG.md";
+    homepage = "https://github.com/linebender/resvg";
+    changelog = "https://github.com/linebender/resvg/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mpl20;
     maintainers = [ ];
     mainProgram = "resvg";

--- a/pkgs/by-name/ri/rime-wanxiang/package.nix
+++ b/pkgs/by-name/ri/rime-wanxiang/package.nix
@@ -11,7 +11,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "amzxyz";
-    repo = "rime_wanxiang";
+    repo = "rime-wanxiang";
     tag = "v" + finalAttrs.version;
     hash = "sha256-qg6QyI2RHKkCfjj41IXfL2cIXt82NR9oh52A/V0O67g=";
   };
@@ -59,9 +59,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         __include: wanxiang_suggested_default:/
       ```
     '';
-    homepage = "https://github.com/amzxyz/rime_wanxiang";
-    downloadPage = "https://github.com/amzxyz/rime_wanxiang/releases";
-    changelog = "https://github.com/amzxyz/rime_wanxiang/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/amzxyz/rime-wanxiang";
+    downloadPage = "https://github.com/amzxyz/rime-wanxiang/releases";
+    changelog = "https://github.com/amzxyz/rime-wanxiang/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.cc-by-40;
     maintainers = with lib.maintainers; [ rc-zb ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/ri/ripunzip/package.nix
+++ b/pkgs/by-name/ri/ripunzip/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "2.0.4";
 
   src = fetchFromGitHub {
-    owner = "google";
+    owner = "GoogleChrome";
     repo = "ripunzip";
     rev = "v${finalAttrs.version}";
     hash = "sha256-oujRw/4yKNNqLJLTN4wxaOllSUGMu077YgWZkD0DJ4M=";
@@ -46,7 +46,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     fetchzipWithRipunzip =
       testers.invalidateFetcherByDrvHash (fetchzip.override { unzip = ripunzip; })
         {
-          url = "https://github.com/google/ripunzip/archive/cb9caa3ba4b0e27a85e165be64c40f1f6dfcc085.zip";
+          url = "https://github.com/GoogleChrome/ripunzip/archive/cb9caa3ba4b0e27a85e165be64c40f1f6dfcc085.zip";
           hash = "sha256-BoErC5VL3Vpvkx6xJq6J+eUJrBnjVEdTuSo7zh98Jy4=";
         };
     version = testers.testVersion {
@@ -57,7 +57,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Tool to unzip files in parallel";
     mainProgram = "ripunzip";
-    homepage = "https://github.com/google/ripunzip";
+    homepage = "https://github.com/GoogleChrome/ripunzip";
     license = with lib.licenses; [
       mit
       asl20

--- a/pkgs/by-name/ri/riscv-pk/package.nix
+++ b/pkgs/by-name/ri/riscv-pk/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   version = "1.0.0-unstable-2024-10-09";
 
   src = fetchFromGitHub {
-    owner = "riscv";
+    owner = "riscv-software-src";
     repo = "riscv-pk";
     rev = "abadfdc507d5a75b6272dc360e70a80a510c758a";
     sha256 = "sha256-02qcj0TAs7g4CSorWWbUzouS6mNthUOSdeocibw5g2A=";
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "RISC-V Proxy Kernel and Bootloader";
-    homepage = "https://github.com/riscv/riscv-pk";
+    homepage = "https://github.com/riscv-software-src/riscv-pk";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.riscv;
     maintainers = [ lib.maintainers.shlevy ];

--- a/pkgs/by-name/ri/risor/package.nix
+++ b/pkgs/by-name/ri/risor/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   version = "2.1.0";
 
   src = fetchFromGitHub {
-    owner = "risor-io";
+    owner = "deepnoodle-ai";
     repo = "risor";
     rev = "v${finalAttrs.version}";
     hash = "sha256-SXUaSJmtWul4LYRdoxv4lXBB4HHp62xrWbEchI691YY=";
@@ -40,8 +40,8 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Fast and flexible scripting for Go developers and DevOps";
     mainProgram = "risor";
-    homepage = "https://github.com/risor-io/risor";
-    changelog = "https://github.com/risor-io/risor/releases/tag/${finalAttrs.src.rev}";
+    homepage = "https://github.com/deepnoodle-ai/risor";
+    changelog = "https://github.com/deepnoodle-ai/risor/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };

--- a/pkgs/by-name/rm/rmount/package.nix
+++ b/pkgs/by-name/rm/rmount/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     rev = "v${finalAttrs.version}";
-    owner = "Luis-Hebendanz";
+    owner = "Qubasa";
     repo = "rmount";
     sha256 = "0j1ayncw1nnmgna7vyx44vwinh4ah1b0l5y8agc7i4s8clbvy3h0";
   };
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://github.com/Luis-Hebendanz/rmount";
+    homepage = "https://github.com/Qubasa/rmount";
     description = "Remote mount utility which parses a json file";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.qubasa ];

--- a/pkgs/by-name/ro/rofi-systemd/package.nix
+++ b/pkgs/by-name/ro/rofi-systemd/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   version = "1.1.0";
 
   src = fetchFromGitHub {
-    owner = "IvanMalison";
+    owner = "colonelpanic8";
     repo = "rofi-systemd";
     tag = "v${version}";
     sha256 = "1zwbw119mblp5b6dj4h92fi0y2ymimlgh4bawi5ks2051hpq6c1a";
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Control your systemd units using rofi";
-    homepage = "https://github.com/IvanMalison/rofi-systemd";
+    homepage = "https://github.com/colonelpanic8/rofi-systemd";
     maintainers = with lib.maintainers; [ imalison ];
     license = lib.licenses.gpl3;
     platforms = with lib.platforms; linux;

--- a/pkgs/by-name/ru/ruplacer/package.nix
+++ b/pkgs/by-name/ru/ruplacer/package.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.10.0";
 
   src = fetchFromGitHub {
-    owner = "TankerHQ";
+    owner = "your-tools";
     repo = "ruplacer";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-Zvbb9pQpxbJZi0qcDU6f2jEgavl9cA7gIYU7NRXZ9fc=";
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Find and replace text in source files";
     mainProgram = "ruplacer";
-    homepage = "https://github.com/TankerHQ/ruplacer";
+    homepage = "https://github.com/your-tools/ruplacer";
     license = lib.licenses.bsd3;
   };
 })

--- a/pkgs/by-name/ru/rustcast/package.nix
+++ b/pkgs/by-name/ru/rustcast/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.5.6";
 
   src = fetchFromGitHub {
-    owner = "unsecretised";
+    owner = "RustCastLabs";
     repo = "rustcast";
     tag = "v${finalAttrs.version}";
     hash = "sha256-88vg+xdASskbYwLbEPGmHf8P1PL4PihJDXT1ua/cfCQ=";
@@ -25,9 +25,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    changelog = "https://github.com/unsecretised/rustcast/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/RustCastLabs/rustcast/releases/tag/v${finalAttrs.version}";
     description = "Modern Spotlight Alternative made opensource";
-    homepage = "https://github.com/unsecretised/rustcast";
+    homepage = "https://github.com/RustCastLabs/rustcast";
     license = lib.licenses.mit;
     platforms = lib.platforms.darwin;
     maintainers = with lib.maintainers; [ eveeifyeve ];

--- a/pkgs/by-name/ru/rustscan/package.nix
+++ b/pkgs/by-name/ru/rustscan/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "2.4.1";
 
   src = fetchFromGitHub {
-    owner = "RustScan";
+    owner = "bee-san";
     repo = "RustScan";
     tag = finalAttrs.version;
     hash = "sha256-+qPSeDpOeCq+KwZb5ANXx6z+pYbgdT1hVgcrSzxyGp0=";
@@ -41,8 +41,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Faster Nmap Scanning with Rust";
-    homepage = "https://github.com/RustScan/RustScan";
-    changelog = "https://github.com/RustScan/RustScan/releases/tag/${finalAttrs.version}";
+    homepage = "https://github.com/bee-san/RustScan";
+    changelog = "https://github.com/bee-san/RustScan/releases/tag/${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ bodier123 ];
     mainProgram = "rustscan";

--- a/pkgs/by-name/ry/rye/package.nix
+++ b/pkgs/by-name/ry/rye/package.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.44.0";
 
   src = fetchFromGitHub {
-    owner = "mitsuhiko";
+    owner = "astral-sh";
     repo = "rye";
     tag = finalAttrs.version;
     hash = "sha256-K9xad5Odza0Oxz49yMJjqpfh3cCgmWnbAlv069fHV6Q=";
@@ -101,8 +101,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Tool to easily manage python dependencies and environments";
-    homepage = "https://github.com/mitsuhiko/rye";
-    changelog = "https://github.com/mitsuhiko/rye/releases/tag/${finalAttrs.version}";
+    homepage = "https://github.com/astral-sh/rye";
+    changelog = "https://github.com/astral-sh/rye/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ GaetanLepage ];
     mainProgram = "rye";

--- a/pkgs/by-name/sa/safe/package.nix
+++ b/pkgs/by-name/sa/safe/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "1.8.0";
 
   src = fetchFromGitHub {
-    owner = "starkandwayne";
+    owner = "egen";
     repo = "safe";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-sg0RyZ5HpYu7M11bNy17Sjxm7C3pkQX3I17edbALuvU=";
@@ -26,7 +26,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Vault CLI";
     mainProgram = "safe";
-    homepage = "https://github.com/starkandwayne/safe";
+    homepage = "https://github.com/egen/safe";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ eonpatapon ];
   };

--- a/pkgs/by-name/sa/satty/package.nix
+++ b/pkgs/by-name/sa/satty/package.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.20.1";
 
   src = fetchFromGitHub {
-    owner = "gabm";
+    owner = "Satty-org";
     repo = "Satty";
     rev = "v${finalAttrs.version}";
     hash = "sha256-pR3Mc5Eue4YcIMcrzkyDhZPpovRFa8TW1PjL/ysH/7s=";
@@ -57,7 +57,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Screenshot annotation tool inspired by Swappy and Flameshot";
-    homepage = "https://github.com/gabm/Satty";
+    homepage = "https://github.com/Satty-org/Satty";
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [
       pinpox

--- a/pkgs/by-name/sa/saunafs/package.nix
+++ b/pkgs/by-name/sa/saunafs/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "leil-io";
-    repo = "saunafs";
+    repo = "leilfs";
     rev = "v${finalAttrs.version}";
     hash = "sha256-OMUW5JJziW3C9R5gsnFTGnxwmVoXRTtu4aIlXfnVdME=";
   };

--- a/pkgs/by-name/sa/savepagenow/package.nix
+++ b/pkgs/by-name/sa/savepagenow/package.nix
@@ -10,7 +10,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "pastpages";
+    owner = "palewire";
     repo = "savepagenow";
     tag = finalAttrs.version;
     sha256 = "sha256-ztM1g71g8SN1LTyFF7sxaLhC3+nVsC9fJwfYPjkUsdE=";
@@ -32,7 +32,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   meta = {
     description = "Simple Python wrapper for archive.org's \"Save Page Now\" capturing service";
-    homepage = "https://github.com/pastpages/savepagenow";
+    homepage = "https://github.com/palewire/savepagenow";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ SuperSandro2000 ];
     mainProgram = "savepagenow";

--- a/pkgs/by-name/sb/sbt-extras/package.nix
+++ b/pkgs/by-name/sb/sbt-extras/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   version = "2025-08-25";
 
   src = fetchFromGitHub {
-    owner = "paulp";
+    owner = "dwijnand";
     repo = "sbt-extras";
     inherit rev;
     sha256 = "UlxZsCi4EdcHvGwatQm1sPyamfcqJs9o8qo2HWLedQw=";
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "More featureful runner for sbt, the simple/scala/standard build tool";
-    homepage = "https://github.com/paulp/sbt-extras";
+    homepage = "https://github.com/dwijnand/sbt-extras";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
       puffnfresh

--- a/pkgs/by-name/sc/scip-go/package.nix
+++ b/pkgs/by-name/sc/scip-go/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "0.2.6";
 
   src = fetchFromGitHub {
-    owner = "sourcegraph";
+    owner = "scip-code";
     repo = "scip-go";
     rev = "v${finalAttrs.version}";
     hash = "sha256-QtfGiMRrGHgL1VHLMX9icXkY/jv567On3xe/dYmoaQI=";
@@ -26,7 +26,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "SCIP (SCIP Code Intelligence Protocol) indexer for Golang";
-    homepage = "https://github.com/sourcegraph/scip-go/tree/v${finalAttrs.version}";
+    homepage = "https://github.com/scip-code/scip-go/tree/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ arikgrahl ];
     mainProgram = "scip-go";

--- a/pkgs/by-name/sc/scip/package.nix
+++ b/pkgs/by-name/sc/scip/package.nix
@@ -13,7 +13,7 @@ buildGo125Module (finalAttrs: {
   version = "0.7.1";
 
   src = fetchFromGitHub {
-    owner = "sourcegraph";
+    owner = "scip-code";
     repo = "scip";
     tag = "v${finalAttrs.version}";
     hash = "sha256-lpzGrTvWUXUFfmyn5z4rsqJEcAOA8D1qfN1assRAdn4=";
@@ -45,8 +45,8 @@ buildGo125Module (finalAttrs: {
   meta = {
     description = "SCIP Code Intelligence Protocol CLI";
     mainProgram = "scip";
-    homepage = "https://github.com/sourcegraph/scip";
-    changelog = "https://github.com/sourcegraph/scip/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    homepage = "https://github.com/scip-code/scip";
+    changelog = "https://github.com/scip-code/scip/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };

--- a/pkgs/by-name/sc/scope-lite/package.nix
+++ b/pkgs/by-name/sc/scope-lite/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.3.0";
 
   src = fetchFromGitHub {
-    owner = "martinmoene";
+    owner = "nonstd-lite";
     repo = "scope-lite";
     tag = "v${finalAttrs.version}";
     hash = "sha256-EZ+bBnMPpgATANa+al5SnVEfUFYc0TkaPTLNHD6zcWU=";
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Migration path to C++ library extensions scope_exit, scope_fail, scope_success, unique_resource";
     license = lib.licenses.boost;
     maintainers = [ lib.maintainers.shlevy ];
-    homepage = "https://github.com/martinmoene/scope-lite";
+    homepage = "https://github.com/nonstd-lite/scope-lite";
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/sc/screen-pipe/package.nix
+++ b/pkgs/by-name/sc/screen-pipe/package.nix
@@ -17,8 +17,8 @@ rustPlatform.buildRustPackage rec {
   version = "0.1.48";
 
   src = fetchFromGitHub {
-    owner = "louis030195";
-    repo = "screen-pipe";
+    owner = "screenpipe";
+    repo = "screenpipe";
     rev = "v${version}";
     hash = "sha256-rWKRCqWFuPO84C52mMrrS4euD6XdJU8kqZsAz28+vWE=";
   };
@@ -64,7 +64,7 @@ rustPlatform.buildRustPackage rec {
     # Marked broken 2025-11-28 because it has failed on Hydra for at least one year.
     broken = true;
     description = "Personalized AI powered by what you've seen, said, or heard";
-    homepage = "https://github.com/louis030195/screen-pipe";
+    homepage = "https://github.com/screenpipe/screenpipe";
     license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "screen-pipe";

--- a/pkgs/by-name/sd/sdate/package.nix
+++ b/pkgs/by-name/sd/sdate/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.7";
 
   src = fetchFromGitHub {
-    owner = "ChristophBerg";
+    owner = "df7cb";
     repo = "sdate";
     rev = finalAttrs.version;
     hash = "sha256-jkwe+bSBa0p1Xzfetsdpw0RYw/gSRxnY2jBOzC5HtJ8=";

--- a/pkgs/by-name/sh/shadowfox/package.nix
+++ b/pkgs/by-name/sh/shadowfox/package.nix
@@ -10,7 +10,7 @@ buildGoModule (finalAttrs: {
   version = "2.2.0";
 
   src = fetchFromGitHub {
-    owner = "SrKomodo";
+    owner = "arguablykomodo";
     repo = "shadowfox-updater";
     rev = "v${finalAttrs.version}";
     sha256 = "125mw70jidbp436arhv77201jdp6mpgqa2dzmrpmk55f9bf29sg6";

--- a/pkgs/by-name/sh/shepherd/package.nix
+++ b/pkgs/by-name/sh/shepherd/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.16.0";
 
   src = fetchFromGitHub {
-    owner = "NerdWalletOSS";
+    owner = "shepherd-tools";
     repo = "shepherd";
     rev = "v${finalAttrs.version}";
     hash = "sha256-LY8Vde4YpGuKnQ5UnSOpsQDY7AOyZRziUrfZb5dRiX4=";
@@ -67,9 +67,9 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    changelog = "https://github.com/NerdWalletOSS/shepherd/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/shepherd-tools/shepherd/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     description = "Utility for applying code changes across many repositories";
-    homepage = "https://github.com/NerdWalletOSS/shepherd";
+    homepage = "https://github.com/shepherd-tools/shepherd";
     license = lib.licenses.asl20;
     mainProgram = "shepherd";
     maintainers = with lib.maintainers; [ dbirks ];

--- a/pkgs/by-name/sh/shopware-cli/package.nix
+++ b/pkgs/by-name/sh/shopware-cli/package.nix
@@ -14,7 +14,7 @@ buildGoModule (finalAttrs: {
   version = "0.14.8";
   src = fetchFromGitHub {
     repo = "shopware-cli";
-    owner = "FriendsOfShopware";
+    owner = "shopware";
     tag = finalAttrs.version;
     hash = "sha256-yN6yuGnZv6BsXoERUdA3aBGEmri1hqmPsbIYsX7HE5Q=";
   };
@@ -45,7 +45,7 @@ buildGoModule (finalAttrs: {
   ldflags = [
     "-s"
     "-w"
-    "-X 'github.com/FriendsOfShopware/shopware-cli/cmd.version=${finalAttrs.version}'"
+    "-X 'github.com/shopware/shopware-cli/cmd.version=${finalAttrs.version}'"
   ];
 
   __darwinAllowLocalNetworking = true;
@@ -53,8 +53,8 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Command line tool for Shopware 6";
     mainProgram = "shopware-cli";
-    homepage = "https://github.com/FriendsOfShopware/shopware-cli";
-    changelog = "https://github.com/FriendsOfShopware/shopware-cli/releases/tag/${finalAttrs.version}";
+    homepage = "https://github.com/shopware/shopware-cli";
+    changelog = "https://github.com/shopware/shopware-cli/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ shyim ];
   };

--- a/pkgs/by-name/si/simple64-netplay-server/package.nix
+++ b/pkgs/by-name/si/simple64-netplay-server/package.nix
@@ -9,8 +9,8 @@ buildGoModule (finalAttrs: {
   version = "2025.03.1";
 
   src = fetchFromGitHub {
-    owner = "simple64";
-    repo = "simple64-netplay-server";
+    owner = "gopher64";
+    repo = "gopher64-netplay-server";
     tag = "v${finalAttrs.version}";
     hash = "sha256-n+au4x6d50rZI5sH7B5jdlD6vXK65UM4TRAtzpPW6ws=";
   };
@@ -19,7 +19,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Dedicated server for simple64 netplay";
-    homepage = "https://github.com/simple64/simple64-netplay-server";
+    homepage = "https://github.com/gopher64/gopher64-netplay-server";
     license = lib.licenses.gpl3Only;
     mainProgram = "simple64-netplay-server";
     maintainers = with lib.maintainers; [ tomasajt ];

--- a/pkgs/by-name/si/simplebluez/package.nix
+++ b/pkgs/by-name/si/simplebluez/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.11.0";
 
   src = fetchFromGitHub {
-    owner = "OpenBluetoothToolbox";
+    owner = "simpleble";
     repo = "SimpleBLE";
     rev = "v${finalAttrs.version}";
     hash = "sha256-SWZdVWBC8udwkn195FdvsXSniMtzd8+WfnMsARLYSQ4=";
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "C++ abstraction layer for BlueZ over DBus";
-    homepage = "https://github.com/OpenBluetoothToolbox/SimpleBLE";
+    homepage = "https://github.com/simpleble/simpleble";
     # SimpleBLE (which SimpleBluez is part of) is under the Business Source License 1.1 (BUSL-1.1)
     # since version 0.9.0
     license = lib.licenses.bsl11;

--- a/pkgs/by-name/si/simpledbus/package.nix
+++ b/pkgs/by-name/si/simpledbus/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.11.0";
 
   src = fetchFromGitHub {
-    owner = "OpenBluetoothToolbox";
+    owner = "simpleble";
     repo = "SimpleBLE";
     rev = "v${finalAttrs.version}";
     hash = "sha256-SWZdVWBC8udwkn195FdvsXSniMtzd8+WfnMsARLYSQ4=";
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "C++ wrapper for libdbus-1";
-    homepage = "https://github.com/OpenBluetoothToolbox/SimpleBLE";
+    homepage = "https://github.com/simpleble/simpleble";
     # SimpleBLE (which SimpleDBus is part of) is under the Business Source License 1.1 (BUSL-1.1)
     # since version 0.9.0
     license = lib.licenses.bsl11;

--- a/pkgs/by-name/si/simulide/package.nix
+++ b/pkgs/by-name/si/simulide/package.nix
@@ -41,7 +41,7 @@ let
       release = "RC1";
       rev = "da3a925491fab9fa2a8633d18e45f8e1b576c9d2";
       src = fetchFromGitHub {
-        owner = "eeTools";
+        owner = "Arcachofo";
         repo = "SimulIDE-dev";
         hash = "sha256-6Gh0efBizDK1rUNkyU+/ysj7QwkAs3kTA1mQZYFb/pI=";
         inherit rev;

--- a/pkgs/by-name/sk/skhd/package.nix
+++ b/pkgs/by-name/sk/skhd/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.3.9";
 
   src = fetchFromGitHub {
-    owner = "koekeishiya";
+    owner = "asmvik";
     repo = "skhd";
     rev = "v${finalAttrs.version}";
     hash = "sha256-fnkWws/g4BdHKDRhqoCpdPFUavOHdk8R7h7H1dAdAYI=";
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Simple hotkey daemon for macOS";
-    homepage = "https://github.com/koekeishiya/skhd";
+    homepage = "https://github.com/asmvik/skhd";
     license = lib.licenses.mit;
     mainProgram = "skhd";
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/sl/slack-term/package.nix
+++ b/pkgs/by-name/sl/slack-term/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "0.5.0";
 
   src = fetchFromGitHub {
-    owner = "erroneousboat";
+    owner = "jpbruinsslot";
     repo = "slack-term";
     rev = "v${finalAttrs.version}";
     sha256 = "1fbq7bdhy70hlkklppimgdjamnk0v059pg73xm9ax1f4616ki1m6";
@@ -18,7 +18,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Slack client for your terminal";
-    homepage = "https://github.com/erroneousboat/slack-term";
+    homepage = "https://github.com/jpbruinsslot/slack-term";
     license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "slack-term";

--- a/pkgs/by-name/sl/slsk-batchdl/package.nix
+++ b/pkgs/by-name/sl/slsk-batchdl/package.nix
@@ -11,14 +11,14 @@ buildDotnetModule (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "fiso64";
-    repo = "slsk-batchdl";
+    repo = "sldl";
     tag = "v${finalAttrs.version}";
     hash = "sha256-H10pApWZ6zUkL1FuSrpbEzGGpDVAiBJB2aZtV9jDTz4=";
   };
 
   postPatch = ''
     # .NET 6 is EOL, .NET 8 works fine modulo the trimming flag.
-    # See: https://github.com/fiso64/slsk-batchdl/issues/112
+    # See: https://github.com/fiso64/sldl/issues/112
     substituteInPlace \
         slsk-batchdl/slsk-batchdl.csproj \
         slsk-batchdl.Tests/slsk-batchdl.Tests.csproj \
@@ -28,7 +28,7 @@ buildDotnetModule (finalAttrs: {
   projectFile = "slsk-batchdl/slsk-batchdl.csproj";
 
   # Tests fail to build.
-  # See: https://github.com/fiso64/slsk-batchdl/issues/111
+  # See: https://github.com/fiso64/sldl/issues/111
   # testProjectFile = "slsk-batchdl.Tests/slsk-batchdl.Tests.csproj";
 
   dotnet-sdk = dotnetCorePackages.sdk_10_0;
@@ -38,7 +38,7 @@ buildDotnetModule (finalAttrs: {
   dotnetFlags = [
     "--property:PublishSingleFile=true"
     # Note: This breaks Spotify authentication!
-    # See: https://github.com/fiso64/slsk-batchdl/issues/112
+    # See: https://github.com/fiso64/sldl/issues/112
     # "--property:PublishTrimmed=true"
   ];
 
@@ -47,7 +47,7 @@ buildDotnetModule (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    homepage = "https://github.com/fiso64/slsk-batchdl";
+    homepage = "https://github.com/fiso64/sldl";
     description = "Advanced download tool for Soulseek";
     license = lib.licenses.gpl3Only;
     maintainers = [

--- a/pkgs/by-name/sn/snapweb/package.nix
+++ b/pkgs/by-name/sn/snapweb/package.nix
@@ -11,7 +11,7 @@ buildNpmPackage rec {
   version = "0.9.2";
 
   src = fetchFromGitHub {
-    owner = "badaix";
+    owner = "snapcast";
     repo = "snapweb";
     rev = "v${version}";
     hash = "sha256-7W7rvJPVcRtXcQt+wWAvrl0DOIh7zEfXZdFDcH23/ls=";
@@ -33,7 +33,7 @@ buildNpmPackage rec {
 
   meta = {
     description = "Web client for Snapcast";
-    homepage = "https://github.com/badaix/snapweb";
+    homepage = "https://github.com/snapcast/snapweb";
     maintainers = with lib.maintainers; [ ettom ];
     license = lib.licenses.gpl3Plus;
   };

--- a/pkgs/by-name/sn/snarkos/package.nix
+++ b/pkgs/by-name/sn/snarkos/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
   version = "2.2.7";
 
   src = fetchFromGitHub {
-    owner = "AleoHQ";
+    owner = "ProvableHQ";
     repo = "snarkOS";
     rev = "v${version}";
     sha256 = "sha256-+z9dgg5HdR+Gomug03gI1zdCU6t4SBHkl1Pxoq69wrc=";

--- a/pkgs/by-name/sn/snippetpixie/package.nix
+++ b/pkgs/by-name/sn/snippetpixie/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.5.3";
 
   src = fetchFromGitHub {
-    owner = "bytepixie";
+    owner = "ianmjones";
     repo = "snippetpixie";
     rev = finalAttrs.version;
     sha256 = "0gs3d9hdywg4vcfbp4qfcagfjqalfgw9xpvywg4pw1cm3rzbdqmz";

--- a/pkgs/by-name/sn/snmpen/package.nix
+++ b/pkgs/by-name/sn/snmpen/package.nix
@@ -11,7 +11,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "fabaff";
+    owner = "affolter-engineering";
     repo = "snmpen";
     tag = finalAttrs.version;
     hash = "sha256-XJP+f5Ahizxgk80B0896sbE6JeNB0Bm7aafwJsFaHYY=";

--- a/pkgs/by-name/sn/snore/package.nix
+++ b/pkgs/by-name/sn/snore/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "snore";
 
   src = fetchFromGitHub {
-    owner = "clamiax";
+    owner = "bitsmanent";
     repo = "snore";
     tag = finalAttrs.version;
     hash = "sha256-bKPGSePzp4XEZFY0QQr37fm3R1v3hLD6FeySFd7zNJc=";
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "'sleep' with feedback";
-    homepage = "https://github.com/clamiax/snore";
+    homepage = "https://github.com/bitsmanent/snore";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ cafkafk ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/sp/spaceship-prompt/package.nix
+++ b/pkgs/by-name/sp/spaceship-prompt/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation rec {
   version = "4.22.1";
 
   src = fetchFromGitHub {
-    owner = "denysdovhan";
+    owner = "spaceship-prompt";
     repo = "spaceship-prompt";
     rev = "v${version}";
     sha256 = "sha256-shZf1IfSkHnaHnQ4idiDrmaJYXtViwGntpfEOBUDyBk=";
@@ -35,7 +35,7 @@ stdenvNoCC.mkDerivation rec {
 
   meta = {
     description = "Zsh prompt for Astronauts";
-    homepage = "https://github.com/denysdovhan/spaceship-prompt/";
+    homepage = "https://github.com/spaceship-prompt/spaceship-prompt/";
     changelog = "https://github.com/spaceship-prompt/spaceship-prompt/releases/tag/v${version}";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/sp/span-lite/package.nix
+++ b/pkgs/by-name/sp/span-lite/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.11.0";
 
   src = fetchFromGitHub {
-    owner = "martinmoene";
+    owner = "nonstd-lite";
     repo = "span-lite";
     rev = "v${finalAttrs.version}";
     hash = "sha256-BYRSdGzIvrOjPXxeabMj4tPFmQ0wfq7y+zJf6BD/bTw=";
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "C++20-like span for C++98, C++11 and later in a single-file header-only library";
-    homepage = "https://github.com/martinmoene/span-lite";
+    homepage = "https://github.com/nonstd-lite/span-lite";
     license = lib.licenses.bsd1;
     maintainers = with lib.maintainers; [ icewind1991 ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/sp/spike/package.nix
+++ b/pkgs/by-name/sp/spike/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   version = "1.1.0-unstable-2024-09-21";
 
   src = fetchFromGitHub {
-    owner = "riscv";
+    owner = "riscv-software-src";
     repo = "riscv-isa-sim";
     rev = "de5094a1a901d77ff44f89b38e00fefa15d4018e";
     sha256 = "sha256-mAgR2VzDgeuIdmPEgrb+MaA89BnWfmNanOVidqn0cgc=";
@@ -45,7 +45,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "RISC-V ISA Simulator";
-    homepage = "https://github.com/riscv/riscv-isa-sim";
+    homepage = "https://github.com/riscv-software-src/riscv-isa-sim";
     license = lib.licenses.bsd3;
     platforms = [
       "x86_64-linux"

--- a/pkgs/by-name/sp/spip/package.nix
+++ b/pkgs/by-name/sp/spip/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation {
   version = "0-unstable-2023-04-19";
 
   src = fetchFromGitHub {
-    owner = "raphaelleman";
+    owner = "LBGC-CFB";
     repo = "SPiP";
     rev = "cae95fe0ee7a2602630b7a4eacbf7cfa0e1763f0";
     hash = "sha256-/CufUaQYnsdo8Rij/24JmixPgMi7o1CApLxeTneWAVc=";
@@ -61,7 +61,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Random forest model for splice prediction in genomics";
     license = lib.licenses.mit;
-    homepage = "https://github.com/raphaelleman/SPiP";
+    homepage = "https://github.com/LBGC-CFB/SPiP";
     maintainers = with lib.maintainers; [ apraga ];
     platforms = lib.platforms.unix;
     mainProgram = "spip";

--- a/pkgs/by-name/sp/splayer/package.nix
+++ b/pkgs/by-name/sp/splayer/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.0.0";
 
   src = fetchFromGitHub {
-    owner = "imsyy";
+    owner = "SPlayer-Dev";
     repo = "SPlayer";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = false;
@@ -157,8 +157,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Simple Netease Cloud Music player";
-    homepage = "https://github.com/imsyy/SPlayer";
-    changelog = "https://github.com/imsyy/SPlayer/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/SPlayer-Dev/SPlayer";
+    changelog = "https://github.com/SPlayer-Dev/SPlayer/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ ccicnce113424 ];
     mainProgram = "splayer";

--- a/pkgs/by-name/sp/spotiflac/package.nix
+++ b/pkgs/by-name/sp/spotiflac/package.nix
@@ -22,7 +22,7 @@ buildGoModule (finalAttrs: {
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
-    owner = "afkarxyz";
+    owner = "spotbye";
     repo = "SpotiFLAC";
     tag = "v${finalAttrs.version}";
     hash = "sha256-2bCKsgrJH8jfggluNdNqX+LdG8NLcsuhrJwkaRTXAOs=";
@@ -101,8 +101,8 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Get Spotify tracks in true FLAC from Tidal, Qobuz & Amazon Music — no account required";
-    homepage = "https://github.com/afkarxyz/SpotiFLAC/";
-    changelog = "https://github.com/afkarxyz/SpotiFLAC/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/spotbye/SpotiFLAC/";
+    changelog = "https://github.com/spotbye/SpotiFLAC/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
     mainProgram = "spotiflac";

--- a/pkgs/by-name/sp/spread/package.nix
+++ b/pkgs/by-name/sp/spread/package.nix
@@ -15,7 +15,7 @@ buildGoModule {
   version = "0-unstable-2025-02-06";
 
   src = fetchFromGitHub {
-    owner = "snapcore";
+    owner = "canonical";
     repo = "spread";
     rev = "d6447c43754c8ca0741901e9db73d5fdb4d21c93";
     hash = "sha256-6d7FuEzO5Ond3xjKpf5iRIp9LEV/4O5g3j/tZQEDCZg=";
@@ -59,7 +59,7 @@ buildGoModule {
     mainProgram = "spread";
     license = lib.licenses.gpl3Only;
     description = "Convenient full-system test (task) distribution";
-    homepage = "https://github.com/snapcore/spread";
+    homepage = "https://github.com/canonical/spread";
     maintainers = with lib.maintainers; [ jnsgruk ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/sq/sqlboiler/package.nix
+++ b/pkgs/by-name/sq/sqlboiler/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "4.19.7";
 
   src = fetchFromGitHub {
-    owner = "volatiletech";
+    owner = "aarondl";
     repo = "sqlboiler";
     tag = "v${finalAttrs.version}";
     hash = "sha256-I67MRrsFCLVdslMFwFnrx1EvyR4eUsupRsqD0T9ZCQg=";
@@ -34,8 +34,8 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Generate a Go ORM tailored to your database schema";
-    homepage = "https://github.com/volatiletech/sqlboiler";
-    changelog = "https://github.com/volatiletech/sqlboiler/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/aarondl/sqlboiler";
+    changelog = "https://github.com/aarondl/sqlboiler/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ mrityunjaygr8 ];
     mainProgram = "sqlboiler";

--- a/pkgs/by-name/sq/sqlitestudio/package.nix
+++ b/pkgs/by-name/sq/sqlitestudio/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "pawelsalawa";
-    repo = "sqlitestudio";
+    repo = "letos";
     rev = finalAttrs.version;
     hash = "sha256-xs0+bB0gPoDkIldaTA/nFofx9KPvIcyxe6kzcHuboxA=";
   };

--- a/pkgs/by-name/sq/sqlpage/package.nix
+++ b/pkgs/by-name/sq/sqlpage/package.nix
@@ -45,7 +45,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.41.0";
 
   src = fetchFromGitHub {
-    owner = "lovasoa";
+    owner = "sqlpage";
     repo = "SQLpage";
     tag = "v${finalAttrs.version}";
     hash = "sha256-rUij1nhXcLEwdUUVpKoUbgNqV47TvmMCEds4ihP9QL4=";
@@ -92,8 +92,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "SQL-only webapp builder, empowering data analysts to build websites and applications quickly";
-    homepage = "https://github.com/lovasoa/SQLpage";
-    changelog = "https://github.com/lovasoa/SQLpage/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    homepage = "https://github.com/sqlpage/SQLPage";
+    changelog = "https://github.com/sqlpage/SQLPage/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "sqlpage";

--- a/pkgs/by-name/sr/srsran/package.nix
+++ b/pkgs/by-name/sr/srsran/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "srsran";
-    repo = "srsran";
+    repo = "srsRAN_4G";
     rev = "release_${builtins.replaceStrings [ "." ] [ "_" ] finalAttrs.version}";
     sha256 = "sha256-DwQ4u17m8D5RqX3OIYSyeE5+51sLah1qchRcwlX5i0A=";
   };

--- a/pkgs/by-name/st/stabber/package.nix
+++ b/pkgs/by-name/st/stabber/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation {
   version = "2020-06-08";
 
   src = fetchFromGitHub {
-    owner = "boothj5";
+    owner = "profanity-im";
     repo = "stabber";
     rev = "3e5c2200715666aad403d0076e8ab584b329965e";
     sha256 = "0042nbgagl4gcxa5fj7bikjdi1gbk0jwyqnzc5lswpb0l5y0i1ql";

--- a/pkgs/by-name/st/stalonetray/package.nix
+++ b/pkgs/by-name/st/stalonetray/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.8.5";
 
   src = fetchFromGitHub {
-    owner = "kolbusa";
+    owner = "d3adb5";
     repo = "stalonetray";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-/55oP6xA1LeLawOBkhh9acaDcObO4L4ojcy7e3vwnBw=";
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Stand alone tray";
-    homepage = "https://github.com/kolbusa/stalonetray";
+    homepage = "https://github.com/d3adb5/stalonetray";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ raskin ];

--- a/pkgs/by-name/st/stargate-libcds/package.nix
+++ b/pkgs/by-name/st/stargate-libcds/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.0.0";
 
   src = fetchFromGitHub {
-    owner = "stargateaudio";
+    owner = "d3v-t00Lz";
     repo = "libcds";
     rev = finalAttrs.version;
     sha256 = "sha256-THThEzS8gGdwn3h0EBttaX5ljZH9Ma2Rcg143+GIdU8=";
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Fix for building on darwin
     (fetchpatch {
       name = "malloc-to-stdlib.patch";
-      url = "https://github.com/stargateaudio/libcds/commit/65dc08f059deda8ba5707ba6116b616d0ad0bd8d.patch";
+      url = "https://github.com/d3v-t00Lz/libcds/commit/65dc08f059deda8ba5707ba6116b616d0ad0bd8d.patch";
       sha256 = "sha256-FIGlobUVrDYOtnHjsWyE420PoULPHEK/3T9Fv8hfTl4=";
     })
   ];
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "C data structure library";
-    homepage = "https://github.com/stargateaudio/libcds";
+    homepage = "https://github.com/d3v-t00Lz/libcds";
     maintainers = [ ];
     license = lib.licenses.lgpl3Only;
   };

--- a/pkgs/by-name/st/stderred/package.nix
+++ b/pkgs/by-name/st/stderred/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "unstable-2021-04-28";
 
   src = fetchFromGitHub {
-    owner = "sickill";
+    owner = "ku1ik";
     repo = "stderred";
     rev = "b2238f7c72afb89ca9aaa2944d7f4db8141057ea";
     sha256 = "sha256-k/EA327AsRHgUYu7QqSF5yzOyO6h5XcE9Uv4l1VcIPI=";
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Colorize all stderr output that goes to terminal, making it distinguishable from stdout";
-    homepage = "https://github.com/sickill/stderred";
+    homepage = "https://github.com/ku1ik/stderred";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ vojta001 ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/st/strawberry/package.nix
+++ b/pkgs/by-name/st/strawberry/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.2.18";
 
   src = fetchFromGitHub {
-    owner = "jonaski";
+    owner = "strawberrymusicplayer";
     repo = "strawberry";
     rev = finalAttrs.finalPackage.version;
     hash = "sha256-5h1psYJDKnFFgIGZY3ecCttgkR+zuUwa3b/A4keLk9o=";

--- a/pkgs/by-name/st/string-view-lite/package.nix
+++ b/pkgs/by-name/st/string-view-lite/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.8.0";
 
   src = fetchFromGitHub {
-    owner = "martinmoene";
+    owner = "nonstd-lite";
     repo = "string-view-lite";
     tag = "v${finalAttrs.version}";
     hash = "sha256-hXm3MLskeZzTegSj79dQV+VcwBatT1VIAUydjisd19U=";
@@ -30,8 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "C++17-like string_view for C++98, C++11 and later in a single-file header-only library";
-    homepage = "https://github.com/martinmoene/string-view-lite";
-    changelog = "https://github.com/martinmoene/string-view-lite/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/nonstd-lite/string-view-lite";
+    changelog = "https://github.com/nonstd-lite/string-view-lite/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.boost;
     maintainers = with lib.maintainers; [ titaniumtown ];
   };

--- a/pkgs/by-name/su/super-productivity/package.nix
+++ b/pkgs/by-name/su/super-productivity/package.nix
@@ -23,7 +23,7 @@ buildNpmPackage rec {
   inherit nodejs;
 
   src = fetchFromGitHub {
-    owner = "johannesjo";
+    owner = "super-productivity";
     repo = "super-productivity";
     tag = "v${version}";
     hash = "sha256-LPLbHmUsFS0iw0iUfWrc4fXJ+/R33ne7aWcPKEtgtyc=";

--- a/pkgs/by-name/sw/swapview/package.nix
+++ b/pkgs/by-name/sw/swapview/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage {
 
   src = fetchFromGitHub {
     owner = "lilydjwg";
-    repo = "swapview";
+    repo = "smapview";
     rev = "cc8e863acd2084413b91572357dab34551c27ed7";
     sha256 = "sha256-H5jMdmtZoN9nQfjXFQyYbuvPY58jmEP2j/XWGdBocFo=";
   };
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage {
   meta = {
     description = "Simple program to view processes' swap usage on Linux";
     mainProgram = "swapview";
-    homepage = "https://github.com/lilydjwg/swapview";
+    homepage = "https://github.com/lilydjwg/smapview";
     platforms = lib.platforms.linux;
     license = with lib.licenses; [ bsd3 ];
     maintainers = with lib.maintainers; [ oxalica ];

--- a/pkgs/by-name/sx/sxiv/package.nix
+++ b/pkgs/by-name/sx/sxiv/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
-    owner = "muennich";
+    owner = "xyb3rt";
     repo = "sxiv";
     tag = "v${finalAttrs.version}";
     hash = "sha256-jrCEx1o7Go0jgwQ3YJ0L97Q5BCHvVTTqOWId3xzlSnU=";
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Simple X Image Viewer";
-    homepage = "https://github.com/muennich/sxiv";
+    homepage = "https://github.com/xyb3rt/sxiv";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ h7x4 ];

--- a/pkgs/by-name/sy/synergy/package.nix
+++ b/pkgs/by-name/sy/synergy/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "symless";
-    repo = "synergy-core";
+    repo = "synergy";
     rev = finalAttrs.version;
     hash = "sha256-0QqklfSsvcXh7I2jaHk82k0nY8gQOj9haA4WOjGqBqY=";
     fetchSubmodules = true;
@@ -142,7 +142,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Share one mouse and keyboard between multiple computers";
     homepage = "https://symless.com/synergy";
-    changelog = "https://github.com/symless/synergy-core/blob/${finalAttrs.version}/ChangeLog";
+    changelog = "https://github.com/symless/synergy/blob/${finalAttrs.version}/ChangeLog";
     mainProgram = lib.optionalString (!withGUI) "synergyc";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ talyz ];

--- a/pkgs/by-name/sy/syntex/package.nix
+++ b/pkgs/by-name/sy/syntex/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   version = "0.0pre20160915";
   src = fetchFromGitHub {
     owner = "mxgmn";
-    repo = "SynTex";
+    repo = "TextureSynthesis";
     rev = "f499a7c8112be4a63eb44843ba72957c2c9a04db";
     sha256 = "13fz6frlxsdz8qq94fsvim27cd5klmdsax5109yxm9175vgvpa0a";
   };

--- a/pkgs/by-name/ta/tabularis/package.nix
+++ b/pkgs/by-name/ta/tabularis/package.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.9.12";
 
   src = fetchFromGitHub {
-    owner = "debba";
+    owner = "TabularisDB";
     repo = "tabularis";
     tag = "v${finalAttrs.version}";
     hash = "sha256-kObjJ+C+0d/wLNt902yUPe8Cvss8d0ILeuo98vIiYDU=";
@@ -71,7 +71,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Lightweight, developer-focused database management tool, built with Tauri and React";
     homepage = "http://tabularis.dev";
-    changelog = "https://github.com/debba/tabularis/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/TabularisDB/tabularis/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     inherit (cargo-tauri.hook.meta) platforms;
     maintainers = with lib.maintainers; [ nartsiss ];

--- a/pkgs/by-name/ta/tagger/package.nix
+++ b/pkgs/by-name/ta/tagger/package.nix
@@ -19,8 +19,8 @@ buildDotnetModule rec {
   version = "2024.6.0-1";
 
   src = fetchFromGitHub {
-    owner = "nlogozzo";
-    repo = "NickvisionTagger";
+    owner = "NickvisionApps";
+    repo = "Tagger";
     rev = version;
     hash = "sha256-4OfByQYhLXmeFWxzhqt8d7pLUyuMLhDM20E2YcA9Q3s=";
   };

--- a/pkgs/by-name/ta/tandem-aligner/package.nix
+++ b/pkgs/by-name/ta/tandem-aligner/package.nix
@@ -13,15 +13,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "seryrzu";
-    repo = "tandem_aligner";
+    repo = "unialigner";
     rev = "v${finalAttrs.version}";
     hash = "sha256-iMDj1HZ8LzmZckuAM3lbG3eSJSd/5JGVA6SBs7+AgX8=";
   };
 
   patches = [
     (fetchpatch {
-      # https://github.com/seryrzu/tandem_aligner/pull/4
-      url = "https://github.com/seryrzu/tandem_aligner/commit/8b516c94f90aaa9cb84278aa811285d4204b03a9.patch";
+      # https://github.com/seryrzu/unialigner/pull/4
+      url = "https://github.com/seryrzu/unialigner/commit/8b516c94f90aaa9cb84278aa811285d4204b03a9.patch";
       hash = "sha256-kD46SykXklG/avK0+sc61YKFw9Bes8ZgFAjVXmcpN8k=";
       stripLen = 1;
     })
@@ -58,8 +58,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Parameter-free algorithm for sequence alignment";
-    homepage = "https://github.com/seryrzu/tandem_aligner";
-    changelog = "https://github.com/seryrzu/tandem_aligner/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/seryrzu/unialigner";
+    changelog = "https://github.com/seryrzu/unialigner/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ matthiasbeyer ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/ta/tango/package.nix
+++ b/pkgs/by-name/ta/tango/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "1.1.0";
 
   src = fetchFromGitHub {
-    owner = "masakichi";
+    owner = "yuanji-dev";
     repo = "tango";
     rev = "v${finalAttrs.version}";
     hash = "sha256-e/M2iRm/UwfnRVnMo1PmQTkz4IGTxnsCXNSSUkhsiHk=";
@@ -19,7 +19,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Local command-line Japanese dictionary tool using yomichan's dictionary files";
-    homepage = "https://github.com/masakichi/tango";
+    homepage = "https://github.com/yuanji-dev/tango";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ donovanglover ];
     mainProgram = "tango";

--- a/pkgs/by-name/tb/tbe/package.nix
+++ b/pkgs/by-name/tb/tbe/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.9.3.1";
 
   src = fetchFromGitHub {
-    owner = "kaa-ching";
+    owner = "the-butterfly-effect";
     repo = "tbe";
     tag = "v${finalAttrs.version}";
     hash = "sha256-UnvFr/ofk6CgtBv6ua8XjZAWScFGfeNx+is5Q8Zl4qk=";

--- a/pkgs/by-name/te/tektoncd-cli-pac/package.nix
+++ b/pkgs/by-name/te/tektoncd-cli-pac/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
   version = "0.41.1";
 
   src = fetchFromGitHub {
-    owner = "openshift-pipelines";
+    owner = "tektoncd";
     repo = "pipelines-as-code";
     tag = "v${finalAttrs.version}";
     hash = "sha256-ZuYaYBSDpU2NCBssw+j3cP4jV6t+pCezFrQRQBS/zKk=";
@@ -51,7 +51,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     homepage = "https://pipelinesascode.com";
-    changelog = "https://github.com/openshift-pipelines/pipelines-as-code/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/tektoncd/pipelines-as-code/releases/tag/v${finalAttrs.version}";
     description = "CLI for interacting with Tekton Pipelines as Code";
     longDescription = ''
       tkn-pac CLI Plugin – Easily manage Pipelines-as-Code repositories.

--- a/pkgs/by-name/te/teler/package.nix
+++ b/pkgs/by-name/te/teler/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "2.0.0";
 
   src = fetchFromGitHub {
-    owner = "kitabisa";
+    owner = "teler-sh";
     repo = "teler";
     tag = "v${finalAttrs.version}";
     hash = "sha256-3+A1QloZQlH31snWfwYa6rprpKUf3fQc/HQgmKQgV9c=";
@@ -33,8 +33,8 @@ buildGoModule (finalAttrs: {
       based on web log that runs in a terminal with resources that
       we collect and provide by the community.
     '';
-    homepage = "https://github.com/kitabisa/teler";
-    changelog = "https://github.com/kitabisa/teler/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/teler-sh/teler";
+    changelog = "https://github.com/teler-sh/teler/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "teler.app";

--- a/pkgs/by-name/te/telescope/package.nix
+++ b/pkgs/by-name/te/telescope/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.11";
 
   src = fetchFromGitHub {
-    owner = "omar-polo";
+    owner = "telescope-browser";
     repo = "telescope";
     tag = finalAttrs.version;
     hash = "sha256-GKeUXa4RKYkoywrCrpenfLt10Rdj9L0xYI3tf2hFAbk=";

--- a/pkgs/by-name/te/terranix/package.nix
+++ b/pkgs/by-name/te/terranix/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.8.0";
 
   src = fetchFromGitHub {
-    owner = "mrVanDalo";
+    owner = "terranix";
     repo = "terranix";
     rev = finalAttrs.version;
     sha256 = "sha256-1Pu2j5xsBTuoyga08ZVf+rKp3FOMmJh/0fXen/idOrA=";

--- a/pkgs/by-name/te/terrascan/package.nix
+++ b/pkgs/by-name/te/terrascan/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "1.19.9";
 
   src = fetchFromGitHub {
-    owner = "accurics";
+    owner = "tenable";
     repo = "terrascan";
     tag = "v${finalAttrs.version}";
     hash = "sha256-4XIhmUUOSROwEPSB+DcMOfG5+q/pmWkVUwKGrWVcNtM=";
@@ -33,7 +33,7 @@ buildGoModule (finalAttrs: {
       mitigate risk before provisioning cloud native infrastructure. It contains
       500+ polices and support for Terraform and Kubernetes.
     '';
-    homepage = "https://github.com/accurics/terrascan";
+    homepage = "https://github.com/tenable/terrascan";
     changelog = "https://github.com/tenable/terrascan/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [ asl20 ];
     maintainers = with lib.maintainers; [ fab ];

--- a/pkgs/by-name/te/testssl/package.nix
+++ b/pkgs/by-name/te/testssl/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.2.3";
 
   src = fetchFromGitHub {
-    owner = "drwetter";
+    owner = "testssl";
     repo = "testssl.sh";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-hR+EhAkv7EXMhBu8wEF6yjpvMzLJZcjH+Jdji0EQkgY=";

--- a/pkgs/by-name/th/thcrap-steam-proton-wrapper/package.nix
+++ b/pkgs/by-name/th/thcrap-steam-proton-wrapper/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation {
   version = "0-unstable-2024-04-03";
 
   src = fetchFromGitHub {
-    owner = "tactikauan";
+    owner = "nerusuki";
     repo = "thcrap-steam-proton-wrapper";
     rev = "2b636c3f5f1ce1b9b41f731aa9397aa68d2ce66b";
     hash = "sha256-J2O8F75NMdsxSaNVr8zLf+vLEJE6CHqWQIIscuuJZ3o=";
@@ -44,7 +44,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Wrapper script for launching the official Touhou games on Steam with patches through Proton on GNU/Linux";
-    homepage = "https://github.com/tactikauan/thcrap-steam-proton-wrapper";
+    homepage = "https://github.com/nerusuki/thcrap-steam-proton-wrapper";
     license = lib.licenses.unlicense;
     maintainers = with lib.maintainers; [ ashuramaruzxc ];
     platforms = [

--- a/pkgs/by-name/th/thokr/package.nix
+++ b/pkgs/by-name/th/thokr/package.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.4.1";
 
   src = fetchFromGitHub {
-    owner = "thatvegandev";
+    owner = "jrnxf";
     repo = "thokr";
     rev = "v${finalAttrs.version}";
     sha256 = "0aryfx9qlnjdq3iq2d823c82fhkafvibmbz58g48b8ah5x5fv3ir";
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Typing tui with visualized results and historical logging";
-    homepage = "https://github.com/thatvegandev/thokr";
+    homepage = "https://github.com/jrnxf/thokr";
     license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "thokr";

--- a/pkgs/by-name/th/thunderbolt/package.nix
+++ b/pkgs/by-name/th/thunderbolt/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "thunderbolt";
   version = "0.9.3";
   src = fetchFromGitHub {
-    owner = "01org";
+    owner = "intel";
     repo = "thunderbolt-software-user-space";
     rev = "v${finalAttrs.version}";
     sha256 = "02w1bfm7xvq0dzkhwqiq0camkzz9kvciyhnsis61c8vzp39cwx0x";

--- a/pkgs/by-name/ti/tinyauth/package.nix
+++ b/pkgs/by-name/ti/tinyauth/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
   version = "5.0.7";
 
   src = fetchFromGitHub {
-    owner = "steveiliop56";
+    owner = "tinyauthapp";
     repo = "tinyauth";
     tag = "v${finalAttrs.version}";
     hash = "sha256-VeII5jSNUJpGZgqons1o1fp6KXxDOBhSMciSqtQfaC4=";
@@ -27,8 +27,8 @@ buildGoModule (finalAttrs: {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/steveiliop56/tinyauth/internal/config.Version=v${finalAttrs.version}"
-    "-X github.com/steveiliop56/tinyauth/internal/config.CommitHash=${finalAttrs.src.rev}"
+    "-X github.com/tinyauthapp/tinyauth/internal/config.Version=v${finalAttrs.version}"
+    "-X github.com/tinyauthapp/tinyauth/internal/config.CommitHash=${finalAttrs.src.rev}"
   ];
 
   preBuild = ''
@@ -95,7 +95,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Simple authentication middleware for web apps";
     homepage = "https://tinyauth.app";
-    changelog = "https://github.com/steveiliop56/tinyauth/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/tinyauthapp/tinyauth/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
     mainProgram = "tinyauth";
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/tl/tlrender/package.nix
+++ b/pkgs/by-name/tl/tlrender/package.nix
@@ -56,14 +56,14 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.10.0";
 
   src = fetchFromGitHub {
-    owner = "darbyjohnston";
+    owner = "grizzlypeak3d";
     repo = "tlRender";
     tag = finalAttrs.version;
     hash = "sha256-TxiDZtMvNmrV1FKXZnekCZHnr/eCWZlsP6VJRnaoWg4=";
   };
 
   patches = [
-    # Minizip-ng 4 support: https://github.com/darbyjohnston/tlRender/pull/145
+    # Minizip-ng 4 support: https://github.com/grizzlypeak3d/tlRender/pull/145
     ./minizip-ng-4.patch
   ];
 
@@ -147,7 +147,7 @@ stdenv.mkDerivation (finalAttrs: {
       image sequences, audio clips, and transitions. Examples are provided for
       integrating the library with Qt and OpenGL applications.
     '';
-    homepage = "https://github.com/darbyjohnston/tlRender";
+    homepage = "https://github.com/grizzlypeak3d/tlRender";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ yzx9 ];
     platforms = with lib.platforms; linux ++ darwin;

--- a/pkgs/by-name/to/topiary/package.nix
+++ b/pkgs/by-name/to/topiary/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.7.3";
 
   src = fetchFromGitHub {
-    owner = "tweag";
+    owner = "topiary";
     repo = "topiary";
     tag = "v${finalAttrs.version}";
     hash = "sha256-3zHO+a/m4Rv+pUm0Y1dBjFfHPZCfjsyAq56EiHSGJ1Y=";
@@ -86,8 +86,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Uniform formatter for simple languages, as part of the Tree-sitter ecosystem";
-    homepage = "https://github.com/tweag/topiary";
-    changelog = "https://github.com/tweag/topiary/blob/v${finalAttrs.version}/CHANGELOG.md";
+    homepage = "https://github.com/topiary/topiary";
+    changelog = "https://github.com/topiary/topiary/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       nartsiss

--- a/pkgs/by-name/tr/trimal/package.nix
+++ b/pkgs/by-name/tr/trimal/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     repo = "trimal";
-    owner = "scapella";
+    owner = "inab";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-ONSkYceCgYGSpABj0iOx6yj2hMyFHqCHflYRW+Q6RVc=";
   };

--- a/pkgs/by-name/tr/trunk-recorder/package.nix
+++ b/pkgs/by-name/tr/trunk-recorder/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "5.1.1";
 
   src = fetchFromGitHub {
-    owner = "robotastic";
+    owner = "TrunkRecorder";
     repo = "trunk-recorder";
     rev = "v${finalAttrs.version}";
     hash = "sha256-2qy6krI5NglkC+bUFfJaEuHIcBoYJrxBRnFs8O0NcZA=";
@@ -72,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Record calls from trunked radio systems";
     homepage = "https://trunkrecorder.com/";
-    changelog = "https://github.com/robotastic/trunk-recorder/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/TrunkRecorder/trunk-recorder/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ PapayaJackal ];
     mainProgram = "trunk-recorder";

--- a/pkgs/by-name/tu/tuner/package.nix
+++ b/pkgs/by-name/tu/tuner/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.0.0";
 
   src = fetchFromGitHub {
-    owner = "louis77";
+    owner = "tuner-labs";
     repo = "tuner";
     tag = "v${finalAttrs.version}";
     hash = "sha256-i6I5NSwiS8FJuZaHbrXvUcumo9RZvEVPcfKOkHUXiLo=";
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    homepage = "https://github.com/louis77/tuner";
+    homepage = "https://github.com/tuner-labs/tuner";
     description = "App to discover and play internet radio stations";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/tv/tvm/package.nix
+++ b/pkgs/by-name/tv/tvm/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "apache";
-    repo = "incubator-tvm";
+    repo = "tvm";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-+YnxYIGaPMgfLDsQEiCpqGuJRBTFEbXWI1L2JdnUyfI=";

--- a/pkgs/by-name/ty/tyson/package.nix
+++ b/pkgs/by-name/ty/tyson/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   version = "0.1.1-unstable-2024-04-10";
 
   src = fetchFromGitHub {
-    owner = "jetpack-io";
+    owner = "jetify-com";
     repo = "tyson";
     rev = "d6b38819db9b260928b29f4d39bf4c72841c6a01";
     hash = "sha256-NoQJBEedV3NDNQ4PVvvjjsO7N+rq40LWKp962P+naEY=";

--- a/pkgs/by-name/ue/uesave/package.nix
+++ b/pkgs/by-name/ue/uesave/package.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.7.1";
   src = fetchFromGitHub {
     owner = "trumank";
-    repo = "uesave-rs";
+    repo = "uesave";
     rev = "v${finalAttrs.version}";
     hash = "sha256-lGtRe3AYJ59CwRaDznO6RNqVFCSKJPWVDhj0tnY5xcs=";
   };
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     maintainers = with lib.maintainers; [ xddxdd ];
     description = "Reading and writing Unreal Engine save files (commonly referred to as GVAS)";
-    homepage = "https://github.com/trumank/uesave-rs";
+    homepage = "https://github.com/trumank/uesave";
     license = lib.licenses.mit;
     mainProgram = "uesave";
   };

--- a/pkgs/by-name/ul/ultimate-doom-builder/package.nix
+++ b/pkgs/by-name/ul/ultimate-doom-builder/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0-unstable-2026-02-01";
 
   src = fetchFromGitHub {
-    owner = "jewalky";
+    owner = "UltimateDoomBuilder";
     repo = "UltimateDoomBuilder";
     rev = "9d7a12b1164dc53964b594395f9d5d825a43ac12";
     hash = "sha256-FwGfrvF+UrmEw1lvcU4qL9OOP0n/ZmQTsIjQIxRvkmg=";
@@ -129,7 +129,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = unstableGitUpdater { };
 
   meta = {
-    homepage = "https://github.com/jewalky/UltimateDoomBuilder";
+    homepage = "https://github.com/UltimateDoomBuilder/UltimateDoomBuilder";
     description = "Advanced Doom map editor based on Doom Builder 2 with Mono support";
     mainProgram = "ultimate-doom-builder";
     longDescription = ''

--- a/pkgs/by-name/ul/ultralist/package.nix
+++ b/pkgs/by-name/ul/ultralist/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "1.7.0";
 
   src = fetchFromGitHub {
-    owner = "ultralist";
+    owner = "gammons";
     repo = "ultralist";
     rev = finalAttrs.version;
     sha256 = "sha256-GGBW6rpwv1bVbLTD//cU8jNbq/27Ls0su7DymCJTSmY=";

--- a/pkgs/by-name/un/unpackerr/package.nix
+++ b/pkgs/by-name/un/unpackerr/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "0.15.2";
 
   src = fetchFromGitHub {
-    owner = "davidnewhall";
+    owner = "Unpackerr";
     repo = "unpackerr";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-npq0CXsaWaFa6RazQXRKVaqTyK87VhzaF/hd/d952Po=";

--- a/pkgs/by-name/ut/utpm/package.nix
+++ b/pkgs/by-name/ut/utpm/package.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.3.0";
 
   src = fetchFromGitHub {
-    owner = "Thumuss";
+    owner = "typst-community";
     repo = "utpm";
     tag = "v${finalAttrs.version}";
     hash = "sha256-MGvPj+qF05zc2rPf1LxWVIpkZGOoDj09UfCZbQ/lBOM=";
@@ -53,7 +53,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       new projects and templates from a singular tool, and then publish it directly
       to Typst!
     '';
-    homepage = "https://github.com/Thumuss/utpm";
+    homepage = "https://github.com/typst-community/utpm";
     license = lib.licenses.mit;
     mainProgram = "utpm";
     maintainers = with lib.maintainers; [ louis-thevenet ];

--- a/pkgs/by-name/uw/uwufetch/package.nix
+++ b/pkgs/by-name/uw/uwufetch/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.1";
 
   src = fetchFromGitHub {
-    owner = "TheDarkBug";
+    owner = "ad-oliviero";
     repo = "uwufetch";
     rev = finalAttrs.version;
     hash = "sha256-cA8sajh+puswyKikr0Jp9ei+EpVkH+vhEp+pTerkUqA=";
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Meme system info tool for Linux";
-    homepage = "https://github.com/TheDarkBug/uwufetch";
+    homepage = "https://github.com/ad-oliviero/uwufetch";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ bbjubjub ];

--- a/pkgs/by-name/va/vale-ls/package.nix
+++ b/pkgs/by-name/va/vale-ls/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.4.0";
 
   src = fetchFromGitHub {
-    owner = "errata-ai";
+    owner = "vale-cli";
     repo = "vale-ls";
     tag = "v${finalAttrs.version}";
     hash = "sha256-lRRKRQTxgXF4E+XghJ5AOp+mtWtiCT13EcsPVydn4Uo=";
@@ -51,7 +51,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "LSP implementation for the Vale command-line tool";
-    homepage = "https://github.com/errata-ai/vale-ls";
+    homepage = "https://github.com/vale-cli/vale-ls";
     license = lib.licenses.mit;
     mainProgram = "vale-ls";
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/va/vale/package.nix
+++ b/pkgs/by-name/va/vale/package.nix
@@ -16,7 +16,7 @@ buildGoModule rec {
   subPackages = [ "cmd/vale" ];
 
   src = fetchFromGitHub {
-    owner = "errata-ai";
+    owner = "vale-cli";
     repo = "vale";
     tag = "v${version}";
     hash = "sha256-cjJ1LDTIaEJaaQigcofi+CfsSVWf3IRsUmxh/T9W7ec=";
@@ -61,7 +61,7 @@ buildGoModule rec {
       ```
     '';
     homepage = "https://vale.sh/";
-    changelog = "https://github.com/errata-ai/vale/releases/tag/v${version}";
+    changelog = "https://github.com/vale-cli/vale/releases/tag/v${version}";
     mainProgram = "vale";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ pbsds ];

--- a/pkgs/by-name/va/vapoursynth-eedi3/package.nix
+++ b/pkgs/by-name/va/vapoursynth-eedi3/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   version = "unstable-2019-09-30";
 
   src = fetchFromGitHub {
-    owner = "HomeOfVapourSynthEvolution";
+    owner = "HolyWu";
     repo = "VapourSynth-EEDI3";
     rev = "d11bdb37c7a7118cd095b53d9f8fbbac02a06ac0";
     hash = "sha256-MIUf6sOnJ2uqGw3ixEHy1ijzlLFkQauwtm1vfgmYmcg=";
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Filter for VapourSynth";
-    homepage = "https://github.com/HomeOfVapourSynthEvolution/VapourSynth-EEDI3";
+    homepage = "https://github.com/HolyWu/VapourSynth-EEDI3";
     license = with lib.licenses; [ gpl2Plus ];
     maintainers = with lib.maintainers; [ snaki ];
     platforms = lib.platforms.x86_64;

--- a/pkgs/by-name/va/vapoursynth-mvtools/package.nix
+++ b/pkgs/by-name/va/vapoursynth-mvtools/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "24";
 
   src = fetchFromGitHub {
-    owner = "dubhater";
+    owner = "dubhatervapoursynth";
     repo = "vapoursynth-mvtools";
     rev = "v${finalAttrs.version}";
     hash = "sha256-bEifU1PPNOBr6o9D6DGIzTaG4xjygBxkQYnZxd/4SwQ=";
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Set of filters for motion estimation and compensation";
-    homepage = "https://github.com/dubhater/vapoursynth-mvtools";
+    homepage = "https://github.com/dubhatervapoursynth/vapoursynth-mvtools";
     license = lib.licenses.gpl2;
     maintainers = with lib.maintainers; [ rnhmjoj ];
   };

--- a/pkgs/by-name/va/variant-lite/package.nix
+++ b/pkgs/by-name/va/variant-lite/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.0.0";
 
   src = fetchFromGitHub {
-    owner = "martinmoene";
+    owner = "nonstd-lite";
     repo = "variant-lite";
     tag = "v${finalAttrs.version}";
     hash = "sha256-+1eSnn7eN8iN6vZg3Qz2m7u1ukWimhUQ+WHXQL4rQco=";
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    # https://github.com/martinmoene/variant-lite/issues/50
+    # https://github.com/nonstd-lite/variant-lite/issues/50
     (lib.cmakeBool "VARIANT_LITE_OPT_BUILD_TESTS" false)
   ];
 
@@ -35,8 +35,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "C++17-like variant, a type-safe union for C++98, C++11 and later in a single-file header-only library";
-    homepage = "https://github.com/martinmoene/variant-lite";
-    changelog = "https://github.com/martinmoene/variant-lite/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/nonstd-lite/variant-lite";
+    changelog = "https://github.com/nonstd-lite/variant-lite/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.boost;
     maintainers = with lib.maintainers; [ titaniumtown ];
   };

--- a/pkgs/by-name/va/vazir-fonts/package.nix
+++ b/pkgs/by-name/va/vazir-fonts/package.nix
@@ -10,7 +10,7 @@ stdenvNoCC.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "rastikerdar";
-    repo = "vazir-font";
+    repo = "vazirmatn";
     rev = "v${version}";
     hash = "sha256-C1UtfrRFzz0uv/hj8e7huXe4sNd5h7ozVhirWEAyXGg=";
   };
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   meta = {
-    homepage = "https://github.com/rastikerdar/vazir-font";
+    homepage = "https://github.com/rastikerdar/vazirmatn";
     description = "Persian (Farsi) Font - قلم (فونت) فارسی وزیر";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/ve/velero/package.nix
+++ b/pkgs/by-name/ve/velero/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   version = "1.18.0";
 
   src = fetchFromGitHub {
-    owner = "vmware-tanzu";
+    owner = "velero-io";
     repo = "velero";
     tag = "v${finalAttrs.version}";
     hash = "sha256-LhoJDIK0S3w2RTpMC7QDcU1nHMUk4rNZSCY/1Wfiaqc=";
@@ -35,7 +35,7 @@ buildGoModule (finalAttrs: {
     "velero-restic-restore-helper"
   ];
 
-  doCheck = false; # Tests expect a running cluster see https://github.com/vmware-tanzu/velero/tree/main/test/e2e
+  doCheck = false; # Tests expect a running cluster see https://github.com/velero-io/velero/tree/main/test/e2e
   doInstallCheck = true;
   installCheckPhase = ''
     $out/bin/velero version --client-only | grep ${finalAttrs.version} > /dev/null
@@ -51,7 +51,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Utility for managing disaster recovery, specifically for your Kubernetes cluster resources and persistent volumes";
     homepage = "https://velero.io/";
-    changelog = "https://github.com/vmware-tanzu/velero/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/velero-io/velero/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       mbode

--- a/pkgs/by-name/ve/vendir/package.nix
+++ b/pkgs/by-name/ve/vendir/package.nix
@@ -9,8 +9,8 @@ buildGoModule (finalAttrs: {
   version = "0.45.3";
 
   src = fetchFromGitHub {
-    owner = "vmware-tanzu";
-    repo = "carvel-vendir";
+    owner = "carvel-dev";
+    repo = "vendir";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-pGChtADYje6tGM0qYTwSrGQkUu6P1N8AZiXLJDWoYjA=";
   };

--- a/pkgs/by-name/vi/vipsdisp/package.nix
+++ b/pkgs/by-name/vi/vipsdisp/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   version = "4.1.4";
 
   src = fetchFromGitHub {
-    owner = "jcupitt";
+    owner = "libvips";
     repo = "vipsdisp";
     tag = "v${version}";
     hash = "sha256-DXXDU/EtpWfNvV0PhQ+qjlxTBNERn9GGNeD00n9ejN0=";
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
   doCheck = false;
 
   meta = {
-    homepage = "https://github.com/jcupitt/vipsdisp";
+    homepage = "https://github.com/libvips/vipsdisp";
     description = "Tiny image viewer with libvips";
     license = lib.licenses.mit;
     mainProgram = "vipsdisp";

--- a/pkgs/by-name/vt/vtm/package.nix
+++ b/pkgs/by-name/vt/vtm/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.9.99.61";
 
   src = fetchFromGitHub {
-    owner = "netxs-group";
+    owner = "directvt";
     repo = "vtm";
     rev = "v${finalAttrs.version}";
     hash = "sha256-IlJbJw2c2Zgl+W5Jh01Iga8duiLgl/GurT620IhPh68=";

--- a/pkgs/by-name/wa/wagyu/package.nix
+++ b/pkgs/by-name/wa/wagyu/package.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.6.3";
 
   src = fetchFromGitHub {
-    owner = "AleoHQ";
+    owner = "howardwu";
     repo = "wagyu";
     rev = "v${finalAttrs.version}";
     hash = "sha256-5n8BmETv5jUvgu0rskAPYaBgYyNL2QU2t/iUb3hNMMw=";
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Rust library for generating cryptocurrency wallets";
-    homepage = "https://github.com/AleoHQ/wagyu";
+    homepage = "https://github.com/howardwu/wagyu";
     license = with lib.licenses; [
       mit
       asl20

--- a/pkgs/by-name/wa/waydroid-helper/package.nix
+++ b/pkgs/by-name/wa/waydroid-helper/package.nix
@@ -29,7 +29,7 @@ let
   version = "0.2.7";
 
   src = fetchFromGitHub {
-    owner = "ayasa520";
+    owner = "waydroid-helper";
     repo = "waydroid-helper";
     tag = "v${version}";
     hash = "sha256-I8DwaPQQz4eSyuTCwkbidhXACfpdOYcmGjP7d03DIU0=";
@@ -112,9 +112,9 @@ python3Packages.buildPythonApplication {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    changelog = "https://github.com/ayasa520/waydroid-helper/releases/tag/${src.tag}";
+    changelog = "https://github.com/waydroid-helper/waydroid-helper/releases/tag/${src.tag}";
     description = "User-friendly way to configure Waydroid and install extensions, including Magisk and ARM translation";
-    homepage = "https://github.com/ayasa520/waydroid-helper";
+    homepage = "https://github.com/waydroid-helper/waydroid-helper";
     license = with lib.licenses; [ gpl3Plus ];
     mainProgram = "waydroid-helper";
     maintainers = [ ];

--- a/pkgs/by-name/wa/wayvr/package.nix
+++ b/pkgs/by-name/wa/wayvr/package.nix
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "26.2.1";
 
   src = fetchFromGitHub {
-    owner = "wlx-team";
+    owner = "wayvr-org";
     repo = "wayvr";
     tag = "v${finalAttrs.version}";
     hash = "sha256-v1Wkelru825KV+ciXD9esLq39oTyMm/Z4rRbN+jjviY=";
@@ -88,7 +88,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Your way to enjoy VR on Linux! Access your Wayland/X11 desktop from SteamVR/Monado (OpenVR+OpenXR support)";
-    homepage = "https://github.com/wlx-team/wayvr";
+    homepage = "https://github.com/wayvr-org/wayvr";
     license = with lib.licenses; [
       gpl3Only
       mit # wayvr-ipc

--- a/pkgs/by-name/wa/wazero/package.nix
+++ b/pkgs/by-name/wa/wazero/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   version = "1.11.0";
 
   src = fetchFromGitHub {
-    owner = "tetratelabs";
+    owner = "wazero";
     repo = "wazero";
     tag = "v${finalAttrs.version}";
     hash = "sha256-FYaWh1zfNcgtQ5S0flk0y6ehP4ZzCwIA+SZgLnha95U=";
@@ -25,7 +25,7 @@ buildGoModule (finalAttrs: {
 
   ldflags = [
     "-s"
-    "-X=github.com/tetratelabs/wazero/internal/version.version=${finalAttrs.version}"
+    "-X=github.com/wazero/wazero/internal/version.version=${finalAttrs.version}"
   ];
 
   checkFlags = [
@@ -42,9 +42,9 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Zero dependency WebAssembly runtime for Go developers";
-    homepage = "https://github.com/tetratelabs/wazero";
+    homepage = "https://github.com/wazero/wazero";
     maintainers = with lib.maintainers; [ liberodark ];
-    changelog = "https://github.com/tetratelabs/wazero/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/wazero/wazero/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     mainProgram = "wazero";
   };

--- a/pkgs/by-name/we/wealthfolio/package.nix
+++ b/pkgs/by-name/we/wealthfolio/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "3.4.0";
 
   src = fetchFromGitHub {
-    owner = "afadil";
+    owner = "wealthfolio";
     repo = "wealthfolio";
     rev = "v${finalAttrs.version}";
     hash = "sha256-SYI0LosdR82rUubxl0pNi1huEDcR6bxcaHbjCVT/T/0=";

--- a/pkgs/by-name/wi/wild-unwrapped/package.nix
+++ b/pkgs/by-name/wi/wild-unwrapped/package.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.8.0";
 
   src = fetchFromGitHub {
-    owner = "davidlattimore";
+    owner = "wild-linker";
     repo = "wild";
     tag = finalAttrs.version;
     hash = "sha256-E5cmZuOtF+MNTPyalKjnguhin70zqtDDB0D71ZpeE48=";
@@ -46,8 +46,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Very fast linker for Linux";
-    homepage = "https://github.com/davidlattimore/wild";
-    changelog = "https://github.com/davidlattimore/wild/blob/${finalAttrs.version}/CHANGELOG.md";
+    homepage = "https://github.com/wild-linker/wild";
+    changelog = "https://github.com/wild-linker/wild/blob/${finalAttrs.version}/CHANGELOG.md";
     license = [
       lib.licenses.asl20 # or
       lib.licenses.mit

--- a/pkgs/by-name/wl/wlcs/package.nix
+++ b/pkgs/by-name/wl/wlcs/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.8.1";
 
   src = fetchFromGitHub {
-    owner = "MirServer";
+    owner = "canonical";
     repo = "wlcs";
     tag = "v${finalAttrs.version}";
     hash = "sha256-W4/a7neFcaqdPIAWDk5TcIuIWZ76rC7xCk3beJVqE/E=";
@@ -65,8 +65,8 @@ stdenv.mkDerivation (finalAttrs: {
       standard debugging tools can follow control flow from the test client to the
       compositor and back again.
     '';
-    homepage = "https://github.com/MirServer/wlcs";
-    changelog = "https://github.com/MirServer/wlcs/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/canonical/wlcs";
+    changelog = "https://github.com/canonical/wlcs/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ OPNA2608 ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/wl/wlinhibit/package.nix
+++ b/pkgs/by-name/wl/wlinhibit/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   version = "0.1.2";
 
   src = fetchFromGitHub {
-    owner = "0x5a4";
+    owner = "einetuer";
     repo = "wlinhibit";
     rev = "v0.1.2";
     hash = "sha256-mAEBnlIfW1R5+3CMH4ZumQ39Ss2K7PfW28I4/O9saWE=";
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Simple, stupid idle inhibitor for wayland";
     license = lib.licenses.mit;
-    homepage = "https://github.com/0x5a4/wlinhibit";
+    homepage = "https://github.com/einetuer/wlinhibit";
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ _0x5a4 ];
   };

--- a/pkgs/by-name/wl/wluma/package.nix
+++ b/pkgs/by-name/wl/wluma/package.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "4.10.0";
 
   src = fetchFromGitHub {
-    owner = "maximbaz";
+    owner = "max-baz";
     repo = "wluma";
     tag = finalAttrs.version;
     hash = "sha256-gO7l0VnOs6BoBxZKkkXyxiBP7JB+G8ScrfuADNveys4=";
@@ -59,8 +59,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Automatic brightness adjustment based on screen contents and ALS";
-    homepage = "https://github.com/maximbaz/wluma";
-    changelog = "https://github.com/maximbaz/wluma/releases/tag/${finalAttrs.version}";
+    homepage = "https://github.com/max-baz/wluma";
+    changelog = "https://github.com/max-baz/wluma/releases/tag/${finalAttrs.version}";
     license = lib.licenses.isc;
     maintainers = with lib.maintainers; [
       yshym

--- a/pkgs/by-name/wo/wordbook/package.nix
+++ b/pkgs/by-name/wo/wordbook/package.nix
@@ -19,7 +19,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pyproject = false; # Built with meson
 
   src = fetchFromGitHub {
-    owner = "fushinari";
+    owner = "mufeedali";
     repo = "Wordbook";
     tag = finalAttrs.version;
     hash = "sha256-oiAXSDJJtlV6EIHzi+jFv+Ym1XHCMLx9DN1YRiXZNzc=";
@@ -57,7 +57,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   meta = {
     description = "Offline English-English dictionary application built for GNOME";
     mainProgram = "wordbook";
-    homepage = "https://github.com/fushinari/Wordbook";
+    homepage = "https://github.com/mufeedali/Wordbook";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ zendo ];

--- a/pkgs/by-name/wo/world-serpant-search/package.nix
+++ b/pkgs/by-name/wo/world-serpant-search/package.nix
@@ -11,7 +11,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "Latrodect";
-    repo = "wss-repo-vulnerability-search-manager";
+    repo = "WSS";
     tag = "v${finalAttrs.version}";
     hash = "sha256-jXTivaXHHt63u9N7w40jyLUU2kg5LxAn50PVpqwUc0M=";
   };
@@ -32,7 +32,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   meta = {
     description = "Command-line tool for vulnerability detection";
-    homepage = "https://github.com/Latrodect/wss-repo-vulnerability-search-manager";
+    homepage = "https://github.com/Latrodect/WSS";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "serpant";

--- a/pkgs/by-name/wp/wprecon/package.nix
+++ b/pkgs/by-name/wp/wprecon/package.nix
@@ -9,7 +9,7 @@ buildGoModule rec {
   version = "2.4.5";
 
   src = fetchFromGitHub {
-    owner = "blackbinn";
+    owner = "ffx64";
     repo = "wprecon";
     rev = version;
     hash = "sha256-23zJD3Nnkeko+J2FjPq5RA5dIjORMXvwt3wtAYiVlQs=";
@@ -24,9 +24,9 @@ buildGoModule rec {
 
   meta = {
     description = "WordPress vulnerability recognition tool";
-    homepage = "https://github.com/blackbinn/wprecon";
+    homepage = "https://github.com/ffx64/wprecon";
     # License Zero Noncommercial Public License 2.0.1
-    # https://github.com/blackbinn/wprecon/blob/master/LICENSE
+    # https://github.com/ffx64/wprecon/blob/master/LICENSE
     license = with lib.licenses; [ unfree ];
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/by-name/wr/wrap/package.nix
+++ b/pkgs/by-name/wr/wrap/package.nix
@@ -12,7 +12,7 @@ buildGoModule (finalAttrs: {
   version = "0.3.1";
 
   src = fetchFromGitHub {
-    owner = "Wraparound";
+    owner = "eprovst";
     repo = "wrap";
     rev = "v${finalAttrs.version}";
     hash = "sha256-58wsH/e3X72S7tJUObazyvvkI8+B7DLPTBmQO9A+jmk=";
@@ -25,12 +25,12 @@ buildGoModule (finalAttrs: {
   patches = [
     (fetchpatch {
       name = "courier-prime-variants.patch";
-      url = "https://github.com/Wraparound/wrap/commit/b72c280b6eddba9ec7b3507c1f143eb28a85c9c1.patch";
+      url = "https://github.com/eprovst/wrap/commit/b72c280b6eddba9ec7b3507c1f143eb28a85c9c1.patch";
       hash = "sha256-hcUsRyv6XVN+GyMN7LXzXPsp8jYUKTJPaK+e5p4CO7U=";
     })
     # Fix build on Go 1.17+
     (fetchpatch {
-      url = "https://github.com/Wraparound/wrap/commit/a222c18a7e0810486741684781ff6158a359a8ba.patch";
+      url = "https://github.com/eprovst/wrap/commit/a222c18a7e0810486741684781ff6158a359a8ba.patch";
       hash = "sha256-eIKvA91olfbNJhOhIUu3GOL/rbgX3m6unmU8nRdKbtc=";
     })
   ];
@@ -41,7 +41,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Fountain export tool with some extras";
-    homepage = "https://github.com/Wraparound/wrap";
+    homepage = "https://github.com/eprovst/wrap";
     license = lib.licenses.gpl3Only;
     maintainers = [ lib.maintainers.austinbutler ];
   };

--- a/pkgs/by-name/x4/x4/package.nix
+++ b/pkgs/by-name/x4/x4/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.1.0";
 
   src = fetchFromGitHub {
-    owner = "pwnwriter";
+    owner = "bytehunt";
     repo = "x4";
     rev = "v${finalAttrs.version}";
     hash = "sha256-IF+8lu56fzYM79p7MiNpVLFIs2GKPlzw5pNXD/hT6BM=";
@@ -35,8 +35,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Execute shell commands to server(s) via ssh protocol";
-    homepage = "https://github.com/pwnwriter/x4";
-    changelog = "https://github.com/pwnwriter/x4/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    homepage = "https://github.com/bytehunt/x4";
+    changelog = "https://github.com/bytehunt/x4/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ pwnwriter ];
     mainProgram = "x4";

--- a/pkgs/by-name/xc/xcbuild/package.nix
+++ b/pkgs/by-name/xc/xcbuild/package.nix
@@ -68,7 +68,7 @@ stdenv'.mkDerivation (finalAttrs: {
 
   version = "0.1.1-unstable-2019-11-20";
   src = fetchFromGitHub {
-    owner = "facebook";
+    owner = "facebookarchive";
     repo = "xcbuild";
     rev = "dbaee552d2f13640773eb1ad3c79c0d2aca7229c";
     hash = "sha256-7mvSuRCWU/LlIBdmnC59F4SSzJPEcQhlmEK13PNe1xc=";
@@ -168,7 +168,7 @@ stdenv'.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Xcode-compatible build tool";
-    homepage = "https://github.com/facebook/xcbuild";
+    homepage = "https://github.com/facebookarchive/xcbuild";
     license = with lib.licenses; [
       bsd2
       bsd3

--- a/pkgs/by-name/xd/xdelta/package.nix
+++ b/pkgs/by-name/xd/xdelta/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     sha256 = "09mmsalc7dwlvgrda56s2k927rpl3a5dzfa88aslkqcjnr790wjy";
     rev = "v${finalAttrs.version}";
-    repo = "xdelta-devel";
+    repo = "xdelta-gpl";
     owner = "jmacd";
   };
 

--- a/pkgs/by-name/xi/xits-math/package.nix
+++ b/pkgs/by-name/xi/xits-math/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.302";
 
   src = fetchFromGitHub {
-    owner = "alif-type";
+    owner = "aliftype";
     repo = "xits";
     rev = "v${finalAttrs.version}";
     sha256 = "1x3r505dylz9rz8dj98h5n9d0zixyxmvvhnjnms9qxdrz9bxy9g1";
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://github.com/alif-type/xits";
+    homepage = "https://github.com/aliftype/xits";
     description = "OpenType implementation of STIX fonts with math support";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/xk/xkb-switch/package.nix
+++ b/pkgs/by-name/xk/xkb-switch/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.8.5";
 
   src = fetchFromGitHub {
-    owner = "ierton";
+    owner = "sergei-mironov";
     repo = "xkb-switch";
     rev = finalAttrs.version;
     sha256 = "sha256-DZAIL6+D+Hgs+fkJwRaQb9BHrEjAkxiqhOZyrR+Mpuk=";
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Switch your X keyboard layouts from the command line";
-    homepage = "https://github.com/ierton/xkb-switch";
+    homepage = "https://github.com/sergei-mironov/xkb-switch";
     license = lib.licenses.gpl2Plus;
     maintainers = [ ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/xm/xmcp/package.nix
+++ b/pkgs/by-name/xm/xmcp/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation {
   version = "0-unstable-2020-10-10";
 
   src = fetchFromGitHub {
-    owner = "blblapco";
+    owner = "glblapco";
     repo = "xmcp";
     rev = "ee56225f1665f9edc04fe5c165809f2fe160a420";
     sha256 = "sha256-B3YkYrVEg6UJ2ApaVook4N2XvrCboxDMUG5CN9I79Sg=";
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Tiny color picker for X11";
-    homepage = "https://github.com/blblapco/xmcp";
+    homepage = "https://github.com/glblapco/xmcp";
     license = lib.licenses.gpl3Plus;
     maintainers = [ ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/xs/xscast/package.nix
+++ b/pkgs/by-name/xs/xscast/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
   version = "2016-07-26";
 
   src = fetchFromGitHub {
-    owner = "KeyboardFire";
+    owner = "tckmn";
     repo = "xscast";
     rev = "9e6fd3c28d3f5ae630619f6dbccaf1f6ca594b21";
     sha256 = "0br27bq9bpglfdpv63h827bipgvhlh10liyhmhcxls4227kagz72";
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
   '';
 
   meta = {
-    homepage = "https://github.com/KeyboardFire/xscast";
+    homepage = "https://github.com/tckmn/xscast";
     license = lib.licenses.mit;
     description = "Screencasts of windows with list of keystrokes overlayed";
     maintainers = [ ];

--- a/pkgs/by-name/ya/yaml-schema-router/package.nix
+++ b/pkgs/by-name/ya/yaml-schema-router/package.nix
@@ -10,7 +10,7 @@ buildGoModule (finalAttrs: {
   version = "0.2.0";
 
   src = fetchFromGitHub {
-    owner = "traiproject";
+    owner = "tepea-code";
     repo = "yaml-schema-router";
     tag = "v${finalAttrs.version}";
     hash = "sha256-GFe5NPW8nxv+bQsG5G26WCf2Z6qrW1WAZBMWFZD8MFI=";
@@ -27,8 +27,8 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Content-based JSON schema routing for yaml-language-server";
-    homepage = "https://github.com/traiproject/yaml-schema-router";
-    changelog = "https://github.com/traiproject/yaml-schema-router/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/tepea-code/yaml-schema-router";
+    changelog = "https://github.com/tepea-code/yaml-schema-router/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ kpbaks ];
     mainProgram = "yaml-schema-router";

--- a/pkgs/by-name/ye/yek/package.nix
+++ b/pkgs/by-name/ye/yek/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage {
   version = version;
 
   src = fetchFromGitHub {
-    owner = "bodo-run";
+    owner = "mohsen1";
     repo = "yek";
     tag = "v${version}";
     hash = "sha256-2gt/leOEhdvj5IXp0Kl3ooUk8eclsMkt6JCIvPsKhMI=";
@@ -48,8 +48,8 @@ rustPlatform.buildRustPackage {
     longDescription = ''
       Tool to read text-based files, chunk them, and serialize them for LLM consumption.
     '';
-    homepage = "https://github.com/bodo-run/yek";
-    changelog = "https://github.com/bodo-run/yek/releases/tag/v${version}";
+    homepage = "https://github.com/mohsen1/yek";
+    changelog = "https://github.com/mohsen1/yek/releases/tag/v${version}";
     license = lib.licenses.mit;
     mainProgram = "yek";
     maintainers = with lib.maintainers; [ louis-thevenet ];

--- a/pkgs/by-name/yo/youki/package.nix
+++ b/pkgs/by-name/yo/youki/package.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.6.0";
 
   src = fetchFromGitHub {
-    owner = "containers";
+    owner = "youki-dev";
     repo = "youki";
     rev = "v${finalAttrs.version}";
     hash = "sha256-O5tk/W2Bybq+6aY7FX/AcJtBKWEYI2Ywk7vYLqvuFos=";
@@ -58,7 +58,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Container runtime written in Rust";
     homepage = "https://containers.github.io/youki/";
-    changelog = "https://github.com/containers/youki/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/youki-dev/youki/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ builditluc ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/yu/yubikey-touch-detector/package.nix
+++ b/pkgs/by-name/yu/yubikey-touch-detector/package.nix
@@ -14,7 +14,7 @@ buildGoModule (finalAttrs: {
   version = "1.13.0";
 
   src = fetchFromGitHub {
-    owner = "maximbaz";
+    owner = "max-baz";
     repo = "yubikey-touch-detector";
     tag = finalAttrs.version;
     hash = "sha256-aHR/y8rAKS+dMvRdB3oAmOiI7hTA6qlF4Z05OjwYOO4=";
@@ -50,7 +50,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Tool to detect when your YubiKey is waiting for a touch";
-    homepage = "https://github.com/maximbaz/yubikey-touch-detector";
+    homepage = "https://github.com/max-baz/yubikey-touch-detector";
     maintainers = with lib.maintainers; [ sumnerevans ];
     license = lib.licenses.isc;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/z6/z64decompress/package.nix
+++ b/pkgs/by-name/z6/z64decompress/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.0.3-unstable-2023-12-21";
 
   src = fetchFromGitHub {
-    owner = "z64tools";
+    owner = "z64dev";
     repo = "z64decompress";
     rev = "e2b3707271994a2a1b3afc6c3997a7cf6b479765";
     hash = "sha256-PHiOeEB9njJPsl6ScdoDVwJXGqOdIIJCZRbIXSieBIY=";
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Zelda 64 rom decompressor";
-    homepage = "https://github.com/z64tools/z64decompress";
+    homepage = "https://github.com/z64dev/z64decompress";
     license = with lib.licenses; [
       gpl3Only
 

--- a/pkgs/by-name/zi/zincsearch/package.nix
+++ b/pkgs/by-name/zi/zincsearch/package.nix
@@ -8,7 +8,7 @@
 let
   version = "0.4.10-unstable-2024-10-25";
   src = fetchFromGitHub {
-    owner = "zinclabs";
+    owner = "zincsearch";
     repo = "zincsearch";
     rev = "0652db6d39badc753f28ee1122dcbc0e5da1c35e";
     hash = "sha256-Py4fiZJ2fMwPe2afd19brR+62PGVoU67nMDMPlUFhKQ=";
@@ -47,7 +47,7 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/zinclabs/zincsearch/pkg/meta.Version=${version}"
+    "-X github.com/zincsearch/zincsearch/pkg/meta.Version=${version}"
   ];
 
   meta = {

--- a/pkgs/by-name/zs/zsh-powerlevel9k/package.nix
+++ b/pkgs/by-name/zs/zsh-powerlevel9k/package.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
   pname = "powerlevel9k";
   version = "2017-11-10";
   src = fetchFromGitHub {
-    owner = "bhilburn";
+    owner = "Powerlevel9k";
     repo = "powerlevel9k";
     rev = "87acc51acab3ed4fd33cda2386abed6f98c80720";
     sha256 = "0v1dqg9hvycdkcvklg2njff97xwr8rah0nyldv4xm39r77f4yfvq";
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
       To make use of this derivation, use
       `programs.zsh.promptInit = "source ''${pkgs.zsh-powerlevel9k}/share/zsh-powerlevel9k/powerlevel9k.zsh-theme";`
     '';
-    homepage = "https://github.com/bhilburn/powerlevel9k";
+    homepage = "https://github.com/Powerlevel9k/powerlevel9k";
     license = lib.licenses.mit;
 
     platforms = lib.platforms.unix;

--- a/pkgs/development/compilers/swift/libdispatch/default.nix
+++ b/pkgs/development/compilers/swift/libdispatch/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Grand Central Dispatch";
-    homepage = "https://github.com/apple/swift-corelibs-libdispatch";
+    homepage = "https://github.com/swiftlang/swift-corelibs-libdispatch";
     platforms = lib.platforms.linux;
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ cmm ];

--- a/pkgs/development/compilers/swift/sourcekit-lsp/default.nix
+++ b/pkgs/development/compilers/swift/sourcekit-lsp/default.nix
@@ -81,7 +81,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Language Server Protocol implementation for Swift and C-based languages";
     mainProgram = "sourcekit-lsp";
-    homepage = "https://github.com/apple/sourcekit-lsp";
+    homepage = "https://github.com/swiftlang/sourcekit-lsp";
     platforms = with lib.platforms; linux ++ darwin;
     license = lib.licenses.asl20;
     teams = [ lib.teams.swift ];

--- a/pkgs/development/compilers/swift/swift-format/default.nix
+++ b/pkgs/development/compilers/swift/swift-format/default.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Formatting technology for Swift source code";
-    homepage = "https://github.com/apple/swift-format";
+    homepage = "https://github.com/swiftlang/swift-format";
     platforms = with lib.platforms; linux ++ darwin;
     license = lib.licenses.asl20;
     teams = [ lib.teams.swift ];

--- a/pkgs/development/compilers/swift/swiftpm/default.nix
+++ b/pkgs/development/compilers/swift/swiftpm/default.nix
@@ -320,7 +320,7 @@ let
   swift-crypto = mkBootstrapDerivation {
     name = "swift-crypto";
     src = fetchFromGitHub {
-      owner = "apple";
+      owner = "swiftlang";
       repo = "swift-crypto";
       rev = "95ba0316a9b733e92bb6b071255ff46263bbe7dc"; # 3.15.1, as opposed to the pinned version of 3.0.0
       sha256 = "sha256-RzoUBx4l12v0ZamSIAEpHHCRQXxJkXJCwVBEj7Qwg9I=";
@@ -492,7 +492,7 @@ stdenv.mkDerivation (
 
     meta = {
       description = "Package Manager for the Swift Programming Language";
-      homepage = "https://github.com/apple/swift-package-manager";
+      homepage = "https://github.com/swiftlang/swift-package-manager";
       platforms = with lib.platforms; linux ++ darwin;
       license = lib.licenses.asl20;
       teams = [ lib.teams.swift ];

--- a/pkgs/development/python-modules/deepdiff/default.nix
+++ b/pkgs/development/python-modules/deepdiff/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage rec {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "seperman";
+    owner = "qlustered";
     repo = "deepdiff";
     tag = version;
     hash = "sha256-/XRPP8O2ykoXwOZ2ou/7Yoa1x7t45dCx6G3aq30o3Wc=";
@@ -89,8 +89,8 @@ buildPythonPackage rec {
   meta = {
     description = "Deep Difference and Search of any Python object/data";
     mainProgram = "deep";
-    homepage = "https://github.com/seperman/deepdiff";
-    changelog = "https://github.com/seperman/deepdiff/blob/${src.tag}/CHANGELOG.md";
+    homepage = "https://github.com/qlustered/deepdiff";
+    changelog = "https://github.com/qlustered/deepdiff/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       mic92

--- a/pkgs/development/python-modules/dodgy/default.nix
+++ b/pkgs/development/python-modules/dodgy/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "landscapeio";
+    owner = "prospector-dev";
     repo = "dodgy";
     rev = version;
     sha256 = "0ywwjpz0p6ls3hp1lndjr9ql6s5lkj7dgpll1h87w04kwan70j0x";
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   meta = {
     description = "Looks at Python code to search for things which look \"dodgy\" such as passwords or diffs";
     mainProgram = "dodgy";
-    homepage = "https://github.com/landscapeio/dodgy";
+    homepage = "https://github.com/prospector-dev/dodgy";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ kamadorueda ];
   };

--- a/pkgs/development/python-modules/dvc/default.nix
+++ b/pkgs/development/python-modules/dvc/default.nix
@@ -68,7 +68,7 @@ buildPythonPackage (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "iterative";
+    owner = "treeverse";
     repo = "dvc";
     tag = finalAttrs.version;
     hash = "sha256-KzHaR7o3PUHMBrtSDWXvH7/YMPxSafPSGUnS9018XKg=";
@@ -162,7 +162,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Version Control System for Machine Learning Projects";
     homepage = "https://dvc.org";
-    changelog = "https://github.com/iterative/dvc/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/treeverse/dvc/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       cmcdragonkai

--- a/pkgs/development/python-modules/fx2/default.nix
+++ b/pkgs/development/python-modules/fx2/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   format = "setuptools";
 
   src = fetchFromGitHub {
-    owner = "whitequark";
+    owner = "GlasgowEmbedded";
     repo = "libfx2";
     rev = "v${version}";
     hash = "sha256-uMgf1VL3yvkLUfRlBn9NKcerfHfcFg9yEgHGWmwyh8I=";
@@ -47,7 +47,7 @@ buildPythonPackage rec {
   meta = {
     description = "Chip support package for Cypress EZ-USB FX2 series microcontrollers";
     mainProgram = "fx2tool";
-    homepage = "https://github.com/whitequark/libfx2";
+    homepage = "https://github.com/GlasgowEmbedded/libfx2";
     license = lib.licenses.bsd0;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/hassil/default.nix
+++ b/pkgs/development/python-modules/hassil/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "home-assistant";
+    owner = "OHF-Voice";
     repo = "hassil";
     tag = "v${version}";
     hash = "sha256-ei4+eGNCzBZQYghgVuQIPgFA2Y1kf8aNtl6ZjwzxIEE=";
@@ -44,10 +44,10 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/home-assistant/hassil/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/OHF-Voice/hassil/blob/${src.tag}/CHANGELOG.md";
     description = "Intent parsing for Home Assistant";
     mainProgram = "hassil";
-    homepage = "https://github.com/home-assistant/hassil";
+    homepage = "https://github.com/OHF-Voice/hassil";
     license = lib.licenses.asl20;
     teams = [ lib.teams.home-assistant ];
   };

--- a/pkgs/development/python-modules/hocr-tools/default.nix
+++ b/pkgs/development/python-modules/hocr-tools/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   format = "setuptools";
 
   src = fetchFromGitHub {
-    owner = "tmbdev";
+    owner = "ocropus";
     repo = "hocr-tools";
     rev = "v${version}";
     sha256 = "14f9hkp7pr677085w8iidwd0la9cjzy3pyj3rdg9b03nz9pc0w6p";
@@ -29,7 +29,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Tools for manipulating and evaluating the hOCR format for representing multi-lingual OCR results by embedding them into HTML";
-    homepage = "https://github.com/tmbdev/hocr-tools";
+    homepage = "https://github.com/ocropus/hocr-tools";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };

--- a/pkgs/development/python-modules/httpie/default.nix
+++ b/pkgs/development/python-modules/httpie/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "httpie";
-    repo = "httpie";
+    repo = "cli";
     tag = version;
     hash = "sha256-uZKkUUrPPnLHPHL8YrZgfsyCsSOR0oZ2eFytiV0PIUY=";
   };
@@ -125,7 +125,7 @@ buildPythonPackage rec {
   meta = {
     description = "Command line HTTP client whose goal is to make CLI human-friendly";
     homepage = "https://httpie.org/";
-    changelog = "https://github.com/httpie/httpie/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/httpie/cli/blob/${version}/CHANGELOG.md";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
       antono

--- a/pkgs/development/python-modules/iocextract/default.nix
+++ b/pkgs/development/python-modules/iocextract/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "InQuest";
-    repo = "python-iocextract";
+    repo = "iocextract";
     tag = "v${version}";
     hash = "sha256-cCp9ug/TuVY1zL+kiDlFGBmfFJyAmVwxLD36WT0oRAE=";
   };
@@ -38,8 +38,8 @@ buildPythonPackage rec {
   meta = {
     description = "Module to extract Indicator of Compromises (IOC)";
     mainProgram = "iocextract";
-    homepage = "https://github.com/InQuest/python-iocextract";
-    changelog = "https://github.com/InQuest/python-iocextract/releases/tag/v${version}";
+    homepage = "https://github.com/InQuest/iocextract";
+    changelog = "https://github.com/InQuest/iocextract/releases/tag/v${version}";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/myjwt/default.nix
+++ b/pkgs/development/python-modules/myjwt/default.nix
@@ -23,7 +23,7 @@ buildPythonPackage (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "mBouamama";
+    owner = "tyki6";
     repo = "MyJWT";
     tag = finalAttrs.version;
     hash = "sha256-jqBnxo7Omn5gLMCQ7SNbjo54nyFK7pn94796z2Qc9lg=";
@@ -58,7 +58,7 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "CLI tool for testing vulnerabilities of JSON Web Tokens (JWT)";
-    homepage = "https://github.com/mBouamama/MyJWT";
+    homepage = "https://github.com/tyki6/MyJWT";
     changelog = "https://github.com/tyki6/MyJWT/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];

--- a/pkgs/development/python-modules/name-that-hash/default.nix
+++ b/pkgs/development/python-modules/name-that-hash/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "HashPals";
+    owner = "bee-san";
     repo = "name-that-hash";
     rev = version;
     hash = "sha256-zOb4BS3zG1x8GLXAooqqvMOw0fNbw35JuRWOdGP26/8=";
@@ -36,7 +36,7 @@ buildPythonPackage rec {
   meta = {
     longDescription = "Don't know what type of hash it is? Name That Hash will name that hash type! Identify MD5, SHA256 and 300+ other hashes.";
     description = "Module and CLI for the identification of hashes";
-    homepage = "https://github.com/HashPals/Name-That-Hash";
+    homepage = "https://github.com/bee-san/Name-That-Hash";
     license = with lib.licenses; [ gpl3Plus ];
     maintainers = with lib.maintainers; [ eyjhb ];
   };

--- a/pkgs/development/python-modules/open-interpreter/default.nix
+++ b/pkgs/development/python-modules/open-interpreter/default.nix
@@ -46,7 +46,7 @@ buildPythonPackage rec {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "KillianLucas";
+    owner = "openinterpreter";
     repo = "open-interpreter";
     tag = "v${version}";
     hash = "sha256-fogCcWAhcrCrrcV0q4oKttkf/GeJaJSZnbgiFxvySs8=";
@@ -114,9 +114,9 @@ buildPythonPackage rec {
   meta = {
     broken = true;
     description = "OpenAI's Code Interpreter in your terminal, running locally";
-    homepage = "https://github.com/KillianLucas/open-interpreter";
+    homepage = "https://github.com/openinterpreter/open-interpreter";
     license = lib.licenses.mit;
-    changelog = "https://github.com/KillianLucas/open-interpreter/releases/tag/v${version}";
+    changelog = "https://github.com/openinterpreter/open-interpreter/releases/tag/v${version}";
     maintainers = with lib.maintainers; [ happysalada ];
     mainProgram = "interpreter";
   };

--- a/pkgs/development/python-modules/pinboard/default.nix
+++ b/pkgs/development/python-modules/pinboard/default.nix
@@ -11,7 +11,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "lionheart";
-    repo = "pinboard";
+    repo = "pinboard.py";
     rev = version;
     sha256 = "sha256-+JWr2QmdqASK/X10U0ZOZ95K2ctWceSW167raxZjIW4=";
   };
@@ -24,6 +24,6 @@ buildPythonPackage rec {
     mainProgram = "pinboard";
     maintainers = with lib.maintainers; [ djanatyn ];
     license = lib.licenses.asl20;
-    homepage = "https://github.com/lionheart/pinboard.py";
+    homepage = "https://github.com/lionheart/pinboard.py.py";
   };
 }

--- a/pkgs/development/python-modules/plover/4.nix
+++ b/pkgs/development/python-modules/plover/4.nix
@@ -29,7 +29,7 @@ buildPythonPackage (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "openstenoproject";
+    owner = "opensteno";
     repo = "plover";
     tag = "v${finalAttrs.version}";
     hash = "sha256-VpQT25bl8yPG4J9IwLkhSkBt31Y8BgPJdwa88WlreA8=";

--- a/pkgs/development/python-modules/plover/5.nix
+++ b/pkgs/development/python-modules/plover/5.nix
@@ -44,7 +44,7 @@ buildPythonPackage (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "openstenoproject";
+    owner = "opensteno";
     repo = "plover";
     tag = "v${finalAttrs.version}";
     hash = "sha256-1NpZmUDq806geKANqswPYglHwInxum/c/Hxq7JhTpbc=";

--- a/pkgs/development/python-modules/pyinfra/default.nix
+++ b/pkgs/development/python-modules/pyinfra/default.nix
@@ -34,7 +34,7 @@ buildPythonPackage (finalAttrs: {
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
-    owner = "Fizzadar";
+    owner = "pyinfra-dev";
     repo = "pyinfra";
     tag = "v${finalAttrs.version}";
     hash = "sha256-0DIG1Msttg7tqLbCZKi07uWTg3KYgH9rVlWPeJs4wwA=";
@@ -81,7 +81,7 @@ buildPythonPackage (finalAttrs: {
     '';
     homepage = "https://pyinfra.com";
     downloadPage = "https://pyinfra.com/Fizzadar/pyinfra/releases";
-    changelog = "https://github.com/Fizzadar/pyinfra/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/pyinfra-dev/pyinfra/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ totoroot ];
     mainProgram = "pyinfra";

--- a/pkgs/development/python-modules/python-matter-server/default.nix
+++ b/pkgs/development/python-modules/python-matter-server/default.nix
@@ -39,7 +39,7 @@ let
   version = "8.1.2";
 
   src = fetchFromGitHub {
-    owner = "home-assistant-libs";
+    owner = "matter-js";
     repo = "python-matter-server";
     tag = version;
     hash = "sha256-vnI57h/aesnaDYorq1PzcMCLmV0z0ZBJvMg4Nzh1Dtc=";
@@ -155,10 +155,10 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/home-assistant-libs/python-matter-server/releases/tag/${src.tag}";
+    changelog = "https://github.com/matter-js/python-matter-server/releases/tag/${src.tag}";
     description = "Python server to interact with Matter";
     mainProgram = "matter-server";
-    homepage = "https://github.com/home-assistant-libs/python-matter-server";
+    homepage = "https://github.com/matter-js/python-matter-server";
     license = lib.licenses.asl20;
     teams = [ lib.teams.home-assistant ];
   };

--- a/pkgs/development/python-modules/stac-validator/default.nix
+++ b/pkgs/development/python-modules/stac-validator/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "stac-utils";
+    owner = "StacLabs";
     repo = "stac-validator";
     tag = "v${version}";
     hash = "sha256-qO1DRYpPn+zarHTj2mZQ2LJ2uhmS1bax6Yxy035ZEUA=";
@@ -42,7 +42,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Validator for the SpatioTemporal Asset Catalog (STAC) specification";
-    homepage = "https://github.com/stac-utils/stac-validator";
+    homepage = "https://github.com/StacLabs/stac-validator";
     license = lib.licenses.asl20;
     teams = [ lib.teams.geospatial ];
   };

--- a/pkgs/development/tools/analysis/radare2/default.nix
+++ b/pkgs/development/tools/analysis/radare2/default.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "6.1.4";
 
   src = fetchFromGitHub {
-    owner = "radare";
+    owner = "radareorg";
     repo = "radare2";
     tag = finalAttrs.version;
     hash = "sha256-3MwBtjR3XQMhbJHnD30OVedUEKcje5jDPszNynkGCT8=";

--- a/pkgs/development/tools/replay-io/default.nix
+++ b/pkgs/development/tools/replay-io/default.nix
@@ -136,7 +136,7 @@ rec {
     pname = "replay-node-cli";
     version = "0.1.7-" + builtins.head (builtins.match ".*/linux-node-(.*)" metadata.replay-node.url);
     src = fetchFromGitHub {
-      owner = "RecordReplay";
+      owner = "replayio";
       repo = "replay-node-cli";
       rev = "5269c8b8e7c5c7a9618a68f883d19c11a68be837";
       sha256 = "04d22q3dvs9vxpb9ps64pdxq9ziwgvnzdgsn6p9p0lzjagh0f5n0";

--- a/pkgs/os-specific/linux/sgx/psw/default.nix
+++ b/pkgs/os-specific/linux/sgx/psw/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "intel";
-    repo = "linux-sgx";
+    repo = "confidential-computing.sgx";
     rev = "sgx_${versionTag}";
     hash = "sha256-hNmh4IgNJDNqt2xF8zBnD/x+saMyMk5hZLA3aOqzqEA=";
     fetchSubmodules = true;
@@ -270,7 +270,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Intel SGX Architectural Enclave Service Manager";
-    homepage = "https://github.com/intel/linux-sgx";
+    homepage = "https://github.com/intel/confidential-computing.sgx";
     maintainers = with lib.maintainers; [
       phlip9
       veehaitch

--- a/pkgs/servers/klipper/default.nix
+++ b/pkgs/servers/klipper/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   version = "0.13.0-unstable-2026-03-21";
 
   src = fetchFromGitHub {
-    owner = "KevinOConnor";
+    owner = "Klipper3d";
     repo = "klipper";
     rev = "594ec7e1205450ff0753d19f0724bbe8b380465d";
     sha256 = "sha256-a496Ayas2IsP3K320EXc/7VDAtrqUzF8OaKNKBWf8lQ=";
@@ -136,7 +136,7 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Klipper 3D printer firmware";
     mainProgram = "klippy";
-    homepage = "https://github.com/KevinOConnor/klipper";
+    homepage = "https://github.com/Klipper3d/klipper";
     maintainers = with lib.maintainers; [
       lovesegfault
       zhaofengli

--- a/pkgs/tools/networking/openvpn/update-resolv-conf.nix
+++ b/pkgs/tools/networking/openvpn/update-resolv-conf.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
   version = "unstable-2017-06-21";
 
   src = fetchFromGitHub {
-    owner = "masterkorp";
+    owner = "alfredopalhares";
     repo = "openvpn-update-resolv-conf";
     rev = "43093c2f970bf84cd374e18ec05ac6d9cae444b8";
     sha256 = "1lf66bsgv2w6nzg1iqf25zpjf4ckcr45adkpgdq9gvhkfnvlp8av";
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Script to update your /etc/resolv.conf with DNS settings that come from the received push dhcp-options";
-    homepage = "https://github.com/masterkorp/openvpn-update-resolv-conf/";
+    homepage = "https://github.com/alfredopalhares/openvpn-update-resolv-conf/";
     maintainers = [ ];
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.unix;

--- a/pkgs/tools/package-management/nix-eval-jobs/default.nix
+++ b/pkgs/tools/package-management/nix-eval-jobs/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   version = "2.34.1";
 
   src = fetchFromGitHub {
-    owner = "nix-community";
+    owner = "NixOS";
     repo = "nix-eval-jobs";
     tag = "v${version}";
     hash = "sha256-OFGRoJOYhvZ3Enk5a8vMy0QNcG5ZxyzFhyHMrwKXde8=";
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Hydra's builtin hydra-eval-jobs as a standalone";
-    homepage = "https://github.com/nix-community/nix-eval-jobs";
+    homepage = "https://github.com/NixOS/nix-eval-jobs";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [
       adisbladis

--- a/pkgs/tools/security/stoken/default.nix
+++ b/pkgs/tools/security/stoken/default.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   version = "0.93";
 
   src = fetchFromGitHub {
-    owner = "cernekee";
+    owner = "stoken-dev";
     repo = "stoken";
     rev = "v${version}";
     hash = "sha256-8N7TXdBu37eXWIKCBdaXVW0pvN094oRWrdlcy9raddI=";
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Software Token for Linux/UNIX";
-    homepage = "https://github.com/cernekee/stoken";
+    homepage = "https://github.com/stoken-dev/stoken";
     license = lib.licenses.lgpl21Plus;
     maintainers = [ ];
     platforms = lib.platforms.all;


### PR DESCRIPTION
This PR updates all `fetchFromGitHub` calls and `github.com/<owner>/<repo>` links in the same files that would otherwise be redirected, so they point directly to the canonical repositories instead of deprecated or redirecting URLs.

**Motivation:**
This avoids silent failures if upstream redirects ever change or disappear, and improves reliability and reproducibility of fetches.

**How:**
Changes were generated using [this script](https://git.kybe.xyz/2kybe3/nixpkgs-github-redirect) on top of nixpkgs commit 7abdd6c20d91c70e9847868e6be53e031ffaf536. Some edge cases requiring manual fixups (mostly when the package's ldflags were expected to be an old repo instead of the new one) are not applied by the script.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
