### PR TITLE
warp-plus: fix build

### DIFF
--- a/pkgs/by-name/wa/warp-plus/package.nix
+++ b/pkgs/by-name/wa/warp-plus/package.nix
@@ -2,13 +2,11 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-
+  writableTmpDirAsHomeHook,
   nix-update-script,
   versionCheckHook,
 }:
 
-# fails with go 1.25, downgrade to 1.24
-# error tls.ConnectionState: struct field count mismatch: 17 vs 16
 buildGoModule (finalAttrs: {
   pname = "warp-plus";
   version = "1.2.6-unstable-2025-11-17";
@@ -20,7 +18,24 @@ buildGoModule (finalAttrs: {
     hash = "sha256-5H0iF+dc+3qQrFCPiaBxHMSoHsmciKvwX1SJX7TMjeE=";
   };
 
-  vendorHash = "sha256-FqyNjnCoeOCraVv9WhQIw+PxrJVfOu2dAnINi++nsW4=";
+  nativeBuildInputs = [ writableTmpDirAsHomeHook ];
+
+  # Replaced `psiphon-tls` with release-branch.go1.26
+  postPatch = ''
+    export GOCACHE=$TMPDIR/go-cache
+    export GOPATH=$TMPDIR/go
+    export GOSUMDB=off
+    go mod edit -replace github.com/Psiphon-Labs/psiphon-tls=github.com/Psiphon-Labs/psiphon-tls@v0.0.0-20260429174135-190516348878
+    if [ -n "$goModules" ]; then
+      export GOPROXY="file://$goModules"
+    fi
+    #only built on windows
+    rm wireguard/ipc/namedpipe/namedpipe_test.go
+    go mod tidy
+  '';
+
+  proxyVendor = true;
+  vendorHash = "sha256-mPIffXUHS4lnnJPlOfuQaGA/1oiQpdKVV3wkrlIH3nE=";
 
   ldflags = [
     "-s"
@@ -57,6 +72,5 @@ buildGoModule (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ phanirithvij ];
     mainProgram = "warp-plus";
-    broken = true;
   };
 })


### PR DESCRIPTION
update psiphon-tls to go1.26 branch version 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
