### PR TITLE
renode: bump dotnet 9 -> 10

### DIFF
--- a/pkgs/by-name/re/renode/package.nix
+++ b/pkgs/by-name/re/renode/package.nix
@@ -6,11 +6,10 @@
   fetchFromGitHub,
   fetchpatch,
   gcc,
-  glibcLocales,
+  glibcLocalesUtf8,
   gtk3-x11,
   gtk3,
   lib,
-  mono,
   python3Packages,
 }:
 
@@ -68,9 +67,16 @@ buildDotnetModule rec {
     fetchSubmodules = true;
   };
 
+  disallowedReferences = [
+    cmake
+    gcc
+    dotnet-sdk
+  ];
+
   projectFile = "Renode_NET.sln";
 
   dotnet-sdk = dotnetCorePackages.sdk_10_0;
+  dotnet-runtime = dotnetCorePackages.runtime_10_0;
 
   nugetDeps = ./deps.json;
 
@@ -100,17 +106,12 @@ buildDotnetModule rec {
     sed -i 's/AssemblyVersion("1.0.*")/AssemblyVersion("1.0.0.0")/g' lib/AntShell/AntShell/Properties/AssemblyInfo.cs lib/CxxDemangler/CxxDemangler/Properties/AssemblyInfo.cs
   '';
 
-  # https://github.com/NixOS/nixpkgs/issues/38991
-  # bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
-  env.LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
-
   nativeBuildInputs = [
     cmake
     gcc
   ];
   runtimeDeps = [
     gtk3
-    mono
   ];
 
   dontUseCmakeConfigure = true;
@@ -162,15 +163,17 @@ buildDotnetModule rec {
   dotnetInstallFlags = [ "-p:TargetFramework=net10.0" ];
 
   postInstall = ''
+    rm -rf build output/properties.csproj
+    find . -type d -name obj -exec rm -rf {} +
     mkdir -p $out/lib/renode
     mv * .renode-root $out/lib/renode
 
     makeWrapper "$out/lib/renode/renode-test" "$out/bin/renode-test" \
-      --prefix PATH : "$out/lib/renode:${lib.makeBinPath [ dotnet-sdk ]}" \
+      --prefix PATH : "$out/lib/renode:${lib.makeBinPath [ dotnet-runtime ]}" \
       --prefix GIO_EXTRA_MODULES : "${lib.getLib dconf}/lib/gio/modules" \
       --suffix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ gtk3-x11 ]}" \
       --prefix PYTHONPATH : "${pythonLibs}" \
-      --set LOCALE_ARCHIVE "${glibcLocales}/lib/locale/locale-archive"
+      --set LOCALE_ARCHIVE "${glibcLocalesUtf8}/lib/locale/locale-archive"
   '';
 
   postFixup = ''

--- a/pkgs/by-name/re/renode/package.nix
+++ b/pkgs/by-name/re/renode/package.nix
@@ -70,13 +70,13 @@ buildDotnetModule rec {
 
   projectFile = "Renode_NET.sln";
 
-  dotnet-sdk = dotnetCorePackages.sdk_9_0;
+  dotnet-sdk = dotnetCorePackages.sdk_10_0;
 
   nugetDeps = ./deps.json;
 
   patches = [ ./renode-test.patch ];
 
-  dotnetFlags = [ "-p:TargetFrameworks=net9.0" ];
+  dotnetFlags = [ "-p:TargetFrameworks=net10.0" ];
 
   prePatch = ''
     sed -i 's/AssemblyVersion("%VERSION%.*")/AssemblyVersion("${version}.0")/g' src/Renode/Properties/AssemblyInfo.template
@@ -159,7 +159,7 @@ buildDotnetModule rec {
     ln -s $out/lib/*.so src/Infrastructure/src/Emulator/Cores/bin/Release/lib
   '';
 
-  dotnetInstallFlags = [ "-p:TargetFramework=net9.0" ];
+  dotnetInstallFlags = [ "-p:TargetFramework=net10.0" ];
 
   postInstall = ''
     mkdir -p $out/lib/renode


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
