### PR TITLE
obs-studio-plugins: move env variable into env for structuredAttrs

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/obs-hyperion/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-hyperion/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     "-DUSE_SYSTEM_FLATBUFFERS_LIBS=ON"
   ];
 
-  NIX_CFLAGS_COMPILE = [ "-Wno-error" ];
+  env.NIX_CFLAGS_COMPILE = toString [ "-Wno-error" ];
 
   preConfigure = ''
     rm -rf external/flatbuffers

--- a/pkgs/applications/video/obs-studio/plugins/obs-source-record.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-source-record.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake ];
   buildInputs = [ obs-studio ];
 
-  NIX_CFLAGS_COMPILE = [ "-Wno-error=deprecated-declarations" ];
+  env.NIX_CFLAGS_COMPILE = toString [ "-Wno-error=deprecated-declarations" ];
 
   cmakeFlags = [ "-DBUILD_OUT_OF_TREE=On" ];
 

--- a/pkgs/applications/video/obs-studio/plugins/obs-teleport/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-teleport/default.nix
@@ -30,8 +30,10 @@ buildGoModule rec {
     "-w"
   ];
 
-  CGO_CFLAGS = "-I${obs-studio}/include/obs";
-  CGO_LDFLAGS = "-L${obs-studio}/lib -lobs -lobs-frontend-api";
+  env = {
+    CGO_CFLAGS = "-I${obs-studio}/include/obs";
+    CGO_LDFLAGS = "-L${obs-studio}/lib -lobs -lobs-frontend-api";
+  };
 
   buildPhase = ''
     runHook preBuild


### PR DESCRIPTION
Found via: https://gist.github.com/Sigmanificient/8b8858dc06a7a2efa6876a0d5cb127e8

- https://github.com/NixOS/nixpkgs/issues/205690

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
