### PR TITLE
nvim-treesitter-parsers: move env variable into env for structuredAttrs

### DIFF
--- a/pkgs/by-name/tr/tree-sitter/grammars/build-grammar.nix
+++ b/pkgs/by-name/tr/tree-sitter/grammars/build-grammar.nix
@@ -30,14 +30,16 @@ stdenv.mkDerivation (
       tree-sitter
     ];
 
-    CFLAGS = [
-      "-Isrc"
-      "-O2"
-    ];
-    CXXFLAGS = [
-      "-Isrc"
-      "-O2"
-    ];
+    env = {
+      CFLAGS = toString [
+        "-Isrc"
+        "-O2"
+      ];
+      CXXFLAGS = toString [
+        "-Isrc"
+        "-O2"
+      ];
+    };
 
     stripDebugList = [ "parser" ];
 

--- a/pkgs/by-name/tr/tree-sitter/grammars/build-grammar.nix
+++ b/pkgs/by-name/tr/tree-sitter/grammars/build-grammar.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation (
 
     inherit version src;
 
+    __structuredAttrs = true;
+
     nativeBuildInputs = [
       jq
     ]


### PR DESCRIPTION
Found via: https://gist.github.com/Sigmanificient/8b8858dc06a7a2efa6876a0d5cb127e8

- https://github.com/NixOS/nixpkgs/issues/205690

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
