### PR TITLE
dustracing2d: init at 2.2.0

### DIFF
--- a/pkgs/by-name/du/dustracing2d/package.nix
+++ b/pkgs/by-name/du/dustracing2d/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  qt6Packages,
+  openal,
+  libvorbis,
+  libogg,
+  libGL,
+  libGLU,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dustracing2d";
+  version = "2.2.0";
+
+  src = fetchFromGitHub {
+    owner = "juzzlin";
+    repo = "DustRacing2D";
+    tag = finalAttrs.version;
+    hash = "sha256-1+oKSO0pjUBgnlM9J2BB7Xyqbk8liebzUqxKY5M82qg=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qt6Packages.wrapQtAppsHook
+    qt6Packages.qttools
+  ];
+
+  buildInputs = [
+    qt6Packages.qtbase
+    qt6Packages.qtsvg
+    qt6Packages.qtwayland
+    openal
+    libvorbis
+    libogg
+    libGL
+    libGLU
+  ];
+
+  cmakeFlags = [
+    "-DReleaseBuild=ON"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Top-down 2D racing game with split-screen multiplayer";
+    homepage = "https://juzzlin.github.io/DustRacing2D/index.html";
+    downloadPage = "https://github.com/juzzlin/DustRacing2D";
+    changelog = "https://github.com/juzzlin/DustRacing2D/releases/tag/${finalAttrs.version}";
+    mainProgram = "dustrac-game";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ castorNova2 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Part of #380688

Add a package of [dustracing2d](https://github.com/juzzlin/DustRacing2D) which is a top-down car racing game.

Note: The game currently fails to create an OpenGL 2.1 context on my Fedora KDE Wayland. This appears to be an upstream Qt6/OpenGL compatibility issue rather than a packaging issue, as the application builds and starts successfully. Additional testing on other platforms would be appreciated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
