### PR TITLE
lazyspotify: init at 0.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7645,6 +7645,12 @@
     github = "eclairevoyant";
     name = "éclairevoyant";
   };
+  eConnah = {
+    email = "git@econnah.uk";
+    github = "eConnah";
+    githubId = 63052937;
+    name = "Connor Alecks";
+  };
   edanaher = {
     email = "nixos@edanaher.net";
     github = "edanaher";

--- a/pkgs/by-name/la/lazyspotify/go-librespot.nix
+++ b/pkgs/by-name/la/lazyspotify/go-librespot.nix
@@ -1,0 +1,59 @@
+{
+  alsa-lib,
+  buildGoModule,
+  fetchFromGitHub,
+  flac,
+  lib,
+  libogg,
+  libvorbis,
+  pkg-config,
+  stdenv,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "lazyspotify-librespot";
+  version = "0.7.1.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "dubeyKartikay";
+    repo = "go-librespot";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Hq9Qk8f8oKzpBwsbLNAvPO7qam3bh4L4RPUQC67/NZY=";
+  };
+
+  vendorHash = "sha256-5J5i2Wc0zHCdvJ3aUkftXeMKS5X8jWimup0Ir4HLuS8=";
+
+  subPackages = [ "cmd/daemon" ];
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    flac
+    libogg
+    libvorbis
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    alsa-lib
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/devgianlu/go-librespot.version=v${finalAttrs.version}"
+  ];
+
+  # rename the generic daemon binary for identification
+  postInstall = ''
+    install -Dm755 $out/bin/daemon $out/bin/lazyspotify-librespot
+    rm $out/bin/daemon
+  '';
+
+  meta = {
+    description = "Librespot daemon tailored for lazyspotify";
+    mainProgram = "lazyspotify-librespot";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ eConnah ];
+  };
+})

--- a/pkgs/by-name/la/lazyspotify/package.nix
+++ b/pkgs/by-name/la/lazyspotify/package.nix
@@ -1,0 +1,47 @@
+{
+  buildGoModule,
+  callPackage,
+  fetchFromGitHub,
+  lib,
+  versionCheckHook,
+  go-librespot ? callPackage ./go-librespot.nix { },
+}:
+buildGoModule (finalAttrs: {
+  pname = "lazyspotify";
+  version = "0.5.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "dubeyKartikay";
+    repo = "lazyspotify";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ZL/UPqQ6ClK0JN9LbPtr8nqcdBLdoOYti94BPRXn/Pk=";
+  };
+
+  vendorHash = "sha256-Axdt3/3ZOZY9Z5VUI6Wh77oIREOO26ODMyEgtscTmn8=";
+
+  subPackages = [ "cmd/lazyspotify" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/dubeyKartikay/lazyspotify/buildinfo.Version=${finalAttrs.version}"
+    "-X github.com/dubeyKartikay/lazyspotify/buildinfo.PackagedDaemonPath=${lib.getExe go-librespot}"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Terminal Spotify client for macOS and Linux";
+    homepage = "https://dubeykartikay.github.io/lazyspotify/";
+    changelog = "https://github.com/dubeyKartikay/lazyspotify/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "lazyspotify";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [
+      eConnah
+    ];
+  };
+})


### PR DESCRIPTION
Terminal Spotify client for macOS and Linux.
Source - https://github.com/dubeyKartikay/lazyspotify
Homepage - https://dubeykartikay.github.io/lazyspotify/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Assisted-by: Gemini 3.1 Pro
