### PR TITLE
opentofu-mcp-server: init at 1.0.0

### DIFF
--- a/pkgs/by-name/op/opentofu-mcp-server/package.nix
+++ b/pkgs/by-name/op/opentofu-mcp-server/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  nodejs,
+  nix-update-script,
+  pnpm_8,
+  pnpmConfigHook,
+  makeWrapper,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "opentofu-mcp-server";
+  version = "1.0.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "opentofu";
+    repo = "opentofu-mcp-server";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qgjAnoduzAjvxgbgG8QW53CMF3/bW0NQhDbVv3ebntw=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    fetcherVersion = 3;
+    pnpm = pnpm_8;
+    hash = "sha256-8U+yGjUtgpASLU5LewUMRFT0uxz45trw27+HH/h+sdA=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm_8
+    pnpmConfigHook
+    makeWrapper
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    pnpm build
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib/opentofu-mcp-server
+    cp -r dist node_modules $out/lib/opentofu-mcp-server/
+    mkdir -p $out/bin
+    makeWrapper ${nodejs}/bin/node $out/bin/opentofu-mcp-server \
+      --add-flags "$out/lib/opentofu-mcp-server/dist/local.js"
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "OpenTofu MCP server for accessing the OpenTofu Registry";
+    homepage = "https://github.com/opentofu/opentofu-mcp-server";
+    changelog = "https://github.com/opentofu/opentofu-mcp-server/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ eana ];
+    mainProgram = "opentofu-mcp-server";
+  };
+})


### PR DESCRIPTION
Add `opentofu-mcp-server`, an MCP server for accessing the OpenTofu Registry. https://github.com/opentofu/opentofu-mcp-server

Built with pnpm and wrapped with Node.js. Built and tested on x86_64-linux and x86_64-darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
