### PR TITLE
context-mode: init at 1.0.143

### DIFF
--- a/pkgs/by-name/co/context-mode/package.nix
+++ b/pkgs/by-name/co/context-mode/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  bun,
+  makeWrapper,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "context-mode";
+  version = "1.0.143";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchurl {
+    url = "https://registry.npmjs.org/context-mode/-/context-mode-${finalAttrs.version}.tgz";
+    hash = "sha256-Qh91ZkeLN11ACg4y1lUpeDbSkTWF8QkY/oWKiHR/+og=";
+  };
+
+  sourceRoot = "package";
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/context-mode
+    cp -r \
+      server.bundle.mjs \
+      cli.bundle.mjs \
+      package.json \
+      .claude-plugin \
+      .codex-plugin \
+      bin \
+      configs \
+      hooks \
+      insight \
+      scripts \
+      skills \
+      $out/lib/context-mode/
+
+    mkdir -p $out/bin
+    # Use bun as the runtime so globalThis.Bun is set at startup, which causes
+    # db-base.js to use bun:sqlite instead of better-sqlite3 (unavailable in
+    # nixpkgs). The server.bundle.mjs shebang says "node" but we override here.
+    # Prepend bun to PATH so the server's runtime detection finds it and avoids
+    # printing a spurious "Install Bun" performance tip.
+    makeWrapper ${bun}/bin/bun $out/bin/context-mode \
+      --add-flags "$out/lib/context-mode/server.bundle.mjs" \
+      --prefix PATH : ${lib.makeBinPath [ bun ]}
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Context window optimization MCP server for AI coding agents";
+    homepage = "https://github.com/mksglu/context-mode";
+    license = lib.licenses.elastic20;
+    maintainers = with lib.maintainers; [ eana ];
+    mainProgram = "context-mode";
+  };
+})


### PR DESCRIPTION
Add `context-mode`, a context window optimization MCP server for AI coding agents. https://github.com/mksglu/context-mode

The package fetches the npm tarball and uses bun as the runtime (instead of Node.js) so that globalThis.Bun is set at startup, enabling the bundled bun:sqlite backend. bun is also prepended to PATH in the wrapper so the server's runtime detection finds it correctly at startup.

Built and tested on `x86_64-linux` and `x86_64-darwin`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
