### PR TITLE
okteta: migrate to by-name

### DIFF
--- a/pkgs/by-name/ok/okteta/package.nix
+++ b/pkgs/by-name/ok/okteta/package.nix
@@ -3,19 +3,10 @@
   stdenv,
   fetchFromGitLab,
   cmake,
-  extra-cmake-modules,
-  wrapQtAppsHook,
   shared-mime-info,
   xz,
-  qttools,
-  karchive,
-  kcmutils,
-  kconfig,
-  kconfigwidgets,
-  kcrash,
-  knewstuff,
-  kparts,
-  qca,
+  kdePackages,
+  qt6,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -32,24 +23,24 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    extra-cmake-modules
-    wrapQtAppsHook
+    kdePackages.extra-cmake-modules
+    qt6.wrapQtAppsHook
   ];
 
   buildInputs = [
     shared-mime-info
     xz
 
-    qttools
+    qt6.qttools
 
-    karchive
-    kcmutils
-    kconfig
-    kconfigwidgets
-    kcrash
-    knewstuff
-    kparts
-    qca
+    kdePackages.karchive
+    kdePackages.kcmutils
+    kdePackages.kconfig
+    kdePackages.kconfigwidgets
+    kdePackages.kcrash
+    kdePackages.knewstuff
+    kdePackages.kparts
+    kdePackages.qca
   ];
 
   outputs = [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9477,8 +9477,6 @@ with pkgs;
     ;
   k3s = k3s_1_35;
 
-  okteta = kdePackages.callPackage ../applications/editors/okteta { };
-
   klayout = qt6Packages.callPackage ../applications/misc/klayout { };
 
   kotatogram-desktop =


### PR DESCRIPTION
This pull request refactors the packaging of `okteta` to modernize its dependencies and location in the repository. The main changes involve migrating the package definition to the `by-name` structure and updating its dependency handling to use the `kdePackages` set, which simplifies maintenance and improves consistency.

**Okteta package refactor and migration:**

* Moved `okteta` package definition from `pkgs/applications/editors/okteta/default.nix` to the new location `pkgs/by-name/ok/okteta/package.nix` for better organization.
* Updated dependencies in `package.nix` to use the `kdePackages` attribute set (e.g., `kdePackages.qttools`, `kdePackages.karchive`, etc.) instead of listing individual KDE dependencies, making the package more maintainable and consistent with other KDE packages.
* Removed the old `okteta` package entry from `pkgs/top-level/all-packages.nix`, as it is now handled via the new `by-name` structure.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
