### PR TITLE
several: unify electron-builder logic

### DIFF
--- a/pkgs/by-name/eq/equibop/package.nix
+++ b/pkgs/by-name/eq/equibop/package.nix
@@ -75,7 +75,6 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postConfigure
   '';
 
-  # electron builds must be writable to support electron fuses
   preBuild = ''
     # Validate electron version matches upstream package.json
     if [ "`jq -r '.devDependencies.electron' < package.json | cut -d. -f1 | tr -d '^'`" != "${lib.versions.major electron.version}" ]
@@ -83,12 +82,8 @@ stdenv.mkDerivation (finalAttrs: {
       echo "ERROR: electron version mismatch between package.json and nixpkgs"
       exit 1
     fi
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    cp -r ${electron.dist}/Electron.app .
-    chmod -R u+w Electron.app
-  ''
-  + lib.optionalString stdenv.hostPlatform.isLinux ''
+
+    # electron builds must be writable to support electron fuses
     cp -r ${electron.dist} electron-dist
     chmod -R u+w electron-dist
   '';
@@ -103,7 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
     # can't run it via bunx / npx since fixupPhase was skipped for node_modules
     node node_modules/electron-builder/out/cli/cli.js \
       --dir \
-      -c.electronDist=${if stdenv.hostPlatform.isDarwin then "." else "electron-dist"} \
+      -c.electronDist=electron-dist \
       -c.electronVersion=${electron.version} \
       -c.npmRebuild=false
 

--- a/pkgs/by-name/fe/feishin/package.nix
+++ b/pkgs/by-name/fe/feishin/package.nix
@@ -74,20 +74,17 @@ buildNpmPackage {
     ln -s ${dart-sass}/bin/dart-sass "$dir"/sass
   '';
 
-  postBuild =
-    lib.optionalString stdenv.hostPlatform.isDarwin ''
-      # electron-builder appears to build directly on top of Electron.app, by overwriting the files in the bundle.
-      cp -r ${electron.dist}/Electron.app ./
-      find ./Electron.app -name 'Info.plist' | xargs -d '\n' chmod +rw
-    ''
-    + ''
-      npm exec electron-builder -- \
-        --dir \
-        -c.electronDist=${if stdenv.hostPlatform.isDarwin then "./" else electron.dist} \
-        -c.electronVersion=${electron.version} \
-        -c.npmRebuild=false \
-        ${lib.optionalString stdenv.hostPlatform.isDarwin "-c.mac.identity=null"}
-    '';
+  postBuild = ''
+    cp -r ${electron.dist} electron-dist
+    chmod -R u+w electron-dist
+
+    npm exec electron-builder -- \
+      --dir \
+      -c.electronDist=electron-dist \
+      -c.electronVersion=${electron.version} \
+      -c.npmRebuild=false \
+      ${lib.optionalString stdenv.hostPlatform.isDarwin "-c.mac.identity=null"}
+  '';
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/go/goofcord/package.nix
+++ b/pkgs/by-name/go/goofcord/package.nix
@@ -64,19 +64,17 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postConfigure
   '';
 
-  preBuild = lib.optionalString stdenv.hostPlatform.isLinux ''
-    cp -r ${electron.dist} electron-dist
-    chmod -R u+w electron-dist
-  '';
-
   buildPhase = ''
     runHook preBuild
 
     bun run build -- --skipTypecheck
 
+    cp -r ${electron.dist} electron-dist
+    chmod -R u+w electron-dist
+
     node node_modules/electron-builder/out/cli/cli.js \
       --dir \
-      -c.electronDist="${if stdenv.hostPlatform.isLinux then "electron-dist" else electron.dist}" \
+      -c.electronDist=electron-dist \
       -c.electronVersion="${electron.version}" \
       -c.npmRebuild=false
 

--- a/pkgs/by-name/pe/pear-desktop/package.nix
+++ b/pkgs/by-name/pe/pear-desktop/package.nix
@@ -47,18 +47,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
 
-  postBuild =
-    lib.optionalString stdenv.hostPlatform.isDarwin ''
-      cp -R ${electron.dist}/Electron.app Electron.app
-      chmod -R u+w Electron.app
-    ''
-    + ''
-      pnpm build
-      ./node_modules/.bin/electron-builder \
-        --dir \
-        -c.electronDist=${if stdenv.hostPlatform.isDarwin then "." else electron.dist} \
-        -c.electronVersion=${electron.version}
-    '';
+  postBuild = ''
+    pnpm build
+
+    cp -r ${electron.dist} electron-dist
+    chmod -R u+w electron-dist
+
+    ./node_modules/.bin/electron-builder \
+      --dir \
+      -c.electronDist=electron-dist \
+      -c.electronVersion=${electron.version}
+  '';
 
   desktopItems = [
     (makeDesktopItem {

--- a/pkgs/by-name/ve/vesktop/package.nix
+++ b/pkgs/by-name/ve/vesktop/package.nix
@@ -87,7 +87,6 @@ stdenv.mkDerivation (finalAttrs: {
     ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
   };
 
-  # electron builds must be writable
   preBuild = ''
     # Validate electron version matches upstream package.json
     if [ "`jq -r '.devDependencies.electron' < package.json | cut -d. -f1 | tr -d '^'`" != "${lib.versions.major electron.version}" ]
@@ -95,12 +94,8 @@ stdenv.mkDerivation (finalAttrs: {
       echo "ERROR: electron version mismatch between package.json and nixpkgs"
       exit 1
     fi
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    cp -r ${electron.dist}/Electron.app .
-    chmod -R u+w Electron.app
-  ''
-  + lib.optionalString stdenv.hostPlatform.isLinux ''
+
+    # electron builds must be writable
     cp -r ${electron.dist} electron-dist
     chmod -R u+w electron-dist
   '';
@@ -112,7 +107,7 @@ stdenv.mkDerivation (finalAttrs: {
     pnpm exec electron-builder \
       --dir \
       -c.asarUnpack="**/*.node" \
-      -c.electronDist=${if stdenv.hostPlatform.isDarwin then "." else "electron-dist"} \
+      -c.electronDist=electron-dist \
       -c.electronVersion=${electron.version} \
       ${lib.optionalString stdenv.hostPlatform.isDarwin "-c.mac.identity=null"} # disable code signing on macos, https://github.com/electron-userland/electron-builder/blob/77f977435c99247d5db395895618b150f5006e8f/docs/code-signing.md#how-to-disable-code-signing-during-the-build-process-on-macos
 


### PR DESCRIPTION
Unifies the linux-darwin logic of some packages using electron-builder.

This is not a complete treewide, because there are some more complicated packages that need separate PRs.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
