### PR TITLE
nixos/fuse: add umount.fuse helper script

### DIFF
--- a/nixos/modules/programs/fuse.nix
+++ b/nixos/modules/programs/fuse.nix
@@ -36,30 +36,82 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable {
-    environment.systemPackages = [
-      pkgs.fuse
-      pkgs.fuse3
-    ];
+  config =
+    let
+      umount-fuse-script = pkgs.writeShellScriptBin "umount.fuse" ''
+        FUSERMOUNT=/run/wrappers/bin/fusermount3 # SUID bit needed
 
-    security.wrappers =
-      let
-        mkSetuidRoot = source: {
-          setuid = true;
-          owner = "root";
-          group = "root";
-          inherit source;
+        usage() {
+            echo "Usage: umount.fuse {directory|device} [-flnrv] [-N namespace] [-t type.subtype]" >&2
+            echo "See umount(8) man page" >&2
+            exit 1 # same error code as umount
+        }
+
+        # the first positional argument is always the target mountpoint/device.
+        (( $# >= 1 )) || usage
+        TARGET="$1"
+        shift
+
+        fuse_args=()
+        fuse_args+=("-u") # unmount flag
+
+        while (( $# > 0 )); do
+            case "$1" in
+                -f) echo "umount.fuse: warning: -f (force) is not supported by this helper, ignoring" >&2 ;;
+                -l) fuse_args+=("-z") ;; # lazy mount
+                -n) echo "umount.fuse: warning: -n (no-mtab) is not supported by this helper, ignoring" >&2 ;;
+                -r) echo "umount.fuse: warning: -r (read-only fallback) is not supported by this helper, ignoring" >&2 ;;
+                -v) ;; # not used by fusermount
+                -N)
+                    echo "umount.fuse: -N (namespace) is not supported by this helper" >&2
+                    exit 1
+                    ;;
+                -t)
+                    echo "umount.fuse: warning: -t (type) is not supported by this helper, ignoring" >&2
+                    shift
+                    ;;
+                *)
+                    echo "umount.fuse: unexpected argument: $1" >&2
+                    usage
+                    ;;
+            esac
+            shift
+        done
+
+        fuse_args+=("--") # ensures that a mountpoint starting with '-' is correctly interpreted
+        fuse_args+=("$TARGET")
+
+        exec "$FUSERMOUNT" "''${fuse_args[@]}"
+
+        echo "umount.fuse: exec failed: $FUSERMOUNT" >&2
+        exit 2 # same error code as umount: system error (cannot fork, etc.)
+      '';
+    in
+    lib.mkIf cfg.enable {
+      environment.systemPackages = [
+        pkgs.fuse
+        pkgs.fuse3
+        umount-fuse-script
+      ];
+
+      security.wrappers =
+        let
+          mkSetuidRoot = source: {
+            setuid = true;
+            owner = "root";
+            group = "root";
+            inherit source;
+          };
+        in
+        {
+          fusermount = mkSetuidRoot "${lib.getBin pkgs.fuse}/bin/fusermount";
+          fusermount3 = mkSetuidRoot "${lib.getBin pkgs.fuse3}/bin/fusermount3";
         };
-      in
-      {
-        fusermount = mkSetuidRoot "${lib.getBin pkgs.fuse}/bin/fusermount";
-        fusermount3 = mkSetuidRoot "${lib.getBin pkgs.fuse3}/bin/fusermount3";
-      };
 
-    environment.etc."fuse.conf".text = ''
-      ${lib.optionalString (!cfg.userAllowOther) "#"}user_allow_other
-      mount_max = ${toString cfg.mountMax}
-    '';
+      environment.etc."fuse.conf".text = ''
+        ${lib.optionalString (!cfg.userAllowOther) "#"}user_allow_other
+        mount_max = ${toString cfg.mountMax}
+      '';
 
-  };
+    };
 }


### PR DESCRIPTION
fixes #523343

The umount syscall needs root privileges to work,
even for fuse and user mounts. This privilege is
usually granted throught the SUID bit on the
umount binary.

In the case of NixOS, systemd calls the umount
binary directly from the nix store which doesn't
have the SUID bit (contrary to the one from the system environment in `/run/wrappers/bin/`).

This means systemd user mount units fail to desactivate.

Fortunatly, umount tries to call `umount helpers` which allows us to then call `/run/wrappers/bin/fusermount3` which has the SUID bit.

This won't help with systemd user mount unit referencing fstab user mounts as those would still require a SUID enabled `umount` like regular distros.

