### PR TITLE
antigravity-cli: fix binary name

### DIFF
--- a/pkgs/by-name/an/antigravity-cli/package.nix
+++ b/pkgs/by-name/an/antigravity-cli/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    install -Dm755 antigravity $out/bin/antigravity-cli
+    install -Dm755 antigravity $out/bin/agy
 
     runHook postInstall
   '';
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [ u3kkasha ];
     platforms = lib.attrNames sources;
-    mainProgram = "antigravity-cli";
+    mainProgram = "agy";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
 })


### PR DESCRIPTION
antigravity-cli called the mainProgram differently than what the upstream project expects

```
> exit                                                                                                                                                                                                     
                                                                                                                                                                                                           
  I understand. Whenever you are ready to continue or start a new task, feel free to reach out. Have a great day!                                                                                          
⡿ Generating...                                                                                                                                                                                                                                                                                                                                                                                 
Resume: agy --conversation=d5d36a32-d82d-4993-bea2-a948b596569e (or -c)                                                                                                                                    
                                                                              
                                         
```            