### PR TITLE
python3Packages.pyfuse3: Fix cross-compilation

### DIFF
--- a/pkgs/development/python-modules/pyfuse3/default.nix
+++ b/pkgs/development/python-modules/pyfuse3/default.nix
@@ -26,6 +26,13 @@ buildPythonPackage rec {
     hash = "sha256-HhEtWYWdxJZOMS3dqB2VdQS7aSdpkRhq7EZCJ55n2OE=";
   };
 
+  patches = [
+    # Fix cross compilation by using PKG_CONFIG env variable instead
+    # of hardcoded binary name
+    # https://github.com/libfuse/pyfuse3/pull/148
+    ./fix_cross_parse_pkg_config.patch
+  ];
+
   build-system = [
     cython
     setuptools

--- a/pkgs/development/python-modules/pyfuse3/fix_cross_parse_pkg_config.patch
+++ b/pkgs/development/python-modules/pyfuse3/fix_cross_parse_pkg_config.patch
@@ -1,0 +1,38 @@
+From a37b18ea421eb20391d0b900844f0c04054247e6 Mon Sep 17 00:00:00 2001
+From: Jonas Heinrich <onny@project-insanity.org>
+Date: Thu, 9 Jul 2026 14:40:16 +0200
+Subject: [PATCH] Fix cross-compilaton by using PKG_CONFIG env variable
+
+---
+ util/build_backend.py | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/util/build_backend.py b/util/build_backend.py
+index 0ec6b21..95e4ee3 100644
+--- a/util/build_backend.py
++++ b/util/build_backend.py
+@@ -15,11 +15,13 @@
+ def pkg_config(pkg, cflags=True, ldflags=False, min_ver=None):
+     """Frontend to pkg-config"""
+ 
++    PKG_CONFIG = os.environ.get('PKG_CONFIG', 'pkg-config').split()
++
+     if min_ver:
+-        cmd = ['pkg-config', pkg, '--atleast-version', min_ver]
++        cmd = PKG_CONFIG + [pkg, '--atleast-version', min_ver]
+ 
+         if subprocess.call(cmd) != 0:
+-            cmd = ['pkg-config', '--modversion', pkg]
++            cmd = PKG_CONFIG + ['--modversion', pkg]
+             proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+             version = proc.communicate()[0].strip()
+             if not version:
+@@ -29,7 +31,7 @@ def pkg_config(pkg, cflags=True, ldflags=False, min_ver=None):
+                     '%s version too old (found: %s, required: %s)' % (pkg, version, min_ver)
+                 )
+ 
+-    cmd = ['pkg-config', pkg]
++    cmd = PKG_CONFIG + [pkg]
+     if cflags:
+         cmd.append('--cflags')
+     if ldflags:


### PR DESCRIPTION
adding patch, otherwise cross-compilation, for example for riscv, will fail because the pkg-config name here will be different
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
