### PR TITLE
[release-25.11] Kimai: 2.46.0 -> 2.58.0; fixes 2+ CVEs

### DIFF
--- a/pkgs/by-name/ki/kimai/package.nix
+++ b/pkgs/by-name/ki/kimai/package.nix
@@ -7,13 +7,13 @@
 
 php.buildComposerProject2 (finalAttrs: {
   pname = "kimai";
-  version = "2.57.0";
+  version = "2.58.0";
 
   src = fetchFromGitHub {
     owner = "kimai";
     repo = "kimai";
     tag = finalAttrs.version;
-    hash = "sha256-WbZivDI5xU/pM52yFvG6vMK3LaCjbLoJGNFP3Exb8qc=";
+    hash = "sha256-JS4Mjn8fUr9CCQiELnCVH1Arg7uk7KbRwYWF1ECuMRM=";
   };
 
   php = php.buildEnv {
@@ -38,7 +38,7 @@ php.buildComposerProject2 (finalAttrs: {
     '';
   };
 
-  vendorHash = "sha256-e0k4u7AZJz5RqcrY5gmz0NBhuH2w+cCwzjBScuhcX9w=";
+  vendorHash = "sha256-UaK0YbYERitqx6WY9nDglTBPrHjl391nAU6VFKbQzi8=";
 
   composerNoPlugins = false;
 

--- a/pkgs/by-name/ki/kimai/package.nix
+++ b/pkgs/by-name/ki/kimai/package.nix
@@ -7,13 +7,13 @@
 
 php.buildComposerProject2 (finalAttrs: {
   pname = "kimai";
-  version = "2.51.0";
+  version = "2.52.0";
 
   src = fetchFromGitHub {
     owner = "kimai";
     repo = "kimai";
     tag = finalAttrs.version;
-    hash = "sha256-3wm8y0Ryl7i3QEBP9hC2pDt8JgkkS6gXQ+Lm0fRE9+E=";
+    hash = "sha256-lh+12X85MM3Efp2DUQ22itXnqnNzPzxqxQ1GNbDaaPQ=";
   };
 
   php = php.buildEnv {
@@ -38,7 +38,7 @@ php.buildComposerProject2 (finalAttrs: {
     '';
   };
 
-  vendorHash = "sha256-OYeLIGxkNrA7xtg4mF1mDLVeFkeRHfWt0O7IT6XoGyI=";
+  vendorHash = "sha256-V3YRkafmCmUOFOgzEg6l08dDsASbhEby2m/pG6adA70=";
 
   composerNoPlugins = false;
 

--- a/pkgs/by-name/ki/kimai/package.nix
+++ b/pkgs/by-name/ki/kimai/package.nix
@@ -7,13 +7,13 @@
 
 php.buildComposerProject2 (finalAttrs: {
   pname = "kimai";
-  version = "2.55.0";
+  version = "2.56.0";
 
   src = fetchFromGitHub {
     owner = "kimai";
     repo = "kimai";
     tag = finalAttrs.version;
-    hash = "sha256-p4Y5hCWr5BVOGYUJtFJhhDftm+A/CWxbdBhPgOR1TcY=";
+    hash = "sha256-rax67E/Zr50ejSAjA4Aa1NDsAbJYuAAE4k8hji5UhOg=";
   };
 
   php = php.buildEnv {
@@ -38,7 +38,7 @@ php.buildComposerProject2 (finalAttrs: {
     '';
   };
 
-  vendorHash = "sha256-KgJpeqaG0uPNiFCUbg8CLE9wL7gmOQB7d8ax56zVZNk=";
+  vendorHash = "sha256-cvywDnVe94RatDBO4ypp16EMUH+mZtggV9y7CyCjXEU=";
 
   composerNoPlugins = false;
 

--- a/pkgs/by-name/ki/kimai/package.nix
+++ b/pkgs/by-name/ki/kimai/package.nix
@@ -7,13 +7,13 @@
 
 php.buildComposerProject2 (finalAttrs: {
   pname = "kimai";
-  version = "2.46.0";
+  version = "2.47.0";
 
   src = fetchFromGitHub {
     owner = "kimai";
     repo = "kimai";
     tag = finalAttrs.version;
-    hash = "sha256-sZjDl3nQ4i5KVnM2fLVvaQxMlE225q7EBkgFmTn+ugc=";
+    hash = "sha256-aMvgioXuKZWstkslfX8bFuxBpTo9F3VHl9aqyNPDMFQ=";
   };
 
   php = php.buildEnv {
@@ -38,7 +38,7 @@ php.buildComposerProject2 (finalAttrs: {
     '';
   };
 
-  vendorHash = "sha256-GuaPJVE97WHediCi7kbGk/CqDR55H5lkpz/QHiBSk7A=";
+  vendorHash = "sha256-TDIACTf64ObdG74ynySyMn2/FqbydNVa+a2twtcOYJQ=";
 
   composerNoPlugins = false;
 

--- a/pkgs/by-name/ki/kimai/package.nix
+++ b/pkgs/by-name/ki/kimai/package.nix
@@ -7,13 +7,13 @@
 
 php.buildComposerProject2 (finalAttrs: {
   pname = "kimai";
-  version = "2.52.0";
+  version = "2.55.0";
 
   src = fetchFromGitHub {
     owner = "kimai";
     repo = "kimai";
     tag = finalAttrs.version;
-    hash = "sha256-lh+12X85MM3Efp2DUQ22itXnqnNzPzxqxQ1GNbDaaPQ=";
+    hash = "sha256-p4Y5hCWr5BVOGYUJtFJhhDftm+A/CWxbdBhPgOR1TcY=";
   };
 
   php = php.buildEnv {
@@ -38,7 +38,7 @@ php.buildComposerProject2 (finalAttrs: {
     '';
   };
 
-  vendorHash = "sha256-V3YRkafmCmUOFOgzEg6l08dDsASbhEby2m/pG6adA70=";
+  vendorHash = "sha256-KgJpeqaG0uPNiFCUbg8CLE9wL7gmOQB7d8ax56zVZNk=";
 
   composerNoPlugins = false;
 

--- a/pkgs/by-name/ki/kimai/package.nix
+++ b/pkgs/by-name/ki/kimai/package.nix
@@ -1,7 +1,6 @@
 {
   php,
   fetchFromGitHub,
-  fetchpatch2,
   lib,
   nixosTests,
 }:
@@ -16,18 +15,6 @@ php.buildComposerProject2 (finalAttrs: {
     tag = finalAttrs.version;
     hash = "sha256-sZjDl3nQ4i5KVnM2fLVvaQxMlE225q7EBkgFmTn+ugc=";
   };
-
-  patches = [
-    # https://github.com/kimai/kimai/pull/5849
-    (fetchpatch2 {
-      name = "CVE-2026-28685.patch";
-      url = "https://github.com/kimai/kimai/commit/a0601c8cb28fed1cca19051a8272425069ab758f.patch?full_index=1";
-      # Kimai specifies `tests export-ignore` in its `.gitattributes`, and
-      # `fetchFromGitHub` uses export archive from GitHub.
-      excludes = [ "tests/*" ];
-      hash = "sha256-LOGyGpkhfDBOy9MojJMm9IIlqqeGqKAejfLVIX6FnJw=";
-    })
-  ];
 
   php = php.buildEnv {
     extensions = (

--- a/pkgs/by-name/ki/kimai/package.nix
+++ b/pkgs/by-name/ki/kimai/package.nix
@@ -7,13 +7,13 @@
 
 php.buildComposerProject2 (finalAttrs: {
   pname = "kimai";
-  version = "2.49.0";
+  version = "2.51.0";
 
   src = fetchFromGitHub {
     owner = "kimai";
     repo = "kimai";
     tag = finalAttrs.version;
-    hash = "sha256-hP67vu/8D7dTOPklyc8g3B//LAvs5YZ0g7fZ5lePM48=";
+    hash = "sha256-3wm8y0Ryl7i3QEBP9hC2pDt8JgkkS6gXQ+Lm0fRE9+E=";
   };
 
   php = php.buildEnv {
@@ -38,7 +38,7 @@ php.buildComposerProject2 (finalAttrs: {
     '';
   };
 
-  vendorHash = "sha256-Cl9BT/AQPDVmCseGDWrKfhCiubaqHeSTRp+Z/CZVuTE=";
+  vendorHash = "sha256-OYeLIGxkNrA7xtg4mF1mDLVeFkeRHfWt0O7IT6XoGyI=";
 
   composerNoPlugins = false;
 

--- a/pkgs/by-name/ki/kimai/package.nix
+++ b/pkgs/by-name/ki/kimai/package.nix
@@ -7,13 +7,13 @@
 
 php.buildComposerProject2 (finalAttrs: {
   pname = "kimai";
-  version = "2.56.0";
+  version = "2.57.0";
 
   src = fetchFromGitHub {
     owner = "kimai";
     repo = "kimai";
     tag = finalAttrs.version;
-    hash = "sha256-rax67E/Zr50ejSAjA4Aa1NDsAbJYuAAE4k8hji5UhOg=";
+    hash = "sha256-WbZivDI5xU/pM52yFvG6vMK3LaCjbLoJGNFP3Exb8qc=";
   };
 
   php = php.buildEnv {
@@ -38,7 +38,7 @@ php.buildComposerProject2 (finalAttrs: {
     '';
   };
 
-  vendorHash = "sha256-cvywDnVe94RatDBO4ypp16EMUH+mZtggV9y7CyCjXEU=";
+  vendorHash = "sha256-e0k4u7AZJz5RqcrY5gmz0NBhuH2w+cCwzjBScuhcX9w=";
 
   composerNoPlugins = false;
 

--- a/pkgs/by-name/ki/kimai/package.nix
+++ b/pkgs/by-name/ki/kimai/package.nix
@@ -7,13 +7,13 @@
 
 php.buildComposerProject2 (finalAttrs: {
   pname = "kimai";
-  version = "2.47.0";
+  version = "2.49.0";
 
   src = fetchFromGitHub {
     owner = "kimai";
     repo = "kimai";
     tag = finalAttrs.version;
-    hash = "sha256-aMvgioXuKZWstkslfX8bFuxBpTo9F3VHl9aqyNPDMFQ=";
+    hash = "sha256-hP67vu/8D7dTOPklyc8g3B//LAvs5YZ0g7fZ5lePM48=";
   };
 
   php = php.buildEnv {
@@ -38,7 +38,7 @@ php.buildComposerProject2 (finalAttrs: {
     '';
   };
 
-  vendorHash = "sha256-TDIACTf64ObdG74ynySyMn2/FqbydNVa+a2twtcOYJQ=";
+  vendorHash = "sha256-Cl9BT/AQPDVmCseGDWrKfhCiubaqHeSTRp+Z/CZVuTE=";
 
   composerNoPlugins = false;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I've learned the hard way that Kimai's commits are not intended to be
cherry-picked, which complicates backporting changes. So I've decided
to stop cherry-picking patches and instead continue bumping minor
versions, accepting one small functionality change along the way.

For reference, such functionality change happens in [Kimai 2.50.0](https://github.com/kimai/kimai/releases/tag/2.50.0), which "Removed support for file:// urls in Markdown (new parsedown package)". I reckon that this is worth it, compare to security fixes from all versions since then.

The first commit in this PR reverts https://github.com/NixOS/nixpkgs/pull/499270 which diverges NixOS 25.11 and Unstable, then subsequently backports upgrade commits from NixOS Unstable, correcting vendor hashes along the way.

This fixes #511427 and https://github.com/NixOS/nixpkgs/issues/511448 for NixOS 25.11. Kimai 2.57.0 is mentioned to contain "multiple security fixes both fro[m] Kimai and its dependencies". Finally, Kimai 2.58.0 "contains quite a few security related improvements and fixes (yep, LLMs are pretty strong nowadays)".

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
