### PR TITLE
haskellPackages.ghc-typelits-natnormalise: fix tests

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1663,6 +1663,15 @@ builtins.intersectAttrs super {
     (disableCabalFlag "icu")
   ];
 
+  # Tests spawn ghc with -fplugin and need this package's in-place package db.
+  # The trailing colon keeps GHC's default package db in the package path.
+  # https://hydra.nixos.org/build/329190094
+  ghc-typelits-natnormalise = overrideCabal (drv: {
+    preCheck = (drv.preCheck or "") + ''
+      export NIX_GHC_PACKAGE_PATH_FOR_TEST=$PWD/dist/package.conf.inplace/:$packageConfDir:
+    '';
+  }) super.ghc-typelits-natnormalise;
+
   # based on https://github.com/gibiansky/IHaskell/blob/aafeabef786154d81ab7d9d1882bbcd06fc8c6c4/release.nix
   ihaskell = overrideCabal (drv: {
     # ihaskell's cabal file forces building a shared executable, which we need


### PR DESCRIPTION
Fixes `ghc-typelits-natnormalise` for https://github.com/NixOS/nixpkgs/pull/521260 (should unblock ihp, ihp-ide, typerep-map)

(done with codex gpt.5-5 extra high)

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Additional validation:

- `git diff --check`
- `nix eval --raw .#haskellPackages.ghc-typelits-natnormalise.version`
- `nix eval --raw .#haskellPackages.ghc-typelits-natnormalise.preCheck`
- `nix build --dry-run --no-link .#haskellPackages.ghc-typelits-natnormalise`

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

