### PR TITLE
weaviate-client: 4.20.5 -> 4.21.0; fix darwin build

### DIFF
--- a/pkgs/development/python-modules/weaviate-client/default.nix
+++ b/pkgs/development/python-modules/weaviate-client/default.nix
@@ -21,8 +21,10 @@
   pytestCheckHook,
   pythonOlder,
   requests,
+  stdenv,
   setuptools-scm,
   validators,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
@@ -72,10 +74,10 @@ buildPythonPackage rec {
     pytest-httpserver
     pytest-asyncio
     pytestCheckHook
+    writableTmpDirAsHomeHook
   ];
 
   preCheck = ''
-    export HOME=$(mktemp -d)
     sed -i '/raw.githubusercontent.com/,+1d' test/test_util.py
     substituteInPlace pytest.ini \
       --replace-fail "--benchmark-skip" ""
@@ -97,7 +99,9 @@ buildPythonPackage rec {
 
   enabledTestPaths = [
     "test"
-    "mock_tests"
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    "mock_tests" # mock gRPC/HTTP servers fail to bind ports in the Darwin sandbox
   ];
 
   __darwinAllowLocalNetworking = true;
@@ -110,9 +114,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/weaviate/weaviate-python-client/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ happysalada ];
-    badPlatforms = [
-      # weaviate.exceptions.WeaviateGRPCUnavailableError
-      lib.systems.inspect.patterns.isDarwin
-    ];
   };
 }

--- a/pkgs/development/python-modules/weaviate-client/default.nix
+++ b/pkgs/development/python-modules/weaviate-client/default.nix
@@ -18,6 +18,7 @@
   pydantic,
   pytest-asyncio,
   pytest-httpserver,
+  pytest-xdist,
   pytestCheckHook,
   pythonOlder,
   requests,
@@ -29,7 +30,7 @@
 
 buildPythonPackage rec {
   pname = "weaviate-client";
-  version = "4.20.5";
+  version = "4.21.0";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -38,7 +39,7 @@ buildPythonPackage rec {
     owner = "weaviate";
     repo = "weaviate-python-client";
     tag = "v${version}";
-    hash = "sha256-3CJLD/bew9qx2aDrIwcaMlgwCe8E4bj3ZDh5t0v8Pf8=";
+    hash = "sha256-nGYslKyIQWAwhu5Fa23jXtgBN9q4jjrmBhWv4EO3Vn8=";
   };
 
   pythonRelaxDeps = [
@@ -71,8 +72,9 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    pytest-httpserver
     pytest-asyncio
+    pytest-httpserver
+    pytest-xdist
     pytestCheckHook
     writableTmpDirAsHomeHook
   ];
@@ -99,9 +101,10 @@ buildPythonPackage rec {
 
   enabledTestPaths = [
     "test"
-  ]
-  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
-    "mock_tests" # mock gRPC/HTTP servers fail to bind ports in the Darwin sandbox
+  ];
+
+  disabledTestPaths = [
+    "mock_tests" # mock gRPC/HTTP servers fail to bind ports
   ];
 
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Update version
- Disable failing tests

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
