### PR TITLE
python3Packages.eth-utils: cleanup, skip failing test

### DIFF
--- a/pkgs/development/python-modules/eth-utils/default.nix
+++ b/pkgs/development/python-modules/eth-utils/default.nix
@@ -2,21 +2,25 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   setuptools,
   isPyPy,
+
   # dependencies
   eth-hash,
   eth-typing,
   cytoolz,
   toolz,
   pydantic,
-  # nativeCheckInputs
+
+  # tests
   hypothesis,
   mypy,
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "eth-utils";
   version = "6.0.0";
   pyproject = true;
@@ -24,7 +28,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "ethereum";
     repo = "eth-utils";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-U1RSKaLw/gDg4lMjkTwR/Wfb5wqQctML9CDZBILMBys=";
   };
 
@@ -35,7 +39,7 @@ buildPythonPackage rec {
 
   build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     eth-hash
     eth-typing
   ]
@@ -52,7 +56,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "eth_utils" ];
 
-  disabledTests = [ "test_install_local_wheel" ];
+  disabledTests = [
+    # Exception: Expected one wheel. Instead found: [] in project /build/source
+    "test_install_local_wheel"
+  ];
 
   disabledTestPaths = [
     # Typing tests fail like:
@@ -61,10 +68,10 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/ethereum/eth-utils/blob/${src.rev}/docs/release_notes.rst";
+    changelog = "https://github.com/ethereum/eth-utils/blob/${finalAttrs.src.tag}/docs/release_notes.rst";
     description = "Common utility functions for codebases which interact with ethereum";
     homepage = "https://github.com/ethereum/eth-utils";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ siraben ];
   };
-}
+})


### PR DESCRIPTION
## Things done

```
FAILED tests/core/functional-utils/test_type_inference.py::test_type_inference[fixtures/mypy/apply_to_return_value_decorator.py-fixtures/mypy/apply_to_return_value_decorator.py:16: note: Revealed type is "builtins.list[builtins.int]"\nSuccess: no issues found in 1 source file\n] - AssertionError:
assert 'fixtures/myp...source file\n' == 'fixtures/myp...source file\n'

  - fixtures/mypy/apply_to_return_value_decorator.py:16: note: Revealed type is "builtins.list[builtins.int]"
  ?                                                                              ---------     ---------
  + fixtures/mypy/apply_to_return_value_decorator.py:16: note: Revealed type is "list[int]"
    Success: no issues found in 1 source file
```

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
