### PR TITLE
[WIP] insomnia: 12.2.0 -> 12.6.0

### DIFF
--- a/pkgs/by-name/in/insomnia/package.nix
+++ b/pkgs/by-name/in/insomnia/package.nix
@@ -7,22 +7,22 @@
 }:
 let
   pname = "insomnia";
-  version = "12.2.0";
+  version = "12.6.0";
 
   src =
     fetchurl
       {
         aarch64-darwin = {
           url = "https://github.com/Kong/insomnia/releases/download/core%40${version}/Insomnia.Core-${version}.dmg";
-          hash = "sha256-ISQVIhR5TWY/Xk6sXeL89/srxppqBS7wdoRINwuoQqg=";
+          hash = "sha256-qSKlQoLwY9qCd1gmOJwFx1H3TjJZqfabjqor8lJTH+8=";
         };
         x86_64-darwin = {
           url = "https://github.com/Kong/insomnia/releases/download/core%40${version}/Insomnia.Core-${version}.dmg";
-          hash = "sha256-ISQVIhR5TWY/Xk6sXeL89/srxppqBS7wdoRINwuoQqg=";
+          hash = "sha256-qSKlQoLwY9qCd1gmOJwFx1H3TjJZqfabjqor8lJTH+8=";
         };
         x86_64-linux = {
           url = "https://github.com/Kong/insomnia/releases/download/core%40${version}/Insomnia.Core-${version}.AppImage";
-          hash = "sha256-/0fJmbXhjrcVVSFvxd847mSKrzrZRK3Sqi6rjyaBOUw=";
+          hash = "sha256-v+Yq8Ufmg8fE/QHIDK8NPD+gNA6jWy+wrP0nrvo2Ur4=";
         };
       }
       .${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");


### PR DESCRIPTION
##### Motivation

Version bump for Insomnia from 12.2.0 to 12.6.0

##### Changelog

**Release notes:** https://github.com/Kong/insomnia/releases/tag/core@12.6.0

- Konnect sync integration (behind a feature flag) with proxy URL/regex, expressions, and nunjucks template sanitization
- Git Sync: credential validation and UX improvements, auto-resolve non-YAML conflicts to remote during merge, canonical repository output, fix for credential migration storage path
- Custom npm registry mirror setting for plugin installation (INS-1269)
- Default user-agent for cURL imports (INS-2416)
- Open request/folder in tab with middle mouse button
- Pin/unpin support for WebSocket and Socket.IO requests
- Database refactor: move model migrate and initModel to the database layer
- Fixes for view transition errors, sentry promise errors, cookie schema expiration handling, and mock route error reporting

##### Checklist

- [x] Built on platform(s): x86_64-linux
- ~~[ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside nixos/tests)~~ N/A (no tests exist for insomnia)
- [x] Tested compilation of all packages that depend on this change using nixpkgs-review
- [x] Tested basic functionality of all binary files (usually in ./result/bin/)
- [x] Built on sandboxed environment
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

##### Notes

- Updated hashes for all platforms (x86_64-linux, x86_64-darwin, aarch64-darwin)
- Package builds successfully and binary executes
- Application reports correct version: 12.6.0