### PR TITLE
tfenv.tests: fix the eval

### DIFF
--- a/pkgs/by-name/tf/tfenv/package.nix
+++ b/pkgs/by-name/tf/tfenv/package.nix
@@ -73,7 +73,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   passthru = {
     updateScript = nix-update-script { };
     tests.version = testers.testVersion {
-      package = finalAttrs.finalPackage.tfenv;
+      package = finalAttrs.finalPackage;
     };
   };
 


### PR DESCRIPTION
Without the change the eval fails as:

    $ nix build --no-link -f. tfenv.tests
    error:
       … while evaluating the attribute 'version'
         at pkgs/by-name/tf/tfenv/package.nix:75:5:
           74|     updateScript = nix-update-script { };
           75|     tests.version = testers.testVersion {
             |     ^
           76|       package = finalAttrs.finalPackage.tfenv;

       … while evaluating the 'name' attribute of a derivation

       … while evaluating a branch condition
         at lib/strings.nix:2903:5:
         2902|     # First detect the common case of already valid strings, to speed those up
         2903|     if stringLength string <= 207 && okRegex string != null then
             |     ^
         2904|       unsafeDiscardStringContext string

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'tfenv' missing
       at pkgs/by-name/tf/tfenv/package.nix:76:17:
           75|     tests.version = testers.testVersion {
           76|       package = finalAttrs.finalPackage.tfenv;
             |                 ^
           77|     };
       Did you mean one of env or stdenv?


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
