### PR TITLE
valkey: 9.0.4 -> 9.1.0

### DIFF
--- a/pkgs/by-name/va/valkey/package.nix
+++ b/pkgs/by-name/va/valkey/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   lua,
   jemalloc,
   pkg-config,
@@ -25,13 +24,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "valkey";
-  version = "9.0.4";
+  version = "9.1.0";
 
   src = fetchFromGitHub {
     owner = "valkey-io";
     repo = "valkey";
     rev = finalAttrs.version;
-    hash = "sha256-FDm6i6G6h9WapMTj7ke4YtOjZ4rwIJZGONunQi0v7CE=";
+    hash = "sha256-RMZz83fycpOTPWB1dIXU0/hdh4ZGC+6JhCws8htAQ5E=";
   };
 
   patches = lib.optional useSystemJemalloc ./use_system_jemalloc.patch;
@@ -94,13 +93,14 @@ stdenv.mkDerivation (finalAttrs: {
     fi
 
     # Skip some more flaky tests.
-    # Skip test requiring custom jemalloc (unit/memefficiency).
+    # Skip test requiring custom jemalloc (unit/memefficiency, unit/type/string).
     ./runtest \
       --no-latency \
       --timeout 2000 \
       --clients "$CLIENTS" \
       --tags -leaks \
       --skipunit unit/memefficiency \
+      --skipunit unit/type/string \
       --skipunit integration/failover \
       --skipunit integration/aof-multi-part
 


### PR DESCRIPTION
changelog: https://github.com/valkey-io/valkey/releases/tag/9.1.0
diff: https://github.com/valkey-io/valkey/compare/9.0.4...9.1.0

Not sure if it's preffered to backport this or not since the changes don't seem to be breaking. Version 9.0 still gets support for a while though.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
