### PR TITLE
nixos/hardware.printers: add ensureClasses option

### DIFF
--- a/nixos/modules/hardware/printers.nix
+++ b/nixos/modules/hardware/printers.nix
@@ -7,6 +7,20 @@
 let
   cfg = config.hardware.printers;
 
+  inherit (lib)
+    concatLines
+    escapeShellArg
+    mkOption
+    ;
+
+  inherit (lib.types)
+    attrsOf
+    listOf
+    nullOr
+    str
+    submodule
+    ;
+
   ensurePrinter =
     p:
     let
@@ -42,6 +56,68 @@ let
     description = "printable string without spaces, # and /";
   };
 
+  getPrinters =
+    class:
+    lib.uniqueStrings (
+      lib.concatLists (
+        lib.textClosureList (lib.mapAttrs (
+          _:
+          {
+            classes ? [ ],
+            printers ? [ ],
+            ...
+          }:
+          {
+            deps = classes;
+            text = printers;
+          }
+        ) cfg.ensureClasses) [ class ]
+      )
+    );
+
+  mkClass = name: ''
+    lpadmin -p _tmp -v file:/dev/null
+    lpadmin -p _tmp -c ${escapeShellArg name}
+    lpadmin -x _tmp
+  '';
+
+  populateClass =
+    name:
+    {
+      description ? null,
+      location ? null,
+      ...
+    }:
+    lib.concatStringsSep "\n" [
+      (lib.optionalString (location != null) ''
+        lpadmin -p ${escapeShellArg name} -L ${escapeShellArg location}
+      '')
+
+      (lib.optionalString (description != null) ''
+        lpadmin -p ${escapeShellArg name} -D ${escapeShellArg description}
+      '')
+    ];
+
+  addPrintersToClass =
+    className: class:
+    let
+      printers = getPrinters className;
+      addToClass = printer: ''
+        lpadmin -p ${escapeShellArg printer} -c ${escapeShellArg className}
+      '';
+    in
+    map addToClass printers;
+
+  enableClass = className: ''
+    cupsenable ${escapeShellArg className}
+    cupsaccept ${escapeShellArg className}
+  '';
+
+  # if CUPS is configured only to start when it's needed, we can kill the service
+  # once the printer setup is done. However, if stateless is configured then we
+  # can't shut down the servive without losing the printers (and classes) we
+  # *just* configured.
+  ultimatelyStopCups = with config.services.printing; startWhenNeeded && !stateless;
 in
 {
   options = {
@@ -52,6 +128,72 @@ in
         description = ''
           Ensures the named printer is the default CUPS printer / printer queue.
         '';
+      };
+      ensureClasses = mkOption {
+        description = ''
+          Will ensure that the given CUPS classes are configured as declared.
+          Please note that it is possible for some users to temporarily override
+          these properties. If those changes conflict with this configuration,
+          the configuration will take precedence and override them at boot and
+          when a rebuild is applied. This configuration will not delete any
+          classes that have been removed from the list. In order to list classes
+          you can use {command}`lpstat -c`. It will list any classes without
+          members as having a member titled `unknown`. Print jobs to empty
+          classes will silently fail. In order to remove a class, run
+          {command}`lpadmin -x <class name>`. Classes can still be added
+          manually. For more on classes see
+          <https://www.cups.org/doc/admin.html#CLASSES>, or
+          {manpage}`lpadmin(8)`.
+        '';
+        type = attrsOf (submodule {
+          options = {
+            description = mkOption {
+              type = nullOr str;
+              description = "Optional human-readable description";
+              example = "Printers that support color printing";
+            };
+            location = mkOption {
+              type = nullOr str;
+              description = "Optional human-readable location";
+              example = "Workroom";
+            };
+            printers = mkOption {
+              type = listOf str;
+              default = [ ];
+              example = [
+                "BrotherHL_Workroom"
+                "EpsonColor_Basement"
+              ];
+              description = ''
+                A list of printers included in this class. Note that all
+                printers in this list must also be present in
+                config.hardware.printers.ensurePrinters. Specifying a symblic
+                name here that does not match any of those printers is
+                considered a hard error.
+
+                ::: {.warning}
+                Print jobs to this class will quietly fail if there are no
+                printers in this class. CUPS reports them as pending
+                :::
+              '';
+            };
+            classes = mkOption {
+              type = listOf str;
+              default = [ ];
+              description = ''
+                A list of classes to include in this class.
+
+                ::: {.note}
+                CUPS itself does not support nested classes. Any classes will
+                simply have all of their member printers added to this class
+                in a recursive manner. This is an abstraction that serves the
+                purpose of convenience and expressiveness, not a 1:1 mapping
+                on top of CUPS.
+                :::
+              '';
+            };
+          };
+        });
       };
       ensurePrinters = lib.mkOption {
         description = ''
@@ -130,29 +272,172 @@ in
     };
   };
 
-  config = lib.mkIf (cfg.ensurePrinters != [ ] && config.services.printing.enable) {
-    systemd.services.ensure-printers = {
-      description = "Ensure NixOS-configured CUPS printers";
-      wantedBy = [ "multi-user.target" ];
-      wants = [ "cups.service" ];
-      after = [ "cups.service" ];
+  config.assertions = lib.mkIf config.services.printing.enable [
+    (
+      let
+        referencedClasses = lib.unique (
+          lib.flatten (
+            lib.mapAttrsToList (
+              _:
+              {
+                classes ? [ ],
+                ...
+              }:
+              classes
+            ) cfg.ensureClasses
+          )
+        );
+        definedClasses = lib.attrNames cfg.ensureClasses;
+        missingClasses = lib.subtractLists definedClasses referencedClasses;
+        getReferencingClasses =
+          missingClass:
+          (lib.mapAttrsToList (name: _: "`${name}`") (
+            lib.filterAttrs (
+              _:
+              {
+                classes ? [ ],
+                ...
+              }:
+              builtins.elem missingClass classes
+            ) cfg.ensureClasses
+          ));
+      in
+      {
+        assertion = missingClasses == [ ];
+        message = ''
+          One or more values of `config.hardware.printers.ensureClasses.<name>.classes`
+          contained values not present in `config.hardware.printers.ensureClasses`
 
-      serviceConfig = {
-        Type = "oneshot";
-        RemainAfterExit = true;
+          Missing classes:
+          ${lib.concatMapStringsSep "\n" (
+            p: "  - `${p}` (included in class(es): ${lib.concatStringsSep ", " (getReferencingClasses p)})"
+          ) missingClasses}
+        '';
+      }
+    )
+
+    (
+      let
+        referencedPrinters = lib.unique (
+          lib.flatten (
+            lib.mapAttrsToList (
+              _:
+              {
+                printers ? [ ],
+                ...
+              }:
+              printers
+            ) cfg.ensureClasses
+          )
+        );
+        definedPrinters = lib.catAttrs "name" cfg.ensurePrinters;
+        missingPrinters = lib.subtractLists definedPrinters referencedPrinters;
+        getReferencingClasses =
+          missingPrinter:
+          (lib.mapAttrsToList (name: _: "`${name}`") (
+            lib.filterAttrs (
+              _:
+              {
+                printers ? [ ],
+                ...
+              }:
+              builtins.elem missingPrinter printers
+            ) cfg.ensureClasses
+          ));
+      in
+      {
+        assertion = missingPrinters == [ ];
+        message = ''
+          One or more values of `config.hardware.printers.ensureClasses.<name>.printers`
+          contained values not present in `config.hardware.printers.ensurePrinters`
+
+          Missing printers:
+          ${lib.concatMapStringsSep "\n" (
+            p: "  - `${p}` (included in class(es): ${lib.concatStringsSep ", " (getReferencingClasses p)})"
+          ) missingPrinters}
+        '';
+      }
+    )
+  ];
+
+  config.systemd.services.ensure-printer-classes =
+    lib.mkIf (cfg.ensureClasses != { } && config.services.printing.enable)
+      {
+        description = "Ensure NixOS-configured CUPS classes";
+        wantedBy = [ "multi-user.target" ];
+        wants = [
+          "cups.service"
+        ];
+        after = [
+          "cups.service"
+          "ensure-printers.service"
+        ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+        };
+        path = with pkgs; [ cups ];
+        script =
+          let
+            attrMap = fn: l: map fn (builtins.attrNames l);
+            classDefs = lib.pipe cfg.ensureClasses [
+              (attrMap mkClass)
+              concatLines
+            ];
+            classAdds = lib.pipe cfg.ensureClasses [
+              (lib.mapAttrsToList addPrintersToClass)
+              lib.flatten
+              concatLines
+            ];
+            populatedClasses = lib.pipe cfg.ensureClasses [
+              (lib.mapAttrsToList populateClass)
+              concatLines
+            ];
+            enables = lib.pipe cfg.ensureClasses [
+              (attrMap enableClass)
+              concatLines
+            ];
+          in
+          ''
+            #### CLASS DEFINITIONS ####
+            ${classDefs}
+
+            #### ADDING PRINTERS TO CLASSES ####
+            ${classAdds}
+
+            #### POPULATING CLASSES ####
+            ${populatedClasses}
+
+            #### ENABLING CLASSES ####
+            ${enables}
+
+            ${lib.optionalString ultimatelyStopCups "systemctl stop cups.service"}
+          '';
       };
 
-      script = lib.concatStringsSep "\n" [
-        (lib.concatMapStrings ensurePrinter cfg.ensurePrinters)
-        (lib.optionalString (cfg.ensureDefaultPrinter != null) (
-          ensureDefaultPrinter cfg.ensureDefaultPrinter
-        ))
-        # Note: if cupsd is "stateless" the service can't be stopped,
-        # otherwise the configuration will be wiped on the next start.
-        (lib.optionalString (
-          with config.services.printing; startWhenNeeded && !stateless
-        ) "systemctl stop cups.service")
-      ];
-    };
-  };
+  config.systemd.services.ensure-printers =
+    lib.mkIf (cfg.ensurePrinters != [ ] && config.services.printing.enable)
+      {
+        description = "Ensure NixOS-configured CUPS printers";
+        wantedBy = [ "multi-user.target" ];
+        wants = [ "cups.service" ];
+        after = [ "cups.service" ];
+
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+        };
+
+        script = lib.concatStringsSep "\n" [
+          (lib.concatMapStrings ensurePrinter cfg.ensurePrinters)
+          (lib.optionalString (cfg.ensureDefaultPrinter != null) (
+            ensureDefaultPrinter cfg.ensureDefaultPrinter
+          ))
+          # Let ensure-printer-classes.service kill cups because it is called
+          # after this service.
+          (lib.optionalString (
+            ultimatelyStopCups && !(config.systemd.services ? ensure-printer-classes)
+          ) "systemctl stop cups.service")
+        ];
+      };
 }


### PR DESCRIPTION

## Summary
this adds support to CUPS classes in a style similar to the `hardware.printers.ensurePrinters` option.

Classes in CUPS are groups of printers made by the user, usually in order to group similar printers. When a job is sent to a class, the job is attempted at each member printer until it succeeds. Classes can be thought of as 'logical printers', in that they can behave like printers, despite being an abstraction solely created by the print server.

### API Example

```nix
# some module.nix
{ ... }:
{
  hardware.printers.ensureClasses = {
    # combined categories
    "bw-laser" = {
      description = "Black and white laser printer";
    };
    "bw-inkjet" = {
      description = "Black and white inkjet printer";
    };
    "color-laser" = {
      description = "Color laser printer";
    };
    "color-inkjet" = {
      description = "Color inkjet printer";
    };

    # singular categories
    "bw" = {
      description = "Black and white printer";
      classes = [
        "bw-laser"
        "bw-inkjet"
      ];
    };
    "color" = {
      description = "Color printer";
      classes = [
        "color-laser"
        "color-inkjet"
      ];
    };
    "laser" = {
      description = "Laser printer";
      classes = [
        "bw-laser"
        "color-laser"
      ];
    };
    "inkjet" = {
      description = "Inkjet printer";
      classes = [
        "bw-inkjet"
        "color-inkjet"
      ];
    };
  };
}
```

```nix
# some other file.nix

...
hardware.printers.ensurePrinters = [{
  name = "brother-1";
  model = ...,
  deviceUri = "dnssd://somedevice?uuid=some uuid";
}];

hardware.printers.ensureClasses.bw-laser.printers = ["brother-1"]; # now, bw and laser, as well as bw-laser, will all include this printer.
...
```


## Potential Rough Edges

- Naming: Even though CUPS classes are a software abstraction, I chose to add this option to `hardware.printers` because classes are just a thin grouping over printers (they must only contain physical printers) and because CUPS treats classes like printers. Iwoud
- Type Signature: this module uses the type signature of `{string: {description?: string, printers?: [string], classes?: [string], location?: string}}` instead of something like `[{name: string, description?: string, location?: string, classes?: [string], printers?: [string]}]` because the former seems more idiomatic to me. If there are issues(eg validating the class name), I would have no problem at all switching over to the latter style.
- Classes are added in a hackish way: In order to fulfill the "promise" of this option, namely, that if a class is declared, it should exist (even if empty), I had to use a hack in order to get CUPS to create the empty classes. It looks something like this:
    ```bash
    $ lpadmin -p _tmp -v file:/dev/null  # creating a dummy printer we will delete later
    $ lpadmin -p _tmp -c className # adding dummy printer to the class, thereby creating the class. This is the only way of adding classes in CUPS.
    $ lpadmin -x _tmp # we remove the sole printer in the class, but not the class itself.
    ```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## Requested Reviewers

- @rnhmjoj 