### PR TITLE
hyprlandPlugins.hyprcapture: init at 0.2.1-0.55

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13245,6 +13245,12 @@
     githubId = 57130301;
     keys = [ { fingerprint = "1CC5 B67C EB9A 13A5 EDF6 F10E 0B4A 3662 FC58 9202"; } ];
   };
+  jonas-elhs = {
+    name = "Jonas Elhs";
+    email = "jonas.elhs@outlook.com";
+    github = "jonas-elhs";
+    githubId = 177471339;
+  };
   jonas-w = {
     email = "nixpkgs@03j.de";
     github = "jonas-w";

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/default.nix
@@ -45,6 +45,7 @@ let
     { hyprsplit = import ./hyprsplit.nix; }
     (import ./hyprland-plugins.nix)
     { imgborders = import ./imgborders.nix; }
+    { hyprcapture = import ./hyprcapture.nix; }
     (lib.optionalAttrs config.allowAliases {
       hycov = throw "hyprlandPlugins.hycov has been removed because it has been marked as broken since September 2024."; # Added 2025-10-12
       hyprscroller = throw "hyprlandPlugins.hyprscroller has been removed as the upstream project is deprecated. Consider using `hyprlandPlugins.hyprscrolling`."; # Added 2025-05-09

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprcapture.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprcapture.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  cmake,
+  qt6,
+  kdePackages,
+  nlohmann_json,
+  fetchFromGitHub,
+  hyprland,
+  mkHyprlandPlugin,
+  nix-update-script,
+}:
+mkHyprlandPlugin (finalAttrs: {
+  pluginName = "hyprcapture";
+  version = "0.2.1-0.55";
+
+  src = fetchFromGitHub {
+    owner = "gfhdhytghd";
+    repo = "HyprCapture";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-uqeDozWxRz7j/8sJ/EYr3rSmdkRFwl8bTKSVjvf942o=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.wrapQtAppsHook
+    kdePackages.layer-shell-qt
+    nlohmann_json
+  ];
+
+  postPatch = ''
+    substituteInPlace src/plugin/session_launcher.cpp \
+      --replace-fail 'const auto helper = firstRunnableHelper(request.defaults.helper);' \
+                     'const std::optional<std::string> helper = std::string("${placeholder "out"}/bin/hyprcapture-ui");'
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/gfhdhytghd/HyprCapture";
+    description = "The best screenshot tool for Hyprland";
+    license = lib.licenses.gpl3;
+    inherit (hyprland.meta) platforms;
+    maintainers = with lib.maintainers; [
+      jonas-elhs
+    ];
+  };
+})


### PR DESCRIPTION
[HyprCapture](https://github.com/gfhdhytghd/HyprCapture/tree/master) is a hyprland-only screencapturing tool packaged as a hyprland plugin that uses a Qt ui helper to select the specified capturing target.
The hyprland plugin tries to find the helper binary using a multistep location process, first it tries the path in `$HYPRCAPTURE_HELPER`, then `$HOME/.local/bin/hyprcapture-ui`, `/usr/local/bin/hyprcapture-ui` and `/usr/bin/hyprcapture-ui`. This whole process is bypassed by replacing the line of the function call with the static path to the nix store binary.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
