### PR TITLE
buttui: init at a498bc38d581613ef07df74c255ba12f256c014f

### DIFF
--- a/pkgs/by-name/bu/buttui/package.nix
+++ b/pkgs/by-name/bu/buttui/package.nix
@@ -1,0 +1,55 @@
+{
+  fetchFromGitea,
+  rustPlatform,
+  lib,
+  stdenv,
+  cargo,
+  pkg-config,
+  dbus,
+  udev,
+  alsa-lib,
+  pipewire,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "buttui";
+  version = "a498bc38d581613ef07df74c255ba12f256c014f";
+  __structuredAttrs = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "derZonk";
+    repo = "buttui";
+    rev = finalAttrs.version;
+    hash = "sha256-092+a/1O3xF1cgH7/p1oeFPw0ENWxqANd+F/Z+wfh40=";
+  };
+
+  buildInputs = [
+    dbus
+    udev
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    udev
+    alsa-lib
+    pipewire
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isFreeBSD [
+    pipewire
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  PKG_CONFIG_PATH = "${dbus.dev}/lib/pkgconfig:";
+
+  cargoHash = "sha256-gMbGVQ7GxfHxLB5/TwxIjCeaQHmreTfFwFht5Sfo1UY=";
+
+  meta = {
+    description = "Terminal UI for buttplug.io compatible devices";
+    homepage = "https://buttui.de/";
+    license = lib.licenses.agpl3Plus;
+    maintainers = [ lib.maintainers.luNeder ];
+    inherit (cargo.meta) platforms;
+    mainProgram = "buttui";
+  };
+})


### PR DESCRIPTION
Add [buttui](https://codeberg.org/derZonk/buttui).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
