### PR TITLE
doit: 0.36.0 -> 0.37.0

### DIFF
--- a/pkgs/development/python-modules/doit/default.nix
+++ b/pkgs/development/python-modules/doit/default.nix
@@ -15,19 +15,20 @@
   pyflakes,
   configclass,
   mergedict,
+  setuptools,
 }:
 
 let
   doit = buildPythonPackage rec {
     pname = "doit";
-    version = "0.36.0";
-    format = "setuptools";
+    version = "0.37.0";
+    pyproject = true;
 
     disabled = !isPy3k;
 
     src = fetchPypi {
       inherit pname version;
-      hash = "sha256-cdB8zJUUyyL+WdmJmVd2ZeqrV+FvZE0EM2rgtLriNLw=";
+      hash = "sha256-08cuDkao+h3avqj4MHYkAt7gkMrzPDDCKVrHAQ248Jw=";
     };
 
     propagatedBuildInputs = [
@@ -37,6 +38,10 @@ let
     ]
     ++ lib.optional stdenv.hostPlatform.isLinux pyinotify
     ++ lib.optional stdenv.hostPlatform.isDarwin macfsevents;
+
+    build-system = [
+      setuptools
+    ];
 
     nativeCheckInputs = [
       configclass


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Tag: https://github.com/pydoit/doit/releases/tag/0.37.0 (released on 2/9/26)
Diff: https://github.com/pydoit/doit/compare/0.36.0...0.37.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
