### PR TITLE
vikunja-desktop: fix desktop integration

### DIFF
--- a/pkgs/by-name/vi/vikunja-desktop/package.nix
+++ b/pkgs/by-name/vi/vikunja-desktop/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   makeWrapper,
   makeDesktopItem,
+  copyDesktopItems,
   pnpm_10_29_2,
   pnpmConfigHook,
   nodejs,
@@ -47,6 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
+    copyDesktopItems
     makeWrapper
     nodejs
     pnpm_10_29_2
@@ -59,6 +61,12 @@ stdenv.mkDerivation (finalAttrs: {
 
     sed -i "s/\$${version}/${version}/g" package.json
     sed -i "s/\"version\": \".*\"/\"version\": \"${version}\"/" package.json
+    substituteInPlace main.js \
+      --replace-fail "path.join(__dirname, 'build', 'icon.png')" \
+      "path.join(__dirname, 'frontend', 'images', 'icons', 'favicon-32x32.png')"
+    substituteInPlace main.js \
+      --replace-fail $'\t// Rebuild tray menu to reflect the new accelerator\n\tif (tray) {\n\t\tsetupTray()\n\t}' \
+      $'\t// Do not recreate the tray item on Linux; Electron can leave duplicate\n\t// StatusNotifier DBus exports behind, which breaks tray activation.'
     ln -s '${vikunja.passthru.frontend}' frontend
     pnpm run pack -c.electronDist="${electron.dist}" -c.electronVersion="${electron.version}"
 
@@ -96,18 +104,21 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   # The desktop item properties should be kept in sync with data from upstream:
-  desktopItem = makeDesktopItem {
-    name = "vikunja-desktop";
-    exec = executableName;
-    icon = "vikunja";
-    desktopName = "Vikunja Desktop";
-    genericName = "To-Do list app";
-    comment = finalAttrs.meta.description;
-    categories = [
-      "ProjectManagement"
-      "Office"
-    ];
-  };
+  desktopItems = [
+    (makeDesktopItem {
+      name = "vikunja-desktop";
+      exec = "${executableName} %u";
+      icon = executableName;
+      desktopName = "Vikunja Desktop";
+      genericName = "To-Do list app";
+      comment = finalAttrs.meta.description;
+      categories = [
+        "ProjectManagement"
+        "Office"
+      ];
+      mimeTypes = [ "x-scheme-handler/vikunja-desktop" ];
+    })
+  ];
 
   meta = {
     description = "Desktop App of the Vikunja to-do list app";


### PR DESCRIPTION
Fixes `vikunja-desktop` desktop integration.

The package already defined a desktop item, but it was not installed because
`copyDesktopItems` was not used and the attribute was named `desktopItem`
instead of `desktopItems`. This made desktop launchers unable to discover the
application.

This also registers `x-scheme-handler/vikunja-desktop` and passes `%u` in the
desktop entry so OAuth callback URLs are delivered to the running app.

Finally, the tray icon path is patched to use an icon that is actually packaged
inside `app.asar`. Upstream references `build/icon.png`, but that path is not
present in the packaged ASAR. The package also avoids recreating the tray item
after shortcut updates, because on Linux/Electron that can leave duplicate
StatusNotifier DBus exports and break tray activation.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Built with:

`nix build .#vikunja-desktop`

Also manually checked the generated desktop file and verified launcher discovery,
OAuth callback login, tray icon rendering, and tray activation on x86_64-linux.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
