### PR TITLE
lufus: move icon to spec-compliant location, cleanup

### DIFF
--- a/pkgs/by-name/lu/lufus/package.nix
+++ b/pkgs/by-name/lu/lufus/package.nix
@@ -14,7 +14,7 @@ python313Packages.buildPythonApplication (finalAttrs: {
     owner = "Hogjects";
     repo = "Lufus";
     tag = "v${finalAttrs.version}";
-    sha256 = "sha256-3i0CnhGvLTXutz8CQoH5q4PwZ23lAwnUo8H5TRJx+KE=";
+    hash = "sha256-3i0CnhGvLTXutz8CQoH5q4PwZ23lAwnUo8H5TRJx+KE=";
   };
 
   propagatedBuildInputs = with python313Packages; [
@@ -45,8 +45,6 @@ python313Packages.buildPythonApplication (finalAttrs: {
       --prefix PYTHONPATH : "$out/${python313Packages.python.sitePackages}:${python313Packages.makePythonPath finalAttrs.propagatedBuildInputs}"
 
     install -Dm644 src/lufus/gui/assets/lufus.png -t $out/share/icons/hicolor/64x64/apps
-
-    copyDesktopItems
   '';
 
   desktopItems = [
@@ -64,7 +62,7 @@ python313Packages.buildPythonApplication (finalAttrs: {
   ];
 
   meta = {
-    description = "A rufus clone written in py and designed to work with linux";
+    description = "Rufus clone written in py and designed to work with linux";
     homepage = "https://github.com/Hogjects/Lufus";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ Simon-Weij ];

--- a/pkgs/by-name/lu/lufus/package.nix
+++ b/pkgs/by-name/lu/lufus/package.nix
@@ -44,7 +44,7 @@ python313Packages.buildPythonApplication (finalAttrs: {
       --add-flags "-m lufus" \
       --prefix PYTHONPATH : "$out/${python313Packages.python.sitePackages}:${python313Packages.makePythonPath finalAttrs.propagatedBuildInputs}"
 
-    install -Dm644 src/lufus/gui/assets/lufus.png $out/share/pixmaps/lufus.png
+    install -Dm644 src/lufus/gui/assets/lufus.png -t $out/share/icons/hicolor/64x64/apps
 
     copyDesktopItems
   '';


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Part of #428824 
Second commit is just some small things I figured I'd do while I was here. 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
