### PR TITLE
cargo-c: 0.10.19 -> 0.10.22

### DIFF
--- a/pkgs/by-name/ca/cargo-c/package.nix
+++ b/pkgs/by-name/ca/cargo-c/package.nix
@@ -12,19 +12,19 @@
 
 let
   # this version may need to be updated along with package version
-  cargoVersion = "0.93.0";
+  cargoVersion = "0.96.0";
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-c";
-  version = "0.10.19";
+  version = "0.10.22";
 
   src = fetchCrate {
     inherit (finalAttrs) pname;
     version = "${finalAttrs.version}+cargo-${cargoVersion}";
-    hash = "sha256-PrBmB+0tmU2MAUnRr+wx4g9hu0Y9i6WfR8U89bwiLVY=";
+    hash = "sha256-yqSrpBZUa0NmsPawYKKgywmbbG4zgguwfDF667s7zdo=";
   };
 
-  cargoHash = "sha256-EM/vAfW/ucOfK/XmAQn9Zk75eFb7pp8uZoByKbALCyo=";
+  cargoHash = "sha256-yeJWZtkgCRB0ipyTslsGcJi9Fi/XoWziuv74exRhAIk=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
Diff: https://diff.rs/cargo-c/0.10.19/0.10.22

Changelog: https://github.com/lu-zero/cargo-c/releases/tag/v0.10.22


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
