### PR TITLE
libeconf: init at 0.8.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22001,6 +22001,12 @@
     githubId = 1601039;
     name = "Cale Black";
   };
+  port22exposed = {
+    email = "contact@port22.exposed";
+    github = "port22exposed";
+    githubId = 191940431;
+    name = "charli";
+  };
   portothree = {
     name = "Gustavo Porto";
     email = "gus@p8s.co";

--- a/pkgs/by-name/li/libeconf/package.nix
+++ b/pkgs/by-name/li/libeconf/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libeconf";
+  version = "0.8.3";
+
+  outputs = [
+    "bin"
+    "out"
+    "dev"
+    "man"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "openSUSE";
+    repo = "libeconf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ZXZcXQdG3hXAMwwftrIWL5GbVdPXk+AyqdhGTnaKL1I=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  postPatch = ''
+    chmod +x tests/*.sh
+    patchShebangs tests/
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Enhanced config file parser which merges config files placed in several locations into one";
+    changelog = "https://github.com/openSUSE/libeconf/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/openSUSE/libeconf";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ port22exposed ];
+    mainProgram = "econftool";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds `libeconf` as a package. libeconf is a highly flexible and configurable library to parse and manage key=value configuration files. It reads configuration file snippets from different directories and build the final configuration from them.

This is a prerequisite for adding `account-utils`, which depends on libeconf.

Upstream: https://github.com/openSUSE/libeconf

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
