### PR TITLE
colmap: cleanup, fix on aarch64-linux and darwin

### DIFF
--- a/pkgs/by-name/co/colmap/package.nix
+++ b/pkgs/by-name/co/colmap/package.nix
@@ -62,13 +62,11 @@ let
     onnxruntime
   ]
   ++ lib.optionals cudaSupport [
-    cudatoolkit
-    (lib.getOutput "static" cudaPackages.cuda_cudart)
+    cudaPackages.cuda_cudart # CUDA::cudart, used by COLMAP and faiss
+    cudaPackages.libcublas # CUDA::cublas, propagated by faiss' exported targets
+    cudaPackages.libcurand # CUDA::curand, used by COLMAP
   ]
   ++ lib.optional stdenv'.cc.isClang llvmPackages.openmp;
-
-  # TODO: migrate to redist packages
-  inherit (cudaPackages) cudatoolkit;
 
   # COLMAP needs these model files to run the ONNX tests
   # Based on: https://github.com/colmap/colmap/blob/79efc74b2b614935a3c69b1f983f2bad23a836a1/src/colmap/feature/resources.h#L36
@@ -179,6 +177,7 @@ stdenv'.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals cudaSupport [
     autoAddDriverRunpath
+    cudaPackages.cuda_nvcc
   ];
 
   doCheck = enableTests;

--- a/pkgs/by-name/co/colmap/package.nix
+++ b/pkgs/by-name/co/colmap/package.nix
@@ -1,8 +1,8 @@
 {
   lib,
   fetchFromGitHub,
-  fetchpatch,
   fetchurl,
+  fetchpatch,
   nix-update-script,
   cmake,
   boost,
@@ -100,15 +100,40 @@ let
     }
   ];
 in
-stdenv'.mkDerivation rec {
+stdenv'.mkDerivation (finalAttrs: {
   version = "4.0.4";
   pname = "colmap";
   src = fetchFromGitHub {
     owner = "colmap";
     repo = "colmap";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-n9YwEqMSIh6vM2MVf7qxxVvDpsTLEsT37xoHiX66bL0=";
   };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  patches =
+    lib.optionals stdenv'.hostPlatform.isAarch64 [
+      # Set SANITIZE_PR for PoissonRecon to fix data races on aarch64
+      # https://github.com/colmap/colmap/pull/4429
+      (fetchpatch {
+        url = "https://github.com/colmap/colmap/commit/e13294e43baae6cf7f4e3ec05a19060e0b230a72.patch";
+        hash = "sha256-hoIjWdrOlXeT78X+g3YCDWaWnmQMzHVQNkdpx5vXpGk=";
+      })
+      (fetchpatch {
+        url = "https://github.com/colmap/colmap/commit/6c5c59f96f9e819bcc57267ef48b193d77707fe0.patch";
+        hash = "sha256-2dAhy3sgxF2SXPAYE/EV1hd61dm05vJ5JJXEjQxEKWM=";
+      })
+    ]
+    ++ lib.optionals (stdenv'.hostPlatform.isLinux && stdenv'.hostPlatform.isAarch64) [
+      # Fix determinism check in rotation_averaging_test
+      # https://github.com/colmap/colmap/pull/4426
+      (fetchpatch {
+        url = "https://github.com/colmap/colmap/commit/d38b65b9312c66e841739989f4a38924d8cb5ec5.patch";
+        hash = "sha256-dbs+TNfa4o5L79+krPpF4VmP8PhFHtzYZehYZbsnx5s=";
+      })
+    ];
 
   cmakeFlags = [
     (lib.cmakeBool "DOWNLOAD_ENABLED" true) # We want COLMAP to be able to fetch models like LightGlue.
@@ -117,8 +142,8 @@ stdenv'.mkDerivation rec {
     (lib.cmakeBool "FETCH_FAISS" false)
     (lib.cmakeBool "FETCH_ONNX" false)
     (lib.cmakeBool "TESTS_ENABLED" enableTests)
-    (lib.cmakeFeature "CHOLMOD_INCLUDE_DIR_HINTS" "${suitesparse.dev}/include")
-    (lib.cmakeFeature "CHOLMOD_LIBRARY_DIR_HINTS" "${suitesparse}/lib")
+    (lib.cmakeFeature "CHOLMOD_INCLUDE_DIR_HINTS" "${lib.getDev suitesparse}/include")
+    (lib.cmakeFeature "CHOLMOD_LIBRARY_DIR_HINTS" "${lib.getLib suitesparse}/lib")
   ]
   ++ lib.optionals cudaSupport [
     (lib.cmakeBool "CUDA_ENABLED" cudaSupport)
@@ -135,6 +160,7 @@ stdenv'.mkDerivation rec {
     glog
     libGLU
     glew
+    gtest
     qt5.qtbase
     flann
     lz4
@@ -156,18 +182,39 @@ stdenv'.mkDerivation rec {
   ];
 
   doCheck = enableTests;
-  preCheck = lib.optionalString enableTests ''
-    export GTEST_FILTER='-*Gpu*:*GPU*:*OpenGL*' # Disable any test involving OpenGL or GPU, these won't work in the sandbox.
-    export HOME=$PWD
+  preCheck = lib.optionalString enableTests (
+    let
+      disabledTestPatterns = [
+        # Disable any test involving OpenGL or GPU, these won't work in the sandbox.
+        "*Gpu*"
+        "*GPU*"
+        "*OpenGL*"
+      ]
+      ++ lib.optionals stdenv'.hostPlatform.isDarwin [
+        # reconstruction_pruning_test.cc:65: Failure
+        # Expected: (redundant_point3D_ids.size()) > (prev_num_redundant_points3D), actual: 0 vs 0
+        "FindRedundantPoints3D.VaryingCoverageGain"
+      ];
+    in
+    ''
+      export GTEST_FILTER='-${lib.concatStringsSep ":" disabledTestPatterns}'
+    ''
+    + ''
+      export HOME=$PWD
+    ''
     # Pre-fetch the ONNX models into COLMAP's cache dir so we can run their tests.
-    mkdir -p .cache/colmap
-    ${lib.concatMapStringsSep "\n" (model: ''
-      ln -s ${fetchurl model} .cache/colmap/${model.sha256}-${model.name}
-    '') modelsForTesting}
-  '';
+    + ''
+      mkdir -p .cache/colmap
+      ${lib.concatMapStringsSep "\n" (model: ''
+        ln -s ${fetchurl model} .cache/colmap/${model.sha256}-${model.name}
+      '') modelsForTesting}
+    ''
+  );
 
-  passthru.depsAlsoForPycolmap = depsAlsoForPycolmap;
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    depsAlsoForPycolmap = depsAlsoForPycolmap;
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Structure-From-Motion and Multi-View Stereo pipeline";
@@ -177,6 +224,8 @@ stdenv'.mkDerivation rec {
     '';
     mainProgram = "colmap";
     homepage = "https://colmap.github.io/index.html";
+    downloadPage = "https://github.com/colmap/colmap";
+    changelog = "https://github.com/colmap/colmap/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
     license = lib.licenses.bsd3;
     platforms = if cudaSupport then lib.platforms.linux else lib.platforms.unix;
     maintainers = with lib.maintainers; [
@@ -185,4 +234,4 @@ stdenv'.mkDerivation rec {
       chpatrick
     ];
   };
-}
+})

--- a/pkgs/by-name/fa/faiss/package.nix
+++ b/pkgs/by-name/fa/faiss/package.nix
@@ -97,10 +97,22 @@ stdenv.mkDerivation (finalAttrs: {
      python -m pip wheel --verbose --no-index --no-deps --no-clean --no-build-isolation --wheel-dir dist .)
   '';
 
-  postInstall = lib.optionalString pythonSupport ''
-    mkdir "$dist"
-    cp faiss/python/dist/*.whl "$dist/"
-  '';
+  postInstall =
+    lib.optionalString pythonSupport ''
+      mkdir "$dist"
+      cp faiss/python/dist/*.whl "$dist/"
+    ''
+    # The GPU targets in faiss-targets.cmake reference CUDA imported targets
+    # (CUDA::cudart, CUDA::cublas), but faiss-config.cmake never finds them.
+    # Declare the dependency so downstream find_package(faiss) resolves them.
+    + lib.optionalString cudaSupport ''
+      substituteInPlace "$out/share/faiss/faiss-config.cmake" \
+        --replace-fail \
+          'include("''${CMAKE_CURRENT_LIST_DIR}/faiss-targets.cmake")' \
+          'include(CMakeFindDependencyMacro)
+      find_dependency(CUDAToolkit)
+      include("''${CMAKE_CURRENT_LIST_DIR}/faiss-targets.cmake")'
+    '';
 
   passthru = {
     inherit cudaSupport cudaPackages pythonSupport;

--- a/pkgs/by-name/tu/turingdb/package.nix
+++ b/pkgs/by-name/tu/turingdb/package.nix
@@ -21,14 +21,26 @@
   zlib,
   llvmPackages_20,
   versionCheckHook,
+
+  config,
+  cudaSupport ? config.cudaSupport,
+  cudaPackages,
 }:
 
 let
-  turingstdenv = if stdenv.hostPlatform.isDarwin then llvmPackages_20.stdenv else stdenv;
+  turingstdenv =
+    if stdenv.hostPlatform.isDarwin then
+      llvmPackages_20.stdenv
+    else if cudaSupport then
+      cudaPackages.backendStdenv
+    else
+      stdenv;
 in
 turingstdenv.mkDerivation (finalAttrs: {
   pname = "turingdb";
   version = "1.33";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "turing-db";
@@ -74,6 +86,10 @@ turingstdenv.mkDerivation (finalAttrs: {
     gitMinimal
     pkg-config
     python3
+  ]
+  ++ lib.optionals cudaSupport [
+    # Needed by transitive dependency faiss
+    cudaPackages.cuda_nvcc
   ];
 
   buildInputs = [
@@ -90,7 +106,11 @@ turingstdenv.mkDerivation (finalAttrs: {
     zlib
   ]
   ++ lib.optionals turingstdenv.isDarwin [ llvmPackages_20.openmp ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc.lib ];
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc.lib ]
+  ++ lib.optionals cudaSupport [
+    cudaPackages.cuda_cudart
+    cudaPackages.libcublas
+  ];
 
   cmakeFlags = [
     (lib.cmakeBool "NIX_BUILD" true)


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
