### PR TITLE
python3Packages.virtualenv-clone: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/virtualenv-clone/default.nix
+++ b/pkgs/development/python-modules/virtualenv-clone/default.nix
@@ -4,12 +4,13 @@
   fetchFromGitHub,
   virtualenv,
   pytestCheckHook,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "virtualenv-clone";
   version = "0.5.7";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "edwardgeorge";
@@ -17,6 +18,8 @@ buildPythonPackage rec {
     rev = version;
     hash = "sha256-qrN74IwLRqiVPxU8gVhdiM34yBmiS/5ot07uroYPDVw=";
   };
+
+  build-system = [ setuptools ];
 
   postPatch = ''
     substituteInPlace tests/__init__.py \
@@ -35,7 +38,7 @@ buildPythonPackage rec {
         "pth = '$(mktemp -d)/test_fixup_pth_file.pth'"
   '';
 
-  propagatedBuildInputs = [ virtualenv ];
+  dependencies = [ virtualenv ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/virtualenv-clone/default.nix
+++ b/pkgs/development/python-modules/virtualenv-clone/default.nix
@@ -47,6 +47,6 @@ buildPythonPackage (finalAttrs: {
     description = "Script to clone virtualenvs";
     mainProgram = "virtualenv-clone";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ skohtv ];
   };
 })

--- a/pkgs/development/python-modules/virtualenv-clone/default.nix
+++ b/pkgs/development/python-modules/virtualenv-clone/default.nix
@@ -7,7 +7,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "virtualenv-clone";
   version = "0.5.7";
   pyproject = true;
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "edwardgeorge";
     repo = "virtualenv-clone";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-qrN74IwLRqiVPxU8gVhdiM34yBmiS/5ot07uroYPDVw=";
   };
 
@@ -23,11 +23,11 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace tests/__init__.py \
-      --replace-fail "'virtualenv'" "'${virtualenv}/bin/virtualenv'" \
+      --replace-fail "'virtualenv'" "'${lib.getExe virtualenv}'" \
       --replace-fail "'3.9', '3.10']" "'3.9', '3.10', '3.11', '3.12', '3.13', '3.14']" # if the Python version used isn't in this list, tests fail
 
     substituteInPlace tests/test_virtualenv_sys.py \
-      --replace-fail "'virtualenv'" "'${virtualenv}/bin/virtualenv'"
+      --replace-fail "'virtualenv'" "'${lib.getExe virtualenv}'"
 
     # PermissionError: [Errno 13] Permission denied: '/tmp/test_fixup_pth_file.pth'
     # Unable to reproduce.
@@ -49,4 +49,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/virtualenv-clone/default.nix
+++ b/pkgs/development/python-modules/virtualenv-clone/default.nix
@@ -46,6 +46,7 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/edwardgeorge/virtualenv-clone";
     description = "Script to clone virtualenvs";
     mainProgram = "virtualenv-clone";
+    changelog = "https://github.com/edwardgeorge/virtualenv-clone/blob/${finalAttrs.src.tag}/changelog.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ skohtv ];
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Tracking https://github.com/NixOS/nixpkgs/issues/515974

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test