### PR TITLE
python3Packages.bitmath: 1.3.3.1 -> 2.1.1, python3Packages.osxphotos: 0.75.1 -> 0.75.9

### DIFF
--- a/pkgs/development/python-modules/bitmath/default.nix
+++ b/pkgs/development/python-modules/bitmath/default.nix
@@ -1,33 +1,35 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-  isPy3k,
-  progressbar231 ? null,
-  progressbar33,
-  mock,
+  fetchFromGitHub,
+  hatchling,
+  pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "bitmath";
-  version = "1.3.3.1";
-  format = "setuptools";
+  version = "2.1.1";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "293325f01e65defe966853111df11d39215eb705a967cb115851da8c4cfa3eb8";
+  src = fetchFromGitHub {
+    owner = "timlnx";
+    repo = "bitmath";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9hiwIpDIAU+N+LhlJ9qlKBZQibbrwwhGM77fvEnABRI=";
   };
 
-  nativeCheckInputs = [
-    (if isPy3k then progressbar33 else progressbar231)
-    mock
-  ];
+  build-system = [ hatchling ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "bitmath" ];
 
   meta = {
     description = "Module for representing and manipulating file sizes with different prefix";
-    mainProgram = "bitmath";
-    homepage = "https://github.com/tbielawa/bitmath";
+    homepage = "https://github.com/timlnx/bitmath";
+    changelog = "https://github.com/timlnx/bitmath/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ twey ];
+    mainProgram = "bitmath";
   };
-}
+})

--- a/pkgs/development/python-modules/osxphotos/default.nix
+++ b/pkgs/development/python-modules/osxphotos/default.nix
@@ -17,6 +17,7 @@
   pathvalidate,
   pip,
   ptpython,
+  psutil,
   pytimeparse2,
   pyyaml,
   requests,
@@ -41,17 +42,29 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "osxphotos";
-  version = "0.75.1";
+  version = "0.75.9";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "RhetTbull";
     repo = "osxphotos";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-aX+4wgjqWxoIez/pJ7ioes5OTHFijztSFTvTxdND6Eo=";
+    hash = "sha256-9oQ9yLNHACLgOegNRcuysGIo8cbYLhlkNa41Y+YHFTM=";
   };
 
+  pythonRelaxDeps = [
+    "bitmath"
+    "mako"
+    "more-itertools"
+    "objexplore"
+    "rich"
+    "textx"
+    "tenacity"
+    "whenever"
+  ];
+
   build-system = [ setuptools ];
+
   dependencies = [
     beautifulsoup4
     bitmath
@@ -64,12 +77,13 @@ buildPythonPackage (finalAttrs: {
     packaging
     pathvalidate
     pip
+    psutil
     ptpython
     pytimeparse2
     pyyaml
     requests
-    rich-theme-manager
     rich
+    rich-theme-manager
     shortuuid
     strpdatetime
     tenacity
@@ -83,16 +97,8 @@ buildPythonPackage (finalAttrs: {
     xdg-base-dirs
   ];
 
-  pythonRelaxDeps = [
-    "mako"
-    "more-itertools"
-    "objexplore"
-    "rich"
-    "textx"
-    "tenacity"
-  ];
-
   pythonImportsCheck = [ "osxphotos" ];
+
   nativeCheckInputs = [
     pytestCheckHook
     pytest-mock


### PR DESCRIPTION
Diff: https://github.com/timlnx/bitmath/compare/v1.3.3.1...v2.1.1

Changelog: https://github.com/timlnx/bitmath/releases/tag/v2.1.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
