### PR TITLE
docker-sbx: init at 0.34.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8303,6 +8303,12 @@
     githubId = 7820865;
     name = "Eric Dallo";
   };
+  erics118 = {
+    name = "Eric Shen";
+    github = "erics118";
+    githubId = 52634785;
+    email = "ericshen118@gmail.com";
+  };
   ericson2314 = {
     email = "John.Ericson@Obsidian.Systems";
     matrix = "@Ericson2314:matrix.org";

--- a/pkgs/by-name/do/docker-sbx/package.nix
+++ b/pkgs/by-name/do/docker-sbx/package.nix
@@ -1,0 +1,128 @@
+{
+  lib,
+  fetchurl,
+  stdenvNoCC,
+  installShellFiles,
+  autoPatchelfHook,
+  makeWrapper,
+  gccForLibs,
+  e2fsprogs,
+  lz4,
+  xxhash,
+  zlib,
+  zstd,
+  versionCheckHook,
+  nix-update-script,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "docker-sbx";
+  version = "0.34.0";
+  src =
+    if stdenvNoCC.hostPlatform.system == "x86_64-linux" then
+      fetchurl {
+        url = "https://github.com/docker/sbx-releases/releases/download/v${finalAttrs.version}/DockerSandboxes-linux-amd64.tar.gz";
+        hash = "sha256-5H9LOyKi0/SBVJ0ld6OkcP1h9r9eHrAb4fsVVVdMusg=";
+      }
+    else if stdenvNoCC.hostPlatform.system == "aarch64-linux" then
+      fetchurl {
+        url = "https://github.com/docker/sbx-releases/releases/download/v${finalAttrs.version}/DockerSandboxes-linux-arm64.tar.gz";
+        hash = "sha256-dZ/ttnmaf62rA5Cs8YSmZGHVQoy9PQh3Ok/AnIjCqZ4=";
+      }
+    else if stdenvNoCC.hostPlatform.system == "aarch64-darwin" then
+      fetchurl {
+        url = "https://github.com/docker/sbx-releases/releases/download/v${finalAttrs.version}/DockerSandboxes-darwin.tar.gz";
+        hash = "sha256-aBh6NbtQ5o2zxuR+d1U1gZpm2bch/J3Y8GZ73DeUBUk=";
+      }
+    else
+      throw "Unsupported host platform ${stdenvNoCC.hostPlatform.system}";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  sourceRoot = if stdenvNoCC.hostPlatform.isDarwin then "." else null;
+
+  nativeBuildInputs = [
+    installShellFiles
+    versionCheckHook
+  ]
+  ++ lib.optionals stdenvNoCC.hostPlatform.isLinux [
+    autoPatchelfHook
+    makeWrapper
+    e2fsprogs
+  ];
+
+  buildInputs = lib.optionals stdenvNoCC.hostPlatform.isLinux [
+    lz4
+    zlib
+    zstd
+    xxhash
+    gccForLibs
+  ];
+
+  dontBuild = true;
+  doInstallCheck = true;
+  versionCheckProgramArg = "version";
+  versionCheckKeepEnvironment = [ "HOME" ];
+  preVersionCheck = ''
+    export HOME=$TMPDIR
+  '';
+
+  installPhase =
+    if stdenvNoCC.hostPlatform.isLinux then
+      ''
+        runHook preInstall
+
+        PREFIX=$out bash ./install.sh
+
+        wrapProgram $out/bin/sbx \
+          --prefix PATH : ${lib.makeBinPath [ e2fsprogs ]}
+
+        ${lib.optionalString (stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform) ''
+          export HOME=$TMPDIR
+          $out/bin/sbx completion bash > sbx.bash
+          $out/bin/sbx completion fish > sbx.fish
+          $out/bin/sbx completion zsh  > sbx.zsh
+          installShellCompletion sbx.{bash,fish,zsh}
+        ''}
+
+        runHook postInstall
+      ''
+    else
+      ''
+        runHook preInstall
+
+        mkdir -pv $out
+        cp -rv bin libexec $out
+
+        installShellCompletion \
+          --bash --name sbx.bash completions/bash/sbx \
+          --zsh  --name _sbx     completions/zsh/_sbx \
+          --fish --name sbx.fish completions/fish/sbx.fish
+
+        runHook postInstall
+      '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Safe environments for agents";
+    longDescription = ''
+      Docker Sandboxes provides sandboxes with controlled access to your
+      filesystem, network, and tools. This means your agents can work
+      autonomously without putting your machine or data at risk.
+    '';
+    homepage = "https://docs.docker.com/reference/cli/sbx/";
+    changelog = "https://github.com/docker/sbx-releases/releases/tag/v${finalAttrs.version}";
+    mainProgram = "sbx";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+    license = lib.licenses.unfree;
+    maintainers = [
+      lib.maintainers.skyesoss
+      lib.maintainers.erics118
+    ];
+  };
+})


### PR DESCRIPTION
Adds the Docker `sbx` cli ([docs](https://docs.docker.com/reference/cli/sbx/)).
This is proprietary software, so the derivation simply unpacks the tarball and fixes-up RPATHs.

Note: the package includes downloads for AMD64 Linux, ARM64 Darwin, and Windows.
As I only have a Linux machine to work with, the Darwin build is likely broken, and is marked as such.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
