### PR TITLE
soularr: init at 1.2.2

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -969,6 +969,7 @@
   ./services/misc/sickbeard.nix
   ./services/misc/snapper.nix
   ./services/misc/soft-serve.nix
+  ./services/misc/soularr.nix
   ./services/misc/spice-autorandr.nix
   ./services/misc/spice-vdagentd.nix
   ./services/misc/spice-webdavd.nix

--- a/nixos/modules/services/misc/soularr.nix
+++ b/nixos/modules/services/misc/soularr.nix
@@ -1,0 +1,164 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.services.soularr;
+  ini = pkgs.formats.ini { };
+in
+{
+  options = {
+    services.soularr = {
+      enable = lib.mkEnableOption "Soularr, a script that connects Lidarr with Soulseek";
+
+      package = lib.mkPackageOption pkgs "soularr" { };
+
+      settings = lib.mkOption {
+        type = lib.types.submodule {
+          freeformType = ini.type;
+        };
+        example = lib.options.literalExpression ''
+          {
+            Lidarr = {
+              host_url = "http://localhost:8686";
+              download_dir = "/media/slsk/downloads";
+            };
+            Slskd = {
+              host_url = "http://localhost:5030";
+              download_dir = "/media/slsk/downloads";
+            };
+            "Search Settings" = {
+              search_source = "missing";
+              minimum_filename_match_ratio = 0.8;
+            };
+            "Release Settings" = {
+              use_selected_lidarr_release = true;
+            };
+          }
+        '';
+        default = { };
+        description = ''
+          Attribute set of arbitrary config options.
+          Please consult the example on the [official website](https://soularr.net/#configure-your-config-file).
+        '';
+      };
+
+      lidarrApiKeyFile = lib.mkOption {
+        type = lib.types.path;
+        description = "Path to the file containing Lidarr's api-key.";
+      };
+
+      slskdApiKeyFile = lib.mkOption {
+        type = lib.types.path;
+        description = "Path to the file containing Slskd's api-key.";
+      };
+
+      interval = lib.mkOption {
+        type = lib.types.str;
+        default = "hourly";
+        description = ''
+          The interval at which the Soularr should run. See
+          {manpage}`systemd.time(7)` to understand the format.
+        '';
+      };
+
+      user = lib.mkOption {
+        type = lib.types.str;
+        default = "soularr";
+        description = ''
+          User account under which Soularr runs.
+        '';
+      };
+
+      group = lib.mkOption {
+        type = lib.types.str;
+        default = "soularr";
+        description = ''
+          Group under which Soularr runs.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !lib.hasAttrByPath [ "Lidarr" "api_key" ] cfg.settings;
+        message = ''
+          Do not set `services.soularr.settings.Lidarr.api_key` in your configuration.
+          Use `services.soularr.lidarrApiKeyFile` instead.
+        '';
+      }
+      {
+        assertion = !lib.hasAttrByPath [ "Slskd" "api_key" ] cfg.settings;
+        message = ''
+          Do not set `services.soularr.settings.Slskd.api_key` in your configuration.
+          Use `services.soularr.slskdApiKeyFile` instead.
+        '';
+      }
+    ];
+
+    systemd.services.soularr = {
+      description = "Soularr";
+      after = [
+        "network.target"
+      ]
+      ++ lib.optional config.services.lidarr.enable "lidarr.service"
+      ++ lib.optional config.services.slskd.enable "slskd.service";
+
+      restartIfChanged = false;
+
+      preStart =
+        let
+          configFile = ini.generate "config.ini" (
+            lib.recursiveUpdate cfg.settings {
+              Lidarr.api_key = "@LIDARR_API_KEY@";
+              Slskd.api_key = "@SLSKD_API_KEY@";
+            }
+          );
+        in
+        ''
+          install -m 700 '${configFile}' "$RUNTIME_DIRECTORY/config.ini"
+          ${lib.getExe pkgs.replace-secret} "@LIDARR_API_KEY@" "$CREDENTIALS_DIRECTORY/LIDARR_API_KEY" "$RUNTIME_DIRECTORY/config.ini"
+          ${lib.getExe pkgs.replace-secret} "@SLSKD_API_KEY@" "$CREDENTIALS_DIRECTORY/SLSKD_API_KEY" "$RUNTIME_DIRECTORY/config.ini"
+        '';
+
+      serviceConfig = {
+        Type = "oneshot";
+        RuntimeDirectory = "soularr";
+        WorkingDirectory = "/run/soularr";
+        User = cfg.user;
+        Group = cfg.group;
+        LoadCredential = [
+          "LIDARR_API_KEY:${cfg.lidarrApiKeyFile}"
+          "SLSKD_API_KEY:${cfg.slskdApiKeyFile}"
+        ];
+        ExecStart = "${lib.getExe cfg.package}";
+        Restart = "on-failure";
+      };
+    };
+
+    systemd.timers.soularr = {
+      timerConfig = {
+        OnCalendar = cfg.interval;
+        Persistent = true;
+      };
+      wantedBy = [ "timers.target" ];
+    };
+
+    users.users = lib.mkIf (cfg.user == "soularr") {
+      soularr = {
+        group = cfg.group;
+        uid = config.ids.uids.soularr;
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == "soularr") {
+      soularr = {
+        gid = config.ids.gids.soularr;
+      };
+    };
+  };
+}

--- a/pkgs/by-name/so/soularr/package.nix
+++ b/pkgs/by-name/so/soularr/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  fetchFromGitHub,
+  installShellFiles,
+  python3Packages,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "soularr";
+  version = "1.2.2";
+  pyproject = false;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "mrusse";
+    repo = "soularr";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-gtz99+DiFjJZuq54qo5C+5Exx++S+ePzldgDM9NHAOA=";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  dependencies = with python3Packages; [
+    music-tag
+    pyarr
+    slskd-api
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mv soularr{.py,}
+    installBin soularr
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Python script that connects Lidarr with Soulseek";
+    homepage = "https://soularr.net/";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ hougo ];
+    mainProgram = "soularr";
+  };
+})

--- a/pkgs/development/python-modules/slskd-api/default.nix
+++ b/pkgs/development/python-modules/slskd-api/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  requests,
+  setuptools-git-versioning,
+  nix-update-script,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "slskd-api";
+  version = "0.2.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "bigoulours";
+    repo = "slskd-python-api";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rEfBT13NutwCfrWcxQf67rhtmxlB8Ws6RY8fObidSs8=";
+  };
+
+  nativeBuildInputs = [ setuptools-git-versioning ];
+
+  dependencies = [ requests ];
+
+  pythonImportsCheck = [ "slskd_api" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "API Wrapper to interact with slskd";
+    homepage = "https://slskd-api.readthedocs.io/";
+    changelog = "https://github.com/bigoulours/slskd-python-api/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ hougo ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18130,6 +18130,8 @@ self: super: with self; {
 
   slpp = callPackage ../development/python-modules/slpp { };
 
+  slskd-api = callPackage ../development/python-modules/slskd-api { };
+
   slugid = callPackage ../development/python-modules/slugid { };
 
   sly = callPackage ../development/python-modules/sly { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
[Soularr](https://soularr.net) is a Python script that connects Lidarr with Soulseek.

Based upon the work on https://github.com/NixOS/nixpkgs/pull/399031.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
