### PR TITLE
gitea-actions-runner: 1.0.3 -> 1.0.6

### DIFF
--- a/pkgs/by-name/gi/gitea-actions-runner/package.nix
+++ b/pkgs/by-name/gi/gitea-actions-runner/package.nix
@@ -8,17 +8,17 @@
 
 buildGoModule (finalAttrs: {
   pname = "gitea-actions-runner";
-  version = "1.0.3";
+  version = "1.0.6";
 
   src = fetchFromGitea {
     domain = "gitea.com";
     owner = "gitea";
     repo = "runner";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-p6NdkQiZiEeuQjJp3CKTayStZlyk3d1XGigSI5uuLp0=";
+    hash = "sha256-kSiyalNcR3puGn3uC51GSEOgRTQ/bt64Q4+3GFKvGDM=";
   };
 
-  vendorHash = "sha256-T1T5ZpGqGmipIkTWlYxlsLdAthW8bhcAvr0xyZ74+wQ=";
+  vendorHash = "sha256-Az8BPGoI4dsun0ZOl1pxxYFpZ7b2oC+0UA115ZkNh9k=";
 
   # Tests require network access (artifactcache tests try to determine outbound IP)
   doCheck = false;


### PR DESCRIPTION
https://gitea.com/gitea/runner/releases/tag/v1.0.6
https://gitea.com/gitea/runner/releases/tag/v1.0.5
https://gitea.com/gitea/runner/releases/tag/v1.0.4

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests in nixos/tests.
  - [x] Package tests at passthru.tests.
  - [ ] Tests in lib/tests or pkgs/test for functions and core functionality.
- [x] Ran nixpkgs-review on this PR.
- [ ] Tested basic functionality of all binary files, usually in ./result/bin/.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.
- [x] Follows the automation/AI policy.