### PR TITLE
dcmtk: 3.6.9 -> 3.7.0

### DIFF
--- a/pkgs/by-name/dc/dcmtk/package.nix
+++ b/pkgs/by-name/dc/dcmtk/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dcmtk";
-  version = "3.6.9";
+  version = "3.7.0";
 
   src = fetchFromGitHub {
     owner = "DCMTK";
     repo = "dcmtk";
     tag = "DCMTK-${finalAttrs.version}";
-    hash = "sha256-mdI/YqM38WhnCbsylIlmqLLWC5/QR+a8Wn9CNcN7KXU=";
+    hash = "sha256-JUF3IX0LOtpeAJPuTbAJo79sCuPuhh7KNIuQJfcFN/A=";
   };
 
   # The following patches are taken from the Debian package
@@ -37,26 +37,6 @@ stdenv.mkDerivation (finalAttrs: {
     (fetchurl {
       url = "https://salsa.debian.org/med-team/dcmtk/-/raw/debian/3.6.9-4/debian/patches/remove_version.patch";
       hash = "sha256-jcV2xQzKdNiBgcaFtaxdJpJCCSVOqGIsi/A4iqVM8U8=";
-    })
-    (fetchurl {
-      url = "https://salsa.debian.org/med-team/dcmtk/-/raw/debian/3.6.9-4/debian/patches/0007-CVE-2024-47796.patch";
-      hash = "sha256-QYWgSbyIcOq3CVg2ynVSPCHBIrDj9uqX4ese1huoOoU=";
-    })
-    (fetchurl {
-      url = "https://salsa.debian.org/med-team/dcmtk/-/raw/debian/3.6.9-4/debian/patches/0008-CVE-2024-52333.patch";
-      hash = "sha256-/4NdauuH0v6CPMh+duMM91wWfylp6l4L2LTO80dDh9g=";
-    })
-    (fetchurl {
-      url = "https://salsa.debian.org/med-team/dcmtk/-/raw/debian/3.6.9-4/debian/patches/0009-CVE-2025-25475.patch";
-      hash = "sha256-ApuVw6aBoasuVlJ3fh/aufB2WRm2hFgLYCq1k3MPrsU=";
-    })
-    (fetchurl {
-      url = "https://salsa.debian.org/med-team/dcmtk/-/raw/debian/3.6.9-4/debian/patches/0010-CVE-2025-25474.patch";
-      hash = "sha256-aX8em1o88ND4srsYkG696elPsAIlvkRRZMT8wzD2GdQ=";
-    })
-    (fetchurl {
-      url = "https://salsa.debian.org/med-team/dcmtk/-/raw/debian/3.6.9-4/debian/patches/0011-CVE-2025-25472.patch";
-      hash = "sha256-o3/PykJFbYlasAFgPNWp09hRuH183tQuvGuaOV4MOoo=";
     })
   ];
 


### PR DESCRIPTION
Diff: https://github.com/DCMTK/dcmtk/compare/DCMTK-3.6.9...DCMTK-3.7.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
