### PR TITLE
antigravity-hub: init at 2.12.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3813,6 +3813,12 @@
     github = "bohanubis";
     githubId = 77834479;
   };
+  BohdanTkachenko = {
+    email = "bohdan@tkachenko.dev";
+    github = "BohdanTkachenko";
+    githubId = 929598;
+    name = "Bohdan Tkachenko";
+  };
   bohreromir = {
     github = "bohreromir";
     githubId = 40412303;

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3986,6 +3986,12 @@
     github = "bohanubis";
     githubId = 77834479;
   };
+  BohdanTkachenko = {
+    email = "bohdan@tkachenko.dev";
+    github = "BohdanTkachenko";
+    githubId = 929598;
+    name = "Bohdan Tkachenko";
+  };
   bohreromir = {
     github = "bohreromir";
     githubId = 40412303;

--- a/pkgs/by-name/an/antigravity-hub/package.nix
+++ b/pkgs/by-name/an/antigravity-hub/package.nix
@@ -1,0 +1,183 @@
+{
+  alsa-lib,
+  asar,
+  at-spi2-atk,
+  at-spi2-core,
+  atk,
+  autoPatchelfHook,
+  copyDesktopItems,
+  cairo,
+  cups,
+  dbus,
+  expat,
+  fetchurl,
+  fontconfig,
+  freetype,
+  gdk-pixbuf,
+  glib,
+  gsettings-desktop-schemas,
+  gtk3,
+  lib,
+  libdrm,
+  libgbm,
+  libGL,
+  libglvnd,
+  libnotify,
+  libpulseaudio,
+  libsecret,
+  libuuid,
+  libx11,
+  libxcb,
+  libxcomposite,
+  libxcursor,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxi,
+  libxkbcommon,
+  libxml2,
+  libxrandr,
+  libxrender,
+  libxshmfence,
+  libxt,
+  libxtst,
+  makeDesktopItem,
+  makeWrapper,
+  mesa,
+  nspr,
+  nss,
+  pango,
+  stdenv,
+  systemd,
+  vulkan-loader,
+  wayland,
+  xdg-utils,
+}:
+
+let
+  desktopLibs = [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gdk-pixbuf
+    glib
+    gsettings-desktop-schemas
+    gtk3
+    libdrm
+    libgbm
+    libGL
+    libglvnd
+    libnotify
+    libpulseaudio
+    libsecret
+    libuuid
+    libx11
+    libxcb
+    libxcomposite
+    libxcursor
+    libxdamage
+    libxext
+    libxfixes
+    libxi
+    libxkbcommon
+    libxml2
+    libxrandr
+    libxrender
+    libxshmfence
+    libxt
+    libxtst
+    mesa
+    nspr
+    nss
+    pango
+    stdenv.cc.cc
+    systemd
+    vulkan-loader
+    wayland
+  ];
+
+  sources = builtins.fromJSON (builtins.readFile ./sources.json);
+  systemSource =
+    sources.sources.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+in
+stdenv.mkDerivation {
+  pname = "antigravity-hub";
+  version = sources.version;
+
+  src = fetchurl {
+    url = systemSource.url;
+    hash = systemSource.sha256;
+  };
+
+  sourceRoot = systemSource.sourceRoot;
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    asar
+    autoPatchelfHook
+    copyDesktopItems
+    makeWrapper
+  ];
+
+  buildInputs = desktopLibs;
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "antigravity-hub";
+      desktopName = "Antigravity";
+      comment = "Antigravity 2 - Agent-first development platform";
+      exec = "antigravity %U";
+      icon = "antigravity";
+      terminal = false;
+      type = "Application";
+      categories = [ "Development" ];
+      startupWMClass = "antigravity";
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/antigravity
+    cp -r . $out/share/antigravity/
+
+    mkdir -p $out/bin
+    makeWrapper $out/share/antigravity/antigravity $out/bin/antigravity \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath desktopLibs} \
+      --prefix XDG_DATA_DIRS : "${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}" \
+      --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}"
+
+    asar extract-file resources/app.asar icon.png
+    install -Dm644 icon.png $out/share/icons/hicolor/512x512/apps/antigravity.png
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Desktop environment for managing multiple autonomous agents across independent projects.";
+    homepage = "https://antigravity.google";
+    changelog = "https://antigravity.google/changelog";
+    downloadPage = "https://antigravity.google/download";
+    license = lib.licenses.unfree;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    mainProgram = "antigravity";
+    maintainers = with lib.maintainers; [
+      BohdanTkachenko
+    ];
+  };
+}

--- a/pkgs/by-name/an/antigravity-hub/package.nix
+++ b/pkgs/by-name/an/antigravity-hub/package.nix
@@ -1,0 +1,172 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  alsa-lib,
+  asar,
+  at-spi2-atk,
+  at-spi2-core,
+  atk,
+  autoPatchelfHook,
+  cairo,
+  copyDesktopItems,
+  cups,
+  dbus,
+  expat,
+  glib,
+  gsettings-desktop-schemas,
+  gtk3,
+  libGL,
+  libgbm,
+  libnotify,
+  libpulseaudio,
+  libsecret,
+  libx11,
+  libxcb,
+  libxcomposite,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxkbcommon,
+  libxrandr,
+  makeDesktopItem,
+  makeShellWrapper,
+  nspr,
+  nss,
+  pango,
+  pipewire,
+  systemd,
+  wrapGAppsHook3,
+}:
+
+let
+  sources = {
+    x86_64-linux = {
+      arch = "x64";
+      hash = "sha256-/C4q9JpFrv7pVYvOVqqku94A1WDTVDV68bg0qd1DzTM=";
+    };
+    aarch64-linux = {
+      arch = "arm";
+      hash = "sha256-cgSbIH0cF5qFJKTc8TxPhtjLulmdhF/cRX3g9/ES6Rg=";
+    };
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "antigravity-hub";
+  version = "2.12.2";
+
+  src =
+    let
+      source =
+        sources.${stdenv.hostPlatform.system}
+          or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+    in
+    fetchurl {
+      url = "https://storage.googleapis.com/antigravity-public/antigravity-hub/${finalAttrs.version}-${finalAttrs.passthru.buildId}/linux-${source.arch}/Antigravity.tar.gz";
+      inherit (source) hash;
+    };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    asar
+    autoPatchelfHook
+    copyDesktopItems
+    makeShellWrapper
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    glib
+    gsettings-desktop-schemas
+    gtk3
+    libgbm
+    libx11
+    libxcb
+    libxcomposite
+    libxdamage
+    libxext
+    libxfixes
+    libxkbcommon
+    libxrandr
+    nspr
+    nss
+    pango
+    systemd
+  ];
+
+  # Loaded with dlopen() by the main binary, so autoPatchelfHook cannot discover them.
+  runtimeDependencies = map lib.getLib [
+    libnotify
+    libpulseaudio
+    libsecret
+    pipewire
+  ];
+  # The bundled ANGLE libraries (libEGL.so, libGLESv2.so) dlopen() the system GL
+  # libraries. runtimeDependencies only applies to executables, so extend the
+  # RUNPATH of every patched ELF file instead.
+  appendRunpaths = [ "${lib.getLib libGL}/lib" ];
+
+  # The wrapper is created in postFixup to add the Wayland flags.
+  dontWrapGApps = true;
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "antigravity-hub";
+      desktopName = "Antigravity";
+      comment = "Manage multiple autonomous agents across independent projects";
+      exec = "antigravity %U";
+      icon = "antigravity";
+      categories = [ "Development" ];
+      mimeTypes = [ "x-scheme-handler/antigravity" ];
+      startupWMClass = "Antigravity";
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/antigravity
+    cp -r . $out/share/antigravity
+
+    asar extract-file resources/app.asar icon.png
+    install -Dm644 icon.png $out/share/icons/hicolor/512x512/apps/antigravity.png
+
+    runHook postInstall
+  '';
+
+  # wrapGAppsHook3 provides makeBinaryWrapper, which cannot expand the shell
+  # variables in --add-flags, hence makeShellWrapper.
+  postFixup = ''
+    makeShellWrapper $out/share/antigravity/antigravity $out/bin/antigravity \
+      "''${gappsWrapperArgs[@]}" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
+  '';
+
+  passthru = {
+    # Download URLs embed a build ID next to the version, e.g. `2.12.2-6298742303883264`.
+    buildId = "6298742303883264";
+    updateScript = ./update.sh;
+  };
+
+  meta = {
+    description = "Desktop environment for managing multiple autonomous agents across independent projects";
+    homepage = "https://antigravity.google";
+    changelog = "https://antigravity.google/changelog";
+    downloadPage = "https://antigravity.google/download";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = lib.attrNames sources;
+    mainProgram = "antigravity";
+    maintainers = with lib.maintainers; [ BohdanTkachenko ];
+  };
+})

--- a/pkgs/by-name/an/antigravity-hub/sources.json
+++ b/pkgs/by-name/an/antigravity-hub/sources.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.5.0",
+  "sources": {
+    "x86_64-linux": {
+      "url": "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.5.0-5471848641724416/linux-x64/Antigravity.tar.gz",
+      "sha256": "sha256-/4mTOa5KgBGndwrkcAK1VUJjWhwi1Wl5MmmkcLW1gNg=",
+      "sourceRoot": "Antigravity-x64"
+    },
+    "aarch64-linux": {
+      "url": "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.5.0-5471848641724416/linux-arm/Antigravity.tar.gz",
+      "sha256": "sha256-NoETsrsLrPzMtapsqP8rCZhspLtUKnsjMkL+G/15hKU=",
+      "sourceRoot": "Antigravity-arm64"
+    }
+  }
+}

--- a/pkgs/by-name/an/antigravity-hub/update.sh
+++ b/pkgs/by-name/an/antigravity-hub/update.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq yq-go nix coreutils cacert
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+SOURCE_JSON="$DIR/sources.json"
+
+MANIFEST_BASE_URL="https://antigravity-hub-auto-updater-974169037036.us-central1.run.app/manifest"
+DOWNLOAD_BASE_URL="https://storage.googleapis.com/antigravity-public/antigravity-hub"
+
+# Function to fetch and resolve latest release details for a platform
+resolve_platform() {
+    local channel_arch="$1"   # e.g., "x64" or "arm64"
+
+    local manifest_url="${MANIFEST_BASE_URL}/latest-${channel_arch}-linux.yml"
+    local yaml_data
+    if ! yaml_data=$(curl -s --fail "$manifest_url"); then
+        echo "Error: Failed to fetch manifest from $manifest_url" >&2
+        exit 1
+    fi
+
+    local ver
+    ver=$(echo "$yaml_data" | yq '. | .version')
+    local url
+    url=$(echo "$yaml_data" | yq '.files[] | select(.url == "https://*") | .url')
+    local exec_id
+    exec_id=$(echo "$url" | sed -E 's|.*/[0-9.]+-([0-9]+)/.*|\1|')
+
+    if [[ -z "$ver" || -z "$exec_id" ]]; then
+        echo "Error: Failed to parse version or execution ID from $manifest_url" >&2
+        exit 1
+    fi
+
+    echo "$ver" "$exec_id"
+}
+
+# Function to prefetch and calculate sha256 hash in SRI format
+prefetch() {
+    local url="$1"
+
+    echo "Prefetching $url..." >&2
+    nix store prefetch-file --json "$url" | jq -r .hash
+}
+
+# Resolve latest versions and execution IDs for both platforms
+echo "Checking latest releases..."
+read -r x64_VERSION x64_EXEC_ID < <(resolve_platform "x64")
+read -r arm64_VERSION arm64_EXEC_ID < <(resolve_platform "arm64")
+
+# Enforce both platforms are on the same version
+if [[ "$x64_VERSION" == "$arm64_VERSION" ]]; then
+    TARGET_VERSION="$x64_VERSION"
+    TARGET_EXEC_ID="$x64_EXEC_ID"
+else
+    # Find the lower version to ensure both platforms support this release
+    TARGET_VERSION=$(echo -e "$x64_VERSION\n$arm64_VERSION" | sort -V | head -n 1)
+    if [[ "$TARGET_VERSION" == "$x64_VERSION" ]]; then
+        TARGET_EXEC_ID="$x64_EXEC_ID"
+    else
+        TARGET_EXEC_ID="$arm64_EXEC_ID"
+    fi
+    echo "Warning: Platform version mismatch detected (x64: $x64_VERSION, arm64: $arm64_VERSION)." >&2
+    echo "Enforcing same version across platforms by aligning to the lower version: $TARGET_VERSION" >&2
+fi
+
+# Construct target GCS URLs
+x64_URL="${DOWNLOAD_BASE_URL}/${TARGET_VERSION}-${TARGET_EXEC_ID}/linux-x64/Antigravity.tar.gz"
+arm64_URL="${DOWNLOAD_BASE_URL}/${TARGET_VERSION}-${TARGET_EXEC_ID}/linux-arm/Antigravity.tar.gz"
+
+# Check if we actually need to update
+if [[ -f "$SOURCE_JSON" ]]; then
+    CURRENT_VERSION=$(jq -r '.version // empty' "$SOURCE_JSON")
+    CURRENT_X64_URL=$(jq -r '.sources."x86_64-linux".url // empty' "$SOURCE_JSON")
+    CURRENT_ARM_URL=$(jq -r '.sources."aarch64-linux".url // empty' "$SOURCE_JSON")
+
+    if [[ "$CURRENT_X64_URL" == "$x64_URL" && "$CURRENT_ARM_URL" == "$arm64_URL" ]]; then
+        echo "Antigravity Hub is already up to date (version: $TARGET_VERSION)"
+        exit 0
+    fi
+
+    if [[ "$CURRENT_VERSION" == "$TARGET_VERSION" ]]; then
+        echo "Version is the same ($TARGET_VERSION), but URLs have changed. Updating to fresh URLs..."
+    fi
+fi
+
+echo "Updating Antigravity Hub..."
+echo "  Target Version: $TARGET_VERSION"
+echo "  Target Exec ID: $TARGET_EXEC_ID"
+echo "  x64 URL:        $x64_URL"
+echo "  arm64 URL:      $arm64_URL"
+
+# Write new sources.json
+jq -n \
+  --arg ver "$TARGET_VERSION" \
+  --arg url_x64 "$x64_URL" \
+  --arg hash_x64 "$(prefetch "$x64_URL")" \
+  --arg root_x64 "Antigravity-x64" \
+  --arg url_arm "$arm64_URL" \
+  --arg hash_arm "$(prefetch "$arm64_URL")" \
+  --arg root_arm "Antigravity-arm64" \
+  '{
+    version: $ver,
+    sources: {
+      "x86_64-linux": { url: $url_x64, sha256: $hash_x64, sourceRoot: $root_x64 },
+      "aarch64-linux": { url: $url_arm, sha256: $hash_arm, sourceRoot: $root_arm }
+    }
+  }' > "$SOURCE_JSON"
+
+echo "Successfully updated sources.json to $TARGET_VERSION."

--- a/pkgs/by-name/an/antigravity-hub/update.sh
+++ b/pkgs/by-name/an/antigravity-hub/update.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash common-updater-scripts curl jq nix yq-go
+
+set -euo pipefail
+
+packageFile=pkgs/by-name/an/antigravity-hub/package.nix
+manifestUrl=https://antigravity-hub-auto-updater-974169037036.us-central1.run.app/manifest/latest-x64-linux.yml
+
+# Download URLs embed a build ID next to the version, e.g.
+# https://storage.googleapis.com/antigravity-public/antigravity-hub/2.12.2-6298742303883264/linux-x64/Antigravity.AppImage
+manifest=$(curl -sSfL "$manifestUrl")
+read -r latestVersion latestUrl < <(yq '.version + " " + .files[0].url' <<<"$manifest")
+latestBuildId=$(cut -d/ -f6 <<<"$latestUrl" | cut -d- -f2)
+
+currentVersion=$(nix-instantiate --eval --raw -E "with import ./. {}; antigravity-hub.version")
+if [[ "$currentVersion" == "$latestVersion" ]]; then
+    echo "antigravity-hub is up-to-date: $currentVersion"
+    exit 0
+fi
+
+# Bump the version and build ID first so that src.url evaluates to the new downloads.
+sed -i \
+    -e "s/version = \"$currentVersion\";/version = \"$latestVersion\";/" \
+    -e "s/buildId = \"[0-9]*\";/buildId = \"$latestBuildId\";/" \
+    "$packageFile"
+
+for system in x86_64-linux aarch64-linux; do
+    url=$(nix-instantiate --eval --raw --system "$system" -E "with import ./. {}; antigravity-hub.src.url")
+    hash=$(nix store prefetch-file --json "$url" | jq -r .hash)
+    update-source-version antigravity-hub "$latestVersion" "$hash" --system="$system" --ignore-same-version
+done


### PR DESCRIPTION
Antigravity 2.0 was recently introduced as a separate product, while an existing Antigravity was renamed to Antigravity IDE. To avoid using a version number in a package name (like `antigravity2`) I chose `antigravity-hub` as it is already non-publicly used as a project name according to the download URL (`https://storage.googleapis.com/antigravity-public/antigravity-hub/...`) which seems to be a good name to distinguish between a family of products (`antigravity-ide`, `antigravity-cli`, `antigravity-sdk`).

This PR includes init at 2.12.2 and an auto-update script that uses a YAML manifest to extract the latest version number and `execution_id`.

Assisted-by: Claude Code (Claude Fable 5.1)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
