### PR TITLE
double-conversion: 3.3.1 -> 3.4.0

### DIFF
--- a/pkgs/by-name/do/double-conversion/package.nix
+++ b/pkgs/by-name/do/double-conversion/package.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   ninja,
   ctestCheckHook,
@@ -11,33 +10,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "double-conversion";
-  version = "3.3.1";
+  version = "3.4.0";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "double-conversion";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-M80H+azCzQYa4/gBLWv5GNNhEuHsH7LbJ/ajwmACnrM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-gxaPqQ51RyXZaTHkvh4RBpedPopcRiuWDoT+PPbI1uw=";
   };
-
-  patches = [
-    # Fix the build with CMake 4.
-    (fetchpatch {
-      name = "double-conversion-fix-cmake-4-1.patch";
-      url = "https://github.com/google/double-conversion/commit/101e1ba89dc41ceb75090831da97c43a76cd2906.patch";
-      hash = "sha256-VRmuNXdzt/I+gWbz5mwWkx5IGn8Vsl9WkdwRsuwZdkU=";
-    })
-    (fetchpatch {
-      name = "double-conversion-fix-cmake-4-2.patch";
-      url = "https://github.com/google/double-conversion/commit/0604b4c18815aadcf7f4b78dfa6bfcb91a634ed7.patch";
-      hash = "sha256-cJBp1ou1O/bMQ/7kvcX52dWbUdhmPfQ9aWmEhQdyhis=";
-    })
-    (fetchpatch {
-      name = "double-conversion-add-pkg-config.patch";
-      url = "https://github.com/google/double-conversion/commit/ddfd18c58ecc32fc74afc1083bb8774240b54efb.patch";
-      hash = "sha256-/pKCL19vS8fNwCm27yTNP+32ApHTH5dEGpnsMI11Lf4=";
-    })
-  ];
 
   outputs = [
     "out"
@@ -68,6 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     pkgConfigModules = [ "double-conversion" ];
+    changelog = "https://github.com/google/double-conversion/blob/${finalAttrs.src.tag}/Changelog";
     description = "Binary-decimal and decimal-binary routines for IEEE doubles";
     homepage = "https://github.com/google/double-conversion";
     license = lib.licenses.bsd3;


### PR DESCRIPTION
Diff: https://github.com/google/double-conversion/compare/v3.3.1...v3.4.0

Changelog: https://github.com/google/double-conversion/releases/tag/v3.4.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
