### PR TITLE
enca: 1.19 -> 1.22

### DIFF
--- a/pkgs/by-name/en/enca/package.nix
+++ b/pkgs/by-name/en/enca/package.nix
@@ -1,18 +1,20 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   libiconv,
   recode,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "enca";
-  version = "1.19";
+  version = "1.22";
 
-  src = fetchurl {
-    url = "https://dl.cihar.com/enca/enca-${finalAttrs.version}.tar.xz";
-    sha256 = "1f78jmrggv3jymql8imm5m9yc8nqjw5l99mpwki2245l8357wj1s";
+  src = fetchFromGitHub {
+    owner = "Project-OSS-Revival";
+    repo = "enca";
+    tag = finalAttrs.version;
+    hash = "sha256-TMWAGT3iY/ND8pB4THU4PbBGpb8EfT6z+peT8T6mp4o=";
   };
 
   buildInputs = [
@@ -21,8 +23,9 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
+    changelog = "https://github.com/Project-OSS-Revival/enca/blob/${finalAttrs.src.tag}/ChangeLog";
     description = "Detects the encoding of text files and reencodes them";
-
+    homepage = "https://cihar.com/software/enca/";
     longDescription = ''
       Enca detects the encoding of text files, on the basis of knowledge
       of their language. It can also convert them to other encodings,


### PR DESCRIPTION
Diff: https://github.com/Project-OSS-Revival/enca/compare/1.19...1.22

Changelog: https://github.com/Project-OSS-Revival/enca/blob/1.22/ChangeLog


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
