### PR TITLE
Added new options to IPTSD service

### DIFF
--- a/nixos/modules/services/hardware/iptsd.nix
+++ b/nixos/modules/services/hardware/iptsd.nix
@@ -43,6 +43,29 @@ in
               type = lib.types.bool;
             };
           };
+          Contacts = {
+            SizeMin = lib.mkOption {
+              default = false;
+              description = "The minimal diameter a contact must have.";
+              type = lib.types.float;
+            };
+            SizeMax = lib.mkOption {
+              default = false;
+              description = "The maximal diameter a contact can have.";
+              type = lib.types.float;
+            };
+            AspectMin = lib.mkOption {
+              default = false;
+              description = "The minimal aspect ratio a contact must have.";
+              type = lib.types.float;
+            };
+            AspectMax = lib.mkOption {
+              default = false;
+              description = "The maximal aspect ratio a contact can have.";
+              type = lib.types.float;
+            };
+            
+          };
         };
       };
     };


### PR DESCRIPTION
This is my first ever PR to nixpkgs, so please forgive any mistakes.
It is a relitavely simple change, and No AI was used.
I noticed the IPTSD service was missing options required to implement calibration. I the four required fields as per the [docs](https://github.com/linux-surface/iptsd/blob/master/etc/iptsd.conf)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ x ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ x ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
