### PR TITLE
mplayer: migrate to by-name

### DIFF
--- a/pkgs/by-name/mp/mplayer/package.nix
+++ b/pkgs/by-name/mp/mplayer/package.nix
@@ -10,7 +10,7 @@
   ffmpeg_7,
   aalibSupport ? true,
   aalib,
-  fontconfigSupport ? true,
+  fontconfigSupport ? config.mplayer.fontconfigSupport or true,
   fontconfig,
   freefont_ttf,
   fribidiSupport ? true,
@@ -33,7 +33,7 @@
   cddaSupport ? !stdenv.hostPlatform.isDarwin,
   cdparanoia,
   dvdnavSupport ? !stdenv.hostPlatform.isDarwin,
-  libdvdnav,
+  libdvdnav_4_2_1,
   dvdreadSupport ? true,
   libdvdread,
   bluraySupport ? true,
@@ -115,6 +115,8 @@ let
       null;
 
   crossBuild = stdenv.hostPlatform != stdenv.buildPlatform;
+
+  libdvdnav = libdvdnav_4_2_1;
 
 in
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9482,13 +9482,6 @@ with pkgs;
     withConplay = false;
   };
 
-  mplayer = callPackage ../applications/video/mplayer (
-    {
-      libdvdnav = libdvdnav_4_2_1;
-    }
-    // (config.mplayer or { })
-  );
-
   mpvScripts = callPackage ../by-name/mp/mpv/scripts.nix { };
 
   mu-repo = python3Packages.callPackage ../applications/misc/mu-repo { };


### PR DESCRIPTION
This PR moves mplayer to pkgs/by-name/mp/mplayer/package.nix, updates how fontconfigSupport and libdvdnav are handled, and removes the old top‑level override. fontconfigSupport now respects config.mplayer.fontconfigSupport, and libdvdnav_4_2_1 is set directly in the package for consistent versioning.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
