### PR TITLE
various: remove vsock CID based instructions

### DIFF
--- a/nixos/tests/kaidan/default.nix
+++ b/nixos/tests/kaidan/default.nix
@@ -34,7 +34,7 @@
   };
 
   enableOCR = true;
-  interactive.sshBackdoor.enable = true; # ssh -o User=root vsock/3
+  interactive.sshBackdoor.enable = true;
 
   testScript =
     { nodes, ... }:

--- a/nixos/tests/reaction/basic.nix
+++ b/nixos/tests/reaction/basic.nix
@@ -83,8 +83,6 @@
   # Debug interactively with:
   # - nix run .#nixosTests.reaction.driverInteractive -L
   # - run_tests()
-  # ssh -o User=root vsock%3 (can also do vsock/3, but % works with scp etc.)
-  # ssh -o User=root vsock%4
   interactive.sshBackdoor.enable = true;
 
   interactive.nodes.server =

--- a/nixos/tests/reaction/firewall.nix
+++ b/nixos/tests/reaction/firewall.nix
@@ -73,7 +73,7 @@
   # Debug interactively with:
   # - nix run .#nixosTests.reaction-firewall.driverInteractive -L
   # - run_tests()
-  interactive.sshBackdoor.enable = true; # ssh -o User=root vsock%3
+  interactive.sshBackdoor.enable = true;
   interactive.nodes.machine = _: {
     virtualisation.graphics = false;
   };

--- a/nixos/tests/reaction/plugins.nix
+++ b/nixos/tests/reaction/plugins.nix
@@ -98,8 +98,6 @@
   # Debug interactively with:
   # - nix run .#nixosTests.reaction.driverInteractive -L
   # - run_tests()
-  # ssh -o User=root vsock%3 (can also do vsock/3, but % works with scp etc.)
-  # ssh -o User=root vsock%4
   interactive.sshBackdoor.enable = true;
 
   interactive.nodes.server =

--- a/nixos/tests/repath-studio.nix
+++ b/nixos/tests/repath-studio.nix
@@ -40,7 +40,6 @@
   # Debug interactively with:
   # - nix run .#nixosTests.repath-studio.driverInteractive -L
   # - start_all()/run_tests()
-  # ssh -o User=root vsock%3 (can also do vsock/3, but % works with scp etc.)
   interactive.sshBackdoor.enable = true;
 
   testScript = /* python */ ''

--- a/nixos/tests/stirling-pdf-desktop.nix
+++ b/nixos/tests/stirling-pdf-desktop.nix
@@ -107,7 +107,6 @@ in
   # - nix-build -A nixosTests.stirling-pdf-desktop.driverInteractive
   # - ./result/bin/nixos-test-driver
   # - run_tests()
-  # ssh -o User=root vsock%3 (can also do vsock/3, but % works with scp etc.)
   interactive.sshBackdoor.enable = true;
   interactive.nodes.client =
     { pkgs, ... }:

--- a/nixos/tests/web-apps/goupile/default.nix
+++ b/nixos/tests/web-apps/goupile/default.nix
@@ -121,7 +121,6 @@ in
   # - nix-build -A nixosTests.goupile.driverInteractive
   # - ./result/bin/nixos-test-driver
   # - run_tests()
-  # ssh -o User=root vsock%3 (can also do vsock/3, but % works with scp etc.)
   interactive.sshBackdoor.enable = true;
 
   interactive.nodes.machine =

--- a/nixos/tests/web-apps/pdfding/basic.nix
+++ b/nixos/tests/web-apps/pdfding/basic.nix
@@ -140,7 +140,7 @@
   # Debug interactively with:
   # - nix run .#nixosTests.pdfding.basic.driverInteractive -L
   # - start_all() / run_tests()
-  interactive.sshBackdoor.enable = true; # ssh -o User=root vsock%3
+  interactive.sshBackdoor.enable = true;
   interactive.nodes.machine =
     { config, ... }:
     let

--- a/nixos/tests/web-apps/pdfding/e2e.nix
+++ b/nixos/tests/web-apps/pdfding/e2e.nix
@@ -59,7 +59,7 @@
   # Debug interactively with:
   # - nix run .#nixosTests.pdfding.e2e.driverInteractive -L
   # - start_all() / run_tests()
-  interactive.sshBackdoor.enable = true; # ssh -o User=root vsock%3
+  interactive.sshBackdoor.enable = true;
   interactive.nodes.machine =
     { config, ... }:
     {

--- a/nixos/tests/web-apps/pdfding/postgres.nix
+++ b/nixos/tests/web-apps/pdfding/postgres.nix
@@ -72,7 +72,7 @@
   # Debug interactively with:
   # - nix run .#nixosTests.pdfding.postgres.driverInteractive -L
   # - start_all() / run_tests()
-  interactive.sshBackdoor.enable = true; # ssh -o User=root vsock%3
+  interactive.sshBackdoor.enable = true;
   interactive.nodes.machine =
     { config, ... }:
     let

--- a/nixos/tests/web-apps/pdfding/s3-backups.nix
+++ b/nixos/tests/web-apps/pdfding/s3-backups.nix
@@ -172,7 +172,7 @@ in
   # Debug interactively with:
   # - nix run .#nixosTests.pdfding.s3.driverInteractive -L
   # - start_all() / run_tests()
-  interactive.sshBackdoor.enable = true; # ssh -o User=root vsock%3
+  interactive.sshBackdoor.enable = true;
   interactive.nodes.machine =
     { config, ... }:
     let


### PR DESCRIPTION
After the recent breaking change in https://github.com/NixOS/nixpkgs/pull/453305, we can't seem to use `vsock%3` or `vsock/3` i.e. vsock with CIDs anymore.

```console
# run a nixos test vm with driverInteractive
# I ran nix run -f . nixosTests.goupile.driverInteractive
$ ssh -o User=root vsock%3
Failed to connect to vsock:3:22: No such device
mm_receive_fd: recvmsg: expected received 1 got 0
proxy dialer did not pass back a connection
$ ssh -o User=root vsock-mux//run/user/1000/tmpxwdu9bxx/machine_host.socket
Warning: Permanently added 'vsock-mux//run/user/1000/tmpxwdu9bxx/machine_host.socket' (ED25519) to the list of known hosts.

[root@machine:~]#
logout
Connection to vsock-mux//run/user/1000/tmpxwdu9bxx/machine_host.socket closed.
```

If this was intentional, this pr removes the outdated references to comments which still suggest using it with CID.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core"
        functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in
      `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and
      other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
