### PR TITLE
fzf: 0.72.0 -> 0.73.1

### DIFF
--- a/pkgs/by-name/fz/fzf/package.nix
+++ b/pkgs/by-name/fz/fzf/package.nix
@@ -11,7 +11,7 @@
 
 buildGoModule (finalAttrs: {
   pname = "fzf";
-  version = "0.72.0";
+  version = "0.73.1";
 
   __structuredAttrs = true;
 
@@ -19,10 +19,10 @@ buildGoModule (finalAttrs: {
     owner = "junegunn";
     repo = "fzf";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rUxbC2+VASAEBmL8WOpywk0SD0gyHArisl4pxnqK32I=";
+    hash = "sha256-xdhlbokeCzeBUP3YHA5u5tr3NTQz7n5TKPlJANp7yvM=";
   };
 
-  vendorHash = "sha256-uFXHoseFOxGIGPiWxWfDl339vUv855VHYgSs9rnDyuI=";
+  vendorHash = "sha256-MLuoKPEAqrpCbUphYOCpHdo8MdW5kvueeDU/3loK33Q=";
 
   env.CGO_ENABLED = 0;
 


### PR DESCRIPTION
Updates `fzf` 0.72.0 → 0.73.1 (latest stable upstream).

Changelog: https://github.com/junegunn/fzf/blob/v0.73.1/CHANGELOG.md
Release: https://github.com/junegunn/fzf/releases/tag/v0.73.1

Mechanical version bump: `version`, source `hash`, and `vendorHash` updated (via `nix-update`). No packaging logic changed.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

<details><summary>Build / version-check proof (aarch64-linux)</summary>

```
$ nix-update --version=stable --build fzf
Update 0.72.0 -> 0.73.1 in .../pkgs/by-name/fz/fzf/package.nix
...
fzf> Executing versionCheckPhase
fzf> Successfully managed to find version 0.73.1 in the output of the command .../bin/fzf --version
fzf> 0.73.1 (refs/tags/v0.73.1)
fzf> Finished versionCheckPhase
```
`nix build -f . fzf` succeeded; the package's `versionCheckHook` confirms the built binary reports `0.73.1`.
</details>

---

**Automation/AI disclosure:** version bump prepared with the `nix-update` tool and an AI coding assistant; reviewed, built, and verified locally by me (Chenglun Hu), who is accountable for this contribution.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
