### PR TITLE
doc2go: 0.12.1 -> 0.12.2

### DIFF
--- a/pkgs/by-name/do/doc2go/package.nix
+++ b/pkgs/by-name/do/doc2go/package.nix
@@ -6,15 +6,15 @@
 
 buildGoModule (finalAttrs: {
   pname = "doc2go";
-  version = "0.12.1";
+  version = "0.12.2";
 
   src = fetchFromGitHub {
     owner = "abhinav";
     repo = "doc2go";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-q3er94/WLCqXIOQaj7Kdty7yIuaLO7qXt6GiGxIxrPQ=";
+    hash = "sha256-H9x4qMYHwox4ceWj1fx/YzD/j4n5+ncMXfoq94SPivo=";
   };
-  vendorHash = "sha256-4s9gVjx+qiBRmL4abBN3FPuH4iMUapIQr1nwN40VmRQ=";
+  vendorHash = "sha256-oV0XSNyR+1WapDvDCdGa67DDb1oDREIuHLu0vEu2/eI=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
Updates `doc2go` 0.12.1 → 0.12.2 (latest stable upstream).

Release: https://github.com/abhinav/doc2go/releases/tag/v0.12.2

Mechanical version bump: `version`, source `hash`, and `vendorHash` updated (via `nix-update`). No packaging logic changed.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

<details><summary>Build proof (aarch64-linux)</summary>

```
$ nix-update --version=stable --build doc2go
Update 0.12.1 -> 0.12.2 in .../pkgs/by-name/do/doc2go/package.nix
$ nix build -f . doc2go
doc2go> stripping ... /nix/store/...-doc2go-0.12.2/bin
(build succeeded; package tests ran green)
```
</details>

---

**Automation/AI disclosure:** version bump prepared with the `nix-update` tool and an AI coding assistant; reviewed, built, and verified locally by me (Chenglun Hu), who is accountable for this contribution.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
