### PR TITLE
home-assistant.custom-components.smarthq: init at 1.1.0

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/smarthq/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/smarthq/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  aiohttp,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+}:
+
+buildHomeAssistantComponent (finalAttrs: {
+  owner = "geappliances";
+  domain = "smarthq";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "geappliances";
+    repo = "geappliances-smarthq-integration";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-LTLlkl4Mh0nSZfNVyLEItVPnQkM1nnDkPjsM98otp3w=";
+  };
+
+  dependencies = [
+    aiohttp
+  ];
+
+  meta = {
+    changelog = "https://github.com/geappliances/geappliances-smarthq-integration/releases/tag/${finalAttrs.src.tag}";
+    description = "Home Assistant integration for GE Appliances SmartHQ connected devices";
+    homepage = "https://github.com/geappliances/geappliances-smarthq-integration";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})


### PR DESCRIPTION
Adds the GE Appliances SmartHQ Home Assistant custom integration.

https://github.com/geappliances/geappliances-smarthq-integration

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
