### PR TITLE
rmfakecloud: 0.0.29 -> 0.0.31

### DIFF
--- a/pkgs/by-name/rm/rmfakecloud/package.nix
+++ b/pkgs/by-name/rm/rmfakecloud/package.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   buildGoModule,
   enableWebui ? true,
-  pnpm_9,
+  pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
   nodejs,
@@ -33,9 +33,9 @@ buildGoModule rec {
       ;
     sourceRoot = "${src.name}/ui";
     pnpmLock = "${src}/ui/pnpm-lock.yaml";
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-pggGMLQ08i8irCDQ1A0u41EXDleaRtSKusDWXuU7khA";
+    pnpm = pnpm_11;
+    fetcherVersion = 4;
+    hash = "sha256-UQT6uYusDw7Hd+1URrSQkyorajih6oF0LSMpPZy9K1w=";
   };
   preBuild = lib.optionals enableWebui ''
     # using sass-embedded fails at executing node_modules/sass-embedded-linux-x64/dart-sass/src/dart
@@ -49,7 +49,7 @@ buildGoModule rec {
   nativeBuildInputs = lib.optionals enableWebui [
     nodejs
     pnpmConfigHook
-    pnpm_9
+    pnpm_11
   ];
 
   # ... or don't embed it in the server

--- a/pkgs/by-name/rm/rmfakecloud/package.nix
+++ b/pkgs/by-name/rm/rmfakecloud/package.nix
@@ -11,16 +11,16 @@
 }:
 buildGoModule rec {
   pname = "rmfakecloud";
-  version = "0.0.29";
+  version = "0.0.31";
 
   src = fetchFromGitHub {
     owner = "ddvk";
     repo = "rmfakecloud";
-    rev = "v${version}";
-    hash = "sha256-N6hAv8dVCM3VWuKpHlK82mjQh6RB7W+n9KBNNQXDrC8=";
+    tag = "v${version}";
+    hash = "sha256-0eESaBe9FGqDrAumS8ANEEaB4FgbZsgWX1487J3Li4I=";
   };
 
-  vendorHash = "sha256-XksCJ9b5NDIutwqnWP63R2udp/Y5qkkgo2a4TPUi0Z4=";
+  vendorHash = "sha256-A+y63w+sEleXFh4ZHgFo1IhsQ2KhqqKW4vRPi393atI=";
 
   # if using webUI build it
   # use env because of https://github.com/NixOS/nixpkgs/issues/358844
@@ -35,7 +35,7 @@ buildGoModule rec {
     pnpmLock = "${src}/ui/pnpm-lock.yaml";
     pnpm = pnpm_9;
     fetcherVersion = 3;
-    hash = "sha256-5dsrf6Iff8z4ujzUccuNFwChChbWzXeXDilh8uZyl+U=";
+    hash = "sha256-pggGMLQ08i8irCDQ1A0u41EXDleaRtSKusDWXuU7khA";
   };
   preBuild = lib.optionals enableWebui ''
     # using sass-embedded fails at executing node_modules/sass-embedded-linux-x64/dart-sass/src/dart


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Updates rmfakecloud, ~~and removes the `env.` from the pnpm stuff as otherwise @r-ryantm has issues updating it (see [its logs](https://nixpkgs-update-logs.nix-community.org/rmfakecloud/2026-05-25.log))~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
