### PR TITLE
webwright: init at 0.1.0-unstable-2026-05-12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5461,6 +5461,11 @@
     githubId = 6487079;
     name = "Dane Rieber";
   };
+  conao3 = {
+    github = "conao3";
+    githubId = 4703128;
+    name = "Naoya Yamashita";
+  };
   conduktorbot = {
     email = "automation@conduktor.io";
     github = "conduktorbot";

--- a/pkgs/by-name/we/webwright/package.nix
+++ b/pkgs/by-name/we/webwright/package.nix
@@ -1,0 +1,66 @@
+{
+  fetchFromGitHub,
+  lib,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "webwright";
+  version = "0.1.0-unstable-2026-05-12";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "Webwright";
+    rev = "1236f4d31186610d23badd997917f86712fe8bed";
+    hash = "sha256-aWLaY890Tu7NGGUTvZUW0S/qwNIxWrIhun4hcIY0nik=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  build-system = with python3Packages; [
+    setuptools
+    wheel
+  ];
+
+  dependencies = with python3Packages; [
+    httpx
+    jinja2
+    pydantic
+    pyyaml
+    rich
+    typer
+    playwright
+    python-dotenv
+    platformdirs
+  ];
+
+  pythonImportsCheck = [ "webwright" ];
+
+  preInstallCheck = ''
+    # webwright/__init__.py creates a global config directory at import
+    # time (`user_config_dir("mini-swe-webagent")` by default), which
+    # fails in the Nix sandbox where HOME is /homeless-shelter.
+    # MSWEBA_GLOBAL_CONFIG_DIR overrides that path.
+    export MSWEBA_GLOBAL_CONFIG_DIR=$TMPDIR/webwright-config
+  '';
+
+  meta = {
+    description = "SWE-style browser agent framework that turns coding models into web agents";
+    longDescription = ''
+      Webwright is a lightweight harness that gives an LLM a terminal in which
+      it can launch and inspect Playwright-controlled browser sessions to
+      complete long-horizon web tasks. The agent loop is intentionally minimal
+      (~1.5k LoC across the core, the Playwright environment, and the CLI),
+      with pluggable OpenAI / Anthropic / OpenRouter backends and no hidden
+      orchestration layer.
+    '';
+    homepage = "https://github.com/microsoft/Webwright";
+    changelog = "https://github.com/microsoft/Webwright/blob/main/README.md#-news";
+    license = lib.licenses.mit;
+    mainProgram = "webwright";
+    maintainers = with lib.maintainers; [ conao3 ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION

[Webwright](https://github.com/microsoft/Webwright) is a small, MIT-licensed SWE-style web agent harness from Microsoft. It hands an LLM a terminal in which it can launch and inspect Playwright-controlled browser sessions to complete long-horizon web tasks. The agent loop is intentionally minimal (~1.5k LoC across the core, the Playwright environment, and the CLI), and the model backend layer is pluggable — OpenAI, Anthropic, and OpenRouter ship in tree, each in ~150–200 lines.

Upstream landed its initial public release on 2026-05-04 (per `README.md` § News) but does not yet cut tagged GitHub releases, so this PR pins the latest `main` commit (`1236f4d`, 2026-05-12). I went with the `<version>-unstable-<date>` form `0.1.0-unstable-2026-05-12` — `0.1.0` is the version field declared in upstream's `pyproject.toml`, and the date is the commit date of the pinned revision.

The packaging is a straightforward `buildPythonApplication` (pyproject, setuptools build backend) over the dependencies declared in upstream's `pyproject.toml`. All of them are already in nixpkgs (`httpx`, `jinja2`, `pydantic`, `pyyaml`, `rich`, `typer`, `playwright`, `python-dotenv`, `platformdirs`), no new Python modules needed.

One quirk worth flagging: `webwright/__init__.py` creates a global config directory at import time (`platformdirs.user_config_dir("mini-swe-webagent")` by default), which fails in the Nix sandbox where `HOME=/homeless-shelter`. Upstream exposes `MSWEBA_GLOBAL_CONFIG_DIR` as an override; I point it at `$TMPDIR/webwright-config` in `preInstallCheck` so that `pythonImportsCheck` can import the module. End users hitting writable HOMEs are unaffected.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] `pythonImportsCheck = [ "webwright" ]` runs during the build and passes.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## Functional verification (x86_64-linux)

Beyond `pythonImportsCheck`:

- `./result/bin/webwright --help` prints the typer-rendered help with the expected `--task` / `--start-url` / `--config` / `--debug` flags.
- Running the agent end-to-end requires both a Playwright browser binary on the host and an LLM API key (OpenAI / Anthropic / OpenRouter); this is not exercised in CI for the same reason `playwright` itself ships browser binaries out-of-band.

## Notes for reviewers

- Source pinned to `1236f4d` on `main`. Upstream has not produced GitHub releases yet; once they do, I will switch to the tagged ref in a follow-up.
- `meta.platforms = lib.platforms.unix`. The package is pure Python and should build on darwin too, but I do not have a Darwin host to verify.
- `meta.sourceProvenance` is intentionally left at its default (`fromSource`); no prebuilt artifacts are shipped.

---
Assisted-by: Claude Code:claude-opus-4-7[1m]