### PR TITLE
taoup: 1.1.23 -> 1.21

### DIFF
--- a/pkgs/by-name/ta/taoup/package.nix
+++ b/pkgs/by-name/ta/taoup/package.nix
@@ -12,13 +12,13 @@ in
 stdenv.mkDerivation (finalAttrs: {
   pname = "taoup";
   # nixpkgs-update: no auto update
-  version = "1.1.23";
+  version = "1.21";
 
   src = fetchFromGitHub {
     owner = "globalcitizen";
     repo = "taoup";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-9J46fKyeSZW71r67R8y9KVPeCH8fn27hOk/XpusqGmk=";
+    hash = "sha256-UHo3c+DQn77CJONy/QXM55rpIdhVkJbhR82tqmUltPQ=";
   };
 
   buildInputs = [


### PR DESCRIPTION
Updates `taoup` 1.1.23 → 1.21 (latest upstream tag).

Upstream is many releases ahead (the package carries `# nixpkgs-update: no auto update`, so it needs a manual bump). Latest tag: https://github.com/globalcitizen/taoup/releases/tag/v1.21

Mechanical version bump: `version` + source `hash` updated (via `nix-update`). No packaging logic changed.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

<details><summary>Build proof (aarch64-linux)</summary>

```
$ nix-update --version=stable --build taoup
Update 1.1.23 -> 1.21 in .../pkgs/by-name/ta/taoup/package.nix
$ nix build -f . taoup
taoup> ... interpreter directive changed ... ruby-3.4.9
taoup> stripping ... /nix/store/...-taoup-1.21/{lib,bin}
(build succeeded)
```
</details>

---

**Automation/AI disclosure:** version bump prepared with the `nix-update` tool and an AI coding assistant; reviewed, built, and verified locally by me (Chenglun Hu), who is accountable for this contribution.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
