### PR TITLE
n2n: 3.0 -> 3.1.1

### DIFF
--- a/pkgs/by-name/n2/n2n/package.nix
+++ b/pkgs/by-name/n2/n2n/package.nix
@@ -9,14 +9,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "n2n";
-  version = "3.0";
+  version = "3.1.1";
   # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "ntop";
     repo = "n2n";
     rev = finalAttrs.version;
-    hash = "sha256-OXmcc6r+fTHs/tDNF3akSsynB/bVRKB6Fl5oYxmu+E0=";
+    hash = "sha256-/Yb6L6Pt2vR7fzVS1QS9Z46yaR26fqE7LPrAEHl5sbw=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Updates `n2n` 3.0 → 3.1.1 (latest upstream tag).

The package is marked `# nixpkgs-update: no auto update`, so it needs a manual bump. Latest tag: https://github.com/ntop/n2n/releases/tag/3.1.1

Mechanical version bump: `version` + source `hash` updated (via `nix-update`). No packaging logic changed.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

<details><summary>Build proof (aarch64-linux)</summary>

```
$ nix-update --version=stable --build n2n
Update 3.0 -> 3.1.1 in .../pkgs/by-name/n2/n2n/package.nix
$ nix build -f . n2n
(build succeeded)
```
</details>

---

**Automation/AI disclosure:** version bump prepared with the `nix-update` tool and an AI coding assistant; reviewed, built, and verified locally by me (Chenglun Hu), who is accountable for this contribution.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
