### PR TITLE
ocamlPackages.tar: 3.3.0 → 3.5.0

### DIFF
--- a/pkgs/development/ocaml-modules/tar/default.nix
+++ b/pkgs/development/ocaml-modules/tar/default.nix
@@ -2,22 +2,18 @@
   lib,
   fetchurl,
   buildDunePackage,
-  camlp-streams,
   decompress,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "tar";
-  version = "3.3.0";
+  version = "3.5.0";
   src = fetchurl {
-    url = "https://github.com/mirage/ocaml-tar/releases/download/v${version}/tar-${version}.tbz";
-    hash = "sha256-89aw1nf9QP0euAvMxgu2EyIDWL5Y9mxfqL8CV/Pl65Y=";
+    url = "https://github.com/mirage/ocaml-tar/releases/download/v${finalAttrs.version}/tar-${finalAttrs.version}.tbz";
+    hash = "sha256-haKmHTDu+B5L+B4LQp0hPOtd1urtzWDJeeHLuRFJ+Qw=";
   };
 
-  minimalOCamlVersion = "4.08";
-
   propagatedBuildInputs = [
-    camlp-streams
     decompress
   ];
 
@@ -29,4 +25,4 @@ buildDunePackage rec {
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.ulrikstrid ];
   };
-}
+})

--- a/pkgs/development/ocaml-modules/tar/eio.nix
+++ b/pkgs/development/ocaml-modules/tar/eio.nix
@@ -2,7 +2,8 @@
   buildDunePackage,
   tar,
   eio,
-  git,
+  alcotest,
+  eio_main,
 }:
 
 buildDunePackage {
@@ -16,8 +17,9 @@ buildDunePackage {
     eio
   ];
 
-  nativeCheckInputs = [
-    git
+  checkInputs = [
+    alcotest
+    eio_main
   ];
 
   meta = tar.meta // {

--- a/pkgs/development/ocaml-modules/tar/unix.nix
+++ b/pkgs/development/ocaml-modules/tar/unix.nix
@@ -1,6 +1,8 @@
 {
   buildDunePackage,
   tar,
+  fpath,
+  logs,
   lwt,
   git,
 }:
@@ -11,6 +13,8 @@ buildDunePackage {
 
   propagatedBuildInputs = [
     tar
+    fpath
+    logs
     lwt
   ];
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2093,9 +2093,7 @@ let
           inherit (pkgs) git;
         };
 
-        tar-eio = callPackage ../development/ocaml-modules/tar/eio.nix {
-          inherit (pkgs) git;
-        };
+        tar-eio = callPackage ../development/ocaml-modules/tar/eio.nix { };
 
         tcpip = callPackage ../development/ocaml-modules/tcpip { };
 


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
