### PR TITLE
rclone: fix build on Darwin

### DIFF
--- a/pkgs/by-name/rc/rclone/package.nix
+++ b/pkgs/by-name/rc/rclone/package.nix
@@ -9,6 +9,7 @@
   makeWrapper,
   enableCmount ? true,
   fuse3,
+  macfuse-stubs,
   librclone,
   nix-update-script,
 }:
@@ -38,9 +39,14 @@ buildGoModule (finalAttrs: {
     makeWrapper
   ];
 
-  buildInputs = lib.optional enableCmount fuse3;
+  buildInputs = lib.optional enableCmount (
+    # cgofuse uses the fuse2 header locations on darwin
+    if stdenv.hostPlatform.isDarwin then (macfuse-stubs.override { isFuse3 = false; }) else fuse3
+  );
 
-  tags = [ "fuse3" ] ++ lib.optionals enableCmount [ "cmount" ];
+  tags =
+    lib.optionals (!stdenv.hostPlatform.isDarwin) [ "fuse3" ]
+    ++ lib.optionals enableCmount [ "cmount" ];
 
   ldflags = [
     "-s"


### PR DESCRIPTION
#521729 changed `rclone` to build `cmount` with `fuse3`. That works on
non-Darwin platforms because nixpkgs rewrites cgofuse's `<fuse.h>`
include to `<fuse3/fuse.h>` there.

Darwin does not use that rewrite. It still builds cgofuse against
`<fuse.h>`, but #521729 also removed the Darwin `macfuse-stubs` build
input that provides that header. This makes the Darwin build fail with:

```text
vendor/github.com/winfsp/cgofuse/fuse/host_cgo.go:119:10: fatal error: 'fuse.h' file not found
```

Restore `macfuse-stubs` on Darwin and keep `fuse3` on non-Darwin
platforms.

Resolves #524220

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - Command: `nixpkgs-review wip --systems aarch64-darwin --no-shell --print-result`
  - `aarch64-darwin`: 7 packages built, 4 reverse dependencies failed.
  - Built: `backrest`, `git-annex-remote-rclone`, `prometheus-restic-exporter`, `rclone`, `redu`, `restic`, `restique`.
  - Failed: `celeste`, `python313Packages.rclone-python`, `python314Packages.rclone-python`, `resticprofile`.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - `rclone version`
  - `rclone cmount --help`
  - `rclonefs --help`
  - `mount.rclone --help`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
