### PR TITLE
qsv: 19.1.0 -> 20.1.0

### DIFF
--- a/pkgs/by-name/qs/qsv/package.nix
+++ b/pkgs/by-name/qs/qsv/package.nix
@@ -33,7 +33,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "qsv";
-  version = "19.1.0";
+  version = "20.1.0";
 
   inherit buildFeatures;
 
@@ -41,10 +41,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "dathere";
     repo = "qsv";
     rev = finalAttrs.version;
-    hash = "sha256-R3Bv0Jkq5esLQSXbhk9m3Xr9K6EmqMtc3iDF7yRspJ0=";
+    hash = "sha256-dYUZ2IwvXTFwpv1cDQjmq+iq2g/vQQovpR0++/ZtSy8=";
   };
 
-  cargoHash = "sha256-Wk5OVUKVWHvhWc1ItJcOafY75Pd8ucA3XAGUR//mtqg=";
+  cargoHash = "sha256-7jZR5u32Hy0XQEeX+tWDbpkj7jM804LBUL93wgnA5bM=";
 
   buildInputs = [
     file


### PR DESCRIPTION
Updates `qsv` (and the `qsvlite` variant, which share this package) 19.1.0 → 20.1.0 (latest upstream tag).

Release: https://github.com/dathere/qsv/releases/tag/20.1.0

Mechanical version bump: `version`, source `hash`, and `cargoHash` updated (via `nix-update`). No packaging logic changed.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

<details><summary>Build proof (aarch64-linux)</summary>

```
$ nix-update --version=stable --build qsvlite
Update 19.1.0 -> 20.1.0 in .../pkgs/by-name/qs/qsv/package.nix
$ nix build -f . qsvlite
(build succeeded — qsvlite variant; src hash + cargoHash validated)
```

The `qsvlite` variant built green, validating the updated `hash`/`cargoHash` (both variants share this package). The full-feature `qsv` variant uses the identical source and was left to ofborg/CI for the longer full-feature compile.
</details>

---

**Automation/AI disclosure:** version bump prepared with the `nix-update` tool and an AI coding assistant; reviewed, built, and verified locally by me (Chenglun Hu), who is accountable for this contribution.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
