### PR TITLE
ghost-complete: 0.9.1 -> 0.16.0

### DIFF
--- a/pkgs/by-name/gh/ghost-complete/package.nix
+++ b/pkgs/by-name/gh/ghost-complete/package.nix
@@ -8,18 +8,26 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ghost-complete";
-  version = "0.9.1";
+  version = "0.16.0";
 
   src = fetchFromGitHub {
     owner = "StanMarek";
     repo = "ghost-complete";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-fsGrhQK28YFksI2pNiZ6fI6KjZOXxXxrhWjxOmBNk08=";
+    hash = "sha256-SL0PRGppuiglP/BStlvc//6dn2lP472lLfhz3Hq7ZVw=";
   };
 
   __structuredAttrs = true;
 
-  cargoHash = "sha256-kiYdMczvnauhu/2ryO0NcK3PAI1P+xmYV8nRrIWaEB8=";
+  # Upstream hardcodes `-fuse-ld=/usr/bin/ld` for darwin targets, which the
+  # Nix clang wrapper rejects ("invalid linker name"). Drop the flag and let
+  # the wrapper pick the right linker.
+  postPatch = ''
+    substituteInPlace .cargo/config.toml \
+      --replace-fail '"-C", "link-arg=-fuse-ld=/usr/bin/ld",' ""
+  '';
+
+  cargoHash = "sha256-F568kxHWcbBQuAwUpkT1AwAr/u486/k094wVmB9SiqY=";
 
   cargoBuildFlags = [ "--package=ghost-complete" ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
