### PR TITLE
rubywarrior: init at gem 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8862,6 +8862,12 @@
       { fingerprint = "7E08 6842 0934 AA1D 6821  1F2A 671E 39E6 744C 807D"; }
     ];
   };
+  ferguscollins = {
+    email = "git@ferguscollins.com";
+    github = "ferguscollins";
+    githubId = 59059263;
+    name = "Fergus Collins";
+  };
   fernsehmuell = {
     email = "fernsehmuel@googlemail.com";
     matrix = "@fernsehmuell:matrix.org";

--- a/pkgs/by-name/ru/rubywarrior/Gemfile
+++ b/pkgs/by-name/ru/rubywarrior/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "rubywarrior"
+gem "base64"
+

--- a/pkgs/by-name/ru/rubywarrior/Gemfile.lock
+++ b/pkgs/by-name/ru/rubywarrior/Gemfile.lock
@@ -1,0 +1,16 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    base64 (0.3.0)
+    rubywarrior (0.2.0)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  base64
+  rubywarrior
+
+BUNDLED WITH
+   2.5.22

--- a/pkgs/by-name/ru/rubywarrior/default.nix
+++ b/pkgs/by-name/ru/rubywarrior/default.nix
@@ -1,0 +1,5 @@
+{
+  callPackage,
+}:
+
+callPackage ./package.nix { }

--- a/pkgs/by-name/ru/rubywarrior/gemset.nix
+++ b/pkgs/by-name/ru/rubywarrior/gemset.nix
@@ -1,0 +1,22 @@
+{
+  base64 = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0yx9yn47a8lkfcjmigk79fykxvr80r4m1i35q82sxzynpbm7lcr7";
+      type = "gem";
+    };
+    version = "0.3.0";
+  };
+  rubywarrior = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0bpxvwgfz0pqfrr0pprpbkh9l8v2fac31klz0h3i77x00gr5fg5f";
+      type = "gem";
+    };
+    version = "0.2.0";
+  };
+}

--- a/pkgs/by-name/ru/rubywarrior/package.nix
+++ b/pkgs/by-name/ru/rubywarrior/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  ruby,
+  bundlerApp,
+  bundlerUpdateScript,
+}:
+
+(bundlerApp rec {
+  pname = "rubywarrior";
+
+  inherit ruby;
+
+  gemdir = ./.;
+
+  exes = [
+    pname
+  ];
+
+  passthru.updateScript = bundlerUpdateScript pname;
+
+  meta = with lib; {
+    description = "Game written in Ruby for learning Ruby.";
+    homepage = "https://github.com/ryanb/ruby-warrior";
+    license = licenses.mit;
+    maintainers = [ lib.maintainers.ferguscollins ];
+    mainProgram = pname;
+    platforms = platforms.unix;
+  };
+}).overrideAttrs
+  (_: {
+    # below 2 lines required for new packages
+    __structuredAttrs = true;
+    strictDeps = true;
+  })


### PR DESCRIPTION
## Description

Package gem for rubywarrior, a game for learning Ruby.

[ruby-warrior Github repo](https://github.com/ryanb/ruby-warrior)
[rubwarrior gem](https://rubygems.org/gems/rubywarrior)

## How to

1. `$ rubywarrior` (generates the game files)
2. program `player.rb` (see `README` on each level to see current abilities)
3. `$ rubywarrior` (runs `player.rb`)

Example `player.rb` file for floor 1:

```ruby
class Player
  def play_turn(warrior)
    warrior.walk!
  end
end
```

Example `player.rb` file for floor 2:

```ruby
class Player
  def play_turn(warrior)
    if warrior.feel.enemy?
      warrior.attack!
    else
      warrior.walk!
    end
  end
end
```

## Dev notes

1. `base64` gem is included in `Gemfile` to mute warnings about it not being available in base Ruby from version 3.4.0.
4. Github repo for this game is called `ruby-warrior` but the gem and executable are named `rubywarrior`. As the versioning is controlled by the gem, I have named this package `rubywarrior`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - N/A [NixOS tests] in [nixos/tests].
  - N/A [Package tests] at `passthru.tests`.
  - N/A Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - N/A Package update: when the change is major or breaking.
- NixOS Release Notes
  - N/A Module addition: when adding a new NixOS module.
  - N/A Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
