### PR TITLE
arrow-cpp: 23.0.0 -> 24.0.0

### DIFF
--- a/pkgs/by-name/ar/arrow-cpp/package.nix
+++ b/pkgs/by-name/ar/arrow-cpp/package.nix
@@ -68,16 +68,16 @@ let
     name = "arrow-testing";
     owner = "apache";
     repo = "arrow-testing";
-    rev = "19dda67f485ffb3ffa92f4c6fa083576ef052d58";
-    hash = "sha256-mna6I/a5ZxMLdWN0QfCsgsre6yMeuSv4syX5ePGLhfg=";
+    rev = "9cfebfef8982fb8612e0a2c59059752bd32321a3";
+    hash = "sha256-mZgiEGlU0oNUVBE56PF60qELQ44zeZEsJZ0AiIXEdkM=";
   };
 
   parquet-testing = fetchFromGitHub {
     name = "parquet-testing";
     owner = "apache";
     repo = "parquet-testing";
-    rev = "a3d96a65e11e2bbca7d22a894e8313ede90a33a3";
-    hash = "sha256-Xd6o3RT6Q0tPutV77J0P1x3F6U3RHdCBOKGUKtkQCKk=";
+    rev = "fa255dfacf58c8bab428b5d0117d188acc8ad03f";
+    hash = "sha256-t91KghbR1fnp5m4/jNjc4Eh/nTa/Q6c47/4EaZ8hTuM=";
   };
 
   version = "24.0.0";
@@ -112,8 +112,8 @@ stdenv.mkDerivation (finalAttrs: {
       ARROW_MIMALLOC_URL = fetchFromGitHub {
         owner = "microsoft";
         repo = "mimalloc";
-        tag = "v3.1.5";
-        hash = "sha256-fk6nfyBFS1G0sJwUJVgTC1+aKd0We/JjsIYTO+IOfyg=";
+        tag = "v3.3.1";
+        hash = "sha256-62orj4WqFCCsrOZyjdF31AcnaSWixdjkudugHlbZgqI=";
       };
 
       ARROW_XSIMD_URL = fetchFromGitHub {


### PR DESCRIPTION
Fixing build failure of rPackages.arrow

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
