### PR TITLE
nixos/test-driver: only require kvm system features when forceAccel is set

### DIFF
--- a/nixos/lib/testing/run.nix
+++ b/nixos/lib/testing/run.nix
@@ -58,14 +58,14 @@ let
       };
       kvm = mkOption {
         type = types.bool;
-        default = isLinux;
-        defaultText = lib.literalMD "`true` if built to run on Linux.";
+        default = config.qemu.forceAccel && isLinux;
+        defaultText = lib.literalMD "`true` if `qemu.forceAccel` is enabled and built to run on Linux.";
         description = "Whether Linux KVM virtualization is required when running this test. Can be disabled to allow emulated execution.";
       };
       apple-virt = mkOption {
         type = types.bool;
-        default = isDarwin;
-        defaultText = lib.literalMD "`true` if built to run on Darwin.";
+        default = config.qemu.forceAccel && isDarwin;
+        defaultText = lib.literalMD "`true` if `qemu.forceAccel` is enabled and built to run on Darwin.";
         description = "Whether Apple virtualization functionality is required for running this test.";
       };
     };


### PR DESCRIPTION
Currently, for running nixos tests, a builder is required to have the `nixos-test` & `kvm`/`apple-virt` system features. If the kvm/apple-virt backends are not accessible during runtime however, the test driver automatically falls back to launching qemu vms via tcg. Therefore, the test driver does not actually require kvm/apple-virt system features to run tests.

This PR removes the default system feature requirement `kvm`/`apple-virt` for nixos tests. These features are now only required when `forceAccel` is explicitly set by the user.

Follow up for https://github.com/NixOS/nixpkgs/pull/509553

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
