### PR TITLE
pid1: 0.1.3 -> 0.1.6

### DIFF
--- a/pkgs/by-name/pi/pid1/package.nix
+++ b/pkgs/by-name/pi/pid1/package.nix
@@ -6,20 +6,26 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "pid1";
-  version = "0.1.3";
+  version = "0.1.6";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "fpco";
     repo = "pid1-rs";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-2dnQj3AQxedyq1YvHKt+lVXNEtuB5sMRSCqX9YeifzI=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-edxDCVEVg4s2RF3wjiUjQ4wfusFM3COUTl5nsCH4ScE=";
   };
 
-  cargoHash = "sha256-ldHtmbLoSFVxb0B3Oj21UOFNSXwu8xAPhpE8jBqOwr4=";
+  cargoHash = "sha256-mXZszLmIOEq3ZL6cJhrhBCi0bHNgbKG6gr6Rf4iFvEM=";
+
+  # all tests require docker env
+  doCheck = false;
 
   meta = {
     description = "Signal handling and zombie reaping for PID1 process";
     homepage = "https://github.com/fpco/pid1-rs";
+    changelog = "https://github.com/fpco/pid1-rs/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ psibi ];
     mainProgram = "pid1";


### PR DESCRIPTION
diff: https://github.com/fpco/pid1-rs/compare/v0.1.3...v0.1.6
changelog: https://github.com/fpco/pid1-rs/blob/v0.1.6/CHANGELOG.md

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
