### PR TITLE
wayback-machine-archiver: 1.9.1 -> 3.5.2

### DIFF
--- a/pkgs/by-name/wa/wayback-machine-archiver/package.nix
+++ b/pkgs/by-name/wa/wayback-machine-archiver/package.nix
@@ -1,43 +1,41 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "wayback-machine-archiver";
-  version = "1.9.1";
+  version = "3.5.2";
   pyproject = true;
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "agude";
     repo = "wayback-machine-archiver";
-    rev = "v${finalAttrs.version}";
-    sha256 = "0dnnqx507gpj8wsx6f2ivfmha969ydayiqsvxh23p9qcixw9257x";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-LUWPc1wMSpBIdaje/pbmQYHTrYog/9UiphMY1fzxgPc=";
   };
 
-  build-system = with python3.pkgs; [
-    setuptools
-    pypandoc
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
+    requests
+    python-dotenv
   ];
 
-  dependencies = with python3.pkgs; [ requests ];
-
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with python3Packages; [
     pytestCheckHook
     requests-mock
   ];
-
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace-fail \"pytest-runner\", ""
-  '';
 
   pythonImportsCheck = [ "wayback_machine_archiver" ];
 
   meta = {
     description = "Python script to submit web pages to the Wayback Machine for archiving";
     homepage = "https://github.com/agude/wayback-machine-archiver";
+    changelog = "https://github.com/agude/wayback-machine-archiver/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ dandellion ];
     mainProgram = "archiver";


### PR DESCRIPTION
diff: https://github.com/agude/wayback-machine-archiver/compare/v1.9.1...v3.5.0

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
