### PR TITLE
Revert "scx.cscheds: move env variable into env for structuredAttrs"

### DIFF
--- a/pkgs/os-specific/linux/scx/scx_cscheds.nix
+++ b/pkgs/os-specific/linux/scx/scx_cscheds.nix
@@ -49,7 +49,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
   ];
 
   __structuredAttrs = true;
-  env.EXPECTED_SCHEDULERS = finalAttrs.passthru.schedulers;
+  EXPECTED_SCHEDULERS = finalAttrs.passthru.schedulers;
 
   doInstallCheck = true;
   installCheckPhase = ''


### PR DESCRIPTION
Reverts NixOS/nixpkgs#524091