### PR TITLE
pierrejo: init at 0-unstable-2026-05-25

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5461,6 +5461,12 @@
     githubId = 6487079;
     name = "Dane Rieber";
   };
+  conao3 = {
+    email = "conao3@gmail.com";
+    github = "conao3";
+    githubId = 4703128;
+    name = "Naoya Yamashita";
+  };
   conduktorbot = {
     email = "automation@conduktor.io";
     github = "conduktorbot";

--- a/pkgs/by-name/pi/pierrejo/package.nix
+++ b/pkgs/by-name/pi/pierrejo/package.nix
@@ -1,0 +1,105 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  makeWrapper,
+  nodejs,
+  runCommand,
+}:
+
+let
+  src = fetchFromGitHub {
+    owner = "harivansh-afk";
+    repo = "pierrejo";
+    rev = "a1960a6ae2d4d933394f245ae679f7e1fcc7ad70";
+    hash = "sha256-gj0Z32iV3bTXEx+VE3P6iGLr7vmN6D7aLCgLHEVnOOc=";
+  };
+
+  version = "0-unstable-2026-05-25";
+
+  ssrPackage = buildNpmPackage {
+    pname = "pierrejo-ssr";
+    inherit version;
+
+    __structuredAttrs = true;
+
+    src = "${src}/ssr";
+
+    npmDepsHash = "sha256-fIj9bUjAYvnIe2o1IT9l9wr8tn1MtomNKb/dvLYfiGQ=";
+
+    dontNpmBuild = true;
+
+    nativeBuildInputs = [ makeWrapper ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/lib/pierrejo-ssr
+      cp -R . $out/lib/pierrejo-ssr
+      makeWrapper ${lib.getExe nodejs} $out/bin/pierre-ssr --add-flags $out/lib/pierrejo-ssr/server.js
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Server-side rendering sidecar for Pierre diffs in Forgejo";
+      homepage = "https://github.com/harivansh-afk/pierrejo";
+      license = lib.licenses.unfree;
+      maintainers = with lib.maintainers; [ conao3 ];
+      mainProgram = "pierre-ssr";
+      platforms = lib.platforms.all;
+    };
+  };
+
+  assets = runCommand "pierrejo-forgejo-assets-${version}" { } ''
+    mkdir -p $out/css
+    cp ${src}/assets/css/pierre-forgejo.css $out/css/pierre-forgejo.css
+  '';
+in
+buildNpmPackage {
+  pname = "pierrejo";
+  inherit version;
+
+  __structuredAttrs = true;
+
+  src = "${src}/frontend";
+
+  npmDepsHash = "sha256-wIyJ3Af65p615GqhbxUbvetOlOTe1Rg75oYAsQnLvPA=";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/js
+    cp -R dist/. $out/js/
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit assets ssrPackage;
+
+    patches = [
+      "${src}/patches/forgejo-15.0.2/0001-pierre-ssr-highlighting.patch"
+      "${src}/patches/forgejo-15.0.2/0002-expose-init-globals.patch"
+    ];
+
+    templates = "${src}/templates";
+
+    mkForgejoWithPierre =
+      forgejoPackage:
+      forgejoPackage.overrideAttrs (oldAttrs: {
+        patches = (oldAttrs.patches or [ ]) ++ [
+          "${src}/patches/forgejo-15.0.2/0001-pierre-ssr-highlighting.patch"
+          "${src}/patches/forgejo-15.0.2/0002-expose-init-globals.patch"
+        ];
+      });
+  };
+
+  meta = {
+    description = "Pierre diffs integration layer for Forgejo";
+    homepage = "https://github.com/harivansh-afk/pierrejo";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ conao3 ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION

## Description of changes

Adds `pierrejo`, the Pierre diffs integration layer for Forgejo.

The package builds the frontend assets as `pierrejo` and exposes the SSR sidecar, Forgejo assets, templates, Forgejo patches, and a `mkForgejoWithPierre` helper through passthru attributes. The package is marked unfree because the upstream repository does not provide a license file.

This also adds `conao3` to `maintainer-list.nix` for the new package.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file#conf-sandbox))
  - [ ] `sandbox = true` is set in `nix.conf`
  - [x] not applicable
- [x] Tested, as applicable:
  - [x] `NIXPKGS_ALLOW_UNFREE=1 nix-build -A pierrejo --no-out-link --impure`
  - [x] `NIXPKGS_ALLOW_UNFREE=1 nix-build -A pierrejo.ssrPackage --no-out-link --impure`
  - [x] `NIXPKGS_ALLOW_UNFREE=1 nix-build -A pierrejo.assets --no-out-link --impure`
  - [x] `PIERRE_SSR_SOCKET=/tmp/pierrejo-test.sock PIERRE_SSR_CACHE_DIR=/tmp/pierrejo-cache $(nix-build -A pierrejo.ssrPackage --no-out-link --impure)/bin/pierre-ssr`
  - [x] `curl --unix-socket /tmp/pierrejo-test.sock -fsS -X POST http://localhost/tokenize -H 'content-type: application/json' --data '{"code":"let x = 1;","language":"javascript","theme":"dark"}'`
- [ ] Tested compilation of all packages that depend on this change using `nixpkgs-review`
- [x] Tested basic functionality of all binary files
- [x] The contribution fits within Nixpkgs contribution standards
- [x] The commit message follows the commit conventions

---
Assisted-by: Yui:gpt-5.5