### PR TITLE
frr: fix cross build with lua scripting

### DIFF
--- a/pkgs/by-name/fr/frr/package.nix
+++ b/pkgs/by-name/fr/frr/package.nix
@@ -46,6 +46,7 @@
   cumulusSupport ? false,
   irdpSupport ? true,
   mgmtdSupport ? true,
+  scriptingSupport ? true,
   # Experimental as of 10.1, reconsider if upstream changes defaults
   grpcSupport ? false,
 
@@ -120,7 +121,6 @@ stdenv.mkDerivation (finalAttrs: {
     python3
     readline
     rtrlib
-    lua53Packages.lua
     sqlite
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
@@ -135,11 +135,17 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals grpcSupport [
     grpc
     protobuf
+  ]
+  ++ lib.optionals scriptingSupport [
+    lua53Packages.lua
   ];
 
   # otherwise in cross-compilation: "configure: error: no working python version found"
   depsBuildBuild = [
     buildPackages.python3
+  ]
+  ++ lib.optionals scriptingSupport [
+    buildPackages.lua53Packages.lua
   ];
 
   # cross-compiling: clippy is compiled with the build host toolchain, split it out to ease
@@ -157,7 +163,6 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-logfile-mask=0640"
     "--enable-multipath=${toString numMultipath}"
     "--enable-config-rollbacks"
-    "--enable-scripting"
     "--enable-user=frr"
     "--enable-vty-group=frrvty"
     "--localstatedir=/var"
@@ -171,6 +176,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.strings.enableFeature irdpSupport "irdp")
     (lib.strings.enableFeature mgmtdSupport "mgmtd")
     (lib.strings.enableFeature grpcSupport "grpc")
+    (lib.strings.enableFeature scriptingSupport "scripting")
 
     # routing protocols
     (lib.strings.enableFeature bgpdSupport "bgpd")


### PR DESCRIPTION
Make the --enable-scripting optional to allow for minimalized builds and ensure lua is correctly referenced in cross builds.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
