### PR TITLE
tiny-wii-backup-manager: init at 6.0.4

### DIFF
--- a/pkgs/by-name/ti/tiny-wii-backup-manager/package.nix
+++ b/pkgs/by-name/ti/tiny-wii-backup-manager/package.nix
@@ -1,0 +1,122 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  makeWrapper,
+  pkg-config,
+
+  dbus,
+  fontconfig,
+  libGL,
+  libx11,
+  libxcb,
+  libxcursor,
+  libxext,
+  libxi,
+  libxinerama,
+  libxkbcommon,
+  libxrandr,
+  openssl,
+  vulkan-loader,
+  wayland,
+  xdg-utils,
+  zenity,
+
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tiny-wii-backup-manager";
+  version = "6.0.4";
+
+  src = fetchFromGitHub {
+    owner = "mq1";
+    repo = "TinyWiiBackupManager";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-utgS0qlrOkZb6BdHPBalOf2Ay2MpIBC6p5FjzVpgQpU=";
+  };
+
+  cargoHash = "sha256-LbJo5a7ZMO0EAhGIhiqcsWR1osE3SNkU3zrrp0y0TR0=";
+
+  cargoBuildFlags = [
+    "--bin"
+    "twbm-gui"
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    dbus
+    fontconfig
+    libGL
+    libx11
+    libxcb
+    libxcursor
+    libxext
+    libxi
+    libxinerama
+    libxkbcommon
+    libxrandr
+    openssl
+    vulkan-loader
+    wayland
+  ];
+
+  # Upstream does not currently ship tests.
+  doCheck = false;
+
+  postInstall = ''
+    mv $out/bin/twbm-gui $out/bin/TinyWiiBackupManager
+
+    install -Dm644 package/linux/AppDir/usr/share/applications/it.mq1.TinyWiiBackupManager.desktop \
+      $out/share/applications/it.mq1.TinyWiiBackupManager.desktop
+    install -Dm644 package/linux/it.mq1.TinyWiiBackupManager.metainfo.xml \
+      $out/share/metainfo/it.mq1.TinyWiiBackupManager.metainfo.xml
+
+    mkdir -p $out/share/icons
+    cp -r package/linux/AppDir/usr/share/icons/hicolor $out/share/icons/
+
+    wrapProgram $out/bin/TinyWiiBackupManager \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          xdg-utils
+          zenity
+        ]
+      } \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          dbus
+          fontconfig
+          libGL
+          libx11
+          libxcb
+          libxcursor
+          libxext
+          libxi
+          libxinerama
+          libxkbcommon
+          libxrandr
+          openssl
+          vulkan-loader
+          wayland
+        ]
+      }
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Tiny game backup and homebrew app manager for the Wii";
+    homepage = "https://github.com/mq1/TinyWiiBackupManager";
+    changelog = "https://github.com/mq1/TinyWiiBackupManager/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ yisraeldov ];
+    mainProgram = "TinyWiiBackupManager";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- For non-Linux: Is sandboxing enabled in nix.conf?
  - [ ] macOS
  - [ ] N/A
- [x] Tested, as applicable:
  - [x] `nix-build -A tiny-wii-backup-manager`
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`.
  - Not run; new leaf package.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - Verified `./result/bin/TinyWiiBackupManager` is executable.
- [x] Determined the impact on package closure size (by running `nix path-info -S` before and after)
  - New package.
- [x] Ensured that relevant documentation is up to date
- [x] Fits `CONTRIBUTING.md`.