### PR TITLE
apfel-llm: add arthurficial as maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2317,6 +2317,12 @@
     githubId = 3965744;
     name = "Arthur Lee";
   };
+  arthurficial = {
+    email = "arti.ficial@fullstackoptimization.com";
+    github = "Arthur-Ficial";
+    githubId = 258112064;
+    name = "Arthur Ficial";
+  };
   arthurteisseire = {
     email = "arthurteisseire33@gmail.com";
     github = "arthurteisseire";

--- a/pkgs/by-name/ap/apfel-llm/package.nix
+++ b/pkgs/by-name/ap/apfel-llm/package.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/Arthur-Ficial/apfel";
     changelog = "https://github.com/Arthur-Ficial/apfel/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ arthurficial ];
     platforms = [ "aarch64-darwin" ];
     mainProgram = "apfel";
     sourceProvenance = [


### PR DESCRIPTION
## Description

Adds `arthurficial` to `maintainers/maintainer-list.nix` and sets `meta.maintainers` on `apfel-llm`, which currently has no maintainer.

I publish and release [apfel](https://github.com/Arthur-Ficial/apfel) (the `apfel-llm` package here) and want to take responsibility for keeping the nixpkgs package current. Today routine version bumps land only via r-ryantm or ad-hoc community PRs, so the package tends to trail releases. Listing a maintainer means r-ryantm can CC me on auto-bumps and I can keep it in sync via the merge bot.

`apfel-llm` is a pre-built binary derivation (the `FoundationModels` framework needs the macOS 26 SDK + Apple Silicon, which the nixpkgs darwin stdenv does not yet ship), so this is `aarch64-darwin` only.

**Automation/AI disclosure:** this contribution was prepared with LLM assistance (Claude Code, Claude Opus 4.8); both commits carry `Assisted-by:` trailers. The diff was human-reviewed before submission and the maintainer account is operated under the accountability of Franz Enzenhofer (fullstackoptimization.com), the publisher of upstream apfel.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
