### PR TITLE
nixos/firewall: allow extra table content with nftables

### DIFF
--- a/nixos/modules/services/networking/firewall-nftables.nix
+++ b/nixos/modules/services/networking/firewall-nftables.nix
@@ -56,6 +56,21 @@ in
           This option only works with the nftables based firewall.
         '';
       };
+
+      extraTableDefinitions = lib.mkOption {
+        type = lib.types.lines;
+        default = "";
+        example = ''
+          define link_wan = {
+            ppp0
+          }
+        '';
+        description = ''
+          Additional definitions prepended to the `nixos-fw` inet table.
+
+          This option only works with the nftables based firewall.
+        '';
+      };
     };
   };
 
@@ -83,6 +98,8 @@ in
 
     networking.nftables.tables."nixos-fw".family = "inet";
     networking.nftables.tables."nixos-fw".content = ''
+      ${cfg.extraTableDefinitions}
+
       set temp-ports {
         comment "Temporarily opened ports"
         type inet_proto . inet_service

--- a/nixos/modules/services/networking/firewall-nftables.nix
+++ b/nixos/modules/services/networking/firewall-nftables.nix
@@ -29,7 +29,9 @@ in
           Additional nftables rules to be appended to the input-allow
           chain.
 
+          ::: {.warning}
           This option only works with the nftables based firewall.
+          :::
         '';
       };
 
@@ -41,7 +43,9 @@ in
           Additional nftables rules to be appended to the forward-allow
           chain.
 
+          ::: {.warning}
           This option only works with the nftables based firewall.
+          :::
         '';
       };
 
@@ -53,7 +57,9 @@ in
           Additional nftables rules to be appended to the rpfilter-allow
           chain.
 
+          ::: {.warning}
           This option only works with the nftables based firewall.
+          :::
         '';
       };
 
@@ -68,7 +74,9 @@ in
         description = ''
           Additional definitions prepended to the `nixos-fw` inet table.
 
+          ::: {.warning}
           This option only works with the nftables based firewall.
+          :::
         '';
       };
     };


### PR DESCRIPTION
This is useful for shared definitions and data structures.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
