### PR TITLE
Passage: Add plugin passthru

### DIFF
--- a/pkgs/by-name/pa/passage/package.nix
+++ b/pkgs/by-name/pa/passage/package.nix
@@ -4,6 +4,8 @@
   fetchFromGitHub,
   makeBinaryWrapper,
   replaceVars,
+  pass,
+  passage,
   age,
   unixtools,
   coreutils,
@@ -36,6 +38,14 @@ stdenv.mkDerivation (finalAttrs: {
     })
     ./set-correct-program-name-for-sleep.patch
   ];
+  postPatch = ''
+    # Since we reuse the pass wrapper the extension will also live in its directory not the passage specific one
+    substituteInPlace Makefile \
+      --replace-fail 's:^SYSTEM_EXTENSION_DIR=.*:SYSTEM_EXTENSION_DIR="$(LIBDIR)/passage/extensions":' "" \
+      --replace-fail '"$(DESTDIR)$(LIBDIR)/passage' '"$(DESTDIR)$(LIBDIR)/password-store'
+    substituteInPlace src/password-store.sh \
+      --replace-fail 'SYSTEM_EXTENSION_DIR=""' 'SYSTEM_EXTENSION_DIR="''${SYSTEM_EXTENSION_DIR:-${placeholder "out"}/lib/password-store/extensions}"'
+  '';
 
   nativeBuildInputs = [ makeBinaryWrapper ];
 
@@ -67,6 +77,9 @@ stdenv.mkDerivation (finalAttrs: {
     "PREFIX=$(out)"
     "WITH_ALLCOMP=yes"
   ];
+  passthru = {
+    withExtensions = pass.withExtensions.override { pass = passage; };
+  };
 
   meta = {
     description = "Stores, retrieves, generates, and synchronizes passwords securely";

--- a/pkgs/by-name/pa/passage/package.nix
+++ b/pkgs/by-name/pa/passage/package.nix
@@ -69,7 +69,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Using $0 is bad, it causes --help to mention ".passage-wrapped".
   postInstall = ''
-    substituteInPlace $out/bin/passage --replace 'PROGRAM="''${0##*/}"' 'PROGRAM=passage'
+    substituteInPlace $out/bin/passage \
+              --replace-fail 'AGE="''${PASSAGE_AGE:-age}"' 'AGE=${lib.getExe age}' \
+              --replace-fail 'PROGRAM="''${0##*/}"' 'PROGRAM=passage'
     wrapProgram $out/bin/passage --prefix PATH : $extraPath --argv0 $pname
   '';
 

--- a/pkgs/tools/security/pass/default.nix
+++ b/pkgs/tools/security/pass/default.nix
@@ -45,7 +45,8 @@ assert dmenuSupport && waylandSupport -> dmenu-wayland != null && ydotool != nul
 let
   passExtensions = import ./extensions { inherit pkgs; };
 
-  env =
+  env = lib.makeOverridable (
+    { pass }:
     extensions:
     let
       selected = [
@@ -55,7 +56,7 @@ let
       ++ lib.optional tombPluginSupport passExtensions.tomb;
     in
     buildEnv {
-      name = "pass-env";
+      name = "${pass.meta.mainProgram}-env";
       paths = selected;
       nativeBuildInputs = [ makeWrapper ];
       buildInputs = lib.concatMap (x: x.buildInputs) selected;
@@ -73,11 +74,12 @@ let
           fi
         done
 
-        wrapProgram $out/bin/pass \
+        wrapProgram $out/bin/${pass.meta.mainProgram} \
           --set SYSTEM_EXTENSION_DIR "$out/lib/password-store/extensions"
       '';
-      meta.mainProgram = "pass";
-    };
+      meta.mainProgram = pass.meta.mainProgram;
+    }
+  );
 in
 
 stdenv.mkDerivation rec {
@@ -190,7 +192,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     extensions = passExtensions;
-    withExtensions = env;
+    withExtensions = env { pass = pass; };
   };
 
   meta = {

--- a/pkgs/tools/security/pass/extensions/otp.nix
+++ b/pkgs/tools/security/pass/extensions/otp.nix
@@ -5,15 +5,15 @@
   oath-toolkit,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "pass-otp";
-  version = "1.2.0";
+  version = "unstable-2026-05-12";
 
   src = fetchFromGitHub {
     owner = "tadfisher";
     repo = "pass-otp";
-    rev = "v${version}";
-    sha256 = "0cpqrf3939hcvwg7sd8055ghc8x964ilimlri16czzx188a9jx9v";
+    rev = "7bb50dbc4b6073f12f40be66a5ee371b9652a646";
+    sha256 = "sha256-dmdZIuDZQLIF7T3crLKQeQ6bqZtb6Wd+Fd5Z7aY0Azc=";
   };
 
   buildInputs = [ oath-toolkit ];
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   dontBuild = true;
 
   patchPhase = ''
-    sed -i -e 's|OATH=\$(which oathtool)|OATH=${oath-toolkit}/bin/oathtool|' otp.bash
+    sed -i -e 's|OATH=\$(command -v oathtool)|OATH=${oath-toolkit}/bin/oathtool|' otp.bash
   '';
 
   installFlags = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
1. This pr adds the ability to use different age implementations that might differ in naming such as `rage`.
2. This pr adds an plugin passthru similar to the one in `pass`.
This passthru has been tested with the included patched `pass-otp` plugin.
This is not meant to be pushed to nixpkgs in this way, only to serve as an example to test the passthru with.

Remaining questions:
Plugins such as `pass-otp` are already packaged in nixpkgs but either the packaged version or upstream does not support `passage`. How should this be handled?
- Do we only package extensions supporting passage in the way this pr does in the extension directory and now have two entries in nixpkgs?
- Do we coordinate with the `pass` maintainers so that each pass-extension also works for passage?
- If so how do we implement a check that loudly fails if the user tries to use an unsupported extension for passage? 

## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
