### PR TITLE
unityhub: Add missing dependencies for the old 2017 and 2018 releases of Unity

### DIFF
--- a/pkgs/by-name/un/unityhub/package.nix
+++ b/pkgs/by-name/un/unityhub/package.nix
@@ -105,6 +105,12 @@ stdenv.mkDerivation rec {
         harfbuzz
         vulkan-loader
 
+        # Unity Editor 2017 and 2018 specific dependencies
+        libcap
+        libGLU
+        gtk2
+        gnome2.GConf
+
         # Unity Bug Reporter specific dependencies
         libice
         libsm


### PR DESCRIPTION
This practically reverts 3eb2467926ff0a2eb980965f8a286f7c444c7739

Adds some dependencies back that very old versions of Unity need to run. Without those Unity 2017 and 2018 refuse to start with the error code 127 (missing dependencies). I tested for around an hour to find all needed packages, removing even a single one from this list will result in 2017 and 2018 not working again. Those packages are `libcap` `libGLU` `gtk2` and `gnome2.GConf`

From my understanding the rule of new packages not being allowed to use gtk2 doesnt apply cleanly here, because im basically just reverting a commit that removed these dependencies as a tradeoff to make the package build, even if its not functional for some older versions of Unity. The packages arent broken anymore. So adding the dependencies back is an option, which is all this PR does.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
