### PR TITLE
helvum: reinit at 0.6.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16271,6 +16271,11 @@
     githubId = 26020062;
     name = "lumi";
   };
+  luminarleaf = {
+    github = "LuminarLeaf";
+    githubId = 80571430;
+    name = "Luminar Leaf";
+  };
   luna_1024 = {
     email = "contact@luna.computer";
     github = "luna-1024";

--- a/pkgs/by-name/he/helvum/package.nix
+++ b/pkgs/by-name/he/helvum/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  cargo,
+  desktop-file-utils,
+  fetchFromGitLab,
+  glib,
+  gtk4,
+  libadwaita,
+  meson,
+  ninja,
+  pipewire,
+  pkg-config,
+  rustPlatform,
+  rustc,
+  stdenv,
+  wrapGAppsHook4,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "helvum";
+  version = "0.5.1";
+
+  src = fetchFromGitLab {
+    domain = "gitlab.freedesktop.org";
+    owner = "pipewire";
+    repo = "helvum";
+    rev = version;
+    hash = "sha256-9vlzLPpyZ9qtCEbCDvYhWDcV+8T63ukdos1l2U6fD+E=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit pname version src;
+    hash = "sha256-rwhhbEaUg7IiszmJUFh4vQV7cYyyh3tqr1z4QgmwIDY=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+    rustPlatform.bindgenHook
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    desktop-file-utils
+    glib
+    gtk4
+    libadwaita
+    pipewire
+  ];
+
+  meta = {
+    description = "GTK patchbay for pipewire";
+    homepage = "https://gitlab.freedesktop.org/pipewire/helvum";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ fufexan ];
+    platforms = lib.platforms.linux;
+    mainProgram = "helvum";
+  };
+}

--- a/pkgs/by-name/he/helvum/package.nix
+++ b/pkgs/by-name/he/helvum/package.nix
@@ -18,19 +18,19 @@
 
 stdenv.mkDerivation rec {
   pname = "helvum";
-  version = "0.5.1";
+  version = "0.6.2";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "pipewire";
     repo = "helvum";
     rev = version;
-    hash = "sha256-9vlzLPpyZ9qtCEbCDvYhWDcV+8T63ukdos1l2U6fD+E=";
+    hash = "sha256-fDsVYFJ2fm5dLpcCp7Pm4s3+jqTx4r9IQokoVQ0sM04=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-rwhhbEaUg7IiszmJUFh4vQV7cYyyh3tqr1z4QgmwIDY=";
+    hash = "sha256-cpRPJap/U20vkfShuTav10IoPIxDKueviFKTDM4jrGs=";
   };
 
   nativeBuildInputs = [
@@ -56,7 +56,10 @@ stdenv.mkDerivation rec {
     description = "GTK patchbay for pipewire";
     homepage = "https://gitlab.freedesktop.org/pipewire/helvum";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ fufexan ];
+    maintainers = with lib.maintainers; [
+      fufexan
+      luminarleaf
+    ];
     platforms = lib.platforms.linux;
     mainProgram = "helvum";
   };

--- a/pkgs/by-name/he/helvum/package.nix
+++ b/pkgs/by-name/he/helvum/package.nix
@@ -14,6 +14,7 @@
   rustc,
   stdenv,
   wrapGAppsHook4,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -51,6 +52,8 @@ stdenv.mkDerivation rec {
     libadwaita
     pipewire
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "GTK patchbay for pipewire";

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -946,7 +946,6 @@ mapAliases {
   haxe_4_0 = throw "'haxe_4_0' has been removed as it reached its end of life. Migrate to 'haxe_4_3'.";
   haxe_4_1 = throw "'haxe_4_1' has been removed as it reached its end of life. Migrate to 'haxe_4_3'.";
   helix-gpt = throw "helix-gpt was deprecated in January 2026 and has been since removed"; # Added 2026-02-05
-  helvum = throw "'helvum' has been removed as it was unmaintained upstream and relied on a vulnerable dependency. Consider using 'crosspipe' instead."; # Added 2026-03-04
   HentaiAtHome = throw "'HentaiAtHome' has been renamed to/replaced by 'hentai-at-home'"; # Converted to throw 2025-10-27
   hiawatha = throw "hiawatha has been removed, since it is no longer actively supported upstream, nor well maintained in nixpkgs"; # Added 2025-09-10
   hibernate = throw "hibernate has been removed due to lack of maintenance"; # Added 2025-09-10


### PR DESCRIPTION
Helvum was recently picked up by a new maintainer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
