### PR TITLE
klipper-flash: support can bus flashing, support flashing avr mcus

### DIFF
--- a/nixos/modules/services/misc/klipper.nix
+++ b/nixos/modules/services/misc/klipper.nix
@@ -33,10 +33,26 @@ let
         '';
         serial = lib.mkOption {
           type = lib.types.nullOr lib.types.path;
-          description = "Path to serial port this printer is connected to. Derived from `service.klipper.settings` by default.";
+          description = "Path to serial port this mcu is connected to. Derived from `service.klipper.settings` by default.";
           defaultText = lib.literalExpression "config.services.klipper.settings.<name>.serial";
           default =
             if lib.hasAttrByPath [ "${mcu}" "serial" ] cfg.settings then cfg.settings."${mcu}".serial else null;
+        };
+        canbus_uuid = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          description = "CAN bus uuid of this mcu. Derived from `service.klipper.settings` by default.";
+          defaultText = lib.literalExpression "config.services.klipper.settings.<name>.canbus_uuid";
+          default =
+            if lib.hasAttrByPath [ "${mcu}" "canbus_uuid" ] cfg.settings then
+              cfg.settings."${mcu}".canbus_uuid
+            else
+              null;
+        };
+        canbusNetwork = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          description = "CAN bus network this mcu is connected to. Defaults to can0 if canbus_uuid is set.";
+          defaultText = lib.literalExpression ''if canbus_uuid != null then "can0" else null'';
+          default = if subcfg.canbus_uuid != null then "can0" else null;
         };
         configFile = lib.mkOption {
           type = lib.types.path;
@@ -71,6 +87,8 @@ let
               klipper-firmware = subcfg.package;
               mcu = lib.strings.sanitizeDerivationName mcu;
               flashDevice = subcfg.serial;
+              canbusDevice = subcfg.canbus_uuid;
+              canbusNetwork = subcfg.canbusNetwork;
               firmwareConfig = subcfg.configFile;
             }
           else
@@ -217,12 +235,15 @@ in
       }
     ]
     ++ lib.mapAttrsToList (mcu: firmware: {
-      assertion = firmware.enableKlipperFlash -> firmware.serial != null;
+      assertion =
+        firmware.enableKlipperFlash -> (firmware.serial != null || firmware.canbus_uuid != null);
       message = ''
-        Unable to determine the serial connection for services.klipper.firmwares."${mcu}". Please set one of the following:
+        Unable to determine the serial or canbus connection for services.klipper.firmwares."${mcu}". Please set one of the following:
 
           - services.klipper.firmwares."${mcu}".serial
+          - services.klipper.firmwares."${mcu}".canbus_uuid
           - services.klipper.settings."${mcu}".serial
+          - services.klipper.settings."${mcu}".canbus_uuid
       '';
     }) cfg.firmwares;
 
@@ -301,7 +322,6 @@ in
 
     environment.systemPackages =
       let
-        default = a: b: if a != null then a else b;
         genconf = pkgs.klipper-genconf.override {
           klipper = cfg.package;
         };

--- a/pkgs/servers/klipper/default.nix
+++ b/pkgs/servers/klipper/default.nix
@@ -90,6 +90,7 @@ stdenv.mkDerivation rec {
       p: with p; [
         numpy
         matplotlib
+        python-can
       ]
     )).interpreter;
 
@@ -126,6 +127,11 @@ stdenv.mkDerivation rec {
       --subst-var "out" \
       --subst-var-by "script" "calibrate_shaper.py"
     chmod 755 "$out/bin/klipper-calibrate-shaper"
+
+    substitute "$pythonScriptWrapper" "$out/bin/klipper-canbus-query" \
+      --subst-var "out" \
+      --subst-var-by "script" "canbus_query.py"
+    chmod 755 "$out/bin/klipper-canbus-query"
 
     runHook postInstall
   '';

--- a/pkgs/servers/klipper/default.nix
+++ b/pkgs/servers/klipper/default.nix
@@ -109,8 +109,10 @@ stdenv.mkDerivation rec {
     # under `klipper_path`
     cp -r $src/docs $out/lib/docs
     cp -r $src/config $out/lib/config
-    cp -r $src/scripts $out/lib/scripts
     cp -r $src/klippy $out/lib/klippy
+    mkdir -p $out/lib/scripts
+    cp -r $src/scripts/* $out/lib/scripts
+    cp $src/lib/katapult/flashtool.py $out/lib/scripts/flash_can.py
 
     # Add version information. For the normal procedure see https://www.klipper3d.org/Packaging.html#versioning
     # This is done like this because scripts/make_version.py is not available when sourceRoot is set to "${src.name}/klippy"

--- a/pkgs/servers/klipper/klipper-firmware.nix
+++ b/pkgs/servers/klipper/klipper-firmware.nix
@@ -95,7 +95,11 @@ stdenv.mkDerivation {
 
   passthru = {
     makeFlasher =
-      { flashDevice }:
+      {
+        flashDevice ? null,
+        canbusNetwork ? null,
+        canbusDevice ? null,
+      }:
       klipper-flash.override {
         klipper-firmware = klipper-firmware.override args;
         inherit
@@ -103,6 +107,8 @@ stdenv.mkDerivation {
           firmwareConfig
           mcu
           flashDevice
+          canbusNetwork
+          canbusDevice
           ;
       };
   };

--- a/pkgs/servers/klipper/klipper-firmware.nix
+++ b/pkgs/servers/klipper/klipper-firmware.nix
@@ -72,6 +72,7 @@ stdenv.mkDerivation {
     cp ./.config $out/config
     cp out/klipper.bin $out/ || true
     cp out/klipper.elf $out/ || true
+    cp out/klipper.elf.hex $out/ || true
     cp out/klipper.uf2 $out/ || true
 
     mkdir -p $out/lib/

--- a/pkgs/servers/klipper/klipper-flash.nix
+++ b/pkgs/servers/klipper/klipper-flash.nix
@@ -7,7 +7,9 @@
   dfu-util,
   stm32flash,
   mcu ? "mcu",
-  flashDevice ? "/dev/null",
+  flashDevice ? null,
+  canbusNetwork ? null,
+  canbusDevice ? null,
   firmwareConfig ? ./simulator.cfg,
 }:
 let
@@ -21,33 +23,41 @@ let
   matchPlatform = getConfigField "CONFIG_BOARD_DIRECTORY";
   matchBoard = getConfigField "CONFIG_MCU";
 in
+assert lib.assertMsg (
+  (flashDevice != null) != (canbusNetwork != null && canbusDevice != null)
+  && ((canbusNetwork != null) == (canbusDevice != null))
+) "Either set flashDevice or both canbusNetwork and canbusDevice";
 writeShellApplication {
   name = "klipper-flash-${mcu}";
   runtimeInputs =
     [ ]
-    ++ lib.optionals (matchPlatform == "avr") [ avrdude ]
-    ++ lib.optionals (matchPlatform == "stm32") [
-      stm32flash
-      dfu-util
-    ]
-    ++ lib.optionals (matchPlatform == "lpc176x") [ dfu-util ]
-  # bossac, hid-flash and RP2040 flash binaries are built by klipper-firmware
-  ;
+    ++ lib.optionals (flashDevice != null) (
+      lib.optionals (matchPlatform == "avr") [ avrdude ]
+      ++ lib.optionals (matchPlatform == "stm32") [
+        stm32flash
+        dfu-util
+      ]
+      ++ lib.optionals (matchPlatform == "lpc176x") [ dfu-util ]
+      # bossac, hid-flash and RP2040 flash binaries are built by klipper-firmware
+    );
   text =
     # generic USB script for most things with serial and bootloader (see MCU_TYPES in scripts/flash_usb.py)
-    if matchBoard != null && matchPlatform != null then
-      ''
-        pushd ${klipper-firmware}
-        ${klipper}/lib/scripts/flash_usb.py -t ${matchBoard} -d ${flashDevice} ${klipper-firmware}/klipper.bin "$@"
-        popd
-      ''
+    if flashDevice != null then
+      if matchBoard != null && matchPlatform != null then
+        ''
+          ${klipper}/lib/scripts/flash_usb.py -t ${matchBoard} -d ${flashDevice} ${klipper-firmware}/klipper.bin "$@"
+        ''
+      else
+        ''
+          cat <<EOF
+          Board pair ${toString matchBoard}/${toString matchPlatform} (config ${firmwareConfig}) is not supported in NixOS auto flashing script.
+          Please manually flash the firmware using the appropriate tool for your board.
+          Built firmware is located here:
+          ${klipper-firmware}
+          EOF
+        ''
     else
       ''
-        cat <<EOF
-        Board pair ${toString matchBoard}/${toString matchPlatform} (config ${firmwareConfig}) is not supported in NixOS auto flashing script.
-        Please manually flash the firmware using the appropriate tool for your board.
-        Built firmware is located here:
-        ${klipper-firmware}
-        EOF
+        ${klipper}/lib/scripts/flash_can.py -i ${canbusNetwork} -f ${klipper-firmware}/klipper.bin -u ${canbusDevice} "$@"
       '';
 }

--- a/pkgs/servers/klipper/klipper-flash.nix
+++ b/pkgs/servers/klipper/klipper-flash.nix
@@ -22,6 +22,26 @@ let
     if matches != null then head matches else null;
   matchPlatform = getConfigField "CONFIG_BOARD_DIRECTORY";
   matchBoard = getConfigField "CONFIG_MCU";
+  matchAvrdudeProtocol = getConfigField "CONFIG_AVRDUDE_PROTOCOL";
+  flashUsbSupportedBoards = [
+    "sam3"
+    "sam4"
+    "same70"
+    "samd"
+    "same5"
+    "lpc176"
+    "stm32f103"
+    "stm32f4"
+    "stm32f042"
+    "stm32f070"
+    "stm32f072"
+    "stm32g0b1"
+    "stm32f7"
+    "stm32h7"
+    "stm32l4"
+    "stm32g4"
+    "rp2"
+  ];
 in
 assert lib.assertMsg (
   (flashDevice != null) != (canbusNetwork != null && canbusDevice != null)
@@ -43,9 +63,13 @@ writeShellApplication {
   text =
     # generic USB script for most things with serial and bootloader (see MCU_TYPES in scripts/flash_usb.py)
     if flashDevice != null then
-      if matchBoard != null && matchPlatform != null then
+      if (builtins.elem matchBoard flashUsbSupportedBoards) && matchPlatform != null then
         ''
           ${klipper}/lib/scripts/flash_usb.py -t ${matchBoard} -d ${flashDevice} ${klipper-firmware}/klipper.bin "$@"
+        ''
+      else if matchPlatform == "avr" && matchAvrdudeProtocol != null && matchBoard != null then
+        ''
+          avrdude -p${matchBoard} -c${matchAvrdudeProtocol} -P"${flashDevice}" -D -U"flash:w:${klipper-firmware}/klipper.elf.hex:i"
         ''
       else
         ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1816,7 +1816,7 @@ with pkgs;
 
   klipper-firmware = callPackage ../servers/klipper/klipper-firmware.nix { };
 
-  klipper-flash = callPackage ../servers/klipper/klipper-flash.nix { };
+  klipper-flash = callPackage ../servers/klipper/klipper-flash.nix { flashDevice = "/dev/null"; };
 
   klipper-genconf = callPackage ../servers/klipper/klipper-genconf.nix { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Currently the `klipper-flash` utility script only supports using the `flash_usb.py` script, which intern only supports a [limited set of mcus](https://github.com/Klipper3d/klipper/blob/4bc56464f9596bbacd31ef38dd360497ce00baf9/scripts/flash_usb.py#L345-L354). Notably, common avr mcus like the ATmega2560 used by most RAMPS boards, are not currently supported. This adds support for those mcus.

Additionally, this also adds support for flashing klipper over CAN for mcus using the [katapult](https://github.com/Arksine/katapult) bootloader. The [`flash_can.py`](https://github.com/Klipper3d/klipper/blob/master/lib/katapult/flashtool.py) script (recently renamed to `flashtool.py`) required for this is already present in klippers `$src` and is added to the `$out/lib/scripts` during install.

Depends on #508693, as the `lib/canboot/flash_can.py` -> `lib/katapult/flashtool.py` update is not part of the current klipper version on master.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
