### PR TITLE
klipper: support using indented strings in settings

### DIFF
--- a/nixos/modules/services/misc/klipper.nix
+++ b/nixos/modules/services/misc/klipper.nix
@@ -14,7 +14,14 @@ let
         lib.generators.mkValueStringDefault { } (lib.head l)
       else
         lib.concatMapStrings (s: "\n  ${lib.generators.mkValueStringDefault { } s}") l;
-    mkKeyValue = lib.generators.mkKeyValueDefault { } ":";
+    mkKeyValue =
+      key: value:
+      lib.generators.mkKeyValueDefault { } ":" key (
+        if builtins.isString value && lib.hasInfix "\n" value then
+          "\n  ${lib.replaceString "\n" "\n  " value}"
+        else
+          value
+      );
   };
   firmwareSubmodule = lib.types.submodule (
     { name, ... }@local:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

There is currently no good way to define klipper gcode_macros via `klipper.settings`.

You can either use a list of strings (no thanks):
```nix
"gcode_macro TEST".gcode = [
    "G91"
    "G90"
];
```
=>
```ini
[gcode_macro TEST]
gcode:
  G91
  G90
```

or a normal string (this is what I've seen most people do):
```nix
"gcode_macro TEST".gcode = "
    G91
    G90
";
```
=>
```ini
[gcode_macro TEST]
gcode:
    G91
    G90
```

(This is a valid klipper config more or less by coincidence.)

What any sane person would rather do is simply:

```nix
"gcode_macro TEST".gcode = ''
    G91
    G90
'';
```
=>
```ini
[gcode_macro TEST]
gcode:G91
G90
```

But this currently results in an **invalid** klipper config (note the missing indentation).

This change overrides `mkKeyValue` to check for multiline strings (`lib.hasInfix "\n"`) and adds indentation, aswell as a leading newline to them. The current implementation results in indented-strings being formatted nicely:

```nix
"gcode_macro TEST".gcode = ''
    G91
    G90
'';
```
=>
```ini
[gcode_macro TEST]
gcode:
  G91
  G90
```

while the other two methods receive an extra leading newline, aswell as some extra indentation. This should never result in an invalid klipper config, but will possibly result in "uglier" formatting than before. (This could be resolved by checking if the multiline string is already indented and already starts with a newline, before applying each, but I've decided against that for simplicities sake.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
