### PR TITLE
dino: migrate to by-name

### DIFF
--- a/pkgs/by-name/di/dino/package.nix
+++ b/pkgs/by-name/di/dino/package.nix
@@ -27,16 +27,20 @@
   srtp,
   libnice,
   gnutls,
-  gstreamer,
-  gst-plugins-base,
-  gst-plugins-good,
+  gst_all_1,
   webrtc-audio-processing,
 }:
 
 # Upstream is very deliberate about which features are enabled per default or are automatically enabled.
 # Everything that is disabled per default has to been seen experimental and should not be enabled without strong reasoning.
 # see https://github.com/NixOS/nixpkgs/issues/469614#issuecomment-3649662176
-
+let
+  inherit (gst_all_1)
+    gstreamer
+    gst-plugins-base
+    ;
+  gst-plugins-good = gst_all_1.gst-plugins-good.override { gtkSupport = true; };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "dino";
   version = "0.5.1";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1698,14 +1698,6 @@ with pkgs;
     plugins = lib.filter (p: p ? pluginName) (builtins.attrValues discourse.plugins);
   };
 
-  dino = callPackage ../applications/networking/instant-messengers/dino {
-    inherit (gst_all_1)
-      gstreamer
-      gst-plugins-base
-      ;
-    gst-plugins-good = gst_all_1.gst-plugins-good.override { gtkSupport = true; };
-  };
-
   inherit (ocamlPackages) dot-merlin-reader;
 
   inherit (ocamlPackages) dune-release;


### PR DESCRIPTION
This PR migrates dino to the by‑name layout and cleans up its packaging. The package is moved to pkgs/by-name/di/dino/package.nix, and the old entry in all-packages.nix is removed. GStreamer dependencies are simplified by using gst_all_1 and enabling gtkSupport via an override on gst-plugins-good.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
