### PR TITLE
authelia: 4.39.19 -> 4.39.20

### DIFF
--- a/pkgs/by-name/au/authelia/package.nix
+++ b/pkgs/by-name/au/authelia/package.nix
@@ -4,9 +4,9 @@
   nodejs,
   fetchPnpmDeps,
   pnpmConfigHook,
-  pnpm_10,
+  pnpm_11,
   fetchFromGitHub,
-  buildGo125Module,
+  buildGo126Module,
   installShellFiles,
   callPackage,
   nixosTests,
@@ -15,16 +15,16 @@
       nodejs
       fetchPnpmDeps
       pnpmConfigHook
-      pnpm_10
+      pnpm_11
       fetchFromGitHub
       ;
   },
 }:
 
 let
-  pnpm = pnpm_10;
+  pnpm = pnpm_11;
 
-  buildGoModule = buildGo125Module;
+  buildGoModule = buildGo126Module;
 
   inherit (import ./sources.nix { inherit fetchFromGitHub; })
     pname
@@ -65,11 +65,6 @@ buildGoModule (finalAttrs: {
       "-X ${p}.BuildBranch=v${finalAttrs.version}"
       "-X ${p}.BuildExtra=nixpkgs"
     ];
-
-  # It is required to set this to avoid a change in the
-  # handling of sync map in go 1.24+
-  # Upstream issue: https://github.com/authelia/authelia/issues/8980
-  env.GOEXPERIMENT = "nosynchashtriemap";
 
   # several tests with networking and several that want chromium
   doCheck = false;

--- a/pkgs/by-name/au/authelia/sources.nix
+++ b/pkgs/by-name/au/authelia/sources.nix
@@ -1,14 +1,14 @@
 { fetchFromGitHub }:
 rec {
   pname = "authelia";
-  version = "4.39.19";
+  version = "4.39.20";
 
   src = fetchFromGitHub {
     owner = "authelia";
     repo = "authelia";
     rev = "v${version}";
-    hash = "sha256-wMOurdgdjykFekn0Pej3meM6WSzq9tJ+kZV9sVDvRwM=";
+    hash = "sha256-JjpfNQsqtmSKXj14fQUJsiTgfkAlSHDfqUC/x+bE+fc=";
   };
-  vendorHash = "sha256-ZDsLRMip2B8PPZu8VxW+91FVvwC2rXzohhAZFifT26g=";
-  pnpmDepsHash = "sha256-HMrC5V+Ak2dF1uPtbh8kgFc8kZI2FPMmZHJciWRYx9w=";
+  vendorHash = "sha256-dZjsYqw/ABEn1y6tZgSjbmqamO4U20Ljj/dQMFruVjU=";
+  pnpmDepsHash = "sha256-syfPg62JrTh496xi39xW/CnIwpJYo+iU5sCPP3bD2Ys=";
 }

--- a/pkgs/by-name/au/authelia/web.nix
+++ b/pkgs/by-name/au/authelia/web.nix
@@ -3,12 +3,12 @@
   nodejs,
   fetchPnpmDeps,
   pnpmConfigHook,
-  pnpm_10,
+  pnpm_11,
   fetchFromGitHub,
 }:
 
 let
-  pnpm = pnpm_10;
+  pnpm = pnpm_11;
 
   inherit (import ./sources.nix { inherit fetchFromGitHub; })
     pname


### PR DESCRIPTION
https://github.com/authelia/authelia/releases/tag/v4.39.20

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
