### PR TITLE
gitte: init at 0.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5135,6 +5135,13 @@
     githubId = 68239;
     name = "Christine Koppelt";
   };
+  ckruse = {
+    email = "cjk@defunct.ch";
+    github = "ckruse";
+    githubId = 175095;
+    name = "Christian Kruse";
+    keys = [ { fingerprint = "BC5D 9F4E F7FB 4382 6056  E834 B8E0 F342 A99A 9D73"; } ];
+  };
   clacke = {
     email = "claes.wallin@greatsinodevelopment.com";
     github = "clacke";

--- a/pkgs/by-name/gi/gitte/package.nix
+++ b/pkgs/by-name/gi/gitte/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenv,
+  fetchFromCodeberg,
+  nix-update-script,
+  meson,
+  ninja,
+  pkg-config,
+  rustPlatform,
+  cargo,
+  rustc,
+  wrapGAppsHook4,
+  desktop-file-utils,
+  appstream,
+  gettext,
+  glib,
+  gtk4,
+  libadwaita,
+  openssl,
+  libgit2,
+  zlib,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gitte";
+  version = "0.6.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "ckruse";
+    repo = "Gitte";
+    tag = finalAttrs.version;
+    hash = "sha256-ieW/oOFdyJWVR/7B62Rzcyii+/zDj/Xp6KCrVOf6mpA=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-VhcJepTeEjA/ZogqR82Whlyz4NRuI5MLB2HqNjGe8zQ=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+    wrapGAppsHook4
+    desktop-file-utils
+    appstream
+    gettext
+    glib
+  ];
+
+  buildInputs = [
+    gtk4
+    libadwaita
+    openssl
+    libgit2
+    zlib
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://codeberg.org/ckruse/Gitte";
+    mainProgram = "gitte";
+    description = "GTK4/libadwaita Git client";
+    license = with lib.licenses; [ agpl3Plus ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      ckruse
+      orzklv
+    ];
+  };
+})


### PR DESCRIPTION
gitte: init at 0.5.0

A new GTK4/libadwaita Git client. For the reference:
https://codeberg.org/ckruse/Gitte/issues/101

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
