### PR TITLE
Revert "nixos/security: warn if wrappers are disabled and wrappers are defined"

### DIFF
--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -245,156 +245,134 @@ in
   };
 
   ###### implementation
-  config = lib.mkMerge [
-    {
-      warnings = lib.optional (wrappers != { } && !config.security.enableWrappers) ''
-        security.enableWrappers is set to false, but the following wrappers are still enabled and will be silently ignored: ${lib.concatStringsSep ", " (lib.attrNames wrappers)}. This might prevent fundamental functionalities, like PAM authentication. To avoid this warning, either set security.enableWrappers = true, or explicitly disable each wrapper with `enable = false`.
-      '';
-      assertions = [
-        {
-          assertion =
-            !(
-              !config.security.enableWrappers && lib.any (u: u.isNormalUser) (lib.attrValues config.users.users)
-            );
-          message = ''
-            security.enableWrappers is disabled but normal users are defined
-            (${
-              lib.concatStringsSep ", " (
-                lib.mapAttrsToList (n: _: n) (lib.filterAttrs (_: u: u.isNormalUser) config.users.users)
-              )
-            }). Without SUID wrappers, users cannot login. Either enable wrappers or remove all normal user accounts.
-          '';
-        }
-      ];
-    }
-    (lib.mkIf config.security.enableWrappers {
-      assertions = lib.mapAttrsToList (name: opts: {
-        assertion = opts.setuid || opts.setgid -> opts.capabilities == "";
-        message = ''
-          The security.wrappers.${name} wrapper is not valid:
-              setuid/setgid and capabilities are mutually exclusive.
-        '';
-      }) wrappers;
+  config = lib.mkIf config.security.enableWrappers {
 
-      security.wrappers =
-        let
-          mkSetuidRoot = source: {
-            setuid = true;
-            owner = "root";
-            group = "root";
-            inherit source;
-          };
-        in
-        {
-          # These are mount related wrappers that require the +s permission.
-          mount = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/mount";
-          umount = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/umount";
+    assertions = lib.mapAttrsToList (name: opts: {
+      assertion = opts.setuid || opts.setgid -> opts.capabilities == "";
+      message = ''
+        The security.wrappers.${name} wrapper is not valid:
+            setuid/setgid and capabilities are mutually exclusive.
+      '';
+    }) wrappers;
+
+    security.wrappers =
+      let
+        mkSetuidRoot = source: {
+          setuid = true;
+          owner = "root";
+          group = "root";
+          inherit source;
         };
-
-      # Make sure our wrapperDir exports to the PATH env variable when
-      # initializing the shell
-      environment.extraInit = ''
-        # Wrappers override other bin directories.
-        export PATH="${wrapperDir}:$PATH"
-      '';
-
-      security.apparmor.includes = lib.mapAttrs' (
-        wrapName: wrap:
-        lib.nameValuePair "nixos/security.wrappers/${wrapName}" ''
-          include "${
-            pkgs.apparmorRulesFromClosure { name = "security.wrappers.${wrapName}"; } [
-              (securityWrapper wrap.source)
-            ]
-          }"
-          mrpx ${wrap.source},
-        ''
-      ) wrappers;
-
-      systemd.mounts = [
-        {
-          where = parentWrapperDir;
-          what = "tmpfs";
-          type = "tmpfs";
-          options = lib.concatStringsSep "," [
-            "nodev"
-            "mode=755"
-            "size=${config.security.wrapperDirSize}"
-          ];
-        }
-      ];
-
-      systemd.services.suid-sgid-wrappers = {
-        description = "Create SUID/SGID Wrappers";
-        wantedBy = [ "sysinit.target" ];
-        before = [
-          "sysinit.target"
-          "shutdown.target"
-        ];
-        conflicts = [ "shutdown.target" ];
-        after = [ "systemd-sysusers.service" ];
-        unitConfig.DefaultDependencies = false;
-        unitConfig.RequiresMountsFor = [
-          "/nix/store"
-          "/run/wrappers"
-        ];
-        serviceConfig.RestrictSUIDSGID = false;
-        serviceConfig.Type = "oneshot";
-        script = ''
-          chmod 755 "${parentWrapperDir}"
-
-          # We want to place the tmpdirs for the wrappers to the parent dir.
-          wrapperDir=$(mktemp --directory --tmpdir="${parentWrapperDir}" wrappers.XXXXXXXXXX)
-          chmod a+rx "$wrapperDir"
-
-          ${lib.concatStringsSep "\n" mkWrappedPrograms}
-
-          if [ -L ${wrapperDir} ]; then
-            # Atomically replace the symlink
-            # See https://axialcorps.com/2013/07/03/atomically-replacing-files-and-directories/
-            old=$(readlink -f ${wrapperDir})
-            if [ -e "${wrapperDir}-tmp" ]; then
-              rm --force --recursive "${wrapperDir}-tmp"
-            fi
-            ln --symbolic --force --no-dereference "$wrapperDir" "${wrapperDir}-tmp"
-            mv --no-target-directory "${wrapperDir}-tmp" "${wrapperDir}"
-            rm --force --recursive "$old"
-          else
-            # For initial setup
-            ln --symbolic "$wrapperDir" "${wrapperDir}"
-          fi
-        '';
+      in
+      {
+        # These are mount related wrappers that require the +s permission.
+        mount = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/mount";
+        umount = mkSetuidRoot "${lib.getBin pkgs.util-linux}/bin/umount";
       };
 
-      ###### wrappers consistency checks
-      system.checks = lib.singleton (
-        pkgs.runCommand "ensure-all-wrappers-paths-exist"
-          {
-            preferLocalBuild = true;
-          }
-          ''
-            # make sure we produce output
-            mkdir -p $out
+    # Make sure our wrapperDir exports to the PATH env variable when
+    # initializing the shell
+    environment.extraInit = ''
+      # Wrappers override other bin directories.
+      export PATH="${wrapperDir}:$PATH"
+    '';
 
-            echo -n "Checking that Nix store paths of all wrapped programs exist... "
+    security.apparmor.includes = lib.mapAttrs' (
+      wrapName: wrap:
+      lib.nameValuePair "nixos/security.wrappers/${wrapName}" ''
+        include "${
+          pkgs.apparmorRulesFromClosure { name = "security.wrappers.${wrapName}"; } [
+            (securityWrapper wrap.source)
+          ]
+        }"
+        mrpx ${wrap.source},
+      ''
+    ) wrappers;
 
-            declare -A wrappers
-            ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "wrappers['${n}']='${v.source}'") wrappers)}
+    systemd.mounts = [
+      {
+        where = parentWrapperDir;
+        what = "tmpfs";
+        type = "tmpfs";
+        options = lib.concatStringsSep "," [
+          "nodev"
+          "mode=755"
+          "size=${config.security.wrapperDirSize}"
+        ];
+      }
+    ];
 
-            for name in "''${!wrappers[@]}"; do
-              path="''${wrappers[$name]}"
-              if [[ "$path" =~ /nix/store ]] && [ ! -e "$path" ]; then
-                test -t 1 && echo -ne '\033[1;31m'
-                echo "FAIL"
-                echo "The path $path does not exist!"
-                echo 'Please, check the value of `security.wrappers."'$name'".source`.'
-                test -t 1 && echo -ne '\033[0m'
-                exit 1
-              fi
-            done
+    systemd.services.suid-sgid-wrappers = {
+      description = "Create SUID/SGID Wrappers";
+      wantedBy = [ "sysinit.target" ];
+      before = [
+        "sysinit.target"
+        "shutdown.target"
+      ];
+      conflicts = [ "shutdown.target" ];
+      after = [ "systemd-sysusers.service" ];
+      unitConfig.DefaultDependencies = false;
+      unitConfig.RequiresMountsFor = [
+        "/nix/store"
+        "/run/wrappers"
+      ];
+      serviceConfig.RestrictSUIDSGID = false;
+      serviceConfig.Type = "oneshot";
+      script = ''
+        chmod 755 "${parentWrapperDir}"
 
-            echo "OK"
-          ''
-      );
-    })
-  ];
+        # We want to place the tmpdirs for the wrappers to the parent dir.
+        wrapperDir=$(mktemp --directory --tmpdir="${parentWrapperDir}" wrappers.XXXXXXXXXX)
+        chmod a+rx "$wrapperDir"
+
+        ${lib.concatStringsSep "\n" mkWrappedPrograms}
+
+        if [ -L ${wrapperDir} ]; then
+          # Atomically replace the symlink
+          # See https://axialcorps.com/2013/07/03/atomically-replacing-files-and-directories/
+          old=$(readlink -f ${wrapperDir})
+          if [ -e "${wrapperDir}-tmp" ]; then
+            rm --force --recursive "${wrapperDir}-tmp"
+          fi
+          ln --symbolic --force --no-dereference "$wrapperDir" "${wrapperDir}-tmp"
+          mv --no-target-directory "${wrapperDir}-tmp" "${wrapperDir}"
+          rm --force --recursive "$old"
+        else
+          # For initial setup
+          ln --symbolic "$wrapperDir" "${wrapperDir}"
+        fi
+      '';
+    };
+
+    ###### wrappers consistency checks
+    system.checks = lib.singleton (
+      pkgs.runCommand "ensure-all-wrappers-paths-exist"
+        {
+          preferLocalBuild = true;
+        }
+        ''
+          # make sure we produce output
+          mkdir -p $out
+
+          echo -n "Checking that Nix store paths of all wrapped programs exist... "
+
+          declare -A wrappers
+          ${lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "wrappers['${n}']='${v.source}'") wrappers)}
+
+          for name in "''${!wrappers[@]}"; do
+            path="''${wrappers[$name]}"
+            if [[ "$path" =~ /nix/store ]] && [ ! -e "$path" ]; then
+              test -t 1 && echo -ne '\033[1;31m'
+              echo "FAIL"
+              echo "The path $path does not exist!"
+              echo 'Please, check the value of `security.wrappers."'$name'".source`.'
+              test -t 1 && echo -ne '\033[0m'
+              exit 1
+            fi
+          done
+
+          echo "OK"
+        ''
+    );
+  };
 }


### PR DESCRIPTION
I didn't realize `security.enableWrappers` *was* supposed to be the override.

For further discussions see #519464 and #518955


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
