### PR TITLE
sgx-psw: 2.27 -> 2.29; nixos/aesmd: update

### DIFF
--- a/nixos/modules/services/security/aesmd.nix
+++ b/nixos/modules/services/security/aesmd.nix
@@ -1,6 +1,5 @@
 {
   config,
-  options,
   pkgs,
   lib,
   ...
@@ -20,7 +19,6 @@ let
     ;
 
   cfg = config.services.aesmd;
-  opt = options.services.aesmd;
 
   sgx-psw = cfg.package;
 
@@ -28,10 +26,10 @@ let
     with cfg.settings;
     pkgs.writeText "aesmd.conf" (
       concatStringsSep "\n" (
-        optional (whitelistUrl != null) "whitelist url = ${whitelistUrl}"
+        optional (defaultQuotingType != null) "default quoting type = ${defaultQuotingType}"
+        ++ optional (qplLogLevel != null) "qpl log level = ${qplLogLevel}"
         ++ optional (proxy != null) "aesm proxy = ${proxy}"
         ++ optional (proxyType != null) "proxy type = ${proxyType}"
-        ++ optional (defaultQuotingType != null) "default quoting type = ${defaultQuotingType}"
         ++
           # Newline at end of file
           [ "" ]
@@ -45,6 +43,12 @@ in
 
           services.aesmd.package = pkgs.sgx-psw.override { debug = true; };
     '')
+    (mkRemovedOptionModule [
+      "services"
+      "aesmd"
+      "settings"
+      "whitelistUrl"
+    ] "sgx-psw-v2.28 no longer supports Intel enclave signer cert whitelist management.")
   ];
 
   options.services.aesmd = {
@@ -66,54 +70,50 @@ in
       example = literalExpression "pkgs.sgx-azure-dcap-client";
       description = "Custom quote provider library to use.";
     };
-    settings = mkOption {
-      description = "AESM configuration";
-      default = { };
-      type = types.submodule {
-        options.whitelistUrl = mkOption {
-          type = with types; nullOr str;
-          default = null;
-          example = "http://whitelist.trustedservices.intel.com/SGX/LCWL/Linux/sgx_white_list_cert.bin";
-          description = "URL to retrieve authorized Intel SGX enclave signers.";
-        };
-        options.proxy = mkOption {
-          type = with types; nullOr str;
-          default = null;
-          example = "http://proxy_url:1234";
-          description = "HTTP network proxy.";
-        };
-        options.proxyType = mkOption {
-          type =
-            with types;
-            nullOr (enum [
-              "default"
-              "direct"
-              "manual"
-            ]);
-          default = if (cfg.settings.proxy != null) then "manual" else null;
-          defaultText = literalExpression ''
-            if (config.${opt.settings}.proxy != null) then "manual" else null
-          '';
-          example = "default";
-          description = ''
-            Type of proxy to use. The `default` uses the system's default proxy.
-            If `direct` is given, uses no proxy.
-            A value of `manual` uses the proxy from
-            {option}`services.aesmd.settings.proxy`.
-          '';
-        };
-        options.defaultQuotingType = mkOption {
-          type =
-            with types;
-            nullOr (enum [
-              "ecdsa_256"
-              "epid_linkable"
-              "epid_unlinkable"
-            ]);
-          default = null;
-          example = "ecdsa_256";
-          description = "Attestation quote type.";
-        };
+    settings = {
+      proxy = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        example = "http://proxy_url:1234";
+        description = "HTTP network proxy.";
+      };
+      proxyType = mkOption {
+        type =
+          with types;
+          nullOr (enum [
+            "default"
+            "direct"
+            "manual"
+          ]);
+        default = if (cfg.settings.proxy != null) then "manual" else null;
+        defaultText = literalExpression ''
+          if (cfg.settings.proxy != null) then "manual" else null
+        '';
+        example = "default";
+        description = ''
+          Type of proxy to use. The `default` uses the system's default proxy.
+          If `direct` is given, uses no proxy.
+          A value of `manual` uses the proxy from
+          {option}`services.aesmd.settings.proxy`.
+        '';
+      };
+      defaultQuotingType = mkOption {
+        # sgx-psw 2.28 removed EPID attestation
+        type = with types; nullOr (enum [ "ecdsa_256" ]);
+        default = null;
+        example = "ecdsa_256";
+        description = "Attestation quote type.";
+      };
+      qplLogLevel = mkOption {
+        type =
+          with types;
+          nullOr (enum [
+            "info"
+            "error"
+          ]);
+        default = null;
+        example = "error";
+        description = "Log level for the default quote provider library.";
       };
     };
   };
@@ -131,8 +131,6 @@ in
     systemd.services.aesmd =
       let
         storeAesmFolder = "${sgx-psw}/aesm";
-        # Hardcoded path AESM_DATA_FOLDER in psw/ae/aesm_service/source/oal/linux/aesm_util.cpp
-        aesmDataFolder = "/var/opt/aesmd/data";
       in
       {
         description = "Intel Architectural Enclave Service Manager";
@@ -154,13 +152,8 @@ in
         unitConfig.AssertPathExists = [ "/dev/sgx_enclave" ];
 
         serviceConfig = {
-          # Run with elevated privileges to create /var/opt/aesmd/... before
-          # dropping to DynamicUser.
-          ExecStartPre = ''
-            +${lib.getExe' pkgs.coreutils "install"} -m 644 -D \
-                "${storeAesmFolder}/data/white_list_cert_to_be_verify.bin" \
-                "${aesmDataFolder}/white_list_cert_to_be_verify.bin"
-          '';
+          # Hardcoded path AESM_DATA_FOLDER in psw/ae/aesm_service/source/oal/linux/aesm_util.cpp
+          ExecStartPre = "+${lib.getExe' pkgs.coreutils "mkdir"} -p -m 755 /var/opt/aesmd/data";
           ExecStart = "${sgx-psw}/bin/aesm_service --no-daemon";
           ExecReload = ''${pkgs.coreutils}/bin/kill -SIGHUP "$MAINPID"'';
 

--- a/nixos/tests/aesmd.nix
+++ b/nixos/tests/aesmd.nix
@@ -14,8 +14,8 @@
         enable = true;
         settings = {
           defaultQuotingType = "ecdsa_256";
+          qplLogLevel = "info";
           proxyType = "direct";
-          whitelistUrl = "http://nixos.org";
         };
       };
 
@@ -74,17 +74,17 @@
           machine.succeed(f"sudo -u sgxtest test {op} {socket_path}")
           machine.fail(f"sudo -u nosgxtest test {op} {socket_path}")
 
-      with subtest("Copies white_list_cert_to_be_verify.bin"):
-        whitelist_path = "/var/opt/aesmd/data/white_list_cert_to_be_verify.bin"
-        whitelist_perms = machine.succeed(
-          f"nsenter -m -t {main_pid} ${pkgs.coreutils}/bin/stat -c '%a' {whitelist_path}"
+      with subtest("Creates aesmd data directory"):
+        data_dir = "/var/opt/aesmd/data"
+        data_dir_perms = machine.succeed(
+          f"nsenter -m -t {main_pid} ${pkgs.coreutils}/bin/stat -c '%a' {data_dir}"
         ).strip()
-        assert "644" == whitelist_perms, f"white_list_cert_to_be_verify.bin has permissions {whitelist_perms}"
+        assert data_dir_perms == "755", f"{data_dir} has permissions {data_dir_perms}"
 
       with subtest("Writes and binds aesm.conf in service namespace"):
         aesmd_config = machine.succeed(f"nsenter -m -t {main_pid} ${pkgs.coreutils}/bin/cat /etc/aesmd.conf")
-
-        assert aesmd_config == "whitelist url = http://nixos.org\nproxy type = direct\ndefault quoting type = ecdsa_256\n", "aesmd.conf differs"
+        expected = "default quoting type = ecdsa_256\nqpl log level = info\nproxy type = direct\n"
+        assert aesmd_config == expected, f"aesmd.conf\n\nactual:\n{aesmd_config}\n---\n\nexpected:\n{expected}"
 
       with subtest("aesmd.service without quote provider library has correct LD_LIBRARY_PATH"):
         status, environment = machine.systemctl("show --property Environment --value aesmd.service")

--- a/pkgs/os-specific/linux/sgx/psw/cppmicroservices-compat.patch
+++ b/pkgs/os-specific/linux/sgx/psw/cppmicroservices-compat.patch
@@ -1,87 +1,26 @@
-diff --git a/external/CppMicroServices/CMakeLists.txt b/external/CppMicroServices/CMakeLists.txt
-index 8d0aff3..44d45d9 100644
---- a/external/CppMicroServices/CMakeLists.txt
-+++ b/external/CppMicroServices/CMakeLists.txt
-@@ -1,7 +1,7 @@
- # Extract the current version from the VERSION file
- file(STRINGS VERSION _version LIMIT_COUNT 1)
- 
--set(US_CMAKE_MINIMUM_REQUIRED_VERSION 3.2)
-+set(US_CMAKE_MINIMUM_REQUIRED_VERSION 3.10)
- 
- cmake_minimum_required(VERSION ${US_CMAKE_MINIMUM_REQUIRED_VERSION})
- 
 diff --git a/external/CppMicroServices/framework/include/cppmicroservices/AnyMap.h b/external/CppMicroServices/framework/include/cppmicroservices/AnyMap.h
-index 3f240f4..e8acef9 100644
+index 3f240f4..e9d5880 100644
 --- a/external/CppMicroServices/framework/include/cppmicroservices/AnyMap.h
 +++ b/external/CppMicroServices/framework/include/cppmicroservices/AnyMap.h
-@@ -25,6 +25,7 @@
- 
+@@ -25,6 +25,8 @@
+
  #include "cppmicroservices/Any.h"
- 
+
 +#include <cstdint>
++
  #include <string>
  #include <unordered_map>
- 
-diff --git a/external/CppMicroServices/framework/include/cppmicroservices/BundleEvent.h b/external/CppMicroServices/framework/include/cppmicroservices/BundleEvent.h
-index 9b36a9b..12894fa 100644
---- a/external/CppMicroServices/framework/include/cppmicroservices/BundleEvent.h
-+++ b/external/CppMicroServices/framework/include/cppmicroservices/BundleEvent.h
-@@ -25,6 +25,7 @@
- 
- #include "cppmicroservices/FrameworkExport.h"
- 
-+#include <cstdint>
- #include <iostream>
- #include <memory>
- 
-diff --git a/external/CppMicroServices/framework/include/cppmicroservices/Constants.h b/external/CppMicroServices/framework/include/cppmicroservices/Constants.h
-index 590a890..cf60926 100644
---- a/external/CppMicroServices/framework/include/cppmicroservices/Constants.h
-+++ b/external/CppMicroServices/framework/include/cppmicroservices/Constants.h
-@@ -25,6 +25,7 @@
- 
- #include "cppmicroservices/FrameworkConfig.h"
- 
-+#include <cstdint>
- #include <string>
- 
- namespace cppmicroservices {
-diff --git a/external/CppMicroServices/framework/include/cppmicroservices/FrameworkEvent.h b/external/CppMicroServices/framework/include/cppmicroservices/FrameworkEvent.h
-index 71caf1b..a29e87c 100644
---- a/external/CppMicroServices/framework/include/cppmicroservices/FrameworkEvent.h
-+++ b/external/CppMicroServices/framework/include/cppmicroservices/FrameworkEvent.h
-@@ -25,6 +25,7 @@
- 
- #include "cppmicroservices/FrameworkExport.h"
- 
-+#include <cstdint>
- #include <iostream>
- #include <memory>
- 
+
 diff --git a/external/CppMicroServices/framework/include/cppmicroservices/ServiceEvent.h b/external/CppMicroServices/framework/include/cppmicroservices/ServiceEvent.h
 index 451cb82..da7c5f0 100644
 --- a/external/CppMicroServices/framework/include/cppmicroservices/ServiceEvent.h
 +++ b/external/CppMicroServices/framework/include/cppmicroservices/ServiceEvent.h
 @@ -25,6 +25,8 @@
- 
+
  #include "cppmicroservices/ServiceReference.h"
- 
+
 +#include <cstdint>
 +
  US_MSVC_PUSH_DISABLE_WARNING(
    4251) // 'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'
- 
-diff --git a/psw/ae/aesm_service/source/CMakeLists.txt b/psw/ae/aesm_service/source/CMakeLists.txt
-index 5728e9b..0169263 100644
---- a/psw/ae/aesm_service/source/CMakeLists.txt
-+++ b/psw/ae/aesm_service/source/CMakeLists.txt
-@@ -30,7 +30,7 @@
- #
- 
- # [proj-begin]
--cmake_minimum_required(VERSION 3.0.0)
-+cmake_minimum_required(VERSION 3.10.0)
- project(ModularAESM VERSION 0.1.0)
- 
- 
+

--- a/pkgs/os-specific/linux/sgx/psw/default.nix
+++ b/pkgs/os-specific/linux/sgx/psw/default.nix
@@ -17,18 +17,18 @@
   which,
   debug ? false,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "sgx-psw";
   # Version as given in se_version.h
-  version = "2.27.100.1";
+  version = "2.29.100.1";
   # Version as used in the Git tag
-  versionTag = "2.27";
+  versionTag = "2.29";
 
   src = fetchFromGitHub {
     owner = "intel";
-    repo = "linux-sgx";
-    rev = "sgx_${versionTag}";
-    hash = "sha256-hNmh4IgNJDNqt2xF8zBnD/x+saMyMk5hZLA3aOqzqEA=";
+    repo = "confidential-computing.sgx";
+    rev = "sgx_${finalAttrs.versionTag}";
+    hash = "sha256-gi4aNXHMHuPmc36JalALAXjIdn4COuXOZzC6dQRB6nU=";
     fetchSubmodules = true;
   };
 
@@ -39,37 +39,38 @@ stdenv.mkDerivation rec {
       # run user application enclaves, verify launch policies, produce remote
       # attestation quotes, and do platform certification.
       ae.prebuilt = fetchurl {
-        url = "https://download.01.org/intel-sgx/sgx-linux/${versionTag}/prebuilt_ae_${versionTag}.tar.gz";
+        url = "https://download.01.org/intel-sgx/sgx-linux/${finalAttrs.versionTag}/prebuilt_ae_${finalAttrs.versionTag}.tar.gz";
         hash = "sha256-Hlh96rYOyml2y50d8ASKz6U97Fl0hbGYECeZiG9nMSQ=";
       };
 
       # Pre-built ipp-crypto with mitigations.
       optlib.prebuilt = fetchurl {
-        url = "https://download.01.org/intel-sgx/sgx-linux/${versionTag}/optimized_libs_${versionTag}.tar.gz";
+        url = "https://download.01.org/intel-sgx/sgx-linux/${finalAttrs.versionTag}/optimized_libs_${finalAttrs.versionTag}.tar.gz";
         hash = "sha256-7mDTaLtpOQLHQ6Fv+FWJ2k/veJZPXIcuj7kOdRtRqhg=";
       };
 
       # Fetch the Data Center Attestation Primitives (DCAP) platform enclaves
       # and pre-built sgxssl.
       dcap = rec {
-        version = "1.24";
+        version = "1.26";
         filename = "prebuilt_dcap_${version}.tar.gz";
         prebuilt = fetchurl {
           url = "https://download.01.org/intel-sgx/sgx-dcap/${version}/linux/${filename}";
-          hash = "sha256-sc/eYIPdhwAyDk2Zh1HU6yuFlobqVy/4++m5OnQE3Bc=";
+          hash = "sha256-TXQ8xh0q9RKPyKqjMvxoQtIH2lxbhCiwpV+HvQxACaw=";
         };
       };
     in
     ''
       # Make sure this is the right version of linux-sgx
-      grep -q '"${version}"' "$src/common/inc/internal/se_version.h" \
-        || (echo "Could not find expected version ${version} in linux-sgx source" >&2 && exit 1)
+      grep -q '"${finalAttrs.version}"' "$src/common/inc/internal/se_version.h" \
+        || (echo "Could not find expected version ${finalAttrs.version} in linux-sgx source" >&2 && exit 1)
 
       tar -xzvf ${ae.prebuilt}     -C $sourceRoot/
       tar -xzvf ${optlib.prebuilt} -C $sourceRoot/
 
       # Make sure we use the correct version of prebuilt DCAP
-      grep -q 'ae_file_name=${dcap.filename}' "$src/external/dcap_source/QuoteGeneration/download_prebuilt.sh" \
+      grep -qE '(dcap_version=${dcap.version}|ae_file_name=${dcap.filename})' \
+        "$src/external/dcap_source/QuoteGeneration/download_prebuilt.sh" \
         || (echo "Could not find expected prebuilt DCAP ${dcap.filename} in linux-sgx source" >&2 && exit 1)
 
       tar -xzvf ${dcap.prebuilt} -C $sourceRoot/external/dcap_source prebuilt/
@@ -91,11 +92,7 @@ stdenv.mkDerivation rec {
     # build because the embedded zip file contents have different modified times.
     ./cppmicroservices-no-mtime.patch
 
-    # CppMicroServices is failing to build with CMake 4 and GCC 15
-    # PR: <https://github.com/intel/confidential-computing.sgx/pull/1098>
-    # - CMake 4 dropped support for <3.5 and warns on <3.10, so bump the
-    #   `cmake_minimum_required` to 3.10
-    # - Various header files now need `#include <cstdint>` to compile
+    # Add `#include <cstdint>` to CppMicroServices headers that GCC 15 needs
     ./cppmicroservices-compat.patch
   ];
 
@@ -270,7 +267,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Intel SGX Architectural Enclave Service Manager";
-    homepage = "https://github.com/intel/linux-sgx";
+    homepage = "https://github.com/intel/confidential-computing.sgx";
     maintainers = with lib.maintainers; [
       phlip9
       veehaitch
@@ -279,4 +276,4 @@ stdenv.mkDerivation rec {
     platforms = [ "x86_64-linux" ];
     license = [ lib.licenses.bsd3 ];
   };
-}
+})

--- a/pkgs/os-specific/linux/sgx/psw/disable-downloads.patch
+++ b/pkgs/os-specific/linux/sgx/psw/disable-downloads.patch
@@ -1,27 +1,44 @@
 diff --git a/Makefile b/Makefile
-index 144f4e4..834c23e 100644
+index 597f167..f59bacc 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -50,22 +50,17 @@ tips:
+@@ -25,12 +25,10 @@ tips:
  preparation:
  # As SDK build needs to clone and patch openmp, we cannot support the mode that download the source from github as zip.
  # Only enable the download from git
 -	git submodule update --init --recursive
  	cd external/dcap_source/external/jwt-cpp && git apply ../0001-Add-a-macro-to-disable-time-support-in-jwt-for-SGX.patch >/dev/null 2>&1 || \
  	git apply ../0001-Add-a-macro-to-disable-time-support-in-jwt-for-SGX.patch -R --check
+ 	cd external/dcap_source/external/wasm-micro-runtime && git apply ../0001-wasm-micro-runtime.patch >/dev/null 2>&1 || \
+ 	git apply ../0001-wasm-micro-runtime.patch -R --check
 -	./external/dcap_source/QuoteVerification/prepare_sgxssl.sh nobuild
  	cd external/openmp/openmp_code && git apply ../0001-Enable-OpenMP-in-SGX.patch >/dev/null 2>&1 ||  git apply ../0001-Enable-OpenMP-in-SGX.patch --check -R
- 	cd external/protobuf/protobuf_code && git apply ../sgx_protobuf.patch >/dev/null 2>&1 ||  git apply ../sgx_protobuf.patch --check -R
- 	cd external/protobuf/protobuf_code && git apply ../0001-bumped-protobuf-to-1.33.0.patch >/dev/null 2>&1 ||  git apply ../0001-bumped-protobuf-to-1.33.0.patch --check -R
--	cd external/protobuf/protobuf_code && git submodule update --init --recursive && cd third_party/abseil-cpp && git apply ../../../sgx_abseil.patch>/dev/null 2>&1 || git apply ../../../sgx_abseil.patch --check -R
- 	./external/sgx-emm/create_symlink.sh
- 	cd external/cbor && cp -r libcbor sgx_libcbor
- 	cd external/cbor/libcbor && git apply ../raw_cbor.patch >/dev/null 2>&1 || git apply ../raw_cbor.patch --check -R
+
+ 	# TODO refactor to remove duplication with the ./external/protobuf/Makefile.
+@@ -38,8 +36,7 @@ preparation:
+ 	# If you are adding a new patch over this one, write your patch's name to .sgx_patched
+ 	@if ! grep -q "sgx_protobuf" external/protobuf/protobuf_code/.sgx_patched 2>/dev/null; then \
+ 		cd external/protobuf/protobuf_code && \
+-		git apply ../sgx_protobuf.patch >/dev/null 2>&1 || git apply ../sgx_protobuf.patch --check -R && \
+-		git submodule update --init --recursive; \
++		git apply ../sgx_protobuf.patch >/dev/null 2>&1 || git apply ../sgx_protobuf.patch --check -R; \
+ 	fi
+ 	# If you are adding a new patch over this one, write your patch's name to .sgx_patched
+ 	@if ! grep -q "sgx_abseil" external/protobuf/abseil-cpp/.sgx_patched 2>/dev/null; then \
+@@ -52,8 +49,6 @@ preparation:
  	cd external/cbor/sgx_libcbor && git apply ../sgx_cbor.patch >/dev/null 2>&1 || git apply ../sgx_cbor.patch --check -R
  	cd external/ippcp_internal/ipp-crypto && git apply ../0001-IPP-crypto-for-SGX.patch > /dev/null 2>&1 || git apply ../0001-IPP-crypto-for-SGX.patch --check -R
  	cd external/ippcp_internal/ipp-crypto && mkdir -p build
 -	./download_prebuilt.sh
 -	./external/dcap_source/QuoteGeneration/download_prebuilt.sh
- 
+ 	cd external/libcxxrt/libcxxrt_code && git apply ../sgx_libcxxrt.patch >/dev/null 2>&1 || git apply ../sgx_libcxxrt.patch --check -R
+
  psw:
- 	$(MAKE) -C psw/ USE_OPT_LIBS=$(USE_OPT_LIBS)
+@@ -87,7 +82,6 @@ servtd_attest_preparation:
+ # Only enable the download from git
+ 	git submodule update --init --recursive external/dcap_source external/sgx-emm/emm_src external/libcxxrt/libcxxrt_code
+ 	./external/sgx-emm/create_symlink.sh
+-	./external/dcap_source/QuoteVerification/prepare_sgxssl.sh nobuild
+ 	cd external/libcxxrt/libcxxrt_code && (git apply ../sgx_libcxxrt.patch >/dev/null 2>&1 || git apply ../sgx_libcxxrt.patch --check -R)
+
+ ipp:


### PR DESCRIPTION
Update `sgx-psw` to the [latest 2.29 release](https://github.com/intel/confidential-computing.sgx/releases/tag/sgx_2.29).

Release notes:
- 2.28: <https://github.com/intel/confidential-computing.sgx/releases/tag/sgx_2.28>
- 2.29: <https://github.com/intel/confidential-computing.sgx/releases/tag/sgx_2.29>

Diff: <https://github.com/intel/linux-sgx/compare/sgx_2.27..sgx_2.29>

### `sgx-psw` package

- Bump version, source hash, and DCAP submodule (1.24 → 1.26).
- Switch the source repo to `intel/confidential-computing.sgx` (the repo was renamed; the old `intel/linux-sgx` URL still redirects, but the new name is canonical).
- Refresh `disable-downloads.patch` against the 2.29 `Makefile` (`preparation` target now uses `.sgx_patched` guards and adds a `wasm-micro-runtime` step).
- Trim `cppmicroservices-compat.patch`: 2.29 officially supports CMake 4+ so the `cmake_minimum_required` bumps are no longer needed, and upstream added `<cstdint>` to `BundleEvent.h` / `FrameworkEvent.h`. `AnyMap.h` and `ServiceEvent.h` still need it for GCC 15.
- Fix the DCAP version check in `postUnpack`: DCAP 1.26's `download_prebuilt.sh` constructs the filename from a `dcap_version=` shell variable rather than embedding the literal `prebuilt_dcap_X.YZ.tar.gz` string, so the existing literal grep no longer matches.

### NixOS `aesmd` module

Upstream removed the Launch Enclave and EPID attestation in 2.28; the changes here are required for the service to work against `sgx-psw` ≥ 2.28.

- Drop `services.aesmd.settings.whitelistUrl` (the Launch Enclave is gone and there is no whitelist to honour).
- Restrict `services.aesmd.settings.defaultQuotingType` to `ecdsa_256` (EPID quoting types were removed upstream).
- Add `services.aesmd.settings.qplLogLevel` (new upstream option).
- Replace the `ExecStartPre` `install … white_list_cert_to_be_verify.bin` with `mkdir -p /var/opt/aesmd/data`, since the cert file is no longer shipped.

### Notes

- This overlaps with the still-open #505172 (2.27 → 2.28 by @phlip9). Once either lands the other will need a quick rebase. I went directly to 2.29 because the deltas between 2.28 and 2.29 are small (CMake 4+/GCC 15 support, Protobuf 33.4, security flags).

### Testing

- Built `sgx-psw` on x86_64-linux from scratch (Nix 2.33).
- `aesm_service` launches and prints usage.
- `nix-build -A nixosTests.aesmd` passes end-to-end (data-dir, aesm.conf, socket perms, quote-provider specialisation).

### Disclosure

This change was prepared with the assistance of Claude Code (an LLM-based coding tool). I reviewed every line of the diff, ran the package build and the NixOS test myself, and verified the upstream release notes and `download_prebuilt.sh` shape by hand. Per the [Automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
