### PR TITLE
python3Packages.mlx{,-bin,-metal}: add Darwin wheel packaging

### DIFF
--- a/pkgs/development/python-modules/mlx-metal/default.nix
+++ b/pkgs/development/python-modules/mlx-metal/default.nix
@@ -1,0 +1,33 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  lib,
+}:
+
+buildPythonPackage rec {
+  pname = "mlx-metal";
+  version = "0.31.2";
+  format = "wheel";
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    pname = "mlx_metal";
+    inherit version;
+    format = "wheel";
+    dist = "py3";
+    python = "py3";
+    abi = "none";
+    platform = "macosx_14_0_arm64";
+    hash = "sha256-slOFvO4Y/BlAkiVbi1O5o9hInrZQ5ZFg8bV6rdB6otw=";
+  };
+
+  meta = {
+    description = "Prebuilt Metal runtime for MLX";
+    homepage = "https://github.com/ml-explore/mlx";
+    changelog = "https://github.com/ml-explore/mlx/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kinnrai ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [ "aarch64-darwin" ];
+  };
+}

--- a/pkgs/development/python-modules/mlx/bin.nix
+++ b/pkgs/development/python-modules/mlx/bin.nix
@@ -1,0 +1,88 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  lib,
+  mlx-metal,
+  python,
+  runCommand,
+  stdenv,
+}:
+
+let
+  version = "0.31.2";
+  inherit (python) pythonVersion;
+
+  getSrcFromPypi =
+    {
+      platform,
+      dist,
+      hash,
+    }:
+    fetchPypi {
+      pname = "mlx";
+      inherit
+        version
+        platform
+        dist
+        hash
+        ;
+      format = "wheel";
+      python = dist;
+      abi = dist;
+    };
+
+  srcs = {
+    "3.13-aarch64-darwin" = getSrcFromPypi {
+      platform = "macosx_14_0_arm64";
+      dist = "cp313";
+      hash = "sha256-Gz+w3alVsNVSzle91vQrMwmrIbBn5AWH1oSEQ9MH6R8=";
+    };
+    "3.14-aarch64-darwin" = getSrcFromPypi {
+      platform = "macosx_14_0_arm64";
+      dist = "cp314";
+      hash = "sha256-oTyc4jw97vaqWgkxXnlT4aXcMR6FH6Fvx0yB+yUJwLk=";
+    };
+  };
+in
+buildPythonPackage (finalAttrs: {
+  pname = "mlx";
+  inherit version;
+  format = "wheel";
+  __structuredAttrs = true;
+
+  disabled = !(srcs ? "${pythonVersion}-${stdenv.hostPlatform.system}");
+
+  src =
+    srcs."${pythonVersion}-${stdenv.hostPlatform.system}"
+      or (throw "mlx-bin is only supported on Python ${builtins.concatStringsSep ", " (builtins.attrNames srcs)}");
+
+  dependencies = [ mlx-metal ];
+
+  postInstall = ''
+    # The Python wheel expects libmlx.dylib and mlx.metallib to live under
+    # mlx/lib next to the extension module, but those files are shipped by the
+    # separate mlx-metal wheel.
+    ln -s ${mlx-metal}/${python.sitePackages}/mlx/lib $out/${python.sitePackages}/mlx/lib
+  '';
+
+  pythonImportsCheck = [ "mlx" ];
+
+  passthru.tests.linkedMetalRuntime =
+    runCommand "python${python.pythonVersion}-mlx-bin-linked-metal-runtime" { }
+      ''
+        test -L ${finalAttrs.finalPackage}/${python.sitePackages}/mlx/lib
+        test -e ${finalAttrs.finalPackage}/${python.sitePackages}/mlx/lib/libmlx.dylib
+        test -e ${finalAttrs.finalPackage}/${python.sitePackages}/mlx/lib/mlx.metallib
+        touch $out
+      '';
+
+  meta = {
+    description = "Prebuilt MLX wheel for Apple silicon with Metal runtime";
+    homepage = "https://github.com/ml-explore/mlx";
+    changelog = "https://github.com/ml-explore/mlx/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kinnrai ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [ "aarch64-darwin" ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10379,7 +10379,11 @@ self: super: with self; {
 
   mlx = callPackage ../development/python-modules/mlx { };
 
+  mlx-bin = callPackage ../development/python-modules/mlx/bin.nix { };
+
   mlx-lm = callPackage ../development/python-modules/mlx-lm { };
+
+  mlx-metal = callPackage ../development/python-modules/mlx-metal { };
 
   mlx-vlm = callPackage ../development/python-modules/mlx-vlm { };
 


### PR DESCRIPTION
This PR adds Darwin wheel packaging for [MLX](https://github.com/ml-explore/mlx).

It introduces:

- `python3Packages.mlx-bin`
- `python3Packages.mlx-metal`

`mlx-bin` packages the upstream `mlx` wheel for Apple silicon, and `mlx-metal` packages the companion `mlx_metal` wheel used by the `mlx` wheel at runtime.

I started working on packaging [oMLX](https://github.com/jundot/omlx) for nixpkgs, and while testing it I found that using the current source-built `mlx` on Darwin makes inference so slow that the service is close to unusable in practice. Looking into it, I found that the current nixpkgs build of `mlx` disables Metal support on Darwin, because building the Metal kernels requires Apple's `metal` command-line tool, which is not available as a normal pure build dependency in nixpkgs. As a result, the current source build cannot provide the upstream Metal-backed runtime on macOS.

If this approach looks reasonable, may I ask whether `mlx-bin` would also be a suitable default for `mlx` on Darwin in a follow-up change?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test