### PR TITLE
nixos/steam: remove unnecessary bwrap wrapper

### DIFF
--- a/nixos/modules/programs/steam.nix
+++ b/nixos/modules/programs/steam.nix
@@ -56,38 +56,29 @@ in
       '';
       apply =
         steam:
-        steam.override (
-          prev:
-          {
-            extraEnv =
-              (lib.optionalAttrs (cfg.extraCompatPackages != [ ]) {
-                STEAM_EXTRA_COMPAT_TOOLS_PATHS = extraCompatPaths;
-              })
-              // (lib.optionalAttrs cfg.extest.enable {
-                LD_PRELOAD = "${pkgs.pkgsi686Linux.extest}/lib/libextest.so";
-              })
-              // (prev.extraEnv or { });
-            extraLibraries =
-              pkgs:
-              let
-                prevLibs = if prev ? extraLibraries then prev.extraLibraries pkgs else [ ];
-                additionalLibs =
-                  with config.hardware.graphics;
-                  if pkgs.stdenv.hostPlatform.is64bit then
-                    [ package ] ++ extraPackages
-                  else
-                    [ package32 ] ++ extraPackages32;
-              in
-              prevLibs ++ additionalLibs;
-            extraPkgs = p: (cfg.extraPackages ++ lib.optionals (prev ? extraPkgs) (prev.extraPkgs p));
-          }
-          // lib.optionalAttrs (cfg.gamescopeSession.enable && gamescopeCfg.capSysNice) {
-            buildFHSEnv = pkgs.buildFHSEnv.override {
-              # use the setuid wrapped bubblewrap
-              bubblewrap = "${config.security.wrapperDir}/..";
-            };
-          }
-        );
+        steam.override (prev: {
+          extraEnv =
+            (lib.optionalAttrs (cfg.extraCompatPackages != [ ]) {
+              STEAM_EXTRA_COMPAT_TOOLS_PATHS = extraCompatPaths;
+            })
+            // (lib.optionalAttrs cfg.extest.enable {
+              LD_PRELOAD = "${pkgs.pkgsi686Linux.extest}/lib/libextest.so";
+            })
+            // (prev.extraEnv or { });
+          extraLibraries =
+            pkgs:
+            let
+              prevLibs = if prev ? extraLibraries then prev.extraLibraries pkgs else [ ];
+              additionalLibs =
+                with config.hardware.graphics;
+                if pkgs.stdenv.hostPlatform.is64bit then
+                  [ package ] ++ extraPackages
+                else
+                  [ package32 ] ++ extraPackages32;
+            in
+            prevLibs ++ additionalLibs;
+          extraPkgs = p: (cfg.extraPackages ++ lib.optionals (prev ? extraPkgs) (prev.extraPkgs p));
+        });
       description = ''
         The Steam package to use. Additional libraries are added from the system
         configuration to ensure graphics work properly.
@@ -216,16 +207,6 @@ in
       # this fixes the "glXChooseVisual failed" bug, context: https://github.com/NixOS/nixpkgs/issues/47932
       enable = true;
       enable32Bit = true;
-    };
-
-    security.wrappers = lib.mkIf (cfg.gamescopeSession.enable && gamescopeCfg.capSysNice) {
-      # needed or steam fails
-      bwrap = {
-        owner = "root";
-        group = "root";
-        source = "${pkgs.bubblewrap}/bin/bwrap";
-        setuid = true;
-      };
     };
 
     programs.steam.extraPackages = cfg.fontPackages;


### PR DESCRIPTION
Remove the Steam module's `bwrap` setuid wrapper that is enabled when
`programs.steam.gamescopeSession.enable` and `programs.gamescope.capSysNice`
are both enabled.

Gamescope has its own wrapper in the gamescope module, so the extra wrapper in the Steam module is unnecessary and causes the failure reported in the issue linked below.

Resolves #523427

## Testing

- `nix-instantiate nixos/release.nix -A tests.steam` - unavailable; no `tests.steam` attribute exists
- Reviewed diff; change only removes the Steam module `bwrap` wrapper requested in #523427

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
