### PR TITLE
cc-switch: init at 3.15.0

### DIFF
--- a/pkgs/by-name/cc/cc-switch/package.nix
+++ b/pkgs/by-name/cc/cc-switch/package.nix
@@ -1,0 +1,138 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+
+  copyDesktopItems,
+  jq,
+  makeDesktopItem,
+  nodejs,
+  pkg-config,
+  pnpm_10,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  wrapGAppsHook3,
+
+  glib-networking,
+  libayatana-appindicator,
+  libsoup_3,
+  openssl,
+  webkitgtk_4_1,
+
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cc-switch";
+  version = "3.15.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "farion1231";
+    repo = "cc-switch";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OR5GnHCa2hwpZw9mYIVHF4blQwzAnxtysPbLun8adAI=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      ;
+    pnpm = pnpm_10;
+    fetcherVersion = 3;
+    hash = "sha256-Vs+/KLICqciF7dnC3iRH9TFzNCtXDgOkWFPLxdwA0rE=";
+  };
+
+  postPatch = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+    # libappindicator-sys dlopens libayatana-appindicator3.so.1 at runtime; autoPatchelf can't catch it.
+    substituteInPlace $cargoDepsCopy/*/libappindicator-sys-*/src/lib.rs \
+      --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
+  '';
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  cargoHash = "sha256-h2yvzz+TDOqAXDTsjjRL6vGLeqSSz3N1Id3H4dtI5nk=";
+
+  nativeBuildInputs = [
+    jq
+    nodejs
+    pnpmConfigHook
+    pnpm_10
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    copyDesktopItems
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs = lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    glib-networking
+    libayatana-appindicator
+    libsoup_3
+    openssl
+    webkitgtk_4_1
+  ];
+
+  # tauri-build embeds frontendDist (../dist) at compile time; populate it
+  # before cargo build runs.
+  preBuild = ''
+    pnpm run build:renderer
+  '';
+
+  # cc_switch_lib is an internal staticlib+cdylib+rlib; only the binary is needed.
+  # tauri/custom-protocol enables embedded-asset serving via `tauri://localhost/`;
+  # without it, WKWebView/webkit2gtk fall through to devUrl (http://localhost:3000)
+  # and blank-screen with NSURLErrorCannotConnectToHost.
+  cargoBuildFlags = [
+    "--bin"
+    "cc-switch"
+    "--features=tauri/custom-protocol"
+  ];
+
+  # Proxy startup test binds to a local address, which the darwin sandbox blocks.
+  checkFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+    "--skip=services::provider::tests::update_current_claude_provider_syncs_live_when_proxy_takeover_detected_without_backup"
+  ];
+
+  postInstall = ''
+    rm -rf $out/lib
+    install -Dm644 src-tauri/icons/32x32.png $out/share/icons/hicolor/32x32/apps/cc-switch.png
+    install -Dm644 src-tauri/icons/128x128.png $out/share/icons/hicolor/128x128/apps/cc-switch.png
+    install -Dm644 src-tauri/icons/128x128@2x.png $out/share/icons/hicolor/256x256/apps/cc-switch.png
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "cc-switch";
+      desktopName = "CC Switch";
+      exec = finalAttrs.meta.mainProgram;
+      icon = "cc-switch";
+      comment = finalAttrs.meta.description;
+      categories = [
+        "Development"
+        "Utility"
+      ];
+      mimeTypes = [ "x-scheme-handler/ccswitch" ];
+      startupWMClass = "cc-switch";
+    })
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "All-in-one assistant for Claude Code, Codex, OpenCode, Gemini CLI and other AI coding agents";
+    homepage = "https://ccswitch.io";
+    downloadPage = "https://github.com/farion1231/cc-switch";
+    changelog = "https://github.com/farion1231/cc-switch/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    mainProgram = "cc-switch";
+    maintainers = with lib.maintainers; [ imcvampire ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Desktop app for managing Claude Code / Codex / Gemini CLI configurations.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
