### PR TITLE
linuxPackages.nvidiaPackages.new_feature: 590.48.01 -> 610.43.02

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/builder.sh
+++ b/pkgs/os-specific/linux/nvidia-x11/builder.sh
@@ -142,7 +142,7 @@ installPhase() {
 
     if [ -n "$firmware" ]; then
         # Install the GSP firmware
-        install -Dm644 -t $firmware/lib/firmware/nvidia/$version firmware/gsp*.bin
+        install -Dm644 -t $firmware/lib/firmware/nvidia/$version firmware/*.bin
     fi
 
     # All libs except GUI-only are installed now, so fixup them.

--- a/pkgs/os-specific/linux/nvidia-x11/default.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/default.nix
@@ -80,13 +80,12 @@ rec {
   };
 
   new_feature = generic {
-    version = "590.48.01";
-    sha256_64bit = "sha256-ueL4BpN4FDHMh/TNKRCeEz3Oy1ClDWto1LO/LWlr1ok=";
-    sha256_aarch64 = "sha256-FOz7f6pW1NGM2f74kbP6LbNijxKj5ZtZ08bm0aC+/YA=";
-    openSha256 = "sha256-hECHfguzwduEfPo5pCDjWE/MjtRDhINVr4b1awFdP44=";
-    settingsSha256 = "sha256-NWsqUciPa4f1ZX6f0By3yScz3pqKJV1ei9GvOF8qIEE=";
-    persistencedSha256 = "sha256-wsNeuw7IaY6Qc/i/AzT/4N82lPjkwfrhxidKWUtcwW8=";
-    patchesOpen = [ kernel_6_19_patch ];
+    version = "610.43.02";
+    sha256_64bit = "sha256-MDSgVLtM33dS/43CclZMsQVROAS/9TU4lFkBsWyndGM=";
+    sha256_aarch64 = "sha256-isWTnokUA/dzWocFBLalnk4+O5gSExVjs3dVpdYTU88=";
+    openSha256 = "sha256-hP5NVZZ4vGsACHLmUDKq4uckpd/kn1GxCSYnnJfAuBs=";
+    settingsSha256 = "sha256-0YAhufRgjDW+uR+kjaTb154fibpcDw8QowfrucoZsKE=";
+    persistencedSha256 = "sha256-Whgv9X+v2fRhzliOl2LzltY9v1SxDafFfv3IUPqj/hk=";
   };
 
   beta = generic {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://www.nvidia.com/en-us/drivers/details/271414/

### Note: Some Wayland compositors, such as KWin, have issues with the new color pipeline. Set the parameter `color_pipeline=0` for the NVIDIA DRM module to work around this issue.
<details>

<summary>changelog</summary>

- Added support for the following Vulkan extensions:
VK_EXT_shader_long_vector
VK_KHR_internally_synchronized_queues
VK_NV_push_constant_bank
- Added support for creating Vulkan logical devices from multiple physical devices on select cards via VK_KHR_device_group_creation. This feature can be enabled by setting the environment variable
__VK_ENABLE_DEVICE_GROUPS=1.
- Fixed a Vulkan performance regression in Doom: The Dark Ages introduced in the 590 driver series.
- Improved performance in Starfield.
- Added support for FP16 EGL framebuffer configurations on Wayland.
- Added support for DRM format modifiers for multiplanar YCbCr formats.
- Added support for mmap on DMABUF file descriptors exported from discrete NVIDIA GPUs.
- Added support in the nvidia-drm kernel module for the per-plane DRM color pipeline API introduced in Linux v6.19. This allows Wayland compositors to offload color management (e.g. for HDR) to NVIDIA display hardware via the upstream COLOR_PIPELINE plane property and associated colorops, in place of NVIDIA's vendor-specific color properties.

Some Wayland compositors may not yet correctly handle color pipelines that contain non-bypassable colorops, which can cause a blank screen (e.g. when enabling system HDR). A new 'color_pipeline' kernel module parameter has been added to nvidia-drm that may be used to disable DRM color pipeline support as a workaround on affected compositors. See the "Wayland Known Issues" appendix of the README for further information.
- Removed support for using the NVIDIA X11 driver with Xinerama.
- Fixed a regression introduced in 580.65.06, that caused some mode timings, such as 1920x1080@75, to no longer be available.
- Reverted a change that led to a user regression in 580.105.08 that caused display modes to be invalidated on a number of monitors.

</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
