### PR TITLE
modular-services: allow running as user-level systemd services

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1958,8 +1958,8 @@
   ./system/boot/zram-as-tmp.nix
   ./system/boot/zswap.nix
   ./system/etc/etc-activation.nix
-  ./system/service/systemd/system.nix
-  ./system/service/systemd/user.nix
+  ./system/service/systemd/system
+  ./system/service/systemd/user
   ./tasks/auto-upgrade.nix
   ./tasks/bcache.nix
   ./tasks/cpu-freq.nix

--- a/nixos/modules/system/service/systemd/system/config-data-path.nix
+++ b/nixos/modules/system/service/systemd/system/config-data-path.nix
@@ -1,0 +1,39 @@
+# Tests in: ../../../tests/modular-service-etc/test.nix
+# This module sets the path for configData entries in systemd services
+let
+  setPathsModule =
+    prefix:
+    { lib, name, ... }:
+    let
+      inherit (lib) mkOption types;
+      servicePrefix = "${prefix}${name}";
+    in
+    {
+      _class = "service";
+      options = {
+        # Extend portable configData option
+        configData = mkOption {
+          type = types.lazyAttrsOf (
+            types.submodule (
+              { config, ... }:
+              {
+                config = {
+                  path = lib.mkDefault "/etc/system-services/${servicePrefix}/${config.name}";
+                };
+              }
+            )
+          );
+        };
+        services = mkOption {
+          type = types.attrsOf (
+            types.submoduleWith {
+              modules = [
+                (setPathsModule "${servicePrefix}-")
+              ];
+            }
+          );
+        };
+      };
+    };
+in
+setPathsModule ""

--- a/nixos/modules/system/service/systemd/system/default.nix
+++ b/nixos/modules/system/service/systemd/system/default.nix
@@ -8,14 +8,14 @@
 
 let
   inherit (lib)
+    concatLists
     concatMapAttrs
+    mapAttrsToList
     mkOption
     types
-    concatLists
-    mapAttrsToList
     ;
 
-  portable-lib = import ../../../../../lib/services/lib.nix { inherit lib; };
+  portable-lib = import ../../../../../../lib/services/lib.nix { inherit lib; };
 
   dash =
     before: after:
@@ -63,7 +63,7 @@ let
   modularServiceConfiguration = portable-lib.configure {
     serviceManagerPkgs = pkgs;
     extraRootModules = [
-      ./service.nix
+      ../service.nix
       ./config-data-path.nix
     ];
     extraRootSpecialArgs = {

--- a/nixos/modules/system/service/systemd/system/test.nix
+++ b/nixos/modules/system/service/systemd/system/test.nix
@@ -92,7 +92,7 @@ let
         };
 
       # irrelevant stuff
-      system.stateVersion = "25.05";
+      system.stateVersion = "26.05";
       fileSystems."/" = {
         device = "/test/dummy";
         fsType = "auto";

--- a/nixos/modules/system/service/systemd/user.nix
+++ b/nixos/modules/system/service/systemd/user.nix
@@ -1,3 +1,0 @@
-# TBD, analogous to system.nix but for user units
-{
-}

--- a/nixos/modules/system/service/systemd/user/config-data-path.nix
+++ b/nixos/modules/system/service/systemd/user/config-data-path.nix
@@ -1,5 +1,10 @@
-# Tests in: ../../tests/modular-service-etc/test.nix
-# This module sets the path for configData entries in systemd services
+# Analogous to ../system/config-data-path.nix but scoped per user.
+# Usage: import ./config-data-path.nix userName
+#
+# configData paths land under the per-user profile:
+#   /etc/profiles/per-user/$USER/etc/xdg/user-services/...
+# which is in $XDG_CONFIG_DIRS (boot/systemd/user.nix wires this in).
+userName:
 let
   setPathsModule =
     prefix:
@@ -11,14 +16,13 @@ let
     {
       _class = "service";
       options = {
-        # Extend portable configData option
         configData = mkOption {
           type = types.lazyAttrsOf (
             types.submodule (
               { config, ... }:
               {
                 config = {
-                  path = lib.mkDefault "/etc/system-services/${servicePrefix}/${config.name}";
+                  path = lib.mkDefault "/etc/profiles/per-user/${userName}/etc/xdg/user-services/${servicePrefix}/${config.name}";
                 };
               }
             )

--- a/nixos/modules/system/service/systemd/user/default.nix
+++ b/nixos/modules/system/service/systemd/user/default.nix
@@ -1,0 +1,208 @@
+{
+  lib,
+  config,
+  options,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    concatMapAttrs
+    mkOption
+    types
+    concatLists
+    mapAttrsToList
+    ;
+
+  portable-lib = import ../../../../../../lib/services/lib.nix { inherit lib; };
+
+  dash =
+    before: after:
+    if after == "" then
+      before
+    else if before == "" then
+      after
+    else
+      "${before}-${after}";
+
+  mkConfiguration =
+    userName:
+    portable-lib.configure {
+      serviceManagerPkgs = pkgs;
+      extraRootModules = [
+        ../service.nix
+        (import ./config-data-path.nix userName)
+        ./defaults.nix
+      ];
+      extraRootSpecialArgs = {
+        systemdPackage = config.systemd.package;
+      };
+    };
+
+  # Like system/default.nix's makeUnits, but prefixes with "${userName}--" and
+  # suppresses WantedBy= on services (auto-start is wired per-user via the profile package).
+  makeUnits =
+    userName: unitType: prefix: service:
+    concatMapAttrs (unitName: unitModule: {
+      "${userName}--${dash prefix unitName}" =
+        { ... }:
+        {
+          imports = [ unitModule ];
+        }
+        // lib.optionalAttrs (unitType == "services") {
+          wantedBy = lib.mkForce [ ];
+        };
+    }) service.systemd.${unitType}
+    // concatMapAttrs (
+      subServiceName: subService: makeUnits userName unitType (dash prefix subServiceName) subService
+    ) service.services;
+
+  # Collect (globalName -> localName) pairs for all service units in the tree,
+  # used to build the per-user profile package symlinks.
+  collectServiceNames =
+    userName: prefix: service:
+    lib.mapAttrs' (
+      unitName: _: lib.nameValuePair "${userName}--${dash prefix unitName}" (dash prefix unitName)
+    ) service.systemd.services
+    // concatMapAttrs (
+      subServiceName: subService: collectServiceNames userName (dash prefix subServiceName) subService
+    ) service.services;
+
+  makeEtcLinks =
+    prefix: service:
+    lib.mapAttrsToList (
+      _: cfg:
+      let
+        # cfg.path is e.g. /etc/profiles/per-user/alice/etc/xdg/user-services/foo/item
+        # Strip the leading /etc/profiles/per-user/<user>/ to get the within-profile path.
+        stripped = lib.removePrefix "/etc/profiles/per-user/" cfg.path;
+        perUserPath = lib.concatStringsSep "/" (lib.tail (lib.splitString "/" stripped));
+      in
+      lib.optionalAttrs cfg.enable { "${perUserPath}" = cfg.source; }
+    ) (service.configData or { })
+    ++ concatLists (
+      mapAttrsToList (
+        subServiceName: subService: makeEtcLinks (dash prefix subServiceName) subService
+      ) service.services
+    );
+
+  # Build the per-user profile package containing unit symlinks and configData.
+  # `user` is the user submodule config; `config.systemd.user.units` is the outer NixOS
+  # config, closed over from the module arguments above.
+  makeUserPkg =
+    userName: user:
+    let
+      allNames = concatMapAttrs (
+        serviceName: service: collectServiceNames userName serviceName service
+      ) user.services;
+
+      etcLinks = lib.foldl' (acc: m: acc // m) { } (
+        concatLists (mapAttrsToList (serviceName: service: makeEtcLinks serviceName service) user.services)
+      );
+
+      unitSymlinks = lib.concatMapAttrs (
+        globalName: localName:
+        let
+          unitDrv = config.systemd.user.units."${globalName}.service".unit;
+        in
+        {
+          "share/systemd/user/${localName}.service" = "${unitDrv}/${globalName}.service";
+          "share/systemd/user/default.target.wants/${localName}.service" = "../${localName}.service";
+        }
+      ) allNames;
+    in
+    pkgs.runCommand "user-services-${userName}" { preferLocalBuild = true; } ''
+      ${lib.concatStringsSep "\n" (
+        mapAttrsToList (dest: src: ''
+          mkdir -p "$out/$(dirname "${dest}")"
+          ln -s ${lib.escapeShellArg src} "$out/${dest}"
+        '') (unitSymlinks // etcLinks)
+      )}
+    '';
+in
+{
+  _class = "nixos";
+
+  # First half of the magic: mix systemd logic into the otherwise abstract services
+  options = {
+    users.users = mkOption {
+      type = types.attrsOf (
+        types.submodule (
+          { name, config, ... }:
+          {
+            options.services = mkOption {
+              description = ''
+                A collection of [modular services](https://nixos.org/manual/nixos/unstable/#modular-services)
+                that are configured as per-user systemd user units.
+              '';
+              type = types.attrsOf (mkConfiguration name).serviceSubmodule;
+              default = { };
+              visible = "shallow";
+            };
+
+            config.packages = lib.mkIf (config.services != { }) [
+              (makeUserPkg name config)
+            ];
+          }
+        )
+      );
+    };
+  };
+
+  # Second half of the magic: siphon units that were defined in isolation to the system
+  config = {
+
+    assertions = concatLists (
+      mapAttrsToList (
+        userName: user:
+        concatLists (
+          mapAttrsToList (
+            serviceName: cfg:
+            portable-lib.getAssertions (
+              options.users.users.loc
+              ++ [
+                userName
+                "services"
+                serviceName
+              ]
+            ) cfg
+          ) user.services
+        )
+      ) config.users.users
+    );
+
+    warnings = concatLists (
+      mapAttrsToList (
+        userName: user:
+        concatLists (
+          mapAttrsToList (
+            serviceName: cfg:
+            portable-lib.getWarnings (
+              options.users.users.loc
+              ++ [
+                userName
+                "services"
+                serviceName
+              ]
+            ) cfg
+          ) user.services
+        )
+      ) config.users.users
+    );
+
+    systemd.user.services = concatMapAttrs (
+      userName: user:
+      concatMapAttrs (
+        serviceName: topLevelService: makeUnits userName "services" serviceName topLevelService
+      ) user.services
+    ) config.users.users;
+
+    systemd.user.sockets = concatMapAttrs (
+      userName: user:
+      concatMapAttrs (
+        serviceName: topLevelService: makeUnits userName "sockets" serviceName topLevelService
+      ) user.services
+    ) config.users.users;
+  };
+}

--- a/nixos/modules/system/service/systemd/user/defaults.nix
+++ b/nixos/modules/system/service/systemd/user/defaults.nix
@@ -1,0 +1,12 @@
+{ lib, ... }:
+{
+  _class = "service";
+
+  config = {
+    # Override the system-level default of `multi-user.target` (set at `mkDefault` priority 1000
+    # in service.nix). `mkOverride 900` wins over `mkDefault` but loses to explicit user settings
+    # (priority 100). The global `systemd.user.services` entry then forces `wantedBy = []` to
+    # suppress auto-start system-wide; auto-start is wired per-user via the profile package.
+    systemd.services."".wantedBy = lib.mkOverride 900 [ "default.target" ];
+  };
+}

--- a/nixos/modules/system/service/systemd/user/test.nix
+++ b/nixos/modules/system/service/systemd/user/test.nix
@@ -1,0 +1,124 @@
+# Run:
+#   nix-build -A nixosTests.modularUserServiceUnit
+
+{
+  evalSystem,
+  runCommand,
+  hello,
+  ...
+}:
+
+let
+  machine = evalSystem (
+    { lib, ... }:
+    let
+      hello' = lib.getExe hello;
+    in
+    {
+      users.users.alice = {
+        isNormalUser = true;
+        services.hello.process.argv = [
+          hello'
+          "--greeting"
+          "hi alice"
+        ];
+        services.bar = {
+          process.argv = [
+            hello'
+            "--greeting"
+            "bar"
+          ];
+          services.db.process.argv = [
+            hello'
+            "--greeting"
+            "bar-db"
+          ];
+        };
+      };
+
+      users.users.bob = {
+        isNormalUser = true;
+        # Same service name as alice — must not collide.
+        services.hello.process.argv = [
+          hello'
+          "--greeting"
+          "hi bob"
+        ];
+      };
+
+      system.stateVersion = "26.05";
+      fileSystems."/" = {
+        device = "/test/dummy";
+        fsType = "auto";
+      };
+      boot.loader.grub.enable = false;
+    }
+  );
+
+  inherit (machine.config.system.build) toplevel;
+
+  # The per-user profile is built as environment.etc."profiles/per-user/<name>".source.
+  # It is a buildEnv derivation whose paths include the user-services package.
+  aliceProfile = machine.config.environment.etc."profiles/per-user/alice".source;
+  bobProfile = machine.config.environment.etc."profiles/per-user/bob".source;
+
+  # Extract the user-services-* package from the buildEnv paths for symlink-target checks.
+  aliceServicePkg = builtins.head (
+    builtins.filter (
+      p: builtins.match ".*user-services-alice.*" (toString p) != null
+    ) aliceProfile.paths
+  );
+
+  bobServicePkg = builtins.head (
+    builtins.filter (p: builtins.match ".*user-services-bob.*" (toString p) != null) bobProfile.paths
+  );
+in
+runCommand "test-modular-user-service-systemd-units"
+  {
+    passthru = {
+      inherit
+        machine
+        toplevel
+        aliceProfile
+        bobProfile
+        aliceServicePkg
+        bobServicePkg
+        ;
+    };
+  }
+  ''
+    (
+      set -x
+
+      # Global units exist in /etc/systemd/user/ with double-dash prefix.
+      [[ -e ${toplevel}/etc/systemd/user/alice--hello.service ]]
+      [[ -e ${toplevel}/etc/systemd/user/bob--hello.service ]]
+      [[ -e ${toplevel}/etc/systemd/user/alice--bar.service ]]
+      [[ -e ${toplevel}/etc/systemd/user/alice--bar-db.service ]]
+
+      # Global units must NOT have WantedBy= (auto-start suppressed system-wide).
+      grep -v 'WantedBy=' ${toplevel}/etc/systemd/user/alice--hello.service
+
+      # Per-user profile for alice: local names exposed via symlinks.
+      [[ -L ${aliceProfile}/share/systemd/user/hello.service ]]
+      [[ -L ${aliceProfile}/share/systemd/user/bar.service ]]
+      [[ -L ${aliceProfile}/share/systemd/user/bar-db.service ]]
+
+      # Auto-start symlinks in default.target.wants/.
+      [[ -L ${aliceProfile}/share/systemd/user/default.target.wants/hello.service ]]
+      [[ -L ${aliceProfile}/share/systemd/user/default.target.wants/bar.service ]]
+      [[ -L ${aliceProfile}/share/systemd/user/default.target.wants/bar-db.service ]]
+
+      # Alice's hello.service symlink resolves to alice-- global unit, not bob--.
+      [[ $(readlink ${aliceServicePkg}/share/systemd/user/hello.service) == *alice--hello* ]]
+
+      # Bob's profile has its own hello.service resolving to bob-- global unit.
+      [[ -L ${bobProfile}/share/systemd/user/hello.service ]]
+      [[ $(readlink ${bobServicePkg}/share/systemd/user/hello.service) == *bob--hello* ]]
+
+      # ExecStart in global unit contains the correct greeting.
+      grep '"hi alice"' ${toplevel}/etc/systemd/user/alice--hello.service
+      grep '"hi bob"' ${toplevel}/etc/systemd/user/bob--hello.service
+    )
+    touch $out
+  ''

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -991,7 +991,11 @@ in
   mobilizon = runTest ./mobilizon.nix;
   mod_perl = runTest ./mod_perl.nix;
   modular-service-etc = runTest ./modular-service-etc/test.nix;
-  modularService = pkgs.callPackage ../modules/system/service/systemd/test.nix {
+  modularService = pkgs.callPackage ../modules/system/service/systemd/system/test.nix {
+    inherit evalSystem;
+  };
+  modularUserService = runTest ./modular-user-service.nix;
+  modularUserServiceUnit = pkgs.callPackage ../modules/system/service/systemd/user/test.nix {
     inherit evalSystem;
   };
   molly-brown = runTest ./molly-brown.nix;

--- a/nixos/tests/modular-user-service.nix
+++ b/nixos/tests/modular-user-service.nix
@@ -1,0 +1,53 @@
+{
+  _class = "nixosTest";
+  name = "modular-user-service";
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      users.users.alice = {
+        isNormalUser = true;
+        password = "alice";
+        services.hello = {
+          process.argv = [
+            "${pkgs.coreutils}/bin/sleep"
+            "infinity"
+          ];
+        };
+      };
+
+      system.stateVersion = "26.05";
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+
+    # Enable linger so alice's user systemd instance starts without interactive login.
+    machine.succeed("loginctl enable-linger alice")
+
+    # Wait for alice's user systemd instance to come up.
+    machine.wait_until_succeeds(
+      "systemctl --user --machine=alice@ is-active basic.target", timeout=30
+    )
+
+    # The per-user profile exposes the local unit name via share/systemd/user/.
+    # systemd discovers it through $XDG_DATA_DIRS.
+    machine.succeed(
+      "test -L /etc/profiles/per-user/alice/share/systemd/user/hello.service"
+    )
+    machine.succeed(
+      "test -L /etc/profiles/per-user/alice/share/systemd/user/default.target.wants/hello.service"
+    )
+
+    # The profile symlink targets the global (prefixed) unit file.
+    machine.succeed(
+      "readlink /etc/profiles/per-user/alice/share/systemd/user/hello.service | grep -q alice--hello"
+    )
+
+    # hello.service should have been auto-started via default.target.wants.
+    machine.wait_until_succeeds(
+      "systemctl --user --machine=alice@ is-active hello.service", timeout=30
+    )
+  '';
+}


### PR DESCRIPTION
Disclaimer: I used a coding agent in the creation of this patch.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
