### PR TITLE
lib: remove assertMsg, throwIf, and throwIfNot usage

### DIFF
--- a/lib/derivations.nix
+++ b/lib/derivations.nix
@@ -6,7 +6,6 @@ let
     isString
     mapAttrs
     removeAttrs
-    throwIfNot
     ;
 
   showMaybeAttrPosPre =
@@ -108,18 +107,18 @@ in
       # attrset spine returned by lazyDerivation does not depend on it.
       # Instead, the individual derivation attributes do depend on it.
       checked =
-        throwIfNot (derivation.type or null == "derivation") "lazyDerivation: input must be a derivation."
-          throwIfNot
-          # NOTE: Technically we could require our outputs to be a subset of the
-          # actual ones, or even leave them unchecked and fail on a lazy basis.
-          # However, consider the case where an output is added in the underlying
-          # derivation, such as dev. lazyDerivation would remove it and cause it
-          # to fail as a buildInputs item, without any indication as to what
-          # happened. Hence the more stringent condition. We could consider
-          # adding a flag to control this behavior if there's a valid case for it,
-          # but the documentation must have a note like this.
-          (derivation.outputs == outputs)
-          ''
+        if derivation.type or null != "derivation" then
+          throw "lazyDerivation: input must be a derivation."
+        # NOTE: Technically we could require our outputs to be a subset of the
+        # actual ones, or even leave them unchecked and fail on a lazy basis.
+        # However, consider the case where an output is added in the underlying
+        # derivation, such as dev. lazyDerivation would remove it and cause it
+        # to fail as a buildInputs item, without any indication as to what
+        # happened. Hence the more stringent condition. We could consider
+        # adding a flag to control this behavior if there's a valid case for it,
+        # but the documentation must have a note like this.
+        else if derivation.outputs != outputs then
+          throw ''
             lib.lazyDerivation: The derivation ${derivation.name or "<unknown>"} has outputs that don't match the assumed outputs.
 
             Assumed outputs passed to lazyDerivation${showMaybeAttrPosPre ",\n    at " "outputs" args}:
@@ -142,6 +141,7 @@ in
             If none of the above works for you, replace the lib.lazyDerivation call by the
             expression in the derivation argument.
           ''
+        else
           derivation;
     in
     {

--- a/lib/fetchers.nix
+++ b/lib/fetchers.nix
@@ -22,7 +22,6 @@ let
     concatMapStringsSep
     head
     length
-    throwIf
     ;
   inherit (lib.attrsets)
     attrsToList
@@ -130,7 +129,7 @@ rec {
             hashesAsNVPairs = attrsToList (intersectAttrs hashSet args);
           in
           if hashesAsNVPairs == [ ] then
-            throwIf required "fetcher called without `hash`" null
+            if required then throw "fetcher called without `hash`" else null
           else if length hashesAsNVPairs != 1 then
             throw "fetcher called with mutually-incompatible arguments: ${
               concatMapStringsSep ", " (a: a.name) hashesAsNVPairs

--- a/lib/generators.nix
+++ b/lib/generators.nix
@@ -24,7 +24,6 @@ let
   inherit (lib)
     addErrorContext
     any
-    assertMsg
     attrNames
     attrValues
     concatLists
@@ -64,7 +63,6 @@ let
     reverseList
     splitString
     tail
-    toList
     ;
 
   inherit (lib.strings)
@@ -849,7 +847,7 @@ rec {
         _type == "lua-inline";
 
       generatedBindings =
-        assert assertMsg (badVarNames == [ ]) "Bad Lua var names: ${toPretty { } badVarNames}";
+        assert badVarNames == [ ] || throw "Bad Lua var names: ${toPretty { } badVarNames}";
         concatStrings (mapAttrsToList (key: value: "${indent}${key} = ${toLua innerArgs value}\n") v);
 
       # https://en.wikibooks.org/wiki/Lua_Programming/variable#Variable_names

--- a/lib/gvariant.nix
+++ b/lib/gvariant.nix
@@ -194,11 +194,12 @@ rec {
       vs = map mkValue (
         if elems == [ ] then throw "Please create empty array with mkEmptyArray." else elems
       );
+      firstType = (head vs).type;
       elemType =
-        if lib.any (t: (head vs).type != t) (map (v: v.type) vs) then
+        if lib.any (v: v.type != firstType) vs then
           throw "Elements in a list should have same type."
         else
-          (head vs).type;
+          firstType;
     in
     mkPrimitive (type.arrayOf elemType) vs
     // {

--- a/lib/gvariant.nix
+++ b/lib/gvariant.nix
@@ -194,9 +194,11 @@ rec {
       vs = map mkValue (
         if elems == [ ] then throw "Please create empty array with mkEmptyArray." else elems
       );
-      elemType = lib.throwIfNot (lib.all (t: (head vs).type == t) (
-        map (v: v.type) vs
-      )) "Elements in a list should have same type." (head vs).type;
+      elemType =
+        if lib.any (t: (head vs).type != t) (map (v: v.type) vs) then
+          throw "Elements in a list should have same type."
+        else
+          (head vs).type;
     in
     mkPrimitive (type.arrayOf elemType) vs
     // {

--- a/lib/gvariant.nix
+++ b/lib/gvariant.nix
@@ -191,7 +191,9 @@ rec {
   mkArray =
     elems:
     let
-      vs = map mkValue (lib.throwIf (elems == [ ]) "Please create empty array with mkEmptyArray." elems);
+      vs = map mkValue (
+        if elems == [ ] then throw "Please create empty array with mkEmptyArray." else elems
+      );
       elemType = lib.throwIfNot (lib.all (t: (head vs).type == t) (
         map (v: v.type) vs
       )) "Elements in a list should have same type." (head vs).type;

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -1848,7 +1848,7 @@ rec {
   */
   last =
     list:
-    assert lib.assertMsg (list != [ ]) "lists.last: list must not be empty!";
+    assert list != [ ] || throw "lists.last: list must not be empty!";
     elemAt list (length list - 1);
 
   /**
@@ -1881,7 +1881,7 @@ rec {
   */
   init =
     list:
-    assert lib.assertMsg (list != [ ]) "lists.init: list must not be empty!";
+    assert list != [ ] || throw "lists.init: list must not be empty!";
     genList (elemAt list) (length list - 1);
 
   /**
@@ -2157,7 +2157,8 @@ rec {
   */
   replaceElemAt =
     list: idx: newElem:
-    assert lib.assertMsg (idx >= 0 && idx < length list)
-      "'lists.replaceElemAt' called with index ${toString idx} on a list of size ${toString (length list)}";
+    assert
+      idx >= 0 && idx < length list
+      || throw "'lists.replaceElemAt' called with index ${toString idx} on a list of size ${toString (length list)}";
     genList (i: if i == idx then newElem else elemAt list i) (length list);
 }

--- a/lib/meta.nix
+++ b/lib/meta.nix
@@ -12,7 +12,6 @@ let
     all
     isDerivation
     getBin
-    assertMsg
     ;
   inherit (lib.attrsets) mapAttrs' filterAttrs;
   inherit (builtins)
@@ -571,12 +570,15 @@ rec {
   */
   getExe' =
     x: y:
-    assert assertMsg (isDerivation x)
-      "lib.meta.getExe': The first argument is of type ${typeOf x}, but it should be a derivation instead.";
-    assert assertMsg (isString y)
-      "lib.meta.getExe': The second argument is of type ${typeOf y}, but it should be a string instead.";
-    assert assertMsg (match ".*/.*" y == null)
-      "lib.meta.getExe': The second argument \"${y}\" is a nested path with a \"/\" character, but it should just be the name of the executable instead.";
+    assert
+      isDerivation x
+      || throw "lib.meta.getExe': The first argument is of type ${typeOf x}, but it should be a derivation instead.";
+    assert
+      isString y
+      || throw "lib.meta.getExe': The second argument is of type ${typeOf y}, but it should be a string instead.";
+    assert
+      match ".*/.*" y == null
+      || throw "lib.meta.getExe': The second argument \"${y}\" is a nested path with a \"/\" character, but it should just be the name of the executable instead.";
     "${getBin x}/bin/${y}";
 
   /**

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -46,7 +46,6 @@ let
     setAttrByPath
     substring
     take
-    throwIfNot
     trace
     typeOf
     types
@@ -680,8 +679,11 @@ let
           config = addFreeformType (addMeta (m.config or { }));
         }
     else
-      # shorthand syntax
-      throwIfNot (isAttrs m) "module ${file} (${key}) does not look like a module." {
+    # shorthand syntax
+    if !isAttrs m then
+      throw "module ${file} (${key}) does not look like a module."
+    else
+      {
         _file = toString m._file or file;
         _class = m._class or null;
         key = toString m.key or key;

--- a/lib/network/internal.nix
+++ b/lib/network/internal.nix
@@ -104,9 +104,9 @@ let
   */
   parseExpandedIpv6 =
     addr:
-    assert lib.assertMsg (
+    assert
       length addr == ipv6Pieces
-    ) "parseExpandedIpv6: expected list of integers with ${ipv6Pieces} elements";
+      || throw "parseExpandedIpv6: expected list of integers with ${ipv6Pieces} elements";
     let
       u16FromHexStr =
         hex:

--- a/lib/path/default.nix
+++ b/lib/path/default.nix
@@ -32,10 +32,6 @@ let
     substring
     ;
 
-  inherit (lib.asserts)
-    assertMsg
-    ;
-
   inherit (lib.path.subpath)
     isValid
     ;
@@ -238,11 +234,14 @@ in
     path:
     # The subpath string to append
     subpath:
-    assert assertMsg (isPath path)
-      "lib.path.append: The first argument is of type ${builtins.typeOf path}, but a path was expected";
-    assert assertMsg (isValid subpath) ''
-      lib.path.append: Second argument is not a valid subpath string:
-          ${subpathInvalidReason subpath}'';
+    assert
+      isPath path
+      || throw "lib.path.append: The first argument is of type ${builtins.typeOf path}, but a path was expected";
+    assert
+      isValid subpath
+      || throw ''
+        lib.path.append: Second argument is not a valid subpath string:
+            ${subpathInvalidReason subpath}'';
     path + ("/" + subpath);
 
   /**
@@ -285,21 +284,25 @@ in
   */
   hasPrefix =
     path1:
-    assert assertMsg (isPath path1)
-      "lib.path.hasPrefix: First argument is of type ${typeOf path1}, but a path was expected";
+    assert
+      isPath path1
+      || throw "lib.path.hasPrefix: First argument is of type ${typeOf path1}, but a path was expected";
     let
       path1Deconstructed = deconstructPath path1;
     in
     path2:
-    assert assertMsg (isPath path2)
-      "lib.path.hasPrefix: Second argument is of type ${typeOf path2}, but a path was expected";
+    assert
+      isPath path2
+      || throw "lib.path.hasPrefix: Second argument is of type ${typeOf path2}, but a path was expected";
     let
       path2Deconstructed = deconstructPath path2;
     in
-    assert assertMsg (path1Deconstructed.root == path2Deconstructed.root) ''
-      lib.path.hasPrefix: Filesystem roots must be the same for both paths, but paths with different roots were given:
-          first argument: "${toString path1}" with root "${toString path1Deconstructed.root}"
-          second argument: "${toString path2}" with root "${toString path2Deconstructed.root}"'';
+    assert
+      path1Deconstructed.root == path2Deconstructed.root
+      || throw ''
+        lib.path.hasPrefix: Filesystem roots must be the same for both paths, but paths with different roots were given:
+            first argument: "${toString path1}" with root "${toString path1Deconstructed.root}"
+            second argument: "${toString path2}" with root "${toString path2Deconstructed.root}"'';
     take (length path1Deconstructed.components) path2Deconstructed.components
     == path1Deconstructed.components;
 
@@ -344,15 +347,17 @@ in
   */
   removePrefix =
     path1:
-    assert assertMsg (isPath path1)
-      "lib.path.removePrefix: First argument is of type ${typeOf path1}, but a path was expected.";
+    assert
+      isPath path1
+      || throw "lib.path.removePrefix: First argument is of type ${typeOf path1}, but a path was expected.";
     let
       path1Deconstructed = deconstructPath path1;
       path1Length = length path1Deconstructed.components;
     in
     path2:
-    assert assertMsg (isPath path2)
-      "lib.path.removePrefix: Second argument is of type ${typeOf path2}, but a path was expected.";
+    assert
+      isPath path2
+      || throw "lib.path.removePrefix: Second argument is of type ${typeOf path2}, but a path was expected.";
     let
       path2Deconstructed = deconstructPath path2;
       success = take path1Length path2Deconstructed.components == path1Deconstructed.components;
@@ -362,10 +367,12 @@ in
         else
           throw ''lib.path.removePrefix: The first path argument "${toString path1}" is not a component-wise prefix of the second path argument "${toString path2}".'';
     in
-    assert assertMsg (path1Deconstructed.root == path2Deconstructed.root) ''
-      lib.path.removePrefix: Filesystem roots must be the same for both paths, but paths with different roots were given:
-          first argument: "${toString path1}" with root "${toString path1Deconstructed.root}"
-          second argument: "${toString path2}" with root "${toString path2Deconstructed.root}"'';
+    assert
+      path1Deconstructed.root == path2Deconstructed.root
+      || throw ''
+        lib.path.removePrefix: Filesystem roots must be the same for both paths, but paths with different roots were given:
+            first argument: "${toString path1}" with root "${toString path1Deconstructed.root}"
+            second argument: "${toString path2}" with root "${toString path2Deconstructed.root}"'';
     joinRelPath components;
 
   /**
@@ -422,8 +429,9 @@ in
   splitRoot =
     # The path to split the root off of
     path:
-    assert assertMsg (isPath path)
-      "lib.path.splitRoot: Argument is of type ${typeOf path}, but a path was expected";
+    assert
+      isPath path
+      || throw "lib.path.splitRoot: Argument is of type ${typeOf path}, but a path was expected";
     let
       deconstructed = deconstructPath path;
     in
@@ -494,14 +502,15 @@ in
     let
       deconstructed = deconstructPath path;
     in
-    assert assertMsg (isPath path)
-      "lib.path.hasStorePathPrefix: Argument is of type ${typeOf path}, but a path was expected";
-    assert assertMsg
+    assert
+      isPath path
+      || throw "lib.path.hasStorePathPrefix: Argument is of type ${typeOf path}, but a path was expected";
+    assert
       # This function likely breaks or needs adjustment if used with other filesystem roots, if they ever get implemented.
       # Let's try to error nicely in such a case, though it's unclear how an implementation would work even and whether this could be detected.
       # See also https://github.com/NixOS/nix/pull/6530#discussion_r1422843117
-      (deconstructed.root == /. && toString deconstructed.root == "/")
-      "lib.path.hasStorePathPrefix: Argument has a filesystem root (${toString deconstructed.root}) that's not /, which is currently not supported.";
+      deconstructed.root == /. && toString deconstructed.root == "/"
+      || throw "lib.path.hasStorePathPrefix: Argument has a filesystem root (${toString deconstructed.root}) that's not /, which is currently not supported.";
     componentsHaveStorePathPrefix deconstructed.components;
 
   /**
@@ -702,9 +711,11 @@ in
   subpath.components =
     # The subpath string to split into components
     subpath:
-    assert assertMsg (isValid subpath) ''
-      lib.path.subpath.components: Argument is not a valid subpath string:
-          ${subpathInvalidReason subpath}'';
+    assert
+      isValid subpath
+      || throw ''
+        lib.path.subpath.components: Argument is not a valid subpath string:
+            ${subpathInvalidReason subpath}'';
     splitRelPath subpath;
 
   /**
@@ -799,9 +810,11 @@ in
   subpath.normalise =
     # The subpath string to normalise
     subpath:
-    assert assertMsg (isValid subpath) ''
-      lib.path.subpath.normalise: Argument is not a valid subpath string:
-          ${subpathInvalidReason subpath}'';
+    assert
+      isValid subpath
+      || throw ''
+        lib.path.subpath.normalise: Argument is not a valid subpath string:
+            ${subpathInvalidReason subpath}'';
     joinRelPath (splitRelPath subpath);
 
 }

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -2532,8 +2532,9 @@ rec {
       strw = lib.stringLength str;
       reqWidth = width - (lib.stringLength filler);
     in
-    assert lib.assertMsg (strw <= width)
-      "fixedWidthString: requested string length (${toString width}) must not be shorter than actual length (${toString strw})";
+    assert
+      strw <= width
+      || throw "fixedWidthString: requested string length (${toString width}) must not be shorter than actual length (${toString strw})";
     if strw == width then str else filler + fixedWidthString reqWidth filler str;
 
   /**

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -1589,15 +1589,14 @@ rec {
   */
   toSentenceCase =
     str:
-    lib.throwIfNot (isString str)
-      "toSentenceCase does only accepts string values, but got ${typeOf str}"
-      (
-        let
-          firstChar = substring 0 1 str;
-          rest = substring 1 (-1) str; # -1 takes till the end of the string
-        in
-        toUpper firstChar + toLower rest
-      );
+    if !isString str then
+      throw "toSentenceCase does only accepts string values, but got ${typeOf str}"
+    else
+      let
+        firstChar = substring 0 1 str;
+        rest = substring 1 (-1) str; # -1 takes till the end of the string
+      in
+      toUpper firstChar + toLower rest;
 
   /**
     Converts a string to camelCase. Handles snake_case, PascalCase,
@@ -1633,7 +1632,9 @@ rec {
   */
   toCamelCase =
     str:
-    lib.throwIfNot (isString str) "toCamelCase does only accepts string values, but got ${typeOf str}" (
+    if !isString str then
+      throw "toCamelCase does only accepts string values, but got ${typeOf str}"
+    else
       let
         separators = splitStringBy (
           prev: curr:
@@ -1653,8 +1654,7 @@ rec {
         first = if length parts > 0 then toLower (head parts) else "";
         rest = if length parts > 1 then map toSentenceCase (tail parts) else [ ];
       in
-      concatStrings ([ first ] ++ rest)
-    );
+      concatStrings ([ first ] ++ rest);
 
   /**
     Appends string context from string like object `src` to `target`.

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -21,7 +21,6 @@ let
     isString
     substring
     sort
-    throwIf
     toDerivation
     toList
     types
@@ -660,10 +659,10 @@ rec {
       inStore ? null,
       absolute ? null,
     }:
-    throwIf (inStore != null && absolute != null && inStore && !absolute)
-      "In pathWith, inStore means the path must be absolute"
-      mkOptionType
-      {
+    if inStore != null && absolute != null && inStore && !absolute then
+      throw "In pathWith, inStore means the path must be absolute"
+    else
+      mkOptionType {
         name = "path";
         description = (
           (if absolute == null then "" else (if absolute then "absolute " else "relative "))
@@ -1079,8 +1078,8 @@ rec {
         builtins.addErrorContext
           "while checking that attrTag tag ${lib.strings.escapeNixIdentifier n} is an option with a type${inAttrPosSuffix tags_ n}"
           (
-            throwIf (opt._type or null != "option")
-              "In attrTag, each tag value must be an option, but tag ${lib.strings.escapeNixIdentifier n} ${
+            if opt._type or null != "option" then
+              throw "In attrTag, each tag value must be an option, but tag ${lib.strings.escapeNixIdentifier n} ${
                 if opt ? _type then
                   if opt._type == "option-type" then
                     "was a bare type, not wrapped in mkOption."
@@ -1089,23 +1088,24 @@ rec {
                 else
                   "was not."
               }"
+            else
               opt
-            // {
-              declarations =
-                opt.declarations or (
-                  let
-                    pos = builtins.unsafeGetAttrPos n tags_;
-                  in
-                  if pos == null then [ ] else [ pos.file ]
-                );
-              declarationPositions =
-                opt.declarationPositions or (
-                  let
-                    pos = builtins.unsafeGetAttrPos n tags_;
-                  in
-                  if pos == null then [ ] else [ pos ]
-                );
-            }
+              // {
+                declarations =
+                  opt.declarations or (
+                    let
+                      pos = builtins.unsafeGetAttrPos n tags_;
+                    in
+                    if pos == null then [ ] else [ pos.file ]
+                  );
+                declarationPositions =
+                  opt.declarationPositions or (
+                    let
+                      pos = builtins.unsafeGetAttrPos n tags_;
+                    in
+                    if pos == null then [ ] else [ pos ]
+                  );
+              }
           )
       ) tags_;
       choicesStr = concatMapStringsSep ", " lib.strings.escapeNixIdentifier (attrNames tags);

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -408,7 +408,7 @@ rec {
       betweenDesc = lowest: highest: "${toString lowest} and ${toString highest} (both inclusive)";
       between =
         lowest: highest:
-        assert lib.assertMsg (lowest <= highest) "ints.between: lowest must be smaller than highest";
+        assert lowest <= highest || throw "ints.between: lowest must be smaller than highest";
         addCheck int (x: x >= lowest && x <= highest)
         // {
           name = "intBetween";
@@ -495,7 +495,7 @@ rec {
     {
       between =
         lowest: highest:
-        assert lib.assertMsg (lowest <= highest) "numbers.between: lowest must be smaller than highest";
+        assert lowest <= highest || throw "numbers.between: lowest must be smaller than highest";
         addCheck number (x: x >= lowest && x <= highest)
         // {
           name = "numberBetween";
@@ -1728,9 +1728,9 @@ rec {
   # converted to `finalType` using `coerceFunc`.
   coercedTo =
     coercedType: coerceFunc: finalType:
-    assert lib.assertMsg (
+    assert
       coercedType.getSubModules == null
-    ) "coercedTo: coercedType must not have submodules (it’s a ${coercedType.description})";
+      || throw "coercedTo: coercedType must not have submodules (it’s a ${coercedType.description})";
     mkOptionType rec {
       name = "coercedTo";
       description = "${optionDescriptionPhrase (class: class == "noun") finalType} or ${


### PR DESCRIPTION
As established in https://github.com/NixOS/nixpkgs/issues/523851. I'm not removing `warnIf` usage yet, because warnings are annoying, and need to still return the final value. They are still a performance loss, but maybe we can only remove them in key functions - I'll have to think about it. Non-warning functions are trivial to remove though, with no readability loss.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
