### PR TITLE
various: remove lib.warnIf from most critical functions

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1158,8 +1158,10 @@ let
       value = if opt ? apply then opt.apply res.mergedValue else res.mergedValue;
 
       warnDeprecation =
-        warnIf (opt.type.deprecationMessage != null)
-          "The type `types.${opt.type.name}' of option `${showOption loc}' defined in ${showFiles opt.declarations} is deprecated. ${opt.type.deprecationMessage}";
+        if (opt.type.deprecationMessage != null) then
+          warn "The type `types.${opt.type.name}' of option `${showOption loc}' defined in ${showFiles opt.declarations} is deprecated. ${opt.type.deprecationMessage}"
+        else
+          x: x;
 
     in
     warnDeprecation opt

--- a/pkgs/build-support/fetchurl/default.nix
+++ b/pkgs/build-support/fetchurl/default.nix
@@ -327,23 +327,27 @@ lib.extendMkDerivation {
 
       outputHashMode = if (recursiveHash || executable) then "recursive" else "flat";
 
-      curlOpts = lib.warnIf (lib.isList curlOpts) (
-        let
-          url = toString (builtins.head urls_);
-          curlOptsRepresentation = lib.generators.toPretty { multiline = false; } curlOpts;
-          curlOptsAsStringRepresentation = lib.strings.escapeNixString (toString curlOpts);
-          curlOptsListElementsRepresentation =
-            lib.concatMapStringsSep " " lib.strings.escapeNixString
-              curlOpts;
-        in
-        ''
-          fetchurl for ${url}: curlOpts is a list (${curlOptsRepresentation}), which is not supported anymore.
-          - If you wish to get the same effect as before, for elements with spaces (even if escaped) to expand to multiple curl arguments, use a string argument instead:
-            curlOpts = ${curlOptsAsStringRepresentation};
-          - If you wish for each list element to be passed as a separate curl argument, allowing arguments to contain spaces, use curlOptsList instead:
-            curlOptsList = [ ${curlOptsListElementsRepresentation} ];
-        ''
-      ) curlOpts;
+      curlOpts =
+        if lib.isList curlOpts then
+          lib.warn (
+            let
+              url = toString (builtins.head urls_);
+              curlOptsRepresentation = lib.generators.toPretty { multiline = false; } curlOpts;
+              curlOptsAsStringRepresentation = lib.strings.escapeNixString (toString curlOpts);
+              curlOptsListElementsRepresentation =
+                lib.concatMapStringsSep " " lib.strings.escapeNixString
+                  curlOpts;
+            in
+            ''
+              fetchurl for ${url}: curlOpts is a list (${curlOptsRepresentation}), which is not supported anymore.
+              - If you wish to get the same effect as before, for elements with spaces (even if escaped) to expand to multiple curl arguments, use a string argument instead:
+                curlOpts = ${curlOptsAsStringRepresentation};
+              - If you wish for each list element to be passed as a separate curl argument, allowing arguments to contain spaces, use curlOptsList instead:
+                curlOptsList = [ ${curlOptsListElementsRepresentation} ];
+            ''
+          ) curlOpts
+        else
+          curlOpts;
 
       inherit
         curlOptsList

--- a/pkgs/build-support/fetchzip/default.nix
+++ b/pkgs/build-support/fetchzip/default.nix
@@ -106,9 +106,11 @@ lib.extendMkDerivation {
       )
       + ''
         ${postFetch}
-        ${lib.warnIf (extraPostFetch != "")
-          "use 'postFetch' instead of 'extraPostFetch' with 'fetchzip' and 'fetchFromGitHub' or 'fetchFromGitLab'."
-          extraPostFetch
+        ${
+          if extraPostFetch != "" then
+            lib.warn "use 'postFetch' instead of 'extraPostFetch' with 'fetchzip' and 'fetchFromGitHub' or 'fetchFromGitLab'." extraPostFetch
+          else
+            extraPostFetch
         }
         chmod 755 "$out"
       '';

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -128,8 +128,8 @@ let
                 # f is not a function; probably { ... }
                 f0;
           in
-          warnIf
-            (
+          (
+            if
               prev ? src
               && thisOverlay ? version
               && prev ? version
@@ -138,32 +138,36 @@ let
               # && prev.version != thisOverlay.version
               && !(thisOverlay ? src)
               && !(thisOverlay.__intentionallyOverridingVersion or false)
-            )
-            (
-              let
-                pos = unsafeGetAttrPos "version" thisOverlay;
-              in
-              ''
-                ${
-                  args.name or "${args.pname or "<unknown name>"}-${args.version or "<unknown version>"}"
-                } was overridden with `version` but not `src` at ${pos.file or "<unknown file>"}:${
-                  toString pos.line or "<unknown line>"
-                }:${toString pos.column or "<unknown column>"}.
 
-                This is most likely not what you want. In order to properly change the version of a package, override
-                both the `version` and `src` attributes:
+            then
+              warn (
+                let
+                  pos = unsafeGetAttrPos "version" thisOverlay;
+                in
+                ''
+                  ${
+                    args.name or "${args.pname or "<unknown name>"}-${args.version or "<unknown version>"}"
+                  } was overridden with `version` but not `src` at ${pos.file or "<unknown file>"}:${
+                    toString pos.line or "<unknown line>"
+                  }:${toString pos.column or "<unknown column>"}.
 
-                hello.overrideAttrs (oldAttrs: rec {
-                  version = "1.0.0";
-                  src = pkgs.fetchurl {
-                    url = "mirror://gnu/hello/hello-''${version}.tar.gz";
-                    hash = "...";
-                  };
-                })
+                  This is most likely not what you want. In order to properly change the version of a package, override
+                  both the `version` and `src` attributes:
 
-                (To silence this warning, set `__intentionallyOverridingVersion = true` in your `overrideAttrs` call.)
-              ''
-            )
+                  hello.overrideAttrs (oldAttrs: rec {
+                    version = "1.0.0";
+                    src = pkgs.fetchurl {
+                      url = "mirror://gnu/hello/hello-''${version}.tar.gz";
+                      hash = "...";
+                    };
+                  })
+
+                  (To silence this warning, set `__intentionallyOverridingVersion = true` in your `overrideAttrs` call.)
+                ''
+              )
+            else
+              x: x
+          )
             (prev // (removeAttrs thisOverlay [ "__intentionallyOverridingVersion" ]))
         );
 


### PR DESCRIPTION
Removing warnIf is often a readability loss, which is why I'm not doing it everywhere. But profiling, these four instances accounted for most of the performance penalty of warnIf (at least on my bench), so I'm targeting these rather than casting a wide net.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
