### PR TITLE
python3Packages.nvidia-cutlass-dsl-libs-base: fix installation for proper discoverability

### DIFF
--- a/pkgs/development/python-modules/nvidia-cutlass-dsl-libs-base/default.nix
+++ b/pkgs/development/python-modules/nvidia-cutlass-dsl-libs-base/default.nix
@@ -81,10 +81,20 @@ buildPythonPackage (finalAttrs: {
     "libcuda.so.1"
   ];
 
-  # This wheel ships the `cutlass` module via `nvidia_cutlass_dsl.pth`.
-  # Python only processes `.pth` files in dirs that `site.py` registers as site-packages, not in
-  # PYTHONPATH entries so pythonImportsCheck (which uses PYTHONPATH) can't see `cutlass`.
-  dontUsePythonImportsCheck = true;
+  # This wheel ships the `cutlass` module nested under `nvidia_cutlass_dsl/python_packages/`,
+  # exposed at the top level via `nvidia_cutlass_dsl.pth`.
+  # Python only processes `.pth` files in directories registered as site dirs by `site.py`, not in
+  # PYTHONPATH entries.
+  # In nixpkgs, `buildPythonPackage` propagates dependencies via PYTHONPATH
+  # (see python's setup-hook), so any downstream consumer (e.g. flash-attn) would not see the
+  # `cutlass` module.
+  # `withPackages` envs work fine because they merge everything into a real site dir.
+  # Symlinking `cutlass` to the site-packages root makes it importable in both modes.
+  postFixup = ''
+    ln -s nvidia_cutlass_dsl/python_packages/cutlass $out/${python.sitePackages}/cutlass
+  '';
+
+  pythonImportsCheck = [ "cutlass" ];
 
   # No tests in the Pypi archive
   doCheck = false;

--- a/pkgs/development/python-modules/nvidia-cutlass-dsl/default.nix
+++ b/pkgs/development/python-modules/nvidia-cutlass-dsl/default.nix
@@ -27,9 +27,7 @@ buildPythonPackage (finalAttrs: {
     nvidia-cutlass-dsl-libs-base
   ];
 
-  # The `cutlass` module is provided by `nvidia-cutlass-dsl-libs-base` via a `.pth` file.
-  # pythonImportsCheck uses PYTHONPATH, which Python's site.py doesn't scan for `.pth` files.
-  dontUsePythonImportsCheck = true;
+  pythonImportsCheck = [ "cutlass" ];
 
   # No tests in the Pypi archive
   doCheck = false;


### PR DESCRIPTION
## Things done

Follow up of #522219. The import was failing in downstream consumers.
This horrible hack seems to do the job (tested in `flash-attn`).

- **python3Packages.nvidia-cutlass-dsl-libs-base: fix installation for proper discoverability**
- **python3Packages.nvidia-cutlass-dsl: enable pythonImportsCheck**

cc @NixOS/cuda-maintainers

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
