### PR TITLE
tana: enable PipeWire audio capture

### DIFF
--- a/pkgs/by-name/ta/tana/package.nix
+++ b/pkgs/by-name/ta/tana/package.nix
@@ -24,6 +24,8 @@
   nspr,
   nss,
   pango,
+  pipewire,
+  replaceVars,
   systemd,
   fetchurl,
   autoPatchelfHook,
@@ -86,6 +88,38 @@ stdenv.mkDerivation {
   runtimeDependencies = [
     systemd
   ];
+
+  patches = [
+    (replaceVars ./pipewire-system-audio.patch {
+      pipewire = lib.getBin pipewire;
+    })
+  ];
+
+  postPatch = ''
+    main="usr/lib/tana/resources/app/build/main.js"
+
+    unsupportedBranch='else Ox=()=>(console.warn("System audio capture not supported on this platform"),"denied"),Dx=async()=>(console.warn("System audio capture not supported on this platform"),"denied"),Nx=async()=>{throw console.warn("System audio capture not supported on this platform"),new Error("System audio capture not supported on this platform")};var HM=require("electron")'
+    pipewireBranch='else { let systemAudio = require("./nix-pipewire-system-audio.js"); Ox = systemAudio.getSystemAudioPermission; Dx = systemAudio.requestSystemAudioPermission; Nx = systemAudio.recordSystemAudio; } var HM=require("electron")'
+
+    # Tana ships minified Electron code. Keep these checks strict so version
+    # bumps fail loudly if upstream changes the audio capture implementation.
+    grep -Fq -- "$unsupportedBranch" "$main" || {
+      echo "Tana system-audio patch target not found" >&2
+      exit 1
+    }
+
+    substituteInPlace "$main" \
+      --replace-fail "$unsupportedBranch" "$pipewireBranch"
+
+    loopbackCount="$(grep -oF 'audio:"loopback"' "$main" | wc -l | tr -d ' ')"
+    if [ "$loopbackCount" -ne 2 ]; then
+      echo "Expected 2 Tana loopback targets, found $loopbackCount" >&2
+      exit 1
+    fi
+
+    substituteInPlace "$main" \
+      --replace-fail 'audio:"loopback"' 'audio:n.frame'
+  '';
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/ta/tana/pipewire-system-audio.patch
+++ b/pkgs/by-name/ta/tana/pipewire-system-audio.patch
@@ -1,0 +1,50 @@
+diff --git a/usr/lib/tana/resources/app/build/nix-pipewire-system-audio.js b/usr/lib/tana/resources/app/build/nix-pipewire-system-audio.js
+new file mode 100644
+index 0000000..ef4e521
+--- /dev/null
++++ b/usr/lib/tana/resources/app/build/nix-pipewire-system-audio.js
+@@ -0,0 +1,41 @@
++const childProcess = require("child_process");
++const stream = require("stream");
++
++function getSystemAudioPermission() {
++  return "authorized";
++}
++
++async function requestSystemAudioPermission() {
++  return "authorized";
++}
++
++async function recordSystemAudio() {
++  const output = new stream.PassThrough();
++  const recorder = childProcess.spawn(
++    "@pipewire@/bin/pw-record",
++    ["--raw", "--format", "f32", "--rate", "48000", "--channels", "2", "-"],
++    { stdio: ["ignore", "pipe", "pipe"] }
++  );
++
++  recorder.stdout.pipe(output);
++  recorder.stderr.on("data", data =>
++    console.warn("pw-record:", data.toString().trim())
++  );
++  recorder.on("error", error => output.emit("error", error));
++  recorder.on("close", (code, signal) => {
++    if (code && code !== 0) {
++      output.emit(
++        "error",
++        new Error("pw-record exited " + code + (signal ? " signal " + signal : ""))
++      );
++    } else {
++      output.end();
++    }
++  });
++  output.on("close", () => {
++    if (!recorder.killed) recorder.kill("SIGTERM");
++  });
++
++  return output;
++}
++
++exports.getSystemAudioPermission = getSystemAudioPermission;
++exports.requestSystemAudioPermission = requestSystemAudioPermission;
++exports.recordSystemAudio = recordSystemAudio;


### PR DESCRIPTION
Enable Tana voice capture on Linux by wiring its unsupported system-audio fallback to PipeWire via `pw-record`.

Tana already has the IPC/audio plumbing for system audio capture, but its Linux branch returns `denied` and throws “System
audio capture not supported on this platform”. This patch adds a small PipeWire-backed helper and redirects the Linux
fallback to it. It also replaces Electron’s Windows-only `audio: "loopback"` display-media path with frame audio capture.

AI assistance was used to help diagnose and prepare this change; the diff was manually reviewed and locally built.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].