### PR TITLE
python3Packages.exfat-raw: init at 0.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17393,6 +17393,12 @@
     githubId = 613740;
     name = "Martin Baillie";
   };
+  mbanucu = {
+    email = "michael.banucu@googlemail.com";
+    github = "MBanucu";
+    githubId = 23436598;
+    name = "Michael Banucu";
+  };
   mbe = {
     email = "brandonedens@gmail.com";
     github = "brandonedens";

--- a/pkgs/development/python-modules/exfat-raw/default.nix
+++ b/pkgs/development/python-modules/exfat-raw/default.nix
@@ -1,7 +1,8 @@
-{ lib
-, buildPythonPackage
-, fetchFromGitHub
-, setuptools
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
 }:
 
 buildPythonPackage rec {

--- a/pkgs/development/python-modules/exfat-raw/default.nix
+++ b/pkgs/development/python-modules/exfat-raw/default.nix
@@ -7,14 +7,14 @@
 
 buildPythonPackage rec {
   pname = "exfat-raw";
-  version = "0.1.1";
+  version = "0.1.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "MBanucu";
     repo = "exfat-raw";
     rev = "v${version}";
-    hash = "sha256-v3OKqzh8eLF0hh1pPc73EIELur94Dw9Ipd7oaR7D0+I=";
+    hash = "sha256-KcmLSjVMQd7UdUzWp1iWe0Tvf89l5VvSiLWvg9CZVjA=";
   };
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/exfat-raw/default.nix
+++ b/pkgs/development/python-modules/exfat-raw/default.nix
@@ -22,7 +22,11 @@ buildPythonPackage rec {
   doCheck = true;
   checkPhase = ''
     runHook preCheck
-    python -m unittest discover -s tests -v
+    if command -v sudo >/dev/null 2>&1; then
+      python -m unittest discover -s tests -v
+    else
+      echo "sudo not available (build sandbox) — skipping tests"
+    fi
     runHook postCheck
   '';
 

--- a/pkgs/development/python-modules/exfat-raw/default.nix
+++ b/pkgs/development/python-modules/exfat-raw/default.nix
@@ -19,6 +19,13 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools ];
 
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    python -m unittest discover -s tests -v
+    runHook postCheck
+  '';
+
   meta = with lib; {
     description = "Raw block-level read/write of exFAT filesystem timestamps (birth time, modification time)";
     homepage = "https://github.com/MBanucu/exfat-raw";

--- a/pkgs/development/python-modules/exfat-raw/default.nix
+++ b/pkgs/development/python-modules/exfat-raw/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
+  udisks2,
 }:
 
 buildPythonPackage rec {
@@ -20,12 +21,16 @@ buildPythonPackage rec {
   nativeBuildInputs = [ setuptools ];
 
   doCheck = true;
+  pythonImportsCheck = [ "exfat_raw" ];
+
+  # Integration tests require sudo (losetup + mount).
+  # In the Nix build sandbox sudo is not available, so tests are skipped.
   checkPhase = ''
     runHook preCheck
     if command -v sudo >/dev/null 2>&1; then
       python -m unittest discover -s tests -v
     else
-      echo "sudo not available (build sandbox) — skipping tests"
+      echo "sudo not available (sandbox) — skipping integration tests"
     fi
     runHook postCheck
   '';

--- a/pkgs/development/python-modules/exfat-raw/default.nix
+++ b/pkgs/development/python-modules/exfat-raw/default.nix
@@ -3,19 +3,18 @@
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
-  udisks2,
 }:
 
 buildPythonPackage rec {
   pname = "exfat-raw";
-  version = "0.1.0";
+  version = "0.1.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "MBanucu";
     repo = "exfat-raw";
     rev = "v${version}";
-    hash = "sha256-nmWMmU6GNnb2vi9ebC0brpCfyFdBICdAraOqhspesng=";
+    hash = "sha256-/blT0neRmfgApHk2mVknOrC2feolhU9u8pz232TIfdg=";
   };
 
   nativeBuildInputs = [ setuptools ];
@@ -23,15 +22,11 @@ buildPythonPackage rec {
   doCheck = true;
   pythonImportsCheck = [ "exfat_raw" ];
 
-  # Integration tests require sudo (losetup + mount).
-  # In the Nix build sandbox sudo is not available, so tests are skipped.
+  # Integration tests require sudo (losetup + mount) and are skipped
+  # in the Nix sandbox. Only sandbox-safe image-based tests are run.
   checkPhase = ''
     runHook preCheck
-    if command -v sudo >/dev/null 2>&1; then
-      python -m unittest discover -s tests -v
-    else
-      echo "sudo not available (sandbox) — skipping integration tests"
-    fi
+    python -m unittest discover -s tests -p 'test_exfat_raw_image.py' -v
     runHook postCheck
   '';
 

--- a/pkgs/development/python-modules/exfat-raw/default.nix
+++ b/pkgs/development/python-modules/exfat-raw/default.nix
@@ -1,0 +1,27 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, setuptools
+}:
+
+buildPythonPackage rec {
+  pname = "exfat-raw";
+  version = "0.1.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "MBanucu";
+    repo = "exfat-raw";
+    rev = "v${version}";
+    hash = "sha256-nmWMmU6GNnb2vi9ebC0brpCfyFdBICdAraOqhspesng=";
+  };
+
+  nativeBuildInputs = [ setuptools ];
+
+  meta = with lib; {
+    description = "Raw block-level read/write of exFAT filesystem timestamps (birth time, modification time)";
+    homepage = "https://github.com/MBanucu/exfat-raw";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ mbanucu ];
+  };
+}

--- a/pkgs/development/python-modules/exfat-raw/default.nix
+++ b/pkgs/development/python-modules/exfat-raw/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
     owner = "MBanucu";
     repo = "exfat-raw";
     rev = "v${version}";
-    hash = "sha256-/blT0neRmfgApHk2mVknOrC2feolhU9u8pz232TIfdg=";
+    hash = "sha256-v3OKqzh8eLF0hh1pPc73EIELur94Dw9Ipd7oaR7D0+I=";
   };
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5266,6 +5266,8 @@ self: super: with self; {
 
   executorch = callPackage ../development/python-modules/executorch { };
 
+  exfat-raw = callPackage ../development/python-modules/exfat-raw { };
+
   exif = callPackage ../development/python-modules/exif { };
 
   exifread = callPackage ../development/python-modules/exifread { };


### PR DESCRIPTION
## Description

Add [exfat-raw](https://github.com/MBanucu/exfat-raw) v0.1.2 — a pure-Python library for raw block-level reading and writing of exFAT filesystem timestamps (birth time/btime, modification time).

## Checklist

- [x] Package builds: `nix build .#python3Packages.exfat-raw`
- [x] 16 sandbox-safe tests pass in `checkPhase`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md) guidelines

## Notes

- No runtime dependencies beyond the Python stdlib
- Maintainer: @MBanucu