### PR TITLE
scid-vs-pc: fix build with Tcl stubs default

### DIFF
--- a/pkgs/by-name/sc/scid-vs-pc/package.nix
+++ b/pkgs/by-name/sc/scid-vs-pc/package.nix
@@ -35,9 +35,13 @@ tcl.mkTclDerivation rec {
     zlib
   ];
 
+  addTclConfigureFlags = false;
   configureFlags = [
     "BINDIR=${placeholder "out"}/bin"
     "SHAREDIR=${placeholder "out"}/share"
+    "--with-tcl=${tcl}/lib"
+    "--with-tclinclude=${tcl}/include"
+    "--exec-prefix=${placeholder "out"}"
   ];
 
   postInstall = ''


### PR DESCRIPTION
## Things done

- Opt `scid-vs-pc` out of the default Tcl configure flags because its non-TEA configure script rejects `--enable-stubs`.
- Preserve the Tcl include/library and exec-prefix flags that the package accepts.

## Tested

- `nix build --no-link --print-out-paths github:johnrichardrinehart/nixpkgs/fix-scid-vs-pc-tcl-stubs#scid-vs-pc`
