### PR TITLE
faac: 1.31.1 -> 1.50

### DIFF
--- a/pkgs/by-name/fa/faac/package.nix
+++ b/pkgs/by-name/fa/faac/package.nix
@@ -2,33 +2,34 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  autoreconfHook,
-  mp4v2Support ? true,
-  mp4v2,
+  meson,
+  ninja,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "faac";
-  version = "1.31.1";
+  version = "1.50";
 
   src = fetchFromGitHub {
     owner = "knik0";
     repo = "faac";
     tag = "faac-${finalAttrs.version}";
-    hash = "sha256-mSdFnmOOpCJ9lvX1vLyAZdK7m+0cUSdLTScGs+Sh1Rc=";
+    hash = "sha256-264+OHyqG5Ccwx15cHhDqsk+9Z6UsdYr0bvrPWHP5xw=";
   };
 
-  configureFlags = lib.optional mp4v2Support "--with-external-mp4v2";
+  nativeBuildInputs = [
+    meson
+    ninja
+  ];
 
-  hardeningDisable = [ "format" ];
-
-  nativeBuildInputs = [ autoreconfHook ];
-
-  buildInputs = lib.optional mp4v2Support mp4v2;
+  mesonFlags = [
+    "-Db_lto=false" # plugin needed to handle lto object
+  ];
 
   enableParallelBuilding = true;
 
   meta = {
+    changelog = "https://github.com/knik0/faac/releases/tag/${finalAttrs.src.tag}";
     description = "Open source MPEG-4 and MPEG-2 AAC encoder";
     homepage = "https://github.com/knik0/faac";
     license = lib.licenses.unfreeRedistributable;


### PR DESCRIPTION
Diff: https://github.com/knik0/faac/compare/faac-1.31.1...faac-1.50

Changelog: https://github.com/knik0/faac/releases/tag/faac-1.50


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
