### PR TITLE
lib.strings.hasStorePathPrefix: init

### DIFF
--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -2695,6 +2695,100 @@ rec {
       false;
 
   /**
+    Whether a value `x`
+    has a [store path](https://nixos.org/manual/nix/stable/store/store-path.html#store-path)
+    as a prefix.
+
+    :::{.note}
+    This function has identical logic to the function under the same name in
+    `lib.path`, but while the `lib.path` equivalent errors on non-path inputs,
+    this function accepts any type, and return false if the type can't be
+    coerced to a string.
+
+    This function is also slightly faster, as it works with the string
+    representation of the path, rather than splitting the path into components
+    :::
+
+    # Inputs
+
+    `x`
+
+    : 1\. Function argument
+
+    # Type
+
+    ```
+    hasStorePathPrefix :: Any -> Bool
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.strings.hasStorePathPrefix` usage example
+
+    ```nix
+    # Subpaths of derivation outputs have a store path as a prefix
+    hasStorePathPrefix /nix/store/nvl9ic0pj1fpyln3zaqrf4cclbqdfn1j-foo/bar/baz
+    => true
+
+    # The store directory itself is not a store path
+    hasStorePathPrefix /nix/store
+    => false
+
+    # Derivations and their string representations are both store paths
+    hasStorePathPrefix pkgs.git && hasStorePathPrefix /nix/store/bcnisk3ydfgv26v2gw3zlky24g00yww2-git-2.54.0
+    => true
+
+    # Store derivations are also store paths themselves
+    hasStorePathPrefix /nix/store/nvl9ic0pj1fpyln3zaqrf4cclbqdfn1j-foo.drv
+    => true
+
+    # Paths outside the Nix store don't have a store path prefix
+    hasStorePathPrefix /home/user
+    => false
+
+    # Not all paths under the Nix store are store paths
+    hasStorePathPrefix /nix/store/.links/10gg8k3rmbw8p7gszarbk7qyd9jwxhcfq9i6s5i0qikx8alkk4hq
+    => false
+
+    # Values that can't be coerced to a string are rejected
+    isStorePath [] || isStorePath 42 || isStorePath {} || …
+    => false
+    ```
+
+    :::
+  */
+  hasStorePathPrefix =
+    let
+      withoutStorePrefix = removePrefix (storeDir + "/");
+      # NOTE: We could change the hash regex to be [0-9a-df-np-sv-z],
+      # because these are the actual ASCII characters used by Nix's base32 implementation,
+      # but this is not fully specified, so let's tie this too much to the currently implemented concept of store paths.
+      # Similar reasoning applies to the validity of the name part.
+      # We care more about discerning store path-ness on realistic values. Making it airtight would be fragile and slow.
+      matchFirstComponent = match ".{32}-[^/]+.*";
+      matchCaDrv = match "/[0-9a-z]{52}(/.*)?";
+    in
+    x:
+    if isStringLike x then
+      let
+        str = toString x;
+        afterStorePath = withoutStorePrefix str;
+      in
+      # path starts with the store directory (typically /nix/store),
+      # and is not the store directory itself, meaning there's at least one extra component
+      str != afterStorePath
+      # and the first component after the store directory has the expected format.
+      && matchFirstComponent afterStorePath != null
+      # alternatively match content‐addressed derivations, which _currently_ do
+      # not have a store directory prefix.
+      # This is a workaround for https://github.com/NixOS/nix/issues/12361 which
+      # was needed during the experimental phase of ca-derivations and should be
+      # removed once the issue has been resolved.
+      || matchCaDrv str != null
+    else
+      false;
+
+  /**
     Parse a string as an int. Does not support parsing of integers with preceding zero due to
     ambiguity between zero-padded and octal numbers. See `toIntBase10`.
 

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -122,6 +122,8 @@ let
     xor
     ;
 
+  inherit (lib.strings) hasStorePathPrefix storeDir;
+
   testingThrow = expr: {
     expr = (builtins.tryEval (builtins.seq expr "didn't throw"));
     expected = {
@@ -960,6 +962,48 @@ runTests {
       caAsPath = true;
       otherPath = false;
       otherVals = {
+        attrset = false;
+        list = false;
+        int = false;
+      };
+    };
+  };
+
+  testHasStorePathPrefix = {
+    expr = {
+      root = hasStorePathPrefix /.;
+      storeDir = hasStorePathPrefix storeDir;
+      nonAbsolute = hasStorePathPrefix "./foo";
+      absoluteNotInStore = hasStorePathPrefix /home/user;
+      derivationOutput = hasStorePathPrefix (storeDir + "/nvl9ic0pj1fpyln3zaqrf4cclbqdfn1j-foo");
+      derivationOutputSubpath = hasStorePathPrefix (
+        storeDir + "/nvl9ic0pj1fpyln3zaqrf4cclbqdfn1j-foo/bar/baz"
+      );
+      storeDerivation = hasStorePathPrefix (storeDir + "/nvl9ic0pj1fpyln3zaqrf4cclbqdfn1j-foo.drv");
+      links = hasStorePathPrefix (
+        storeDir + "/.links/10gg8k3rmbw8p7gszarbk7qyd9jwxhcfq9i6s5i0qikx8alkk4hq"
+      );
+      contentAddressedOutput = hasStorePathPrefix "/1121rp0gvr1qya7hvy925g5kjwg66acz6sn1ra1hca09f1z5dsab";
+      contentAddressedOutputSubpath = hasStorePathPrefix "/1121rp0gvr1qya7hvy925g5kjwg66acz6sn1ra1hca09f1z5dsab/foo/bar";
+
+      otherTypes = {
+        attrset = hasStorePathPrefix { };
+        list = hasStorePathPrefix [ ];
+        int = hasStorePathPrefix 1;
+      };
+    };
+    expected = {
+      root = false;
+      storeDir = false;
+      nonAbsolute = false;
+      absoluteNotInStore = false;
+      derivationOutput = true;
+      derivationOutputSubpath = true;
+      storeDerivation = true;
+      links = false;
+      contentAddressedOutput = true;
+      contentAddressedOutputSubpath = true;
+      otherTypes = {
         attrset = false;
         list = false;
         int = false;

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -83,7 +83,10 @@ let
     unions
     empty
     ;
-  inherit (lib.path) hasStorePathPrefix;
+
+  # lib.path also has a version of this function, but this one is faster since
+  # it works on non-path values
+  inherit (lib.strings) hasStorePathPrefix;
 
   inAttrPosSuffix =
     v: name:
@@ -728,14 +731,7 @@ rec {
         check =
           x:
           let
-            isInStore = hasStorePathPrefix (
-              if isPath x then
-                x
-              # Discarding string context is necessary to convert the value to
-              # a path and safe as the result is never used in any derivation.
-              else
-                /. + builtins.unsafeDiscardStringContext x
-            );
+            isInStore = if isExpectedType then hasStorePathPrefix x else false;
             isAbsolute = substring 0 1 (toString x) == "/";
             isExpectedType = (
               if inStore == null || inStore then isStringLike x else isString x # Do not allow a true path, which could be copied to the store later on.


### PR DESCRIPTION
I noticed hasStorePathPrefix in the profiler being less performant than I expected. Going through lib.path to check if a path has a valid store path prefix requires the overhead of first deconstructing the path and then operating over each component. Instead, we can use string-specific logic and prevent that overhead. lib.strings already has functions like isStorePath, so I think this overlap is acceptable. However, this isn't _that_ big of a win, so if we prefer DRY, I can close this.

Comes with tests and documentation, combining the tests of `lib.strings.isStorePath` and `lib.path.hasStorePathPrefix`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
