### PR TITLE
syshud: 0-unstable-2026-05-11 -> 0-unstable-2026-05-28

### DIFF
--- a/pkgs/by-name/sy/syshud/package.nix
+++ b/pkgs/by-name/sy/syshud/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "syshud";
-  version = "0-unstable-2026-05-26";
+  version = "0-unstable-2026-05-28";
 
   src = fetchFromGitHub {
     owner = "System64fumo";
     repo = "syshud";
-    rev = "4b5957bc95172268ba390e435be8916c4d1e7238";
-    hash = "sha256-j2fCi1dgb9w2Hu9pVXUemcIyuX+Rn5wYEfID6qYEPm4=";
+    rev = "4d0c4775fe38a14bd68fc654f8cc4ad624eed92a";
+    hash = "sha256-3DqBg3RUaEJCG5o/pt2B/+m/8X+Ifu9uHLJpjzLo9t8=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/sy/syshud/package.nix
+++ b/pkgs/by-name/sy/syshud/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  glibmm,
+  gtk4-layer-shell,
+  gtkmm4,
+  libevdev,
+  nix-update-script,
+  pkg-config,
+  wireplumber,
+  wrapGAppsHook4,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "syshud";
+  version = "0-unstable-2026-05-26";
+
+  src = fetchFromGitHub {
+    owner = "System64fumo";
+    repo = "syshud";
+    rev = "4b5957bc95172268ba390e435be8916c4d1e7238";
+    hash = "sha256-j2fCi1dgb9w2Hu9pVXUemcIyuX+Rn5wYEfID6qYEPm4=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/main.cpp \
+      --replace-fail /usr/share/sys64/hud/config.conf $out/share/sys64/hud/config.conf
+    substituteInPlace src/window.cpp \
+      --replace-fail /usr/share/sys64/hud/style.css $out/share/sys64/hud/style.css
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    glibmm
+    gtk4-layer-shell
+    gtkmm4
+    libevdev
+    wireplumber
+  ];
+
+  makeFlags = [
+    "DESTDIR=${placeholder "out"}"
+    "PREFIX="
+  ];
+
+  # populate version info used by `syshud -v`:
+  configurePhase = ''
+    runHook preConfigure
+
+    echo '#define GIT_COMMIT_MESSAGE "${finalAttrs.src.rev}"' >> src/git_info.hpp
+    echo '#define GIT_COMMIT_DATE "${lib.removePrefix "0-unstable-" finalAttrs.version}"' >> src/git_info.hpp
+
+    runHook postConfigure
+  '';
+
+  # syshud manually `dlopen`'s its library component
+  postInstall = ''
+    wrapProgram $out/bin/syshud --prefix LD_LIBRARY_PATH : $out/lib
+  '';
+
+  strictDeps = true;
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version"
+      "branch"
+    ];
+  };
+
+  meta = {
+    description = "Simple heads up display written in gtkmm 4";
+    mainProgram = "syshud";
+    homepage = "https://github.com/System64fumo/syshud";
+    license = lib.licenses.wtfpl;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ colinsane ];
+  };
+})


### PR DESCRIPTION
https://github.com/System64fumo/syshud/commit/4b5957bc95172268ba390e435be8916c4d1e7238
https://github.com/System64fumo/syshud/commit/4d0c4775fe38a14bd68fc654f8cc4ad624eed92a
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
