### PR TITLE
filezilla: 3.69.6 -> 3.70.5

### DIFF
--- a/pkgs/by-name/fi/filezilla/package.nix
+++ b/pkgs/by-name/fi/filezilla/package.nix
@@ -1,9 +1,10 @@
 {
   lib,
   stdenv,
-  fetchsvn,
+  fetchurl,
   autoreconfHook,
   dbus,
+  fzssh,
   gettext,
   gnutls,
   libfilezilla,
@@ -20,14 +21,15 @@
   xdg-utils,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "filezilla";
-  version = "3.69.6";
+  version = "3.70.5";
 
-  src = fetchsvn {
-    url = "https://svn.filezilla-project.org/svn/FileZilla3/trunk";
-    rev = "11365";
-    hash = "sha256-KJI+UxKiwmZfVG0CiS3lDnjz+YNjTy7IoTcOmlGkluk=";
+  src = fetchurl {
+    # Upstream download link was made unstable on purpose
+    # See https://trac.filezilla-project.org/ticket/13186
+    url = "https://sources.archlinux.org/other/filezilla/filezilla-${finalAttrs.version}.tar.xz";
+    hash = "sha256-d8FsJfsdlNUSlLAe/SDT5cwRmESFfktDmCrKa4mO5dY=";
   };
 
   configureFlags = [
@@ -44,6 +46,7 @@ stdenv.mkDerivation {
   buildInputs = [
     boost
     dbus
+    fzssh
     gettext
     gnutls
     libfilezilla
@@ -75,4 +78,4 @@ stdenv.mkDerivation {
       pSub
     ];
   };
-}
+})

--- a/pkgs/by-name/fz/fzssh/package.nix
+++ b/pkgs/by-name/fz/fzssh/package.nix
@@ -1,0 +1,60 @@
+{
+  fetchurl,
+  lib,
+  libargon2,
+  libfilezilla,
+  meson,
+  nettle,
+  ninja,
+  pkg-config,
+  stdenv,
+  testers,
+
+  autoreconfHook,
+  gettext,
+  gnutls,
+  libiconv,
+  libxcrypt,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fzssh";
+  version = "1.2.1";
+  __structuredAttrs = true;
+
+  src = fetchurl {
+    # Upstream download link was made unstable on purpose
+    # See https://trac.filezilla-project.org/ticket/13186
+    url = "https://sources.archlinux.org/other/packages/fzssh/fzssh-${finalAttrs.version}.tar.xz";
+    hash = "sha256-oFj1meahLF00t0hu4Ra4zvfG5sq/6xchd5xDjGHx/h0=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    libargon2
+    libfilezilla
+    nettle
+  ];
+
+  passthru.tests = {
+    pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+      versionCheck = true;
+    };
+  };
+
+  meta = {
+    homepage = "https://lib.filezilla-project.org/";
+    description = "SSH/SFTP library based on libfilezilla";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ ];
+    pkgConfigModules = [ "libfzssh-client" ];
+  };
+})

--- a/pkgs/by-name/li/libfilezilla/package.nix
+++ b/pkgs/by-name/li/libfilezilla/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchsvn,
+  fetchurl,
   autoreconfHook,
   gettext,
   gnutls,
@@ -11,14 +11,15 @@
   libxcrypt,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libfilezilla";
-  version = "0.54.1";
+  version = "0.55.5";
 
-  src = fetchsvn {
-    url = "https://svn.filezilla-project.org/svn/libfilezilla/trunk";
-    rev = "11363";
-    hash = "sha256-m4CfnovtZPvwwjlyWKx/L1OkjiIlKfR7tqg+xB+nqzw=";
+  src = fetchurl {
+    # Upstream download link was made unstable on purpose
+    # See https://trac.filezilla-project.org/ticket/13186
+    url = "https://sources.archlinux.org/other/libfilezilla/libfilezilla-${finalAttrs.version}.tar.xz";
+    hash = "sha256-SQwDLvB8WOurdpe3xRAk3XceovgPxM3JKQjDSDV+BT4=";
   };
 
   nativeBuildInputs = [
@@ -49,4 +50,4 @@ stdenv.mkDerivation {
     platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isDarwin;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
