### PR TITLE
happy-coder: 0.11.2 -> 0.13.0

### DIFF
--- a/pkgs/by-name/ha/happy-coder/package.nix
+++ b/pkgs/by-name/ha/happy-coder/package.nix
@@ -12,18 +12,18 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "happy-coder";
-  version = "0.11.2";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "slopus";
     repo = "happy-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-WKzbpxHqE3Dxqy/PDj51tM9+Wl2Pallfrc5UU2MxNn8=";
+    hash = "sha256-q4o8FHBhZsNL+D8rREjPzI1ky5+p3YNSxKc1OlA2pcs=";
   };
 
   yarnOfflineCache = fetchYarnDeps {
     yarnLock = finalAttrs.src + "/yarn.lock";
-    hash = "sha256-3/qcbCJ+Iwc+9zPCHKsCv05QZHPUp0it+QR3z7m+ssw=";
+    hash = "sha256-DlUUAj5b47KFhUBsftLjxYJJxyCxW9/xfp3WUCCClDY=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Updates `happy-coder` 0.11.2 → 0.13.0 (latest stable upstream tag).

Release: https://github.com/slopus/happy-cli/releases/tag/v0.13.0

Note: upstream also has `v0.14.0-0` / `v0.13.0-1` tags, but those are `-N`-suffixed pre-release tags — v0.13.0 is the latest non-prerelease. `nix-update` defaults to the atom-feed top (`0.14.0-0`); I pinned to `0.13.0` deliberately.

Mechanical version bump: `version`, source `hash`, and `yarnOfflineCache` hash updated. No packaging logic changed.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

<details><summary>Build proof (aarch64-linux)</summary>

```
$ nix-update --version=0.13.0 --build happy-coder
Update 0.11.2 -> 0.13.0 in .../pkgs/by-name/ha/happy-coder/package.nix
$ nix build -f . happy-coder
(build succeeded; src hash + yarnOfflineCache hash recomputed)
```
</details>

---

**Automation/AI disclosure:** version bump prepared with the `nix-update` tool and an AI coding assistant; reviewed, built, and verified locally by me (Chenglun Hu), who is accountable for this contribution. I manually corrected the target version to the latest **stable** tag (0.13.0) after nix-update initially selected the `0.14.0-0` prerelease.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
