### PR TITLE
yarpgen: init at 0-unstable-2025-08-12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24140,6 +24140,12 @@
     name = "Ryan Eschinger";
     keys = [ { fingerprint = "E4F4 1EAB BF0F C785 06D8  62EF EF68 CF41 D42A 593D"; } ];
   };
+  ryanfanchiotti = {
+    email = "ryan@rur.com";
+    github = "ryanfanchiotti";
+    githubId = 112440089;
+    name = "Ryan Fanchiotti";
+  };
   ryangibb = {
     email = "ryan@freumh.org";
     github = "ryangibb";

--- a/pkgs/by-name/ya/yarpgen/package.nix
+++ b/pkgs/by-name/ya/yarpgen/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "yarpgen";
+  version = "0-unstable-2025-08-12";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "yarpgen";
+    rev = "e0f63b6580cc9f1c50d18928a4273106dc3a6c41";
+    hash = "sha256-Y0TH2qiczrNQIZeEsFLzbUPptdwVGZ8NXcniY7LlVoU=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp yarpgen $out/bin
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Random program generator that produces correct runnable C/C++ and DPC++ programs";
+    homepage = "https://github.com/intel/yarpgen";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ ryanfanchiotti ];
+  };
+})


### PR DESCRIPTION
`yarpgen` is a C and C++ program generator used for compiler testing alongside `csmith` and other generators, and has found hundreds of bugs in `gcc`, `clang`, etc

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
