### PR TITLE
fontconfig: add support for aliases

### DIFF
--- a/nixos/modules/config/fonts/fontconfig.nix
+++ b/nixos/modules/config/fonts/fontconfig.nix
@@ -154,7 +154,7 @@ let
       <fontconfig>
 
         <!-- User defined aliases -->
-        ${lib.concatStringsSep "" (lib.mapAttrsToList mkAliasBlock cfg.aliases)}
+        ${lib.concatStrings (lib.mapAttrsToList mkAliasBlock cfg.aliases)}
 
       </fontconfig>
     '';

--- a/nixos/modules/config/fonts/fontconfig.nix
+++ b/nixos/modules/config/fonts/fontconfig.nix
@@ -135,7 +135,7 @@ let
         key: fonts:
         lib.optionalString ((builtins.length fonts) > 0) ''
           <${key}>
-          ${lib.concatStringsSep "" (map (font: "<family>${font}</family>") fonts)}
+          ${lib.concatMapStrings (font: "<family>${font}</family>") fonts}
           </${key}>
         '';
 

--- a/nixos/modules/config/fonts/fontconfig.nix
+++ b/nixos/modules/config/fonts/fontconfig.nix
@@ -127,6 +127,38 @@ let
       </fontconfig>
     '';
 
+  # user defined font aliases
+  # priority 53
+  aliases =
+    let
+      mkFontBlock =
+        key: fonts:
+        lib.optionalString ((builtins.length fonts) > 0) ''
+          <${key}>
+          ${lib.concatStringsSep "" (map (font: "<family>${font}</family>") fonts)}
+          </${key}>
+        '';
+
+      mkAliasBlock = family: opts: ''
+        <alias binding="${opts.binding}">
+          <family>${family}</family>
+          ${mkFontBlock "prefer" opts.prefer}
+          ${mkFontBlock "accept" opts.accept}
+          ${mkFontBlock "default" opts.default}
+        </alias>
+      '';
+    in
+    pkgs.writeText "fc-53-user-aliases.conf" ''
+      <?xml version='1.0'?>
+      <!DOCTYPE fontconfig SYSTEM 'urn:fontconfig:fonts.dtd'>
+      <fontconfig>
+
+        <!-- User defined aliases -->
+        ${lib.concatStringsSep "" (lib.mapAttrsToList mkAliasBlock cfg.aliases)}
+
+      </fontconfig>
+    '';
+
   # bitmap font options
   # priority 53
   rejectBitmaps = pkgs.writeText "fc-53-no-bitmaps.conf" ''
@@ -244,6 +276,9 @@ let
 
         # 53-no-bitmaps.conf
         ln -s ${rejectBitmaps} $dst/53-no-bitmaps.conf
+
+        # 53-user-aliases.conf
+        ln -s ${aliases} $dst/53-user-aliases.conf
 
         ${lib.optionalString (!cfg.allowType1) ''
           # 53-nixos-reject-type1.conf
@@ -522,6 +557,69 @@ in
           description = "Use embedded bitmaps in fonts like Calibri.";
         };
 
+        aliases = lib.mkOption {
+          type = lib.types.attrsOf (
+            lib.types.submodule {
+              options = {
+                binding = lib.mkOption {
+                  type = lib.types.enum [
+                    "same"
+                    "weak"
+                    "strong"
+                  ];
+                  default = "same";
+                  description = ''
+                    Binding precedence for this font family. See
+                    fontconfig "Font Matching" section for details.
+                  '';
+                };
+
+                prefer = lib.mkOption {
+                  type = lib.types.listOf lib.types.str;
+                  default = [ ];
+                  description = ''
+                    Fonts whose glyphs are chosen preferentially prior
+                    to fonts which match the alias family.
+                  '';
+                };
+
+                accept = lib.mkOption {
+                  type = lib.types.listOf lib.types.str;
+                  default = [ ];
+                  description = ''
+                    Fonts that are chosen if none of the preferred
+                    fonts, nor the alias family could provide the
+                    desired glyph.
+                  '';
+                };
+
+                default = lib.mkOption {
+                  type = lib.types.listOf lib.types.str;
+                  default = [ ];
+                  description = ''
+                    Last chance fallback fonts which are chosen by
+                    default if none of the other options could
+                    provide the desired glyph.
+                  '';
+                };
+              };
+            }
+          );
+          default = { };
+          example = lib.literalExpression ''
+            {
+                # use FreeSans for Greek symbols missing in Helvetica
+                "Helvetica" = {
+                    default = [ "FreeSans" ];
+                };
+            };
+          '';
+          description = ''
+            Font aliases that can substitute preferential fonts,
+            or specify custom fallback fonts.
+          '';
+        };
+
       };
 
     };
@@ -556,6 +654,9 @@ in
 
         # 52-nixos-default-fonts.conf
         r ${defaultFontsConf},
+
+        # 53-user-aliases.conf
+        r ${aliases},
 
         # 53-no-bitmaps.conf
         r ${rejectBitmaps},


### PR DESCRIPTION
This PR adds support for configuring fontconfig `<alias>` blocks, see freedesktop documentation [here](https://www.freedesktop.org/software/fontconfig/fontconfig-user.html) or archlinux summary [here](https://wiki.archlinux.org/title/Font_configuration#Alias).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].