### PR TITLE
[staging-26.05] cargo: add patches for CVE-2026-5222 and CVE-2026-5223

### DIFF
--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -3,6 +3,7 @@
   stdenv,
   pkgsHostHost,
   pkgsBuildBuild,
+  fetchpatch,
   file,
   curl,
   pkg-config,
@@ -25,6 +26,23 @@ rustPlatform.buildRustPackage.override
   {
     pname = "cargo";
     inherit (rustc.unwrapped) version src;
+
+    patches = [
+      (fetchpatch {
+        name = "CVE-2026-5222.patch";
+        url = "https://github.com/rust-lang/cargo/commit/c4d63a44234de22dc745231c416b80ed848d997f.patch";
+        stripLen = 1;
+        extraPrefix = "src/tools/cargo/";
+        hash = "sha256-YG7xtC308z+o1xVzrV81qqWov1121GVouyAXKflyBF8=";
+      })
+      (fetchpatch {
+        name = "CVE-2026-5223.patch";
+        url = "https://github.com/rust-lang/cargo/commit/285cebf58911eca5b7f177f5d0b1c53e1f646577.patch";
+        stripLen = 1;
+        extraPrefix = "src/tools/cargo/";
+        hash = "sha256-DbmPQ31N4AIYZEBiwwGAn59hgPsFEVTzA6PrI071LXE=";
+      })
+    ];
 
     # the rust source tarball already has all the dependencies vendored, no need to fetch them again
     cargoVendorDir = "vendor";


### PR DESCRIPTION
My understanding is that the release branches do not upgrade their Rust versions, so we should patch these issues on 26.05. There won't be another staging-next-25.11 cycle, and the issues don't seem of high enough severity to disrupt the current one, so I don't think we need to bother with this on 25.11.

Please let me know if there's a different/better place to apply this patch; I wasn't sure if I should do it in `rust/cargo.nix`, `rust/1_95.nix`, or elsewhere.

Upstream pull request: https://github.com/rust-lang/cargo/pull/17031

Fixes: CVE-2026-5222, https://blog.rust-lang.org/2026/05/25/cve-2026-5222/
Fixes: CVE-2026-5223, https://blog.rust-lang.org/2026/05/25/cve-2026-5223/
Not-cherry-picked-because: master will get these fixes via the rust 1.96 upgrade on 2026-05-28

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
