### PR TITLE
harfbuzz: 13.2.1 -> 14.4.0

### DIFF
--- a/pkgs/by-name/ha/harfbuzz/package.nix
+++ b/pkgs/by-name/ha/harfbuzz/package.nix
@@ -14,6 +14,8 @@
     lib.meta.availableOn stdenv.hostPlatform gobject-introspection
     && stdenv.hostPlatform.emulatorAvailable buildPackages,
   withRaster ? false,
+  withVector ? false,
+  withGPU ? false,
   withCairo ? false,
   cairo,
   icu,
@@ -37,11 +39,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "harfbuzz${lib.optionalString withIcu "-icu"}";
-  version = "13.2.1";
+  version = "14.4.0";
 
   src = fetchurl {
     url = "https://github.com/harfbuzz/harfbuzz/releases/download/${finalAttrs.version}/harfbuzz-${finalAttrs.version}.tar.xz";
-    hash = "sha256-ZpXaPrfhvgqjCS/k2BQzoztH9FGSWcdZ1ynjqaVcFCk=";
+    hash = "sha256-I1ftlmxs7Xv6cgsGQMAjEGWvARWPvqIVCT/6Fa7UQ3E=";
   };
 
   # This test fails reliably when executed through mesonCheckPhase but passes with
@@ -71,7 +73,13 @@ stdenv.mkDerivation (finalAttrs: {
     # Cairo causes transitive (build) dependencies on various X11 or other
     # GUI-related libraries, so it shouldn't be re-added lightly.
     (lib.mesonEnable "cairo" withCairo)
+    # experimental libraries
     (lib.mesonEnable "raster" withRaster)
+    (lib.mesonEnable "vector" withVector)
+    (lib.mesonEnable "gpu" withGPU)
+    # hb-gpu has a dependency on glfw3, which would introduce a cyclic dependency on harfbuzz
+    # (glfw3 -> libdecor -> gtk3 -> harfbuzz)
+    (lib.mesonEnable "gpu_demo" false)
     # chafa is only used in a development utility, not in the library
     (lib.mesonEnable "chafa" false)
     (lib.mesonEnable "coretext" withCoreText)


### PR DESCRIPTION
Major update to new harfbuzz release.

This release notably introduced the `vector` and `gpu` experimental libraries. They are supported as overridable option by the package.

I have tested a build on `x86_64-linux` with all experimental libraries (and each individual one) enabled but kept them off by default for now. Given that their usage is presumably rather low for now it doesn't seem necessary to include them yet.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
