### PR TITLE
ocamlPackages.lua-ml: 0.9.4 → 0.9.5

### DIFF
--- a/pkgs/development/ocaml-modules/lua-ml/default.nix
+++ b/pkgs/development/ocaml-modules/lua-ml/default.nix
@@ -2,23 +2,24 @@
   lib,
   fetchFromGitHub,
   buildDunePackage,
+  menhir,
 }:
 buildDunePackage (finalAttrs: {
   pname = "lua-ml";
-  version = "0.9.4";
-
-  minimalOCamlVersion = "4.07";
+  version = "0.9.5";
 
   src = fetchFromGitHub {
     owner = "lindig";
     repo = "lua-ml";
     tag = finalAttrs.version;
-    hash = "sha256-kMBTHzmlrRWNpWwG321jYcM61rE1J3YQkygSrfnZ6Wc=";
+    hash = "sha256-+kg/hwcmRoM6sSL2GXOC2GrnJRu52BR5UiNu3nl5Lnk=";
   };
+
+  nativeBuildInputs = [ menhir ];
 
   meta = {
     description = "Embeddable Lua 2.5 interpreter implemented in OCaml";
-    inherit (finalAttrs.src.meta) homepage;
+    homepage = "https://github.com/lindig/lua-ml";
     license = lib.licenses.bsd2;
     maintainers = [ lib.maintainers.vbgl ];
   };


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
