### PR TITLE
dufs: 0.45.0 -> 0.46.0

### DIFF
--- a/pkgs/by-name/du/dufs/package.nix
+++ b/pkgs/by-name/du/dufs/package.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "dufs";
-  version = "0.45.0";
+  version = "0.46.0";
 
   src = fetchFromGitHub {
     owner = "sigoden";
     repo = "dufs";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-83lFnT4eRYaBe4e2o6l6AGQycm/oK96n5DXutBNvBsE=";
+    hash = "sha256-Be7aJ5Bo5JSMcyyWsZ3ZamQ691TSIO4Ylxzil7UNJxk=";
   };
 
-  cargoHash = "sha256-WdjqG2URtloh5OnpBBnEWHD3WKGkCKLDcCyWRVGIXto=";
+  cargoHash = "sha256-H2ew+sb60UnXe3Dls9MSKwAk4hT/yLSbgZz6pVOkHQQ=";
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
## Things done

`dufs`: 0.45.0 -> 0.46.0

Upstream release: https://github.com/sigoden/dufs/releases/tag/v0.46.0 (2026-05-07).

Built and ran locally on `x86_64-linux`:

```
$ nix-build -A dufs
...
test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
$ result/bin/dufs --version
dufs 0.46.0
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (N/A — Linux)
- [x] Tested, as applicable: package test suite passes (22/22) via `versionCheckHook` + cargo checks
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` — no reverse deps
- [x] Tested execution of all binary files added or changed: `result/bin/dufs --version` -> `dufs 0.46.0`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
