### PR TITLE
mprocs: 0.9.2 -> 0.9.3

### DIFF
--- a/pkgs/by-name/mp/mprocs/package.nix
+++ b/pkgs/by-name/mp/mprocs/package.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mprocs";
-  version = "0.9.2";
+  version = "0.9.3";
 
   src = fetchFromGitHub {
     owner = "pvolok";
     repo = "mprocs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-UZFFeaesT71UQHPjiG2w5O2Ulyt86OVuFw7i3A7b91I=";
+    hash = "sha256-ciYvdmSGNz256VnVGIu3DnW7IyKJmBTZVRLPAkbaICI=";
   };
 
-  cargoHash = "sha256-htgl0zh73oHXbc9E90xtb5jM8zhXvSJCE9DBhd1SH2E=";
+  cargoHash = "sha256-HO9C/Ch9E2kjcWbV/hMcx74/iCFimBxCYXPl04S+ZFo=";
 
   nativeInstallCheckInputs = [
     versionCheckHook


### PR DESCRIPTION
## Things done

Bumps `mprocs` to the latest upstream release [v0.9.3](https://github.com/pvolok/mprocs/releases/tag/v0.9.3) (2026-05-20).

Verified locally on `x86_64-linux`:

```
$ nix-build -A mprocs
...
Executing versionCheckPhase
Successfully managed to find version 0.9.3 in the output of the command .../bin/mprocs --version
mprocs 0.9.3
Finished versionCheckPhase
/nix/store/xjlq5fp6859rwpjy912i37l0miqx4wq4-mprocs-0.9.3
```

`versionCheckHook` passes, so the built binary reports the expected version.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (N/A — Linux)
- [x] Tested, as applicable: `versionCheckHook` passes (`mprocs --version` -> `mprocs 0.9.3`)
- [x] Tested compilation of all packages that depend on this change: no reverse dependencies
- [x] Tested execution of all binary files added or changed: `result/bin/mprocs --version` -> `mprocs 0.9.3`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
