### PR TITLE
buildMozillaMach: fix darwin build for 140.x

### DIFF
--- a/pkgs/build-support/build-mozilla-mach/140-bindgen-string-view.patch
+++ b/pkgs/build-support/build-mozilla-mach/140-bindgen-string-view.patch
@@ -1,0 +1,15 @@
+diff --git a/tools/profiler/rust-api/build.rs b/tools/profiler/rust-api/build.rs
+index 9bb27eb83e5e..3f09f7f01bcb 100644
+--- a/tools/profiler/rust-api/build.rs
++++ b/tools/profiler/rust-api/build.rs
+@@ -88,6 +88,10 @@ fn generate_bindings() {
+         // successfully. Otherwise, it fails to build because MarkerSchema has
+         // some std::strings as its fields.
+         .opaque_type("std::string")
++        .blocklist_type(".*basic_string_view.*")
++        .opaque_type(".*basic_string_view.*")
++        .blocklist_type(".*basic_string___self_view.*")
++        .opaque_type(".*basic_string___self_view.*")
+         // std::vector needs to be converted to an opaque type because, if it's
+         // not an opaque type, bindgen can't find its size properly and
+         // MarkerSchema's total size reduces. That causes a heap buffer overflow.

--- a/pkgs/build-support/build-mozilla-mach/default.nix
+++ b/pkgs/build-support/build-mozilla-mach/default.nix
@@ -332,6 +332,14 @@ buildStdenv.mkDerivation {
       # https://hg-edge.mozilla.org/mozilla-central/rev/aa8a29bd1fb9
       ./139-wayland-drag-animation.patch
     ]
+    ++ lib.optionals (lib.versionAtLeast version "140" && lib.versionOlder version "144") [
+      # Versions before 144 vendor bindgen 0.69. On Darwin, libc++ 21 changed
+      # basic_string::__self_view from a typedef to an attributed using alias;
+      # bindgen then emits it without its template parameter, producing invalid
+      # Rust. Vendored bindgen was updated in:
+      # https://bugzilla.mozilla.org/show_bug.cgi?id=1985509
+      ./140-bindgen-string-view.patch
+    ]
     ++ extraPatches;
 
   postPatch = ''


### PR DESCRIPTION
Versions before 144 vendor bindgen 0.69, which emits invalid Rust for
libc++ 21's attributed basic_string::__self_view alias on Darwin.

This was exposed by commit 0758fc3addcc ("darwin.libcxx:
20.1.0+apple-sdk-26.0 -> 21.1.6+apple-sdk-26.4"), where libc++
changed `basic_string::__self_view` from a typedef to an attributed
`using` alias. bindgen then drops the alias template parameter and emits
`basic_string___self_view = ...<_CharT>`.

The solution is to blocklist the unused `string_view` internals for the
profiler Rust API. They are not used in the actual build.

Note: Mozilla 144 updated vendored bindgen via:
https://bugzilla.mozilla.org/show_bug.cgi?id=1985509

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
