### PR TITLE
zetui: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30829,6 +30829,12 @@
       { fingerprint = "897B 6DF1 D6FC 152C 9347  486D 042F 1F94 C62D DB03"; }
     ];
   };
+  zexk = {
+    email = "zexkeientei@protonmail.com";
+    github = "zexk";
+    githubId = 22141326;
+    name = "zexk";
+  };
   zfnmxt = {
     name = "zfnmxt";
     email = "zfnmxt@zfnmxt.com";

--- a/pkgs/by-name/ze/zetui/package.nix
+++ b/pkgs/by-name/ze/zetui/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  zig_0_14,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "zetui";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "zexk";
+    repo = "zetui";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-D5vpMUZAhIUMO3xvm3mlqy4Ky0VzTxeVX85y+w7vzpY=";
+  };
+
+  nativeBuildInputs = [ zig_0_14.hook ];
+
+  meta = {
+    description = "ANSI/C89 single-header TUI library with first-class Zig bindings";
+    homepage = "https://github.com/zexk/zetui";
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [ zexk ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
C89 single-header TUI library with Zig bindings. Builds a static library, installs the header, and includes example binaries.

Tested on x86_64-linux.

- `nix-build -A zetui` passes
- outputs: `lib/libzetui.a`, `include/zetui.h`, example binaries under `bin/`