### PR TITLE
monero-{cli,gui}: 0.18.4.6 -> 0.18.5.0

### DIFF
--- a/pkgs/by-name/mo/monero-cli/package.nix
+++ b/pkgs/by-name/mo/monero-cli/package.nix
@@ -6,7 +6,6 @@
   pkg-config,
   boost186,
   libsodium,
-  miniupnpc,
   openssl,
   python3,
   randomx,
@@ -39,13 +38,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "monero-cli";
-  version = "0.18.4.6";
+  version = "0.18.5.0";
 
   src = fetchFromGitHub {
     owner = "monero-project";
     repo = "monero";
     rev = "v${version}";
-    hash = "sha256-A7EqamADbTyK6l26foSXfZLH94OUUMsgi7jdsKRubXU=";
+    hash = "sha256-clw+7mZenWp58iA7fuEp4BPFH3KUwL53cC4IChIVh7w=";
   };
 
   patches = [
@@ -69,7 +68,6 @@ stdenv.mkDerivation rec {
   buildInputs = [
     boost186 # uses boost/asio/io_service.hpp
     libsodium
-    miniupnpc
     openssl
     randomx
     rapidjson

--- a/pkgs/by-name/mo/monero-cli/use-system-libraries.patch
+++ b/pkgs/by-name/mo/monero-cli/use-system-libraries.patch
@@ -1,79 +1,11 @@
 diff --git a/external/CMakeLists.txt b/external/CMakeLists.txt
-index 538e4d215..cc4b0a346 100644
+index 5bdd5d9b4..3af6c5f5a 100644
 --- a/external/CMakeLists.txt
 +++ b/external/CMakeLists.txt
-@@ -35,26 +35,14 @@
- # ...except for FreeBSD, because FreeBSD is a special case that doesn't play well with
- # others.
- 
--find_package(Miniupnpc REQUIRED)
--
--message(STATUS "Using in-tree miniupnpc")
--set(UPNPC_NO_INSTALL TRUE CACHE BOOL "Disable miniupnp installation" FORCE)
--set(UPNPC_BUILD_SHARED OFF CACHE BOOL "Disable building shared library" FORCE)
--add_subdirectory(miniupnp/miniupnpc)
--set_property(TARGET libminiupnpc-static PROPERTY FOLDER "external")
--set_property(TARGET libminiupnpc-static PROPERTY POSITION_INDEPENDENT_CODE ON)
--if(MSVC)
--  set_property(TARGET libminiupnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -wd4244 -wd4267")
--elseif(NOT MSVC)
--  set_property(TARGET libminiupnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-undef -Wno-unused-result -Wno-unused-value")
--endif()
--if(CMAKE_SYSTEM_NAME MATCHES "NetBSD")
--	set_property(TARGET libminiupnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -D_NETBSD_SOURCE")
--endif()
--
--set(UPNP_LIBRARIES "libminiupnpc-static" PARENT_SCOPE)
-+find_package(PkgConfig REQUIRED)
-+pkg_check_modules(MINIUPNPC REQUIRED miniupnpc)
-+link_libraries(${MINIUPNPC_LIBRARIES})
-+include_directories(${MINIUPNPC_INCLUDE_DIRS})
- 
-+find_package(RapidJSON)
- find_package(Unbound)
-+find_library(RANDOMX_LIBRARY randomx)
- 
- if(NOT UNBOUND_INCLUDE_DIR)
-   die("Could not find libunbound")
-@@ -70,4 +58,3 @@ endif()
+@@ -44,4 +44,5 @@ endif()
  add_subdirectory(db_drivers)
  add_subdirectory(easylogging++)
  add_subdirectory(qrcodegen)
 -add_subdirectory(randomx EXCLUDE_FROM_ALL)
-diff --git a/src/p2p/net_node.inl b/src/p2p/net_node.inl
-index 884a7b5fc..24c10334e 100644
---- a/src/p2p/net_node.inl
-+++ b/src/p2p/net_node.inl
-@@ -60,9 +60,9 @@
- #include "cryptonote_core/cryptonote_core.h"
- #include "net/parse.h"
- 
--#include <miniupnp/miniupnpc/miniupnpc.h>
--#include <miniupnp/miniupnpc/upnpcommands.h>
--#include <miniupnp/miniupnpc/upnperrors.h>
-+#include <miniupnpc/miniupnpc.h>
-+#include <miniupnpc/upnpcommands.h>
-+#include <miniupnpc/upnperrors.h>
- 
- #undef MONERO_DEFAULT_LOG_CATEGORY
- #define MONERO_DEFAULT_LOG_CATEGORY "net.p2p"
-@@ -2989,7 +2989,8 @@ namespace nodetool
-     UPNPUrls urls;
-     IGDdatas igdData;
-     char lanAddress[64];
--    result = UPNP_GetValidIGD(deviceList, &urls, &igdData, lanAddress, sizeof lanAddress);
-+    char wanAddress[64];
-+    result = UPNP_GetValidIGD(deviceList, &urls, &igdData, lanAddress, sizeof lanAddress, wanAddress, sizeof wanAddress);
-     freeUPNPDevlist(deviceList);
-     if (result > 0) {
-       if (result == 1) {
-@@ -3057,7 +3058,8 @@ namespace nodetool
-     UPNPUrls urls;
-     IGDdatas igdData;
-     char lanAddress[64];
--    result = UPNP_GetValidIGD(deviceList, &urls, &igdData, lanAddress, sizeof lanAddress);
-+    char wanAddress[64];
-+    result = UPNP_GetValidIGD(deviceList, &urls, &igdData, lanAddress, sizeof lanAddress, wanAddress, sizeof wanAddress);
-     freeUPNPDevlist(deviceList);
-     if (result > 0) {
-       if (result == 1) {
++find_library(RANDOMX_LIBRARY randomx)
++find_package(RapidJSON)

--- a/pkgs/by-name/mo/monero-gui/package.nix
+++ b/pkgs/by-name/mo/monero-gui/package.nix
@@ -7,7 +7,6 @@
   libgcrypt,
   libgpg-error,
   libsodium,
-  miniupnpc,
   monero-cli,
   pkg-config,
   qt5,
@@ -28,13 +27,13 @@
 
 stdenv.mkDerivation rec {
   pname = "monero-gui";
-  version = "0.18.4.7";
+  version = "0.18.5.0";
 
   src = fetchFromGitHub {
     owner = "monero-project";
     repo = "monero-gui";
     rev = "v${version}";
-    hash = "sha256-22v4KwtmjIkeQXfMdxCQr6TUdAEih6xwtNPbuzpQDZk=";
+    hash = "sha256-uBZMBQ6Co1+H8DsyeL1vbjtVlKyIkJopKxHxr24BZv0=";
   };
 
   nativeBuildInputs = [
@@ -49,7 +48,6 @@ stdenv.mkDerivation rec {
     libgcrypt
     libgpg-error
     libsodium
-    miniupnpc
     qt5.qtbase
     qt5.qtdeclarative
     qt5.qtgraphicaleffects


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] Running `monero-wallet-gui`, connecting to a remote node and sync
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
