### PR TITLE
renovate: Add runtime dependencies

### DIFF
--- a/pkgs/by-name/re/renovate/package.nix
+++ b/pkgs/by-name/re/renovate/package.nix
@@ -100,6 +100,12 @@ stdenv.mkDerivation (finalAttrs: {
     cp -r dist node_modules package.json renovate-schema.json $out/lib/node_modules/renovate
 
     makeWrapper "${lib.getExe nodejs}" "$out/bin/renovate" \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          nodejs_24
+          pnpm_10
+        ]
+      } \
       --add-flags "$out/lib/node_modules/renovate/dist/renovate.js"
     makeWrapper "${lib.getExe nodejs}" "$out/bin/renovate-config-validator" \
       --add-flags "$out/lib/node_modules/renovate/dist/config-validator.js"


### PR DESCRIPTION
When using in the `nodejs` ecosystem on a repository using `pnpm`, `renovate` needs to be able to call these programs.

Not 100% certain we want to "bloat" the `renovate` binary with all the dependencies needed to cover all ecosystems and package managers there exists :thinking: 
However, it would be nice to be able to produce a `renovate` that works out-of-the-box, and don't require certain binaries to be present in its ambiant environment.
Thoughts?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
