### PR TITLE
gnomeExtensions.gsconnect: 71 -> 72

### DIFF
--- a/pkgs/desktops/gnome/extensions/gsconnect/default.nix
+++ b/pkgs/desktops/gnome/extensions/gsconnect/default.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-shell-extension-gsconnect";
-  version = "71";
+  version = "72";
 
   outputs = [
     "out"
@@ -34,13 +34,14 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "GSConnect";
     repo = "gnome-shell-extension-gsconnect";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-OgASLH/mPmRmT8RcXOAZLzDhhidLnlZNcgpAQNbO30Q=";
+    hash = "sha256-w9MQVEUQUcO1lqftBi76w5xSTlryKuZJxE6Ogg1J+ho=";
   };
 
   patches = [
     # Make typelibs available in the extension
     (replaceVars ./fix-paths.patch {
       gapplication = "${glib.bin}/bin/gapplication";
+      gjs = "${gjs}/bin/gjs";
       # Replaced in postPatch
       typelibPath = null;
     })

--- a/pkgs/desktops/gnome/extensions/gsconnect/default.nix
+++ b/pkgs/desktops/gnome/extensions/gsconnect/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "GSConnect";
     repo = "gnome-shell-extension-gsconnect";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-w9MQVEUQUcO1lqftBi76w5xSTlryKuZJxE6Ogg1J+ho=";
   };
 
@@ -121,6 +121,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "KDE Connect implementation for Gnome Shell";
     homepage = "https://github.com/GSConnect/gnome-shell-extension-gsconnect/wiki";
+    changelog = "https://github.com/GSConnect/gnome-shell-extension-gsconnect/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ doronbehar ];
     teams = [ lib.teams.gnome ];

--- a/pkgs/desktops/gnome/extensions/gsconnect/fix-paths.patch
+++ b/pkgs/desktops/gnome/extensions/gsconnect/fix-paths.patch
@@ -13,14 +13,14 @@ index 3fb887c3..e8cbe1bd 100644
  Icon=org.gnome.Shell.Extensions.GSConnect
 diff --git a/src/__nix-prepend-search-paths.js b/src/__nix-prepend-search-paths.js
 new file mode 100644
-index 00000000..d009dfd9
+index 00000000..e664ad9b
 --- /dev/null
 +++ b/src/__nix-prepend-search-paths.js
 @@ -0,0 +1,2 @@
 +import GIRepository from 'gi://GIRepository';
 +'@typelibPath@'.split(':').forEach(path => GIRepository.Repository.dup_default().prepend_search_path(path));
 diff --git a/src/extension.js b/src/extension.js
-index 53ecd5fc..78782357 100644
+index b82a9754..7303ee7a 100644
 --- a/src/extension.js
 +++ b/src/extension.js
 @@ -2,6 +2,8 @@
@@ -32,11 +32,22 @@ index 53ecd5fc..78782357 100644
  import Gio from 'gi://Gio';
  import GObject from 'gi://GObject';
  
-diff --git i/src/gsconnect-preferences w/src/gsconnect-preferences
-index b16ddc7d..263dfb04 100755
+diff --git a/src/gsconnect-preferences b/src/gsconnect-preferences
+index 652f6b2e..7122bed6 100755
 --- a/src/gsconnect-preferences
 +++ b/src/gsconnect-preferences
-@@ -6,6 +6,8 @@
+@@ -15,5 +15,5 @@ if [ ! -f "./gsconnect-preferences.js" ]; then
+     fi
+     cd "$extension_dir" || exit 1
+ fi
+-exec /usr/bin/env gjs -m gsconnect-preferences.js
++exec @gjs@ -m gsconnect-preferences.js
+
+diff --git a/src/gsconnect-preferences.js b/src/gsconnect-preferences.js
+index e2b1efe9..c2060e61 100644
+--- a/src/gsconnect-preferences.js
++++ b/src/gsconnect-preferences.js
+@@ -4,6 +4,8 @@
  
  // -*- mode: js; -*-
  
@@ -46,7 +57,7 @@ index b16ddc7d..263dfb04 100755
  import 'gi://GdkPixbuf?version=2.0';
  import Gio from 'gi://Gio?version=2.0';
 diff --git a/src/prefs.js b/src/prefs.js
-index dd20fd20..5f82c53a 100644
+index e4d38f8c..e177810b 100644
 --- a/src/prefs.js
 +++ b/src/prefs.js
 @@ -2,6 +2,8 @@
@@ -58,3 +69,24 @@ index dd20fd20..5f82c53a 100644
  import Gio from 'gi://Gio';
  import GLib from 'gi://GLib';
  import Adw from 'gi://Adw';
+@@ -28,6 +30,6 @@ export default class GSConnectExtensionPreferences extends ExtensionPreferences
+ 
+         const _launcher = Gio.SubprocessLauncher.new({flags: Gio.SubprocessFlags.NONE});
+         _launcher.set_cwd(this.path);
+-        _launcher.spawnv(['gjs', '-m', 'gsconnect-preferences.js']);
++        _launcher.spawnv(['@gjs@', '-m', 'gsconnect-preferences.js']);
+     }
+ }
+diff --git a/src/service/daemon.js b/src/service/daemon.js
+index dda8b434..889c7d48 100755
+--- a/src/service/daemon.js
++++ b/src/service/daemon.js
+@@ -214,7 +214,7 @@ const Service = GObject.registerClass({
+             {flags: Gio.SubprocessFlags.NONE}
+         );
+         _launcher.set_cwd(Config.PACKAGE_DATADIR);
+-        _launcher.spawnv(['gjs', '-m', 'gsconnect-preferences.js']);
++        _launcher.spawnv(['@gjs@', '-m', 'gsconnect-preferences.js']);
+     }
+ 
+     /**


### PR DESCRIPTION
Changelog: https://github.com/GSConnect/gnome-shell-extension-gsconnect/releases/tag/v72
Diff: https://github.com/GSConnect/gnome-shell-extension-gsconnect/compare/v71...v72

Adds support for GNOME 50 and therefore fixes the build of `nix-build -A nixosTests.installed-tests.gsconnect`. Tested basic functionality on a GNOME 50 system.

Hydra: https://hydra.nixos.org/build/329735899
ZHF: https://github.com/NixOS/nixpkgs/issues/516381

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`. — 
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
