### PR TITLE
php8*Extensions.{pdo_sqlsrv,sqlsrv}: 5.10.1/5.12.0 -> 5.13.1

### DIFF
--- a/pkgs/development/php-packages/pdo_sqlsrv/default.nix
+++ b/pkgs/development/php-packages/pdo_sqlsrv/default.nix
@@ -10,8 +10,8 @@
 buildPecl {
   pname = "pdo_sqlsrv";
 
-  version = "5.10.1";
-  sha256 = "sha256-x4VBlqI2vINQijRvjG7x35mbwh7rvYOL2wUTIV4GKK0=";
+  version = "5.13.1";
+  sha256 = "sha256-NQpdZqE74R+t/26w1zkeWMG4ryzQq+FBJj9a8ZMP62k=";
 
   internalDeps = [ php.extensions.pdo ];
 
@@ -22,6 +22,5 @@ buildPecl {
     license = lib.licenses.mit;
     homepage = "https://github.com/Microsoft/msphpsql";
     teams = [ lib.teams.php ];
-    broken = lib.versionAtLeast php.version "8.5";
   };
 }

--- a/pkgs/development/php-packages/sqlsrv/default.nix
+++ b/pkgs/development/php-packages/sqlsrv/default.nix
@@ -9,8 +9,8 @@
 buildPecl {
   pname = "sqlsrv";
 
-  version = "5.12.0";
-  sha256 = "sha256-qeu4gLKlWNPWaE9uaALFPFv/pJ4e5g0Uc6cST8nLcq0=";
+  version = "5.13.1";
+  sha256 = "sha256-fE6o8l67yJmQhCOefg73UxUJfgE98OKQ/O92w9l3udg=";
 
   buildInputs = [ unixodbc ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
 


### PR DESCRIPTION
- `pdo_sqlsrv`: 5.10.1 → 5.13.1 — removes `broken = lib.versionAtLeast php.version "8.5"` since 5.13.0 adds PHP 8.5 support
- `sqlsrv`: 5.12.0 → 5.13.1

Both packages are co-released by Microsoft as part of the [v5.13.0](https://github.com/microsoft/msphpsql/releases/tag/v5.13.0) / [v5.13.1](https://github.com/microsoft/msphpsql/releases/tag/v5.13.1) releases. PHP 8.5 compatibility was broken due to API changes in the `pdo_dbh_t` struct; 5.13.0 resolves this.

Fixes: https://github.com/microsoft/msphpsql/issues/1539