### PR TITLE
porxie: 0.3.1 -> 0.3.3, nixos/porxie: update options for version 

### DIFF
--- a/nixos/modules/services/networking/porxie.nix
+++ b/nixos/modules/services/networking/porxie.nix
@@ -62,9 +62,9 @@ in
             description = ''
               Admin password for authenticating privileged requests.
 
-              When unset, all authenticated endpoints will reject requests with HTTP 401.
-
               Authenticated requests always expect the username `admin` as per specification.
+
+              When not set, authenticated endpoints will be unavailable.
 
               Should be set via {option}`environmentFiles` rather than directly.
             '';
@@ -90,20 +90,17 @@ in
             description = ''
               Maximum blob size that can be served.
 
-              Blobs that exceed this limit will return HTTP 413.
-
-              The minimum value is 512kb and the maximum is the system's total memory.
+              This value cannot be set higher than the system's total memory.
             '';
           };
           PORXIE_BLOB_CACHE_HEADER = lib.mkOption {
             type = lib.types.nullOr lib.types.str;
             default = null;
             description = ''
-              The `Cache-Control` header value to send alongside blob responses.
+              The Cache-Control header value to send alongside blob responses.
 
-              This does not affect internal cache lifetimes, only how downstream clients such as
-              CDNs and browsers are instructed to cache responses. Intermediary caches may need
-              to be cleared manually for changes to take effect quickly.
+              This does not affect internal cache lifetimes, only how downstream clients such as CDNs
+              and browsers are instructed to cache responses.
             '';
           };
           PORXIE_BLOB_PROCESSING_TIMEOUT = lib.mkOption {
@@ -116,39 +113,12 @@ in
             default = null;
             description = "Maximum duration before blob fetch requests are timed out.";
           };
-          PORXIE_BLOB_HTTP_CONNECT_TIMEOUT = lib.mkOption {
-            type = lib.types.nullOr lib.types.str;
-            default = null;
-            description = ''
-              Maximum duration before an attempted connection to a blob upstream is aborted.
-
-              This value should be lower than {option}`settings.PORXIE_BLOB_HTTP_TIMEOUT`.
-            '';
-          };
 
           # Identity.
           PORXIE_IDENTITY_PLC_URL = lib.mkOption {
             type = lib.types.nullOr lib.types.str;
             default = null;
-            description = ''
-              URL of the PLC instance used for `did:plc` lookups.
-
-              Can typically be left as default unless using a custom or local development setup.
-            '';
-          };
-          PORXIE_IDENTITY_HTTP_TIMEOUT = lib.mkOption {
-            type = lib.types.nullOr lib.types.str;
-            default = null;
-            description = "Maximum duration before identity resolution requests are timed out.";
-          };
-          PORXIE_IDENTITY_HTTP_CONNECT_TIMEOUT = lib.mkOption {
-            type = lib.types.nullOr lib.types.str;
-            default = null;
-            description = ''
-              Maximum duration before a connection attempt to an identity upstream is aborted.
-
-              This value should be lower than {option}`settings.PORXIE_IDENTITY_HTTP_TIMEOUT`.
-            '';
+            description = "URL of the PLC instance used for `did:plc` lookups.";
           };
 
           # Cache.
@@ -158,8 +128,7 @@ in
             description = ''
               Total memory allocation for the internal cache.
 
-              Blobs are cached using an LFU policy. The most frequently requested blobs are kept
-              longest when the cache approaches its limit.
+              Blobs are cached using an LFU policy. The most frequently requested blobs are kept longest when the cache reaches maximum size.
 
               For production deployments, a CDN or caching layer in front of this server is
               recommended for lower latency and better global availability.
@@ -195,7 +164,7 @@ in
             description = ''
               Policy service URL that DID+CID pairs will be checked against.
 
-              Requests are sent via XRPC to `<url>/xrpc/dev.blooym.porxie.getBlobPolicy?did=<did>&cid=<cid>`.
+              Requests are sent via XRPC to `<url>/xrpc/dev.blooym.porxie.getBlobPolicy`.
             '';
           };
           PORXIE_POLICY_REQUEST_HEADERS = lib.mkOption {
@@ -203,10 +172,11 @@ in
             default = null;
             apply = v: if v != null then lib.concatStringsSep "|" v else null;
             description = ''
-              Headers sent alongside all requests to the policy service.
+              Headers sent alongside requests to the policy service.
+
               Each header must be in the format `Name: value`.
 
-              As pipes are used as a delimiter, they cannot be contained in header values.
+              As pipes are used as a delimiter, they cannot be contained in headers.
 
               Should be set via {option}`environmentFiles` for sensitive values such as API keys.
             '';
@@ -216,24 +186,10 @@ in
             default = null;
             apply = v: if v != null then lib.boolToString v else null;
             description = ''
-              Allow requests to proceed if the policy service is unavailable.
+              Allow requests to proceed even if the policy service is unavailable.
 
-              Warning: enabling this means restricted blobs may be served when the policy
-              service is unreachable.
-            '';
-          };
-          PORXIE_POLICY_HTTP_TIMEOUT = lib.mkOption {
-            type = lib.types.nullOr lib.types.str;
-            default = null;
-            description = "Maximum duration before policy service requests are timed out.";
-          };
-          PORXIE_POLICY_HTTP_CONNECT_TIMEOUT = lib.mkOption {
-            type = lib.types.nullOr lib.types.str;
-            default = null;
-            description = ''
-              Maximum duration before an attempted connection to the policy service is aborted.
-
-              This value should be lower than {option}`settings.PORXIE_POLICY_HTTP_TIMEOUT`.
+              Warning: enabling this means restricted blobs may be served when the policy service
+              is unavailable.
             '';
           };
         };

--- a/pkgs/by-name/po/porxie/package.nix
+++ b/pkgs/by-name/po/porxie/package.nix
@@ -11,15 +11,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "porxie";
-  version = "0.3.1";
+  version = "0.3.3";
 
   src = fetchFromCodeberg {
     owner = "Blooym";
     repo = "porxie";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-XtJD9W0eF6jNWk0xyvGlV6h0JCAUUjFnMk/MRiVBv9I=";
+    hash = "sha256-nB0QbGJ6emO1WLbIYAvCni6Xjs1AgQo8in6Y3Tof01g=";
   };
-  cargoHash = "sha256-q/Q4h39EzkjdWApfVf2VT1Rac+/2nQxpn+gp3l8tbeQ=";
+  cargoHash = "sha256-7iupGBdDvk4hofMVNuVTt67M7EOveYb3hD1mk2BJRbU=";
 
   buildInputs = [ rust-jemalloc-sys ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
