### PR TITLE
qmplay2: add deno support for yt-dlp

### DIFF
--- a/pkgs/by-name/qm/qmplay2/package.nix
+++ b/pkgs/by-name/qm/qmplay2/package.nix
@@ -24,6 +24,7 @@
   vulkan-headers,
   vulkan-tools,
   rubberband,
+  deno,
   # Configurable options
   qtVersion ? "6", # Can be 5 or 6
 }:
@@ -74,6 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
     taglib
     vulkan-headers-qmplay2
     vulkan-tools
+    deno
   ]
   ++ lib.optionals (qtVersion == "6") [
     rubberband
@@ -93,6 +95,9 @@ stdenv.mkDerivation (finalAttrs: {
   # But sometimes we come across case-insensitive filesystems...
   postInstall = ''
     [ -e $out/bin/qmplay2 ] || ln -s $out/bin/QMPlay2 $out/bin/qmplay2
+
+    wrapQtApp $out/bin/qmplay2 \
+      --prefix PATH : ${lib.makeBinPath [ deno ]}
   '';
 
   passthru = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This took longer than expected – I attempted to add yt-dlp as a proper dependency rather than relying on qmplay2’s own download‑and‑auto‑update, but it required more work. For now, I think we can use the solution suggested by @zdhd122a.

Fixes #522179

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
