### PR TITLE
createrepo-rs: init at 0.1.8

### DIFF
--- a/pkgs/by-name/cr/createrepo-rs/package.nix
+++ b/pkgs/by-name/cr/createrepo-rs/package.nix
@@ -1,0 +1,25 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "createrepo-rs";
+  version = "0.1.8";
+
+  src = fetchFromGitHub {
+    owner = "jamesarch";
+    repo = "createrepo_rs";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-skeASya0ARGM6vcO5OVvKD20SGYSCws1RSnbnJDYIdI=";
+  };
+
+  cargoHash = "sha256-70KuriwRVWSRKpGMYF5kY0e1PA4lL7YSU5j8p7ojdgA=";
+
+  meta = {
+    description = "Pure Rust RPM repository metadata generator — dnf/yum-compatible, zero FFI";
+    homepage = "https://github.com/jamesarch/createrepo_rs";
+    changelog = "https://github.com/jamesarch/createrepo_rs/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "createrepo_rs";
+    maintainers = with lib.maintainers; [ ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/cr/createrepo-rs/package.nix
+++ b/pkgs/by-name/cr/createrepo-rs/package.nix
@@ -1,4 +1,8 @@
-{ lib, rustPlatform, fetchFromGitHub }:
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "createrepo-rs";
@@ -13,13 +17,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-70KuriwRVWSRKpGMYF5kY0e1PA4lL7YSU5j8p7ojdgA=";
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Pure Rust RPM repository metadata generator — dnf/yum-compatible, zero FFI";
     homepage = "https://github.com/jamesarch/createrepo_rs";
     changelog = "https://github.com/jamesarch/createrepo_rs/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl2Plus;
     mainProgram = "createrepo_rs";
-    maintainers = with lib.maintainers; [ ];
+    maintainers = [ ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })


### PR DESCRIPTION
Pure Rust RPM repository metadata generator — dnf/yum-compatible, zero FFI.

- GitHub: https://github.com/jamesarch/createrepo_rs
- crates.io: https://crates.io/crates/createrepo_rs
- License: GPL-2.0-or-later