### PR TITLE
python3Packages.wsgidav: 4.3.3 -> 4.3.4

### DIFF
--- a/pkgs/development/python-modules/wsgidav/default.nix
+++ b/pkgs/development/python-modules/wsgidav/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  bcrypt,
   buildPythonPackage,
   cheroot,
   defusedxml,
@@ -7,6 +8,7 @@
   jinja2,
   json5,
   lxml,
+  passlib,
   pytestCheckHook,
   python-pam,
   pyyaml,
@@ -17,26 +19,30 @@
 
 buildPythonPackage rec {
   pname = "wsgidav";
-  version = "4.3.3";
+  version = "4.3.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mar10";
     repo = "wsgidav";
     tag = "v${version}";
-    hash = "sha256-vUqNC7ixpta0s7wRC5ROSKMa/MsgEBu5rr0XNu69FRw=";
+    hash = "sha256-2Pn5kMioMr4COpcIDEhlfolG0/5hpv8zMO0X7l6fSwY=";
   };
+
+  pythonRelaxDeps = [ "bcrypt" ];
 
   __darwinAllowLocalNetworking = true;
 
   build-system = [ setuptools ];
 
   dependencies = [
+    bcrypt
     defusedxml
     jinja2
     json5
     cheroot
     lxml
+    passlib
     pyyaml
   ];
 

--- a/pkgs/development/python-modules/wsgidav/default.nix
+++ b/pkgs/development/python-modules/wsgidav/default.nix
@@ -17,7 +17,7 @@
   webtest,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "wsgidav";
   version = "4.3.4";
   pyproject = true;
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "mar10";
     repo = "wsgidav";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-2Pn5kMioMr4COpcIDEhlfolG0/5hpv8zMO0X7l6fSwY=";
   };
 
@@ -61,9 +61,9 @@ buildPythonPackage rec {
   meta = {
     description = "Generic and extendable WebDAV server based on WSGI";
     homepage = "https://wsgidav.readthedocs.io/";
-    changelog = "https://github.com/mar10/wsgidav/blob/v${version}/CHANGELOG.md";
-    license = with lib.licenses; [ mit ];
+    changelog = "https://github.com/mar10/wsgidav/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "wsgidav";
   };
-}
+})


### PR DESCRIPTION
Changelog: https://github.com/mar10/wsgidav/blob/v4.3.4/CHANGELOG.md

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
