### PR TITLE
wapiti: 3.2.10 -> 3.3.0

### DIFF
--- a/pkgs/by-name/wa/wapiti/package.nix
+++ b/pkgs/by-name/wa/wapiti/package.nix
@@ -11,14 +11,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "wapiti";
-  version = "3.2.10";
+  version = "3.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "wapiti-scanner";
     repo = "wapiti";
     tag = finalAttrs.version;
-    hash = "sha256-/w5t/BcMPewl0Wp6vx9kZamqHArb7+fnfktfEIUDL8Y=";
+    hash = "sha256-hUkEwyIzYhlip6vtwO8EYcUsL5B/ZVnbJKpTR6osVuc=";
   };
 
   pythonRelaxDeps = true;
@@ -87,11 +87,15 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "test_explorer_extract_links"
     "test_explorer_filtering"
     "test_false"
+    "test_fetch_source_files_typo3"
+    "test_fetch_source_files"
     "test_frame"
     "test_headers_detection"
     "test_html_detection"
     "test_implies_detection"
     "test_inclusion_detection"
+    "test_magento_multi_version_detected"
+    "test_magento_version_detected"
     "test_merge_with_and_without_redirection"
     "test_meta_detection"
     "test_multi_detection"

--- a/pkgs/development/python-modules/wapiti-arsenic/default.nix
+++ b/pkgs/development/python-modules/wapiti-arsenic/default.nix
@@ -11,14 +11,14 @@
   packaging,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "wapiti-arsenic";
   version = "28.5";
   pyproject = true;
 
   src = fetchPypi {
     pname = "wapiti_arsenic";
-    inherit version;
+    inherit (finalAttrs) version;
     hash = "sha256-snIKEdrBOIfPeHkVLv0X5lsBzDbOtDrbOj4m8UNCj60=";
   };
 
@@ -45,8 +45,8 @@ buildPythonPackage rec {
   meta = {
     description = "Asynchronous WebDriver client";
     homepage = "https://github.com/wapiti-scanner/arsenic";
-    changelog = "https://github.com/wapiti-scanner/arsenic/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/wapiti-scanner/arsenic/blob/${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ GaetanLepage ];
   };
-}
+})

--- a/pkgs/development/python-modules/wapiti-arsenic/default.nix
+++ b/pkgs/development/python-modules/wapiti-arsenic/default.nix
@@ -22,6 +22,8 @@ buildPythonPackage rec {
     hash = "sha256-snIKEdrBOIfPeHkVLv0X5lsBzDbOtDrbOj4m8UNCj60=";
   };
 
+  pythonRelaxDeps = [ "packaging" ];
+
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail "poetry>=2.1.3" "poetry-core" \


### PR DESCRIPTION
Changelog: https://github.com/wapiti-scanner/wapiti/blob/3.3.0/doc/ChangeLog_Wapiti

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
