### PR TITLE
project-graph: init at 3.0.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29450,6 +29450,12 @@
     github = "wdavidw";
     githubId = 46896;
   };
+  wduo87391 = {
+    name = "wduo87391";
+    email = "wduo87391@gmail.com";
+    github = "wduo87391";
+    githubId = 197874825;
+  };
   weathercold = {
     name = "Weathercold";
     email = "weathercold.scr@proton.me";

--- a/pkgs/by-name/pr/project-graph/package.nix
+++ b/pkgs/by-name/pr/project-graph/package.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  pnpm_10,
+  nodejs_24,
+  cargo-tauri,
+  openssl,
+  pkg-config,
+  webkitgtk_4_1,
+  glib-networking,
+  wrapGAppsHook4,
+  pnpmConfigHook,
+  jq,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "project-graph";
+  version = "3.0.7";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "graphif";
+    repo = "project-graph";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-QC1YTcyH7q+TJiGLF7zjKTe1OcfFd74fSFr+23iYMyQ=";
+  };
+
+  cargoHash = "sha256-bsRX+iVo2jInWZvrX1fVE2oAqM8L/5zNzjRwtoviQN0=";
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_10;
+    fetcherVersion = 3;
+    hash = "sha256-sTThym++UWKpKFZqhQJCewRKtdYe1tKNcESrxyxpLmY=";
+  };
+
+  postPatch = ''
+    TAURI_CONFIG="app/src-tauri/tauri.conf.json"
+    if [ -f "$TAURI_CONFIG" ]; then
+      echo "Applying Tauri v2 sandbox patches via jq..."
+      ${jq}/bin/jq '.bundle.targets = [] | .bundle.createUpdaterArtifacts = false' "$TAURI_CONFIG" > temp.json && mv temp.json "$TAURI_CONFIG"
+    fi
+  '';
+
+  preConfigure = ''
+    export HOME="$TMPDIR"
+  '';
+
+  preBuild = ''
+    pnpm run build
+  '';
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    pnpmConfigHook
+    nodejs_24
+    pnpm_10
+    pkg-config
+    jq
+    wrapGAppsHook4
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    glib-networking
+    openssl
+    webkitgtk_4_1
+  ];
+
+  cargoRoot = "app/src-tauri";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  docheck = true;
+
+  nativeCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Node-based visual tool for organizing thoughts and notes";
+    homepage = "https://graphif.dev";
+    license = with lib.licenses; [
+      mit
+      gpl3Plus
+    ];
+    mainProgram = "project-graph";
+    maintainers = with lib.maintainers; [ wduo87391 ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
init project-graph at 3.0.7

This PR introduces `project-graph`, a node-based visual tool for organizing thoughts and notes. 
Homepage: https://graphif.dev/

It is built as a Tauri v2 application using a pnpm Monorepo structure, and configured following the modern `by-name` layout guidelines.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
