### PR TITLE
strictdoc 0.19.0 -> 0.21.1

### DIFF
--- a/pkgs/by-name/st/strictdoc/package.nix
+++ b/pkgs/by-name/st/strictdoc/package.nix
@@ -6,14 +6,14 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "strictdoc";
-  version = "0.19.0";
+  version = "0.21.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "strictdoc-project";
     repo = "strictdoc";
     tag = finalAttrs.version;
-    hash = "sha256-UkXVn1GVWBBhjFaRvkVk+E9mug3i2k7SQk+7JVA8KSo=";
+    hash = "sha256-kKygvUCrkftEEKLoinVkP5DARsHGguSfsPaTpYYXPpU=";
   };
 
   build-system = [

--- a/pkgs/by-name/st/strictdoc/package.nix
+++ b/pkgs/by-name/st/strictdoc/package.nix
@@ -79,7 +79,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   meta = {
     description = "Software for technical documentation and requirements management";
     homepage = "https://github.com/strictdoc-project/strictdoc";
-    changelog = "https://github.com/strictdoc-project/strictdoc/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/strictdoc-project/strictdoc/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.puzzlewolf ];
     mainProgram = "strictdoc";

--- a/pkgs/development/python-modules/html2pdf4doc/default.nix
+++ b/pkgs/development/python-modules/html2pdf4doc/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "html2pdf4doc";
-  version = "0.0.31";
+  version = "0.0.33";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mettta";
     repo = "html2pdf4doc_python";
     tag = version;
-    hash = "sha256-ailiZfqO2NacJmCbWWtZ2bnerjc9mdJZKDVWNUTMEAg=";
+    hash = "sha256-d5Y1llC7Yb1Vw2tvxAhgIw7wk18mFJ+sm8Rrr+UwxUI=";
   };
 
   build-system = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- update stricdoc 0.19.0 -> 0.21.1
- update html2pdf4doc 0.0.31 -> 0.0.33 (borrowed from @r-ryantm's #497169)
- fix strictdoc's changelog link

html2pdf4doc is only used by strictdoc and must be present in the exactly correct version, so they are updated together.

supersedes #497169 and #515029

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
