### PR TITLE
oci-cli: 3.82.0 -> 3.84.0

### DIFF
--- a/pkgs/by-name/oc/oci-cli/package.nix
+++ b/pkgs/by-name/oc/oci-cli/package.nix
@@ -31,14 +31,14 @@ in
 
 py.pkgs.buildPythonApplication (finalAttrs: {
   pname = "oci-cli";
-  version = "3.82.0";
+  version = "3.84.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "oracle";
     repo = "oci-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-zOxtFJ+gCTD6PpFUBIFzgrRfj4A6MEcI6H084XZvvy0=";
+    hash = "sha256-YIr0PX+qw+0bnBr8UcFlQ/m1u0yPDtX4nSRuGIjOdbY=";
   };
 
   nativeBuildInputs = [ installShellFiles ];

--- a/pkgs/by-name/oc/oci-cli/package.nix
+++ b/pkgs/by-name/oc/oci-cli/package.nix
@@ -62,6 +62,7 @@ py.pkgs.buildPythonApplication (finalAttrs: {
     retrying
     six
     terminaltables
+    urllib3
   ];
 
   pythonRelaxDeps = [


### PR DESCRIPTION
https://github.com/oracle/oci-cli/compare/refs/tags/v3.82.0...refs/tags/v3.84.0
https://github.com/oracle/oci-cli/releases/tag/v3.84.0

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 524819`
Commit: `988d9fa64b3170598d0cb60d0df7cb58cb735d77`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>oci-cli</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test