### PR TITLE
erlang: 27.3.4.11 -> 27.3.4.12, 28.5 -> 28.5.0.1, 29.0 -> 29.0.1 

### DIFF
--- a/pkgs/development/interpreters/erlang/27.nix
+++ b/pkgs/development/interpreters/erlang/27.nix
@@ -1,6 +1,6 @@
 genericBuilder:
 
 genericBuilder {
-  version = "27.3.4.11";
-  hash = "sha256-yOgsaeUv6GwFX6qPVb28zet6Hli5vg/PZCKW2s2/JEA=";
+  version = "27.3.4.12";
+  hash = "sha256-RnCBGuqEEJ+3kkbiVNLSb8sAh2i9SNyH9ixkqtAbjsk=";
 }

--- a/pkgs/development/interpreters/erlang/28.nix
+++ b/pkgs/development/interpreters/erlang/28.nix
@@ -1,6 +1,6 @@
 genericBuilder:
 
 genericBuilder {
-  version = "28.5";
-  hash = "sha256-A4gIjfWsrfZR89xNWyynTAdJtGj6ZWth3xIQBMLqcpc=";
+  version = "28.5.0.1";
+  hash = "sha256-tZQQCBDpDcrN9QX8Qwz6HqNVATck1+emGVOviEhqsLc=";
 }

--- a/pkgs/development/interpreters/erlang/29.nix
+++ b/pkgs/development/interpreters/erlang/29.nix
@@ -1,6 +1,6 @@
 genericBuilder:
 
 genericBuilder {
-  version = "29.0";
-  hash = "sha256-AUt/Mlp84cVEypqDsyD5VbywYEGda0eikMDmSnzlKUI=";
+  version = "29.0.1";
+  hash = "sha256-0I82VBCgA8KfdNYkNWyqcH+f0Kc6al11BAErtxfVDZo=";
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
