### PR TITLE
tinysparql: include upstream patch for sqlite float-related test fixes

### DIFF
--- a/pkgs/by-name/ti/tinysparql/package.nix
+++ b/pkgs/by-name/ti/tinysparql/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchurl,
+  fetchpatch,
   gettext,
   meson,
   mesonEmulatorHook,
@@ -48,6 +49,18 @@ stdenv.mkDerivation (finalAttrs: {
       "mirror://gnome/sources/tinysparql/${lib.versions.majorMinor version}/tinysparql-${version}.tar.xz";
     hash = "sha256-z9RgIe4VFK1DXnFPeqHsenh8f1FqlPTHQ4iX7j1uyh4=";
   };
+
+  patches = [
+    # sqlite changed the precision of float <-> text conversions, causing
+    # failures in the test suite. patch here until this appears in a release.
+    # https://gitlab.gnome.org/GNOME/tinysparql/-/work_items/496
+    # https://gitlab.gnome.org/GNOME/tinysparql/-/merge_requests/811
+    (fetchpatch {
+      name = "tinysparql-sqlite-double-value-precision.patch";
+      url = "https://gitlab.gnome.org/GNOME/tinysparql/-/commit/47d5bf9313d0ccb1feb7169eed9047d0e1597a39.patch";
+      hash = "sha256-k6eELZCEEtD8s7GiMckjTlf6QcAiUNY1Mraw7GROsm4=";
+    })
+  ];
 
   strictDeps = true;
 


### PR DESCRIPTION
Issue: https://gitlab.gnome.org/GNOME/tinysparql/-/work_items/496
Merge request: https://gitlab.gnome.org/GNOME/tinysparql/-/merge_requests/811

Changes in the precision of floating point values in SQLite (update: https://github.com/NixOS/nixpkgs/pull/519724) are causing test failures in TinySPARQL. We include a patch from the (merged) MR above to fix this.

I'm not sure whether we want to include this patch now, or wait for a release from upstream (I see @trofi was the author of the issue and mentioned it in the SQLite update PR). However, I hit this while testing some changes on staging and thus wanted to propose it now. Since it's from a merged pull request, and a test-only fix, I think it's fairly low-risk, but I'd be fine closing this and waiting if folks would prefer that.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
