### PR TITLE
barman: 3.14.1 -> 3.19.0

### DIFF
--- a/pkgs/by-name/ba/barman/package.nix
+++ b/pkgs/by-name/ba/barman/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch2,
   file,
   python3Packages,
   rsync,
@@ -12,23 +11,18 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "barman";
-  version = "3.14.1";
+  version = "3.19.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "EnterpriseDB";
     repo = "barman";
     tag = "release/${finalAttrs.version}";
-    hash = "sha256-Z3+PgUJcyG/M05hMmIhRr3HttzHUDx7BGIs44LA/qE4=";
+    hash = "sha256-qjde8NdI+/2BH4L3LoxoYqdVwsaBXw1IcxYBx6sYqG8=";
   };
 
   patches = [
     ./unwrap-subprocess.patch
-    # fix building with Python 3.13
-    (fetchpatch2 {
-      url = "https://github.com/EnterpriseDB/barman/commit/931f997f1d73bbe360abbca737bea9ae93172989.patch?full_index=1";
-      hash = "sha256-0aqyjsEabxLf4dpC4DeepmypAl7QfCedh7vy98iVifU=";
-    })
   ];
 
   # https://github.com/EnterpriseDB/barman/blob/release/3.14.1/barman/encryption.py#L214
@@ -70,6 +64,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     # Assertion error
     "test_help_output"
     "test_exits_on_unsupported_target"
+    "test_resolve_mounted_volume_failure"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # FsOperationFailed


### PR DESCRIPTION
Changelog: https://github.com/EnterpriseDB/barman/blob/release/3.19.0/RELNOTES.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
