### PR TITLE
quodlibet: broken on darwin

### DIFF
--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   tag ? "",
 
@@ -196,5 +197,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     homepage = "https://quodlibet.readthedocs.io/en/latest";
     license = lib.licenses.gpl2Plus;
     maintainers = [ ];
+    broken = stdenv.hostPlatform.isDarwin;
   };
 })


### PR DESCRIPTION
Even after adding the required pyobjc frameworks, it crashes on:

```
0   CoreFoundation                	       0x184e7d1b4 __exceptionPreprocess + 164
1   libobjc.A.dylib               	       0x18490691c objc_exception_throw + 88
2   CoreFoundation                	       0x184e7d0b0 +[NSException exceptionWithName:reason:userInfo:] + 0
3   AppKit                        	       0x18920c8d4 __33+[NSAppearance _initializeCoreUI]_block_invoke + 88
4   libdispatch.dylib             	       0x184bb04b0 _dispatch_client_callout + 16
5   libdispatch.dylib             	       0x184b99630 _dispatch_once_callout + 32
6   AppKit                        	       0x18922b704 +[NSAppearance _aquaAppearance] + 60
7   AppKit                        	       0x18920c03c +[NSAppearance appearanceNamed:] + 32
8   AppKit                        	       0x18920b620 -[NSSystemAppearanceProxy init] + 124
9   AppKit                        	       0x18920b594 __38+[NSSystemAppearanceProxy systemProxy]_block_invoke + 24
10  libdispatch.dylib             	       0x184bb04b0 _dispatch_client_callout + 16
11  libdispatch.dylib             	       0x184b99630 _dispatch_once_callout + 32
12  AppKit                        	       0x18920b570 +[NSSystemAppearanceProxy systemProxy] + 60
13  AppKit                        	       0x18920b500 -[NSApplication(NSApplicationAppearance_Internal) _registerForAppearanceNotifications] + 32
14  AppKit                        	       0x189209298 -[NSApplication init] + 972
15  AppKit                        	       0x189208d00 +[NSApplication sharedApplication] + 128
16  libgdk-3.0.dylib              	       0x10b6e43e8 _gdk_quartz_display_open + 208
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
