### PR TITLE
nixos/tests/caddy: drop `withPlugins` test path

### DIFF
--- a/nixos/tests/caddy.nix
+++ b/nixos/tests/caddy.nix
@@ -1,11 +1,11 @@
-{ pkgs, ... }:
+{ lib, ... }:
+
 {
   name = "caddy";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [
-      stepbrobd
-    ];
-  };
+
+  meta.maintainers = with lib.maintainers; [
+    stepbrobd
+  ];
 
   nodes = {
     webserver =
@@ -69,24 +69,6 @@
             respond "hello world"
           '';
         };
-        specialisation.with-plugins.configuration = {
-          services.caddy = {
-            package = pkgs.caddy.withPlugins {
-              plugins = [ "github.com/caddyserver/replace-response@v0.0.0-20250618171559-80962887e4c6" ];
-              hash = "sha256-0N/bQAM5yT6g9UAteWsfxofGcelmU/NDTroS2oL43Gs=";
-            };
-            configFile = pkgs.writeText "Caddyfile" ''
-              {
-                order replace after encode
-              }
-
-              localhost:80 {
-                respond "hello world"
-                replace world caddy
-              }
-            '';
-          };
-        };
       };
   };
 
@@ -98,7 +80,6 @@
       multipleConfigs = "${nodes.webserver.system.build.toplevel}/specialisation/multiple-configs";
       multipleHostnames = "${nodes.webserver.system.build.toplevel}/specialisation/multiple-hostnames";
       rfc42Config = "${nodes.webserver.system.build.toplevel}/specialisation/rfc42";
-      withPluginsConfig = "${nodes.webserver.system.build.toplevel}/specialisation/with-plugins";
     in
     ''
       url = "http://localhost/example.html"
@@ -141,12 +122,5 @@
           )
           webserver.wait_for_open_port(80)
           webserver.succeed("curl http://localhost | grep hello")
-
-      with subtest("plugins are correctled installed and configurable"):
-          webserver.succeed(
-              "${withPluginsConfig}/bin/switch-to-configuration test >&2"
-          )
-          webserver.wait_for_open_port(80)
-          webserver.succeed("curl http://localhost | grep caddy")
     '';
 }

--- a/pkgs/by-name/ca/caddy/package.nix
+++ b/pkgs/by-name/ca/caddy/package.nix
@@ -10,18 +10,12 @@
   writableTmpDirAsHomeHook,
   versionCheckHook,
 }:
-let
-  version = "2.11.4";
-  dist = fetchFromGitHub {
-    owner = "caddyserver";
-    repo = "dist";
-    tag = "v${version}";
-    hash = "sha256-oRQfQH1GKjAjVMj+dZo1f1+HOaOdJIyEfod0iGLYcc8=";
-  };
-in
+
 buildGoModule (finalAttrs: {
   pname = "caddy";
-  inherit version;
+  version = "2.11.4";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "caddyserver";
@@ -52,7 +46,7 @@ buildGoModule (finalAttrs: {
   __darwinAllowLocalNetworking = true;
 
   postInstall = ''
-    install -Dm644 ${dist}/init/caddy.service ${dist}/init/caddy-api.service -t $out/lib/systemd/system
+    install -Dm644 ${finalAttrs.passthru.dist}/init/caddy.service ${finalAttrs.passthru.dist}/init/caddy-api.service -t $out/lib/systemd/system
 
     substituteInPlace $out/lib/systemd/system/caddy.service \
       --replace-fail "/usr/bin/caddy" "$out/bin/caddy"
@@ -72,20 +66,28 @@ buildGoModule (finalAttrs: {
       --zsh <($out/bin/caddy completion zsh)
   '';
 
-  passthru = {
-    tests = {
-      inherit (nixosTests) caddy;
-      acme-integration = nixosTests.acme.caddy;
-    };
-    withPlugins = callPackage ./plugins.nix { inherit caddy; };
-  };
-
+  doInstallCheck = true;
   nativeInstallCheckInputs = [
     writableTmpDirAsHomeHook
     versionCheckHook
   ];
   versionCheckKeepEnvironment = [ "HOME" ];
-  doInstallCheck = true;
+
+  passthru = {
+    withPlugins = callPackage ./plugins.nix { inherit caddy; };
+
+    dist = fetchFromGitHub {
+      owner = "caddyserver";
+      repo = "dist";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-oRQfQH1GKjAjVMj+dZo1f1+HOaOdJIyEfod0iGLYcc8=";
+    };
+
+    tests = {
+      inherit (nixosTests) caddy;
+      acme-integration = nixosTests.acme.caddy;
+    };
+  };
 
   meta = {
     homepage = "https://caddyserver.com";

--- a/pkgs/by-name/ca/caddy/package.nix
+++ b/pkgs/by-name/ca/caddy/package.nix
@@ -3,6 +3,7 @@
   buildGoModule,
   callPackage,
   fetchFromGitHub,
+  testers,
   nixosTests,
   caddy,
   installShellFiles,
@@ -21,6 +22,7 @@ buildGoModule (finalAttrs: {
     owner = "caddyserver";
     repo = "caddy";
     tag = "v${finalAttrs.version}";
+    # remember to update hashes for `dist` and `plugins` test!
     hash = "sha256-wzk8KRZfDCbbjRlBwkoKAoMjOhV4xF3yuXUueqtl1xM=";
   };
 
@@ -85,6 +87,7 @@ buildGoModule (finalAttrs: {
 
     tests = {
       inherit (nixosTests) caddy;
+      plugins = testers.runNixOSTest ./plugins.test.nix;
       acme-integration = nixosTests.acme.caddy;
     };
   };

--- a/pkgs/by-name/ca/caddy/plugins.test.nix
+++ b/pkgs/by-name/ca/caddy/plugins.test.nix
@@ -1,0 +1,36 @@
+{ lib, ... }:
+
+{
+  name = "caddy-plugins";
+  meta.maintainers = with lib.maintainers; [
+    stepbrobd
+  ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.caddy = {
+        enable = true;
+
+        package = pkgs.caddy.withPlugins {
+          plugins = [ "github.com/caddyserver/replace-response@v0.0.0-20250618171559-80962887e4c6" ];
+          hash = "sha256-oj0IpspxslpNZbJFsexh0W2Sja19XRUsbShoCuY6qkQ=";
+        };
+
+        globalConfig = ''
+          order replace after encode
+        '';
+
+        virtualHosts."localhost:80".extraConfig = ''
+          respond "hello world"
+          replace world nixos
+        '';
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("caddy")
+    machine.wait_for_open_port(80)
+    machine.succeed("curl http://localhost | grep nixos")
+  '';
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

the plugin test was added in https://github.com/NixOS/nixpkgs/pull/368657

since then, every bump of caddy or go will cause the fod hash to change and its quite annoying to maintain

it'd be better to test the with plugins feature off tree rather than keeping this fragile test here and bumping it in every caddy update (this was also failing on hydra last time i checked)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
