### PR TITLE
nixos-rebuild-ng: use hash control path format

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
@@ -19,7 +19,7 @@ SSH_DEFAULT_OPTS: Final = [
     "-o",
     "ControlMaster=auto",
     "-o",
-    f"ControlPath={tmpdir.TMPDIR_PATH / 'ssh-%n'}",
+    f"ControlPath={tmpdir.TMPDIR_PATH / 'ssh-%C'}",
     "-o",
     "ControlPersist=60",
 ]


### PR DESCRIPTION
Replaced the token `%n` with the token `%C` in the ssh ControlPath.
From the `ssh_config` man page:

```
             %C    Hash of %l%h%p%r%j.
             %h    The remote hostname.
             %j    The contents of the ProxyJump option, or the empty string if this option is unset.
             %l    The local hostname, including the domain name.
             %n    The original remote hostname, as given on the command line.
             %p    The remote port.
             %r    The remote username.
```

The reason for this change is that nixos-rebuild currently fails when provided with a long host name for `--build-host`/`--target-host`.

> unix_listener: path "/tmp/nixos-rebuild.ACxecV/ssh-[long hostname].HPfEVw5glKRqAfQR" too long for Unix domain socket

A current workaround is setting the env variable `NIX_SSHOPTS='-oControlPath=ssh-%C'`.

This change fixes https://github.com/NixOS/nixpkgs/issues/495484

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
