### PR TITLE
{tor,mullvad}-browser: remove unnecessary auto-update policies 

### DIFF
--- a/pkgs/by-name/mu/mullvad-browser/package.nix
+++ b/pkgs/by-name/mu/mullvad-browser/package.nix
@@ -123,12 +123,6 @@ let
       };
     }
   );
-
-  policiesJson = writeText "policies.json" (
-    builtins.toJSON {
-      policies.DisableAppUpdate = true;
-    }
-  );
 in
 stdenv.mkDerivation rec {
   pname = "mullvad-browser";
@@ -200,7 +194,7 @@ stdenv.mkDerivation rec {
     mv mullvadbrowser.real mullvadbrowser
 
     # store state at `~/.mullvad` instead of relative to executable
-    touch "$MB_IN_STORE/system-install"
+    touch "$MB_IN_STORE/is-packaged-app"
 
     # Add bundled libraries to libPath.
     libPath=${libPath}:$MB_IN_STORE
@@ -282,7 +276,6 @@ stdenv.mkDerivation rec {
 
     # Install distribution customizations
     install -Dvm644 ${distributionIni} $out/share/mullvad-browser/distribution/distribution.ini
-    install -Dvm644 ${policiesJson} $out/share/mullvad-browser/distribution/policies.json
 
     runHook postInstall
   '';

--- a/pkgs/by-name/to/tor-browser/package.nix
+++ b/pkgs/by-name/to/tor-browser/package.nix
@@ -136,12 +136,6 @@ let
       };
     }
   );
-
-  policiesJson = writeText "policies.json" (
-    builtins.toJSON {
-      policies.DisableAppUpdate = true;
-    }
-  );
 in
 stdenv.mkDerivation rec {
   pname = "tor-browser";
@@ -213,8 +207,8 @@ stdenv.mkDerivation rec {
     # firefox is a wrapper that checks for a more recent libstdc++ & appends it to the ld path
     mv firefox.real firefox
 
-    # store state at `~/.tor browser` instead of relative to executable
-    touch "$TBB_IN_STORE/system-install"
+    # store state at `~/.tor project` instead of relative to executable
+    touch "$TBB_IN_STORE/is-packaged-app"
 
     # The final libPath.  Note, we could split this into firefoxLibPath
     # and torLibPath for accuracy, but this is more convenient ...
@@ -331,7 +325,6 @@ stdenv.mkDerivation rec {
 
     # Install distribution customizations
     install -Dvm644 ${distributionIni} $out/share/tor-browser/distribution/distribution.ini
-    install -Dvm644 ${policiesJson} $out/share/tor-browser/distribution/policies.json
 
     runHook postInstall
   '';


### PR DESCRIPTION
This came up in Firefox as https://bugzilla.mozilla.org/show_bug.cgi?id=2042197, where policies caused different behavior to be active (also see https://github.com/NixOS/nixpkgs/pull/524793). We should not observe any such differences, but this indicates that the policy is unnecessary for disabling the updater.

Tor/Mullvad Browser have supported is-packaged-app for a long time (https://gitlab.torproject.org/tpo/applications/tor-browser/-/merge_requests/985), and it's preferred by Firefox (i.e. it actually has meaning there: https://searchfox.org/firefox-main/search?q=is-packaged-app&path=&case=false&regexp=false), so we switch from `system-install` to that one. This shouldn't change anything else user visible.

This removes the "Your browser is being managed by your organization." text from about:preferences and changes about:policies from showing this singular policy to "The Enterprise Policies service is inactive." (the intended upstream behavior), so this seems like a win for clarity.

Tested by downgrading the version in the derivation, and seeing no update UI appear, either in the hamburger menu in the toolbar or under Help > About Tor/Mullvad Browser.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
