### PR TITLE
various: migrate to finalAttrs pattern

### DIFF
--- a/pkgs/by-name/_0/_0xproto/package.nix
+++ b/pkgs/by-name/_0/_0xproto/package.nix
@@ -4,16 +4,16 @@
   fetchzip,
   nix-update-script,
 }:
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "0xproto";
   version = "2.502";
 
   src =
     let
-      underscoreVersion = builtins.replaceStrings [ "." ] [ "_" ] version;
+      underscoreVersion = builtins.replaceStrings [ "." ] [ "_" ] finalAttrs.version;
     in
     fetchzip {
-      url = "https://github.com/0xType/0xProto/releases/download/${version}/0xProto_${underscoreVersion}.zip";
+      url = "https://github.com/0xType/0xProto/releases/download/${finalAttrs.version}/0xProto_${underscoreVersion}.zip";
       hash = "sha256-ffYvfEGMoIJKVEcs2XzhDrq++SkTbQOVvb6X9q+uyu8=";
       stripRoot = false;
     };
@@ -38,4 +38,4 @@ stdenvNoCC.mkDerivation rec {
     maintainers = with lib.maintainers; [ edswordsmith ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/_3/_3270font/package.nix
+++ b/pkgs/by-name/_3/_3270font/package.nix
@@ -4,12 +4,12 @@
   fetchzip,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "3270font";
   version = "3.0.1";
 
   src = fetchzip {
-    url = "https://github.com/rbanffy/3270font/releases/download/v${version}/3270_fonts_d916271.zip";
+    url = "https://github.com/rbanffy/3270font/releases/download/v${finalAttrs.version}/3270_fonts_d916271.zip";
     sha256 = "sha256-Zi6Lp5+sqfjIaHmnaaemaw3i+hXq9mqIsK/81lTkwfM=";
     stripRoot = false;
   };
@@ -32,7 +32,7 @@ stdenvNoCC.mkDerivation rec {
   meta = {
     description = "Monospaced font based on IBM 3270 terminals";
     homepage = "https://github.com/rbanffy/3270font";
-    changelog = "https://github.com/rbanffy/3270font/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/rbanffy/3270font/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = [
       lib.licenses.bsd3
       lib.licenses.ofl
@@ -40,4 +40,4 @@ stdenvNoCC.mkDerivation rec {
     maintainers = [ ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/_9/_90secondportraits/package.nix
+++ b/pkgs/by-name/_9/_90secondportraits/package.nix
@@ -12,35 +12,14 @@
   zip,
 }:
 
-let
+stdenv.mkDerivation (finalAttrs: {
   pname = "90secondportraits";
-
-  icon = fetchurl {
-    url = "http://tangramgames.dk/img/thumb/90secondportraits.png";
-    sha256 = "13k6cq8s7jw77j81xfa5ri41445m778q6iqbfplhwdpja03c6faw";
-  };
-
-  desktopItems = [
-    (makeDesktopItem {
-      name = "90secondportraits";
-      exec = pname;
-      icon = icon;
-      comment = "A silly speed painting game";
-      desktopName = "90 Second Portraits";
-      genericName = "90secondportraits";
-      categories = [ "Game" ];
-    })
-  ];
-
-in
-stdenv.mkDerivation rec {
-  inherit pname desktopItems;
   version = "1.01b";
 
   src = fetchFromGitHub {
     owner = "SimonLarsen";
     repo = "90-Second-Portraits";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-xxgB8Aw7QTK9lPus7Q4E7iP2/rRfCwwiYbk5NqzujHI=";
     fetchSubmodules = true;
   };
@@ -58,6 +37,21 @@ stdenv.mkDerivation rec {
     copyDesktopItems
     strip-nondeterminism
     zip
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "90secondportraits";
+      exec = "90secondportraits";
+      icon = fetchurl {
+        url = "http://tangramgames.dk/img/thumb/90secondportraits.png";
+        sha256 = "13k6cq8s7jw77j81xfa5ri41445m778q6iqbfplhwdpja03c6faw";
+      };
+      comment = "A silly speed painting game";
+      desktopName = "90 Second Portraits";
+      genericName = "90secondportraits";
+      categories = [ "Game" ];
+    })
   ];
 
   buildPhase = ''
@@ -89,5 +83,4 @@ stdenv.mkDerivation rec {
     ];
     downloadPage = "http://tangramgames.dk/games/90secondportraits";
   };
-
-}
+})

--- a/pkgs/by-name/aa/aapt/package.nix
+++ b/pkgs/by-name/aa/aapt/package.nix
@@ -6,7 +6,7 @@
   libcxx,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "aapt";
   version = "8.13.2-14304508";
 
@@ -15,12 +15,12 @@ stdenvNoCC.mkDerivation rec {
       urlAndHash =
         if stdenvNoCC.hostPlatform.isLinux then
           {
-            url = "https://dl.google.com/android/maven2/com/android/tools/build/aapt2/${version}/aapt2-${version}-linux.jar";
+            url = "https://dl.google.com/android/maven2/com/android/tools/build/aapt2/${finalAttrs.version}/aapt2-${finalAttrs.version}-linux.jar";
             hash = "sha256-eiNY58ueDpcyKvAteRuKFVr3r22kOhwSADkaH3CRwKw=";
           }
         else if stdenvNoCC.hostPlatform.isDarwin then
           {
-            url = "https://dl.google.com/android/maven2/com/android/tools/build/aapt2/${version}/aapt2-${version}-osx.jar";
+            url = "https://dl.google.com/android/maven2/com/android/tools/build/aapt2/${finalAttrs.version}/aapt2-${finalAttrs.version}-osx.jar";
             hash = "sha256-RI/S2oXMSvipALRfeRTsiXUh130/b8iP+EO0yltd7x0=";
           }
         else
@@ -55,4 +55,4 @@ stdenvNoCC.mkDerivation rec {
     platforms = lib.platforms.darwin ++ [ "x86_64-linux" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
-}
+})

--- a/pkgs/by-name/ab/abaddon/package.nix
+++ b/pkgs/by-name/ab/abaddon/package.nix
@@ -21,14 +21,14 @@
   sqlite,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "abaddon";
   version = "0.2.4";
 
   src = fetchFromGitHub {
     owner = "uowuo";
     repo = "abaddon";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-fSNXMbyYmUOA4x911/an02fhhhWe6a4xlLVb2DIqIOE=";
     fetchSubmodules = true;
   };
@@ -74,11 +74,11 @@ stdenv.mkDerivation rec {
 
   desktopItems = [
     (makeDesktopItem {
-      name = pname;
-      exec = pname;
+      name = "abaddon";
+      exec = "abaddon";
       desktopName = "Abaddon";
-      genericName = meta.description;
-      startupWMClass = pname;
+      genericName = "Discord client reimplementation, written in C++";
+      startupWMClass = "abaddon";
       categories = [
         "Network"
         "InstantMessaging"
@@ -95,4 +95,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ choco98 ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/ac/acl2/libipasirglucose4/default.nix
+++ b/pkgs/by-name/ac/acl2/libipasirglucose4/default.nix
@@ -6,14 +6,14 @@
   unzip,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libipasirglucose4";
   # This library has no version number AFAICT (beyond generally being based on
   # Glucose 4.x), but it was submitted to the 2017 SAT competition so let's use
   # that as the version number, I guess.
   version = "2017";
 
-  libname = pname + stdenv.hostPlatform.extensions.sharedLibrary;
+  libname = "libipasirglucose4" + stdenv.hostPlatform.extensions.sharedLibrary;
 
   src = fetchurl {
     url = "https://baldur.iti.kit.edu/sat-competition-2017/solvers/incremental/glucose-ipasir.zip";
@@ -29,13 +29,13 @@ stdenv.mkDerivation rec {
   makeFlags = [ "CXX=${stdenv.cc.targetPrefix}c++" ];
 
   postBuild = ''
-    $CXX -shared -o ${libname} \
-        ${lib.optionalString (!stdenv.cc.isClang) "-Wl,-soname,${libname}"} \
+    $CXX -shared -o ${finalAttrs.libname} \
+        ${lib.optionalString (!stdenv.cc.isClang) "-Wl,-soname,${finalAttrs.libname}"} \
         ipasirglucoseglue.o libipasirglucose4.a
   '';
 
   installPhase = ''
-    install -D ${libname} $out/lib/${libname}
+    install -D ${finalAttrs.libname} $out/lib/${finalAttrs.libname}
   '';
 
   meta = {
@@ -44,4 +44,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ kini ];
   };
-}
+})

--- a/pkgs/by-name/ac/acl2/package.nix
+++ b/pkgs/by-name/ac/acl2/package.nix
@@ -32,14 +32,14 @@ let
   '';
 
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "acl2";
   version = "8.6";
 
   src = fetchFromGitHub {
     owner = "acl2-devel";
     repo = "acl2-devel";
-    rev = version;
+    rev = finalAttrs.version;
     sha256 = "sha256-fF9bbEacwCHP1m/eVgFrTD4Ne7L2mzq0K9vJ1tiy9go=";
   };
 
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
     })
 
     (replaceVars ./0001-path-changes-for-nix.patch {
-      libipasir = "${libipasir}/lib/${libipasir.libname}";
+      libipasir = "${finalAttrs.libipasir}/lib/${finalAttrs.libipasir.libname}";
       libssl = "${lib.getLib openssl}/lib/libssl${stdenv.hostPlatform.extensions.sharedLibrary}";
       libcrypto = "${lib.getLib openssl}/lib/libcrypto${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
@@ -92,7 +92,7 @@ stdenv.mkDerivation rec {
     glucose
     minisat
     abc-verifier
-    libipasir
+    finalAttrs.libipasir
     z3
     (python3.withPackages (ps: [ ps.z3-solver ]))
   ];
@@ -115,10 +115,10 @@ stdenv.mkDerivation rec {
     # ACL2 and its books need to be built in place in the out directory because
     # the proof artifacts are not relocatable. Since ACL2 mostly expects
     # everything to exist in the original source tree layout, we put it in
-    # $out/share/${pname} and create symlinks in $out/bin as necessary.
-    mkdir -p $out/share/${pname}
-    cp -pR . $out/share/${pname}
-    cd $out/share/${pname}
+    # $out/share/${finalAttrs.pname} and create symlinks in $out/bin as necessary.
+    mkdir -p $out/share/${finalAttrs.pname}
+    cp -pR . $out/share/${finalAttrs.pname}
+    cd $out/share/${finalAttrs.pname}
   '';
 
   preBuild = "mkdir -p $HOME";
@@ -132,19 +132,19 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    ln -s $out/share/${pname}/saved_acl2           $out/bin/${pname}
+    ln -s $out/share/${finalAttrs.pname}/saved_acl2           $out/bin/${finalAttrs.pname}
   ''
   + lib.optionalString certifyBooks ''
-    ln -s $out/share/${pname}/books/build/cert.pl  $out/bin/${pname}-cert
-    ln -s $out/share/${pname}/books/build/clean.pl $out/bin/${pname}-clean
+    ln -s $out/share/${finalAttrs.pname}/books/build/cert.pl  $out/bin/${finalAttrs.pname}-cert
+    ln -s $out/share/${finalAttrs.pname}/books/build/clean.pl $out/bin/${finalAttrs.pname}-clean
   '';
 
   preDistPhases = [ (if certifyBooks then "certifyBooksPhase" else "removeBooksPhase") ];
 
   certifyBooksPhase = ''
     # Certify the community books
-    pushd $out/share/${pname}/books
-    makeFlags="ACL2=$out/share/${pname}/saved_acl2"
+    pushd $out/share/${finalAttrs.pname}/books
+    makeFlags="ACL2=$out/share/${finalAttrs.pname}/saved_acl2"
     buildFlags="all"
     buildPhase
 
@@ -157,7 +157,7 @@ stdenv.mkDerivation rec {
 
   removeBooksPhase = ''
     # Delete the community books
-    rm -rf $out/share/${pname}/books
+    rm -rf $out/share/${finalAttrs.pname}/books
   '';
 
   meta = {
@@ -172,9 +172,9 @@ stdenv.mkDerivation rec {
       ACL2 is part of the Boyer-Moore family of provers, for which its authors
       have received the 2005 ACM Software System Award.
 
-      This package installs the main ACL2 executable ${pname}, as well as the
-      build tools cert.pl and clean.pl, renamed to ${pname}-cert and
-      ${pname}-clean.
+      This package installs the main ACL2 executable ${finalAttrs.pname}, as well as the
+      build tools cert.pl and clean.pl, renamed to ${finalAttrs.pname}-cert and
+      ${finalAttrs.pname}-clean.
 
     ''
     + (
@@ -212,4 +212,4 @@ stdenv.mkDerivation rec {
     ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/ac/acpilight/package.nix
+++ b/pkgs/by-name/ac/acpilight/package.nix
@@ -7,13 +7,13 @@
   udevCheckHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "acpilight";
   version = "1.2";
 
   src = fetchgit {
     url = "https://gitlab.com/wavexx/acpilight.git";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "1r0r3nx6x6vkpal6vci0zaa1n9dfacypldf6k8fxg7919vzxdn1w";
   };
 
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     substituteInPlace Makefile --replace-fail udevadm true
   '';
 
-  buildInputs = [ pyenv ];
+  buildInputs = [ finalAttrs.pyenv ];
 
   makeFlags = [ "DESTDIR=$(out) prefix=" ];
 
@@ -45,4 +45,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     mainProgram = "xbacklight";
   };
-}
+})

--- a/pkgs/by-name/ad/adl/package.nix
+++ b/pkgs/by-name/ad/adl/package.nix
@@ -11,7 +11,7 @@
   trackma,
   ueberzug,
 }:
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "adl";
   version = "3.2.8";
 
@@ -41,7 +41,7 @@ stdenvNoCC.mkDerivation rec {
     mkdir -p $out/bin
     cp $src/adl $out/bin
     wrapProgram $out/bin/adl \
-      --prefix PATH : ${lib.makeBinPath buildInputs}
+      --prefix PATH : ${lib.makeBinPath finalAttrs.buildInputs}
   '';
 
   meta = {
@@ -52,4 +52,4 @@ stdenvNoCC.mkDerivation rec {
     maintainers = with lib.maintainers; [ weathercold ];
     mainProgram = "adl";
   };
-}
+})

--- a/pkgs/by-name/ad/adr-tools/package.nix
+++ b/pkgs/by-name/ad/adr-tools/package.nix
@@ -20,14 +20,14 @@
   runCommand,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "adr-tools";
   version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "npryce";
     repo = "adr-tools";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-JEwLn+SY6XcaQ9VhN8ARQaZc1zolgAJKfIqPggzV+sU=";
   };
 
@@ -112,4 +112,4 @@ stdenv.mkDerivation rec {
     mainProgram = "adr";
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/af/afsctool/package.nix
+++ b/pkgs/by-name/af/afsctool/package.nix
@@ -9,14 +9,14 @@
   sparsehash,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "afsctool";
   version = "1.7.3";
 
   src = fetchFromGitHub {
     owner = "RJVB";
     repo = "afsctool";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
     gitConfigFile = builtins.toFile "gitconfig" ''
       [url "https://github.com/"]
@@ -46,4 +46,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.darwin;
     homepage = "https://github.com/RJVB/afsctool";
   };
-}
+})

--- a/pkgs/by-name/ag/agdsn-zsh-config/package.nix
+++ b/pkgs/by-name/ag/agdsn-zsh-config/package.nix
@@ -4,14 +4,14 @@
   fetchFromGitHub,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "agdsn-zsh-config";
   version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "agdsn";
     repo = "agdsn-zsh-config";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-8POQPk/hsJBMJ/ZJe9XzVj7Rd7C2+QnpzgYbUR0s3Fc=";
   };
 
@@ -35,4 +35,4 @@ stdenvNoCC.mkDerivation rec {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ fugi ];
   };
-}
+})

--- a/pkgs/by-name/ag/agi/package.nix
+++ b/pkgs/by-name/ag/agi/package.nix
@@ -13,12 +13,12 @@
   android-tools,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "agi";
   version = "3.3.1";
 
   src = fetchzip {
-    url = "https://github.com/google/agi/releases/download/${version}/agi-${version}-linux.zip";
+    url = "https://github.com/google/agi/releases/download/${finalAttrs.version}/agi-${finalAttrs.version}-linux.zip";
     sha256 = "sha256-Yawl6InBYSWNw3clHyGAeC2PVfXEzWmbd6vcYrqAPO0=";
   };
 
@@ -39,7 +39,7 @@ stdenvNoCC.mkDerivation rec {
     cp -r lib $out
 
     for i in 16 32 48 64 96 128 256 512 1024; do
-      install -D ${src}/icon.png $out/share/icons/hicolor/''${i}x$i/apps/agi.png
+      install -D ${finalAttrs.src}/icon.png $out/share/icons/hicolor/''${i}x$i/apps/agi.png
     done
 
     runHook postInstall
@@ -71,7 +71,7 @@ stdenvNoCC.mkDerivation rec {
   meta = {
     description = "Android GPU Inspector";
     homepage = "https://gpuinspector.dev";
-    changelog = "https://github.com/google/agi/releases/tag/v${version}";
+    changelog = "https://github.com/google/agi/releases/tag/v${finalAttrs.version}";
     platforms = [ "x86_64-linux" ];
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ kashw2 ];
@@ -80,4 +80,4 @@ stdenvNoCC.mkDerivation rec {
       binaryNativeCode
     ];
   };
-}
+})

--- a/pkgs/by-name/ag/agkozak-zsh-prompt/package.nix
+++ b/pkgs/by-name/ag/agkozak-zsh-prompt/package.nix
@@ -4,14 +4,14 @@
   fetchFromGitHub,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "agkozak-zsh-prompt";
   version = "3.11.5";
 
   src = fetchFromGitHub {
     owner = "agkozak";
     repo = "agkozak-zsh-prompt";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-C9lyOm2+RVLOUSO5Vz013uTobnN+SBE1Jm8GuJZ7T7U=";
   };
 
@@ -33,4 +33,4 @@ stdenvNoCC.mkDerivation rec {
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ ambroisie ];
   };
-}
+})

--- a/pkgs/by-name/ai/aixlog/package.nix
+++ b/pkgs/by-name/ai/aixlog/package.nix
@@ -4,14 +4,14 @@
   fetchFromGitHub,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "aixlog";
   version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "badaix";
     repo = "aixlog";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Xhle7SODRZlHT3798mYIzBi1Mqjz8ai74/UnbVWetiY=";
   };
 
@@ -30,8 +30,8 @@ stdenvNoCC.mkDerivation rec {
   meta = {
     description = "Header-only C++ logging library";
     homepage = "https://github.com/badaix/aixlog";
-    changelog = "https://github.com/badaix/aixlog/releases/tag/${src.rev}";
+    changelog = "https://github.com/badaix/aixlog/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/al/alienarena/package.nix
+++ b/pkgs/by-name/al/alienarena/package.nix
@@ -14,14 +14,14 @@
   stdenv,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "alienarena";
   version = "7.71.7";
 
   src = fetchFromGitHub {
     owner = "alienarena";
     repo = "alienarena";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-ri0p/0onI5DU7kDxwdFxRyT1LQLVe89VNEYPXPgilOs=";
   };
 
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    changelog = "https://github.com/alienarena/alienarena/releases/tag/${version}";
+    changelog = "https://github.com/alienarena/alienarena/releases/tag/${finalAttrs.version}";
     description = "Free, stand-alone first-person shooter computer game";
     longDescription = ''
       Do you like old school deathmatch with modern features? How
@@ -63,4 +63,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     hydraPlatforms = [ ];
   };
-}
+})

--- a/pkgs/by-name/al/alpine-make-rootfs/package.nix
+++ b/pkgs/by-name/al/alpine-make-rootfs/package.nix
@@ -14,14 +14,14 @@
   util-linux,
   wget,
 }:
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "alpine-make-rootfs";
   version = "0.8.1";
 
   src = fetchFromGitHub {
     owner = "alpinelinux";
     repo = "alpine-make-rootfs";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ktGJXPJK94RbdqcgsA3fA8+MO0inaRcwaDLx18KFo1w=";
   };
 
@@ -55,4 +55,4 @@ stdenvNoCC.mkDerivation rec {
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/al/altermime/package.nix
+++ b/pkgs/by-name/al/altermime/package.nix
@@ -4,12 +4,12 @@
   fetchurl,
 }:
 
-gccStdenv.mkDerivation rec {
+gccStdenv.mkDerivation (finalAttrs: {
   pname = "altermime";
   version = "0.3.11";
 
   src = fetchurl {
-    url = "https://pldaniels.com/altermime/altermime-${version}.tar.gz";
+    url = "https://pldaniels.com/altermime/altermime-${finalAttrs.version}.tar.gz";
     sha256 = "15zxg6spcmd35r6xbidq2fgcg2nzyv1sbbqds08lzll70mqx4pj7";
   };
 
@@ -36,4 +36,4 @@ gccStdenv.mkDerivation rec {
     downloadPage = "https://pldaniels.com/altermime/";
     mainProgram = "altermime";
   };
-}
+})

--- a/pkgs/by-name/am/amiri/package.nix
+++ b/pkgs/by-name/am/amiri/package.nix
@@ -4,12 +4,12 @@
   fetchzip,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "amiri";
   version = "1.003";
 
   src = fetchzip {
-    url = "https://github.com/aliftype/amiri/releases/download/${version}/Amiri-${version}.zip";
+    url = "https://github.com/aliftype/amiri/releases/download/${finalAttrs.version}/Amiri-${finalAttrs.version}.zip";
     hash = "sha256-BsYPMBlRdzlkvyleZIxGDuGjmqhDlEJ4udj8zoKUSzA=";
   };
 
@@ -18,8 +18,8 @@ stdenvNoCC.mkDerivation rec {
 
     mkdir -p $out/share/fonts/truetype
     mv *.ttf $out/share/fonts/truetype/
-    mkdir -p $out/share/doc/${pname}-${version}
-    mv {*.html,*.txt,*.md} $out/share/doc/${pname}-${version}/
+    mkdir -p $out/share/doc/amiri-${finalAttrs.version}
+    mv {*.html,*.txt,*.md} $out/share/doc/amiri-${finalAttrs.version}/
 
     runHook postInstall
   '';
@@ -31,4 +31,4 @@ stdenvNoCC.mkDerivation rec {
     maintainers = [ lib.maintainers.vbgl ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/am/amrwb/package.nix
+++ b/pkgs/by-name/am/amrwb/package.nix
@@ -5,7 +5,7 @@
   unzip,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "amrwb";
   version = "11.0.0.0";
 
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   };
 
   src = fetchurl {
-    url = "http://www.penguin.cz/~utx/ftp/amr/amrwb-${version}.tar.bz2";
+    url = "http://www.penguin.cz/~utx/ftp/amr/amrwb-${finalAttrs.version}.tar.bz2";
     sha256 = "1p6m9nd08mv525w14py9qzs9zwsa5i3vxf5bgcmcvc408jqmkbsw";
   };
 
@@ -38,4 +38,4 @@ stdenv.mkDerivation rec {
     # some countries, not redistributable.
     license = lib.licenses.unfree;
   };
-}
+})

--- a/pkgs/by-name/an/anakron/package.nix
+++ b/pkgs/by-name/an/anakron/package.nix
@@ -5,12 +5,12 @@
   mkfontscale,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "anakron";
   version = "0.3.3";
 
   src = fetchzip {
-    url = "https://github.com/molarmanful/ANAKRON/releases/download/v${version}/ANAKRON-release_v${version}.zip";
+    url = "https://github.com/molarmanful/ANAKRON/releases/download/v${finalAttrs.version}/ANAKRON-release_v${finalAttrs.version}.zip";
     hash = "sha256-l4MA3OsMnqPIBWKx3ZO5XnxjE0gnIGyAtsZe2z/9zrw=";
   };
 
@@ -33,11 +33,11 @@ stdenvNoCC.mkDerivation rec {
   meta = {
     description = "Thicc retrofuturistic bitmap font made for the modern screen";
     homepage = "https://github.com/molarmanful/ANAKRON";
-    changelog = "https://github.com/molarmanful/ANAKRON/releases/tag/v${version}";
+    changelog = "https://github.com/molarmanful/ANAKRON/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [
       ejiektpobehuk
     ];
   };
-}
+})

--- a/pkgs/by-name/an/andyetitmoves/package.nix
+++ b/pkgs/by-name/an/andyetitmoves/package.nix
@@ -17,7 +17,7 @@
   commercialVersion ? false,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "andyetitmoves";
   version = "1.2.2";
 
@@ -25,8 +25,8 @@ stdenv.mkDerivation rec {
     if stdenv.hostPlatform.system == "i686-linux" || stdenv.hostPlatform.system == "x86_64-linux" then
       let
         postfix = if stdenv.hostPlatform.system == "i686-linux" then "i386" else "x86_64";
-        commercialName = "${pname}-${version}_${postfix}.tar.gz";
-        demoUrl = "http://www.andyetitmoves.net/demo/${pname}Demo-${version}_${postfix}.tar.gz";
+        commercialName = "andyetitmoves-${finalAttrs.version}_${postfix}.tar.gz";
+        demoUrl = "http://www.andyetitmoves.net/demo/andyetitmovesDemo-${finalAttrs.version}_${postfix}.tar.gz";
       in
       if commercialVersion then
         requireFile {
@@ -96,4 +96,4 @@ stdenv.mkDerivation rec {
     homepage = "http://www.andyetitmoves.net/";
     license = lib.licenses.unfree;
   };
-}
+})

--- a/pkgs/by-name/an/ankacoder-condensed/package.nix
+++ b/pkgs/by-name/an/ankacoder-condensed/package.nix
@@ -4,12 +4,12 @@
   fetchzip,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "ankacoder-condensed";
   version = "1.100";
 
   src = fetchzip {
-    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/anka-coder-fonts/AnkaCoderCondensed.${version}.zip";
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/anka-coder-fonts/AnkaCoderCondensed.${finalAttrs.version}.zip";
     stripRoot = false;
     hash = "sha256-NHrkV4Sb7i+DC4e4lToEYzah3pI+sKyYf2rGbhWj7iY=";
   };
@@ -30,4 +30,4 @@ stdenvNoCC.mkDerivation rec {
     maintainers = [ ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/an/ankacoder/package.nix
+++ b/pkgs/by-name/an/ankacoder/package.nix
@@ -4,12 +4,12 @@
   fetchzip,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "ankacoder";
   version = "1.100";
 
   src = fetchzip {
-    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/anka-coder-fonts/AnkaCoder.${version}.zip";
+    url = "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/anka-coder-fonts/AnkaCoder.${finalAttrs.version}.zip";
     stripRoot = false;
     hash = "sha256-14ItaSQ/fO/WDq0O4SXGWnZgiM0kayJrWQgsKb7bsyY=";
   };
@@ -30,4 +30,4 @@ stdenvNoCC.mkDerivation rec {
     maintainers = [ ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/ap/apache-airflow/python-package.nix
+++ b/pkgs/by-name/ap/apache-airflow/python-package.nix
@@ -99,10 +99,10 @@ let
 
   pnpm = pnpm_10;
 
-  airflowUi = stdenv.mkDerivation rec {
+  airflowUi = stdenv.mkDerivation (finalAttrs: {
     pname = "airflow-ui-assets";
     inherit src version;
-    sourceRoot = "${src.name}/airflow-core/src/airflow/ui";
+    sourceRoot = "${finalAttrs.src.name}/airflow-core/src/airflow/ui";
 
     nativeBuildInputs = [
       nodejs
@@ -112,12 +112,10 @@ let
 
     pnpmDeps = fetchPnpmDeps {
       pname = "airflow-ui";
-      inherit
-        sourceRoot
-        src
-        version
-        pnpm
-        ;
+      src = finalAttrs.src;
+      version = finalAttrs.version;
+      sourceRoot = finalAttrs.sourceRoot;
+      inherit pnpm;
       fetcherVersion = 3;
       hash = "sha256-OkSDQoWsHQ6w1vIoX5W9zXHghV0obvL6Wji0HYN6CSs=";
     };
@@ -131,12 +129,12 @@ let
       mkdir -p $out/share/airflow/ui
       cp -r dist $out/share/airflow/ui/
     '';
-  };
+  });
 
-  airflowSimpleAuthUi = stdenv.mkDerivation rec {
+  airflowSimpleAuthUi = stdenv.mkDerivation (finalAttrs: {
     pname = "airflow-simple-ui-assets";
     inherit src version;
-    sourceRoot = "${src.name}/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui";
+    sourceRoot = "${finalAttrs.src.name}/airflow-core/src/airflow/api_fastapi/auth/managers/simple/ui";
 
     nativeBuildInputs = [
       nodejs
@@ -146,7 +144,9 @@ let
 
     pnpmDeps = fetchPnpmDeps {
       pname = "simple-auth-manager-ui";
-      inherit sourceRoot src version;
+      src = finalAttrs.src;
+      version = finalAttrs.version;
+      sourceRoot = finalAttrs.sourceRoot;
       fetcherVersion = 3;
       hash = "sha256-uQIVHzX0BcJuxgbPp6wqKhALbsfACSJjiMOdmrpuzOk=";
     };
@@ -160,7 +160,7 @@ let
       mkdir -p $out/share/airflow/simple-ui
       cp -r dist $out/share/airflow/simple-ui/
     '';
-  };
+  });
 
   requiredProviders = [
     "common_compat"
@@ -174,13 +174,13 @@ let
 
   buildProvider =
     provider:
-    buildPythonPackage {
+    buildPythonPackage (finalAttrs: {
       pname = "apache-airflow-providers-${provider}";
       version = providers.${provider}.version;
       pyproject = true;
 
       inherit src;
-      sourceRoot = "${src.name}/providers/${lib.replaceStrings [ "_" ] [ "/" ] provider}";
+      sourceRoot = "${finalAttrs.src.name}/providers/${lib.replaceStrings [ "_" ] [ "/" ] provider}";
 
       buildInputs = [ flit-core ];
 
@@ -193,14 +193,14 @@ let
       pythonRelaxDeps = [
         "flit-core"
       ];
-    };
+    });
 
-  airflowCore = buildPythonPackage {
+  airflowCore = buildPythonPackage (finalAttrs: {
     pname = "apache-airflow-core";
     inherit src version;
     pyproject = true;
 
-    sourceRoot = "${src.name}/airflow-core";
+    sourceRoot = "${finalAttrs.src.name}/airflow-core";
 
     postPatch = ''
       # remove cyclic dependency
@@ -291,14 +291,14 @@ let
       uvicorn
     ]
     ++ (map buildProvider requiredProviders);
-  };
+  });
 
-  taskSdk = buildPythonPackage {
+  taskSdk = buildPythonPackage (finalAttrs: {
     pname = "task-sdk";
     inherit src version;
     pyproject = true;
 
-    sourceRoot = "${src.name}/task-sdk";
+    sourceRoot = "${finalAttrs.src.name}/task-sdk";
 
     postPatch = ''
       # resolve cyclic dependency
@@ -341,10 +341,10 @@ let
       tenacity
       types-requests
     ];
-  };
+  });
 
 in
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "apache-airflow";
   inherit src version;
   pyproject = true;
@@ -414,11 +414,11 @@ buildPythonPackage rec {
   meta = {
     description = "Platform to programmatically author, schedule and monitor workflows";
     homepage = "https://airflow.apache.org/";
-    changelog = "https://airflow.apache.org/docs/apache-airflow/${version}/release_notes.html";
+    changelog = "https://airflow.apache.org/docs/apache-airflow/${finalAttrs.version}/release_notes.html";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       taranarmo
     ];
     mainProgram = "airflow";
   };
-}
+})

--- a/pkgs/by-name/ap/apache-jena-fuseki/package.nix
+++ b/pkgs/by-name/ap/apache-jena-fuseki/package.nix
@@ -10,11 +10,11 @@
   pkgs,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "apache-jena-fuseki";
   version = "5.1.0";
   src = fetchurl {
-    url = "mirror://apache/jena/binaries/apache-jena-fuseki-${version}.tar.gz";
+    url = "mirror://apache/jena/binaries/apache-jena-fuseki-${finalAttrs.version}.tar.gz";
     hash = "sha256-GcwXcLVM2txPC+kkHjEIpqK9dTkQEN9Jkka0EaJRO7Q=";
   };
   nativeBuildInputs = [
@@ -52,4 +52,4 @@ stdenv.mkDerivation rec {
     downloadPage = "https://archive.apache.org/dist/jena/binaries/";
     mainProgram = "fuseki";
   };
-}
+})

--- a/pkgs/by-name/ap/apache-jena/package.nix
+++ b/pkgs/by-name/ap/apache-jena/package.nix
@@ -6,11 +6,11 @@
   makeWrapper,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "apache-jena";
   version = "6.1.0";
   src = fetchurl {
-    url = "mirror://apache/jena/binaries/apache-jena-${version}.tar.gz";
+    url = "mirror://apache/jena/binaries/apache-jena-${finalAttrs.version}.tar.gz";
     hash = "sha256-ZTEIqR/Zswmom8dWJYuuC8oBWHzvR1lC0RhS4766KuM=";
   };
   nativeBuildInputs = [
@@ -30,4 +30,4 @@ stdenv.mkDerivation rec {
     homepage = "https://jena.apache.org";
     downloadPage = "https://archive.apache.org/dist/jena/binaries/";
   };
-}
+})

--- a/pkgs/by-name/ap/apksigner/package.nix
+++ b/pkgs/by-name/ap/apksigner/package.nix
@@ -8,9 +8,23 @@
   makeWrapper,
   bashNonInteractive,
 }:
-let
-  # "Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0."
-  gradle = gradle_8;
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "apksigner";
+  # Major version is derived from the API version of the corresponding Android release.
+  # Patch version is derived from the release number.
+  # For example, Android 15 had releases starting at r24 -> r30 is patch 6.
+
+  version = "35.0.6";
+
+  src = fetchgit {
+    name = "apksigner";
+    url = "https://android.googlesource.com/platform/tools/apksig";
+    tag = "android-15.0.0_r30";
+    hash = "sha256-f/PggxvBv8nYUyL9Ukd4YVpunpRWbLL5UYsYhsiDWRE=";
+  };
+
+  # Define jre directly inside finalAttrs so it's accessible to the build phases
   jre = jre_minimal.override {
     modules = [
       "java.base"
@@ -22,25 +36,22 @@ let
       "jdk.unsupported"
     ];
   };
-in
-stdenv.mkDerivation rec {
-  pname = "apksigner";
-  # Major version is derived from the API version of the corresponding Android release.
-  # Patch version is derived from the release number.
-  # For example, Android 15 had releases starting at r24 -> r30 is patch 6.
-  version = "35.0.6";
 
-  src = fetchgit {
-    # use pname here because the final jar uses this as the filename
-    name = pname;
-    url = "https://android.googlesource.com/platform/tools/apksig";
-    tag = "android-15.0.0_r30";
-    hash = "sha256-f/PggxvBv8nYUyL9Ukd4YVpunpRWbLL5UYsYhsiDWRE=";
+  # Reference gradle_8 directly
+  mitmCache = gradle_8.fetchDeps {
+    inherit (finalAttrs) pname;
+    data = ./deps.json;
   };
 
-  mitmCache = gradle.fetchDeps {
-    inherit pname;
-    data = ./deps.json;
+  # Force Gradle to run in the foreground and resolve IPv4/IPv6 localhost sandbox issues
+  gradleFlags = [
+    "--no-daemon"
+  ];
+
+  # NEW: Force ALL spawned Java processes to use IPv4
+  # This fixes the IPC daemon connection timeout in the macOS sandbox
+  env = {
+    JAVA_TOOL_OPTIONS = "-Djava.net.preferIPv4Stack=true";
   };
 
   __darwinAllowLocalNetworking = true;
@@ -48,7 +59,8 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   nativeBuildInputs = [
-    gradle
+    jdk_headless
+    gradle_8
     makeWrapper
   ];
 
@@ -65,7 +77,7 @@ stdenv.mkDerivation rec {
     mv apksigner $out/opt
     mkdir -p $out/bin
     makeWrapper $out/opt/apksigner/bin/apksigner $out/bin/apksigner \
-      --set JAVA_HOME ${jre.home}
+      --set JAVA_HOME ${finalAttrs.jre.home}
 
     runHook postInstall
   '';
@@ -83,4 +95,4 @@ stdenv.mkDerivation rec {
     teams = [ lib.teams.android ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/ap/appgate-sdp/package.nix
+++ b/pkgs/by-name/ap/appgate-sdp/package.nix
@@ -97,12 +97,12 @@ let
     zlib
   ];
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "appgate-sdp";
   version = "6.4.2";
 
   src = fetchurl {
-    url = "https://bin.appgate-sdp.com/${lib.versions.majorMinor version}/client/appgate-sdp_${version}_amd64.deb";
+    url = "https://bin.appgate-sdp.com/${lib.versions.majorMinor finalAttrs.version}/client/appgate-sdp_${finalAttrs.version}_amd64.deb";
     sha256 = "sha256-xFpBC6X95C01wUfzJ3a0kMz898k6BItkpJLcUmfd7oY=";
   };
 
@@ -176,4 +176,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ ymatsiuk ];
     mainProgram = "appgate";
   };
-}
+})

--- a/pkgs/by-name/ap/appstream-glib/package.nix
+++ b/pkgs/by-name/ap/appstream-glib/package.nix
@@ -24,7 +24,7 @@
   pkg-config,
   pngquant,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "appstream-glib";
   version = "0.8.3";
 
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "hughsie";
     repo = "appstream-glib";
-    tag = "appstream_glib_${lib.replaceStrings [ "." ] [ "_" ] version}";
+    tag = "appstream_glib_${lib.replaceStrings [ "." ] [ "_" ] finalAttrs.version}";
     hash = "sha256-GjXrYV+EBduhG88LaxQWICKuUDJeeotcZgqgaG0/dqo=";
   };
 
@@ -91,11 +91,11 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    changelog = "https://github.com/hughsie/appstream-glib/blob/${src.tag}/NEWS";
+    changelog = "https://github.com/hughsie/appstream-glib/blob/${finalAttrs.src.tag}/NEWS";
     description = "Objects and helper methods to read and write AppStream metadata";
     homepage = "https://people.freedesktop.org/~hughsient/appstream-glib/";
     license = lib.licenses.lgpl2Plus;
     platforms = lib.platforms.unix;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/ar/arachne-pnr/package.nix
+++ b/pkgs/by-name/ar/arachne-pnr/package.nix
@@ -5,7 +5,7 @@
   icestorm,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "arachne-pnr";
   version = "2019.07.29";
 
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace ./Makefile \
-      --replace 'echo UNKNOWN' 'echo ${lib.substring 0 10 src.rev}'
+      --replace 'echo UNKNOWN' 'echo ${lib.substring 0 10 finalAttrs.src.rev}'
   '';
 
   meta = {
@@ -48,4 +48,4 @@ stdenv.mkDerivation rec {
     ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/ar/arc-icon-theme/package.nix
+++ b/pkgs/by-name/ar/arc-icon-theme/package.nix
@@ -10,14 +10,14 @@
   hicolor-icon-theme,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "arc-icon-theme";
   version = "20161122";
 
   src = fetchFromGitHub {
     owner = "horst3180";
     repo = "arc-icon-theme";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-TfYtzwo69AC5hHbzEqB4r5Muqvn/eghCGSlmjMCFA7I=";
   };
 
@@ -45,4 +45,4 @@ stdenvNoCC.mkDerivation rec {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ romildo ];
   };
-}
+})

--- a/pkgs/by-name/ar/arc-theme/package.nix
+++ b/pkgs/by-name/ar/arc-theme/package.nix
@@ -15,14 +15,14 @@
   python3,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "arc-theme";
   version = "20221218";
 
   src = fetchFromGitHub {
     owner = "jnsh";
     repo = "arc-theme";
-    tag = version;
+    tag = finalAttrs.version;
     sha256 = "sha256-7VmqsUCeG5GwmrVdt9BJj0eZ/1v+no/05KwGFb7E9ns=";
   };
 
@@ -71,4 +71,4 @@ stdenv.mkDerivation rec {
       romildo
     ];
   };
-}
+})

--- a/pkgs/by-name/ar/arena/package.nix
+++ b/pkgs/by-name/ar/arena/package.nix
@@ -22,13 +22,13 @@ let
   libDir = "lib64";
 
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "arena";
   version = "3.10-beta";
 
   src = fetchurl {
     url = "http://www.playwitharena.de/downloads/arenalinux_64bit_${
-      lib.replaceStrings [ "-" ] [ "" ] version
+      lib.replaceStrings [ "-" ] [ "" ] finalAttrs.version
     }.tar.gz";
     sha256 = "1pzb9sg4lzbbi4gbldvlb85p8xyl9xnplxwyb9pkk2mwzvvxkf0d";
   };
@@ -48,19 +48,19 @@ stdenv.mkDerivation rec {
   unpackPhase = ''
     # This is is a tar bomb, i.e. it extract a dozen files and directories to
     # the top-level, so we must create a sub-directory first.
-    mkdir -p $out/lib/${pname}-${version}
-    tar -C $out/lib/${pname}-${version} -xf ${src}
+    mkdir -p $out/lib/arena-${finalAttrs.version}
+    tar -C $out/lib/arena-${finalAttrs.version} -xf ${finalAttrs.src}
 
     # Remove executable bits from data files. This matters for the find command
     # we'll use below to find all bundled engines.
-    chmod -x $out/lib/${pname}-${version}/Engines/*/*.{txt,bin,bmp,zip}
+    chmod -x $out/lib/arena-${finalAttrs.version}/Engines/*/*.{txt,bin,bmp,zip}
   '';
 
   buildPhase = ''
     # Arena has (at least) two executables plus a couple of bundled chess
     # engines that we need to patch.
     exes=( $(find $out -name '*x86_64_linux')
-           $(find $out/lib/${pname}-${version}/Engines -type f -perm /u+x)
+           $(find $out/lib/arena-${finalAttrs.version}/Engines -type f -perm /u+x)
          )
     for i in "''${exes[@]}"; do
       # Arminius is statically linked.
@@ -68,14 +68,14 @@ stdenv.mkDerivation rec {
       echo Fixing interpreter and rpath paths in $i ...
       patchelf                                                                                   \
         --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)"                                \
-        --set-rpath ${makeLibraryPath buildInputs}:$(cat $NIX_CC/nix-support/orig-cc)/${libDir}  \
+        --set-rpath ${makeLibraryPath finalAttrs.buildInputs}:$(cat $NIX_CC/nix-support/orig-cc)/${libDir}  \
         $i
     done
   '';
 
   installPhase = ''
     mkdir -p $out/bin
-    ln -s $out/lib/${pname}-${version}/Arena_x86_64_linux $out/bin/arena
+    ln -s $out/lib/arena-${finalAttrs.version}/Arena_x86_64_linux $out/bin/arena
   '';
 
   dontStrip = true;
@@ -95,4 +95,4 @@ stdenv.mkDerivation rec {
     platforms = [ "x86_64-linux" ];
   };
 
-}
+})

--- a/pkgs/by-name/ar/argyllcms/package.nix
+++ b/pkgs/by-name/ar/argyllcms/package.nix
@@ -24,14 +24,14 @@
   writeScript,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "argyllcms";
   version = "3.4.1";
 
   src = fetchzip {
     # Kind of flacky URL, it was reaturning 406 and inconsistent binaries for a
     # while on me. It might be good to find a mirror
-    url = "https://www.argyllcms.com/Argyll_V${version}_src.zip";
+    url = "https://www.argyllcms.com/Argyll_V${finalAttrs.version}_src.zip";
     hash = "sha256-QVugWtAk8xBn+/fRFqCoi072Q2q8OlB0LRhavrHC5MI=";
   };
 
@@ -118,7 +118,7 @@ stdenv.mkDerivation rec {
         HAVE_SSL = true ;
 
         LINKFLAGS +=
-          ${lib.concatStringsSep " " (map (x: "-L${x}/lib") buildInputs)}
+          ${lib.concatStringsSep " " (map (x: "-L${x}/lib") finalAttrs.buildInputs)}
           -lrt -lX11 -lXext -lXxf86vm -lXinerama -lXrandr -lXau -lXdmcp -lXss
           -ljpeg -ltiff -lpng -lssl ;
       '';
@@ -178,7 +178,7 @@ stdenv.mkDerivation rec {
       # Expect the text in format of 'Current Version 3.0.1 (19th October 2023)'
       new_version="$(curl -s https://www.argyllcms.com/ |
           pcregrep -o1 '>Current Version ([0-9.]+) ')"
-      update-source-version ${pname} "$new_version"
+      update-source-version argyllcms "$new_version"
     '';
   };
 
@@ -189,4 +189,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/ar/ario/package.nix
+++ b/pkgs/by-name/ar/ario/package.nix
@@ -17,12 +17,12 @@
   wrapGAppsHook3,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ario";
   version = "1.6";
 
   src = fetchurl {
-    url = "mirror://sourceforge/ario-player/${pname}-${version}.tar.gz";
+    url = "mirror://sourceforge/ario-player/ario-${finalAttrs.version}.tar.gz";
     sha256 = "16nhfb3h5pc7flagfdz7xy0iq6kvgy6h4bfpi523i57rxvlfshhl";
   };
 
@@ -63,4 +63,4 @@ stdenv.mkDerivation rec {
     maintainers = [ lib.maintainers.garrison ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/ar/arkpandora_ttf/package.nix
+++ b/pkgs/by-name/ar/arkpandora_ttf/package.nix
@@ -4,15 +4,15 @@
   fetchurl,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "arkpandora";
   version = "2.04";
 
   src = fetchurl {
     urls = [
-      "http://distcache.FreeBSD.org/ports-distfiles/ttf-arkpandora-${version}.tgz"
-      "ftp://ftp.FreeBSD.org/pub/FreeBSD/ports/distfiles/ttf-arkpandora-${version}.tgz"
-      "http://www.users.bigpond.net.au/gavindi/ttf-arkpandora-${version}.tgz"
+      "http://distcache.FreeBSD.org/ports-distfiles/ttf-arkpandora-${finalAttrs.version}.tgz"
+      "ftp://ftp.FreeBSD.org/pub/FreeBSD/ports/distfiles/ttf-arkpandora-${finalAttrs.version}.tgz"
+      "http://www.users.bigpond.net.au/gavindi/ttf-arkpandora-${finalAttrs.version}.tgz"
     ];
     hash = "sha256-ofyVPJjQD8w+8WgETF2UcJlfbSsKQgBsH3ob+yjvrpo=";
   };
@@ -30,4 +30,4 @@ stdenvNoCC.mkDerivation rec {
     description = "Font, metrically identical to Arial and Times New Roman";
     license = lib.licenses.bitstreamVera;
   };
-}
+})

--- a/pkgs/by-name/ar/arp-scan/package.nix
+++ b/pkgs/by-name/ar/arp-scan/package.nix
@@ -8,14 +8,14 @@
   perlPackages,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "arp-scan";
   version = "1.10.0";
 
   src = fetchFromGitHub {
     owner = "royhills";
     repo = "arp-scan";
-    tag = version;
+    tag = finalAttrs.version;
     sha256 = "sha256-BS+ItZd6cSMX92M6XGYrIeAiCB2iBdvbMvKdLfwawLQ=";
   };
 
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     for binary in get-{oui,iab}; do
-      wrapProgram "$out/bin/$binary" --set PERL5LIB "${perlPackages.makeFullPerlPath perlModules}"
+      wrapProgram "$out/bin/$binary" --set PERL5LIB "${perlPackages.makeFullPerlPath finalAttrs.perlModules}"
     done;
   '';
 
@@ -62,4 +62,4 @@ stdenv.mkDerivation rec {
     ];
     mainProgram = "arp-scan";
   };
-}
+})

--- a/pkgs/by-name/ar/arphic-ukai/package.nix
+++ b/pkgs/by-name/ar/arphic-ukai/package.nix
@@ -6,12 +6,12 @@
   mkfontscale,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "arphic-ukai";
   version = "0.2.20080216.2";
 
   src = fetchurl {
-    url = "mirror://ubuntu/pool/main/f/fonts-arphic-ukai/fonts-arphic-ukai_${version}.orig.tar.bz2";
+    url = "mirror://ubuntu/pool/main/f/fonts-arphic-ukai/fonts-arphic-ukai_${finalAttrs.version}.orig.tar.bz2";
     hash = "sha256-tJaNc1GfT4dH6FVI+4XSG2Zdob8bqQCnxJmXbmqK49I=";
   };
 
@@ -39,4 +39,4 @@ stdenvNoCC.mkDerivation rec {
     maintainers = [ lib.maintainers.changlinli ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/ar/arphic-uming/package.nix
+++ b/pkgs/by-name/ar/arphic-uming/package.nix
@@ -6,12 +6,12 @@
   mkfontscale,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "arphic-uming";
   version = "0.2.20080216.2";
 
   src = fetchurl {
-    url = "mirror://ubuntu/pool/main/f/fonts-arphic-uming/fonts-arphic-uming_${version}.orig.tar.bz2";
+    url = "mirror://ubuntu/pool/main/f/fonts-arphic-uming/fonts-arphic-uming_${finalAttrs.version}.orig.tar.bz2";
     hash = "sha256-48GeBOp6VltKz/bx5CSAhNLhB1LjBb991sdugIYNwds=";
   };
 
@@ -39,4 +39,4 @@ stdenvNoCC.mkDerivation rec {
     maintainers = [ lib.maintainers.changlinli ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/as/astromenace/package.nix
+++ b/pkgs/by-name/as/astromenace/package.nix
@@ -21,14 +21,14 @@
   runtimeShell,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "astromenace";
   version = "1.4.3";
 
   src = fetchFromGitHub {
     owner = "viewizard";
     repo = "astromenace";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-W6d+8iw7/r2qJbE75U7egxqvK2HXaKzk+GtnspZRAxk=";
   };
 
@@ -84,4 +84,4 @@ stdenv.mkDerivation rec {
     mainProgram = "astromenace";
     maintainers = with lib.maintainers; [ fgaz ];
   };
-}
+})

--- a/pkgs/by-name/at/atasm/package.nix
+++ b/pkgs/by-name/at/atasm/package.nix
@@ -5,14 +5,14 @@
   zlib,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "atasm";
   version = "1.29";
 
   src = fetchFromGitHub {
     owner = "CycoPH";
     repo = "atasm";
-    rev = "V${version}";
+    rev = "V${finalAttrs.version}";
     hash = "sha256-TGSmlNz8kxsHlIhq4ZNDBU8uhpsZGK0oEp2qD4SndE8=";
   };
 
@@ -43,24 +43,24 @@ stdenv.mkDerivation rec {
 
   preInstall = ''
     mkdir -p $out/bin/
-    install -d $out/share/doc/${pname} $out/man/man1
+    install -d $out/share/doc/atasm $out/man/man1
     installFlagsArray+=(
       DESTDIR=$out/bin/
-      DOCDIR=$out/share/doc/${pname}
+      DOCDIR=$out/share/doc/atasm
       MANDIR=$out/man/man1
     )
   '';
 
   postInstall = ''
-    mv docs/* $out/share/doc/${pname}
+    mv docs/* $out/share/doc/atasm
   '';
 
   meta = {
     homepage = "https://github.com/CycoPH/atasm";
     description = "Commandline 6502 assembler compatible with Mac/65";
     license = lib.licenses.gpl2Plus;
-    changelog = "https://github.com/CycoPH/atasm/releases/tag/V${version}";
+    changelog = "https://github.com/CycoPH/atasm/releases/tag/V${finalAttrs.version}";
     maintainers = [ ];
     platforms = with lib.platforms; unix;
   };
-}
+})

--- a/pkgs/by-name/at/ats2/package.nix
+++ b/pkgs/by-name/at/ats2/package.nix
@@ -28,12 +28,12 @@ let
   '';
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ats2";
   version = versionPkg;
 
   src = fetchurl {
-    url = "mirror://sourceforge/ats2-lang/ATS2-Postiats-gmp-${version}.tgz";
+    url = "mirror://sourceforge/ats2-lang/ATS2-Postiats-gmp-${finalAttrs.version}.tgz";
     hash = "sha256-UWgDjFojPBYgykrCrJyYvVWY+Gc5d4aRGjTWjc528AM=";
   };
 
@@ -80,4 +80,4 @@ stdenv.mkDerivation rec {
       bbarker
     ];
   };
-}
+})


### PR DESCRIPTION
This PR updates several packages to the modern mkDerivation (finalAttrs: { … }) style, replacing rec and switching all internal references (e.g., version, pname) to finalAttrs.<attr> for consistency. It also cleans up desktop entry generation, fixes minor variable issues, simplifies build inputs, and updates meta fields to use the new attribute style.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
