### PR TITLE
home-assistant-custom-lovelace-modules.tankerkoenig-card: init at 1.7.2

### DIFF
--- a/pkgs/servers/home-assistant/custom-lovelace-modules/tankerkoenig-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/tankerkoenig-card/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "tankerkoenig-card";
+  version = "1.7.2";
+
+  src = fetchFromGitHub {
+    owner = "timmaurice";
+    repo = "lovelace-tankerkoenig-card";
+    tag = finalAttrs.version;
+    hash = "sha256-XBgroe7DT8fAaRkwcI5VU69jt1NnPiTcbjQovmrc200=";
+  };
+
+  npmDepsHash = "sha256-Bcu0K4SSDUyYFgYqk1HdjJA6jJSAO7Z53sUOEihv2T4=";
+
+  installPhase = ''
+    runHook preInstall
+
+    install ./dist/tankerkoenig-card.js -Dt $out
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Lovelace card to display German fuel prices from Tankerkönig";
+    homepage = "https://github.com/timmaurice/lovelace-tankerkoenig-card";
+    changelog = "https://github.com/timmaurice/lovelace-tankerkoenig-card/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
I did an experiment and this was fully vibe coded, but the resulting code is basically the same as in identically to what I would have written by hand and was reviewed by me. I also tested this in a Home-Assistant installation and it properly displayed the data from the upstream integration.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
