### PR TITLE
tree-sitter-grammars: fix build

### DIFF
--- a/pkgs/by-name/he/helix/package.nix
+++ b/pkgs/by-name/he/helix/package.nix
@@ -10,6 +10,9 @@
   lockedGrammars ? lib.importJSON ./grammars.json,
   grammarsOverlay ? (
     final: prev: {
+      tree-sitter-agda = prev.tree-sitter-agda.override {
+        excludeBrokenTreeSitterJson = false;
+      };
       tree-sitter-beancount = prev.tree-sitter-beancount.override {
         excludeBrokenTreeSitterJson = false;
       };
@@ -27,6 +30,15 @@
       };
       tree-sitter-sql = prev.tree-sitter-sql.override {
         generate = false;
+      };
+      tree-sitter-strace = prev.tree-sitter-strace.override {
+        excludeBrokenTreeSitterJson = false;
+      };
+      tree-sitter-tact = prev.tree-sitter-tact.override {
+        excludeBrokenTreeSitterJson = false;
+      };
+      tree-sitter-vue = prev.tree-sitter-vue.override {
+        excludeBrokenTreeSitterJson = false;
       };
     }
   ),

--- a/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
@@ -2538,6 +2538,8 @@
         aciceri
       ];
     };
+    # Empty `metadata.links.funding` fails URL parsing
+    excludeBrokenTreeSitterJson = true;
   };
 
   supercollider = {

--- a/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
@@ -1830,6 +1830,8 @@
     meta = {
       license = lib.licenses.mit;
     };
+    # Missing required `metadata.links`
+    excludeBrokenTreeSitterJson = true;
   };
 
   opencl = {

--- a/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
@@ -30,6 +30,8 @@
         aciceri
       ];
     };
+    # Non-schema `queries` nesting in grammar entry
+    excludeBrokenTreeSitterJson = true;
   };
 
   alloy = {

--- a/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
@@ -1026,6 +1026,8 @@
         aciceri
       ];
     };
+    # Slash in grammar name and non-schema top-level `tree-sitter` field
+    excludeBrokenTreeSitterJson = true;
   };
 
   groovy = {

--- a/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
@@ -2629,6 +2629,8 @@
         aciceri
       ];
     };
+    # Non-schema `metadata.links.homepage`
+    excludeBrokenTreeSitterJson = true;
   };
 
   talon = rec {

--- a/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
@@ -742,6 +742,8 @@
         sei40kr
       ];
     };
+    # Non-schema `camelCase` and `external-scanner` fields
+    excludeBrokenTreeSitterJson = true;
   };
 
   gas = {

--- a/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
@@ -2208,6 +2208,8 @@
         aciceri
       ];
     };
+    # Missing required `grammars[0].name` and `metadata`
+    excludeBrokenTreeSitterJson = true;
   };
 
   r = {

--- a/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
@@ -2985,6 +2985,8 @@
         jeafleohj
       ];
     };
+    # Relative repository URL, empty funding and author URLs
+    excludeBrokenTreeSitterJson = true;
   };
 
   wast = {

--- a/pkgs/development/python-modules/tree-sitter-grammars/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-grammars/default.nix
@@ -33,6 +33,7 @@ let
   # of overrides ensures the binding can find the correct symbol
   langIdentOverrides = {
     tree_sitter_org_nvim = "tree_sitter_org";
+    tree_sitter_go_template_helm = "tree_sitter_helm";
   };
   langIdent = langIdentOverrides.${snakeCaseName} or snakeCaseName;
 in


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

i saw some python tree sitter binding failures on hydra


<details>
  <summary>copied from zh.fail</summary>

[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-agda.aarch64-darwin](https://hydra.nixos.org/build/329748370)	python3.13-python-tree-sitter-agda-1.3.3	aarch64-darwin	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-agda.aarch64-linux](https://hydra.nixos.org/build/329741161)	python3.13-python-tree-sitter-agda-1.3.3	aarch64-linux	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-agda.x86_64-darwin](https://hydra.nixos.org/build/329748358)	python3.13-python-tree-sitter-agda-1.3.3	x86_64-darwin	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-agda.x86_64-linux](https://hydra.nixos.org/build/329741149)	python3.13-python-tree-sitter-agda-1.3.3	x86_64-linux	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-fstar.aarch64-darwin](https://hydra.nixos.org/build/329748602)	python3.13-python-tree-sitter-fstar-0+unstable20260314	aarch64-darwin	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-fstar.aarch64-linux](https://hydra.nixos.org/build/329741266)	python3.13-python-tree-sitter-fstar-0+unstable20260314	aarch64-linux	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-fstar.x86_64-darwin](https://hydra.nixos.org/build/329748600)	python3.13-python-tree-sitter-fstar-0+unstable20260314	x86_64-darwin	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-fstar.x86_64-linux](https://hydra.nixos.org/build/329741270)	python3.13-python-tree-sitter-fstar-0+unstable20260314	x86_64-linux	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-go-template-helm.aarch64-darwin](https://hydra.nixos.org/build/329748722)	python3.13-python-tree-sitter-go-template-helm-0+unstable20260321	aarch64-darwin	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-go-template-helm.aarch64-linux](https://hydra.nixos.org/build/329741301)	python3.13-python-tree-sitter-go-template-helm-0+unstable20260321	aarch64-linux	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-go-template-helm.x86_64-darwin](https://hydra.nixos.org/build/329748669)	python3.13-python-tree-sitter-go-template-helm-0+unstable20260321	x86_64-darwin	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-go-template-helm.x86_64-linux](https://hydra.nixos.org/build/329741298)	python3.13-python-tree-sitter-go-template-helm-0+unstable20260321	x86_64-linux	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-gren.aarch64-darwin](https://hydra.nixos.org/build/329748689)	python3.13-python-tree-sitter-gren-2.0.0+unstable20250503	aarch64-darwin	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-gren.aarch64-linux](https://hydra.nixos.org/build/329741313)	python3.13-python-tree-sitter-gren-2.0.0+unstable20250503	aarch64-linux	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-gren.x86_64-darwin](https://hydra.nixos.org/build/329748742)	python3.13-python-tree-sitter-gren-2.0.0+unstable20250503	x86_64-darwin	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-gren.x86_64-linux](https://hydra.nixos.org/build/329741312)	python3.13-python-tree-sitter-gren-2.0.0+unstable20250503	x86_64-linux	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-opam.aarch64-darwin](https://hydra.nixos.org/build/329749020)	python3.13-python-tree-sitter-opam-0+unstable20260405	aarch64-darwin	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-opam.aarch64-linux](https://hydra.nixos.org/build/329741478)	python3.13-python-tree-sitter-opam-0+unstable20260405	aarch64-linux	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-opam.x86_64-darwin](https://hydra.nixos.org/build/329748976)	python3.13-python-tree-sitter-opam-0+unstable20260405	x86_64-darwin	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-opam.x86_64-linux](https://hydra.nixos.org/build/329741474)	python3.13-python-tree-sitter-opam-0+unstable20260405	x86_64-linux	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-quint.aarch64-darwin](https://hydra.nixos.org/build/329749103)	python3.13-python-tree-sitter-quint-0+unstable20250409	aarch64-darwin	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-quint.aarch64-linux](https://hydra.nixos.org/build/329741528)	python3.13-python-tree-sitter-quint-0+unstable20250409	aarch64-linux	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-quint.x86_64-darwin](https://hydra.nixos.org/build/329749105)	python3.13-python-tree-sitter-quint-0+unstable20250409	x86_64-darwin	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-quint.x86_64-linux](https://hydra.nixos.org/build/329741556)	python3.13-python-tree-sitter-quint-0+unstable20250409	x86_64-linux	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-strace.aarch64-darwin](https://hydra.nixos.org/build/329749320)	python3.13-python-tree-sitter-strace-0+unstable20251221	aarch64-darwin	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-strace.aarch64-linux](https://hydra.nixos.org/build/329741573)	python3.13-python-tree-sitter-strace-0+unstable20251221	aarch64-linux	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-strace.x86_64-darwin](https://hydra.nixos.org/build/329749250)	python3.13-python-tree-sitter-strace-0+unstable20251221	x86_64-darwin	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-strace.x86_64-linux](https://hydra.nixos.org/build/329741574)	python3.13-python-tree-sitter-strace-0+unstable20251221	x86_64-linux	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-tact.aarch64-darwin](https://hydra.nixos.org/build/329749253)	python3.13-python-tree-sitter-tact-1.6.0+unstable20250501	aarch64-darwin	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-tact.aarch64-linux](https://hydra.nixos.org/build/329741591)	python3.13-python-tree-sitter-tact-1.6.0+unstable20250501	aarch64-linux	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-tact.x86_64-darwin](https://hydra.nixos.org/build/329749312)	python3.13-python-tree-sitter-tact-1.6.0+unstable20250501	x86_64-darwin	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-tact.x86_64-linux](https://hydra.nixos.org/build/329741590)	python3.13-python-tree-sitter-tact-1.6.0+unstable20250501	x86_64-linux	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-vue.aarch64-darwin](https://hydra.nixos.org/build/329749366)	python3.13-python-tree-sitter-vue-0.1.0	aarch64-darwin	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-vue.aarch64-linux](https://hydra.nixos.org/build/329741649)	python3.13-python-tree-sitter-vue-0.1.0	aarch64-linux	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-vue.x86_64-darwin](https://hydra.nixos.org/build/329749426)	python3.13-python-tree-sitter-vue-0.1.0	x86_64-darwin	Failed
[nixpkgs.python313Packages.tree-sitter-grammars.tree-sitter-vue.x86_64-linux](https://hydra.nixos.org/build/329741665)	python3.13-python-tree-sitter-vue-0.1.0	x86_64-linux	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-agda.aarch64-darwin](https://hydra.nixos.org/build/329749913)	python3.14-python-tree-sitter-agda-1.3.3	aarch64-darwin	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-agda.aarch64-linux](https://hydra.nixos.org/build/329742007)	python3.14-python-tree-sitter-agda-1.3.3	aarch64-linux	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-agda.x86_64-darwin](https://hydra.nixos.org/build/329749931)	python3.14-python-tree-sitter-agda-1.3.3	x86_64-darwin	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-agda.x86_64-linux](https://hydra.nixos.org/build/329742003)	python3.14-python-tree-sitter-agda-1.3.3	x86_64-linux	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-fstar.aarch64-darwin](https://hydra.nixos.org/build/329750155)	python3.14-python-tree-sitter-fstar-0+unstable20260314	aarch64-darwin	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-fstar.aarch64-linux](https://hydra.nixos.org/build/329742112)	python3.14-python-tree-sitter-fstar-0+unstable20260314	aarch64-linux	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-fstar.x86_64-darwin](https://hydra.nixos.org/build/329750239)	python3.14-python-tree-sitter-fstar-0+unstable20260314	x86_64-darwin	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-fstar.x86_64-linux](https://hydra.nixos.org/build/329742110)	python3.14-python-tree-sitter-fstar-0+unstable20260314	x86_64-linux	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-go-template-helm.aarch64-darwin](https://hydra.nixos.org/build/329750263)	python3.14-python-tree-sitter-go-template-helm-0+unstable20260321	aarch64-darwin	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-go-template-helm.aarch64-linux](https://hydra.nixos.org/build/329742141)	python3.14-python-tree-sitter-go-template-helm-0+unstable20260321	aarch64-linux	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-go-template-helm.x86_64-darwin](https://hydra.nixos.org/build/329750224)	python3.14-python-tree-sitter-go-template-helm-0+unstable20260321	x86_64-darwin	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-go-template-helm.x86_64-linux](https://hydra.nixos.org/build/329742142)	python3.14-python-tree-sitter-go-template-helm-0+unstable20260321	x86_64-linux	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-gren.aarch64-darwin](https://hydra.nixos.org/build/329750265)	python3.14-python-tree-sitter-gren-2.0.0+unstable20250503	aarch64-darwin	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-gren.aarch64-linux](https://hydra.nixos.org/build/329742163)	python3.14-python-tree-sitter-gren-2.0.0+unstable20250503	aarch64-linux	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-gren.x86_64-darwin](https://hydra.nixos.org/build/329750321)	python3.14-python-tree-sitter-gren-2.0.0+unstable20250503	x86_64-darwin	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-gren.x86_64-linux](https://hydra.nixos.org/build/329742156)	python3.14-python-tree-sitter-gren-2.0.0+unstable20250503	x86_64-linux	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-opam.aarch64-darwin](https://hydra.nixos.org/build/329750579)	python3.14-python-tree-sitter-opam-0+unstable20260405	aarch64-darwin	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-opam.aarch64-linux](https://hydra.nixos.org/build/329742333)	python3.14-python-tree-sitter-opam-0+unstable20260405	aarch64-linux	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-opam.x86_64-darwin](https://hydra.nixos.org/build/329750525)	python3.14-python-tree-sitter-opam-0+unstable20260405	x86_64-darwin	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-opam.x86_64-linux](https://hydra.nixos.org/build/329742298)	python3.14-python-tree-sitter-opam-0+unstable20260405	x86_64-linux	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-quint.aarch64-darwin](https://hydra.nixos.org/build/329750653)	python3.14-python-tree-sitter-quint-0+unstable20250409	aarch64-darwin	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-quint.aarch64-linux](https://hydra.nixos.org/build/329742381)	python3.14-python-tree-sitter-quint-0+unstable20250409	aarch64-linux	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-quint.x86_64-darwin](https://hydra.nixos.org/build/329750654)	python3.14-python-tree-sitter-quint-0+unstable20250409	x86_64-darwin	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-quint.x86_64-linux](https://hydra.nixos.org/build/329742372)	python3.14-python-tree-sitter-quint-0+unstable20250409	x86_64-linux	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-strace.aarch64-darwin](https://hydra.nixos.org/build/329750791)	python3.14-python-tree-sitter-strace-0+unstable20251221	aarch64-darwin	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-strace.aarch64-linux](https://hydra.nixos.org/build/329742438)	python3.14-python-tree-sitter-strace-0+unstable20251221	aarch64-linux	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-strace.x86_64-darwin](https://hydra.nixos.org/build/329750765)	python3.14-python-tree-sitter-strace-0+unstable20251221	x86_64-darwin	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-strace.x86_64-linux](https://hydra.nixos.org/build/329742458)	python3.14-python-tree-sitter-strace-0+unstable20251221	x86_64-linux	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-tact.aarch64-darwin](https://hydra.nixos.org/build/329750803)	python3.14-python-tree-sitter-tact-1.6.0+unstable20250501	aarch64-darwin	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-tact.aarch64-linux](https://hydra.nixos.org/build/329742433)	python3.14-python-tree-sitter-tact-1.6.0+unstable20250501	aarch64-linux	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-tact.x86_64-darwin](https://hydra.nixos.org/build/329750809)	python3.14-python-tree-sitter-tact-1.6.0+unstable20250501	x86_64-darwin	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-tact.x86_64-linux](https://hydra.nixos.org/build/329742488)	python3.14-python-tree-sitter-tact-1.6.0+unstable20250501	x86_64-linux	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-vue.aarch64-darwin](https://hydra.nixos.org/build/329750925)	python3.14-python-tree-sitter-vue-0.1.0	aarch64-darwin	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-vue.aarch64-linux](https://hydra.nixos.org/build/329742535)	python3.14-python-tree-sitter-vue-0.1.0	aarch64-linux	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-vue.x86_64-darwin](https://hydra.nixos.org/build/329750919)	python3.14-python-tree-sitter-vue-0.1.0	x86_64-darwin	Failed
[nixpkgs.python314Packages.tree-sitter-grammars.tree-sitter-vue.x86_64-linux](https://hydra.nixos.org/build/329742494)	python3.14-python-tree-sitter-vue-0.1.0	x86_64-linux	Failed

</details>





## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
