### PR TITLE
swpui: init at 0.8.0

### DIFF
--- a/pkgs/by-name/sw/swpui/package.nix
+++ b/pkgs/by-name/sw/swpui/package.nix
@@ -1,0 +1,32 @@
+{
+  fetchFromGitHub,
+  lib,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "swpui";
+  version = "0.8.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "beeb";
+    repo = "swpui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-w9JQPSIMQUAUu6wkOH7wZH9ZV8eGSieXHlrppovicjY=";
+  };
+
+  cargoHash = "sha256-JWeUv98zcgVQl1qXqD9wmpu4Dk0Qan0F9ypvcFpRxRM=";
+
+  meta = {
+    description = "TUI utility to search and replace with a focus on ergonomics, speed and case-awareness";
+    homepage = "https://github.com/beeb/swpui";
+    changelog = "https://github.com/beeb/swpui/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ beeb ];
+    mainProgram = "swp";
+  };
+})


### PR DESCRIPTION
Init `swpui`, a TUI to search and replace with a focus on ergonomics, speed and case awareness.

https://github.com/beeb/swpui

Follow-up to https://github.com/NixOS/nixpkgs/pull/514814 now that the tool has gained some users.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
