### PR TITLE
python314Packages.opentelemetry-semantic-conventions-ai: update meta.homepage, run the test

### DIFF
--- a/pkgs/development/python-modules/opentelemetry-semantic-conventions-ai/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-semantic-conventions-ai/default.nix
@@ -5,6 +5,7 @@
   hatchling,
   opentelemetry-sdk,
   opentelemetry-semantic-conventions,
+  pytestCheckHook,
 }:
 let
   version = "0.4.15";
@@ -25,6 +26,10 @@ buildPythonPackage {
   dependencies = [
     opentelemetry-sdk
     opentelemetry-semantic-conventions
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
   ];
 
   pythonImportsCheck = [ "opentelemetry.semconv_ai" ];

--- a/pkgs/development/python-modules/opentelemetry-semantic-conventions-ai/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-semantic-conventions-ai/default.nix
@@ -31,7 +31,7 @@ buildPythonPackage {
 
   meta = {
     description = "Open-source observability for your GenAI or LLM application, based on OpenTelemetry";
-    homepage = "https://github.com/traceloop/openllmetry";
+    homepage = "https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-semantic-conventions-ai";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ lach ];
   };


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
