### PR TITLE
 poezio: 0.16 -> 0.18

### DIFF
--- a/pkgs/by-name/po/poezio/package.nix
+++ b/pkgs/by-name/po/poezio/package.nix
@@ -8,14 +8,14 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "poezio";
-  version = "0.16";
+  version = "0.18";
   pyproject = true;
 
   src = fetchFromCodeberg {
     owner = "poezio";
     repo = "poezio";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-bpudgf9oZ+7w7izAuWYKFVO9CIHraHaGvRKLDuSIF7c=";
+    hash = "sha256-/QGxJrWK8Sl+t8SBsU8ZAMU/5pR+daf7Q43jczzENmw=";
   };
 
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/development/python-modules/slixmpp/default.nix
+++ b/pkgs/development/python-modules/slixmpp/default.nix
@@ -22,14 +22,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "slixmpp";
-  version = "1.15.0";
+  version = "1.16.0";
   pyproject = true;
 
   src = fetchFromCodeberg {
     owner = "poezio";
     repo = "slixmpp";
     tag = "slix-${finalAttrs.version}";
-    hash = "sha256-1Jns7kqYGpUvwfwyMoZ9ygD2Sm148f/QdJ0atvfwGTo=";
+    hash = "sha256-d0laQWaqZUoviF7NM/egENQ3ArQE12ER0TzfPBcnc7Q=";
   };
 
   patches = [
@@ -71,7 +71,10 @@ buildPythonPackage (finalAttrs: {
     safer-xml-parsing = [ defusedxml ];
   };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ lib.concatAttrValues optional-dependencies;
+  nativeCheckInputs = [
+    pytestCheckHook
+  ]
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 
   preCheck = ''
     # don't test against pure python version in the source tree

--- a/pkgs/development/python-modules/slixmpp/default.nix
+++ b/pkgs/development/python-modules/slixmpp/default.nix
@@ -20,7 +20,7 @@
   setuptools-scm,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "slixmpp";
   version = "1.15.0";
   pyproject = true;
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   src = fetchFromCodeberg {
     owner = "poezio";
     repo = "slixmpp";
-    tag = "slix-${version}";
+    tag = "slix-${finalAttrs.version}";
     hash = "sha256-1Jns7kqYGpUvwfwyMoZ9ygD2Sm148f/QdJ0atvfwGTo=";
   };
 
@@ -90,8 +90,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python library for XMPP";
     homepage = "https://slixmpp.readthedocs.io/";
-    changelog = "https://codeberg.org/poezio/slixmpp/releases/tag/${src.tag}";
+    changelog = "https://codeberg.org/poezio/slixmpp/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/slixmpp/default.nix
+++ b/pkgs/development/python-modules/slixmpp/default.nix
@@ -22,14 +22,14 @@
 
 buildPythonPackage rec {
   pname = "slixmpp";
-  version = "1.13.2";
+  version = "1.15.0";
   pyproject = true;
 
   src = fetchFromCodeberg {
     owner = "poezio";
     repo = "slixmpp";
     tag = "slix-${version}";
-    hash = "sha256-hjM1OIFYpHV5SSN32858pyuwOvaAA0tFZWCZI+5n9u4=";
+    hash = "sha256-1Jns7kqYGpUvwfwyMoZ9ygD2Sm148f/QdJ0atvfwGTo=";
   };
 
   patches = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Poezio 0.18 has released: https://codeberg.org/poezio/poezio/releases/tag/v0.18
It requires a newer version of slixmpp (at least >= 1.14.0). I updated the derivation for slixmpp to its latest release:
https://codeberg.org/poezio/slixmpp/releases/tag/slix-1.15.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
