### PR TITLE
nixos/stage-1: make "testing patched programs" build output more useful

### DIFF
--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -206,6 +206,7 @@ let
         if [ -z "${toString (pkgs.stdenv.hostPlatform != pkgs.stdenv.buildPlatform)}" ]; then
         # Make sure that the patchelf'ed binaries still work.
         echo "testing patched programs..."
+        set -x
         $out/bin/ash -c 'echo hello world' | grep "hello world"
         $out/bin/mount -V 2>&1 | grep -q "mount from util-linux"
         $out/bin/blkid -V 2>&1 | grep -q 'libblkid'
@@ -218,6 +219,7 @@ let
         ''}
 
         ${config.boot.initrd.extraUtilsCommandsTest}
+        set +x
         fi
       ''; # */
 


### PR DESCRIPTION
Most of the commands executed during the "testing patched programs" phase of the extra-utils build don't produce any output whatsoever. Therefore, if something goes wrong in that phase, the build log is uninformative.  Mitigate this by adding a `set -x` immediately after the "testing patched programs" message is printed, causing the shell to print an execution trace.  This way we'll at least know _which command_ failed.

I believe it would be worthwhile to backport this patch to all active release branches once it is merged to trunk.

(This is an updated version of #441915. I regret the churn; I did not realize that renaming a branch would close the PR associated with it.  All review comments from #441915 have been addressed and the branch has been updated to latest trunk.)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
