### PR TITLE
nixos/security/pam: install unix_chkpwd wrapper with capabilities instead of setuid

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -2637,7 +2637,7 @@ in
 
     security.wrappers = {
       unix_chkpwd = {
-        setuid = true;
+        capabilities = "cap_dac_read_search,cap_audit_write=ep";
         owner = "root";
         group = "root";
         source = "${package}/bin/unix_chkpwd";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1320,7 +1320,8 @@ in
   pam-pgsql = runTest ./pam/pam-pgsql.nix;
   pam-u2f = runTest ./pam/pam-u2f.nix;
   pam-u2f-polkit = runTest ./pam/pam-u2f-polkit.nix;
-  pam-unix-chkpwd = runTest ./pam/pam-unix-chkpwd.nix;
+  pam-unix-chkpwd-self = runTest ./pam/pam-unix-chkpwd-self.nix;
+  pam-unix-chkpwd-ssh = runTest ./pam/pam-unix-chkpwd-ssh.nix;
   pam-ussh = runTest ./pam/pam-ussh.nix;
   pam-zfs-key = runTest ./pam/zfs-key.nix;
   pangolin = runTest ./pangolin.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1320,6 +1320,7 @@ in
   pam-pgsql = runTest ./pam/pam-pgsql.nix;
   pam-u2f = runTest ./pam/pam-u2f.nix;
   pam-u2f-polkit = runTest ./pam/pam-u2f-polkit.nix;
+  pam-unix-chkpwd = runTest ./pam/pam-unix-chkpwd.nix;
   pam-ussh = runTest ./pam/pam-ussh.nix;
   pam-zfs-key = runTest ./pam/zfs-key.nix;
   pangolin = runTest ./pangolin.nix;

--- a/nixos/tests/pam/pam-unix-chkpwd-self.nix
+++ b/nixos/tests/pam/pam-unix-chkpwd-self.nix
@@ -1,0 +1,148 @@
+# Test that an unprivileged user can reauthenticate *themselves* using
+# their own password, without the reauthenticating program needing to
+# be set-id itself.  This is the main function of the set-id unix_chkpwd(8)
+# helper binary.
+#
+# Note: this test validates the behavior of a set-id binary, and
+# therefore requires test VMs.
+
+{ lib, pkgs, ... }:
+let
+  # You would _think_ we could do this entirely in the top-level test script
+  # using machine.wait_until_tty_matches and .send_chars, but that has proven
+  # unreliable due to unrelated console spew from systemd's logs.  Thus, expect.
+  makeUserTestScript = pkgs.writeScript "pam-unix-chkpwd-tester" ''
+    #! ${pkgs.expect}/bin/expect -f
+    set pamtester {${pkgs.pamtester}/bin/pamtester}
+    set user [lindex $argv 0]
+    set password [lindex $argv 1]
+    set should_succeed [lindex $argv 2]
+
+    log_user 1
+    set junk 0
+    set success 0
+    set failure 0
+
+    spawn $pamtester login $user authenticate
+
+    # caution: this has to come after the spawn or it'll be ignored
+    expect_after {
+      -re {^[\r\n]+} { exp_continue }
+      -re {^.+} {
+        puts "ERROR: unexpected: $expect_out(buffer)"
+        set junk 1
+        exp_continue
+      }
+      eof {
+        puts "ERROR: unexpected EOF"
+        exit 1
+      }
+      timeout {
+        puts "ERROR: timed out waiting for next message"
+        exit 1
+      }
+    }
+
+    expect "^Password: $"
+    send "$password\n"
+
+    expect {
+      -re {^pamtester: successfully authenticated\M} {
+        set success 1
+        exp_continue
+      }
+      -re {^pamtester: Authentication failure\M} {
+        set failure 1
+        exp_continue
+      }
+      eof
+    }
+
+    set status [wait]
+    if { [llength $status] > 4 } {
+      if { [lindex $status 4] == "CHILDKILLED" } {
+        puts "ERROR: pamtester process killed by [lindex $status 5]"
+      } else {
+        puts "ERROR: strange wait status [lrange $status 4 end]"
+      }
+      exit 1
+    }
+    if { [lindex $status 2] == -1 } {
+      puts "ERROR: wait failed, errno=[lindex $status 3]"
+      exit 1
+    }
+
+    set exit_ok [expr [lindex $status 3] == 0]
+
+    if {$junk} {
+      exit 1
+    }
+    if {$success && $failure} {
+      puts "ERROR: got both success and failure messages"
+      exit 1
+    }
+    if {!$success && !$failure} {
+      puts "ERROR: got neither success nor failure messages"
+      exit 1
+    }
+    if {$should_succeed && ($failure || !$exit_ok)} {
+      puts "FAIL: authentication failed (should have succeeded)"
+      exit 1
+    }
+    if {!$should_succeed && ($success || $exit_ok)} {
+      puts "FAIL: authentication succeeded (should have failed)"
+      exit 1
+    }
+    puts "PASS"
+    exit 0
+  '';
+  correctPassword = "correct-password-for-alice";
+  wrongPassword = "wrong-password-for-alice";
+  makeTestVM =
+    mutableUsers: extraOptions:
+    lib.recursiveUpdate {
+      users.mutableUsers = mutableUsers;
+      users.users = {
+        alice = {
+          description = "Alice Normaluser";
+          isNormalUser = true;
+          password = correctPassword;
+        };
+      };
+    } extraOptions;
+in
+{
+  name = "pam-unix-chkpwd-self";
+
+  nodes = {
+    mutable-legacy = makeTestVM true { };
+    immutable-legacy = makeTestVM false { };
+    mutable-userborn = makeTestVM true { services.userborn.enable = true; };
+    immutable-userborn = makeTestVM false { services.userborn.enable = true; };
+    # tests with systemd.sysusers.enable = true are disabled because
+    # systemd-sysusers (currently) cannot create normal users.
+    #mutable-userborn = makeTestVM true { systemd.sysusers.enable = true; };
+    #immutable-userborn = makeTestVM false { systemd.sysusers.enable = true; };
+  };
+
+  testScript = ''
+    script = "${makeUserTestScript}"
+    correctPassword = "${correctPassword}"
+    wrongPassword = "${wrongPassword}"
+
+    for m in machines:
+      assert isinstance(m, QemuMachine)
+      m.start()
+      m.wait_for_unit("multi-user.target")
+
+      with subtest(f"{m.name}: correct password"):
+        m.succeed(
+          f"su -c '\"{script}\" alice {correctPassword} 1' -l alice 2>&1"
+        )
+
+      with subtest(f"{m.name}: wrong password"):
+        m.succeed(
+          f"su -c '\"{script}\" alice {wrongPassword} 0' -l alice 2>&1"
+        )
+  '';
+}

--- a/nixos/tests/pam/pam-unix-chkpwd-ssh.nix
+++ b/nixos/tests/pam/pam-unix-chkpwd-ssh.nix
@@ -1,6 +1,6 @@
 # Test that PAM is able to distinguish expired from active accounts
-# even when invoked from an unprivileged context (as is done by sshd).
-# This is the purpose of the set-id unix_chkpwd(8) helper binary.
+# when invoked by ssh's sandboxed "preauth" process.  This is a
+# secondary function of the set-id unix_chkpwd(8) helper binary.
 #
 # Note: this test validates the behavior of a set-id binary, and
 # therefore requires test VMs.
@@ -19,25 +19,27 @@ let
         mkdir -p $out
         ssh-keygen -t ed25519 -N "" -f $out/alice
       '';
-  makeTestScript =
-    toUser:
-    pkgs.writeShellScript "pam-unix-chkpwd-test-ssh-to-${toUser}" ''
-      set -xeuo pipefail
-      sshbin=${pkgs.openssh}/bin
+  makeTestScript = pkgs.writeShellScript "pam-unix-chkpwd-test-ssh" ''
+    set -xeuo pipefail
 
-      if [ ! -f "$HOME/.ssh/config" ]; then
-        mkdir -p "$HOME/.ssh"
-        chmod 700 "$HOME/.ssh"
-        echo "StrictHostKeyChecking accept-new" > "$HOME/.ssh/config"
-        chmod 600 "$HOME/.ssh/config"
-      fi
+    corebin='${pkgs.coreutils}/bin'
+    sshbin='${pkgs.openssh}/bin'
+    sshcreds='${testOnlySSHCredentials}'
+    toUser="$1"
 
-      eval $($sshbin/ssh-agent)
-      $sshbin/ssh-add ${testOnlySSHCredentials}/alice
-      $sshbin/ssh-add -l &>2
+    if [ ! -f "$HOME/.ssh/config" ]; then
+      mkdir -p "$HOME/.ssh"
+      chmod 700 "$HOME/.ssh"
+      echo "StrictHostKeyChecking accept-new" > "$HOME/.ssh/config"
+      chmod 600 "$HOME/.ssh/config"
+    fi
 
-      exec $sshbin/ssh -v ${toUser}@localhost ${pkgs.coreutils}/bin/id
-    '';
+    eval $("$sshbin"/ssh-agent)
+    "$sshbin"/ssh-add "$sshcreds"/alice
+    "$sshbin"/ssh-add -l 1&>2
+
+    exec "$sshbin"/ssh -v "$toUser"@localhost "$corebin"/id
+  '';
   makeTestVM =
     mutableUsers: extraOptions:
     lib.recursiveUpdate {
@@ -78,7 +80,7 @@ let
     } extraOptions;
 in
 {
-  name = "pam-unix-chkpwd";
+  name = "pam-unix-chkpwd-ssh";
 
   nodes = {
     mutable-legacy = makeTestVM true { };
@@ -96,8 +98,7 @@ in
   testScript = ''
     import re
 
-    testBobScript = "${makeTestScript "bob"}"
-    testCarolScript = "${makeTestScript "carol"}"
+    testScript = "${makeTestScript}"
     expectedBobOutput = re.compile(r"^uid=[0-9]+\(bob\) ", re.MULTILINE)
 
     for m in machines:
@@ -106,11 +107,11 @@ in
       m.wait_for_unit("systemd-user-sessions.service")
 
       with subtest(f"{m.name}: alice should be able to ssh bob@localhost"):
-        bobOutput = m.succeed(f"su -c '{testBobScript}' -l alice")
+        bobOutput = m.succeed(f"su -c '\"{testScript}\" bob' -l alice")
         log.debug(f"{m.name}: bob output: {bobOutput}")
         t.assertIsNotNone(expectedBobOutput.search(bobOutput))
 
       with subtest(f"{m.name}: alice should not be able to ssh carol@localhost"):
-        m.fail(f"su -c '{testCarolScript}' -l alice")
+        m.fail(f"su -c '\"{testScript}\" carol' -l alice")
   '';
 }

--- a/nixos/tests/pam/pam-unix-chkpwd.nix
+++ b/nixos/tests/pam/pam-unix-chkpwd.nix
@@ -1,0 +1,116 @@
+# Test that PAM is able to distinguish expired from active accounts
+# even when invoked from an unprivileged context (as is done by sshd).
+# This is the purpose of the set-id unix_chkpwd(8) helper binary.
+#
+# Note: this test validates the behavior of a set-id binary, and
+# therefore requires test VMs.
+#
+# Note: this test assumes that the system clock within each test VM
+# is set to a date and time no earlier than 1970-01-03T00:00:01Z.
+
+{ lib, pkgs, ... }:
+let
+  testOnlySSHCredentials =
+    pkgs.runCommand "pam-unix-chkpwd-keygen"
+      {
+        nativeBuildInputs = [ pkgs.openssh ];
+      }
+      ''
+        mkdir -p $out
+        ssh-keygen -t ed25519 -N "" -f $out/alice
+      '';
+  makeTestScript =
+    toUser:
+    pkgs.writeShellScript "pam-unix-chkpwd-test-ssh-to-${toUser}" ''
+      set -xeuo pipefail
+      sshbin=${pkgs.openssh}/bin
+
+      if [ ! -f "$HOME/.ssh/config" ]; then
+        mkdir -p "$HOME/.ssh"
+        chmod 700 "$HOME/.ssh"
+        echo "StrictHostKeyChecking accept-new" > "$HOME/.ssh/config"
+        chmod 600 "$HOME/.ssh/config"
+      fi
+
+      eval $($sshbin/ssh-agent)
+      $sshbin/ssh-add ${testOnlySSHCredentials}/alice
+      $sshbin/ssh-add -l &>2
+
+      exec $sshbin/ssh -v ${toUser}@localhost ${pkgs.coreutils}/bin/id
+    '';
+  makeTestVM =
+    mutableUsers: extraOptions:
+    lib.recursiveUpdate {
+      services.openssh.enable = true;
+      users.mutableUsers = mutableUsers;
+      users.users = {
+        alice = {
+          description = "This account will attempt to ssh to the other accounts.";
+          isNormalUser = true;
+          hashedPassword = ""; # ensure initial "su alice" succeeds
+        };
+        bob = {
+          description = "This account is active and should be ssh-able from alice.";
+          isNormalUser = true;
+          hashedPassword = null;
+          openssh.authorizedKeys.keyFiles = [
+            "${testOnlySSHCredentials}/alice.pub"
+          ];
+        };
+        carol = {
+          description = "This account is expired and should not be ssh-able from alice.";
+          isNormalUser = true;
+          hashedPassword = null;
+          openssh.authorizedKeys.keyFiles = [
+            "${testOnlySSHCredentials}/alice.pub"
+          ];
+          # The account expiration date is recorded in /etc/shadow as
+          # a count of days since 1970-01-01.  shadow(5) warns that an
+          # expiration date *of* 1970-01-01 (which translates to 0 in
+          # the expiration date field) cannot be used, as some systems
+          # interpret an explicit zero in this field as "no expiration date".
+          # shadow(5) does not say whether dates *before* 1970-01-01 are
+          # permissible.  Thus, we use 1970-01-02 (1 in the field) and rely
+          # on the system clock being set later than that.
+          expires = "1970-01-02";
+        };
+      };
+    } extraOptions;
+in
+{
+  name = "pam-unix-chkpwd";
+
+  nodes = {
+    mutable-legacy = makeTestVM true { };
+    immutable-legacy = makeTestVM false { };
+    # tests with services.userborn.enable = true are disabled because
+    # userborn currently ignores users.users.<name>.expires.
+    #mutable-userborn = makeTestVM true { services.userborn.enable = true; };
+    #immutable-userborn = makeTestVM false { services.userborn.enable = true; };
+    # tests with systemd.sysusers.enable = true are disabled because
+    # systemd-sysusers (currently) cannot create normal users.
+    #mutable-userborn = makeTestVM true { systemd.sysusers.enable = true; };
+    #immutable-userborn = makeTestVM false { systemd.sysusers.enable = true; };
+  };
+
+  testScript = ''
+    import re
+
+    testBobScript = "${makeTestScript "bob"}"
+    testCarolScript = "${makeTestScript "carol"}"
+    expectedBobOutput = re.compile(r"^uid=[0-9]+\(bob\) ", re.MULTILINE)
+
+    for m in machines:
+      m.start()
+      m.wait_for_unit("sshd.service")
+      m.wait_for_unit("systemd-user-sessions.service")
+
+      with subtest(f"{m.name}: alice should be able to ssh bob@localhost"):
+        bobOutput = m.succeed(f"su -c '{testBobScript}' -l alice")
+        log.debug(f"{m.name}: bob output: {bobOutput}")
+        t.assertIsNotNone(expectedBobOutput.search(bobOutput))
+
+      with subtest(f"{m.name}: alice should not be able to ssh carol@localhost"):
+        m.fail(f"su -c '{testCarolScript}' -l alice")
+  '';
+}


### PR DESCRIPTION
The `pam_unix` module unconditionally relies on a helper binary, `unix_chkpwd`, to read "shadow password" records from `/etc/shadow`.

The most important thing in a shadow password record is of course the user's hashed password, if any, but there are also several other fields, including some that can affect whether the user is allowed to log in at all.  (See the [`shadow(5)`](https://man7.org/linux/man-pages/man5/shadow.5.html) manpage for full detail.)  Therefore, unless the system’s PAM configuration has been radically modified, `unix_chkpwd` is needed *even if* access to accounts is entirely via means other than passwords (e.g. SSH key only).

However, `unix_chkpwd` does not need to be installed setuid root.  The only special privileges it needs are the ability to read `/etc/shadow` and the ability to write audit logs.  This can be expressed using capability bits: `CAP_DAC_READ_SEARCH` + `CAP_AUDIT_WRITE` is sufficient.  Make that change to the wrapper configuration.

(`CAP_DAC_READ_SEARCH` gives read access to *all files on the system*, which is still a lot more than what’s *necessary*, but substantially narrower than full root privileges.  One could instead make `/etc/shadow` group-readable and have `unix_chkpwd` be setgid to the relevant group, but that wouldn’t be a two-line change anymore.)

(This is an updated version of #523099. I regret the churn; I did not realize that renaming a branch would close the PR associated with it. All review comments from #523099 have been addressed and the branch has been updated to latest staging-nixos.)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
