### PR TITLE
make-initrd-ng: don't error out if a copy source is nonexistent

### DIFF
--- a/pkgs/build-support/kernel/make-initrd-ng/src/main.rs
+++ b/pkgs/build-support/kernel/make-initrd-ng/src/main.rs
@@ -3,6 +3,7 @@ use std::env;
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::hash::Hash;
+use std::io::ErrorKind;
 use std::iter::FromIterator;
 use std::os::unix;
 use std::path::{Component, Path, PathBuf};
@@ -247,9 +248,22 @@ fn handle_path(
             Component::Normal(name) => {
                 target.push(name);
                 source.push(name);
-                let typ = fs::symlink_metadata(&source)
-                    .wrap_err_with(|| format!("failed to get symlink metadata for {:?}", source))?
-                    .file_type();
+                let typ = match fs::symlink_metadata(&source) {
+                    Ok(md) => md.file_type(),
+                    Err(e) => {
+                        // If `source` doesn't exist, this is not an error.
+                        // It just means whatever we were trying to copy is
+                        // not needed in this system configuration.  Abandon
+                        // processing of the rest of the path.
+                        if e.kind() == ErrorKind::NotFound {
+                            break;
+                        }
+                        return Err(e).wrap_err(
+                            format!("failed to get symlink metadata for {:?}", source)
+                        );
+                    }
+                };
+
                 if typ.is_file() && !target.exists() {
                     copy_file(&source, &target, &p.dlopen, queue)?;
 


### PR DESCRIPTION
If the source of something that we normally copy into the initrd doesn't exist, or one of its parent directories doesn't exist, don't error out. Instead, assume this means that thing, whatever it is, isn't needed in the system configuration whose initrd we are constructing; skip that path and go on.

A concrete example of a system configuration that requires this change to build successfully is

```nix
  boot.kernelPackages = pkgs.linuxPackagesFor (pkgs.linuxManualConfig {
    inherit (pkgs.linuxKernel.packageAliases.linux_default.kernel)
      src version modDirVersion;
    configfile = ./monolithic.kconf;
  });
```

where `monolithic.kconf` specifies `CONFIG_MODULES=n`.  The modules-shrunk package for a monolithic kernel is completely empty -- not even an empty `lib/modules` directory -- so, without this change, make-initrd-ng barfs because it always tries to copy `/lib/modules` into the initrd.

(Arguably, make-initrd-ng should instead notice when it's working with a monolithic kernel and should skip trying to copy the contents of modules-shrunk; but *I* would argue that the empty modules-shrunk *is* sufficient notification that the kernel is monolithic, and therefore, this *is* noticing and skipping it.)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
