### PR TITLE
python3Packages.asyncua: 1.1.8 -> 2.0

### DIFF
--- a/pkgs/development/python-modules/asyncua/default.nix
+++ b/pkgs/development/python-modules/asyncua/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   aiofiles,
   aiosqlite,
+  anyio,
   buildPythonPackage,
   cryptography,
   fetchFromGitHub,
@@ -20,14 +21,14 @@
 
 buildPythonPackage rec {
   pname = "asyncua";
-  version = "1.1.8";
+  version = "2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "FreeOpcUa";
     repo = "opcua-asyncio";
     tag = "v${version}";
-    hash = "sha256-0eay/NlWn0I2oF0fTln9/d4y31zGfAj9ph3bWkgd8Nk=";
+    hash = "sha256-mJ4ZUKx4zuprpH6FUrw7MLkekX0RDnzkJscQ4XC7tHE=";
     fetchSubmodules = true;
   };
 
@@ -43,6 +44,7 @@ buildPythonPackage rec {
   dependencies = [
     aiofiles
     aiosqlite
+    anyio
     cryptography
     pyopenssl
     python-dateutil
@@ -59,22 +61,41 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "asyncua" ];
 
+  # PermissionError: [Errno 1] Operation not permitted
+  __darwinAllowLocalNetworking = true;
+
   disabledTests = [
     # Failed: DID NOT RAISE <class 'asyncio.exceptions.TimeoutError'>
     "test_publish"
+    # KeyError: 'Simple'
+    "test_full_simple"
   ]
   ++ lib.optionals (pythonAtLeast "3.13") [
     # dbm.sqlite3.error: SQLite objects created in a thread can only be used in that same thread.
     # The object was created in thread id 140737220687552 and this is thread id 140737343690560.
     "test_runTest"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    # OSError: [Errno 48] error while attempting to bind on address ('127.0.0.1',...
-    "test_anonymous_rejection"
-    "test_certificate_handling_success"
-    "test_encrypted_private_key_handling_success"
-    "test_encrypted_private_key_handling_success_with_cert_props"
-    "test_encrypted_private_key_handling_failure"
+    # error while attempting to bind on address
+    "test_failover_warm"
+    "test_client_admin"
+    "test_client_user"
+    "test_client_anonymous"
+    "test_x509identity_user"
+    "test_x509identity_anonymous"
+    "test_client_user_x509identity_admin"
+  ];
+
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
+    "tests/test_callback_service.py"
+    "tests/test_client_cert_chain.py"
+    "tests/test_crypto_connect.py"
+    "tests/test_crypto_connect.py"
+    "tests/test_gen_certificates.py"
+    "tests/test_password.py"
+    "tests/test_permissions.py"
+    "tests/test_pubsub.py"
+    "tests/test_sync.py"
+    "tests/test_truststore.py"
+    "tests/test_subscriptions.py"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/asyncua/default.nix
+++ b/pkgs/development/python-modules/asyncua/default.nix
@@ -19,7 +19,7 @@
   typing-extensions,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "asyncua";
   version = "2.0";
   pyproject = true;
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "FreeOpcUa";
     repo = "opcua-asyncio";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-mJ4ZUKx4zuprpH6FUrw7MLkekX0RDnzkJscQ4XC7tHE=";
     fetchSubmodules = true;
   };
@@ -101,8 +101,8 @@ buildPythonPackage rec {
   meta = {
     description = "OPC UA / IEC 62541 Client and Server for Python";
     homepage = "https://github.com/FreeOpcUa/opcua-asyncio";
-    changelog = "https://github.com/FreeOpcUa/opcua-asyncio/releases/tag/${src.tag}";
+    changelog = "https://github.com/FreeOpcUa/opcua-asyncio/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.lgpl3Plus;
     maintainers = with lib.maintainers; [ harvidsen ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://github.com/FreeOpcUa/opcua-asyncio/releases/tag/v1.2b2

Fix build failure for python 3.14

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
