### PR TITLE
nixos/nominatim: make UI optional

### DIFF
--- a/nixos/modules/services/search/nominatim.nix
+++ b/nixos/modules/services/search/nominatim.nix
@@ -50,6 +50,10 @@ in
     };
 
     ui = {
+      enable = lib.mkEnableOption "Nominatim UI" // {
+        default = true;
+      };
+
       package = lib.mkPackageOption pkgs "nominatim-ui" { };
 
       config = lib.mkOption {
@@ -277,7 +281,7 @@ in
 
       services.nginx = {
         enable = true;
-        appendHttpConfig = ''
+        appendHttpConfig = lib.mkIf cfg.ui.enable ''
           map $args $format {
               default                  default;
               ~(^|&)format=html(&|$)   html;
@@ -304,19 +308,19 @@ in
             enableACME = lib.mkDefault true;
             locations = {
               "= /" = {
-                extraConfig = ''
+                extraConfig = lib.mkIf cfg.ui.enable ''
                   return 301 $scheme://$http_host/ui/search.html;
                 '';
               };
               "/" = {
                 proxyPass = "http://nominatim";
-                extraConfig = ''
+                extraConfig = lib.mkIf cfg.ui.enable ''
                   if ($forward_to_ui) {
                       rewrite ^(/[^/.]*) /ui$1.html redirect;
                   }
                 '';
               };
-              "/ui/" = {
+              "/ui/" = lib.mkIf cfg.ui.enable {
                 alias = "${uiPackage}/";
               };
             };


### PR DESCRIPTION
The UI should be toggleable. It's fine for it to be enabled by default, but without the toggle we have to override several specific options to disable it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `c70d115158535aaffdfe08992d7b4570ad45b530`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 2 packages blacklisted:</summary>
  <ul>
    <li>nixos-install-tools</li>
    <li>tests.nixos-functions.nixos-test</li>
  </ul>
</details>
