### PR TITLE
openvino-genai: init at 2026.2.0.0

### DIFF
--- a/pkgs/by-name/op/openvino-genai/move-gguf-format-template-into-header.patch
+++ b/pkgs/by-name/op/openvino-genai/move-gguf-format-template-into-header.patch
@@ -1,0 +1,37 @@
+--- a/src/cpp/src/gguf_utils/gguf.hpp
++++ b/src/cpp/src/gguf_utils/gguf.hpp
+@@ -28,7 +28,12 @@
+                             std::unordered_map<std::string, gguf_tensor_type>>;
+ 
+ template <typename... Args>
+-std::string format(std::string fmt, Args... args);
++std::string format(std::string fmt, Args... args) {
++    char buf[1000];
++    int n = snprintf(buf, sizeof(buf), fmt.c_str(), args...);
++    assert(n >= 0 && n < static_cast<int>(sizeof(buf)));
++    return std::string(buf);
++}
+ 
+ ov::Shape get_shape(const gguf_tensor& tensor);
+ 
+--- a/src/cpp/src/gguf_utils/gguf.cpp
++++ b/src/cpp/src/gguf_utils/gguf.cpp
+@@ -13,18 +13,6 @@
+ // https://github.com/antirez/gguf-tools/blob/af7d88d808a7608a33723fba067036202910acb3/gguflib.h#L102-L108
+ constexpr int gguf_array_header_size = 12;
+ 
+-template <typename... Args>
+-std::string format(std::string fmt, Args... args) {
+-    size_t bufferSize = 1000;
+-    char* buffer = new char[bufferSize];
+-    int n = sprintf(buffer, fmt.c_str(), args...);
+-    assert(n >= 0 && n < (int)bufferSize - 1);
+-
+-    std::string fmtStr(buffer);
+-    delete[] buffer;
+-    return fmtStr;
+-}
+-
+ std::optional<uint32_t> dtype_to_gguf_tensor_type(const ov::element::Type& dtype) {
+     switch (dtype) {
+     case ov::element::f64:

--- a/pkgs/by-name/op/openvino-genai/package.nix
+++ b/pkgs/by-name/op/openvino-genai/package.nix
@@ -1,0 +1,205 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoPatchelfHook,
+  cmake,
+  gtest,
+  nix-update-script,
+  nlohmann_json,
+  ocl-icd,
+  opencl-clhpp,
+  opencl-headers,
+  onetbb,
+  openvino,
+  openvino-tokenizers,
+  pkg-config,
+  python3Packages,
+}:
+
+let
+  inherit (lib) cmakeBool cmakeFeature;
+
+  minja-src = fetchFromGitHub {
+    owner = "google";
+    repo = "minja";
+    rev = "3e4c61c616eda133cfb1e440fc7a14bf1729bbee";
+    hash = "sha256-aqOpLNB7XiY/W2gDRtnAqx37gMhHMRCJQmcX24vGIxA=";
+  };
+
+  safetensors-h-src = fetchFromGitHub {
+    owner = "hsnyder";
+    repo = "safetensors.h";
+    rev = "974a85d7dfd6e010558353226638bb26d6b9d756";
+    hash = "sha256-sBgm4panHB9X2RghC3Qi0wEL0k9uUz+h60pfxTGZ0BA=";
+  };
+
+  gguflib-src = fetchFromGitHub {
+    owner = "Lourdle";
+    repo = "gguf-tools";
+    rev = "bac796ada809ac293e685db59b075971181cb008";
+    hash = "sha256-yoIjTATYs2IzT/LnCz+G6PtxVXZ27B0mZOIipZbaOI8=";
+  };
+
+  python = python3Packages.python.withPackages (ps: [ ps.pybind11 ]);
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "openvino-genai";
+  version = "2026.2.0.0";
+
+  __structuredAttrs = true;
+
+  src =
+    assert lib.hasPrefix openvino.version finalAttrs.version;
+    fetchFromGitHub {
+      owner = "openvinotoolkit";
+      repo = "openvino.genai";
+      tag = finalAttrs.version;
+      hash = "sha256-C60e4F+NuUPA4pQ/o2+EekOmp47QH1fTGDyXYqPJ57s=";
+    };
+
+  outputs = [
+    "out"
+    "dev"
+    "python"
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    cmake
+    pkg-config
+    python
+  ];
+
+  buildInputs = [
+    nlohmann_json
+    ocl-icd
+    opencl-clhpp
+    opencl-headers
+    onetbb
+    openvino
+  ];
+
+  strictDeps = true;
+
+  patches = [
+    # gguf_utils' format() is a function template declared in gguf.hpp but
+    # defined in gguf.cpp, so instantiations from other TUs are unresolved at
+    # link time (surfaces as an ImportError on libopenvino_genai.so load).
+    # Move the definition into the header.
+    ./move-gguf-format-template-into-header.patch
+  ];
+
+  postPatch = ''
+    # pybind11 3.0 removed keep_alive support from def_property/def_readwrite.
+    # parsers is vector<shared_ptr<Parser>> so shared_ptr ref-counting is sufficient.
+    substituteInPlace src/python/py_generation_config.cpp \
+      --replace-fail ', py::keep_alive<1, 2>()' ""
+  '';
+
+  cmakeFlags = [
+    # Point cmake's FetchContent at pre-packaged nixpkgs sources so nothing is
+    # downloaded at build time.
+    (cmakeFeature "FETCHCONTENT_SOURCE_DIR_NLOHMANN_JSON" "${nlohmann_json.src}")
+    (cmakeFeature "FETCHCONTENT_SOURCE_DIR_MINJA" "${minja-src}")
+    (cmakeFeature "FETCHCONTENT_SOURCE_DIR_SAFETENSORS.H" "${safetensors-h-src}")
+    (cmakeFeature "FETCHCONTENT_SOURCE_DIR_PYBIND11" "${python3Packages.pybind11.src}")
+    (cmakeFeature "FETCHCONTENT_SOURCE_DIR_GGUFLIB" "${gguflib-src}")
+    (cmakeFeature "FETCHCONTENT_SOURCE_DIR_GOOGLETEST" "${gtest.src}")
+    (cmakeFeature "Python3_EXECUTABLE" "${python.interpreter}")
+    (cmakeFeature "OpenVINO_DIR" "${openvino}/runtime/cmake")
+
+    # Normalise install destinations to the standard Nix layout.
+    (cmakeFeature "ARCHIVE_DESTINATION" "lib")
+    (cmakeFeature "LIBRARY_DESTINATION" "lib")
+    (cmakeFeature "RUNTIME_DESTINATION" "bin")
+
+    (cmakeBool "ENABLE_SYSTEM_OPENCL" true)
+    # Tokenizers are provided at runtime by openvino-tokenizers (C++) and
+    # python3Packages.openvino-tokenizers; don't build them into this output.
+    (cmakeBool "BUILD_TOKENIZERS" false)
+    (cmakeBool "ENABLE_GGUF" true)
+    (cmakeBool "ENABLE_PYTHON" true)
+    (cmakeBool "ENABLE_SAMPLES" false)
+    (cmakeBool "ENABLE_TESTS" true)
+    (cmakeBool "ENABLE_TOOLS" false)
+    (cmakeBool "ENABLE_XGRAMMAR" false)
+  ];
+
+  postInstall = ''
+    # cmake installs to runtime/{include,cmake,lib/...}; move to standard paths.
+    mkdir -p $dev/include $dev/lib/cmake $out/lib
+    cp -r $out/runtime/include/. $dev/include/
+    cp -r $out/runtime/cmake/. $dev/lib/cmake/
+
+    # Copy any shared libraries cmake put in runtime/lib subdirs (e.g. intel64/)
+    # before we remove the runtime/ tree.
+    find $out/runtime \( -name '*.so' -o -name '*.so.*' \) -print0 \
+      | xargs -0r cp -Pft $out/lib/
+    rm -rf $out/runtime
+
+    # The generated cmake targets files compute _IMPORT_PREFIX relative to
+    # their location and use it to reference headers and libraries; fix those
+    # paths to absolute nix store paths since we've reorganised the tree.
+    substituteInPlace $dev/lib/cmake/OpenVINOGenAITargets.cmake \
+      --replace-fail \
+        "\''${_IMPORT_PREFIX}/runtime/include" "$dev/include"
+    substituteInPlace $dev/lib/cmake/OpenVINOGenAITargets-release.cmake \
+      --replace-fail \
+        "\''${_IMPORT_PREFIX}/runtime/lib/intel64/" "$out/lib/"
+  '';
+
+  postFixup = ''
+    # Split Python module into its own output.
+    mkdir -p $python
+    cp -r $out/python/. $python/
+    rm -rf $out/python
+
+    # Help autoPatchelfHook find: (1) libopenvino_genai.so.* in our own $out/lib
+    # when patching the $python output, (2) libopenvino.so.* which openvino
+    # installs to runtime/lib/intel64/ instead of lib/.
+    autoPatchelfLibs+=("$out/lib" "${openvino}/runtime/lib/intel64")
+  '';
+
+  nativeCheckInputs = [ openvino-tokenizers ];
+
+  doCheck = true;
+
+  preCheck = ''
+    mkdir -p tests/cpp/data
+    cp -r ${finalAttrs.src}/tests/cpp/data/. tests/cpp/data/
+    export OPENVINO_TOKENIZERS_PATH_GENAI="${openvino-tokenizers}/lib/libopenvino_tokenizers.so"
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    # GetCacheTypesRealModel and LLMPipelineBackendRealModel require on-disk
+    # model data (CACHE_TYPES_CSV + TEST_MODELS_BASE_DIR) unavailable in the
+    # Nix sandbox; with zero ValuesIn entries GTest ≥ 1.12 reports them via
+    # GoogleTestVerification.UninstantiatedParameterizedTestSuite<*>, so
+    # exclude that verification check for these two suites.
+    ./tests/cpp/tests_continuous_batching \
+      --gtest_filter="-GoogleTestVerification.UninstantiatedParameterizedTestSuite*"
+    runHook postCheck
+  '';
+
+  enableParallelBuilding = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Generative AI inference pipeline library built on OpenVINO Runtime";
+    longDescription = ''
+      OpenVINO GenAI provides a high-level C++ and Python API for running large
+      language models and other generative AI workloads using OpenVINO Runtime as
+      the inference backend. It supports continuous batching, speculative decoding,
+      and a range of text, image, and speech generation pipelines.
+    '';
+    homepage = "https://github.com/openvinotoolkit/openvino.genai";
+    changelog = "https://github.com/openvinotoolkit/openvino.genai/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ jpds ];
+  };
+})

--- a/pkgs/by-name/op/openvino-tokenizers/package.nix
+++ b/pkgs/by-name/op/openvino-tokenizers/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  nix-update-script,
+  onetbb,
+  openvino,
+  pcre2,
+  pkg-config,
+  sentencepiece,
+}:
+
+let
+  inherit (lib) cmakeBool cmakeFeature;
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "openvino-tokenizers";
+  version = "2026.2.0.0";
+
+  __structuredAttrs = true;
+
+  src =
+    assert lib.hasPrefix openvino.version finalAttrs.version;
+    fetchFromGitHub {
+      owner = "openvinotoolkit";
+      repo = "openvino_tokenizers";
+      tag = finalAttrs.version;
+      hash = "sha256-J138ungdkkq1qa5/eEQTgKKtGyx9KHCrQwUsIGkf3mI=";
+    };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    onetbb
+    openvino
+    pcre2
+  ];
+
+  strictDeps = true;
+
+  patches = [
+    # Use system pcre2 via pkg-config rather than FetchContent, and add
+    # sentencepiece's binary dir to the include path so cmake-generated config.h
+    # is found at compile time.
+    ./use-system-pcre2-and-sentencepiece-binary-dir.patch
+  ];
+
+  cmakeFlags = [
+    (cmakeFeature "OpenVINO_DIR" "${openvino}/runtime/cmake")
+    # Supply FetchContent source so nothing is downloaded at build time.
+    (cmakeFeature "FETCHCONTENT_SOURCE_DIR_SENTENCEPIECE" "${sentencepiece.src}")
+    # Install library to standard lib/ rather than runtime/lib/<arch>/
+    (cmakeFeature "OPENVINO_TOKENIZERS_INSTALL_LIBDIR" "lib")
+    (cmakeFeature "OPENVINO_TOKENIZERS_INSTALL_BINDIR" "bin")
+    (cmakeBool "BUILD_CPP_EXTENSION" true)
+    (cmakeBool "FETCHCONTENT_FULLY_DISCONNECTED" true)
+  ];
+
+  enableParallelBuilding = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "OpenVINO Tokenizers - text tokenisation extensions for OpenVINO";
+    homepage = "https://github.com/openvinotoolkit/openvino_tokenizers";
+    changelog = "https://github.com/openvinotoolkit/openvino_tokenizers/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ jpds ];
+  };
+})

--- a/pkgs/by-name/op/openvino-tokenizers/use-system-pcre2-and-sentencepiece-binary-dir.patch
+++ b/pkgs/by-name/op/openvino-tokenizers/use-system-pcre2-and-sentencepiece-binary-dir.patch
@@ -1,0 +1,40 @@
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -156,6 +156,7 @@
+         "${_sp_src}/third_party/protobuf-lite" # for "google/protobuf/port_def.inc"
+         "${_sp_src}/third_party/" # for "absl/strings/string_view.h" and "darts_clone/darts.h"
+         "${_sp_src}" # for "third_party/absl/strings/string_view.h"
++        "${sentencepiece_BINARY_DIR}" # for "config.h"
+         )
+     else()
+       target_include_directories(${TARGET_NAME} SYSTEM PRIVATE
+@@ -180,27 +181,9 @@
+ endfunction()
+ 
+ function(ov_tokenizers_link_pcre2 TARGET_NAME)
+-  FetchContent_Declare(
+-      pcre2
+-      URL https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.46/pcre2-10.46.zip
+-      URL_HASH SHA256=d872153b2d2338f7bc7b6e9bcc2f7f0c8a529c34fe48c538fea0b3a4e062f046
+-  )
+-  FetchContent_GetProperties(pcre2)
+-  if(NOT pcre2_POPULATED)
+-    FetchContent_Populate(pcre2)
+-
+-    set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+-    set(CMAKE_POLICY_DEFAULT_CMP0126 NEW)
+-    set(PCRE2_SUPPORT_JIT ON)
+-    set(PCRE2_STATIC_PIC ON)
+-    set(PCRE2_BUILD_TESTS OFF)
+-    set(PCRE2_BUILD_PCRE2GREP OFF)
+-
+-    add_subdirectory(${pcre2_SOURCE_DIR} ${pcre2_BINARY_DIR} EXCLUDE_FROM_ALL)
+-  endif()
+-
+-  target_include_directories(${TARGET_NAME} SYSTEM PRIVATE ${pcre2_BINARY_DIR})
+-  target_link_libraries(${TARGET_NAME} PRIVATE pcre2-8)
++  find_package(PkgConfig REQUIRED)
++  pkg_check_modules(PCRE2_8 REQUIRED IMPORTED_TARGET libpcre2-8)
++  target_link_libraries(${TARGET_NAME} PRIVATE PkgConfig::PCRE2_8)
+   target_compile_definitions(${TARGET_NAME} PRIVATE PCRE2_CODE_UNIT_WIDTH=8)
+ endfunction()

--- a/pkgs/by-name/op/openvino/package.nix
+++ b/pkgs/by-name/op/openvino/package.nix
@@ -34,6 +34,7 @@
 let
   inherit (lib)
     cmakeBool
+    cmakeFeature
     getLib
     ;
 
@@ -97,6 +98,19 @@ stdenv.mkDerivation (finalAttrs: {
     "-DOpenCV_DIR=${getLib opencv}/lib/cmake/opencv4/"
     "-DProtobuf_LIBRARIES=${getLib protobuf}/lib/libprotobuf${stdenv.hostPlatform.extensions.sharedLibrary}"
     "-DPython_EXECUTABLE=${python.interpreter}"
+
+    # OV_CPACK_* variables are normally set by packaging macros that only run
+    # when CPACK_GENERATOR matches a known type to upstream.
+    # Without one, all vars remain undefined and install() destinations are empty,
+    # putting files in $out/ root or producing absolute paths. Set them directly
+    # here so the build produces a standard layout.
+    (cmakeFeature "OV_CPACK_LIBRARYDIR" "lib")
+    (cmakeFeature "OV_CPACK_RUNTIMEDIR" "lib")
+    (cmakeFeature "OV_CPACK_ARCHIVEDIR" "lib")
+    (cmakeFeature "OV_CPACK_INCLUDEDIR" "include")
+    (cmakeFeature "OV_CPACK_OPENVINO_CMAKEDIR" "lib/cmake/OpenVINO")
+    (cmakeFeature "OV_CPACK_PYTHONDIR" "python")
+    (cmakeFeature "OV_CPACK_PLUGINSDIR" "lib")
 
     (cmakeBool "CMAKE_VERBOSE_MAKEFILE" true)
     (cmakeBool "NCC_SYLE" false)

--- a/pkgs/development/python-modules/openvino-genai/default.nix
+++ b/pkgs/development/python-modules/openvino-genai/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  openvino-genai-native,
+  numpy,
+  openvino-tokenizers,
+  python,
+}:
+
+buildPythonPackage {
+  pname = "openvino-genai";
+  inherit (openvino-genai-native) version;
+  pyproject = false;
+
+  src = openvino-genai-native.python;
+
+  dependencies = [
+    numpy
+    # openvino-genai loads tokenizers via py::module_::import("openvino_tokenizers")
+    # at runtime, so the Python wrapper must be available on the import path.
+    openvino-tokenizers
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/${python.sitePackages}
+    cp -R * $out/${python.sitePackages}/
+
+    runHook postInstall
+  '';
+
+  pythonImportsCheck = [ "openvino_genai" ];
+
+  meta = {
+    description = "OpenVINO GenAI Python API";
+    homepage = "https://github.com/openvinotoolkit/openvino.genai";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jpds ];
+  };
+}

--- a/pkgs/development/python-modules/openvino-tokenizers/default.nix
+++ b/pkgs/development/python-modules/openvino-tokenizers/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  openvino,
+  openvino-tokenizers-native,
+  python,
+}:
+
+buildPythonPackage {
+  pname = "openvino-tokenizers";
+  inherit (openvino-tokenizers-native) version;
+  pyproject = false;
+
+  src = openvino-tokenizers-native.src;
+
+  dependencies = [ openvino ];
+
+  installPhase = ''
+    runHook preInstall
+
+    target=$out/${python.sitePackages}/openvino_tokenizers
+    mkdir -p $target/lib
+    cp -r python/openvino_tokenizers/. $target/
+
+    # __version__.py ships with a placeholder; py-build-cmake normally rewrites
+    # it at configure time. We're not using py-build-cmake, so substitute here.
+    substituteInPlace $target/__version__.py \
+      --replace-fail '0.0.0.0' '${openvino-tokenizers-native.version}'
+
+    # Place the extension where __init__.py looks for it
+    # (<site-packages>/openvino_tokenizers/lib/libopenvino_tokenizers.so).
+    cp ${openvino-tokenizers-native}/lib/libopenvino_tokenizers.so $target/lib/
+
+    runHook postInstall
+  '';
+
+  pythonImportsCheck = [ "openvino_tokenizers" ];
+
+  meta = {
+    description = "OpenVINO Tokenizers Python API";
+    homepage = "https://github.com/openvinotoolkit/openvino_tokenizers";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jpds ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12032,6 +12032,10 @@ self: super: with self; {
     openvino-native = pkgs.openvino.override { python3Packages = self; };
   };
 
+  openvino-tokenizers = callPackage ../development/python-modules/openvino-tokenizers {
+    openvino-tokenizers-native = pkgs.openvino-tokenizers;
+  };
+
   openwebifpy = callPackage ../development/python-modules/openwebifpy { };
 
   openwrt-luci-rpc = callPackage ../development/python-modules/openwrt-luci-rpc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12032,6 +12032,10 @@ self: super: with self; {
     openvino-native = pkgs.openvino.override { python3Packages = self; };
   };
 
+  openvino-genai = callPackage ../development/python-modules/openvino-genai {
+    openvino-genai-native = pkgs.openvino-genai.override { python3Packages = self; };
+  };
+
   openvino-tokenizers = callPackage ../development/python-modules/openvino-tokenizers {
     openvino-tokenizers-native = pkgs.openvino-tokenizers;
   };


### PR DESCRIPTION
Packages up https://github.com/openvinotoolkit/openvino.genai which I needed for a downstream app.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
