### PR TITLE
mujoco: 3.8.1 -> 3.9.0

### DIFF
--- a/pkgs/by-name/mu/mujoco/mujoco-system-deps-dont-fetch.patch
+++ b/pkgs/by-name/mu/mujoco/mujoco-system-deps-dont-fetch.patch
@@ -84,6 +84,15 @@ index d2404bc1..5c7ddaf6 100644
    TARGETS
    ccd
    EXCLUDE_FROM_ALL
+@@ -256,8 +256,6 @@ set(BUILD_TESTS OFF)
+ set(BUILD_TESTS OFF)
+ fetchpackage(
+   PACKAGE_NAME  miniz
+-  GIT_REPO      https://github.com/richgel999/miniz.git
+-  GIT_TAG       ${MUJOCO_DEP_VERSION_miniz}
+   TARGETS       miniz
+ )
+ if(_BUILD_TESTS_WAS_DEFINED)
 @@ -261,10 +241,6 @@ if(MUJOCO_BUILD_TESTS OR MUJOCO_BUILD_STUDIO OR MUJOCO_USE_FILAMENT)
      absl
      LIBRARY_NAME

--- a/pkgs/by-name/mu/mujoco/package.nix
+++ b/pkgs/by-name/mu/mujoco/package.nix
@@ -20,14 +20,14 @@ let
     abseil-cpp = fetchFromGitHub {
       owner = "abseil";
       repo = "abseil-cpp";
-      rev = "255c84dadd029fd8ad25c5efb5933e47beaa00c7";
-      hash = "sha256-TJT2Kzc64zI42FAbbGWP3Sshh1dU/D/AtEpgZrrhebg=";
+      rev = "5650e9cf76d3be4318d5fa3af38ee483ddfd5e4a";
+      hash = "sha256-O9ClnGm4WSTX3g1Q2VYTMhUtGG52XBwxzgHtWW9WSG0=";
     };
     benchmark = fetchFromGitHub {
       owner = "google";
       repo = "benchmark";
-      rev = "5c55f5d4f45a1b09c5d98aa63a671993ebd42c69";
-      hash = "sha256-CChXn58cqam3d6Q61ZJMr5NFq1Ezc5uywA7FSPhk4GI=";
+      rev = "834a61fc65e8b7885fcf177f1230ae4b897118fa";
+      hash = "sha256-V5pVCG5QdFlgBIVKMv4jyTTB22BWfTHD3HolVPDFpgQ=";
     };
     ccd = fetchFromGitHub {
       owner = "danfis";
@@ -38,8 +38,8 @@ let
     eigen3 = fetchFromGitLab {
       owner = "libeigen";
       repo = "eigen";
-      rev = "75bcd155c40cb48e647c87c3f29052360255bc9e";
-      hash = "sha256-ZBm3ac6Kt7gOqNip6PeNNMiOF0fwG+7PJYA47KT0ogI=";
+      rev = "ea13a98decd497a8c5588fb5de71b57bcf10d864";
+      hash = "sha256-v9bNWc9yfK3vG8hYhQ7vkc7DHaoPF6RAKfX9kC0Gw8c=";
     };
     googletest = fetchFromGitHub {
       owner = "google";
@@ -53,11 +53,17 @@ let
       rev = "17d08dd26cac4d63f43af217ebd70318bfb8189c";
       hash = "sha256-vnw52G0lY68471dzH7NXc++bTbLRsITSxGYXOTicA5w=";
     };
+    miniz = fetchFromGitHub {
+      owner = "richgel999";
+      repo = "miniz";
+      rev = "d10b03cc73475af673df40f06e5cefd1d5f940d9";
+      hash = "sha256-hRB/0TVVQjr4VwjozfRnYKUJfeqO+1PNfdvP/rrOCR4=";
+    };
     qhull = fetchFromGitHub {
       owner = "qhull";
       repo = "qhull";
-      rev = "62ccc56af071eaa478bef6ed41fd7a55d3bb2d80";
-      hash = "sha256-kIxHtE0L/axV9WKnQzyFN0mxoIFAI33Z+MP0P/MtQPw=";
+      rev = "d1c2fc0caa5f644f3a0f220290d4a868c68ed4f6";
+      hash = "sha256-enwzl4td3lgYwQ4PXfcONKQrxChnJcvf8ehnJ6vf0yg=";
     };
     tinyobjloader = fetchFromGitHub {
       owner = "tinyobjloader";
@@ -82,7 +88,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "mujoco";
-  version = "3.8.1";
+  version = "3.10.0";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -93,7 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "google-deepmind";
     repo = "mujoco";
     tag = finalAttrs.version;
-    hash = "sha256-eoZblIIH+tUNKPdVERGh1dE0KoWwMpP0LA6FgcJCiNU=";
+    hash = "sha256-wNsTTq5z+wKE0rSw2cyY1tJxP5i7LGu05DR7KfZEBtE=";
   };
 
   patches = [
@@ -128,8 +134,13 @@ stdenv.mkDerivation (finalAttrs: {
   # Move things into place so that cmake doesn't try downloading dependencies.
   preConfigure = ''
     mkdir -p build/_deps
-    ln -s ${pin.abseil-cpp} build/_deps/abseil-cpp-src
     ln -s ${pin.benchmark} build/_deps/benchmark-src
+  ''
+  # mujoco applies a patch on top of abseil-cpp's sources
+  # https://github.com/google-deepmind/mujoco/blob/3.10.0/cmake/MujocoDependencies.cmake#L299-L300
+  + ''
+    cp -r ${pin.abseil-cpp} build/_deps/abseil-cpp-src
+    chmod -R +w build/_deps/abseil-cpp-src
   ''
   # cccd is patched by mujoco's cmake and thus needs to be writable
   # https://github.com/google-deepmind/mujoco/blob/3.4.0/cmake/MujocoDependencies.cmake#L232-L235
@@ -141,6 +152,7 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s ${pin.eigen3} build/_deps/eigen3-src
     ln -s ${pin.googletest} build/_deps/googletest-src
     ln -s ${pin.lodepng} build/_deps/lodepng-src
+    ln -s ${pin.miniz} build/_deps/miniz-src
   ''
   # qhull is patched by mujoco's cmake and thus needs to be writable
   # https://github.com/google-deepmind/mujoco/blob/3.4.0/cmake/MujocoDependencies.cmake#L132-L135

--- a/pkgs/development/python-modules/brax/default.nix
+++ b/pkgs/development/python-modules/brax/default.nix
@@ -54,13 +54,21 @@ buildPythonPackage (finalAttrs: {
     ./dont-use-device_put_replicated-compat.patch
   ];
 
-  # TypeError: clip() got an unexpected keyword argument 'a_min'
-  postPatch = ''
-    substituteInPlace brax/fluid.py \
-      --replace-fail \
-        "box = 6.0 * jp.clip(jp.sum(diag_inertia_v, axis=-1), a_min=1e-12)" \
-        "box = 6.0 * jp.clip(jp.sum(diag_inertia_v, axis=-1), min=1e-12)"
-  '';
+  postPatch =
+    # TypeError: clip() got an unexpected keyword argument 'a_min'
+    ''
+      substituteInPlace brax/fluid.py \
+        --replace-fail \
+          "box = 6.0 * jp.clip(jp.sum(diag_inertia_v, axis=-1), a_min=1e-12)" \
+          "box = 6.0 * jp.clip(jp.sum(diag_inertia_v, axis=-1), min=1e-12)"
+    ''
+    # mujoco >= 3.10 changed mj_fullM's signature from (m, dst, qM) to (m, d, dst).
+    + ''
+      substituteInPlace brax/generalized/mass_test.py \
+        --replace-fail \
+          "mujoco.mj_fullM(model, mj_mass_mx, mj_next.qM)" \
+          "mujoco.mj_fullM(model, mj_next, mj_mass_mx)"
+    '';
 
   build-system = [
     hatchling

--- a/pkgs/development/python-modules/dm-control/default.nix
+++ b/pkgs/development/python-modules/dm-control/default.nix
@@ -29,7 +29,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "dm-control";
-  version = "1.0.41";
+  version = "1.0.43";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -37,7 +37,7 @@ buildPythonPackage (finalAttrs: {
     owner = "google-deepmind";
     repo = "dm_control";
     tag = finalAttrs.version;
-    hash = "sha256-AxyxI9sRF822oNLk/zVUnGVRGSQ3BHCBQJ9HtD8aL/M=";
+    hash = "sha256-6c67sOcKsygtjdn3NOjfK0K3IsZIOZHDMXr5qMp+W5A=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/mujoco/default.nix
+++ b/pkgs/development/python-modules/mujoco/default.nix
@@ -31,6 +31,7 @@ buildPythonPackage (finalAttrs: {
   inherit (mujoco) version;
 
   pyproject = true;
+  __structuredAttrs = true;
 
   # We do not fetch from the repository because the PyPi tarball is
   # impurely build via
@@ -38,7 +39,7 @@ buildPythonPackage (finalAttrs: {
   # in the project's CI.
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-AZoLNAaJK8mEVOr1XL0n+F0Wd1iteF93xgimHzo0rRc=";
+    hash = "sha256-yejV2H2CIE7VvMyH2EPApT51qvOB3ik47EbQTxrG4k4=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
## Things done

Diff: https://github.com/google-deepmind/mujoco/compare/3.8.1...3.10.0
Changelog: https://mujoco.readthedocs.io/en/3.10.0/changelog.html

cc @samuela @tmplt

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test