### PR TITLE
fltk_1_4: 1.4.4 -> 1.4.5

### DIFF
--- a/pkgs/by-name/fl/fltk_1_4/package.nix
+++ b/pkgs/by-name/fl/fltk_1_4/package.nix
@@ -56,13 +56,13 @@ assert withWayland -> withCairo;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fltk";
-  version = "1.4.4";
+  version = "1.4.5";
 
   src = fetchFromGitHub {
     owner = "fltk";
     repo = "fltk";
-    rev = "release-${finalAttrs.version}";
-    hash = "sha256-xba9uiiwQhM4a3Rf4PoGshY3mUKZrcsm+Iv7qnE2sEA=";
+    tag = "release-${finalAttrs.version}";
+    hash = "sha256-8Go/UNuZ1LEn8BniAyBbAPk7jdvSs5QvXxin9LAFvhU=";
   };
 
   outputs = [ "out" ] ++ lib.optional withExamples "bin" ++ lib.optional withDocs "doc";
@@ -211,6 +211,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
+    changelog = "https://github.com/fltk/fltk/blob/${finalAttrs.src.tag}/CHANGES.txt";
     description = "C++ cross-platform lightweight GUI library";
     homepage = "https://www.fltk.org";
     platforms = lib.platforms.unix;


### PR DESCRIPTION
Diff: https://github.com/fltk/fltk/compare/release-1.4.4...release-1.4.5

Changelog: https://github.com/fltk/fltk/blob/release-1.4.5/CHANGES.txt

closes https://github.com/NixOS/nixpkgs/pull/513445
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
