### PR TITLE
cantarell-fonts: 0.303.1 -> 0.311

### DIFF
--- a/pkgs/by-name/ca/cantarell-fonts/package.nix
+++ b/pkgs/by-name/ca/cantarell-fonts/package.nix
@@ -1,50 +1,44 @@
 {
   stdenv,
   lib,
-  fetchurl,
+  fetchFromGitLab,
   meson,
   ninja,
   python3,
   gettext,
-  appstream-glib,
-  gnome,
+  gitUpdater,
 }:
 
 stdenv.mkDerivation rec {
   pname = "cantarell-fonts";
-  version = "0.303.1";
+  version = "0.311";
 
-  src = fetchurl {
-    url = "mirror://gnome/sources/cantarell-fonts/${lib.versions.majorMinor version}/cantarell-fonts-${version}.tar.xz";
-    sha256 = "+UY6BlnGPlfjgf3XU88ZKSJTlcW0kTWYlCR2GDBTBBE=";
+  src = fetchFromGitLab {
+    domain = "gitlab.gnome.org";
+    owner = "GNOME";
+    repo = "cantarell-fonts";
+    tag = version;
+    hash = "sha256-FR53OZxJ7WRUDqMB2GriQ3UOxozWwbFiz3/9VaUWYrc=";
   };
 
   nativeBuildInputs = [
     meson
     ninja
-    python3
-    python3.pkgs.psautohint
+    python3.pkgs.afdko # for otfautohint
     python3.pkgs.cffsubr
-    python3.pkgs.statmake
     python3.pkgs.ufo2ft
-    python3.pkgs.setuptools
-    python3.pkgs.ufolib2
+    python3.pkgs.uharfbuzz
     gettext
-    appstream-glib
   ];
 
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "sha256-OjHj4h3n+/ozbrLaiH4bGppQ+2LA2RB/sZQVO9EPOEw=";
-
   passthru = {
-    updateScript = gnome.updateScript {
-      packageName = pname;
-    };
+    updateScript = gitUpdater { };
   };
 
   meta = {
+    changelog = "https://gitlab.gnome.org/GNOME/cantarell-fonts/-/blob/${src.tag}/NEWS";
     description = "Default typeface used in the user interface of GNOME since version 3.0";
+    homepage = "https://cantarell.gnome.org/";
     platforms = lib.platforms.all;
     license = lib.licenses.ofl;
     maintainers = [ ];


### PR DESCRIPTION
Changelog: https://gitlab.gnome.org/GNOME/cantarell-fonts/-/blob/0.311/NEWS


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
