### PR TITLE
python3Packages.fonttools: 4.61.1 -> 4.63.0

### DIFF
--- a/pkgs/development/python-modules/fonttools/default.nix
+++ b/pkgs/development/python-modules/fonttools/default.nix
@@ -25,7 +25,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "fonttools";
   version = "4.63.0";
   pyproject = true;
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "fonttools";
     repo = "fonttools";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-XTE18TKpIa4MpbJ5tcHwCyLk3Q6CV/ElzMtddG86HJA=";
   };
 
@@ -83,7 +83,7 @@ buildPythonPackage rec {
             "pathops" # broken
           ]
       ++ [ "repacker" ]
-    ) optional-dependencies
+    ) finalAttrs.passthru.optional-dependencies
   );
 
   pythonImportsCheck = [ "fontTools" ];
@@ -99,8 +99,8 @@ buildPythonPackage rec {
   meta = {
     homepage = "https://github.com/fonttools/fonttools";
     description = "Library to manipulate font files from Python";
-    changelog = "https://github.com/fonttools/fonttools/blob/${src.tag}/NEWS.rst";
+    changelog = "https://github.com/fonttools/fonttools/blob/${finalAttrs.src.tag}/NEWS.rst";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.sternenseemann ];
   };
-}
+})

--- a/pkgs/development/python-modules/fonttools/default.nix
+++ b/pkgs/development/python-modules/fonttools/default.nix
@@ -21,19 +21,20 @@
   xattr,
   skia-pathops,
   uharfbuzz,
+  addBinToPathHook,
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "fonttools";
-  version = "4.61.1";
+  version = "4.63.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "fonttools";
     repo = "fonttools";
     tag = version;
-    hash = "sha256-762bqAhOqqnuNSH8yFLTBnzYuigs716nt+uC1UwUqT4=";
+    hash = "sha256-XTE18TKpIa4MpbJ5tcHwCyLk3Q6CV/ElzMtddG86HJA=";
   };
 
   build-system = [
@@ -50,7 +51,7 @@ buildPythonPackage rec {
           (if isPyPy then brotlicffi else brotli)
           zopfli
         ];
-        unicode = lib.optional (pythonOlder "3.13") unicodedata2;
+        unicode = lib.optional (pythonOlder "3.15") unicodedata2;
         graphite = [ lz4 ];
         interpolatable = [
           pycairo
@@ -59,13 +60,14 @@ buildPythonPackage rec {
         plot = [ matplotlib ];
         symfont = [ sympy ];
         type1 = lib.optional stdenv.hostPlatform.isDarwin xattr;
-        pathops = lib.optional (lib.meta.availableOn stdenv.hostPlatform skia-pathops) skia-pathops;
+        pathops = [ skia-pathops ];
         repacker = [ uharfbuzz ];
       };
     in
     extras // { all = lib.concatLists (lib.attrValues extras); };
 
   nativeCheckInputs = [
+    addBinToPathHook
     pytestCheckHook
   ]
   ++ lib.concatLists (
@@ -75,19 +77,16 @@ buildPythonPackage rec {
         # "interpolatable" is not included because it only contains 2 tests at the time of writing but adds 270 extra dependencies
         "ufo"
       ]
-      ++ lib.optionals (!skia-pathops.meta.broken) [
-        "pathops" # broken
-      ]
+      ++
+        lib.optionals (lib.meta.availableOn stdenv.hostPlatform skia-pathops && !skia-pathops.meta.broken)
+          [
+            "pathops" # broken
+          ]
       ++ [ "repacker" ]
     ) optional-dependencies
   );
 
   pythonImportsCheck = [ "fontTools" ];
-
-  preCheck = ''
-    # tests want to execute the "fonttools" executable from $PATH
-    export PATH="$out/bin:$PATH"
-  '';
 
   # Timestamp tests have timing issues probably related
   # to our file timestamp normalization


### PR DESCRIPTION
Diff: https://github.com/fonttools/fonttools/compare/4.61.1...4.63.0

Changelog: https://github.com/fonttools/fonttools/blob/4.63.0/NEWS.rst


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
