### PR TITLE
zellijPlugins: add more plugins

### DIFF
--- a/pkgs/by-name/ze/zellij/plugins/README.md
+++ b/pkgs/by-name/ze/zellij/plugins/README.md
@@ -5,11 +5,13 @@ develop plugins in many different languages. Currently, nixpkgs focuses only on
 Rust plugins (the majority of them).
 
 Most of the plugins were generated using `nix-init` on [awesome-zellij].
-Excluded plugins from that list (should be packaged later anyway):
+Excluded plugins from that list (should be packaged later anyway, contributions
+are welcome):
 
 - [bar-theme-config](https://github.com/allisonhere/zellij-bar-theme-config): not a plugin, but a separate application
 - [fzf-zellij](https://github.com/k-kuroguro/fzf-zellij): [closed source](https://github.com/k-kuroguro/fzf-zellij/issues/1)
 - [gitpod-zellij](https://github.com/ona-samples/gitpod.zellij): not a plugin, but a separate application?
+- [neolij.nvim](https://github.com/y2w8/neolij.nvim): written in Lua
 - [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer): written in TypeScript, not Rust
 - [theme-configurator](https://rosmur.github.io/zellij-theme-configurator/): not a plugin, but a separate application
 - [yazelix](https://github.com/luccahuguet/yazelix): written in Nushell
@@ -17,13 +19,15 @@ Excluded plugins from that list (should be packaged later anyway):
 - [zellij-load](https://github.com/Christian-Prather/zellij-load): has daemon, so that needs to be packaged too
 - [zellij-vscode-toolkit](https://github.com/atoolz/zellij-vscode-toolkit): not a plugin, but a VSCode plugin
 - [zellix](https://github.com/EmeraldPandaTurtle/zellix): written in Nushell
+- [zj-docker](https://github.com/dj95/zj-docker): plugin is broken, see https://github.com/dj95/zj-docker/issues/4
 - [zj-quit](https://github.com/cristiand391/zj-quit): archived
 - [zj-status-bar](https://github.com/cristiand391/zj-status-bar): archived
 - [zrw](https://github.com/ivoronin/zrw): written in Go
 
-Contributions are welcome!
+Other plugins were deleted because they had less than 50 stars and unless
+someone requests it, they won't be packaged.
 
-[awesome-zellij]: https://github.com/zellij-org/awesome-zellij/blob/95fce2c02a2dcca33e4972eed3eba64d516693c9/README.md
+[awesome-zellij]: https://github.com/zellij-org/awesome-zellij/blob/b066d3ed708963ea1c34ea2b1bf27b9cf04bd4c7/README.md
 
 ## Specifying runtime dependencies
 

--- a/pkgs/by-name/ze/zellij/plugins/default.nix
+++ b/pkgs/by-name/ze/zellij/plugins/default.nix
@@ -44,7 +44,12 @@ let
       };
 
       meta = pkg.meta // {
-        maintainers = pkg.meta.maintainers or [ ] ++ [ lib.maintainers.PerchunPak ];
+        maintainers =
+          pkg.meta.maintainers or [ ]
+          ++ (with lib.maintainers; [
+            PerchunPak
+            dtomvan
+          ]);
         platforms = pkg.meta.platforms or zellij.platforms;
       };
     });

--- a/pkgs/by-name/ze/zellij/plugins/rust/autolock.nix
+++ b/pkgs/by-name/ze/zellij/plugins/rust/autolock.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "zellij-autolock";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "fresh2dev";
+    repo = "zellij-autolock";
+    tag = finalAttrs.version;
+    hash = "sha256-uU7wWSdOhRLQN6cG4NvA9yASlvRwB6gggX89B5K9dyQ=";
+  };
+
+  cargoHash = "sha256-ULBQN+EBvyEIdoaLpiMNqoDEQ8Lu0Sc3OeweuKMiIU0=";
+
+  meta = {
+    description = "Autolock Zellij when certain processes open";
+    homepage = "https://github.com/fresh2dev/zellij-autolock";
+    changelog = "https://github.com/fresh2dev/zellij-autolock/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/by-name/ze/zellij/plugins/rust/bookmarks.nix
+++ b/pkgs/by-name/ze/zellij/plugins/rust/bookmarks.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "zellij-bookmarks";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "yaroslavborbat";
+    repo = "zellij-bookmarks";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-QTQsZsNupWkua0oO2FqicHrK7utavZ+fRCR8dIDBYyU=";
+  };
+
+  cargoHash = "sha256-htBt3HQo8P76WludBmBxt/5wKbiGnmCJnJkFoUoMzZ0=";
+
+  meta = {
+    description = "Create, manage, and quickly insert command bookmarks into the terminal";
+    homepage = "https://github.com/yaroslavborbat/zellij-bookmarks";
+    changelog = "https://github.com/yaroslavborbat/zellij-bookmarks/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/by-name/ze/zellij/plugins/rust/cb.nix
+++ b/pkgs/by-name/ze/zellij/plugins/rust/cb.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "zellij-cb";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "ndavd";
+    repo = "zellij-cb";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6TZyC5Ib1FbN2JTcPM1zYnAWb+cQZoWPIW7Sh+VYxiI=";
+  };
+
+  cargoHash = "sha256-F68Cgyu8+HuxdPOzBBhemc16AYpn+3hRR5XU07C02AY=";
+
+  meta = {
+    description = "Customizable compact bar plugin for Zellij";
+    homepage = "https://github.com/ndavd/zellij-cb";
+    changelog = "https://github.com/ndavd/zellij-cb/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/by-name/ze/zellij/plugins/rust/choose-tree.nix
+++ b/pkgs/by-name/ze/zellij/plugins/rust/choose-tree.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "zellij-choose-tree";
+  version = "0.4.2";
+
+  src = fetchFromGitHub {
+    owner = "laperlej";
+    repo = "zellij-choose-tree";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-g6R+LfSN7IgRPWr7sf3mLIn6c2xP/oaFO/MsxX7oB0s=";
+  };
+
+  cargoHash = "sha256-CPw+9dnlJi/5CFZNlYu3DTHvku5p8dAYh48awQ20ncs=";
+
+  meta = {
+    description = "Quickly switch between sessions";
+    homepage = "https://github.com/laperlej/zellij-choose-tree";
+    changelog = "https://github.com/laperlej/zellij-choose-tree/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/by-name/ze/zellij/plugins/rust/datetime.nix
+++ b/pkgs/by-name/ze/zellij/plugins/rust/datetime.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "zellij-datetime";
+  version = "0.21.0";
+
+  src = fetchFromGitHub {
+    owner = "h1romas4";
+    repo = "zellij-datetime";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hMkzhP+4r6PLeJBOr6AZlvC+qn2HOiwQYdakOr8bkHE=";
+  };
+
+  cargoHash = "sha256-ZakKWSS/lUXafLJtVwQfOMAOyqs45n9xe+V7Bp4e/Qg=";
+
+  meta = {
+    description = "Add a date and time pane to Zellij";
+    homepage = "https://github.com/h1romas4/zellij-datetime";
+    changelog = "https://github.com/h1romas4/zellij-datetime/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/by-name/ze/zellij/plugins/rust/forgot.nix
+++ b/pkgs/by-name/ze/zellij/plugins/rust/forgot.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "zellij-forgot";
+  version = "0.4.2";
+
+  src = fetchFromGitHub {
+    owner = "karimould";
+    repo = "zellij-forgot";
+    tag = finalAttrs.version;
+    hash = "sha256-QS09lC6yyUZA13PHERrdY/phfo1QoHAmRPpQUGL3pP8=";
+  };
+
+  cargoHash = "sha256-GR3bg6Rf6opb0jh8Hyv1y7gpsBh8nRExPjcGzIafHXg=";
+
+  meta = {
+    description = "Remember your keybinds and all the other things";
+    homepage = "https://github.com/karimould/zellij-forgot";
+    changelog = "https://github.com/karimould/zellij-forgot/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/by-name/ze/zellij/plugins/rust/ghost.nix
+++ b/pkgs/by-name/ze/zellij/plugins/rust/ghost.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ghost";
+  version = "0.7.1";
+
+  src = fetchFromGitHub {
+    owner = "vdbulcke";
+    repo = "ghost";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-3VqDzYOhSiA7PhGvNzHw93r0xGHZMd3HN7HbkCiXkxA=";
+  };
+
+  cargoHash = "sha256-YNsZ87NVLNnkX6OyordIaeQvtXbnHfN1kSy5R/FGcGg=";
+
+  meta = {
+    description = "Zellij plugin for spawning floating command terminal pane";
+    homepage = "https://github.com/vdbulcke/ghost";
+    changelog = "https://github.com/vdbulcke/ghost/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/by-name/ze/zellij/plugins/rust/harpoon.nix
+++ b/pkgs/by-name/ze/zellij/plugins/rust/harpoon.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "harpoon";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "Nacho114";
+    repo = "harpoon";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JmYcbzxIF6qZs2/RKuspHqNpyDibGp9CVQJj47y/BOQ=";
+  };
+
+  cargoHash = "sha256-lsv5Wssakni18jif++fPo3Z5WyBtvPsGpWwG3abR7jQ=";
+
+  meta = {
+    description = "Quickly navigate your panes (clone of nvim's harpoon)";
+    homepage = "https://github.com/Nacho114/harpoon";
+    changelog = "https://github.com/Nacho114/harpoon/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/by-name/ze/zellij/plugins/rust/jbz.nix
+++ b/pkgs/by-name/ze/zellij/plugins/rust/jbz.nix
@@ -27,6 +27,5 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/nim65s/jbz";
     changelog = "https://github.com/nim65s/jbz/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ PerchunPak ];
   };
 })

--- a/pkgs/by-name/ze/zellij/plugins/rust/monocle.nix
+++ b/pkgs/by-name/ze/zellij/plugins/rust/monocle.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "monocle";
+  version = "0.100.2";
+
+  src = fetchFromGitHub {
+    owner = "imsnif";
+    repo = "monocle";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-LZQn4aXroYPpn6pMydo3R4mEcZpUm2m6CDSY4azrJlw=";
+  };
+
+  cargoHash = "sha256-pEskD/J8+zmd6wdGYeJdNlVtnU/2103z5FW3KTXB4Xk=";
+
+  meta = {
+    description = "Fuzzy find file names and contents in style";
+    homepage = "https://github.com/imsnif/monocle";
+    changelog = "https://github.com/imsnif/monocle/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/by-name/ze/zellij/plugins/rust/multitask.nix
+++ b/pkgs/by-name/ze/zellij/plugins/rust/multitask.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "multitask";
+  version = "0.44.3";
+
+  src = fetchFromGitHub {
+    owner = "leakec";
+    repo = "multitask";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dtAGjF7EwtVL+IUF55ePsRhYfjfe+sXB+vpMhQFWPfA=";
+  };
+
+  cargoHash = "sha256-L3Vx+3YUDOpL65wlHRNAuhBsGfDfnhEPbTlKTQEXXtw=";
+
+  meta = {
+    description = "Mini-CI as a Zellij plugin";
+    homepage = "https://github.com/leakec/multitask";
+    changelog = "https://github.com/leakec/multitask/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/by-name/ze/zellij/plugins/rust/room.nix
+++ b/pkgs/by-name/ze/zellij/plugins/rust/room.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "room";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "rvcas";
+    repo = "room";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KHCt4U0uqK/qkTGq2/Jf5bqBBhVDqAgFh80RPpU/KY0=";
+  };
+
+  cargoHash = "sha256-CtaMzE72YV/DPPhjxL6LCvA03J8MneSOnMdy4mkyXvE=";
+
+  meta = {
+    description = "Quickly searching and switching tabs";
+    homepage = "https://github.com/rvcas/room";
+    changelog = "https://github.com/rvcas/room/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/by-name/ze/zellij/plugins/rust/sessionizer.nix
+++ b/pkgs/by-name/ze/zellij/plugins/rust/sessionizer.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "zellij-sessionizer";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "laperlej";
+    repo = "zellij-sessionizer";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-uCUoafvtDY62eqUH9d9HEAAqQ0/q6glivcYQyYx5T5w=";
+  };
+
+  cargoHash = "sha256-txSzHKGeAScRFwx1RzlNT0oscEw+5hLcCpb3N5ke4yo=";
+
+  meta = {
+    description = "Fuzzy-find your projects (port of tmux-sessionizer)";
+    homepage = "https://github.com/laperlej/zellij-sessionizer";
+    changelog = "https://github.com/laperlej/zellij-sessionizer/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/by-name/ze/zellij/plugins/rust/switch.nix
+++ b/pkgs/by-name/ze/zellij/plugins/rust/switch.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "zellij-switch";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "mostafaqanbaryan";
+    repo = "zellij-switch";
+    tag = finalAttrs.version;
+    hash = "sha256-IPg0pBw0ciF+xl6viq3nK+dvZoDZrfBDui7dkPLz258=";
+  };
+
+  cargoHash = "sha256-Fv8PRfVzIOTHHChXBy9rkrnu7/bD07a+sQJlLw9Qwgc=";
+
+  meta = {
+    description = "Switch between sessions in CLI using `zellij pipe`";
+    homepage = "https://github.com/mostafaqanbaryan/zellij-switch";
+    license = lib.licenses.unfree; # https://github.com/mostafaqanbaryan/zellij-switch/pull/14
+  };
+})

--- a/pkgs/by-name/ze/zellij/plugins/rust/vertical-tabs.nix
+++ b/pkgs/by-name/ze/zellij/plugins/rust/vertical-tabs.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "zellij-vertical-tabs";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "cfal";
+    repo = "zellij-vertical-tabs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0+Ye7IUtGjOqCtzCkZZgwUkYaFFX+74HBZwtRdY4sH4=";
+  };
+
+  cargoHash = "sha256-m9so6yv9lHBjAJGM4u+S+Tzh06aCAjN+Db2caV+1QA4=";
+
+  meta = {
+    description = "Display tabs vertically on the left or right side of the screen";
+    homepage = "https://github.com/cfal/zellij-vertical-tabs";
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/by-name/ze/zellij/plugins/rust/vim-zellij-navigator.nix
+++ b/pkgs/by-name/ze/zellij/plugins/rust/vim-zellij-navigator.nix
@@ -21,6 +21,5 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/hiasr/vim-zellij-navigator";
     changelog = "https://github.com/hiasr/vim-zellij-navigator/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ PerchunPak ];
   };
 })

--- a/pkgs/by-name/ze/zellij/plugins/rust/zellaude.nix
+++ b/pkgs/by-name/ze/zellij/plugins/rust/zellaude.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkgsBuildBuild,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "zellaude";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "ishefi";
+    repo = "zellaude";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jPFiMabR4LHDg6w/1M4PA/w/3VBnrVA6QjwZrMnTwbo=";
+  };
+
+  cargoHash = "sha256-4tplwN0qGUhPZay/U03jgxbWl7sdgNL+H6HxCar7jo0=";
+
+  passthru.runtimeDeps = [ pkgsBuildBuild.jq ];
+
+  meta = {
+    description = "Claude Code-aware status bar plugin for Zellij";
+    homepage = "https://github.com/ishefi/zellaude";
+    license = lib.licenses.mit;
+  };
+})

--- a/pkgs/by-name/ze/zellij/plugins/rust/zjstatus.nix
+++ b/pkgs/by-name/ze/zellij/plugins/rust/zjstatus.nix
@@ -25,6 +25,5 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/dj95/zjstatus";
     changelog = "https://github.com/dj95/zjstatus/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ PerchunPak ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is part 2 of https://github.com/NixOS/nixpkgs/pull/511825, which adds all other plugins from [awesome-zellij](https://github.com/zellij-org/awesome-zellij).

CC @0x4A6F, @matthiasbeyer, @ryan4yin, @therealansh, @wahjava (maintainers of Zellij) and @dtomvan, @ethancedwards8 (reviewers of the original PR)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

  I do not use AI

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
