### PR TITLE
rustPlatform.importCargoLock: use static.crates.io

### DIFF
--- a/pkgs/build-support/rust/import-cargo-lock.nix
+++ b/pkgs/build-support/rust/import-cargo-lock.nix
@@ -130,7 +130,7 @@ let
     };
 
   registries = {
-    "https://github.com/rust-lang/crates.io-index" = "https://crates.io/api/v1/crates";
+    "https://github.com/rust-lang/crates.io-index" = "https://static.crates.io/crates";
   }
   // extraRegistries;
 


### PR DESCRIPTION
As mentioned in https://github.com/NixOS/nixpkgs/pull/512735#issuecomment-4321022053, `ìmportCargoLock` still uses the crates.io API, which is subject to a 1 req/s rate limit and has recently been more strictly enforcing their Data Access Policy by preventing various user agents from accessing the API.
At the time of writing this is currently affecting `importCargoLock` because the user agent string used by `fetchurl` is getting blocked: https://github.com/rust-lang/crates.io/issues/13783

While this particular instance of the problem will likely be resolved upstream by crates.io, using the CDN for `importCargoLock` matches the behavior already implemented in `rustPlatform.fetchCargoVendor` and should also help protect Nixpkgs against further upstream changes of the API access.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
