### PR TITLE
 unifiedpush-common-proxies: 2.0.1 -> 3.1.0; adopt

### DIFF
--- a/pkgs/by-name/un/unifiedpush-common-proxies/package.nix
+++ b/pkgs/by-name/un/unifiedpush-common-proxies/package.nix
@@ -1,27 +1,27 @@
 {
   lib,
-  fetchFromGitHub,
+  fetchFromCodeberg,
   buildGoModule,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "unifiedpush-common-proxies";
-  version = "2.0.1";
+  version = "3.1.0";
 
-  src = fetchFromGitHub {
-    owner = "unifiedpush";
+  src = fetchFromCodeberg {
+    owner = "UnifiedPush";
     repo = "common-proxies";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-pMzKK18FZCqJ86nqXfOT7tKCqIw6P0ioxRUi72aef0A=";
+    rev = finalAttrs.version;
+    sha256 = "sha256-VRxwEsQt1LlcMIMEkGqkVtMrqJ7f4tYh3OExE9VITh4=";
   };
 
-  vendorHash = "sha256-wVZR/h0AtwZ1eo7EoRKNzaS2Wp0X01e2u3Ugmsnj644=";
+  vendorHash = "sha256-rGsSuO7cnb9e4A1SnIwfgfz4vu18JzxKtLnDfCSQqck=";
 
   meta = {
     description = "Set of rewrite proxies and gateways for UnifiedPush";
     homepage = "https://github.com/UnifiedPush/common-proxies";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.zimward ];
-    mainProgram = "up_rewrite";
+    mainProgram = "common-proxies";
   };
 })

--- a/pkgs/by-name/un/unifiedpush-common-proxies/package.nix
+++ b/pkgs/by-name/un/unifiedpush-common-proxies/package.nix
@@ -21,7 +21,7 @@ buildGoModule (finalAttrs: {
     description = "Set of rewrite proxies and gateways for UnifiedPush";
     homepage = "https://github.com/UnifiedPush/common-proxies";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.zimward ];
     mainProgram = "up_rewrite";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
The package used the github mirror so far which is no longer mirrored, so this version has been out of date by like 2 years now
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
