### PR TITLE
nushell-plugin-dns: init at 4.0.11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7003,6 +7003,14 @@
     githubId = 1427254;
     name = "Jack O'Sullivan";
   };
+  devurandom = {
+    name = "Dennis Schridde";
+    email = "heri@mailbox.org";
+    matrix = "@devurandom:matrix.org";
+    github = "devurandom";
+    githubId = 63082;
+    keys = [ { fingerprint = "F857 7089 4E67 B9FF 705A  91A5 4DC8 A2F1 0752 C237"; } ];
+  };
   devusb = {
     email = "mhelton@devusb.us";
     github = "devusb";

--- a/pkgs/by-name/nu/nushell/plugins/default.nix
+++ b/pkgs/by-name/nu/nushell/plugins/default.nix
@@ -6,6 +6,7 @@
   bson = callPackage ./bson/package.nix;
   dbus = callPackage ./dbus/package.nix { inherit dbus; };
   desktop_notifications = callPackage ./desktop_notifications/package.nix { };
+  dns = callPackage ./dns/package.nix { };
   formats = callPackage ./formats/package.nix { };
   gstat = callPackage ./gstat/package.nix { };
   hcl = callPackage ./hcl/package.nix { };

--- a/pkgs/by-name/nu/nushell/plugins/dns/package.nix
+++ b/pkgs/by-name/nu/nushell/plugins/dns/package.nix
@@ -1,0 +1,41 @@
+{
+  stdenv,
+  lib,
+  rustPlatform,
+  pkg-config,
+  nix-update-script,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "nu_plugin_dns";
+  version = "4.0.11";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "dead10ck";
+    repo = "nu_plugin_dns";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pC/OS2FyQYGWbRFC87BAfWMINNc2OfbrzDKi+Ic2osw=";
+  };
+
+  cargoHash = "sha256-P7ELKvC7o3a3dyKD8/ksMiFFC1XT5RqQADgSjFBk9L8=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
+
+  # All tests fail with `Error: Io(IoError { kind: DirectoryNotFound, span: Span[60..61], path: Some("."), additional_context: None, location: None })`,
+  # probably because of https://github.com/dead10ck/nu_plugin_dns/blob/d4cd3deae47336643dc4f3e7608a8275c6acc984/tests/integration.rs#L173-L179:
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Nushell plugin to query DNS";
+    mainProgram = "nu_plugin_dns";
+    homepage = "https://github.com/dead10ck/nu_plugin_dns";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ devurandom ];
+  };
+})


### PR DESCRIPTION
`nushell-plugin-dns` installs `nu_plugin_dns`, a plugin for nushell that adds a `dns query` command.  See https://github.com/dead10ck/nu_plugin_dns.  Install e.g. using home-manager `programs.nushell.plugins = [ pkgs.nushellPlugins.dns ];`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
