### PR TITLE
stereotool: fix build

### DIFF
--- a/pkgs/by-name/st/stereotool/package.nix
+++ b/pkgs/by-name/st/stereotool/package.nix
@@ -10,6 +10,8 @@
   zlib,
   kdePackages,
   libgcc,
+  libxfixes,
+  libjack2,
   makeWrapper,
   copyDesktopItems,
   makeDesktopItem,
@@ -156,6 +158,8 @@ stdenv.mkDerivation rec {
     bzip2
     zlib
     libxpm
+    libxfixes
+    libjack2
     libgcc
   ];
 


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/516381

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

```
error: builder for '/nix/store/y9fh54wmz32lk7fszh28rm5hqrl80bkk-aw-webui-0.13.2.drv' failed with exit code 1;
       last 25 log lines:
       > Error: Cannot find module 'vue-template-compiler'
       > Require stack:
       > - /build/aw-webui/node_modules/@vue/vue2-jest/lib/process.js
       > - /build/aw-webui/node_modules/@vue/vue2-jest/lib/index.js
       > - /build/aw-webui/node_modules/jest-util/build/requireOrImportModule.js
       > - /build/aw-webui/node_modules/jest-util/build/index.js
       > - /build/aw-webui/node_modules/@jest/core/build/FailedTestsInteractiveMode.js
       > - /build/aw-webui/node_modules/@jest/core/build/plugins/FailedTestsInteractive.js
       > - /build/aw-webui/node_modules/@jest/core/build/watch.js
       > - /build/aw-webui/node_modules/@jest/core/build/cli/index.js
       > - /build/aw-webui/node_modules/@jest/core/build/index.js
       > - /build/aw-webui/node_modules/jest-cli/build/run.js
       > - /build/aw-webui/node_modules/jest-cli/build/index.js
       > - /build/aw-webui/node_modules/jest-cli/bin/jest.js
       > - /build/aw-webui/node_modules/jest/bin/jest.js
       >     at Module._resolveFilename (node:internal/modules/cjs/loader:1476:15)
       >     at wrapResolveFilename (node:internal/modules/cjs/loader:1049:27)
       >     at defaultResolveImplForCJSLoading (node:internal/modules/cjs/loader:1073:10)
       >     at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1094:12)
       >     at Module._load (node:internal/modules/cjs/loader:1262:25)
       >     at wrapModuleLoad (node:internal/modules/cjs/loader:255:19)
       >     at Module.require (node:internal/modules/cjs/loader:1576:12)
       >     at require (node:internal/modules/helpers:153:16)
       >     at Object.<anonymous> (/build/aw-webui/node_modules/@vue/vue2-jest/lib/process.js:1:29)
       >     at Module._compile (node:internal/modules/cjs/loader:1830:14)
       For full logs, run:
             nix log /nix/store/y9fh54wmz32lk7fszh28rm5hqrl80bkk-aw-webui-0.13.2.drv
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
