### PR TITLE
espresso: fix build

### DIFF
--- a/pkgs/by-name/es/espresso/package.nix
+++ b/pkgs/by-name/es/espresso/package.nix
@@ -15,6 +15,11 @@ stdenv.mkDerivation rec {
     hash = "sha256-z5By57VbmIt4sgRgvECnLbZklnDDWUA6fyvWVyXUzsI=";
   };
 
+  postPatch = ''
+    substituteInPlace utility/port.h \
+      --replace-fail "VOID_HACK srandom();" "VOID_HACK srandom(unsigned int __seed);"
+  '';
+
   nativeBuildInputs = [ cmake ];
 
   doCheck = true;


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/516381

```
build flags: -j1 SHELL=/nix/store/gik3rh1vz2jlgnifb9dh6vc6sxwwz9jj-bash-5.3p9/bin/bash
[  1%] Building C object CMakeFiles/utility.dir/utility/cpu_time.c.o
In file included from /build/source/utility/cpu_time.c:3:
/build/source/utility/port.h:158:18: error: conflicting types for 'srandom'; have 'void(void)'
  158 | extern VOID_HACK srandom();
      |                  ^~~~~~~
In file included from /build/source/utility/port.h:122:
/nix/store/15h9askp4k1lx44d9871wid23j2a8ijp-glibc-2.42-61-dev/include/stdlib.h:524:13: note: previous declaration of 'srandom' with type 'void(unsigned int)'
  524 | extern void srandom (unsigned int __seed) __THROW;
      |             ^~~~~~~
make[2]: *** [CMakeFiles/utility.dir/build.make:79: CMakeFiles/utility.dir/utility/cpu_time.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:90: CMakeFiles/utility.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
error: builder for '/nix/store/n24kj2f922g4a6zgnbcigrkasknwvfl8-espresso-2.4.drv' failed with exit code 2;
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
