### PR TITLE
exiftags: fix build

### DIFF
--- a/pkgs/by-name/ex/exiftags/package.nix
+++ b/pkgs/by-name/ex/exiftags/package.nix
@@ -15,6 +15,12 @@ stdenv.mkDerivation rec {
 
   patchPhase = ''
     sed -i -e s@/usr/local@$out@ Makefile
+
+    substituteInPlace makers.h \
+      --replace-fail "void (*propfun)();" "void (*propfun)(struct exifprop *, struct exiftags *);" \
+      --replace-fail "struct ifd *(*ifdfun)();" "struct ifd *(*ifdfun)(u_int32_t, struct tiffmeta *);"
+    substituteInPlace canon.c \
+      --replace-fail "int (*valfun)()" "int (*valfun)(struct exifprop *, struct exifprop *, unsigned char *, struct exiftags *)"
   '';
 
   preInstall = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- https://github.com/NixOS/nixpkgs/issues/516381

```
error: Cannot build '/nix/store/j19y43s3rkg80qsvjy8wsdsfx653y15h-exiftags-1.01.drv'.
       Reason: builder failed with exit code 2.
       Output paths:
         /nix/store/mx113f1427n8lhdbmh1x3dqmxghzz8s7-exiftags-1.01
       Last 20 log lines:
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/33d8z1lk98ypc7vpfl8n4vhad1xaxyml-exiftags-1.01.tar.gz
       > source root is exiftags-1.01
       > setting SOURCE_DATE_EPOCH to timestamp 1197776759 of file "exiftags-1.01/CHANGES"
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > build flags: SHELL=/nix/store/gik3rh1vz2jlgnifb9dh6vc6sxwwz9jj-bash-5.3p9/bin/bash
       > cc  -o exiftags.o -c exiftags.c
       > cc  -o exif.o -c exif.c
       > exif.c: In function 'parsetag':
       > exif.c:596:66: error: passing argument 1 of 'makers[(int)t->mkrval].ifdfun' makes pointer from integer without a cast [-Wint-conversion]
       >   596 |                                     makers[t->mkrval].ifdfun(prop->value, md);
       >       |                                                              ~~~~^~~~~~~
       >       |                                                                  |
       >       |                                                                  u_int32_t {aka unsigned int}
       > exif.c:596:66: note: expected 'void *' but argument is of type 'u_int32_t' {aka 'unsigned int'}
       > make: *** [Makefile:33: exif.o] Error 1
```
followed by
```
error: Cannot build '/nix/store/7ygc4mda2y1f26xyxchvn207a7ky6v3c-exiftags-1.01.drv'.
       Reason: builder failed with exit code 2.
       Output paths:
         /nix/store/s56675j045p39ffg6mgalgn8hxy2xg0j-exiftags-1.01
       Last 25 log lines:
       >   938 | canon_prop01(struct exifprop *aprop, struct exifprop *prop,
       >       | ^~~~~~~~~~~~
       > canon.c:1290:53: error: passing argument 4 of 'canon_subval' from incompatible pointer type [-Wincompatible-pointer-types]
       >  1290 |                 canon_subval(prop, t, canon_tags04, canon_prop04);
       >       |                                                     ^~~~~~~~~~~~
       >       |                                                     |
       >       |                                                     int (*)(struct exifprop *, struct exifprop *, unsigned char *, struct exiftags *)
       > canon.c:1107:36: note: expected 'int (*)(void)' but argument is of type 'int (*)(struct exifprop *, struct exifprop *, unsigned char *, struct exiftags *)'
       >  1107 |     struct exiftag *subtags, int (*valfun)())
       >       |                              ~~~~~~^~~~~~~~~
       > canon.c:1003:1: note: 'canon_prop04' declared here
       >  1003 | canon_prop04(struct exifprop *aprop, struct exifprop *prop,
       >       | ^~~~~~~~~~~~
       > canon.c:1294:58: error: passing argument 4 of 'canon_subval' from incompatible pointer type [-Wincompatible-pointer-types]
       >  1294 |                 if (!canon_subval(prop, t, canon_tagsA0, canon_propA0))
       >       |                                                          ^~~~~~~~~~~~
       >       |                                                          |
       >       |                                                          int (*)(struct exifprop *, struct exifprop *, unsigned char *, struct exiftags *)
       > canon.c:1107:36: note: expected 'int (*)(void)' but argument is of type 'int (*)(struct exifprop *, struct exifprop *, unsigned char *, struct exiftags *)'
       >  1107 |     struct exiftag *subtags, int (*valfun)())
       >       |                              ~~~~~~^~~~~~~~~
       > canon.c:1084:1: note: 'canon_propA0' declared here
       >  1084 | canon_propA0(struct exifprop *aprop, struct exifprop *prop,
       >       | ^~~~~~~~~~~~
       > make: *** [Makefile:33: canon.o] Error 1
       For full logs, run:
         nix log /nix/store/7ygc4mda2y1f26xyxchvn207a7ky6v3c-exiftags-1.01.drv
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
