### PR TITLE
prooftree: refactor

### DIFF
--- a/pkgs/by-name/pr/prooftree/package.nix
+++ b/pkgs/by-name/pr/prooftree/package.nix
@@ -2,31 +2,25 @@
   lib,
   stdenv,
   fetchurl,
-  pkg-config,
-  ncurses,
   ocamlPackages,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "prooftree";
   version = "0.14";
 
   src = fetchurl {
-    url = "https://askra.de/software/prooftree/releases/prooftree-${version}.tar.gz";
-    sha256 = "sha256-nekV2UnjibOk4h0jZ1jV7W5pE/hXWb3fUoLTJb3Jzc0=";
+    url = "https://askra.de/software/prooftree/releases/prooftree-${finalAttrs.version}.tar.gz";
+    hash = "sha256-nekV2UnjibOk4h0jZ1jV7W5pE/hXWb3fUoLTJb3Jzc0=";
   };
 
   strictDeps = true;
 
-  nativeBuildInputs = [
-    pkg-config
-  ]
-  ++ (with ocamlPackages; [
+  nativeBuildInputs = with ocamlPackages; [
     ocaml
     findlib
-    camlp5
-  ]);
-  buildInputs = [ ncurses ] ++ (with ocamlPackages; [ lablgtk ]);
+  ];
+  buildInputs = with ocamlPackages; [ lablgtk ];
 
   prefixKey = "--prefix ";
 
@@ -55,4 +49,4 @@ stdenv.mkDerivation rec {
     maintainers = [ lib.maintainers.jwiegley ];
     license = lib.licenses.gpl3;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11250,10 +11250,6 @@ with pkgs;
     inherit (ocaml-ng.ocamlPackages_4_14_unsafe_string) ocaml camlp4;
   };
 
-  prooftree = callPackage ../applications/science/logic/prooftree {
-    ocamlPackages = ocaml-ng.ocamlPackages_4_12;
-  };
-
   satallax = callPackage ../applications/science/logic/satallax {
     inherit (ocaml-ng.ocamlPackages_4_14) ocaml;
   };


### PR DESCRIPTION
Move to pkgs/by-name/
Build with default version of OCaml
Use finalAttrs pattern
Remove unused dependencies

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
