### PR TITLE
python3Packages.pylance: 6.0.1 -> 7.0.0

### DIFF
--- a/pkgs/development/python-modules/lancedb/default.nix
+++ b/pkgs/development/python-modules/lancedb/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage (finalAttrs: {
     owner = "lancedb";
     repo = "lancedb";
     tag = "python-v${finalAttrs.version}";
-    hash = "sha256-oXKlpgGACMVn/86PWQng9NXHpCzdjzikVzVfoAgvQJQ=";
+    hash = "sha256-OIoQCk0YlWpaaau4AiWxarvH4oy1rAjaS9yvs3mIzzo=";
   };
 
   buildAndTestSubdir = "python";

--- a/pkgs/development/python-modules/pylance/default.nix
+++ b/pkgs/development/python-modules/pylance/default.nix
@@ -34,7 +34,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pylance";
-  version = "6.0.1";
+  version = "7.0.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -42,7 +42,7 @@ buildPythonPackage (finalAttrs: {
     owner = "lancedb";
     repo = "lance";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-n9x4Q1UlIuVWcDTdJd72JyQk/nuFMsWfzK2OmoO9wbU=";
+    hash = "sha256-wOFfG2CPt292WkdLUM+5Rl0OKej9b8WzV9LRpCoao3M=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/python";
@@ -54,7 +54,7 @@ buildPythonPackage (finalAttrs: {
       src
       sourceRoot
       ;
-    hash = "sha256-b2O38ZKks6oiBAtUx0fTtFSy5nbsZCZD/BmeJY5zda8=";
+    hash = "sha256-8ngtq1AlOj0ZgiAwsibz1MGxSJ8kfIbXCafsIneOMqA=";
   };
 
   nativeBuildInputs = [
@@ -135,6 +135,7 @@ buildPythonPackage (finalAttrs: {
     "test_lance_log_file"
     "test_lance_log_file_invalid_path"
     "test_lance_log_file_with_directory_creation"
+    "test_lance_log_filters_trace_event_targets"
     "test_timestamp_precision"
     "test_tracing"
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/lancedb/lance/compare/v6.0.1...v7.0.0
Changelog: https://github.com/lancedb/lance/releases/tag/v7.0.0

cc @natsukium

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test