### PR TITLE
reaction: 2.3.1 -> 2.4.0

### DIFF
--- a/pkgs/by-name/re/reaction/nftables-aarch64-linux-compat.patch
+++ b/pkgs/by-name/re/reaction/nftables-aarch64-linux-compat.patch
@@ -1,0 +1,33 @@
+From 94fafae651077be5e7a6dfd29fc06327a2f218ed Mon Sep 17 00:00:00 2001
+From: ppom <reaction@ppom.me>
+Date: Thu, 28 May 2026 12:00:00 +0200
+Subject: [PATCH] nftables: fix compilation on aarch64-linux
+
+---
+ plugins/reaction-plugin-nftables/src/nft.rs | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/plugins/reaction-plugin-nftables/src/nft.rs b/plugins/reaction-plugin-nftables/src/nft.rs
+index c234f77..2ac49df 100644
+--- a/plugins/reaction-plugin-nftables/src/nft.rs
++++ b/plugins/reaction-plugin-nftables/src/nft.rs
+@@ -1,5 +1,6 @@
+ use std::{
+     ffi::{CStr, CString},
++    os::raw::c_char,
+     thread,
+ };
+ 
+@@ -71,7 +72,7 @@ struct NftCommand {
+     ret: oneshot::Sender<Result<String, String>>,
+ }
+ 
+-fn to_rust_string(c_ptr: *const i8) -> Option<String> {
++fn to_rust_string(c_ptr: *const c_char) -> Option<String> {
+     if c_ptr.is_null() {
+         None
+     } else {
+-- 
+GitLab
+
+

--- a/pkgs/by-name/re/reaction/package.nix
+++ b/pkgs/by-name/re/reaction/package.nix
@@ -66,7 +66,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru = {
     inherit (callPackage ./plugins { }) mkReactionPlugin plugins;
     updateScript = nix-update-script { };
-    tests = nixosTests.reaction;
+    tests = {
+      inherit (nixosTests) reaction;
+    }
+    // finalAttrs.passthru.plugins;
   };
 
   meta = {

--- a/pkgs/by-name/re/reaction/package.nix
+++ b/pkgs/by-name/re/reaction/package.nix
@@ -13,17 +13,17 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "reaction";
-  version = "2.3.1";
+  version = "2.4.0";
 
   src = fetchFromGitLab {
     domain = "framagit.org";
     owner = "ppom";
     repo = "reaction";
-    rev = "c0868d6fe1d155de183a89729b5f3f0ede7be4a2"; # TODO: return to tagged release
-    hash = "sha256-QlSXZ2Wk1OXzAY2x6YjtW+xNchY+Ghb/6AsJgjfgoFE=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Y6scgbcwhg56SQ1DefNtdja+n89Gc5bJUHKHKn2EYwQ=";
   };
 
-  cargoHash = "sha256-FYd7I93MAAzD6y0VMd9kMU7DAgS6v5CKt2KjrskaKeo=";
+  cargoHash = "sha256-NAcMpASvphAqjBjbAPWLG5qZbSgdaFC3GvU25exCS3g=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/re/reaction/package.nix
+++ b/pkgs/by-name/re/reaction/package.nix
@@ -4,6 +4,7 @@
   callPackage,
   rustPlatform,
   fetchFromGitLab,
+  fetchpatch,
 
   versionCheckHook,
   installShellFiles,
@@ -22,6 +23,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-Y6scgbcwhg56SQ1DefNtdja+n89Gc5bJUHKHKn2EYwQ=";
   };
+
+  patches = [
+    # nftables: fix compilation on aarch64-linux; remove in 2.4.1
+    ./nftables-aarch64-linux-compat.patch
+  ];
 
   cargoHash = "sha256-NAcMpASvphAqjBjbAPWLG5qZbSgdaFC3GvU25exCS3g=";
 

--- a/pkgs/by-name/re/reaction/plugins/default.nix
+++ b/pkgs/by-name/re/reaction/plugins/default.nix
@@ -12,7 +12,12 @@
     rustPlatform.buildRustPackage (
       {
         pname = name;
-        inherit (reaction) version src cargoHash;
+        inherit (reaction)
+          version
+          src
+          patches
+          cargoHash
+          ;
         buildAndTestSubdir = "plugins/${name}";
 
         meta = {


### PR DESCRIPTION
https://framagit.org/ppom/reaction/-/releases/v2.4.0

Making sure we return to a release. Thanks for all the guidance last time round!


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
