### PR TITLE
libredwg: 0.13.3 -> 0.13.4.8200 [backport release-25.11]

### DIFF
--- a/pkgs/by-name/li/libredwg/package.nix
+++ b/pkgs/by-name/li/libredwg/package.nix
@@ -18,13 +18,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "libredwg";
-  version = "0.13.3";
+  version = "0.13.4";
 
   src = fetchFromGitHub {
     owner = "LibreDWG";
     repo = "libredwg";
     tag = version;
-    hash = "sha256-FlBHwNsqVSBE8dTDewoKkCbs8Jd/4d69MPpEFzg6Ruc=";
+    hash = "sha256-FeDQCByFGKfHJDOPQA92GslXZ33nhGfB6/63t2TeugE=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/li/libredwg/package.nix
+++ b/pkgs/by-name/li/libredwg/package.nix
@@ -18,13 +18,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "libredwg";
-  version = "0.13.4";
+  version = "0.13.4.8200";
 
   src = fetchFromGitHub {
     owner = "LibreDWG";
     repo = "libredwg";
     tag = version;
-    hash = "sha256-FeDQCByFGKfHJDOPQA92GslXZ33nhGfB6/63t2TeugE=";
+    hash = "sha256-HaQvJyuEeaTfuUJbmlV4qcfXiLdHJ2vO4EGInwAKJYk=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
## Summary

Backport of #525031 to release-25.11.

Update libredwg to latest pre-release 0.13.4.8200 to fix 8 security vulnerabilities:

- **CVE-2026-9500**: heap-buffer-overflow in `decode.c` (`decompress_R2004_section`) — [upstream](https://github.com/LibreDWG/libredwg/issues/1003), fixes #524384
- **CVE-2026-9501**: heap-buffer-overflow in `decode.c` (`read_2004_compressed_section`) — [upstream](https://github.com/LibreDWG/libredwg/issues/1004), fixes #524385
- **CVE-2026-9502**: heap-buffer-overflow in `decode.c` (`decompress_R2004_section`) — [upstream](https://github.com/LibreDWG/libredwg/issues/1005), fixes #524380
- **CVE-2026-9503**: heap-buffer-overflow in `decode.c` (`decompress_R2004_section`) — [upstream](https://github.com/LibreDWG/libredwg/issues/1006), fixes #524381
- **CVE-2026-9504**: null pointer dereference in `dwggrep.c` (`main`) — [upstream](https://github.com/LibreDWG/libredwg/issues/1007), fixes #524382
- **CVE-2026-9529**: heap-buffer-overflow in `decode.c` (`decompress_R2004_section`) — [upstream](https://github.com/LibreDWG/libredwg/issues/1009), fixes #524788
- **CVE-2026-9530**: heap-buffer-overflow in `decode.c` (`read_2004_compressed_section`) — [upstream](https://github.com/LibreDWG/libredwg/issues/1010), fixes #524773
- **CVE-2026-9605**: heap-buffer-overflow in `bits.c` (`bit_read_RC`) — [upstream](https://github.com/LibreDWG/libredwg/issues/1011), fixes #524780

release-25.11 had 0.13.3 so the cherry-pick from master required manual conflict resolution (version and hash lines).

## Test plan

- [x] `nix-build` and PoC verification done on master PR (#525031)
- [ ] nixpkgs-review on this backport

cc @NixOS/security