### PR TITLE
webwormhole: 0-unstable-2023-11-15 -> 0-unstable-2025-12-22

### DIFF
--- a/pkgs/by-name/we/webwormhole/package.nix
+++ b/pkgs/by-name/we/webwormhole/package.nix
@@ -6,16 +6,16 @@
 
 buildGoModule {
   pname = "webwormhole";
-  version = "0-unstable-2023-11-15";
+  version = "0-unstable-2025-12-22";
 
   src = fetchFromGitHub {
     owner = "saljam";
     repo = "webwormhole";
-    rev = "6ceee76274ee881e828bd48c5cc15c758b9ad77c";
-    hash = "sha256-C9r6wFhP5BkIClgTQol7LyMUHXOzyrX9Pn91VqBaqFQ=";
+    rev = "abf852af0458ba79772d9c26ef01434165f217d8";
+    hash = "sha256-hP5MtIoGod3FS4TipNkgoyo43HWnywPintqpjmvrTc8=";
   };
 
-  vendorHash = "sha256-+7ctAm2wnjmfMd6CHXlcAUwiUMS7cH4koDAvlEUAXEg=";
+  vendorHash = "sha256-ULlaicl4o/YyHSS64Q2hsl5l5Mm3C6cBG8zaxrEijOU=";
 
   meta = {
     description = "Send files using peer authenticated WebRTC";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Updated webwormhole to the latest revision from 2025-12-22.
The default signal server changed from https://webwormhole.io to https://webwormhole.com, so the old version did not work anymore without changing the signal server explicitly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
