### PR TITLE
[Backport release-25.11] gh: 2.83.2 ->2.93.0 

### DIFF
--- a/pkgs/by-name/gh/gh/package.nix
+++ b/pkgs/by-name/gh/gh/package.nix
@@ -10,13 +10,13 @@
 
 buildGoModule rec {
   pname = "gh";
-  version = "2.85.0";
+  version = "2.86.0";
 
   src = fetchFromGitHub {
     owner = "cli";
     repo = "cli";
     tag = "v${version}";
-    hash = "sha256-XngvPEVrUNKuNs+9/osXEagwqe0KW25xFwEjcPfMO0M=";
+    hash = "sha256-+MPhDgXIVfYGp5ALI5GjRoeLRRUtNgpzUawxoqR76iE=";
   };
 
   vendorHash = "sha256-pBHEqMgEoR3sWNbQjGBNso7WLP9Rz2gu89Bzu+7jz5c=";

--- a/pkgs/by-name/gh/gh/package.nix
+++ b/pkgs/by-name/gh/gh/package.nix
@@ -10,16 +10,16 @@
 
 buildGoModule rec {
   pname = "gh";
-  version = "2.83.2";
+  version = "2.85.0";
 
   src = fetchFromGitHub {
     owner = "cli";
     repo = "cli";
     tag = "v${version}";
-    hash = "sha256-YpbxdD+83pK326EmwLCzUh+wASdOjuCqSP2eXIJndxI=";
+    hash = "sha256-XngvPEVrUNKuNs+9/osXEagwqe0KW25xFwEjcPfMO0M=";
   };
 
-  vendorHash = "sha256-AkcbtVR1+uYy2AtRl1hvUBBF8vI3hH4NXznmgwmAzmw=";
+  vendorHash = "sha256-pBHEqMgEoR3sWNbQjGBNso7WLP9Rz2gu89Bzu+7jz5c=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/gh/gh/package.nix
+++ b/pkgs/by-name/gh/gh/package.nix
@@ -1,25 +1,25 @@
 {
   lib,
   fetchFromGitHub,
-  buildGoModule,
+  buildGo126Module,
   installShellFiles,
   stdenv,
   testers,
   gh,
 }:
 
-buildGoModule rec {
+buildGo126Module rec {
   pname = "gh";
-  version = "2.87.3";
+  version = "2.88.1";
 
   src = fetchFromGitHub {
     owner = "cli";
     repo = "cli";
     tag = "v${version}";
-    hash = "sha256-F4xUwj/krB5vjIfnvmwySlztBrcxJ+k1GvXb2gs7eXY=";
+    hash = "sha256-aM5hpkI4MTQ6eNUB4FVNQRSNUmwI84dTdVMUANtrnJk=";
   };
 
-  vendorHash = "sha256-POrm4lHEO2Eti7dbohKBwXW+DTs22EUZX+tMNUCL3lg=";
+  vendorHash = "sha256-RD40Lqg6EF0T12JJ7Y4B5L2KIvwRHcgGRU1UMiU3qTo=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/gh/gh/package.nix
+++ b/pkgs/by-name/gh/gh/package.nix
@@ -7,7 +7,6 @@
   testers,
   gh,
   makeWrapper,
-  enableTelemetry ? false,
 }:
 
 buildGo126Module rec {
@@ -39,10 +38,8 @@ buildGo126Module rec {
   installPhase = ''
     runHook preInstall
     install -Dm755 bin/gh -t $out/bin
-  ''
-  + lib.optionalString (!enableTelemetry) ''
     wrapProgram $out/bin/gh \
-      --set GH_TELEMETRY false
+      --set-default GH_TELEMETRY false
   ''
   + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installManPage share/man/*/*.[1-9]

--- a/pkgs/by-name/gh/gh/package.nix
+++ b/pkgs/by-name/gh/gh/package.nix
@@ -10,13 +10,13 @@
 
 buildGoModule rec {
   pname = "gh";
-  version = "2.87.2";
+  version = "2.87.3";
 
   src = fetchFromGitHub {
     owner = "cli";
     repo = "cli";
     tag = "v${version}";
-    hash = "sha256-QPQVsdZy17rNX5ACoKHiJG+f/2CAiBfO3B1ucton0tw=";
+    hash = "sha256-F4xUwj/krB5vjIfnvmwySlztBrcxJ+k1GvXb2gs7eXY=";
   };
 
   vendorHash = "sha256-POrm4lHEO2Eti7dbohKBwXW+DTs22EUZX+tMNUCL3lg=";

--- a/pkgs/by-name/gh/gh/package.nix
+++ b/pkgs/by-name/gh/gh/package.nix
@@ -10,16 +10,16 @@
 
 buildGoModule rec {
   pname = "gh";
-  version = "2.86.0";
+  version = "2.87.2";
 
   src = fetchFromGitHub {
     owner = "cli";
     repo = "cli";
     tag = "v${version}";
-    hash = "sha256-+MPhDgXIVfYGp5ALI5GjRoeLRRUtNgpzUawxoqR76iE=";
+    hash = "sha256-QPQVsdZy17rNX5ACoKHiJG+f/2CAiBfO3B1ucton0tw=";
   };
 
-  vendorHash = "sha256-pBHEqMgEoR3sWNbQjGBNso7WLP9Rz2gu89Bzu+7jz5c=";
+  vendorHash = "sha256-POrm4lHEO2Eti7dbohKBwXW+DTs22EUZX+tMNUCL3lg=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/gh/gh/package.nix
+++ b/pkgs/by-name/gh/gh/package.nix
@@ -10,16 +10,16 @@
 
 buildGo126Module rec {
   pname = "gh";
-  version = "2.88.1";
+  version = "2.89.0";
 
   src = fetchFromGitHub {
     owner = "cli";
     repo = "cli";
     tag = "v${version}";
-    hash = "sha256-aM5hpkI4MTQ6eNUB4FVNQRSNUmwI84dTdVMUANtrnJk=";
+    hash = "sha256-SiPcji8CbJd6GwWmsIFWq3874Mr9/VggOATX9yKYjow=";
   };
 
-  vendorHash = "sha256-RD40Lqg6EF0T12JJ7Y4B5L2KIvwRHcgGRU1UMiU3qTo=";
+  vendorHash = "sha256-Sko+jTkGUTiR66Mv/p5INv/CLID1EK2v9fY0GfIeckg=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/gh/gh/package.nix
+++ b/pkgs/by-name/gh/gh/package.nix
@@ -11,16 +11,16 @@
 
 buildGo126Module rec {
   pname = "gh";
-  version = "2.92.0";
+  version = "2.93.0";
 
   src = fetchFromGitHub {
     owner = "cli";
     repo = "cli";
     tag = "v${version}";
-    hash = "sha256-/7EiX4ZZPhSNgY/D5OVOako/c0ujHq05GMj3UB11bqQ=";
+    hash = "sha256-r/+JFdMOUIb32St+VkUw+Q7Lb2L6IiPczmONFE4hwDw=";
   };
 
-  vendorHash = "sha256-pBLRCIRjN3VoXbTFSq+R9/N3uAUCEjvPtk8LKKKS51s=";
+  vendorHash = "sha256-eMPcla1XKfq+zBb633Zz4cn820FWuEaRrXQJ1TQ8Lkg=";
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/by-name/gh/gh/package.nix
+++ b/pkgs/by-name/gh/gh/package.nix
@@ -63,6 +63,7 @@ buildGo126Module rec {
     maintainers = with lib.maintainers; [
       mdaniels5757
       zowoq
+      savtrip
     ];
   };
 }

--- a/pkgs/by-name/gh/gh/package.nix
+++ b/pkgs/by-name/gh/gh/package.nix
@@ -12,16 +12,16 @@
 
 buildGo126Module rec {
   pname = "gh";
-  version = "2.91.0";
+  version = "2.92.0";
 
   src = fetchFromGitHub {
     owner = "cli";
     repo = "cli";
     tag = "v${version}";
-    hash = "sha256-2ggQd2sCybdtNGwiP7+GqB1CwZDNA/bDq24NC5btNFU=";
+    hash = "sha256-/7EiX4ZZPhSNgY/D5OVOako/c0ujHq05GMj3UB11bqQ=";
   };
 
-  vendorHash = "sha256-4xZAcwn9/vUTkahIlqwyGb/2SYYGusdXY4nye8ldp/g=";
+  vendorHash = "sha256-pBLRCIRjN3VoXbTFSq+R9/N3uAUCEjvPtk8LKKKS51s=";
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/by-name/gh/gh/package.nix
+++ b/pkgs/by-name/gh/gh/package.nix
@@ -10,16 +10,16 @@
 
 buildGo126Module rec {
   pname = "gh";
-  version = "2.89.0";
+  version = "2.90.0";
 
   src = fetchFromGitHub {
     owner = "cli";
     repo = "cli";
     tag = "v${version}";
-    hash = "sha256-SiPcji8CbJd6GwWmsIFWq3874Mr9/VggOATX9yKYjow=";
+    hash = "sha256-yVc4UvC+CsW+pP/BJRjcOGX7h8zO2M8yM0m57Mr89JY=";
   };
 
-  vendorHash = "sha256-Sko+jTkGUTiR66Mv/p5INv/CLID1EK2v9fY0GfIeckg=";
+  vendorHash = "sha256-hz6oMLTibnSLB11vEWsO0O5ZFGKYJaVce6POqINObnI=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/gh/gh/package.nix
+++ b/pkgs/by-name/gh/gh/package.nix
@@ -10,16 +10,16 @@
 
 buildGo126Module rec {
   pname = "gh";
-  version = "2.90.0";
+  version = "2.91.0";
 
   src = fetchFromGitHub {
     owner = "cli";
     repo = "cli";
     tag = "v${version}";
-    hash = "sha256-yVc4UvC+CsW+pP/BJRjcOGX7h8zO2M8yM0m57Mr89JY=";
+    hash = "sha256-2ggQd2sCybdtNGwiP7+GqB1CwZDNA/bDq24NC5btNFU=";
   };
 
-  vendorHash = "sha256-hz6oMLTibnSLB11vEWsO0O5ZFGKYJaVce6POqINObnI=";
+  vendorHash = "sha256-4xZAcwn9/vUTkahIlqwyGb/2SYYGusdXY4nye8ldp/g=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/gh/gh/package.nix
+++ b/pkgs/by-name/gh/gh/package.nix
@@ -6,6 +6,8 @@
   stdenv,
   testers,
   gh,
+  makeWrapper,
+  enableTelemetry ? false,
 }:
 
 buildGo126Module rec {
@@ -21,7 +23,10 @@ buildGo126Module rec {
 
   vendorHash = "sha256-4xZAcwn9/vUTkahIlqwyGb/2SYYGusdXY4nye8ldp/g=";
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+  ];
 
   # N.B.: using the Makefile is intentional.
   # We pass "nixpkgs" for build.Date to avoid `gh --version` reporting a very old date.
@@ -34,6 +39,10 @@ buildGo126Module rec {
   installPhase = ''
     runHook preInstall
     install -Dm755 bin/gh -t $out/bin
+  ''
+  + lib.optionalString (!enableTelemetry) ''
+    wrapProgram $out/bin/gh \
+      --set GH_TELEMETRY false
   ''
   + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installManPage share/man/*/*.[1-9]


### PR DESCRIPTION
Backport of:
- #480147
- #482409
- #493028
- #493858
- #499873
- #503005
- #503878
- #510703
- #512533
- #515047
- #515103
- #515125
- #525026

Release notes: https://github.com/cli/cli/releases

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
