### PR TITLE
linux: add stable staging-nixos workflow

### DIFF
--- a/.github/workflows/periodic-merge-24h.yml
+++ b/.github/workflows/periodic-merge-24h.yml
@@ -35,10 +35,14 @@ jobs:
             into: staging-next-25.11
           - from: staging-next-25.11
             into: staging-25.11
+          - from: release-25.11
+            into: staging-nixos-25.11
           - from: release-26.05
             into: staging-next-26.05
           - from: staging-next-26.05
             into: staging-26.05
+          - from: release-26.05
+            into: staging-nixos-26.05
           - name: merge-base(master,staging) → haskell-updates
             from: master staging
             into: haskell-updates

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -442,6 +442,7 @@ The staging workflow is used for all stable branches with corresponding names:
 - `master`/`release-YY.MM`
 - `staging`/`staging-YY.MM`
 - `staging-next`/`staging-next-YY.MM`
+- `staging-nixos`/`staging-nixos-YY.MM`
 
 [^1]: Except changes that cause no more rebuilds than kernel updates
 
@@ -505,7 +506,7 @@ These PRs go to `staging-nixos`, see [the next section for more context](#change
 Changes causing a rebuild of all NixOS tests get a special [`10.rebuild-nixos-tests`](https://github.com/NixOS/nixpkgs/issues?q=state%3Aopen%20label%3A10.rebuild-nixos-tests) label.
 These changes pose a significant impact on the build infrastructure.
 
-Hence, these PRs should either target a `staging`-branch or `staging-nixos`, provided one of following conditions applies:
+Hence, these PRs should either target a `staging`-branch or `staging-nixos`-branch, provided one of following conditions applies:
 
 * The label `10.rebuild-nixos-tests` is set, or
 * The PR is a change affecting the Linux kernel.

--- a/ci/github-script/check-target-branch.js
+++ b/ci/github-script/check-target-branch.js
@@ -102,9 +102,8 @@ async function checkTargetBranch({ github, context, core, dry }) {
     changed.attrdiff.changed.includes('nixosTests.simple-container') ||
     changed.attrdiff.changed.includes('nixosTests.simple-vm')
 
-  // https://github.com/NixOS/nixpkgs/pull/481205#issuecomment-3790123921
-  // These should go to staging-nixos instead of master,
-  // but release-xx.xx (not staging-xx.xx) when backported
+  // https://github.com/NixOS/nixpkgs/pull/521157
+  // These should go to master and release-xx.xx when backported
   let isExemptKernelUpdate = false
   if (prInfo.changed_files === 1) {
     const changedFiles = (
@@ -115,11 +114,8 @@ async function checkTargetBranch({ github, context, core, dry }) {
     ).data
     isExemptKernelUpdate =
       changedFiles.length === 1 &&
-      (changedFiles[0].filename ===
-        'pkgs/os-specific/linux/kernel/xanmod-kernels.nix' ||
-        (base.startsWith('release-') &&
-          changedFiles[0].filename ===
-            'pkgs/os-specific/linux/kernel/kernels-org.json'))
+      changedFiles[0].filename ===
+        'pkgs/os-specific/linux/kernel/xanmod-kernels.nix'
   }
 
   // https://github.com/NixOS/nixpkgs/pull/483194#issuecomment-3793393218
@@ -164,8 +160,10 @@ async function checkTargetBranch({ github, context, core, dry }) {
       branchText = '(probably either `staging-nixos` or `staging`)'
     } else if (base === 'master') {
       branchText = '(probably `staging-nixos`)'
+    } else if (maxRebuildCount >= 500) {
+      branchText = `(probably either \`staging-nixos-${split(base).version}\` or \`staging-${split(base).version}\`)`
     } else {
-      branchText = `(probably \`staging-${split(base).version}\`)`
+      branchText = `(probably \`staging-nixos-${split(base).version}\`)`
     }
     const body = [
       `The PR's base branch is set to \`${base}\`, but this PR rebuilds all NixOS tests.`,

--- a/doc/packages/linux.section.md
+++ b/doc/packages/linux.section.md
@@ -119,11 +119,10 @@ $ pkgs/os-specific/linux/kernel/update.sh
 The change gets submitted like this:
 
 * File a PR against `staging-nixos`.
-  * Add a `backport release-XX.XX` label for an automated backport.
-    We don't expect many other changes on that branch to require a backport, hence there's no such branch for stable.
+  * Add a `backport staging-nixos-XX.XX` label for an automated backport.
     By using an additional PR, we get the automatic backport against stable without manual cherry-picks.
-* Merge into `staging-nixos`.
-* File as PR from `staging-nixos` against `master`.
+* Merge into `staging-nixos` or `staging-nixos-XX.XX`.
+* File as PR from `staging-nixos` against `master` or `staging-nixos-XX.XX` against `release-xx.xx`.
 * When all status checks are green, merge.
 
 ### Add a new (major) version of the Linux kernel {#sec-linux-add-new-kernel-version}


### PR DESCRIPTION
stable counterpart to https://github.com/NixOS/nixpkgs/commit/d28cc2a2f5922960861a0c3d08b7ef05cbd47694

Closes #512923

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
