### PR TITLE
python3Packages.ocrmypdf: 17.4.2 -> 17.5.0

### DIFF
--- a/pkgs/development/python-modules/ocrmypdf/default.nix
+++ b/pkgs/development/python-modules/ocrmypdf/default.nix
@@ -32,7 +32,7 @@
 
 buildPythonPackage rec {
   pname = "ocrmypdf";
-  version = "17.4.2";
+  version = "17.5.0";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     postFetch = ''
       rm "$out/.git_archival.txt"
     '';
-    hash = "sha256-UH05Q80FgbHzCvTnMX/J5LXGb7mNj5giLIx+8FdbKfU=";
+    hash = "sha256-t8uczNeuGgFRMToXNn/aX/eXlfeDU5Hgq82gJl9zB1E=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/ocrmypdf/paths.patch
+++ b/pkgs/development/python-modules/ocrmypdf/paths.patch
@@ -1,8 +1,8 @@
 diff --git a/src/ocrmypdf/_exec/ghostscript.py b/src/ocrmypdf/_exec/ghostscript.py
-index ec9017ca..0986641d 100644
+index 5afd6e17..0db47849 100644
 --- a/src/ocrmypdf/_exec/ghostscript.py
 +++ b/src/ocrmypdf/_exec/ghostscript.py
-@@ -35,7 +35,7 @@ COLOR_CONVERSION_STRATEGIES = frozenset(
+@@ -36,7 +36,7 @@ COLOR_CONVERSION_STRATEGIES = frozenset(
      ]
  )
  # Ghostscript executable - gswin32c is not supported
@@ -12,19 +12,19 @@ index ec9017ca..0986641d 100644
  
  log = logging.getLogger(__name__)
 diff --git a/src/ocrmypdf/_exec/jbig2enc.py b/src/ocrmypdf/_exec/jbig2enc.py
-index 736de67e..d8c24ebd 100644
+index 9f107a07..469aed48 100644
 --- a/src/ocrmypdf/_exec/jbig2enc.py
 +++ b/src/ocrmypdf/_exec/jbig2enc.py
-@@ -15,7 +15,7 @@ from ocrmypdf.subprocess import get_version, run
+@@ -13,7 +13,7 @@ from ocrmypdf._exec._probe import ToolProbe
+ from ocrmypdf.exceptions import MissingDependencyError
+ from ocrmypdf.subprocess import run
+ 
+-_PROBE = ToolProbe(program='jbig2', version_regex=r'jbig2enc (\d+(\.\d+)*).*')
++_PROBE = ToolProbe(program='@jbig2@', version_regex=r'jbig2enc (\d+(\.\d+)*).*')
+ 
  
  def version() -> Version:
-     try:
--        version = get_version('jbig2', regex=r'jbig2enc (\d+(\.\d+)*).*')
-+        version = get_version('@jbig2@', regex=r'jbig2enc (\d+(\.\d+)*).*')
-     except CalledProcessError as e:
-         # TeX Live for Windows provides an incompatible jbig2.EXE which may
-         # be on the PATH.
-@@ -32,7 +32,7 @@ def available():
+@@ -34,7 +34,7 @@ def available() -> bool:
  
  
  def convert_single(cwd, infile, outfile, threshold):
@@ -34,19 +34,19 @@ index 736de67e..d8c24ebd 100644
          proc = run(args, cwd=cwd, stdout=fstdout, stderr=PIPE)
      proc.check_returncode()
 diff --git a/src/ocrmypdf/_exec/pngquant.py b/src/ocrmypdf/_exec/pngquant.py
-index 5b8600d0..fcad771b 100644
+index 94bcdbf0..c0ae0fa3 100644
 --- a/src/ocrmypdf/_exec/pngquant.py
 +++ b/src/ocrmypdf/_exec/pngquant.py
-@@ -15,7 +15,7 @@ from ocrmypdf.subprocess import get_version, run
+@@ -11,7 +11,7 @@ from subprocess import PIPE
+ from ocrmypdf._exec._probe import ToolProbe
+ from ocrmypdf.subprocess import run
  
+-PROBE = ToolProbe(program='pngquant', version_regex=r'(\d+(\.\d+)*).*')
++PROBE = ToolProbe(program='@pngquant@', version_regex=r'(\d+(\.\d+)*).*')
+ version = PROBE.version
+ available = PROBE.available
  
- def version() -> Version:
--    return Version(get_version('pngquant', regex=r'(\d+(\.\d+)*).*'))
-+    return Version(get_version('@pngquant@', regex=r'(\d+(\.\d+)*).*'))
- 
- 
- def available():
-@@ -37,7 +37,7 @@ def quantize(input_file: Path, output_file: Path, quality_min: int, quality_max:
+@@ -27,7 +27,7 @@ def quantize(input_file: Path, output_file: Path, quality_min: int, quality_max:
      """
      with open(input_file, 'rb') as input_stream:
          args = [
@@ -56,19 +56,19 @@ index 5b8600d0..fcad771b 100644
              '--skip-if-larger',
              '--quality',
 diff --git a/src/ocrmypdf/_exec/tesseract.py b/src/ocrmypdf/_exec/tesseract.py
-index d41a0af7..b189b0de 100644
+index 861f2d50..010ef6a6 100644
 --- a/src/ocrmypdf/_exec/tesseract.py
 +++ b/src/ocrmypdf/_exec/tesseract.py
-@@ -116,7 +116,7 @@ class TesseractVersion(Version):
+@@ -117,7 +117,7 @@ class TesseractVersion(Version):
  
  
- def version() -> Version:
--    return TesseractVersion(get_version('tesseract', regex=r'tesseract\s(.+)'))
-+    return TesseractVersion(get_version('@tesseract@', regex=r'tesseract\s(.+)'))
- 
- 
- def has_thresholding() -> bool:
-@@ -134,7 +134,7 @@ def get_languages() -> set[str]:
+ PROBE = ToolProbe(
+-    program='tesseract',
++    program='@tesseract@',
+     version_regex=r'tesseract\s(.+)',
+     version_cls=TesseractVersion,
+ )
+@@ -140,7 +140,7 @@ def get_languages() -> set[str]:
          msg += output
          return msg
  
@@ -77,7 +77,7 @@ index d41a0af7..b189b0de 100644
      try:
          proc = run(
              args_tess,
-@@ -156,7 +156,7 @@ def get_languages() -> set[str]:
+@@ -162,7 +162,7 @@ def get_languages() -> set[str]:
  
  
  def tess_base_args(langs: list[str], engine_mode: int | None) -> list[str]:
@@ -87,19 +87,19 @@ index d41a0af7..b189b0de 100644
          args.extend(['-l', '+'.join(langs)])
      if engine_mode is not None:
 diff --git a/src/ocrmypdf/_exec/unpaper.py b/src/ocrmypdf/_exec/unpaper.py
-index 065fc9ef..4fab9313 100644
+index 54bf6a24..5d8ee18a 100644
 --- a/src/ocrmypdf/_exec/unpaper.py
 +++ b/src/ocrmypdf/_exec/unpaper.py
-@@ -47,7 +47,7 @@ class UnpaperImageTooLargeError(Exception):
+@@ -46,7 +46,7 @@ class UnpaperImageTooLargeError(Exception):
+         super().__init__(self.message)
  
  
- def version() -> Version:
--    return Version(get_version('unpaper', regex=r'(?m).*?(\d+(\.\d+)(\.\d+)?)'))
-+    return Version(get_version('@unpaper@', regex=r'(?m).*?(\d+(\.\d+)(\.\d+)?)'))
+-PROBE = ToolProbe(program='unpaper', version_regex=r'(?m).*?(\d+(\.\d+)(\.\d+)?)')
++PROBE = ToolProbe(program='@unpaper@', version_regex=r'(?m).*?(\d+(\.\d+)(\.\d+)?)')
+ version = PROBE.version
+ available = PROBE.available
  
- 
- @contextmanager
-@@ -69,7 +69,7 @@ def _setup_unpaper_io(input_file: Path) -> Iterator[tuple[Path, Path, Path]]:
+@@ -70,7 +70,7 @@ def _setup_unpaper_io(input_file: Path) -> Iterator[tuple[Path, Path, Path]]:
  def run_unpaper(
      input_file: Path, output_file: Path, *, dpi: DecFloat, mode_args: list[str]
  ) -> None:


### PR DESCRIPTION
Diff: https://github.com/ocrmypdf/OCRmyPDF/compare/v17.4.2...v17.5.0

Changelog: https://github.com/ocrmypdf/OCRmyPDF/blob/v17.5.0/docs/releasenotes/version17.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
