### PR TITLE
verapdf: 1.28.2 -> 1.30.1

### DIFF
--- a/pkgs/by-name/ve/verapdf-gui/package.nix
+++ b/pkgs/by-name/ve/verapdf-gui/package.nix
@@ -1,0 +1,5 @@
+{ verapdf }:
+verapdf.override {
+  withCli = false;
+  withGui = true;
+}

--- a/pkgs/by-name/ve/verapdf/package.nix
+++ b/pkgs/by-name/ve/verapdf/package.nix
@@ -7,6 +7,7 @@
   makeDesktopItem,
   copyDesktopItems,
   jre,
+  versionCheckHook,
 }:
 maven.buildMavenPackage rec {
   pname = "verapdf";
@@ -73,6 +74,18 @@ maven.buildMavenPackage rec {
       mimeTypes = [ "application/pdf" ];
     })
   ];
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  versionCheckProgram = "${placeholder "out"}/bin/verapdf";
+
+  preVersionCheck = ''
+    version=${lib.versions.majorMinor version}.0
+  '';
 
   meta = {
     changelog = "https://github.com/veraPDF/veraPDF-library/blob/${src.tag}/RELEASENOTES.md";

--- a/pkgs/by-name/ve/verapdf/package.nix
+++ b/pkgs/by-name/ve/verapdf/package.nix
@@ -10,7 +10,7 @@
 }:
 maven.buildMavenPackage rec {
   pname = "verapdf";
-  version = "1.28.2";
+  version = "1.30.1";
 
   mvnParameters =
     "-pl '!installer' -Dverapdf.timestamp=1980-01-01T00:00:02Z -Dproject.build.outputTimestamp=1980-01-01T00:00:02Z "
@@ -27,13 +27,13 @@ maven.buildMavenPackage rec {
   src = fetchFromGitHub {
     owner = "veraPDF";
     repo = "veraPDF-apps";
-    rev = "v${version}";
-    hash = "sha256-tv5iffIQkyjHyulnmagcJuSGbc4tXRYTwB3hSEGLQrc=";
+    tag = "v${version}";
+    hash = "sha256-IoQbAYEUJuK5FxGSxiLfcn5X1KOJca70hu4cMaYXfmw=";
   };
 
   patches = [ ./stable-maven-plugins.patch ];
 
-  mvnHash = "sha256-CrpiomKsAyD7SyVzwbjVXy8BoVnkejQVcim+kwVP5Ng=";
+  mvnHash = "sha256-hY+zPuSujMr3RntuLOZVEN8GN4n8201+S5OYvwB1+j4=";
 
   nativeBuildInputs = [
     makeWrapper
@@ -46,10 +46,11 @@ maven.buildMavenPackage rec {
 
     mkdir -p $out/bin $out/share
 
-    install -Dm644 greenfield-apps/target/greenfield-apps-${lib.versions.majorMinor version}.0.jar $out/share/verapdf.jar
+    install -Dm644 cli/target/cli-${lib.versions.majorMinor version}.0.jar $out/share/verapdf.jar
+    install -Dm644 gui/target/gui-${lib.versions.majorMinor version}.0.jar $out/share/verapdf-gui.jar
 
-    makeWrapper ${jre}/bin/java $out/bin/verapdf-gui --add-flags "-jar $out/share/verapdf.jar"
-    makeWrapper ${jre}/bin/java $out/bin/verapdf --add-flags "-cp $out/share/verapdf.jar org.verapdf.apps.GreenfieldCliWrapper"
+    makeWrapper ${lib.getExe jre} $out/bin/verapdf-gui --add-flags "-jar $out/share/verapdf-gui.jar"
+    makeWrapper ${lib.getExe jre} $out/bin/verapdf --add-flags "-jar $out/share/verapdf.jar"
 
     install -Dm644 gui/src/main/resources/org/verapdf/gui/images/icon.png $out/share/icons/hicolor/256x256/apps/verapdf.png
 
@@ -74,6 +75,7 @@ maven.buildMavenPackage rec {
   ];
 
   meta = {
+    changelog = "https://github.com/veraPDF/veraPDF-library/blob/${src.tag}/RELEASENOTES.md";
     description = "Command line and GUI industry supported PDF/A and PDF/UA Validation";
     homepage = "https://github.com/veraPDF/veraPDF-apps";
     license = [

--- a/pkgs/by-name/ve/verapdf/package.nix
+++ b/pkgs/by-name/ve/verapdf/package.nix
@@ -8,9 +8,11 @@
   copyDesktopItems,
   jre,
   versionCheckHook,
+  withCli ? true,
+  withGui ? false,
 }:
 maven.buildMavenPackage rec {
-  pname = "verapdf";
+  pname = "verapdf" + lib.optionalString (withGui && !withCli) "-gui";
   version = "1.30.1";
 
   mvnParameters =
@@ -46,19 +48,22 @@ maven.buildMavenPackage rec {
     runHook preInstall
 
     mkdir -p $out/bin $out/share
-
+  ''
+  + lib.optionalString withCli ''
     install -Dm644 cli/target/cli-${lib.versions.majorMinor version}.0.jar $out/share/verapdf.jar
-    install -Dm644 gui/target/gui-${lib.versions.majorMinor version}.0.jar $out/share/verapdf-gui.jar
-
-    makeWrapper ${lib.getExe jre} $out/bin/verapdf-gui --add-flags "-jar $out/share/verapdf-gui.jar"
     makeWrapper ${lib.getExe jre} $out/bin/verapdf --add-flags "-jar $out/share/verapdf.jar"
+  ''
+  + lib.optionalString withGui ''
+    install -Dm644 gui/target/gui-${lib.versions.majorMinor version}.0.jar $out/share/verapdf-gui.jar
+    makeWrapper ${lib.getExe jre} $out/bin/verapdf-gui --add-flags "-jar $out/share/verapdf-gui.jar"
 
     install -Dm644 gui/src/main/resources/org/verapdf/gui/images/icon.png $out/share/icons/hicolor/256x256/apps/verapdf.png
-
+  ''
+  + ''
     runHook postInstall
   '';
 
-  desktopItems = [
+  desktopItems = lib.optionals withGui [
     (makeDesktopItem {
       name = "veraPDF";
       comment = meta.description;
@@ -75,7 +80,8 @@ maven.buildMavenPackage rec {
     })
   ];
 
-  doInstallCheck = true;
+  # GUI has no --version flag
+  doInstallCheck = withCli;
 
   nativeInstallCheckInputs = [
     versionCheckHook
@@ -96,10 +102,15 @@ maven.buildMavenPackage rec {
       # or
       lib.licenses.mpl20
     ];
-    mainProgram = "verapdf-gui";
     maintainers = [
       lib.maintainers.mohe2015
       lib.maintainers.kilianar
     ];
+  }
+  // lib.optionalAttrs (withCli && !withGui) {
+    mainProgram = "verapdf";
+  }
+  // lib.optionalAttrs (withGui && !withCli) {
+    mainProgram = "verapdf-gui";
   };
 }

--- a/pkgs/by-name/ve/verapdf/package.nix
+++ b/pkgs/by-name/ve/verapdf/package.nix
@@ -14,6 +14,7 @@
 maven.buildMavenPackage rec {
   pname = "verapdf" + lib.optionalString (withGui && !withCli) "-gui";
   version = "1.30.1";
+  __structuredAttrs = true;
 
   mvnParameters =
     "-pl '!installer' -Dverapdf.timestamp=1980-01-01T00:00:02Z -Dproject.build.outputTimestamp=1980-01-01T00:00:02Z "
@@ -37,6 +38,8 @@ maven.buildMavenPackage rec {
   patches = [ ./stable-maven-plugins.patch ];
 
   mvnHash = "sha256-hY+zPuSujMr3RntuLOZVEN8GN4n8201+S5OYvwB1+j4=";
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     makeWrapper


### PR DESCRIPTION
Diff: https://github.com/veraPDF/veraPDF-apps/compare/v1.28.2...v1.30.1

Changelog: https://github.com/veraPDF/veraPDF-library/blob/v1.30.1/RELEASENOTES.md

closes https://github.com/NixOS/nixpkgs/issues/525080

Should we split CLI and GUI into separate packages? What would they be called?
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
