### PR TITLE
bstone: fix dependencies & modernize

### DIFF
--- a/pkgs/by-name/bs/bstone/package.nix
+++ b/pkgs/by-name/bs/bstone/package.nix
@@ -6,6 +6,7 @@
   makeWrapper,
   sdl2-compat,
   vulkan-loader,
+  openal,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -26,7 +27,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     sdl2-compat
-    vulkan-loader
   ];
 
   postInstall = ''
@@ -35,7 +35,12 @@ stdenv.mkDerivation (finalAttrs: {
     mv $out/*.txt $out/share/bibendovsky/bstone
 
     wrapProgram $out/bin/bstone \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ vulkan-loader ]}
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          openal
+          vulkan-loader
+        ]
+      }
   '';
 
   meta = {

--- a/pkgs/by-name/bs/bstone/package.nix
+++ b/pkgs/by-name/bs/bstone/package.nix
@@ -13,6 +13,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "bstone";
   version = "1.3.4";
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   src = fetchFromGitHub {
     owner = "bibendovsky";
     repo = "bstone";

--- a/pkgs/by-name/bs/bstone/package.nix
+++ b/pkgs/by-name/bs/bstone/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Unofficial source port for the Blake Stone series";
-    homepage = "https://github.com/bibendovsky/bstone";
+    homepage = "https://bibendovsky.github.io/bstone";
     changelog = "https://github.com/bibendovsky/bstone/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = with lib.licenses; [
       gpl2Plus # Original game source code


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Add openal dependency and remove vulkan-loader from buildInputs as it is not required
- Add __structuredAttrs and strictDeps
- Fix homepage

Note: openal clips sound for me, but may not be the case for others. Should be in the build regardless.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
