### PR TITLE
nixos/pam: Refactor for performance & readability

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -8,6 +8,21 @@
   ...
 }:
 let
+  inherit (lib)
+    attrNames
+    catAttrs
+    concatLines
+    concatMap
+    filter
+    unique
+    flip
+    elem
+    attrValues
+    concatMapStrings
+    hasPrefix
+    concatStringsSep
+    sort
+    ;
 
   moduleSettingsType =
     with lib.types;
@@ -881,41 +896,30 @@ let
 
         text =
           let
-            ensureUniqueOrder =
-              type: rules:
-              let
-                checkPair =
-                  a: b:
-                  assert lib.assertMsg (a.order != b.order)
-                    "security.pam.services.${name}.rules.${type}: rules '${a.name}' and '${b.name}' cannot have the same order value (${toString a.order})";
-                  b;
-                checked = lib.zipListsWith checkPair rules (lib.drop 1 rules);
-              in
-              lib.take 1 rules ++ checked;
             # Formats a string for use in `module-arguments`. See `man pam.conf`.
             formatModuleArgument =
               token: if lib.hasInfix " " token then "[${lib.replaceStrings [ "]" ] [ "\\]" ] token}]" else token;
+
             formatRules =
               type:
-              lib.pipe cfg.rules.${type} [
-                lib.attrValues
-                (lib.filter (rule: rule.enable))
-                (lib.sort (a: b: a.order < b.order))
-                (ensureUniqueOrder type)
-                (map (
-                  rule:
-                  lib.concatStringsSep " " (
-                    [
-                      type
-                      rule.control
-                      rule.modulePath
-                    ]
-                    ++ map formatModuleArgument rule.args
-                    ++ [ "# ${rule.name} (order ${toString rule.order})" ]
+              concatStringsSep "\n" (
+                map
+                  (
+                    rule:
+                    "${type} ${rule.control} ${rule.modulePath}${
+                      if rule.args == [ ] then "" else " " + concatStringsSep " " (map formatModuleArgument rule.args)
+                    } # ${rule.name} (order ${toString rule.order})"
                   )
-                ))
-                (lib.concatStringsSep "\n")
-              ];
+                  (
+                    sort (
+                      a: b:
+                      if a.order != b.order then
+                        a.order < b.order
+                      else
+                        throw "security.pam.services.${name}.rules.${type}: rules '${a.name}' and '${b.name}' cannot have the same order value (${toString a.order})"
+                    ) (filter (rule: rule.enable) (attrValues cfg.rules.${type}))
+                  )
+              );
           in
           lib.mkDefault ''
             # Account management.
@@ -2637,35 +2641,29 @@ in
     };
 
     security.apparmor.includes."abstractions/pam" =
-      lib.concatMapStrings (name: "r ${config.environment.etc."pam.d/${name}".source},\n") (
-        lib.attrNames enabledServices
+      concatMapStrings (name: "r ${config.environment.etc."pam.d/${name}".source},\n") (
+        attrNames enabledServices
       )
       + (
-        with lib;
-        pipe enabledServices [
-          lib.attrValues
-          (catAttrs "rules")
-          (lib.concatMap lib.attrValues)
-          (lib.concatMap lib.attrValues)
-          (lib.filter (rule: rule.enable))
-          (lib.filter (
+        let
+          types = concatMap attrValues (catAttrs "rules" (attrValues enabledServices));
+          rules = concatMap attrValues types;
+
+          isDirect = flip elem [
+            "include"
+            "substack"
+          ];
+          activeRules = filter (rule: rule.enable && !isDirect rule.control) rules;
+
+          modulePaths = concatMap (
             rule:
-            !builtins.elem rule.control [
-              "include"
-              "substack"
-            ]
-          ))
-          (lib.catAttrs "modulePath")
-          (map (
-            modulePath:
-            lib.throwIfNot (lib.hasPrefix "/" modulePath)
-              ''non-absolute PAM modulePath "${modulePath}" is unsupported by apparmor''
-              modulePath
-          ))
-          lib.unique
-          (map (module: "mr ${module},"))
-          concatLines
-        ]
+            if (!hasPrefix "/" rule.modulePath) then
+              throw ''non-absolute PAM modulePath "${rule.modulePath}" is unsupported by apparmor''
+            else
+              [ rule.modulePath ]
+          ) activeRules;
+        in
+        concatLines (map (module: "mr ${module},") (unique modulePaths))
       );
 
     security.sudo.extraConfig = optionalSudoConfigForSSHAgentAuth;


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
