### PR TITLE
flashlabel-yxwl: 1.2.1 -> 1.2.3

### DIFF
--- a/pkgs/by-name/fl/flashlabel-yxwl/package.nix
+++ b/pkgs/by-name/fl/flashlabel-yxwl/package.nix
@@ -8,14 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "flashlabel-yxwl";
-  version = "1.2.1";
+  version = "1.2.3";
 
-  # The source URL currently redirects through “pCloud”, a file storage service
-  # that resists direct downloads.
+  # The source URL redirects to Google Drive, which resists direct downloads.
   src = requireFile {
     name = "A4_Linux_Driver_Ver${version}.run";
     url = "https://flashlabel.net/YXWL-A4driver-linux";
-    hash = "sha256-qkc3NJ1dK0nJf+Q7xL7f1/+X0COWSWMEbH4luzaFARc=";
+    hash = "sha256-LqVQKkh6B+zGl5swknHefaB0EfHYVXXEEqDb6NUaxqc=";
   };
 
   # The driver is distributed as a self-extracting executable consisting of a
@@ -73,6 +72,14 @@ stdenv.mkDerivation rec {
         - C80Y1
         - D80
         - D80 Pro
+        - K80
+        - S8
+        - ST80
+        - ST80K
+        - ST81
+        - ST82
+        - ST83
+        - T8810
         - Y8
         - Y8 Pro
         - Y80


### PR DESCRIPTION
Added hardware support:

- According to homepage: ST80K, T8810
- According to drivers: K80, S8, ST80, ST80K, ST81, ST82, ST83, T8810

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
