### PR TITLE
nixos/systemd-boot: set default boot entry even when target is outside configurationLimit

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -431,7 +431,9 @@ def boot_file(
     return (list(filter(None, [kernel, initrd, devicetree, entry])), bootctl_id)
 
 
-def get_generations(profile: str | None = None) -> list[SystemIdentifier]:
+def get_generations(
+    profile: str | None = None, limit: int = CONFIGURATION_LIMIT
+) -> list[SystemIdentifier]:
     gen_list = run(
         [
             f"{NIX}/bin/nix-env",
@@ -445,14 +447,13 @@ def get_generations(profile: str | None = None) -> list[SystemIdentifier]:
     gen_lines = gen_list.split("\n")
     gen_lines.pop()
 
-    configurationLimit = CONFIGURATION_LIMIT
     configurations = [
         SystemIdentifier(
             profile=profile, generation=int(line.split()[0]), specialisation=None
         )
         for line in gen_lines
     ]
-    return configurations[-configurationLimit:]
+    return configurations[-limit:]
 
 
 def cleanup_esp() -> None:
@@ -471,6 +472,18 @@ def get_profiles() -> list[str]:
         ]
     else:
         return []
+
+
+def generation_toplevel(gen: SystemIdentifier) -> Path:
+    return system_dir(*gen).resolve()
+
+
+def get_default_generation(default_config: Path) -> SystemIdentifier | None:
+    for profile in [None, *get_profiles()]:
+        for gen in reversed(get_generations(profile, limit=0)):
+            if generation_toplevel(gen) == default_config:
+                return gen
+    return None
 
 
 def install_bootloader(args: argparse.Namespace) -> None:
@@ -558,6 +571,18 @@ def install_bootloader(args: argparse.Namespace) -> None:
 
     default_config = Path(args.default_config)
     default_entry_id: str | None = None
+
+    # The toplevel that switch-to-configuration handed us to make the default may
+    # have been truncated out of the lists above by `configurationLimit`. `configurationLimit`
+    # is only meant to cap how many old generations appear in the menu, not to stop
+    # the requested configuration from getting an entry and becoming the default.
+    # Re-add it; otherwise the `if is_default` branch below never runs and the
+    # default boot entry is silently left unchanged.
+    resolved_default_config = default_config.resolve()
+    if not any(generation_toplevel(gen) == resolved_default_config for gen in gens):
+        default_gen = get_default_generation(resolved_default_config)
+        if default_gen is not None:
+            gens.append(default_gen)
 
     for gen in gens:
         bootspec = get_bootspec(gen.profile, gen.generation)


### PR DESCRIPTION
`systemd-boot-builder` only wrote loader.conf's `default` when the toplevel passed by switch-to-configuration matched one of the last `configurationLimit` generations. Selecting an older generation with `nix-env --switch-generation` to a generation past the limit followed by `switch-to-configuration boot` therefore silently left the default unchanged.

configurationLimit is meant to cap how many old generations appear in the menu, not to prevent the requested configuration from becoming the default. Re-add the requested generation to the list if it was truncated out, matching the behavior GRUB's builder already has.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. -- ran the systemd-boot test
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
