### PR TITLE
nixos/utils: Refactor with an eye for performance

### DIFF
--- a/nixos/lib/systemd-lib.nix
+++ b/nixos/lib/systemd-lib.nix
@@ -62,7 +62,7 @@ let
 in
 rec {
 
-  shellEscape = s: (replaceStrings [ "\\" ] [ "\\\\" ] s);
+  shellEscape = replaceStrings [ "\\" ] [ "\\\\" ];
 
   mkPathSafeName = replaceStrings [ "@" ":" "\\" "[" "]" ] [ "-" "-" "-" "" "" ];
 

--- a/nixos/lib/utils.nix
+++ b/nixos/lib/utils.nix
@@ -35,6 +35,7 @@ let
     replaceStrings
     stringToCharacters
     types
+    flip
     ;
 
   inherit (lib.strings) toJSON normalizePath escapeC;
@@ -103,21 +104,24 @@ let
     # The escaping algorithm operates as follows: given a string, any "/" character is replaced by "-", and all other characters which are not ASCII alphanumerics, ":", "_" or "." are replaced by C-style "\x2d" escapes. In addition, "." is replaced with such a C-style escape when it would appear as the first character in the escaped string.
     # When the input qualifies as absolute file system path, this algorithm is extended slightly: the path to the root directory "/" is encoded as single dash "-". In addition, any leading, trailing or duplicate "/" characters are removed from the string before transformation. Example: /foo//bar/baz/ becomes "foo-bar-baz".
     escapeSystemdPath =
+      let
+        specialChars = stringToCharacters " !\"#$%&'()*+,;<=>=@[\\]^`{|}~-";
+        escapeSpecialChars = escapeC specialChars;
+        replace' = replaceStrings [ "/" ] [ "-" ];
+        cDot = escapeC [ "." ] ".";
+      in
       s:
       let
-        replacePrefix =
-          p: r: s:
-          (if (hasPrefix p s) then r + (removePrefix p s) else s);
-        trim = s: removeSuffix "/" (removePrefix "/" s);
         normalizedPath = normalizePath s;
+        trimmed =
+          if normalizedPath == "/" then
+            normalizedPath
+          else
+            removeSuffix "/" (removePrefix "/" normalizedPath);
+        escaped = escapeSpecialChars trimmed;
+        dotEscaped = if hasPrefix "." escaped then cDot + removePrefix "." escaped else escaped;
       in
-      replaceStrings [ "/" ] [ "-" ] (
-        replacePrefix "." (escapeC [ "." ] ".") (
-          escapeC (stringToCharacters " !\"#$%&'()*+,;<=>=@[\\]^`{|}~-") (
-            if normalizedPath == "/" then normalizedPath else trim normalizedPath
-          )
-        )
-      );
+      replace' dotEscaped;
 
     # Quotes an argument for use in Exec* service lines.
     # systemd accepts "-quoted strings with escape sequences, toJSON produces
@@ -127,9 +131,12 @@ let
     # Every $ is escaped to $$, this makes it unnecessary to disable environment
     # substitution for the directive.
     escapeSystemdExecArg =
-      arg:
       let
-        s =
+        replace' = replaceStrings [ "%" "$" ] [ "%%" "$$" ];
+      in
+      arg:
+      replace' (
+        toJSON (
           if isPath arg then
             "${arg}"
           else if isString arg then
@@ -137,9 +144,9 @@ let
           else if isInt arg || isFloat arg || isDerivation arg then
             toString arg
           else
-            throw "escapeSystemdExecArg only allows strings, paths, numbers and derivations";
-      in
-      replaceStrings [ "%" "$" ] [ "%%" "$$" ] (toJSON s);
+            throw "escapeSystemdExecArg only allows strings, paths, numbers and derivations"
+        )
+      );
 
     # Quotes a list of arguments into a single string for use in a Exec*
     # line.
@@ -558,15 +565,25 @@ let
         The `order` option on the resulting rules will automatically be configured according to the
         (implied) ordering of the input rules.
       */
-      autoOrderRules = lib.flip lib.pipe [
-        (lib.imap1 (
-          index: rule:
-          assert lib.assertMsg (!rule ? order) "the 'order' option may not be set when using autoOrderRules";
-          rule // { order = lib.mkDefault (10000 + index * 100); }
-        ))
-        (map (rule: lib.nameValuePair rule.name (removeAttrs rule [ "name" ])))
-        lib.listToAttrs
-      ];
+      autoOrderRules =
+        let
+          removeName = flip removeAttrs [ "name" ];
+        in
+        rules:
+        listToAttrs (
+          map
+            (rule: {
+              inherit (rule) name;
+              value = removeName rule;
+            })
+            (
+              imap1 (
+                index: rule:
+                assert (!rule ? order) || throw "the 'order' option may not be set when using autoOrderRules";
+                rule // { order = lib.mkDefault (10000 + index * 100); }
+              ) rules
+            )
+        );
     };
   };
 in


### PR DESCRIPTION
## Things done

This moves up many variables in scope and eliminates use of `lib.pipe`.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
