### PR TITLE
libpsl: remove gtk-doc dependency

### DIFF
--- a/pkgs/by-name/li/libpsl/package.nix
+++ b/pkgs/by-name/li/libpsl/package.nix
@@ -6,7 +6,6 @@
   autoreconfHook,
   docbook_xsl,
   docbook_xml_dtd_43,
-  gtk-doc,
   lzip,
   libidn2,
   libunistring,
@@ -44,7 +43,6 @@ stdenv.mkDerivation (finalAttrs: {
     autoreconfHook
     docbook_xsl
     docbook_xml_dtd_43
-    gtk-doc
     lzip
     pkg-config
     libxslt
@@ -64,10 +62,6 @@ stdenv.mkDerivation (finalAttrs: {
   # use the libpsl-with-scripts package if you need this
   postInstall = ''
     rm $out/bin/psl-make-dafsa $out/share/man/man1/psl-make-dafsa*
-  '';
-
-  preAutoreconf = ''
-    gtkdocize
   '';
 
   configureFlags = [


### PR DESCRIPTION
This isn't used, as doc generation has been disabled since https://github.com/nixos/nixpkgs/commit/ffc9bdea32339de7aef905e17cfe9c1bb643462e. Built the package before and after, and can confirm that it creates the exact same output:
```
❯ diff -q /nix/store/79kr7fafcvvmch13cyczpckz40159pk5-libpsl-0.21.5 /nix/store/y4b4nz29pfkbh5icp8n7g5778znmsbp4-libpsl-0.21.5 && echo hi
Common subdirectories: /nix/store/79kr7fafcvvmch13cyczpckz40159pk5-libpsl-0.21.5/bin and /nix/store/y4b4nz29pfkbh5icp8n7g5778znmsbp4-libpsl-0.21.5/bin
Common subdirectories: /nix/store/79kr7fafcvvmch13cyczpckz40159pk5-libpsl-0.21.5/lib and /nix/store/y4b4nz29pfkbh5icp8n7g5778znmsbp4-libpsl-0.21.5/lib
Common subdirectories: /nix/store/79kr7fafcvvmch13cyczpckz40159pk5-libpsl-0.21.5/share and /nix/store/y4b4nz29pfkbh5icp8n7g5778znmsbp4-libpsl-0.21.5/share
hi
```
Slight improvement to the eval time for packages that rely on this, like git.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
