### PR TITLE
ocamlPackages.rpclib: 9.0.0 → 10.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/ppx_deriving_rpc/default.nix
+++ b/pkgs/development/ocaml-modules/ppx_deriving_rpc/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildDunePackage,
-  fetchpatch,
   rpclib,
   alcotest,
   ppxlib,
@@ -13,13 +12,6 @@ buildDunePackage {
   pname = "ppx_deriving_rpc";
 
   inherit (rpclib) version src;
-
-  minimalOCamlVersion = "4.08";
-
-  patches = lib.optional (lib.versionAtLeast ppxlib.version "0.36") (fetchpatch {
-    url = "https://github.com/mirage/ocaml-rpc/commit/678b7c0e59f6add174f2a732861be21c3e9583d0.patch";
-    hash = "sha256-6Vl4/C02NQ/nPn+h9I/eT86R7GLZ/C8nSqBs4Ywzhwc=";
-  });
 
   propagatedBuildInputs = [
     ppxlib

--- a/pkgs/development/ocaml-modules/rpclib/default.nix
+++ b/pkgs/development/ocaml-modules/rpclib/default.nix
@@ -12,14 +12,13 @@
 
 buildDunePackage (finalAttrs: {
   pname = "rpclib";
-  version = "9.0.0";
+  version = "10.2.0";
 
-  minimalOCamlVersion = "4.08";
-  duneVersion = "3";
+  minimalOCamlVersion = "4.14";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-rpc/releases/download/${finalAttrs.version}/rpclib-${finalAttrs.version}.tbz";
-    hash = "sha256-ziPrdWwCjZN0vRmCMpa923wjfT8FVFLTDRz30VIW6WM=";
+    hash = "sha256-N+xKTdU/yy042EZBXTpFl21aeMFTHm2HbbJDbpRxcvM=";
   };
 
   buildInputs = [

--- a/pkgs/development/ocaml-modules/rpclib/lwt.nix
+++ b/pkgs/development/ocaml-modules/rpclib/lwt.nix
@@ -10,7 +10,6 @@
 buildDunePackage {
   pname = "rpclib-lwt";
   inherit (rpclib) version src;
-  duneVersion = "3";
 
   propagatedBuildInputs = [
     lwt


### PR DESCRIPTION
cc maintainer (@vyorkin)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
