### PR TITLE
ocamlPackages.arp: 4.0.0 → 4.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/arp/default.nix
+++ b/pkgs/development/ocaml-modules/arp/default.nix
@@ -8,6 +8,7 @@
   ethernet,
   ipaddr,
   logs,
+  lru,
   lwt,
   macaddr,
   mirage-sleep,
@@ -18,14 +19,12 @@
 
 buildDunePackage (finalAttrs: {
   pname = "arp";
-  version = "4.0.0";
+  version = "4.1.0";
 
   src = fetchurl {
     url = "https://github.com/mirage/arp/releases/download/v${finalAttrs.version}/arp-${finalAttrs.version}.tbz";
-    hash = "sha256-C2Bh/2NwZqCJEidCnkhwRMoW3AsbQtvwdFh9IiJkDaU=";
+    hash = "sha256-AvjxveUgSRBNhZQvCp1oa+JfEXSIronECk4nNos8hl0=";
   };
-
-  minimalOCamlVersion = "4.08";
 
   propagatedBuildInputs = [
     cstruct
@@ -33,6 +32,7 @@ buildDunePackage (finalAttrs: {
     ethernet
     ipaddr
     logs
+    lru
     lwt
     macaddr
     mirage-sleep


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
