### PR TITLE
aionui-web: init at 2.1.5

### DIFF
--- a/pkgs/by-name/ai/aionui-web/package.nix
+++ b/pkgs/by-name/ai/aionui-web/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  autoPatchelfHook,
+  xz,
+  zlib,
+  gcc-unwrapped,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "aionui-web";
+  version = "2.1.5";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchurl {
+    url = "https://github.com/iOfficeAI/AionUi/releases/download/v${finalAttrs.version}/aionui-web-${finalAttrs.version}-linux-x86_64.tar.gz";
+    hash = "sha256-QPNgXZhprIfYP+phIlLFsyY+PjRctOeAN7kaUAp1PQw=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    xz
+    zlib
+    gcc-unwrapped.lib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/aionui-web $out/bin
+    cp -r ./. "$out/share/aionui-web/"
+    chmod +x "$out/share/aionui-web/aionui-web"
+    ln -s "$out/share/aionui-web/aionui-web" "$out/bin/aionui-web"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Cowork with AI agents through a Web UI";
+    homepage = "https://github.com/iOfficeAI/AionUi";
+    changelog = "https://github.com/iOfficeAI/AionUi/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    mainProgram = "aionui-web";
+    maintainers = with lib.maintainers; [ qrzbing ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
Aionui-Web: Cowork with AI agents through a Web UI
https://github.com/iOfficeAI/AionUi.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
