### PR TITLE
 Revert "systemd: drop 0001-Start-device-units-for-uninitialised-encrypted-devic.patch"

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1608,6 +1608,7 @@ in
   systemd-initrd-luks-fido2 = runTest ./systemd-initrd-luks-fido2.nix;
   systemd-initrd-luks-keyfile = runTest ./systemd-initrd-luks-keyfile.nix;
   systemd-initrd-luks-password = runTest ./systemd-initrd-luks-password.nix;
+  systemd-initrd-luks-password-to-keyfile = runTest ./systemd-initrd-luks-password-to-keyfile.nix;
   systemd-initrd-luks-tpm2 = runTest ./systemd-initrd-luks-tpm2.nix;
   systemd-initrd-luks-unl0kr = runTest ./systemd-initrd-luks-unl0kr.nix;
   systemd-initrd-modprobe = runTest ./systemd-initrd-modprobe.nix;

--- a/nixos/tests/systemd-initrd-luks-password-to-keyfile.nix
+++ b/nixos/tests/systemd-initrd-luks-password-to-keyfile.nix
@@ -1,0 +1,82 @@
+{ lib, ... }:
+{
+  name = "systemd-initrd-luks-password-to-keyfile";
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      # Use systemd-boot
+      virtualisation = {
+        emptyDiskImages = [
+          512
+          512
+          512
+        ];
+        useBootLoader = true;
+        # Booting off the encrypted disk requires an available init script
+        mountHostNixStore = true;
+        useEFIBoot = true;
+      };
+      boot.loader.systemd-boot.enable = true;
+
+      environment.systemPackages = [ pkgs.cryptsetup ];
+      boot.initrd.systemd = {
+        enable = true;
+        emergencyAccess = true;
+      };
+
+      specialisation.boot-luks.configuration = {
+        boot.initrd.luks.devices = lib.mkVMOverride {
+          cryptkey.device = "/dev/vdb";
+          cryptroot = {
+            device = "/dev/vdc";
+            keyFile = "/dev/mapper/cryptkey";
+            keyFileSize = 1024;
+          };
+          cryptroot2 = {
+            device = "/dev/vdd";
+            keyFile = "/dev/mapper/cryptkey";
+            keyFileSize = 1024;
+          };
+        };
+        virtualisation.rootDevice = "/dev/mapper/cryptroot";
+        # test mounting device unlocked in initrd after switching root
+        virtualisation.fileSystems."/cryptroot2" = {
+          device = "/dev/mapper/cryptroot2";
+          fsType = "auto";
+        };
+      };
+    };
+
+  testScript = /* python */ ''
+    # Create encrypted volume
+    machine.wait_for_unit("multi-user.target")
+
+    machine.succeed("echo -n supersecret | cryptsetup luksFormat -q --iter-time=1 /dev/vdb -")
+    machine.succeed("echo -n supersecret | cryptsetup luksOpen   -q               /dev/vdb cryptkey")
+    machine.succeed("dd if=/dev/urandom of=/dev/mapper/cryptkey bs=1024 count=1")
+
+    machine.succeed("cryptsetup luksFormat -q --keyfile-size 1024 /dev/vdc /dev/mapper/cryptkey")
+    machine.succeed("cryptsetup luksFormat -q --keyfile-size 1024 /dev/vdd /dev/mapper/cryptkey")
+
+    machine.succeed("cryptsetup luksOpen -q --keyfile-size 1024 --key-file /dev/mapper/cryptkey /dev/vdc cryptroot")
+    machine.succeed("cryptsetup luksOpen -q --keyfile-size 1024 --key-file /dev/mapper/cryptkey /dev/vdd cryptroot2")
+
+    machine.succeed("mkfs.ext4 /dev/mapper/cryptroot")
+    machine.succeed("mkfs.ext4 /dev/mapper/cryptroot2")
+
+    # Boot from the encrypted disk
+    machine.succeed("bootctl set-default nixos-generation-1-specialisation-boot-luks.conf")
+    machine.succeed("sync")
+    machine.crash()
+
+    # Boot and decrypt the disk
+    machine.start()
+    machine.wait_for_console_text("Please enter passphrase for disk cryptkey")
+    machine.send_console("supersecret\n")
+    machine.wait_for_unit("multi-user.target")
+
+    assert "/dev/mapper/cryptroot on / type ext4" in machine.succeed("mount"), "/dev/mapper/cryptroot do not appear in mountpoints list"
+    assert "/dev/mapper/cryptroot2 on /cryptroot2 type ext4" in machine.succeed("mount")
+  '';
+}

--- a/pkgs/os-specific/linux/systemd/0000-Start-device-units-for-uninitialised-encrypted-devic.patch
+++ b/pkgs/os-specific/linux/systemd/0000-Start-device-units-for-uninitialised-encrypted-devic.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Eelco Dolstra <eelco.dolstra@logicblox.com>
+Date: Tue, 8 Jan 2013 15:46:30 +0100
+Subject: [PATCH] Start device units for uninitialised encrypted devices
+
+This is necessary because the NixOS service that initialises the
+filesystem depends on the appearance of the device unit.  Also, this
+makes more sense to me: the device is ready; it's the filesystem
+that's not, but taking care of that is the responsibility of the mount
+unit.  (However, this ignores the fsck unit, so it's not perfect...)
+---
+ rules.d/99-systemd.rules.in | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/rules.d/99-systemd.rules.in b/rules.d/99-systemd.rules.in
+index bebc4d7d09..60278a0da7 100644
+--- a/rules.d/99-systemd.rules.in
++++ b/rules.d/99-systemd.rules.in
+@@ -30,10 +30,6 @@ SUBSYSTEM=="block", ACTION=="add", KERNEL=="dm-*", ENV{DM_NAME}!="?*", ENV{SYSTE
+ # Import previous SYSTEMD_READY state.
+ SUBSYSTEM=="block", ENV{DM_UDEV_DISABLE_OTHER_RULES_FLAG}=="1", ENV{SYSTEMD_READY}=="", IMPORT{db}="SYSTEMD_READY"
+ 
+-# Ignore encrypted devices with no identified superblock on it, since
+-# we are probably still calling mke2fs or mkswap on it.
+-SUBSYSTEM=="block", ENV{DM_UUID}=="CRYPT-*", ENV{ID_PART_TABLE_TYPE}=="", ENV{ID_FS_USAGE}=="", ENV{SYSTEMD_READY}="0"
+-
+ # Ignore raid devices that are not yet assembled and started
+ SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="md*", TEST!="md/array_state", ENV{SYSTEMD_READY}="0"
+ SUBSYSTEM=="block", ENV{DEVTYPE}=="disk", KERNEL=="md*", ATTR{md/array_state}=="|clear|inactive", ENV{SYSTEMD_READY}="0"

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -753,6 +753,7 @@ stdenv.mkDerivation (finalAttrs: {
             systemd-initrd-luks-keyfile
             systemd-initrd-luks-empty-passphrase
             systemd-initrd-luks-password
+            systemd-initrd-luks-password-to-keyfile
             systemd-initrd-luks-tpm2
             systemd-initrd-modprobe
             systemd-initrd-shutdown

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -232,6 +232,7 @@ stdenv.mkDerivation (finalAttrs: {
   # Use `find . -name "*.patch" | sort` to get an up-to-date listing of all
   # patches
   patches = [
+    ./0000-Start-device-units-for-uninitialised-encrypted-devic.patch
     ./0001-Don-t-try-to-unmount-nix-or-nix-store.patch
     ./0002-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
     ./0003-add-rootprefix-to-lookup-dir-paths.patch


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The systemd `Start-device-units-for-uninitialised-encrypted-devic.patch` was recently removed in b5611f96b6e1be1bf94165b3acd3bf49970a4c56 via https://github.com/NixOS/nixpkgs/pull/488508 (cc @nikstur ).

The cited reason was that this is no longer need due to b13891782fdec1b72e1e9ab4f86fce1638f20203, however, dropping the patch breaks booting configurations where a password-encrypted luks volume is then used as key-file to decrypt another luks volume. I've added a test case/reproduction for this (breaks without the patch, fixed after reverting).

Note: the existing systemd patches were reflowed after this patch was dropped. As part of the revert I renamed the prefix to `0000` to avoid having to reflow patches again, but let me know if there's a preferred approach here

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
