### PR TITLE
simplelogin-cli: init at 0.3.0

### DIFF
--- a/pkgs/by-name/si/simplelogin-cli/package.nix
+++ b/pkgs/by-name/si/simplelogin-cli/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+}:
+
+buildGoModule rec {
+  pname = "simplelogin-cli";
+  version = "0.3.0";
+
+  __structuredAttrs = true;
+  __darwinAllowLocalNetworking = true;
+
+  src = fetchFromGitHub {
+    owner = "mexcool";
+    repo = "simplelogin-cli";
+    rev = "v${version}";
+    hash = "sha256-xArmFEBxigd7/iPp4gaQ6iU3jyKbvSf3NpIl4XcYiQ0=";
+  };
+
+  vendorHash = "sha256-P0+WT/1HKxSLmfDaIeQ8JThPbBuaf59rZjJjxuI+lzg=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=main.version=${version}"
+    "-X=main.commit=${src.rev}"
+    "-X=main.date=1970-01-01T00:00:00Z"
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  postInstall = ''
+    $out/bin/gen-man && rm $out/bin/gen-man
+    installManPage man/*.[1-9]
+  '';
+
+  meta = {
+    description = "SimpleLogin cli to manage email aliases from the terminal.";
+    homepage = "https://github.com/mexcool/simplelogin-cli";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ afh ];
+    mainProgram = "simplelogin-cli";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
