### PR TITLE
home-assistant-custom-lovelace-modules.trash-card: init at 2.4.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10661,6 +10661,11 @@
     githubId = 147689;
     name = "Hans-Christian Esperer";
   };
+  hchokshi = {
+    github = "hchokshi";
+    githubId = 10136407;
+    name = "Harsh Chokshi";
+  };
   hdhog = {
     name = "Serg Larchenko";
     email = "hdhog@hdhog.ru";

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/trash-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/trash-card/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "trash-card";
+  version = "2.4.7";
+
+  src = fetchFromGitHub {
+    owner = "idaho";
+    repo = "hassio-trash-card";
+    tag = finalAttrs.version;
+    hash = "sha256-Zf+iUcJs45eguaDJcuto6ccc/puormFajmYMc7Qpdsw=";
+  };
+
+  npmDepsHash = "sha256-zvsJASztDfecn+FRvQPmT0vIblaCD11eBM9LLq+VFrg=";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    cp dist/trashcard.js $out/
+
+    runHook postInstall
+  '';
+
+  passthru.entrypoint = "trashcard.js";
+
+  meta = {
+    description = "Custom Home Assistant card that displays your current and upcoming trash collection schedule.";
+    homepage = "https://github.com/idaho/hassio-trash-card";
+    changelog = "https://github.com/idaho/hassio-trash-card/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.hchokshi ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add the Trash Card Home Assistant Lovelace card from https://github.com/idaho/hassio-trash-card. UI component that works with local calendar integrations, including the `waste_collection_schedule` custom component [already in nixpkgs](https://github.com/NixOS/nixpkgs/blob/d254b4b33cc35a6ff6cdd13e0f02ddddf5b77488/pkgs/servers/home-assistant/custom-components/waste_collection_schedule/package.nix).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Verified derivation output is hash-identical to the `trashcard.js` artifact on the [original 2.4.7 release](https://github.com/idaho/hassio-trash-card/releases/tag/2.4.7).
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
  - No AI use.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
