### PR TITLE
python3Packages.optuna: enable __structuredAttrs, skip crashing tests on darwin

### DIFF
--- a/pkgs/development/python-modules/optuna/default.nix
+++ b/pkgs/development/python-modules/optuna/default.nix
@@ -119,9 +119,19 @@ buildPythonPackage (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # ValueError: Failed to start Kaleido subprocess. Error stream
     # kaleido/executable/kaleido: line 5:  5956 Illegal instruction: 4  ./bin/kaleido $@
+    "test_edf_plot_no_trials"
+    "test_edf_plot_no_trials_studies"
     "test_get_optimization_history_plot"
+    "test_get_timeline_plot"
+    "test_plot_contour"
+    "test_plot_edf_with_multiple_studies"
+    "test_plot_edf_with_target"
+    "test_plot_edf_with_target_name"
     "test_plot_intermediate_values"
+    "test_plot_parallel_coordinate"
+    "test_plot_param_importances"
     "test_plot_rank"
+    "test_plot_slice"
     "test_plot_terminator_improvement"
   ];
 

--- a/pkgs/development/python-modules/optuna/default.nix
+++ b/pkgs/development/python-modules/optuna/default.nix
@@ -45,6 +45,7 @@ buildPythonPackage (finalAttrs: {
   pname = "optuna";
   version = "4.8.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "optuna";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python3Packages.optuna: enable __structuredAttrs**
- **python3Packages.optuna: skip crashing tests on darwin**

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
