### PR TITLE
zellijPlugins: implement centralized updater

### DIFF
--- a/pkgs/by-name/ze/zellij/plugins/README.md
+++ b/pkgs/by-name/ze/zellij/plugins/README.md
@@ -74,10 +74,31 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/nim65s/jbz";
     changelog = "https://github.com/nim65s/jbz/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ PerchunPak ];
   };
 })
 ```
 
 If you are wondering why `pkgsBuildBuild` is named like that, refer to
 [the docs on cross-compilation](https://nixos.org/manual/nixpkgs/unstable/#possible-dependency-types).
+
+## Updater script
+
+All updates are done in the `updater` directory. It runs [nix-update] on all
+derivations in the `zellijPlugins` set. You can specify extra arguments for
+nix-update using `passthru.updateScriptArgs`:
+
+```nix
+buildRustPackage {
+  # ...
+  passthru = {
+    runtimeDeps = with pkgsBuildBuild; [ things ];
+    updateScriptArgs = "--version=branch";
+  };
+}
+```
+
+If you specify `passthru.updateScript`, it will throw an error, because the
+centralized updater will still be run on your package. Currently, custom
+per-plugin updaters are not implemented.
+
+[nix-update]: https://github.com/Mic92/nix-update

--- a/pkgs/by-name/ze/zellij/plugins/default.nix
+++ b/pkgs/by-name/ze/zellij/plugins/default.nix
@@ -38,9 +38,10 @@ let
 
       passthru = pkg.passthru or { } // {
         unwrapped = pkg;
-        updateScript = pkg.passthru.updateScript or nix-update-script {
-          attrPath = "zellijPlugins.${attrName}.unwrapped";
-        };
+        updateScript =
+          assert lib.assertMsg (!pkg.passthru or { } ? updateScript)
+            "zellijPlugins.${attrName}: Currently, custom per-plugin updater scripts are not implemented. Refer to `pkgs/by-name/ze/zellij/plugins/README.md`";
+          null;
       };
 
       meta = pkg.meta // {
@@ -50,4 +51,8 @@ let
     });
   rustPlugins = lib.mapAttrs wrapper (callPackage ./rust { });
 in
-rustPlugins // { inherit wrapper; }
+rustPlugins
+// {
+  inherit wrapper;
+  _updater = callPackage ./updater { };
+}

--- a/pkgs/by-name/ze/zellij/plugins/updater/default.nix
+++ b/pkgs/by-name/ze/zellij/plugins/updater/default.nix
@@ -1,0 +1,16 @@
+{ stdenvNoCC }:
+stdenvNoCC.mkDerivation {
+  pname = "zellij-plugins-updater";
+  version = "2026-05-28";
+
+  src = ./default.nix;
+  dontUnpack = true;
+
+  buildPhase = ''
+    cp $src $out
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta.description = "This is an internal hack to trigger @r-ryanthm on Zellij plugins";
+}

--- a/pkgs/by-name/ze/zellij/plugins/updater/gen-update-commands.nix
+++ b/pkgs/by-name/ze/zellij/plugins/updater/gen-update-commands.nix
@@ -1,0 +1,15 @@
+{
+  pkgsPath ? ./.,
+}:
+let
+  pkgs = import pkgsPath { };
+  inherit (pkgs) lib;
+
+  filtered = lib.filterAttrs (
+    name: value: lib.isDerivation value && name != "_updater"
+  ) pkgs.zellijPlugins;
+
+  genCommand =
+    name: plugin: "nix-update 'zellijPlugins.${name}.unwrapped' ${plugin.updateScriptArgs or ""}";
+in
+lib.mapAttrsToList genCommand filtered

--- a/pkgs/by-name/ze/zellij/plugins/updater/update.sh
+++ b/pkgs/by-name/ze/zellij/plugins/updater/update.sh
@@ -1,0 +1,15 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p nix-update
+set -xeuo pipefail
+IFS=$'\n\t'
+
+readarray -t commands < <(
+  nix-instantiate --eval --json --strict --arg pkgsPath ./. \
+    pkgs/by-name/ze/zellij/plugins/updater/gen-update-commands.nix \
+  | jq -r '.[]'
+)
+for command in "${commands[@]}"; do
+  bash -c "$command"
+done
+
+sed -i "s/version = .*/version = \"$(date --iso-8601)\";/" pkgs/by-name/ze/zellij/plugins/updater/default.nix


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This implements a centralized updater script rather than letting @r-ryantm run on each plugin separately (as requested in https://github.com/NixOS/nixpkgs/pull/524984). If you know a better solution, please let me know

CC @ethancedwards8 @matthiasbeyer

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
    I do not use AI

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
