### PR TITLE
bashunit: 0.26.0 -> 0.36.0

### DIFF
--- a/pkgs/by-name/ba/bashunit/package.nix
+++ b/pkgs/by-name/ba/bashunit/package.nix
@@ -3,7 +3,12 @@
   lib,
   fetchFromGitHub,
   bash,
+  bc,
+  gitMinimal,
+  gnugrep,
+  jq,
   which,
+  writableTmpDirAsHomeHook,
   versionCheckHook,
   coreutils,
   makeBinaryWrapper,
@@ -12,13 +17,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "bashunit";
-  version = "0.26.0";
+  version = "0.36.0";
 
   src = fetchFromGitHub {
     owner = "TypedDevs";
     repo = "bashunit";
     tag = finalAttrs.version;
-    hash = "sha256-cZ2fcm4OxA3Ly8QRkOQSjaSZW80/Pu2z10+iN4pDFOs=";
+    hash = "sha256-alhqJ7coRk5O4dYGx8m6u8/j7KMfr2m9Jeb5pn0wwiU=";
     forceFetchGit = true; # needed to include the tests directory for the check phase
   };
 
@@ -43,9 +48,21 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   doCheck = true;
-  nativeCheckInputs = [ which ];
+  nativeCheckInputs = [
+    bc
+    gitMinimal
+    jq
+    which
+  ];
   checkPhase = ''
     runHook preCheck
+    patchShebangs bin/bashunit
+  ''
+  # Disabling a failing test on Darwin platforms only
+  + lib.optionalString stdenvNoCC.hostPlatform.isDarwin ''
+    rm tests/unit/console_results_test.sh
+  ''
+  + ''
     make test
     runHook postCheck
   '';
@@ -54,14 +71,21 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     wrapProgram $out/bin/bashunit \
       --prefix PATH : "${
         lib.makeBinPath [
-          coreutils
+          coreutils # cat, mktemp
+          gnugrep # grep
           which
         ]
       }"
   '';
 
-  nativeInstallCheckInputs = [ versionCheckHook ];
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
   doInstallCheck = true;
+  versionCheckKeepEnvironment = [
+    "HOME"
+  ];
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
