### PR TITLE
gnat: 13.2.0 -> 15.2.0, bootstrap with gnat-bootstrap15/16

### DIFF
--- a/pkgs/development/compilers/gnat-bootstrap/default.nix
+++ b/pkgs/development/compilers/gnat-bootstrap/default.nix
@@ -112,6 +112,33 @@ stdenv.mkDerivation (
           };
         }
         .${stdenv.hostPlatform.system} or throwUnsupportedSystem;
+        "16" = {
+          gccVersion = "16.1.0";
+          alireRevision = "1";
+        }
+        // {
+          x86_64-darwin = {
+            inherit url;
+            hash = "sha256-u/cYFKqWLTaFADTscDxnrkYSoemKrfKpNIZ8XPlTbLI=";
+            upstreamTriplet = "x86_64-apple-darwin24.6.0";
+          };
+          x86_64-linux = {
+            inherit url;
+            hash = "sha256-5bKYPJnXDGa80BtAogLE82X0zTuYKdN2cKh503oMeic=";
+            upstreamTriplet = "x86_64-pc-linux-gnu";
+          };
+          aarch64-linux = {
+            inherit url;
+            hash = "sha256-jJnqDJGBOjqbT4hDW0nRpV0oA3RXxJhvI7BuvQkPDQI=";
+            upstreamTriplet = "aarch64-linux-gnu";
+          };
+          aarch64-darwin = {
+            inherit url;
+            hash = "sha256-TJlV/Ngq6SwpIgGkwamTN3aRGP2BnEzJyBGovtWb6Y0=";
+            upstreamTriplet = "aarch64-apple-darwin24.6.0";
+          };
+        }
+        .${stdenv.hostPlatform.system} or throwUnsupportedSystem;
       };
     inherit (versionMap.${majorVersion}) gccVersion alireRevision upstreamTriplet;
   in

--- a/pkgs/development/compilers/gnat-bootstrap/default.nix
+++ b/pkgs/development/compilers/gnat-bootstrap/default.nix
@@ -33,23 +33,6 @@ stdenv.mkDerivation (
         url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-${finalAttrs.version}/gnat-${stdenv.hostPlatform.system}-${finalAttrs.version}.tar.gz";
       in
       {
-        "12" = {
-          gccVersion = "12.1.0";
-          alireRevision = "2";
-        }
-        // {
-          x86_64-darwin = {
-            inherit url;
-            hash = "sha256-zrcVFvFZMlGUtkG0p1wST6kGInRI64Icdsvkcf25yVs=";
-            upstreamTriplet = "x86_64-apple-darwin19.6.0";
-          };
-          x86_64-linux = {
-            inherit url;
-            hash = "sha256-EPDPOOjWJnJsUM7GGxj20/PXumjfLoMIEFX1EDtvWVY=";
-            upstreamTriplet = "x86_64-pc-linux-gnu";
-          };
-        }
-        .${stdenv.hostPlatform.system} or throwUnsupportedSystem;
         "13" = {
           gccVersion = "13.2.0";
           alireRevision = "2";
@@ -96,6 +79,36 @@ stdenv.mkDerivation (
             inherit url;
             hash = "sha256-/nARwdQzAMd41fslUbrgloxn0hVZp9PokfQ9yPmL1g8=";
             upstreamTriplet = "aarch64-apple-darwin23.6.0";
+          };
+        }
+        .${stdenv.hostPlatform.system} or throwUnsupportedSystem;
+        "15" = {
+          gccVersion = "15.2.0";
+        }
+        // {
+          x86_64-darwin = {
+            alireRevision = "1";
+            inherit url;
+            hash = "sha256-1YTqWsLBwNH/GBAtF5CL/YZHQvfE/3PE0LlLJ9HmjAg=";
+            upstreamTriplet = "x86_64-apple-darwin22.6.0";
+          };
+          x86_64-linux = {
+            alireRevision = "1";
+            inherit url;
+            hash = "sha256-b4hAg3ifoBRqgPxpfMYuOdunw7wzRTL/G5YGBO+im24=";
+            upstreamTriplet = "x86_64-pc-linux-gnu";
+          };
+          aarch64-linux = {
+            alireRevision = "1";
+            inherit url;
+            hash = "sha256-0V/VHqOSYQI6LmvpUIHy3zB6hI3dG0njOcDsrg8oZq8=";
+            upstreamTriplet = "aarch64-linux-gnu";
+          };
+          aarch64-darwin = {
+            alireRevision = "2-pre0";
+            url = "https://github.com/alire-project/GNAT-FSF-builds/releases/download/gnat-15.2.0-2-macos-pre0/gnat-${stdenv.hostPlatform.system}-${finalAttrs.version}.tar.gz";
+            hash = "sha256-4bFtsjixfXYc8wYOc+5iAbp1MmiIS1h1NcdKno2IdJg=";
+            upstreamTriplet = "aarch64-apple-darwin24.6.0";
           };
         }
         .${stdenv.hostPlatform.system} or throwUnsupportedSystem;
@@ -146,13 +159,15 @@ stdenv.mkDerivation (
     ++
       lib.optionals
         (
-          lib.versionAtLeast majorVersion "14" && stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux
+          (majorVersion == "14" && stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux)
+          || (lib.versionAtLeast majorVersion "15" && stdenv.hostPlatform.isLinux)
         )
         [
           # not sure why the bootstrap binaries link to zstd only on this architecture but they do
           zstd
         ];
 
+    __structuredAttrs = true;
     strictDeps = true;
 
     # https://github.com/alire-project/GNAT-FSF-builds/issues/51
@@ -245,8 +260,6 @@ stdenv.mkDerivation (
       platforms = [
         "x86_64-linux"
         "x86_64-darwin"
-      ]
-      ++ lib.optionals (lib.versionAtLeast majorVersion "13") [
         "aarch64-darwin"
       ]
       ++ lib.optionals (lib.versionAtLeast majorVersion "14") [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3467,7 +3467,7 @@ with pkgs;
     enableLTO = false;
   };
 
-  gnat = gnat13; # When changing this, update also gnatPackages
+  gnat = pkgs."gnat${toString default-gcc-version}"; # When changing this, update also gnatPackages
 
   gnat13 = wrapCC (
     gcc13.cc.override {
@@ -3577,7 +3577,8 @@ with pkgs;
     }
   );
 
-  gnat-bootstrap = gnat-bootstrap13;
+  gnat-bootstrap = pkgs."gnat-bootstrap${toString default-gcc-version}";
+
   gnat-bootstrap13 = wrapCCWith {
     cc = callPackage ../development/compilers/gnat-bootstrap { majorVersion = "13"; };
     isAlireGNAT = true;
@@ -3602,7 +3603,7 @@ with pkgs;
   gnat14Packages = recurseIntoAttrs (callPackage ./ada-packages.nix { gnat = buildPackages.gnat14; });
   gnat15Packages = recurseIntoAttrs (callPackage ./ada-packages.nix { gnat = buildPackages.gnat15; });
   gnat16Packages = recurseIntoAttrs (callPackage ./ada-packages.nix { gnat = buildPackages.gnat16; });
-  gnatPackages = gnat13Packages;
+  gnatPackages = pkgs."gnat${toString default-gcc-version}Packages";
 
   inherit (gnatPackages)
     gprbuild

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3535,7 +3535,7 @@ with pkgs;
       # If we are cross-compiling GNAT, we may as well do the same.
       gnat-bootstrap =
         if stdenv.hostPlatform == stdenv.targetPlatform && stdenv.buildPlatform == stdenv.hostPlatform then
-          buildPackages.gnat-bootstrap14
+          buildPackages.gnat-bootstrap15
         else
           buildPackages.gnat15;
       stdenv =
@@ -3544,7 +3544,7 @@ with pkgs;
           && stdenv.buildPlatform == stdenv.hostPlatform
           && stdenv.buildPlatform.isDarwin
         then
-          overrideCC gccStdenv gnat-bootstrap14
+          overrideCC gccStdenv gnat-bootstrap15
         else
           stdenv;
     }
@@ -3562,7 +3562,7 @@ with pkgs;
       # If we are cross-compiling GNAT, we may as well do the same.
       gnat-bootstrap =
         if stdenv.hostPlatform == stdenv.targetPlatform && stdenv.buildPlatform == stdenv.hostPlatform then
-          buildPackages.gnat-bootstrap14
+          buildPackages.gnat-bootstrap15
         else
           buildPackages.gnat16;
       stdenv =
@@ -3571,7 +3571,7 @@ with pkgs;
           && stdenv.buildPlatform == stdenv.hostPlatform
           && stdenv.buildPlatform.isDarwin
         then
-          overrideCC gccStdenv gnat-bootstrap14
+          overrideCC gccStdenv gnat-bootstrap15
         else
           stdenv;
     }
@@ -3585,6 +3585,11 @@ with pkgs;
 
   gnat-bootstrap14 = wrapCCWith {
     cc = callPackage ../development/compilers/gnat-bootstrap { majorVersion = "14"; };
+    isAlireGNAT = true;
+  };
+
+  gnat-bootstrap15 = wrapCCWith {
+    cc = callPackage ../development/compilers/gnat-bootstrap { majorVersion = "15"; };
     isAlireGNAT = true;
   };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3562,7 +3562,7 @@ with pkgs;
       # If we are cross-compiling GNAT, we may as well do the same.
       gnat-bootstrap =
         if stdenv.hostPlatform == stdenv.targetPlatform && stdenv.buildPlatform == stdenv.hostPlatform then
-          buildPackages.gnat-bootstrap15
+          buildPackages.gnat-bootstrap16
         else
           buildPackages.gnat16;
       stdenv =
@@ -3571,7 +3571,7 @@ with pkgs;
           && stdenv.buildPlatform == stdenv.hostPlatform
           && stdenv.buildPlatform.isDarwin
         then
-          overrideCC gccStdenv gnat-bootstrap15
+          overrideCC gccStdenv gnat-bootstrap16
         else
           stdenv;
     }
@@ -3590,6 +3590,11 @@ with pkgs;
 
   gnat-bootstrap15 = wrapCCWith {
     cc = callPackage ../development/compilers/gnat-bootstrap { majorVersion = "15"; };
+    isAlireGNAT = true;
+  };
+
+  gnat-bootstrap16 = wrapCCWith {
+    cc = callPackage ../development/compilers/gnat-bootstrap { majorVersion = "16"; };
     isAlireGNAT = true;
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Just a bulk standard gnat update. Also adds two new `gnat-bootstrap` version. Made against staging so we have the darwin changes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
