### PR TITLE
osu-lazer: remove OSU_DISABLE_ERROR_REPORTING

### DIFF
--- a/pkgs/by-name/os/osu-lazer/package.nix
+++ b/pkgs/by-name/os/osu-lazer/package.nix
@@ -70,14 +70,9 @@ buildDotnetModule rec {
   fixupPhase = ''
     runHook preFixup
 
-    # Disabling error reporting.
-    # https://github.com/ppy/osu/commit/48434dd683d095c42c01def8ff7cb95ce0a85ce4
-    # Unhandled exception. System.ArgumentException: Invalid DSN: No public key provided.
-
     wrapProgram $out/bin/osu! \
       ${lib.optionalString nativeWayland "--set SDL_VIDEODRIVER wayland"} \
-      --set OSU_EXTERNAL_UPDATE_PROVIDER 1 \
-      --set OSU_DISABLE_ERROR_REPORTING 1
+      --set OSU_EXTERNAL_UPDATE_PROVIDER 1
 
     for i in 16 32 48 64 96 128 256 512 1024; do
       install -D ./assets/lazer.png $out/share/icons/hicolor/''${i}x$i/apps/osu.png


### PR DESCRIPTION
In https://github.com/ppy/osu/commit/48434dd683d095c42c01def8ff7cb95ce0a85ce4, the sentry configuration was changed to send errors to localhost rather than upstream's endpoin, but this caused a runtime error:

```console
Unhandled exception. System.ArgumentException: Invalid DSN: No public key provided.
   at Sentry.Dsn.Parse(String dsn)
   at Sentry.SentrySdk.InitHub(SentryOptions options)
   at Sentry.SentrySdk.Init(SentryOptions options)
   at Sentry.SentrySdk.Init(Action`1 configureOptions)
   at osu.Game.Utils.SentryLogger..ctor(OsuGame game, Storage storage) in /_/osu.Game/Utils/SentryLogger.cs:line 59
   at osu.Game.OsuGame.SetupLogging(Storage gameStorage, Storage cacheStorage) in /_/osu.Game/OsuGame.cs:line 354
   at osu.Framework.Platform.GameHost.Run(Game game)
   at osu.Desktop.Program.Main(String[] args) in /_/osu.Desktop/Program.cs:line 141
```
We fixed it by adding `OSU_DISABLE_ERROR_REPORTING=1` variable.

However after https://github.com/ppy/osu/commit/c74c54d7706ae823d2ca33203ba1eee15a1002b5 it works without the environment variable set.

To keep the build script a little bit cleaner and avoid small confusions like https://github.com/NixOS/nixpkgs/pull/521962#discussion_r3299077571, I think it's best to remove this environment variable.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
