### PR TITLE
ghr-cli: init at 0.8.1

### DIFF
--- a/pkgs/by-name/gh/ghr-cli/package.nix
+++ b/pkgs/by-name/gh/ghr-cli/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  gitMinimal,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ghr-cli";
+  version = "0.8.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "chenyukang";
+    repo = "ghr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lo8a5EhLslqjnUG/xM8XFU1x1Eam47lFD8KRMzuCSD4=";
+  };
+
+  cargoHash = "sha256-PtnQVdW9yC2309047PFt/HXV1QyqNttZ0zJ8hocLRAo=";
+
+  passthru.updateScript = nix-update-script { };
+
+  nativeCheckInputs = [
+    gitMinimal
+  ];
+
+  meta = {
+    description = "Fast terminal workspace for staying on top of GitHub";
+    homepage = "https://catcoding.me/ghr/";
+    changelog = "https://github.com/chenyukang/ghr/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pborzenkov ];
+    mainProgram = "ghr";
+  };
+})


### PR DESCRIPTION
This PR adds new package - [ghr-cli](https://catcoding.me/ghr/).

`ghr-cli` provides pull requests, issues, notifications, conversations, checks,
diffs, and review actions in one snapshot-first terminal workspace.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
