### PR TITLE
gitlab: 18.11.3 -> 18.11.4

### DIFF
--- a/pkgs/by-name/gi/gitaly/package.nix
+++ b/pkgs/by-name/gi/gitaly/package.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  version = "18.11.3";
+  version = "18.11.4";
   package_version = "v${lib.versions.major version}";
   gitaly_package = "gitlab.com/gitlab-org/gitaly/${package_version}";
 
@@ -21,10 +21,10 @@ let
       owner = "gitlab-org";
       repo = "gitaly";
       rev = "v${version}";
-      hash = "sha256-oFQevVXbxu9G4LF3BrC0EUUviypSwB4cKRjipdiO3jU=";
+      hash = "sha256-YQpNsSCjcMC1tpwLVN0fCB9T3vBFxp0TyrvxzJfTnFg=";
     };
 
-    vendorHash = "sha256-123WUtoUaPIyDywcTKEhiZP2SYYHxAQoOPyCebsHYRI=";
+    vendorHash = "sha256-/RJnCcmUoqGy08MSGEVM/taV1qZK65kiZw19n6S3ZQ0=";
 
     ldflags = [
       "-X ${gitaly_package}/internal/version.version=${version}"

--- a/pkgs/by-name/gi/gitlab-elasticsearch-indexer/package.nix
+++ b/pkgs/by-name/gi/gitlab-elasticsearch-indexer/package.nix
@@ -11,17 +11,17 @@ let
 in
 buildGoModule (finalAttrs: {
   pname = "gitlab-elasticsearch-indexer";
-  version = "5.14.1";
+  version = "5.14.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-elasticsearch-indexer";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-yYl2cSPY5hn1GSda5ioMD3rEectNMtYGstVpz73pi3Y=";
+    hash = "sha256-1fVBCem23X8u1NQ6ph37EiXRvMpzF/8Yac+VefAe9Yg=";
   };
 
-  vendorHash = "sha256-yeVEQEXHGAkdkfcnjok8iOvVRxucObVAxhuACmyFDJw=";
+  vendorHash = "sha256-cUHXrUd+pSMiS6iSwKKA+o1B6ZHbaQYHYPeVk1Y6wYM=";
 
   buildInputs = [ icu ];
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/by-name/gi/gitlab-pages/package.nix
+++ b/pkgs/by-name/gi/gitlab-pages/package.nix
@@ -6,14 +6,14 @@
 
 buildGoModule (finalAttrs: {
   pname = "gitlab-pages";
-  version = "18.11.3";
+  version = "18.11.4";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-pages";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-ozkrU3QF/LK0uqfF52dnm2MCga+vRD8dGsLNnze6E+Y=";
+    hash = "sha256-tE2PHWk12S482TjNhI0u7Afm0mPAgJWqcJiU5dgqN60=";
   };
 
   vendorHash = "sha256-PUW4cgAiM1GTtvja894OZ4pe0SWChf5JsL4/fkns2kI=";

--- a/pkgs/by-name/gi/gitlab-shell/package.nix
+++ b/pkgs/by-name/gi/gitlab-shell/package.nix
@@ -8,14 +8,14 @@
 
 buildGoModule (finalAttrs: {
   pname = "gitlab-shell";
-  version = "14.49.0";
+  version = "14.50.0";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitLab {
     owner = "gitlab-org";
     repo = "gitlab-shell";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-8PnFRwP5vctnOh6t45crxkoVF6Z03bfYry24KfFHCww=";
+    hash = "sha256-a9s+TCm5yKPjNh+BD9fm6iVA4H9KJiMyWNulY+7BKZo=";
   };
 
   buildInputs = [
@@ -27,7 +27,7 @@ buildGoModule (finalAttrs: {
     ./remove-hardcoded-locations.patch
   ];
 
-  vendorHash = "sha256-JBKU134/Yyz49HWfU9Dw/EC4bI/o3Hs56Ou7wtzp5qM=";
+  vendorHash = "sha256-ceSnQQTtGdLb0QGR9fDbGC0NtRPGqkyXJ6b0TRXkjQM=";
 
   subPackages = [
     "cmd/gitlab-shell"

--- a/pkgs/by-name/gi/gitlab/data.json
+++ b/pkgs/by-name/gi/gitlab/data.json
@@ -1,17 +1,17 @@
 {
-  "version": "18.11.3",
-  "repo_hash": "sha256-QxaLdWErE+b4SpwHtxnCa2tqheWUfEixRcQwYD/A9s8=",
+  "version": "18.11.4",
+  "repo_hash": "sha256-ThtRXdUreorOIea5Izd+zKb88cC4nhitkzqT+Yf5UtU=",
   "yarn_hash": "sha256-k8JHi0f/XfSV4kICyPW01Erk3YnKw33yeUWYrOaPdTM=",
   "frontend_islands_yarn_hash": "sha256-EvGQin+5DqqIgM36jlVkVI49WcJzVvceYnkSS9ybfcY=",
   "owner": "gitlab-org",
   "repo": "gitlab",
-  "rev": "v18.11.3-ee",
+  "rev": "v18.11.4-ee",
   "passthru": {
-    "GITALY_SERVER_VERSION": "18.11.3",
-    "GITLAB_KAS_VERSION": "18.11.3",
-    "GITLAB_PAGES_VERSION": "18.11.3",
-    "GITLAB_SHELL_VERSION": "14.49.0",
-    "GITLAB_ELASTICSEARCH_INDEXER_VERSION": "5.14.1",
-    "GITLAB_WORKHORSE_VERSION": "18.11.3"
+    "GITALY_SERVER_VERSION": "18.11.4",
+    "GITLAB_KAS_VERSION": "18.11.4",
+    "GITLAB_PAGES_VERSION": "18.11.4",
+    "GITLAB_SHELL_VERSION": "14.50.0",
+    "GITLAB_ELASTICSEARCH_INDEXER_VERSION": "5.14.7",
+    "GITLAB_WORKHORSE_VERSION": "18.11.4"
   }
 }

--- a/pkgs/by-name/gi/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/by-name/gi/gitlab/gitlab-workhorse/default.nix
@@ -10,7 +10,7 @@ in
 buildGoModule (finalAttrs: {
   pname = "gitlab-workhorse";
 
-  version = "18.11.3";
+  version = "18.11.4";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitLab {

--- a/pkgs/by-name/gi/gitlab/rubyEnv/Gemfile
+++ b/pkgs/by-name/gi/gitlab/rubyEnv/Gemfile
@@ -765,3 +765,6 @@ gem "gitlab-cloud-connector", "~> 1.45", require: 'gitlab/cloud_connector', feat
 gem "gvltools", "~> 0.4.0", feature_category: :shared # rubocop:todo Gemfile/MissingFeatureCategory -- https://gitlab.com/gitlab-org/gitlab/-/issues/581839
 
 gem 'gitlab_query_language', '~> 0.26.0', feature_category: :integrations
+
+# standard Gem, version increase to resolve vulnerabilities
+gem "zlib", "~> 3.2", ">= 3.2.3", feature_category: :shared # rubocop:todo Gemfile/MissingFeatureCategory -- https://gitlab.com/gitlab-org/gitlab/-/work_items/596593

--- a/pkgs/by-name/gi/gitlab/rubyEnv/Gemfile.lock
+++ b/pkgs/by-name/gi/gitlab/rubyEnv/Gemfile.lock
@@ -2174,6 +2174,7 @@ GEM
     yard-solargraph (0.1.0)
       yard (~> 0.9)
     zeitwerk (2.6.18)
+    zlib (3.2.3)
 
 PLATFORMS
   ruby
@@ -2553,6 +2554,7 @@ DEPENDENCIES
   yajl-ruby (~> 1.4.3)
   yard (~> 0.9)
   zeitwerk (= 2.6.18)
+  zlib (~> 3.2, >= 3.2.3)
 
 BUNDLED WITH
    2.7.1

--- a/pkgs/by-name/gi/gitlab/rubyEnv/gemset.nix
+++ b/pkgs/by-name/gi/gitlab/rubyEnv/gemset.nix
@@ -10473,4 +10473,14 @@ src: {
     };
     version = "2.6.18";
   };
+  zlib = {
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "084w64p55s3l2rmbs6x84qbclhi451n8n2limdj1mwrjidlidlsv";
+      type = "gem";
+    };
+    version = "3.2.3";
+  };
 }


### PR DESCRIPTION
https://gitlab.com/gitlab-org/gitlab/-/blob/v18.11.4-ee/CHANGELOG.md

GitLab 19 removed resource owner password credentials from the [supported OAuth 2.0 flows](https://docs.gitlab.com/18.11/api/oauth2/#supported-oauth-20-flows), breaking the NixOS test, so we stay on 18.11 for a little longer.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
