### PR TITLE
pipeform: init at 0.2.1

### DIFF
--- a/pkgs/by-name/pi/pipeform/package.nix
+++ b/pkgs/by-name/pi/pipeform/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  libx11,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "pipeform";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "magodo";
+    repo = "pipeform";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qmA+4xNstR1VRoYZW+xukNCEuEq6aGVkja3DYxZZVyY=";
+  };
+
+  vendorHash = "sha256-QI6Rnq3JxQuKRMkeo9Fvv6wfcTMgDEQ3Ot+es3IAUIA=";
+
+  subPackages = [ "." ];
+
+  __structuredAttrs = true;
+
+  # Clipboard support
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ libx11 ];
+
+  meta = {
+    description = "TUI for Terraform runtime progress";
+    homepage = "https://github.com/magodo/pipeform";
+    license = lib.licenses.mpl20;
+    mainProgram = "pipeform";
+    maintainers = with lib.maintainers; [ jlesquembre ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add https://github.com/magodo/pipeform


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
