### PR TITLE
python3Packages.emmiai-noether: init at 2026.4.0

### DIFF
--- a/lib/licenses/licenses.nix
+++ b/lib/licenses/licenses.nix
@@ -575,6 +575,13 @@ lib.mapAttrs mkLicense (
       free = false;
     };
 
+    enpl = {
+      fullName = "Emmi AI Non-Production License";
+      url = "https://github.com/Emmi-AI/noether/blob/main/LICENSE.txt";
+      free = false;
+      redistributable = true;
+    };
+
     epl10 = {
       spdxId = "EPL-1.0";
       fullName = "Eclipse Public License 1.0";

--- a/pkgs/development/python-modules/aistore/default.nix
+++ b/pkgs/development/python-modules/aistore/default.nix
@@ -1,0 +1,111 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  braceexpand,
+  cloudpickle,
+  humanize,
+  msgspec,
+  overrides,
+  packaging,
+  pydantic,
+  python-dateutil,
+  pyyaml,
+  requests,
+  tenacity,
+  urllib3,
+  xxhash,
+
+  # optional-dependencies
+  # botocore:
+  wrapt,
+  # etl:
+  aiofiles,
+  fastapi,
+  flask,
+  gunicorn,
+  httpx,
+  uvicorn,
+  # mcp:
+  mcp,
+  # pytorch:
+  alive-progress,
+  torch,
+  torchdata,
+  webdataset,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "aistore";
+  version = "1.25.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  # Tags on GitHub do not match
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-aslNCRSV7QKgvvDuUQPgcbUyUDdGP2kC4ryFu6IVYYE=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    braceexpand
+    cloudpickle
+    humanize
+    msgspec
+    overrides
+    packaging
+    pydantic
+    python-dateutil
+    pyyaml
+    requests
+    tenacity
+    urllib3
+    xxhash
+  ];
+
+  optional-dependencies = {
+    botocore = [
+      wrapt
+    ];
+    etl = [
+      aiofiles
+      fastapi
+      flask
+      gunicorn
+      httpx
+      uvicorn
+    ];
+    mcp = [
+      mcp
+    ];
+    pytorch = [
+      alive-progress
+      torch
+      torchdata
+      webdataset
+    ];
+  };
+
+  pythonImportsCheck = [ "aistore" ];
+
+  # No tests in the Pypi archive
+  doCheck = false;
+
+  meta = {
+    description = "Client-side APIs to access and utilize clusters, buckets, and objects on AIStore";
+    homepage = "https://aistore.nvidia.com";
+    downloadPage = "https://github.com/NVIDIA/aistore/tree/main/python/aistore/sdk";
+    changelog = "https://github.com/NVIDIA/aistore/blob/main/python/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/development/python-modules/emmiai-noether/default.nix
+++ b/pkgs/development/python-modules/emmiai-noether/default.nix
@@ -1,0 +1,105 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  aistore,
+  boto3,
+  einops,
+  fsspec,
+  h5py,
+  huggingface-hub,
+  hydra-core,
+  loguru,
+  numpy,
+  pandas,
+  psutil,
+  pyvista,
+  rtree,
+  submitit,
+  torch,
+  trimesh,
+  typer,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "emmiai-noether";
+  version = "2026.4.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Emmi-AI";
+    repo = "noether";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ySQxI0n4mPKio7tlRkRRdSq/ieIigznur2CZhJfbyLs=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  pythonRelaxDeps = [
+    "numpy"
+  ];
+  dependencies = [
+    aistore
+    boto3
+    einops
+    fsspec
+    h5py
+    huggingface-hub
+    hydra-core
+    loguru
+    numpy
+    pandas
+    psutil
+    pyvista
+    rtree
+    submitit
+    torch
+    trimesh
+    typer
+  ];
+
+  pythonImportsCheck = [ "noether" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Checks if code.tar.gz exists
+    "test_train_pipeline_copies_code"
+
+    # Fails to properly count the number of cores in the sandbox
+    "test_total_cpu_count_fallback"
+    "test_total_cpu_count_linux"
+    "test_total_cpu_count_mac"
+    "test_total_cpu_count_windows"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # flaky: assert 0.32007395901018754 == 0.3 ± 0.02
+    "test_real_time_accuracy"
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  meta = {
+    description = "Deep-Learning framework for Engineering AI";
+    homepage = "https://github.com/Emmi-AI/noether";
+    changelog = "https://github.com/Emmi-AI/noether/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.enpl;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -618,6 +618,8 @@ self: super: with self; {
 
   airtouch5py = callPackage ../development/python-modules/airtouch5py { };
 
+  aistore = callPackage ../development/python-modules/aistore { };
+
   aistudio-sdk = callPackage ../development/python-modules/aistudio-sdk { };
 
   ajpy = callPackage ../development/python-modules/ajpy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5042,6 +5042,8 @@ self: super: with self; {
 
   emcee = callPackage ../development/python-modules/emcee { };
 
+  emmiai-noether = callPackage ../development/python-modules/emmiai-noether { };
+
   emoji = callPackage ../development/python-modules/emoji { };
 
   emoji-country-flag = callPackage ../development/python-modules/emoji-country-flag { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add [emmiai-noether](https://github.com/Emmi-AI/noether), a Deep-Learning framework for Engineering AI.

- **python3Packages.aistore: init at 1.25.0**
- **licenses: add enpl, Emmi AI Non-Production License**
- **python3Packages.emmiai-noether: init at 2026.4.0**

---

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
