### PR TITLE
sherpa-onnx: revert fix darwin runtime linking to onnxruntime

### DIFF
--- a/pkgs/by-name/sh/sherpa-onnx/package.nix
+++ b/pkgs/by-name/sh/sherpa-onnx/package.nix
@@ -191,10 +191,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
-  preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    export DYLD_FALLBACK_LIBRARY_PATH=${lib.getLib onnxruntime}/lib
-  '';
-
   # Use ctest directly because the default `make check` target includes clang-tidy.
   checkPhase = ''
     runHook preCheck
@@ -206,10 +202,6 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $python
     cp -r ../sherpa-onnx/python/sherpa_onnx $python/
     rm $out/lib/_sherpa_onnx*.so
-    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
-      install_name_tool -add_rpath ${lib.getLib onnxruntime}/lib \
-        $python/sherpa_onnx/lib/_sherpa_onnx*.so
-    ''}
   '';
 
   passthru = {


### PR DESCRIPTION
Thanks to #525092, I reverted my fix for darwin. It is not needed any more.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
