### PR TITLE
haskellPackages.amazonka: fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2934,13 +2934,13 @@ with haskellLib;
     amazonkaSrc = pkgs.fetchFromGitHub {
       owner = "brendanhay";
       repo = "amazonka";
-      rev = "7645bd335f008912b9e5257486f622b674de7afa";
-      sha256 = "sha256-ObamDnJdcLA2BlX9iGIxkaknUeL3Po3madKO4JA/em0=";
+      rev = "c87e5cbb67d8116c8829c9f84db4f8da92734830";
+      sha256 = "sha256-mO9kbooiReW1cdnrG9t4yjAsm/qVQKhEN8CmCiEfJgY=";
     };
     setAmazonkaSourceRoot =
       dir: drv:
       (overrideSrc {
-        version = "2.0-unstable-2025-04-16";
+        version = "2.0-unstable-2026-05-20";
         src = amazonkaSrc + "/${dir}";
       })
         drv;
@@ -3311,9 +3311,14 @@ with haskellLib;
         self.microlens-pro
       ])
     ];
-    amazonka = warnAfterVersion "2.0" (
-      setAmazonkaSourceRoot "lib/amazonka" (doJailbreak super.amazonka)
-    );
+    amazonka = lib.pipe super.amazonka [
+      (setAmazonkaSourceRoot "lib/amazonka")
+      (addBuildDepends [
+        self.tasty
+        self.tasty-hunit
+      ])
+      (warnAfterVersion "2.0")
+    ];
     amazonka-test = warnAfterVersion "2.0" (
       setAmazonkaSourceRoot "lib/amazonka-test" (doJailbreak super.amazonka-test)
     );


### PR DESCRIPTION
Fixes `amazonka` for https://github.com/NixOS/nixpkgs/pull/521260 by updating to a newer upstream snapshot and adding the new `tasty` / `tasty-hunit` test dependencies required by that snapshot.

(done with codex gpt-5)

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Additional validation:

- `git diff --check`
- `nix shell nixpkgs#nixfmt -c nixfmt --check pkgs/development/haskell-modules/configuration-common.nix`
- `nix build -L --show-trace .#haskell.packages.ghc912.amazonka --no-link` on `claude-netcup` using cached `/nix/store/1spad6fbf6xbnnxvba9676zi7vf91d25-ghc-9.12.3`

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test