### PR TITLE
nixos/doc: Update stable channel in upgrading chapter

### DIFF
--- a/nixos/doc/manual/installation/upgrading.chapter.md
+++ b/nixos/doc/manual/installation/upgrading.chapter.md
@@ -8,7 +8,7 @@ passed and a selection of packages has been built successfully
 (see `nixos/release-combined.nix` and `nixos/release-small.nix`).
 These channels are:
 
--   *Stable channels*, such as [`nixos-25.11`](https://channels.nixos.org/nixos-25.11).
+-   *Stable channels*, such as [`nixos-26.05`](https://channels.nixos.org/nixos-26.05).
     These only get conservative bug fixes and package upgrades. For
     instance, a channel update may cause the Linux kernel on your system
     to be upgraded from 4.19.34 to 4.19.38 (a minor bug fix), but not
@@ -21,7 +21,7 @@ These channels are:
     radical changes between channel updates. It's not recommended for
     production systems.
 
--   *Small channels*, such as [`nixos-25.11-small`](https://channels.nixos.org/nixos-25.11-small)
+-   *Small channels*, such as [`nixos-26.05-small`](https://channels.nixos.org/nixos-26.05-small)
     or [`nixos-unstable-small`](https://channels.nixos.org/nixos-unstable-small).
     These are identical to the stable and unstable channels described above,
     except that they contain fewer binary packages. This means they get updated
@@ -40,8 +40,8 @@ supported stable release.
 
 When you first install NixOS, you're automatically subscribed to the
 NixOS channel that corresponds to your installation source. For
-instance, if you installed from a 25.11 ISO, you will be subscribed to
-the `nixos-25.11` channel. To see which NixOS channel you're subscribed
+instance, if you installed from a 26.05 ISO, you will be subscribed to
+the `nixos-26.05` channel. To see which NixOS channel you're subscribed
 to, run the following as root:
 
 ```ShellSession
@@ -56,16 +56,16 @@ To switch to a different NixOS channel, do
 ```
 
 (Be sure to include the `nixos` parameter at the end.) For instance, to
-use the NixOS 25.11 stable channel:
+use the NixOS 26.05 stable channel:
 
 ```ShellSession
-# nix-channel --add https://channels.nixos.org/nixos-25.11 nixos
+# nix-channel --add https://channels.nixos.org/nixos-26.05 nixos
 ```
 
 If you have a server, you may want to use the "small" channel instead:
 
 ```ShellSession
-# nix-channel --add https://channels.nixos.org/nixos-25.11-small nixos
+# nix-channel --add https://channels.nixos.org/nixos-26.05-small nixos
 ```
 
 And if you want to live on the bleeding edge:
@@ -118,5 +118,5 @@ the new generation contains a different kernel, initrd or kernel
 modules. You can also specify a channel explicitly, e.g.
 
 ```nix
-{ system.autoUpgrade.channel = "https://channels.nixos.org/nixos-25.11"; }
+{ system.autoUpgrade.channel = "https://channels.nixos.org/nixos-26.05"; }
 ```


### PR DESCRIPTION
The next release is around the corner, so it is time to update the channel name in the upgrade section. :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
