### PR TITLE
haskellPackages.pdftotext: fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2571,20 +2571,41 @@ with haskellLib;
   # https://github.com/phadej/zinza/pull/28
   zinza = dontCheck super.zinza;
 
-  pdftotext = overrideCabal (drv: {
-    jailbreak = true;
-    postPatch = ''
+  pdftotext =
+    let
+      decodeSourceHutMboxPatch = lib.escapeShellArgs [
+        "${pkgs.perl}/bin/perl"
+        "-MMIME::QuotedPrint=decode_qp"
+        "-0777"
+        "-ne"
+        "print decode_qp($_)"
+      ];
+    in
+    appendPatches [
       # Fixes https://todo.sr.ht/~geyaeb/haskell-pdftotext/6
-      substituteInPlace pdftotext.cabal --replace-quiet c-sources cxx-sources
-
       # Fix cabal ignoring cxx because the cabal format version is too old
-      substituteInPlace pdftotext.cabal --replace-quiet ">=1.10" 2.2
-
       # Fix wrong license name that breaks recent cabal version
-      substituteInPlace pdftotext.cabal --replace-quiet BSD3 BSD-3-Clause
-    ''
-    + (drv.postPatch or "");
-  }) super.pdftotext;
+      (fetchpatch {
+        name = "pdftotext-use-cxx-sources-for-cxx-sources.patch";
+        url = "https://lists.sr.ht/~geyaeb/haskell-pdftotext/patches/69754/mbox";
+        decode = decodeSourceHutMboxPatch;
+        hash = "sha256-5DvNBFlbP0o5Hso+mzKweQAINUUTequPMoOJZfgeIzU=";
+      })
+      # Adapt the executable to range 1.0's Ranges API.
+      (fetchpatch {
+        name = "pdftotext-support-range-1.0-in-the-cli.patch";
+        url = "https://lists.sr.ht/~geyaeb/haskell-pdftotext/patches/69755/mbox";
+        decode = decodeSourceHutMboxPatch;
+        hash = "sha256-hZFMSI8Yyh5QIXMRs9VkBKPPP2IM+cbU2ILcqYc9oIw=";
+      })
+      # Relax stale dependency bounds, replacing jailbreak.
+      (fetchpatch {
+        name = "pdftotext-relax-dependency-bounds.patch";
+        url = "https://lists.sr.ht/~geyaeb/haskell-pdftotext/patches/69756/mbox";
+        decode = decodeSourceHutMboxPatch;
+        hash = "sha256-wYM0SsOk9eZXR+/g+VOkj7okhmy1sEONCLHcrHlV2EI=";
+      })
+    ] super.pdftotext;
 
   # Allow QuickCheck 2.16
   # https://github.com/google/proto-lens/issues/403


### PR DESCRIPTION
Fixes `pdftotext` for https://github.com/NixOS/nixpkgs/pull/521260 by applying upstreamable compatibility patches submitted to the upstream SourceHut patch tracker.

The patches cover:

- `cxx-sources`/modern Cabal metadata for the C++ sources
- the `range` 1.0 `Ranges` API migration in the CLI
- relaxed stale dependency bounds for the current Haskell package set

Patch submissions:

- https://lists.sr.ht/~geyaeb/haskell-pdftotext/patches/69754
- https://lists.sr.ht/~geyaeb/haskell-pdftotext/patches/69755
- https://lists.sr.ht/~geyaeb/haskell-pdftotext/patches/69756

(done with codex gpt-5)

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Additional validation:

- `git diff --check`
- `nix shell nixpkgs#nixfmt -c nixfmt --check pkgs/development/haskell-modules/configuration-common.nix`
- SourceHut `fetchpatch` mbox URLs for all three patches fetched and normalized successfully with the committed hashes
- `nix build -L --show-trace .#haskell.packages.ghc984Binary.pdftotext --no-link` on `claude-netcup` with `range-1.0.0.0`


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
