### PR TITLE
redis{bloom,json,timeseries}: init at 8.10.0

### DIFF
--- a/pkgs/by-name/re/redisbloom/package.nix
+++ b/pkgs/by-name/re/redisbloom/package.nix
@@ -1,0 +1,65 @@
+{
+  cmake,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  redis,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "redisbloom";
+  version = "8.8.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "RedisBloom";
+    repo = "RedisBloom";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-vagAHAJBbgeAfGadCeHe4RUJABMFzCB1uor/YuBiE6k=";
+  };
+
+  makeFlags = [
+    # Force building shared libray
+    "SO_LD_FLAGS=-shared"
+    # Some modules require an extra platform mapping.
+    # https://github.com/redis/redis/blob/65401042dc6105eac649dfc3b52eadb3fbb852a2/modules/common.mk#L8-L12
+    "ARCH=${
+      with stdenv.hostPlatform;
+      if isAarch64 then
+        "arm64v8"
+      else if (isx86 || isi686) then
+        "x64"
+      else
+        throw "Unsupported sytem: ${system}"
+    }"
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  nativeBuildInputs = [ cmake ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    cp bin/*/*.so $out/lib
+
+    runHook postInstall
+  '';
+
+  # Try to keep redis modules in sync with the version of redis.
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=${redis.version}" ];
+  };
+
+  meta = {
+    description = "Probabilistic Datatypes Module for Redis";
+    license = lib.licenses.agpl3Only;
+    platforms = lib.platforms.all;
+    teams = [ lib.teams.redis ];
+  };
+})

--- a/pkgs/by-name/re/redisjson/package.nix
+++ b/pkgs/by-name/re/redisjson/package.nix
@@ -1,0 +1,40 @@
+{
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  redis,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "redisjson";
+  version = "8.8.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "RedisJSON";
+    repo = "RedisJSON";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-eHLQvzFrCOrEHJwFESUX+0+nIBiB7NEoapos1A/zeOk=";
+  };
+
+  cargoHash = "sha256-EXFR0hM5IX2shMrZRmD0an+xg8vAhlKDoQVDxrH+h0A=";
+
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
+  ];
+
+  # Try to keep redis modules in sync with the version of redis.
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=${redis.version}" ];
+  };
+
+  meta = {
+    description = "JSON data type for Redis";
+    license = lib.licenses.agpl3Only;
+    mainProgram = "jsonpath";
+    platforms = lib.platforms.all;
+    teams = [ lib.teams.redis ];
+  };
+})

--- a/pkgs/by-name/re/redistimeseries/package.nix
+++ b/pkgs/by-name/re/redistimeseries/package.nix
@@ -1,0 +1,85 @@
+{
+  autoconf,
+  automake,
+  cmake,
+  fetchFromGitHub,
+  glibtool,
+  jq,
+  lib,
+  libtool,
+  nix-update-script,
+  openssl,
+  redis,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "redistimeseries";
+  version = "8.8.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "RedisTimeSeries";
+    repo = "RedisTimeSeries";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-KcxRuoXvQ48uaNx5ycUzfW2wuS8KVyICQNaxf6dT8Lc=";
+  };
+
+  makeFlags = [
+    # Force building shared libray
+    "SO_LD_FLAGS=-shared"
+    # Some modules require an extra platform mapping.
+    # https://github.com/redis/redis/blob/65401042dc6105eac649dfc3b52eadb3fbb852a2/modules/common.mk#L8-L12
+    "ARCH=${
+      with stdenv.hostPlatform;
+      if isAarch64 then
+        "arm64v8"
+      else if (isx86 || isi686) then
+        "x64"
+      else
+        throw "Unsupported sytem: ${system}"
+    }"
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    cmake
+    jq
+    libtool
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ glibtool ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    cp bin/*/*.so $out/lib
+
+    runHook postInstall
+  '';
+
+  # Try to keep redis modules in sync with the version of redis.
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=${redis.version}" ];
+  };
+
+  meta = {
+    # Currently only supports 64bit platforms.
+    # https://github.com/RedisTimeSeries/RedisTimeSeries/blob/b0ecf8a8cbb903cd227ce61db46735f01486a3b9/Makefile#L35-L37
+    badPlatforms = [ lib.systems.inspect.patterns.is32bit ];
+    description = "Time Series data structure for Redis";
+    license = lib.licenses.agpl3Only;
+    platforms = lib.platforms.all;
+    teams = [ lib.teams.redis ];
+  };
+})


### PR DESCRIPTION
This is probably one of multiple PRs trying to bring the whole Redis Stack into `nixpkgs`. This PR will solely focus on implementing the raw builds of the modules. I hope I'll be able to bring Redisearch to `nixpkgs` too but it vendors a lot of libraries by fetching them so this could take a while and will probably turn out a bit ugly. I'll also try to add some convenience method for loading modules to the `nixos/redis` module in the future.

This could be put into its own package set like `redis.modules` but for the sake of RFC 197 I'd keep them as separate packages for now.

To test them you can load the modules by adding `loadmodule /nix/store/.../lib/whatever.so` to your `redis.conf`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
