### PR TITLE
meandmyshadow: init at 0-unstable-2024-12-12

### DIFF
--- a/pkgs/by-name/me/meandmyshadow/package.nix
+++ b/pkgs/by-name/me/meandmyshadow/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  SDL2,
+  SDL2_image,
+  SDL2_mixer,
+  freetype,
+  curl,
+  libarchive,
+  lua5_3,
+  libx11,
+  makeWrapper,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "meandmyshadow";
+  version = "0.5a-unstable-2024-12-12";
+
+  src = fetchFromGitHub {
+    owner = "acmepjz";
+    repo = "meandmyshadow";
+    rev = "28392b7a770c12e3ac1dd6cdfc85b0a66b6a300b";
+    hash = "sha256-YIszFi1I66h4Db1GYOqApYOYzt88V6q68NOCNP8NzVo=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    SDL2
+    SDL2_image
+    SDL2_mixer
+    freetype
+    curl
+    libarchive
+    lua5_3
+    libx11
+  ];
+
+  #Fix the upstream code with modern standards
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "CMake_Minimum_Required (VERSION 3.1)" \
+                    "CMake_Minimum_Required (VERSION 3.10)"
+
+    substituteInPlace src/EasterEggScreen.cpp \
+      --replace-fail 'char date[8];' 'char date[32];'
+
+    substituteInPlace src/MusicManager.h \
+      --replace-fail 'typedef struct _Mix_Music Mix_Music;' \
+                    'typedef struct Mix_Music Mix_Music;'
+  '';
+  #Fix image icon location warning
+  postInstall = ''
+    install -Dm644 \
+      $out/share/icons/hicolor/16x16/apps/meandmyshadow.png \
+      $out/share/meandmyshadow/icons/16x16/meandmyshadow.png
+  '';
+
+  #Force the renderer under X11
+  postFixup = ''
+    wrapProgram $out/bin/meandmyshadow \
+      --set SDL_VIDEODRIVER x11
+  '';
+
+  meta = {
+    description = "Puzzle platform game where you cooperate with your shadow to reach exit";
+    homepage = "https://github.com/acmepjz/meandmyshadow";
+    mainProgram = "meandmyshadow";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ castorNova2 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add a package of [meandmyshadow](https://github.com/acmepjz/meandmyshadow) which is a platform puzzle game.

- patches compatibility issues with modern CMake, GCC, and SDL2_mixer,
- wraps the executable with SDL_VIDEODRIVER=x11 to avoid renderer initialization failures on Wayland.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
