### PR TITLE
apktool: 2.2.1 -> 3.0.2

### DIFF
--- a/pkgs/by-name/ap/apktool/package.nix
+++ b/pkgs/by-name/ap/apktool/package.nix
@@ -19,14 +19,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "apktool";
-  version = "2.12.1";
+  version = "3.0.2";
 
   src = fetchurl {
     urls = [
-      "https://bitbucket.org/iBotPeaches/apktool/downloads/apktool_${finalAttrs.version}.jar"
       "https://github.com/iBotPeaches/Apktool/releases/download/v${finalAttrs.version}/apktool_${finalAttrs.version}.jar"
     ];
-    hash = "sha256-Zs9FJKSkWn9WVn0Issm27CN7zdeM7mn9SlnIoCQ66vo=";
+    hash = "sha256-7uRmmnBKFOBiNAfmcBsLkYh+YeHkBJy3qCgz4Urotf0=";
   };
 
   dontUnpack = true;
@@ -38,19 +37,26 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     install -D ${finalAttrs.src} "$out/libexec/apktool/apktool.jar"
     mkdir -p "$out/bin"
+
+    # Keep the default JVM flags from Apktool's upstream launcher script:
+    # https://github.com/iBotPeaches/Apktool/blob/b4a8719101b250b6ad26a7829482c06767a7bbc4/scripts/linux/apktool#L57-L61
     makeWrapper "${jre}/bin/java" "$out/bin/apktool" \
-        --add-flags "-jar $out/libexec/apktool/apktool.jar" \
-        --prefix PATH : ${lib.getBin aapt}
+      --add-flags "-Xmx1024M" \
+      --add-flags "-Dfile.encoding=utf-8" \
+      --add-flags "-Djdk.util.zip.disableZip64ExtraFieldValidation=true" \
+      --add-flags "-Djdk.nio.zipfs.allowDotZipEntry=true" \
+      --add-flags "-jar $out/libexec/apktool/apktool.jar" \
+      --prefix PATH : ${lib.getBin aapt}
   '';
 
   meta = {
     description = "Tool for reverse engineering Android apk files";
     mainProgram = "apktool";
-    homepage = "https://ibotpeaches.github.io/Apktool/";
+    homepage = "https://apktool.org";
     changelog = "https://github.com/iBotPeaches/Apktool/releases/tag/v${finalAttrs.version}";
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ qrzbing ];
     platforms = with lib.platforms; unix;
   };
 })


### PR DESCRIPTION
see <https://github.com/iBotPeaches/Apktool/releases/tag/v3.0.2>
update apktool from 2.2.1 to 3.0.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
