### PR TITLE
zluda: add helper binaries and trace libraries

### DIFF
--- a/pkgs/by-name/zl/zluda/package.nix
+++ b/pkgs/by-name/zl/zluda/package.nix
@@ -76,9 +76,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   preInstall = ''
-    mkdir -p $out/lib/
-    find target/release/ -maxdepth 1 -type l -name '*.so*' -exec \
+    mkdir -p $out/lib/trace $out/bin
+    cp target/${stdenv.hostPlatform.rust.rustcTargetSpec}/release/zluda_precompile $out/bin
+    find target/release/ -maxdepth 1 -type l -name '*.so*' -or -name 'zluda_ld' -exec \
       cp --recursive --no-clobber --target-directory=$out/lib/ {} +
+    find target/release/trace -maxdepth 1 -type l -name '*.so*' -or -name 'zluda_ld' -exec \
+      cp --recursive --no-clobber --target-directory=$out/lib/trace {} +
   '';
 
   meta = {


### PR DESCRIPTION
This adds the zluda helper binaries (`zluda_ld` and `zluda_precompile`) as well as the instrumented `trace` libraries. Both are mentioned in the zluda docs for troubleshooting/ speeding up binaries so we probably should also include them in the package outputs too.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
