### PR TITLE
nixosModules.openems: init at 2026.5.0

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -65,6 +65,18 @@
   "module-services-keycloak-unix-socket": [
     "index.html#module-services-keycloak-unix-socket"
   ],
+  "module-services-openems": [
+    "index.html#module-services-openems"
+  ],
+  "module-services-openems-basic-usage": [
+    "index.html#module-services-openems-basic-usage"
+  ],
+  "module-services-openems-config": [
+    "index.html#module-services-openems-config"
+  ],
+  "module-services-openems-ui": [
+    "index.html#module-services-openems-ui"
+  ],
   "module-services-tandoor-recipes-migrating-media-option-move": [
     "index.html#module-services-tandoor-recipes-migrating-media-option-move",
     "index.html#module-services-tandoor-recipes-migrating-media-option-1"

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -733,6 +733,10 @@
   ./services/home-automation/homebridge.nix
   ./services/home-automation/matter-server.nix
   ./services/home-automation/matterjs-server.nix
+  ./services/home-automation/openems/backend.nix
+  ./services/home-automation/openems/common.nix
+  ./services/home-automation/openems/edge.nix
+  ./services/home-automation/openems/ui.nix
   ./services/home-automation/openthread-border-router.nix
   ./services/home-automation/wyoming/faster-whisper.nix
   ./services/home-automation/wyoming/openwakeword.nix

--- a/nixos/modules/services/home-automation/openems/backend.nix
+++ b/nixos/modules/services/home-automation/openems/backend.nix
@@ -1,0 +1,132 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkIf
+    mkOption
+    mkEnableOption
+    mkPackageOption
+    getExe
+    types
+    ;
+  cfg = config.services.openems.backend;
+in
+{
+  options.services.openems.backend = {
+    enable = mkEnableOption "OpenEMS platform connecting decentralized Edge systems and providing aggregation, monitoring and control";
+
+    package = mkPackageOption pkgs "openems-backend" { };
+
+    configDir = mkOption {
+      type = types.path;
+      default = "/var/lib/openems-backend/config.d";
+      example = "/etc/openems-backend/config.d";
+      description = ''
+        Path to the OSGi configs.
+        Must be provisioned manually because some configs contain secrets that should not live in the world-readable Nix store.
+        Alternatively, configs can be edited via the Apache Felix web interface at
+        http://admin:admin@localhost:<felix-port>/system/console/configMgr
+      '';
+    };
+
+    ui = {
+      port = mkOption {
+        type = types.port;
+        default = 8082;
+        description = "Websocket port to for openems-ui to connect to";
+      };
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Set to true to open the TCP port for the UI websocket port";
+      };
+    };
+
+    edgeManager = {
+      port = mkOption {
+        type = types.port;
+        default = 8081;
+        description = "Websocket port for openems-edge nodes to connect to";
+      };
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Set to true to open the TCP port for the edge websocket port";
+      };
+    };
+
+    felix = {
+      port = mkOption {
+        type = types.port;
+        default = 8079;
+        description = "Port of the Apache Felix web console";
+      };
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Set to true to open the TCP port for the Apache Felix web console";
+      };
+    };
+
+    watchdog.timeout = mkOption {
+      type = types.nullOr types.int;
+      default = 180;
+      description = "Service watchdog timeout in seconds (`null` to disable)";
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.openems-backend = {
+      description = "OpenEMS Backend";
+
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        Restart = "always";
+        RestartSec = 10;
+        WatchdogSec = cfg.watchdog.timeout;
+        ExecStart = getExe cfg.package;
+      };
+
+      environment.JAVA_OPTS = lib.concatStringsSep " " [
+        "-Dfelix.cm.dir=${cfg.configDir}"
+        "-Dorg.osgi.service.http.port=${toString cfg.felix.port}"
+        "-Djava.util.concurrent.ForkJoinPool.common.parallelism=100"
+        "-XX:+ExitOnOutOfMemoryError"
+      ];
+
+      preStart = ''
+                mkdir -p ${cfg.configDir}/Edge
+                cat > ${cfg.configDir}/Edge/Manager.config <<EOF
+        :org.apache.felix.configadmin.revision:=L"1"
+        poolSize=I"10"
+        port=I"${toString cfg.edgeManager.port}"
+        service.pid="Edge.Manager"
+        EOF
+                mkdir -p ${cfg.configDir}/Ui
+                cat > ${cfg.configDir}/Ui/Websocket.config <<EOF
+        :org.apache.felix.configadmin.revision:=L"1"
+        poolSize=I"10"
+        port=I"${toString cfg.ui.port}"
+        requestLimit=I"20"
+        service.pid="Ui.Websocket"
+        EOF
+      '';
+    };
+
+    networking.firewall.allowedTCPPorts =
+      (lib.optional cfg.ui.openFirewall cfg.ui.port)
+      ++ (lib.optional (cfg.edgeManager.openFirewall) cfg.edgeManager.port)
+      ++ (lib.optional cfg.felix.openFirewall cfg.felix.port);
+  };
+}

--- a/nixos/modules/services/home-automation/openems/common.nix
+++ b/nixos/modules/services/home-automation/openems/common.nix
@@ -1,0 +1,7 @@
+{ lib, ... }:
+{
+  meta = {
+    maintainers = [ lib.maintainers.mrcjkb ];
+    doc = ./openems.md;
+  };
+}

--- a/nixos/modules/services/home-automation/openems/edge.nix
+++ b/nixos/modules/services/home-automation/openems/edge.nix
@@ -1,0 +1,112 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkIf
+    mkOption
+    mkEnableOption
+    mkPackageOption
+    getExe
+    types
+    ;
+  cfg = config.services.openems.edge;
+in
+{
+  options.services.openems.edge = {
+    enable = mkEnableOption "OpenEMS Edge service for communicating with devices and services, collecting data and executing control algorithms";
+
+    package = mkPackageOption pkgs "openems-edge" { };
+
+    configDir = mkOption {
+      type = types.path;
+      default = "/var/lib/openems.d";
+      example = "/etc/openems.d";
+      description = ''
+        Path to the OSGi configs.
+        Must be provisioned manually because some configs contain secrets that should not live in the world-readable Nix store.
+        Alternatively, configs can be edited via the Apache Felix web interface at
+        http://admin:admin@localhost:<felix-port>/system/console/configMgr
+      '';
+    };
+
+    ui = {
+      enable = mkEnableOption "OpenEMS web UI";
+      port = mkOption {
+        type = types.port;
+        default = 8085;
+        description = "Websocket port to for openems-ui to connect to";
+      };
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Set to true to open the TCP port for the OpenEMS Edge websocket";
+      };
+    };
+
+    felix = {
+      port = mkOption {
+        type = types.port;
+        default = 8080;
+        description = "Port of the Apache Felix web console";
+      };
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Set to true to open the TCP port for the Apache Felix web console";
+      };
+    };
+
+    watchdog.timeout = mkOption {
+      type = types.nullOr types.int;
+      default = 60;
+      description = "Service watchdog timeout in seconds (`null` to disable)";
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.openems-edge = {
+      description = "OpenEMS Edge";
+
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        Restart = "always";
+        RestartSec = 10;
+        WatchdogSec = cfg.watchdog.timeout;
+        ExecStart = getExe cfg.package;
+      };
+
+      environment.JAVA_OPTS = lib.concatStringsSep " " [
+        "-Dfelix.cm.dir=${cfg.configDir}"
+        "-Dorg.osgi.service.http.port=${toString cfg.felix.port}"
+      ];
+
+      preStart = ''
+                mkdir -p ${cfg.configDir}/Controller/Api/Websocket
+                cat > ${cfg.configDir}/Controller/Api/Websocket/13718db7-fae4-48ae-b023-dcf6b764c25b.config <<EOF
+        alias=""
+        apiTimeout=I"60"
+        enabled=B"${if cfg.ui.enable then "true" else "false"}"
+        id="ctrlApiWebsocket0"
+        port=I"${toString cfg.ui.port}"
+        service.factoryPid="Controller.Api.Websocket"
+        service.pid="Controller.Api.Websocket.13718db7-fae4-48ae-b023-dcf6b764c25b"
+        EOF
+      '';
+    };
+
+    networking.firewall.allowedTCPPorts =
+      (lib.optional (cfg.ui.enable && cfg.ui.openFirewall) cfg.ui.port)
+      ++ (lib.optional cfg.felix.openFirewall cfg.felix.port);
+
+  };
+}

--- a/nixos/modules/services/home-automation/openems/openems.md
+++ b/nixos/modules/services/home-automation/openems/openems.md
@@ -1,0 +1,148 @@
+# Open Energy Management System {#module-services-openems}
+
+A modular platform for energy management applications.
+
+Please also refer to the [full OpenEMS documentation](https://openems.io/openems/latest/introduction.html).
+
+## Basic usage {#module-services-openems-basic-usage}
+
+OpenEMS can be configured to run [edge nodes](https://openems.github.io/openems.io//openems/latest/edge/architecture.html):
+
+```nix
+{ ... }:
+
+{
+  services.openems.edge = {
+    enable = true;
+  };
+}
+```
+
+...and [backend nodes](https://openems.github.io/openems.io//openems/latest/backend/architecture.html):
+
+```nix
+{ ... }:
+
+{
+  services.openems.backend = {
+    enable = true;
+  };
+}
+```
+
+Enable a backend node if you intend to aggregate data from multiple edge nodes.
+
+After enabling a node, OSGi components must be provisioned before the node is fully operational,
+see [Configuration](#module-services-openems-config) below.
+
+You can modify the default configuration:
+
+```nix
+{ config, ... }:
+
+{
+  services.openems = {
+    edge = {
+      enable = true;
+      dataDir = "/var/lib/edge.d"; # Default: "/var/lib/openems.d"
+      ui = {
+        enable = true;
+        port = 4567; # Default: 8085
+        openFirewall = true;
+      };
+      felix = {
+        port = 4568; # Default: 8080
+        openFirewall = true;
+      };
+      watchdog.timeout = null; # Disable watchdog (default 60 s)
+    };
+    backend = {
+      enable = true;
+      dataDir = "/var/lib/backend.d"; # Default: "/var/lib/openems-backend/config.d"
+      ui = {
+        port = 4567; # Default: 8082
+        openFirewall = true;
+      };
+      edgeManager = {
+        port = 4568; # Default: 8081
+        openFirewall = true;
+      };
+      felix = {
+        port = 4569; # Default: 8079
+        openFirewall = true;
+      };
+      watchdog.timeout = null; # Disable watchdog (default 60 s)
+    };
+    ui = {
+      enable = true;
+      hostName = "openems.io";
+      websocket.port = config.services.openems.edge.websocket.port; # Default: 8082
+    };
+  };
+}
+```
+
+## Configuration {#module-services-openems-config}
+
+OpenEMS edge and backend nodes use the [OSGi platform](https://en.wikipedia.org/wiki/OSGi)
+for component configuration.
+Each component must be configured via a file that lives in the specified `dataDir`.
+Because the configuration files can contain secrets, they should not live in the Nix store
+and must be provisioned manually.
+
+:::{.note}
+Due to the large and constantly growing number of OSGi component configurations
+that OpenEMS supports, the NixOS module only provisions the minimal set of
+components needed to start and connect the services. All other components must be configured
+via `dataDir`.
+:::
+
+You can manage component configuration interactively using the
+[Apache Felix Web Console](https://openems.io//openems/latest/gettingstarted.html#_basic_configuration)
+at `http://localhost:<felix.port>/system/console/configMgr`,
+or via the
+[Apache Felix Web Console REST API](https://felix.apache.org/documentation/subprojects/apache-felix-web-console/web-console-restful-api.html).
+
+:::{.warning}
+The default Felix Web Console credentials are `admin`/`admin`.
+These should be changed before exposing the port to untrusted networks.
+:::
+
+For example, to configure edge node authentication for a backend node
+(adjust the port to match your `felix.port`):
+
+```bash
+curl -u admin:admin \
+  -d 'apply=true' \
+  -d 'pid=Metadata.Dummy' \
+  -d 'propertylist=edgeIdMax,edgeIdTemplate' \
+  -d 'edgeIdMax=1' \
+  -d 'edgeIdTemplate=edge%25d' \
+  http://localhost:8079/system/console/configMgr/Metadata.Dummy
+```
+
+...and to configure a connection to a backend for an edge node:
+
+```bash
+curl -u admin:admin \
+  -d 'apply=true' \
+  -d 'factoryPid=Controller.Api.Backend' \
+  -d 'propertylist=id,uri,apikey,enabled' \
+  -d 'id=ctrlBackend0' \
+  -d 'uri=ws://backend:1234' \
+  -d 'apikey=DEMO_API_KEY' \
+  -d 'enabled=true' \
+  http://localhost:8080/system/console/configMgr/Controller.Api.Backend
+```
+
+## UI {#module-services-openems-ui}
+
+The `services.openems.ui` module enables an nginx server that servers the OpenEMS web UI,
+built with the default theme and configured to connect to an OpenEMS edge or backend node
+via `ws://localhost:<port>`, where `<port>` is set by `services.openems.ui.websocket.port`
+(defaults to `8082`, the same default as `services.openems.backend.ui.port`).
+
+To use a custom theme or branding, you will need to provide your own fork of the
+OpenEMS source and override the `openems-ui` package. Refer to the
+[OpenEMS UI documentation](https://openems.io/openems/latest/ui/build.html) for
+available build options.

--- a/nixos/modules/services/home-automation/openems/ui.nix
+++ b/nixos/modules/services/home-automation/openems/ui.nix
@@ -1,0 +1,63 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkIf
+    mkOption
+    mkEnableOption
+    mkPackageOption
+    types
+    ;
+  cfg = config.services.openems.ui;
+in
+{
+  options.services.openems.ui = {
+    enable = mkEnableOption "OpenEMS UI";
+
+    package = mkPackageOption pkgs "openems-ui" { };
+
+    hostName = lib.mkOption {
+      type = lib.types.str;
+      description = "Hostname to use for the nginx vhost.";
+      example = "openems.example.com";
+    };
+
+    websocket = {
+      port = mkOption {
+        type = types.port;
+        default = 8082;
+        description = "Websocket port to connect to";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services = {
+      nginx = {
+        enable = true;
+        virtualHosts."${cfg.hostName}" =
+          let
+            ui-package = cfg.ui.package.override { websocket-port = cfg.websocket.port; };
+          in
+          {
+            root = "${ui-package}/share/openems-ui/browser";
+            serverAliases = [
+              "localhost"
+            ];
+            locations = {
+              "/" = {
+                tryFiles = "$uri $uri/ /index.html";
+                extraConfig = ''
+                  error_page 404 300 /index.html;
+                '';
+              };
+            };
+          };
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1225,6 +1225,7 @@ in
   openarena = runTest ./openarena.nix;
   openbao = runTest ./openbao.nix;
   opencloud = runTest ./opencloud.nix;
+  openems = runTest ./openems.nix;
   openldap = runTest ./openldap.nix;
   openresty-lua = runTest ./openresty-lua.nix;
   opensearch = discoverTests (import ./opensearch.nix);

--- a/nixos/tests/openems.nix
+++ b/nixos/tests/openems.nix
@@ -1,0 +1,75 @@
+{ pkgs, ... }:
+let
+  edge_felix_port = 1234;
+  edge_ui_port = 1235;
+  backend_felix_port = 1234;
+  backend_ui_port = 1235;
+  backend_edge_port = 1236;
+
+in
+{
+  name = "openems";
+  meta.maintainers = with pkgs.lib.maintainers; [ mrcjkb ];
+  nodes = {
+    edge =
+      { pkgs, ... }:
+      {
+        environment.systemPackages = [
+          # For testing
+          pkgs.websocat
+        ];
+
+        services.openems.edge = {
+          enable = true;
+          ui = {
+            enable = true;
+            port = edge_ui_port;
+          };
+          felix.port = edge_felix_port;
+          watchdog.timeout = null; # watchdog can make the tests flaky
+        };
+      };
+    backend =
+      { pkgs, ... }:
+      {
+        services.openems = {
+          backend = {
+            enable = true;
+            ui.port = backend_ui_port;
+            edgeManager = {
+              port = backend_edge_port;
+              openFirewall = true;
+            };
+            felix.port = backend_felix_port;
+            watchdog.timeout = null; # watchdog can make the tests flaky
+          };
+        };
+      };
+  };
+
+  testScript = /* python */ ''
+    backend.wait_for_unit("openems-backend.service")
+    backend.wait_for_open_port(${toString backend_felix_port})
+    backend.wait_until_succeeds("curl -u admin:admin --fail http://localhost:${toString backend_felix_port}/system/console/configMgr")
+
+    config_json = backend.succeed("curl -u admin:admin http://localhost:${toString backend_felix_port}/system/console/status-Configurations.json")
+    assert "port = ${toString backend_edge_port}" in config_json
+    assert "port = ${toString backend_ui_port}" in config_json
+
+    # Configure authentication service provider for edge nodes
+    backend.succeed("curl --verbose -u admin:admin --fail -d 'apply=true' -d 'pid=Metadata.Dummy' -d 'propertylist=edgeIdMax,edgeIdTemplate' -d 'edgeIdMax=1' -d 'edgeIdTemplate=edge%25d' http://localhost:${toString backend_felix_port}/system/console/configMgr/Metadata.Dummy")
+
+    backend.wait_for_console_text("\[Edge\.Manager\] Starting websocket server")
+
+    edge.wait_for_unit("openems-edge.service")
+    edge.wait_for_console_text("\[ctrlApiWebsocket0\] Starting websocket server")
+    edge.wait_for_console_text("There are no Schedulers configured!") # The node is ready - this gets printed repeatedly
+    edge.succeed("echo | websocat --origin 'http://localhost' 'ws://localhost:${toString edge_ui_port}'")
+    edge.wait_for_open_port(${toString edge_felix_port})
+    edge.wait_until_succeeds("curl --user admin:admin --fail http://localhost:${toString edge_felix_port}/system/console/configMgr")
+
+    # Configure edge-backend connection
+    edge.succeed("curl --verbose -u admin:admin --fail -d 'apply=true' -d 'factoryPid=Controller.Api.Backend' -d 'propertylist=id,uri,apikey,enabled' -d 'id=ctrlBackend0' -d 'uri=ws://backend:${toString backend_edge_port}' -d 'apikey=DEMO_API_KEY' -d 'enabled=true' http://localhost:${toString edge_felix_port}/system/console/configMgr/Controller.Api.Backend")
+    edge.wait_for_console_text("Connected to OpenEMS Backend")
+  '';
+}

--- a/pkgs/by-name/op/openems-backend/package.nix
+++ b/pkgs/by-name/op/openems-backend/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  gradle_9,
+  jre,
+  makeWrapper,
+  openems-edge,
+  writableTmpDirAsHomeHook,
+  ...
+}:
+stdenv.mkDerivation (finalAttrs: {
+
+  pname = "openems-backend";
+
+  inherit (openems-edge)
+    src
+    version
+    mitmCache
+    ;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+  __darwinAllowLocalNetworking = true;
+
+  nativeBuildInputs = [
+    gradle_9
+    makeWrapper
+    writableTmpDirAsHomeHook
+  ];
+
+  gradleBuildTask = "buildBackend";
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 build/openems-backend.jar -t $out/share/openems-backend
+    mkdir -p $out/bin
+    makeWrapper ${lib.getExe jre} $out/bin/openems-backend \
+      --add-flags "\$JAVA_OPTS" \
+      --add-flags "-jar $out/share/openems-backend/openems-backend.jar"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Open energy management system (backend)";
+    longDescription = "Connects decentralized openems-edge systems and provides aggregation, monitoring and control)";
+    license = lib.licenses.epl20;
+    homepage = "https://openems.io/";
+    changelog = "https://github.com/openems/openems/releases/tag/${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ mrcjkb ];
+    mainProgram = "openems-backend";
+    platforms = lib.platforms.all;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode # mitm cache
+    ];
+  };
+
+})

--- a/pkgs/by-name/op/openems-edge/deps.json
+++ b/pkgs/by-name/op/openems-edge/deps.json
@@ -1,0 +1,4602 @@
+{
+ "!comment": "This is a nixpkgs Gradle dependency lockfile. For more details, refer to the Gradle section in the nixpkgs manual.",
+ "!version": 1,
+ "https://bndtools.jfrog.io/bndtools/libs-release-local/biz/aQute": {
+  "bnd#biz.aQute.bnd.embedded-repo/7.2.3": {
+   "jar": "sha256-EjGa4jFuk34DAxXEg1qjpOsySVIKZQDdSvqHq38R4/Q=",
+   "pom": "sha256-rj5O78tqaXfzbO6mS/ra5wqxJSsJoloOcU7DrtjZ6WA="
+  },
+  "bnd#biz.aQute.bnd.gradle/7.2.3": {
+   "jar": "sha256-5emoTr8nk8/wYMdiVbaA/MkWuRU+ycX+XUcIDk3zFvk=",
+   "pom": "sha256-hprtaGi5Pq3ZB9CK9GW0OprZEaewD77nt5OQks0VWjA="
+  },
+  "bnd#biz.aQute.bnd.util/7.2.3": {
+   "jar": "sha256-q3gS3GUaqBE80Da3pvIOWv6xABGORQFCPDQR21qRtac=",
+   "pom": "sha256-4XzcZDa43ZbTiHKtyVsu4CrIRoqvngKMobt55hpizfo="
+  },
+  "bnd#biz.aQute.bndlib/7.2.3": {
+   "jar": "sha256-FoeHgSkmks1XzV9Sla732bsZNI40zbkJeOgGCvCKHGI=",
+   "pom": "sha256-P03eVP4s127oPPqrHZaNM0sUImLO8awO2CTQf+Cb7AE="
+  },
+  "bnd#biz.aQute.repository/7.2.3": {
+   "jar": "sha256-/EZrt9XXlz8ngcKSEveEIHeTiWRw9QrIFcLceRu72oM=",
+   "pom": "sha256-upc25AAdhTANzWTnRzYV/NptjvT84PIynlhLLWVWC/E="
+  },
+  "bnd#biz.aQute.resolve/7.2.3": {
+   "jar": "sha256-k4t4sbTYU1V/r89WxmdDvNGXqhuhc1E3+9VE+OZ5UE0=",
+   "pom": "sha256-fw6AFeImcjhU/s0JcCaBpdzDYTlfOfaK96K7UnqZ/b0="
+  },
+  "bnd/workspace#biz.aQute.bnd.workspace.gradle.plugin/7.2.3": {
+   "pom": "sha256-qenCWR+Np7ADwsddqzkdmd0wbYqufJGIXce0Nxi5Srs="
+  }
+ },
+ "https://central.sonatype.com": {
+  "repository/maven-snapshots/org/mongodb/bson/maven-metadata": {
+   "xml": {
+    "groupId": "org.mongodb",
+    "lastUpdated": "20260526083833",
+    "latest": "5.8.0-SNAPSHOT"
+   }
+  }
+ },
+ "https://plugins.gradle.org/m2": {
+  "com/github/node-gradle#gradle-node-plugin/7.1.0": {
+   "jar": "sha256-mqJsOwdfQuuAH8lMsy/FnGlop4EZ79qc4CNWg0otMZg=",
+   "module": "sha256-bPJ3uCmG5BMhDeDj5P6cEJx72qUWnUjP7VJtBqHD0LA=",
+   "pom": "sha256-MUPnII/Dc2Ollk6OvhV/oe8PX3BeTah+jj8R6GBiSU8="
+  },
+  "com/github/node-gradle/node#com.github.node-gradle.node.gradle.plugin/7.1.0": {
+   "pom": "sha256-3A6OeCug2sXE0NhngIHBE4Clx5OzxG8tD40kLRcztis="
+  },
+  "org/barfuin/gradle/jacocolog#gradle-jacoco-log/3.1.0": {
+   "jar": "sha256-saR0RuWKDQnO96dsKLD2jiP35x8Fmj6yNnOIMZE+Wvs=",
+   "module": "sha256-IppKsfEguNeaG9nFdPowdHrMf87DZME3blgjOTEWVjc=",
+   "pom": "sha256-yA24bchsjlydJBtTYX/t7XGS/4QjTjfnTa83peohUKs="
+  },
+  "org/barfuin/gradle/jacocolog#org.barfuin.gradle.jacocolog.gradle.plugin/3.1.0": {
+   "pom": "sha256-chK3zzZRjyAz+OLG3jQW8dcZiT3hkpU91ksTBqifPt4="
+  },
+  "org/sonarqube#org.sonarqube.gradle.plugin/7.2.0.6526": {
+   "pom": "sha256-fV24VmN2JpzoC/+Fa/YnUFFdXTJKmPLq2Zn88wh1ZHA="
+  },
+  "org/sonarsource/scanner/gradle#sonarqube-gradle-plugin/7.2.0.6526": {
+   "jar": "sha256-Ti2LwhxcnTi8ikLub8KHc9dhXrGBsU4R7BBC9bvOKN8=",
+   "module": "sha256-Jtj/EjhfT3ESm4O6ayLu7fve4tkotX9gBF4bpZNsyNY=",
+   "pom": "sha256-nV2kEaQZbI6IxquFHj0WZrUTYDJn0Yf2SjNx1n9HXg4="
+  }
+ },
+ "https://repo.maven.apache.org/maven2": {
+  "ant#ant-nodeps/1.6.2": {
+   "jar": "sha256-bylB7s4e7mCSebv/JblCjRUtELCVIyVMLDKw0t+Yqa4=",
+   "pom": "sha256-9XaP46Bd/8T8EouOJLb4l1JvcLBCLhLjx4BrZo2/uGQ="
+  },
+  "ant#ant-trax/1.6.2": {
+   "jar": "sha256-AKG+AJ4k3GjjgHYds+1O/TFd1rAIOTwXwcxh34P3esk=",
+   "pom": "sha256-2Fa17yPNxTanVMPUVgdogLBEGU1+Qdnik4/1PclaQXA="
+  },
+  "ant#ant/1.5.1": {
+   "jar": "sha256-lMGDgiiNv37vpvGWYy74i92wi+SQBLYzZdwG9CTQD0g=",
+   "pom": "sha256-kcppc+vU5htVI09tz1BjSQwQ5vBrLLlYmodSPK1w4zQ="
+  },
+  "ant#ant/1.6.2": {
+   "jar": "sha256-zu1jn6b5+p68Ya4HM73uDc2eAEvC9Nh3LtcwSPkaoUA=",
+   "pom": "sha256-SPv4BXLByvpFcm+vS52vKsynzOxRrtfk+bcq/JCWsvI="
+  },
+  "antlr#antlr/2.7.2": {
+   "jar": "sha256-KlMgaWPfp44zdGtvg2f32ZcPo2hlqCXXv7zheE3A9NQ=",
+   "pom": "sha256-Xpq9bJk8fShZ+3Wb+3c1WmyBhKpdIAqnQONF2l9MWP4="
+  },
+  "antlr#antlr/2.7.7": {
+   "jar": "sha256-iPvaS5Ellrn1bo4S5YDMlUus+1F3bs/d0+GPwc9W3Ew=",
+   "pom": "sha256-EA95O6J/i05CBO20YXHr825U4PlM/AJSf+oHoLsfzrc="
+  },
+  "asm#asm/2.2.1": {
+   "jar": "sha256-lAoUqlSJGR442WP2LTcLWZRA06FtFC4Qf8JdDEsqtmI=",
+   "pom": "sha256-fcMl4urs1DfqDodCJG38GfbiynWd46jiVmEylLn0MBw="
+  },
+  "avalon-framework#avalon-framework/4.1.3": {
+   "jar": "sha256-F3Mf4yGnp8w7Vst5djS47Cn6AyIASIahUju8e8fuz3E=",
+   "pom": "sha256-xslxsUbsjlluZg5k1VF6rgLjTDzOJA3kS7kszZjwRr8="
+  },
+  "avalon-framework#avalon-framework/4.1.5": {
+   "jar": "sha256-gz8eUN+mKPE9SkIGs+xtj0LpYoSjXXbActiAgEt0egQ=",
+   "pom": "sha256-WsHHwtsp/rJWj1xxlZpsCKbEHgZZsSa/owisdCHyysg="
+  },
+  "bcel#bcel/5.1": {
+   "jar": "sha256-cjxhlVzcZmOI9X0jiSYrSVuX4s5Pc78aLbPUKnR33YM=",
+   "pom": "sha256-yojOVYxFE/nCIP64VOeZlp5URP0QdmnLoiUillebkZ0="
+  },
+  "biz/aQute/bnd#biz.aQute.bnd.embedded-repo/7.2.3": {
+   "jar": "sha256-EjGa4jFuk34DAxXEg1qjpOsySVIKZQDdSvqHq38R4/Q=",
+   "pom": "sha256-rj5O78tqaXfzbO6mS/ra5wqxJSsJoloOcU7DrtjZ6WA="
+  },
+  "biz/aQute/bnd#biz.aQute.bnd.gradle/7.2.3": {
+   "jar": "sha256-5emoTr8nk8/wYMdiVbaA/MkWuRU+ycX+XUcIDk3zFvk=",
+   "pom": "sha256-hprtaGi5Pq3ZB9CK9GW0OprZEaewD77nt5OQks0VWjA="
+  },
+  "biz/aQute/bnd#biz.aQute.bnd.util/7.2.3": {
+   "jar": "sha256-q3gS3GUaqBE80Da3pvIOWv6xABGORQFCPDQR21qRtac=",
+   "pom": "sha256-4XzcZDa43ZbTiHKtyVsu4CrIRoqvngKMobt55hpizfo="
+  },
+  "biz/aQute/bnd#biz.aQute.bndlib/7.2.3": {
+   "jar": "sha256-FoeHgSkmks1XzV9Sla732bsZNI40zbkJeOgGCvCKHGI=",
+   "pom": "sha256-P03eVP4s127oPPqrHZaNM0sUImLO8awO2CTQf+Cb7AE="
+  },
+  "biz/aQute/bnd#biz.aQute.repository/7.2.3": {
+   "jar": "sha256-/EZrt9XXlz8ngcKSEveEIHeTiWRw9QrIFcLceRu72oM=",
+   "pom": "sha256-upc25AAdhTANzWTnRzYV/NptjvT84PIynlhLLWVWC/E="
+  },
+  "biz/aQute/bnd#biz.aQute.resolve/7.2.3": {
+   "jar": "sha256-k4t4sbTYU1V/r89WxmdDvNGXqhuhc1E3+9VE+OZ5UE0=",
+   "pom": "sha256-fw6AFeImcjhU/s0JcCaBpdzDYTlfOfaK96K7UnqZ/b0="
+  },
+  "bsf#bsf/2.4.0": {
+   "jar": "sha256-+HN3PeuRwaHBIVD2zbE7ii4bSWp1rJA8S7+hA7Njp8c=",
+   "pom": "sha256-I58zl7efkahm5gZ88El0FG1+hk/rKqNKmUODHJ9trqs="
+  },
+  "cglib#cglib-nodep/2.2": {
+   "jar": "sha256-Eaq46RmKU6PeZar02Q8ZsSQTW7B43Yze/L8vzaAM5Zk=",
+   "pom": "sha256-QWaUs/87LXQwCIo8OHtAt4XN1jWE3kSxAuJyM2CokEc="
+  },
+  "ch/qos/logback#logback-classic/1.2.3": {
+   "jar": "sha256-+1P4U55/y48JOlbhOBEgVuwdyAnrsCC1nYo2peusN+A=",
+   "pom": "sha256-oFHrGiVIuTyZq8qOtx1cddL/BpdmgpYDSBJLxJAaUxU="
+  },
+  "ch/qos/logback#logback-parent/1.2.3": {
+   "pom": "sha256-ec0CHa/HsCVdPN0/1wy6pjjfc5lXSaNI7oLEVjXqsmo="
+  },
+  "ch/qos/reload4j#reload4j/1.2.22": {
+   "jar": "sha256-Ii+Q0+aVQSGO9ucFR3SdaTvUwYRoF+W9eUmz4olQ+Z8=",
+   "pom": "sha256-8Tj74PC/646UKudkhCloKL2a77Z6qztIceyFhzdn5Pw="
+  },
+  "cobertura#cobertura/1.8": {
+   "jar": "sha256-Vwrkxoeg7RPsJtiEedQMltggX/mX8Dw5kEidg3orOo8=",
+   "pom": "sha256-sA9QFzG5TL7L2S/YdD1Q26oBVr9lU4QjfrvXduz+g6w="
+  },
+  "com/amazonaws#aws-java-sdk-core/1.12.782": {
+   "jar": "sha256-eli8W0NRXv3FSHihZmV9pDZYXd8LfoDK/8h39bBN46w=",
+   "pom": "sha256-/v1gRwU6xaE7RLEBS+TWhxHFUyA/sZ8rE6Yj3IIRS2k="
+  },
+  "com/amazonaws#aws-java-sdk-pom/1.12.782": {
+   "pom": "sha256-4O6wYsVjyO/F2zEiOgURDvIocI3q/y2U3gGi+ZwjL1g="
+  },
+  "com/amazonaws#aws-java-sdk-sts/1.12.782": {
+   "jar": "sha256-InR/7fAIF+TmwwaMdKNtERQNYpYQNvGAU/edxzcVs/I=",
+   "pom": "sha256-yaEmrs5jTIdbtWp4Njjixjds/77wUoEuTIdDiu+kutU="
+  },
+  "com/amazonaws#jmespath-java/1.12.782": {
+   "jar": "sha256-UcXhYlf0tEazSP3OhD6/XNgx7qNAS+SdphL3NTOUwZY=",
+   "pom": "sha256-o03aGwrnwki+pCVIGjI73YmP0lybBmYm3pAVma8OMCA="
+  },
+  "com/auth0#auth0/3.5.0": {
+   "jar": "sha256-aKR1jeTWIn/Cezn53KycmdPpCf6TVtAH62cNnCtK6iE=",
+   "pom": "sha256-YHj/7g5i/5m60ni2t4NghtA/D/AzkNE6QotKGXNYWXk="
+  },
+  "com/auth0#java-jwt/4.4.0": {
+   "jar": "sha256-FzqrKjByflWG4TBV+2xOJxEkU/XYzxE2szacZ0y+AR8=",
+   "pom": "sha256-My/99ea1dEYPHTieK/yk5r2eCwf4CHj/loyMz8Q5vPc="
+  },
+  "com/auth0#java-jwt/4.5.2": {
+   "jar": "sha256-1ZVSteOeP14CHfN/PpRxWGw9V4uY2B5A+x/jrs1ZlmE=",
+   "pom": "sha256-q72b9us07IZiAo2gYYvqvdRT/dTre9wpxWwmagRGX1I="
+  },
+  "com/auth0#jwks-rsa/0.22.1": {
+   "jar": "sha256-32e7x3dqM8ku3AHgIBn+ygWTtNDkSiwo0yBUVOwgoIw=",
+   "pom": "sha256-IsxMQcFJRbG2oHzKZDRxOqC684CO1RPKRuqEgk9oXR0="
+  },
+  "com/auth0#jwks-rsa/0.23.1": {
+   "jar": "sha256-rm1P7nZcqPnmjfs06MeJ7M0Tv7izAoat73apsegdR+0=",
+   "pom": "sha256-kS+Mw7cWlKxOEzDZtEZOhWOpCrOutKjkTdGNq7m1y2w="
+  },
+  "com/beust#jcommander/1.27": {
+   "jar": "sha256-C3hz9RpfKSY39JQj2ag7Gd4VxL49wJLey9av7/ViY/o=",
+   "pom": "sha256-gaeSIIEZM6huK2WZ3BNmJsa8I5gojwPqiR4wZ6Wok9g="
+  },
+  "com/beust#jcommander/1.47": {
+   "jar": "sha256-jctH3n/C5yE46CpywRoFXNXfj+iCn/86PFQZSdX23pk=",
+   "pom": "sha256-IEw1iiyQENTVj2ZECXDa2LT2ZW47gS2NA0wZmPFVBww="
+  },
+  "com/conversantmedia#disruptor/1.2.10": {
+   "pom": "sha256-ci6/RCxfid3irYbRKjZ/EeOr0P8J6zgnxjLXKSFgLLs="
+  },
+  "com/conversantmedia#disruptor/1.2.10/jdk7": {
+   "jar": "sha256-NDhEnSI2cfZO0AsyghNWst/COkFpuAFrqJDoEPOKqvY="
+  },
+  "com/conversantmedia#disruptor/1.2.15": {
+   "jar": "sha256-vTFUo/tBWUsClQrVK82bd1pFV3vU1u8b7mbqaIXJ854=",
+   "pom": "sha256-i/8ETEFfMYa+BKwV7VGpBYSrK17l9Mc4yZ5+7mbk+IU="
+  },
+  "com/fasterxml#aalto-xml/1.3.4": {
+   "jar": "sha256-9Kxo2RGEootCBM72sSS4qvQ5sj0/E/WCG1znpnVPXyA=",
+   "pom": "sha256-klKG9TV8CCLMl5lWME+Ly8pvvTE7V3j+4m38BBmIL9c="
+  },
+  "com/fasterxml#classmate/1.3.4": {
+   "jar": "sha256-wr/MIUZzUdD5oVWIIrctusKyH2ufcApE/Gs0VJHvPIg=",
+   "pom": "sha256-2Of20UYomsoUdxleZ7tLe+Xym7u1+AQZjQPPupL9hJA="
+  },
+  "com/fasterxml#oss-parent/24": {
+   "pom": "sha256-44CdWFcDkMMn7+Vlh9jeo8qlMYa5GHXgs2Im4IIR8Fo="
+  },
+  "com/fasterxml#oss-parent/28": {
+   "pom": "sha256-xMNp42uIIK0m0ubHD/RK2Z76/hk5ml0ReOnqgvTS/Tg="
+  },
+  "com/fasterxml#oss-parent/32": {
+   "pom": "sha256-nTmNtjDE0lLoYVSHXPKT8mpG45lv2sDQSoFAVYAd4DY="
+  },
+  "com/fasterxml#oss-parent/33": {
+   "pom": "sha256-xUNwlkz8ziMZvZqF9eFPUAyFGJia5WsbR13xs0i3MQg="
+  },
+  "com/fasterxml#oss-parent/34": {
+   "pom": "sha256-mnXz4yv51uAGeNlEes5N6FlqLSIa9c9bvH9XHKx5UAY="
+  },
+  "com/fasterxml#oss-parent/35": {
+   "pom": "sha256-r8Be0hBk6srI3jACUwyxkiCL0RTrJIQX2tGIbL9UBW4="
+  },
+  "com/fasterxml#oss-parent/37": {
+   "pom": "sha256-YKEr3AmZFKsceL60ylMSgea2yQcZtnvCp/Z/YcIOep4="
+  },
+  "com/fasterxml#oss-parent/38": {
+   "pom": "sha256-yD+PRd/cqNC2s2YcYLP4R4D2cbEuBvka1dHBodH5Zug="
+  },
+  "com/fasterxml#oss-parent/48": {
+   "pom": "sha256-EbuiLYYxgW4JtiOiAHR0U9ZJGmbqyPXAicc9ordJAU8="
+  },
+  "com/fasterxml#oss-parent/50": {
+   "pom": "sha256-9dpV3XuI+xcMRoAdF3dKZS+y9FgftbHQpfyGqhgrhXc="
+  },
+  "com/fasterxml#oss-parent/55": {
+   "pom": "sha256-D14Y8rNev22Dn3/VSZcog/aWwhD5rjIwr9LCC6iGwE0="
+  },
+  "com/fasterxml#oss-parent/58": {
+   "pom": "sha256-VnDmrBxN3MnUE8+HmXpdou+qTSq+Q5Njr57xAqCgnkA="
+  },
+  "com/fasterxml#oss-parent/68": {
+   "pom": "sha256-Jer9ltriQra1pxCPVbLBQBW4KNqlq+I0KJ/W53Shzlc="
+  },
+  "com/fasterxml#oss-parent/75": {
+   "pom": "sha256-/LvxwYyQR+aRfThPIGTiG0Klj8hfsFI6ni4BXv98YZ0="
+  },
+  "com/fasterxml/jackson#jackson-base/2.10.2": {
+   "pom": "sha256-fj71bOHtu3I/f8NxL2yGifS8BvVkElx1ptZY0CO97FY="
+  },
+  "com/fasterxml/jackson#jackson-base/2.14.2": {
+   "pom": "sha256-OuJFud+VEnMh8fkF9wO9MndP5VcVip06nlB9grK8TtQ="
+  },
+  "com/fasterxml/jackson#jackson-base/2.15.0": {
+   "pom": "sha256-UkKWvt4yGFrBEBLwfZJG44wZJTwrUT8c8oeZEho053A="
+  },
+  "com/fasterxml/jackson#jackson-base/2.17.2": {
+   "pom": "sha256-fPnFn70UyQVnRxN7kNcKleh3YN/huCRWufAjF9W1b68="
+  },
+  "com/fasterxml/jackson#jackson-base/2.21.2": {
+   "pom": "sha256-OMeJjHY7iZH/+9dpRZly4Bdr8MUFxzlRjHD3xX0W7tc="
+  },
+  "com/fasterxml/jackson#jackson-base/2.21.3": {
+   "pom": "sha256-xELoDDE7VTLbLqfc0g4KAw+odvJACDRqS44Qof0uP/g="
+  },
+  "com/fasterxml/jackson#jackson-base/2.9.9": {
+   "pom": "sha256-QzaIZ9LYww3EbwzebLWjIL+5/XRjcovlAd5hVFJll10="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.10.2": {
+   "pom": "sha256-olDkpgIFTfr57pZVr7fWA1OSJslzJ78jfs2LPhcuuQ8="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.14.2": {
+   "pom": "sha256-mqIJuzI5HL9fG9Pn+hGQFnYWms0ZDZiWtcHod8mZ/rw="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.15.0": {
+   "pom": "sha256-4AwuhiKc2Wh5RpGukO7hWwjE1PV0jJs0u0ItcTRG3ZU="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.17.2": {
+   "pom": "sha256-H0crC8IATVz0IaxIhxQX+EGJ5481wElxg4f9i0T7nzI="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.21.2": {
+   "pom": "sha256-vGxUnmMpJ7udigraIMhGe1AH07eXx/XbA6m2DR3lm+M="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.21.3": {
+   "pom": "sha256-BccqDyCuH9ec7X7SnP9y2yhC0WCXCn6gM06bX9BH1Zc="
+  },
+  "com/fasterxml/jackson#jackson-bom/2.9.9": {
+   "pom": "sha256-I39YkwqwLX1S6a/MglsuLYoKvdDobR1dobV53GWAnJE="
+  },
+  "com/fasterxml/jackson#jackson-parent/2.10": {
+   "pom": "sha256-pQ24CCnE+JfG0OfpVHLLtDsOvs4TWmjjnCe4pv4z5IE="
+  },
+  "com/fasterxml/jackson#jackson-parent/2.14": {
+   "pom": "sha256-CQat2FWuOfkjV9Y/SFiJsI/KTEOl/kM1ItdTROB1exk="
+  },
+  "com/fasterxml/jackson#jackson-parent/2.15": {
+   "pom": "sha256-bN+XvGbzifY+NoUNL1UtEhZoj45aWHJ9P2qY7fhnXN4="
+  },
+  "com/fasterxml/jackson#jackson-parent/2.17": {
+   "pom": "sha256-rubeSpcoOwQOQ/Ta1XXnt0eWzZhNiSdvfsdWc4DIop0="
+  },
+  "com/fasterxml/jackson#jackson-parent/2.21": {
+   "pom": "sha256-OFHfYn+utGiHuVYQRjC3Sou7X33iLpdM8VmC4g4Dc94="
+  },
+  "com/fasterxml/jackson#jackson-parent/2.9.0": {
+   "pom": "sha256-AAUIth3RJDh+WBmfueIRPBtdizhsW/eokbLeYEHrHVI="
+  },
+  "com/fasterxml/jackson#jackson-parent/2.9.1.2": {
+   "pom": "sha256-lRfkBcazuKA1IVrVcnATo1Get1kXQ/4dzATfZjVoPPk="
+  },
+  "com/fasterxml/jackson/core#jackson-annotations/2.10.2": {
+   "jar": "sha256-jDy6ib8+A7NaDm+JLC6xftj93i4hTDpMGHA9Y3lrrkY=",
+   "pom": "sha256-f2SWXv0l28EHkekHNbZjbet4fNcY0wLgkG5Uqnrew+o="
+  },
+  "com/fasterxml/jackson/core#jackson-annotations/2.14.2": {
+   "jar": "sha256-LGhp1QXPYNwGZzS31QM5+XW9OtxjXianirtxrLRHPA0=",
+   "pom": "sha256-hK4DQYN9dpamEEPYCeQyYKXrB3Iy0dyqRkyNpUnNnqA="
+  },
+  "com/fasterxml/jackson/core#jackson-annotations/2.15.0": {
+   "jar": "sha256-ka3NPc9f2aFkmZNOdTaiPUVmkqAJPj1P1S8TjDk2NIw=",
+   "pom": "sha256-L4FZtEIZb6qg4TdOLSI0tX/uwysnYX+h1/XZqOC+Nyg="
+  },
+  "com/fasterxml/jackson/core#jackson-annotations/2.17.2": {
+   "jar": "sha256-hzpgbiNQeWn5u76pOdXhknSoh3XqWhabp+LXlapRVuE=",
+   "pom": "sha256-Q3gYTWCK3Nu7BKd4vGRmhj8HpFUqcgREZckQQD+ewLs="
+  },
+  "com/fasterxml/jackson/core#jackson-annotations/2.21": {
+   "jar": "sha256-U8oIX0oVD3A/SeGqvZNb0DtD4eo9VdE1Q4KSryLO9Ws=",
+   "pom": "sha256-ccrFOSFR4qUozJoJF58KM0F58FxS+OWWz1jd8Suyfys="
+  },
+  "com/fasterxml/jackson/core#jackson-annotations/2.9.0": {
+   "jar": "sha256-RdMqxh74p0S0ZMVMKzQUvlcQFt1Gv8K+wiZ2HPeuRXo=",
+   "pom": "sha256-7eudm/ynJrRBv64Jtp2UtduZzVqdpfSgYbkOcrZAkFw="
+  },
+  "com/fasterxml/jackson/core#jackson-core/2.10.2": {
+   "jar": "sha256-TEHyKkj267KHUrrrbSW/CbpP8K2L+4JlDd5EiSi52k8=",
+   "pom": "sha256-Mlo8lNkkrw9s6sykDp6IehiIZMFT+fw0zpxPAT2ogo4="
+  },
+  "com/fasterxml/jackson/core#jackson-core/2.14.2": {
+   "jar": "sha256-tdN6d8iCd7l+NZPIdAklIWwG345BcrveBYUo3wStPno=",
+   "pom": "sha256-9EzGPWEvA7Hb/IKJLc2zL9t1vxYEn9hZVWHnx6M7xFE="
+  },
+  "com/fasterxml/jackson/core#jackson-core/2.15.0": {
+   "jar": "sha256-W0g/aPqd1qo32jfR953VxLlGQjj08GYKJCy2tccklQw=",
+   "pom": "sha256-Cjr13zbx8n4XZEgXpiQJuqJYZKNJOj0ogK1wCbDnA64="
+  },
+  "com/fasterxml/jackson/core#jackson-core/2.17.2": {
+   "jar": "sha256-choYkkHasFJdnoWOXLYE0+zA7eCB4t531vNPpXeaW0Y=",
+   "pom": "sha256-F4IeGYjoMnB6tHGvGjBvSl7lATTyLY0nF7WNqFnrNbs="
+  },
+  "com/fasterxml/jackson/core#jackson-core/2.21.2": {
+   "jar": "sha256-EuhlWxACZ7RNDxTQGx9QgqUQXmFhdNxDB74adh6SQHs=",
+   "pom": "sha256-urDlWZZJzLWrIanPnS5XGS3h5I5tI1JNwlPWL8c8ljQ="
+  },
+  "com/fasterxml/jackson/core#jackson-core/2.21.3": {
+   "jar": "sha256-uvi3OenZuTvNsz8lBGv9uNvXTJfeKoaYU5++DH7qwLs=",
+   "pom": "sha256-t7i+9Rpmfc4nBvbq5X4megm/FgUHRjJVsKhUgFcjBHI="
+  },
+  "com/fasterxml/jackson/core#jackson-core/2.9.9": {
+   "jar": "sha256-MIMHm+YIjbLtCgxv+SIE4KpI+h3p21tZxGjzWs+ILCw=",
+   "pom": "sha256-xWqygptlPMfKZIEGCV8GA4Vm2AlcAfIYE1XckHskT2E="
+  },
+  "com/fasterxml/jackson/core#jackson-databind/2.10.2": {
+   "jar": "sha256-QsJWRONfrfve0bfzWo0ecKhnN/GQ5DqixWzqS5bL2og=",
+   "pom": "sha256-ZPiADf5bm2CO1Hp033PEwkRaiRa6a/os+7cBgfITAXg="
+  },
+  "com/fasterxml/jackson/core#jackson-databind/2.14.2": {
+   "jar": "sha256-UB06vOTRjcw4EFjsWTxblEd5Brum77rBTa5ApkL3dCQ=",
+   "pom": "sha256-IoCOu0t12MQDfZzuEgitxlvHgqmIVzIjSjG3tXTF2Qw="
+  },
+  "com/fasterxml/jackson/core#jackson-databind/2.15.0": {
+   "jar": "sha256-AMWl1a5xrI6NW42mBoQeIlHIBjVZOctdUcTNxrZEoNw=",
+   "pom": "sha256-jDgNP+PcwpjQKHmKH5Lfwxgk/aBBFEryNi8fzzDueI8="
+  },
+  "com/fasterxml/jackson/core#jackson-databind/2.17.2": {
+   "jar": "sha256-wEmT8zwPhFNCZTeE8U84Nz0AUoDmNZ21+AhwHPrnPAw=",
+   "pom": "sha256-0kUGmLrpC+M48rmfrtppTNRQrbUhJCE+elO0Ehm1QGI="
+  },
+  "com/fasterxml/jackson/core#jackson-databind/2.21.2": {
+   "jar": "sha256-jJgvAfFI2AXwqqwjOQESRHV+DffG/4lR8vo/QzuO2Ek=",
+   "pom": "sha256-z44OzcNfAtoG4n9BV2ALqddknFJy5Na3le8qQvBwomI="
+  },
+  "com/fasterxml/jackson/core#jackson-databind/2.21.3": {
+   "jar": "sha256-85dWPY5nYwwQyrjCM0yg5Vr4Mvo+veFgo3nCyW1DvyU=",
+   "pom": "sha256-GtcwZNlrjQKDccdJnGgHymjAh+1usDl2Y1qJTPMwEK4="
+  },
+  "com/fasterxml/jackson/core#jackson-databind/2.9.9": {
+   "jar": "sha256-XLv0KdnjLjiB8KFDih9maRIhkyfp5otdyu9tjlxfayg=",
+   "pom": "sha256-yixM1fBD2GlKAgK6wJ3NkecOvvmnBP9AAHaLTKac+xE="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformat-cbor/2.17.2": {
+   "jar": "sha256-HX3GNLo9eYHXAX9PRNQ883HpIsgAKLTrPlN0zmVG1fY=",
+   "pom": "sha256-q4WEo3wQxVJPxsdMa3NqOxtAFbr4TrQcX2KG/Ev68G4="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformat-xml/2.10.2": {
+   "jar": "sha256-Gbv2/CNYGqKTPbvqK2YDnIyeAN7tv8+299HM+/C7024=",
+   "pom": "sha256-eFMU/9hwrzylLhQ0mwckC2oaYGqq92U7jZoV2kC+ZJA="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformat-xml/2.9.9": {
+   "jar": "sha256-9awA/cUihU066C/DWIdEL8qYSk3xuETinVXohwgLtSE=",
+   "pom": "sha256-7UuA/A6bqlaAmOeB5gkX4qCgsKyxHzHUeMN0wh31GMA="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformat-yaml/2.10.2": {
+   "jar": "sha256-Kjm5bB4VlgslerX8K25+PnfPi93EIlT/IMhFXfXN5pk=",
+   "pom": "sha256-am8bFiJUxmLEbr3ln/x+l0fGMjT9XXFQEPc+6BrdzQo="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformat-yaml/2.9.9": {
+   "jar": "sha256-Kg/Kz6ulEopxZMIxGzWjXi+e7bKfWTXeVVNxa0VEVc8=",
+   "pom": "sha256-EtJnHO/DWLoIDt5JKgcq/4xOE7zTJ68tjvpBqRujdys="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformats-binary/2.17.2": {
+   "pom": "sha256-9rAxareGEy43yUSh92iYwg0WyjHbLh9U5ntdV5jOl1o="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformats-text/2.10.2": {
+   "pom": "sha256-etv3OnkhSgiRvxBm2QKDvJ13E7Fe9rxBwBHeoSan2WE="
+  },
+  "com/fasterxml/jackson/dataformat#jackson-dataformats-text/2.9.9": {
+   "pom": "sha256-sKeKkfcT3GFBMJ2aLqHqJWcG+CWUX6dh/eCKV+STUxk="
+  },
+  "com/fasterxml/jackson/datatype#jackson-datatype-jdk8/2.10.2": {
+   "jar": "sha256-5poexP/m8TsqA1wME9d7Gwj9ydPh9ga2nnTEsu/IkZc=",
+   "pom": "sha256-FmzQxwbPGuABWqNqtwPgzAZPdmtgSlzBzikkML4h+14="
+  },
+  "com/fasterxml/jackson/datatype#jackson-datatype-jdk8/2.21.2": {
+   "jar": "sha256-5YG78/xWItFrVzZt1B4Q/FaSH7ICh53i70h/h92bMOc=",
+   "pom": "sha256-kS6F4iGHClCQbJcISkQrJTwJfpbZ8y/Xwk7/XOyAxCs="
+  },
+  "com/fasterxml/jackson/datatype#jackson-datatype-jsr310/2.21.2": {
+   "jar": "sha256-oIPVfNHEoo/vzGvQcXQHeet/wcIqPBtARRtUd8RD8C8=",
+   "pom": "sha256-0Fd4iCjfgV6Y4BjJsAQBoR4boyctNNmEdqc2rG2X734="
+  },
+  "com/fasterxml/jackson/module#jackson-module-jaxb-annotations/2.10.2": {
+   "jar": "sha256-/4fcttG+3fRFgSc4DuL7NQRGOn8gQg1muqFZCmXBXTM=",
+   "pom": "sha256-c1Soepv2Jy6ELr/s1Mkvt5X8belYVqb+oZ4qzDckx+8="
+  },
+  "com/fasterxml/jackson/module#jackson-module-jaxb-annotations/2.9.9": {
+   "jar": "sha256-GwkfiBZzpbsnWvwXE+bbfaQwOOGT71DUd+1l1OMnT0M=",
+   "pom": "sha256-6X2CwI3TKVEP48KG9PrzaZvGl6Dz50ZSnZBMSEX8v7w="
+  },
+  "com/fasterxml/jackson/module#jackson-modules-base/2.10.2": {
+   "pom": "sha256-Olf31T/yX0WCkZzKVdTbVz4IoB9YCXHt9GnnePIp5J0="
+  },
+  "com/fasterxml/jackson/module#jackson-modules-base/2.9.9": {
+   "pom": "sha256-nXLydpcfZBK+YWUdUGwaIunwzfRN0ZNgCPjIJ0/JIK8="
+  },
+  "com/fasterxml/jackson/module#jackson-modules-java8/2.10.2": {
+   "pom": "sha256-qEP2Sj7WEp6ebkfd/s8JDGzYQ5rAvLsQaaNYpIyYefo="
+  },
+  "com/fasterxml/jackson/module#jackson-modules-java8/2.21.2": {
+   "pom": "sha256-T0KMISebw0vUTVHCeWdB53r9f523/0qTGkPHsBocRZU="
+  },
+  "com/fasterxml/woodstox#woodstox-core/5.0.3": {
+   "jar": "sha256-ocBLZPv+IK6fLGCjvxYz/tZoiuMZNba9SkV6G7sugtQ=",
+   "pom": "sha256-26nRm1kGhX4eJ7l3HXps9/+aMiJNTgQbILw1vFBEuO8="
+  },
+  "com/fasterxml/woodstox#woodstox-core/5.1.0": {
+   "jar": "sha256-bWEHw+aqyPHD43YriRZLMp+ysV7Ar8iWHPbE3DVfEL8=",
+   "pom": "sha256-ECyQFgiNXtZyRmcpK9xefv82gQJkCbqeg/tciX34ckI="
+  },
+  "com/fasterxml/woodstox#woodstox-core/6.0.3": {
+   "jar": "sha256-RCSr6kyD0ghiguUGKd4fjL48rqcty0X+wtAI3tOtj18=",
+   "pom": "sha256-Swtcbu0FyqREUCY+mSGsnFSbN06dH9JcMwL8gCfwgN4="
+  },
+  "com/fazecast#jSerialComm/2.11.4": {
+   "jar": "sha256-tffsQNYihkuS3GeRWc26owMNN4hPCvLe70W1bBa9p6Y=",
+   "pom": "sha256-embDslkCW75eNtkDTpgb53UMZOTUKPdmS523ZBHP5J8="
+  },
+  "com/github/ben-manes/caffeine#caffeine/2.6.2": {
+   "jar": "sha256-53pEV3NfB1FY29Ahx2YXl91IVpX8Ttkt/d401HFNl1A=",
+   "pom": "sha256-eqIrRA0IMjeSHZ3NsFa/hClciPOMBy9kepWY3rHWjH4="
+  },
+  "com/github/ben-manes/caffeine#caffeine/2.8.0": {
+   "jar": "sha256-sRB6QJe+RRWpI6Vbxj2gTkEeaWSqBFvs4bx6y4SHLtc=",
+   "pom": "sha256-vS0LYOArPQ2j68bC8pRm57urMhEkxi3oy4MdpPEA0K8="
+  },
+  "com/github/ben-manes/caffeine#caffeine/2.8.2": {
+   "jar": "sha256-U60wqcyKOJZbqkmGQoDP5zyINxyvZoDFGd5CqqNvd64=",
+   "pom": "sha256-i/LHJhAA9GSUIiCLHg/xPMcqH+jBESJ5Nb8b/oR5f50="
+  },
+  "com/github/jnr#jffi/1.2.15": {
+   "pom": "sha256-GpQ74LUWtUxTDJcH7pk2mpOMKtGi8E9FO7OhezsBhYE="
+  },
+  "com/github/jnr#jffi/1.2.15/native": {
+   "jar": "sha256-xwKlmSnBrYs7ZVyFJJLxU7rv/dJR8MaDQtd9+HuP+rs="
+  },
+  "com/github/jnr#jffi/1.3.9": {
+   "pom": "sha256-zEqmwymkRXqBhdvE2iH17AYuIiWux5wgCDsg11ESehw="
+  },
+  "com/github/jnr#jffi/1.3.9/native": {
+   "jar": "sha256-vd/kYNUoxopx0NTJ0wEi8o9vGC+eu0vo9l5wkMTKiBw="
+  },
+  "com/github/jnr#jnr-a64asm/1.0.0": {
+   "jar": "sha256-U65ep/pcKE6Ceao0jnud5FSLDK4Qv9BY+iF8eRh15M8=",
+   "pom": "sha256-ndnCmco+ySh9suwmVxpcxhHcIaGk9dLvElWpJPrOR6g="
+  },
+  "com/github/jnr#jnr-constants/0.10.3": {
+   "jar": "sha256-phew2EY9PqNkNb0WERE97bN0kVev0iaZCKswbJkq7+0=",
+   "pom": "sha256-5s/r5K5E3pah7I7j/z6xE07Uk7ChWymoZj45tv2rp6I="
+  },
+  "com/github/jnr#jnr-constants/0.9.8": {
+   "jar": "sha256-vNaOmz0/thzR3IaIl/y9U4D6CRCSV1w0Pf2Y00cVzvM=",
+   "pom": "sha256-iGMBkpXyoRViQqFc8qbktqIRbLty1IkyU2sGliXo6sg="
+  },
+  "com/github/jnr#jnr-enxio/0.16": {
+   "jar": "sha256-Z1ABzhHoz8iFnU3XK8jeiNCdCXmJ9jUtu9CMDVXyPfA=",
+   "pom": "sha256-GuLkMPxvlpqA0db1UjTo5vnZcI9o+H/IOTWe5ZaQcFc="
+  },
+  "com/github/jnr#jnr-enxio/0.32.13": {
+   "jar": "sha256-08ATbrAXYJIhDVyHDb4w8dkrQ9c+6bHkqGHijGRgUnw=",
+   "pom": "sha256-pcrvbflKJYBULdQsZzN004RQ2W+82Od8mOaoX4ln/Tk="
+  },
+  "com/github/jnr#jnr-ffi/2.1.4": {
+   "jar": "sha256-ZHRaPedCV+7x0yr3z5jEkovg9sXXLBFynNUA2yHF1Hg=",
+   "pom": "sha256-MegSk5j3uZxYVMN3Bx+Dh2HS2vdqchUKCE9GsKnT1j8="
+  },
+  "com/github/jnr#jnr-ffi/2.2.11": {
+   "jar": "sha256-qcC955JRTZLonxneBBLF4m7nLbWYkUAkKykCpDt6x/U=",
+   "pom": "sha256-i+JCWRyszLbK6dpwD0Nz3a0Adg6NpnlpepgSi7QqX3s="
+  },
+  "com/github/jnr#jnr-posix/3.0.35": {
+   "jar": "sha256-3zyrRVry1tbjdw4RAfICX4uP6eTDXCRSEZ3GE91J3Dk=",
+   "pom": "sha256-2cRG7iMHN4wGQUxQgCOBrrUCjfl/Mhw4DwpBOJHN7m8="
+  },
+  "com/github/jnr#jnr-posix/3.1.15": {
+   "jar": "sha256-w47PzNJOXyHxemLkXVvUVIQsXbF+1CsBuGj5IG0Omec=",
+   "pom": "sha256-qjwjbl+8bsNl5MgR7OpNvKdZGFHOx8eh32syTE6wgqM="
+  },
+  "com/github/jnr#jnr-unixsocket/0.18": {
+   "jar": "sha256-aaJV0GENyKYe8Oy2kPIHYG1rFSZ+Mhc+aPSrHIC/XKE=",
+   "pom": "sha256-0f3acOph52IiBM5pv3ayiM6XQU7h3mLUx/bk7cnlsAU="
+  },
+  "com/github/jnr#jnr-unixsocket/0.38.17": {
+   "jar": "sha256-mPYscZs0gUV/Jf0l4lAqznqQ1F91olVOvPy2vgsWGhc=",
+   "pom": "sha256-3oSBWeFSRkTp8cV0r39Gt1Hm5TDzWifutMhT6R6hwuE="
+  },
+  "com/github/jnr#jnr-x86asm/1.0.2": {
+   "jar": "sha256-OfNnW5EObpuTgl+ChL7J9K0wRM0gpvfI/54vhpXr8h4=",
+   "pom": "sha256-6oYs472WzLjKNrjp57rvLaP7v73CVrrqqMioc5EQdOc="
+  },
+  "com/github/jponge#lzma-java/1.3": {
+   "jar": "sha256-dczA4k037VuJFuG8/60eBnwrHPohtjUof5aNtcPBljo=",
+   "pom": "sha256-+8uoGyGovDwHYeR5j6BShURLQ9aBwDya9J+bLh7LAYQ="
+  },
+  "com/github/luben#zstd-jni/1.3.3-3": {
+   "jar": "sha256-pli+366HNk+Pg19atex+xQGy1GVIW7iJf/fQw3rn4hs=",
+   "pom": "sha256-k/UebVjOoHpv3msZZhwh84sakhnPIyoywstzvLVGxcE="
+  },
+  "com/github/luben#zstd-jni/1.3.8-3": {
+   "jar": "sha256-+hubI+UEe3omj6KyDZsFYLwFCFpb8haG5sLi5eYIPoA=",
+   "pom": "sha256-kStreRbWLCobmVoDEV6nrg5EbIIZSbQFxuobEjLIb7A="
+  },
+  "com/github/luben#zstd-jni/1.4.0-1": {
+   "jar": "sha256-DUWEfHofxZwk7nHZQswfrqanjOeoi/ZYODWL2ioxZWc=",
+   "pom": "sha256-ioBftAWpc0VzvC/xTL5n+6xcQEN6cBezMXxyU+VSaBY="
+  },
+  "com/github/luben#zstd-jni/1.4.4-7": {
+   "jar": "sha256-JP9dvga7ftMfQIfffYJNe4Q4gPPJU9YItIZ/P/0Wun4=",
+   "pom": "sha256-sp6aBGs4r51iSPHlTdJ393bZCkQElP7q++AtPbJE15Q="
+  },
+  "com/github/luben#zstd-jni/1.5.5-3": {
+   "jar": "sha256-rGxTfN6l4yiV9czmMzMa4hYz2Xu/iufJah/GfD4UzHI=",
+   "pom": "sha256-W5hFPOHPlJYQraNQePbZrt89VLU2F8xW4hXefZvX00s="
+  },
+  "com/github/luben#zstd-jni/1.5.7-4": {
+   "jar": "sha256-5/Bkvx6rg/p4XPWH9lfwlknjsK9vJ8qlOCQWlTtaNfg=",
+   "pom": "sha256-bWATTHZEhSV0zKTKo3VzIGsh/yFDn9MgPEJ4XQcRZrk="
+  },
+  "com/github/rzymek#opczip/1.2.0": {
+   "jar": "sha256-JTpOG8p5y/JCzFLvt8kxEhvCjDOT4q7yTx7+A81tnCg=",
+   "pom": "sha256-rMzJeID8//WwrSUbSb99xqDRHNdISsGLBlKvf2lfBvI="
+  },
+  "com/github/spotbugs#spotbugs-annotations/4.9.3": {
+   "jar": "sha256-E1Mr/i9F/NSRQyIh33LZzQ77j5h8kkXhK++hksiSXOM=",
+   "pom": "sha256-al3AL2Ye8y5MwfndQnfAwNtjeN+e+DFO3xfPv5DPXgs="
+  },
+  "com/github/waffle#waffle-jna/1.9.1": {
+   "jar": "sha256-Xf6wrL6Re5CvZXBcYUJDuE1LG52ShY7q6vqIhfyg+I4=",
+   "pom": "sha256-u6f5l3LQL4RObAKMh15Meoyhd9Fj+n5EKHlA46KrVj0="
+  },
+  "com/github/waffle#waffle-parent/1.9.1": {
+   "pom": "sha256-TG9mYCNhCmC9IEFNXz32GxVeuMpGI/bpCvT+wKxjvGQ="
+  },
+  "com/google#google/1": {
+   "pom": "sha256-zW2xehGjHt55TMvR3w5Nl1D2QCNHMfIc/4hamZcnfoE="
+  },
+  "com/google/code/findbugs#jsr305/1.3.9": {
+   "jar": "sha256-kFchoO6pCoFTSrt+5u9OouXmRfod7wpc2IQC3xtGye0=",
+   "pom": "sha256-/quRkTEcPXru8rZtYGSvyA09HVLZgPsHrkPHjJh7qTo="
+  },
+  "com/google/code/findbugs#jsr305/3.0.2": {
+   "jar": "sha256-dmrSoHg/JoeWLIrXTO7MOKKLn3Ki0IXuQ4t4E+ko0Mc=",
+   "pom": "sha256-GYidvfGyVLJgGl7mRbgUepdGRIgil2hMeYr+XWPXjf4="
+  },
+  "com/google/code/gson#gson-parent/2.10.1": {
+   "pom": "sha256-QkjgiCQmxhUYI4XWCGw+8yYudplXGJ4pMGKAuFSCuDM="
+  },
+  "com/google/code/gson#gson-parent/2.12.1": {
+   "pom": "sha256-yeewt+Mb574iaEl5wGgAHGUssRPE5u2JTjm2Q97gf8E="
+  },
+  "com/google/code/gson#gson-parent/2.13.1": {
+   "pom": "sha256-+IEKzlDd/j/ag9ESbeZdmdXSUVoUo2uIvrG5mkdpeDY="
+  },
+  "com/google/code/gson#gson-parent/2.13.2": {
+   "pom": "sha256-g6tSip1Q/XauuK1vcns+6ct2ZYYlV3TtFsqMTHbZ2s0="
+  },
+  "com/google/code/gson#gson-parent/2.14.0": {
+   "pom": "sha256-grD2aUxXWKuLsH4FYwII1Q9YnUteBP0KBG1Zzfe6PR0="
+  },
+  "com/google/code/gson#gson-parent/2.7": {
+   "pom": "sha256-hx6Mc3MiMB8MyKz+OaKWDEV52dhmau6lKYu2/MnkJys="
+  },
+  "com/google/code/gson#gson-parent/2.8.9": {
+   "pom": "sha256-sW4CbmNCfBlyrQ/GhwPsN5sVduQRuknDL6mjGrC7z/s="
+  },
+  "com/google/code/gson#gson/2.10.1": {
+   "jar": "sha256-QkHBSncnw0/uplB+yAExij1KkPBw5FJWgQefuU7kxZM=",
+   "pom": "sha256-0rEVY09cCF20ucn/wmWOieIx/b++IkISGhzZXU2Ujdc="
+  },
+  "com/google/code/gson#gson/2.12.1": {
+   "jar": "sha256-6+4T1ft0d81/HMAQ4MNW34yoBwlxUkjal/eeNcy0++w=",
+   "pom": "sha256-C1c17IX0UoLx4sdpd5gAQnsVCoFj9AUJOpKAtxyrGXg="
+  },
+  "com/google/code/gson#gson/2.13.1": {
+   "jar": "sha256-lIVZQtSZLxEpRtPeHDNOcJI3uBJtgTC/B4B8AYpKISA=",
+   "pom": "sha256-wPZXItdcDljNGDWzBGBG9ga12mmZBBYfjba3j+ubQBo="
+  },
+  "com/google/code/gson#gson/2.13.2": {
+   "jar": "sha256-3QzhtVo+0ggMtw+cZVhQzahsIGhiMQAJ3LXlyVJlpeA=",
+   "pom": "sha256-OqBqp8D5rwkpYaQtCVeOQyS+FGNIoO5u1HhX98Jne3Y="
+  },
+  "com/google/code/gson#gson/2.14.0": {
+   "jar": "sha256-LL0Rm/GWHCh4gxCWPcgLpl9Yze7B3ROci9sSQPqiw28=",
+   "pom": "sha256-H6ASLA43MxkmQoYcNr5Mb3maeVMnojvdKSJpG26bpIA="
+  },
+  "com/google/code/gson#gson/2.7": {
+   "jar": "sha256-LUPrXqnhM9LuJAXMFPXuCJUbg2EwL92TSUo6mXtQjTI=",
+   "pom": "sha256-cjk27Ae4eyEKRO+AWPMvVuPVZEIhjfv49OU4qScWDt4="
+  },
+  "com/google/code/gson#gson/2.8.9": {
+   "jar": "sha256-05mSkYVd5JXJTHQ3YbirUXbP6r4oGlqw2OjUUyb9cD4=",
+   "pom": "sha256-r97W5qaQ+/OtSuZa2jl/CpCl9jCzA9G3QbnJeSb91N4="
+  },
+  "com/google/errorprone#error_prone_annotations/2.0.12": {
+   "jar": "sha256-fpxoj3NO5c8jhtPvw2fUo+bQkTDSr+tSQ04cwogIIKQ=",
+   "pom": "sha256-lf4P3VNtFlXUiRR0w+owHOYBbnK4LaWwixDlz4epTzc="
+  },
+  "com/google/errorprone#error_prone_annotations/2.18.0": {
+   "jar": "sha256-nmgUy3GBaYik/RsHqZOo8hu3BY1SLBYrHehJ4ZvqVK4=",
+   "pom": "sha256-kgE1eX3MpZF7WlwBdkKljTQKTNG80S9W+JKlZjvXvdw="
+  },
+  "com/google/errorprone#error_prone_annotations/2.3.2": {
+   "jar": "sha256-NXzWz7BnyWkibEQkUVAq7hOACiTpUP3953vNtFZaZo0=",
+   "pom": "sha256-jRdVYWGSiaUnVzz73Phy61wSFs+atpKg7z26bXk/Y7Q="
+  },
+  "com/google/errorprone#error_prone_annotations/2.3.3": {
+   "jar": "sha256-7FnxtwLZr8CejDkp9cQnd97GI6bqJzGsaUMyx9doD1o=",
+   "pom": "sha256-v9aSVaDAETr+5NoBNruAsSaMuw1h3wBp2NIrO+8laNU="
+  },
+  "com/google/errorprone#error_prone_annotations/2.3.4": {
+   "jar": "sha256-uvfW6pfOYGxT4RtoVLpfLOfvXCTd3wr6GNEmC9JbACw=",
+   "pom": "sha256-EyZziktPfMrPYHuGahH7hRk+9g9qWUYRh85yZfm+W+0="
+  },
+  "com/google/errorprone#error_prone_annotations/2.36.0": {
+   "jar": "sha256-d0QOJwsLyaJJkDxaB2w2pyLEiGyk9CZ18pA6HFPtYaU=",
+   "pom": "sha256-15z9N8hfdta3VMdQHuHchEe3smQsI4LXeCUhZr0zHpw="
+  },
+  "com/google/errorprone#error_prone_annotations/2.38.0": {
+   "jar": "sha256-ZmHVM1CQpfxh3YadIJW8bB4hVuOqR6bkq6vfZMmaeIk=",
+   "pom": "sha256-MAe++K/zro6hLYHD/qy08Vl5ss9cPjj8kYmpjeoUEWc="
+  },
+  "com/google/errorprone#error_prone_annotations/2.41.0": {
+   "jar": "sha256-pW54K1tQgRrCBAc6NVoh2RWiEH/OE+xxEzGtA29mD8w=",
+   "pom": "sha256-oVHfHi4LSGGNiwahgHSKKbOrs5sbI5b2och5pydIjG4="
+  },
+  "com/google/errorprone#error_prone_annotations/2.47.0": {
+   "jar": "sha256-U2S8byLnLpgZXkBqWNO6HAn/oR3qBylZLLhw3C3kBW0=",
+   "pom": "sha256-2AyImkpvcR9pRfvueeBewkexeKVn6dWr9Y6ybr8KB1I="
+  },
+  "com/google/errorprone#error_prone_annotations/2.48.0": {
+   "jar": "sha256-tJxclYMW7WegnGmd2pqnScr0NNUdhj3qWZ7zakm5yFU=",
+   "pom": "sha256-GJ4JrQSJwyXpDaqp1cj0BjMGAvo2Zgm8oHy82tA6udo="
+  },
+  "com/google/errorprone#error_prone_parent/2.0.12": {
+   "pom": "sha256-QWSZjNypSnOsfHnpgvlQGSMXgJxg9sNA46Z6fgi6q/Q="
+  },
+  "com/google/errorprone#error_prone_parent/2.18.0": {
+   "pom": "sha256-R/Iumce/RmOR3vFvg3eYXl07pvW7z2WFNkSAVRPhX60="
+  },
+  "com/google/errorprone#error_prone_parent/2.3.2": {
+   "pom": "sha256-jTtbn6IRl56cQl6YmCXAd0PS603Iwg7GHeD1s9waYzM="
+  },
+  "com/google/errorprone#error_prone_parent/2.3.3": {
+   "pom": "sha256-awWm9S4rZbTvzjy7pTNbCBsdykuX3mkCNM1TZHmkDzI="
+  },
+  "com/google/errorprone#error_prone_parent/2.3.4": {
+   "pom": "sha256-QElbQ3pg0jmPD9/AVLidnDlKgjR6J0oHIcLpUKQwIYY="
+  },
+  "com/google/errorprone#error_prone_parent/2.36.0": {
+   "pom": "sha256-Okz8imvtYetI6Wl5b8MeoNJwtj5nBZmUamGIOttwlNw="
+  },
+  "com/google/errorprone#error_prone_parent/2.38.0": {
+   "pom": "sha256-5iRYpqPmMIG8fFezwPrJ8E92zjL2BlMttp/is9R7k0w="
+  },
+  "com/google/errorprone#error_prone_parent/2.41.0": {
+   "pom": "sha256-xTg4jXYKXByY3PBvbtPP5fEaZRgn21y9LtgojHlcrUI="
+  },
+  "com/google/errorprone#error_prone_parent/2.47.0": {
+   "pom": "sha256-I2ipkMemMJXh0NREWdWkCS8Osx+FYr0SzfDhyHe2poU="
+  },
+  "com/google/errorprone#error_prone_parent/2.48.0": {
+   "pom": "sha256-sz+opFyfF5SlAIwLLYOoTrKLXQEXptFW8AP58JvnQQ8="
+  },
+  "com/google/guava#failureaccess/1.0.1": {
+   "jar": "sha256-oXHuTHNN0tqDfksWvp30Zhr6typBra8x64Tf2vk2yiY=",
+   "pom": "sha256-6WBCznj+y6DaK+lkUilHyHtAopG1/TzWcqQ0kkEDxLk="
+  },
+  "com/google/guava#failureaccess/1.0.3": {
+   "jar": "sha256-y/w5BrGbj1XdfP1t/gqkUy6DQlDX8IC9jSEaPiRrWcs=",
+   "pom": "sha256-xUvv839tQtQ+FHItVKUiya1R75f8W3knfmKj6/iC87s="
+  },
+  "com/google/guava#guava-parent/20.0": {
+   "pom": "sha256-8SJv0H/HKvjWIyvfpwvzHYg6GgHLxUfyOnTpBmxpLfE="
+  },
+  "com/google/guava#guava-parent/26.0-android": {
+   "pom": "sha256-+GmKtGypls6InBr8jKTyXrisawNNyJjUWDdCNgAWzAQ="
+  },
+  "com/google/guava#guava-parent/28.1-jre": {
+   "pom": "sha256-8xpYRr2eFKTDdNobmxRqVxXs3Kkl4HHh0r9Notqt7ZA="
+  },
+  "com/google/guava#guava-parent/29.0-jre": {
+   "pom": "sha256-alf54C9436L0vaNBYGWmRCauG2beIoz24Zbi4ZElU78="
+  },
+  "com/google/guava#guava-parent/32.1.1-jre": {
+   "pom": "sha256-BqpdGsBo8vgJUw8/9T+1yMlAFSolNiPQtTxPU/WhOj0="
+  },
+  "com/google/guava#guava-parent/33.4.0-android": {
+   "pom": "sha256-ciDt5hAmWW+8cg7kuTJG+i0U8ygFhTK1nvBT3jl8fYM="
+  },
+  "com/google/guava#guava-parent/33.5.0-jre": {
+   "pom": "sha256-aHGeaHxuTJ/z4P7L73vSCJbw9PezFHQ+0zxy+WJWghU="
+  },
+  "com/google/guava#guava-parent/33.6.0-jre": {
+   "pom": "sha256-N0vTH2Gxz2Er7pqy5NcLvfd92FpJtDH4CdT73JAfLdQ="
+  },
+  "com/google/guava#guava/20.0": {
+   "jar": "sha256-NqZm47ca5/Dw3KI2VLZ+CG5sk9GS9gul39VRnbbCiMg=",
+   "pom": "sha256-NjzIN2e3YNelZNUwHglGfm1I/BwcFmSx4YxQgVzhkHY="
+  },
+  "com/google/guava#guava/28.1-jre": {
+   "jar": "sha256-ML64uFJ70HxudH538akhIsLynVfONHRhpKVesm44LaQ=",
+   "pom": "sha256-dK8Ojdk1iUzpvLjihC3QABWBuEy2p3UcPvkxQBE5m6Q="
+  },
+  "com/google/guava#guava/29.0-jre": {
+   "jar": "sha256-sixftm1h57lSJTHQSy+RW1FY6AqgtA7nKCyL+wew2iU=",
+   "pom": "sha256-kCfpNAmJA9KH8bphyLZfAdHR4dp6b7zAS/PeBUQBRCY="
+  },
+  "com/google/guava#guava/32.1.1-jre": {
+   "jar": "sha256-kfu6N/HIslHPnqnn06Np63nrHmpd8dS79IPdA4B0AoE=",
+   "pom": "sha256-LJBx19FSKwx2IFfDToub+uOZJ6DrdVw2qnZRlyGHDXs="
+  },
+  "com/google/guava#guava/33.5.0-jre": {
+   "jar": "sha256-HjAfDFKsJIsLFP3D0SKDx3JS1Nb0hSHVcufYxMLMSsc=",
+   "module": "sha256-d+1CyMiyzru5OsngdUP/ZBiqJL24UXWAz1Mk6aZRCVY=",
+   "pom": "sha256-BHj6eKkIs8Mf5td76ZeKqmIeKhgduEAH49OzdCSirGE="
+  },
+  "com/google/guava#guava/33.6.0-jre": {
+   "jar": "sha256-3Fc+H8pP1UVPSl/T19ot8DACh2pBdbr8FKlZgN13E7M=",
+   "pom": "sha256-tFt4lEKABUMRxT2pJwgJ+0Dcq8QIzmbOVXMAmbT1fTI="
+  },
+  "com/google/guava#listenablefuture/9999.0-empty-to-avoid-conflict-with-guava": {
+   "jar": "sha256-s3KgN9QjCqV/vv/e8w/WEj+cDC24XQrO0AyRuXTzP5k=",
+   "pom": "sha256-GNSx2yYVPU5VB5zh92ux/gXNuGLvmVSojLzE/zi4Z5s="
+  },
+  "com/google/j2objc#j2objc-annotations/1.1": {
+   "jar": "sha256-KZSn63jycQvT07+2ObLJTiGc7awNTQhNUW54wW3d7PY=",
+   "pom": "sha256-8MmMVx6Tp8tN0Y3w+jCPCWPnoGIKwtQkTmHnCdA61r4="
+  },
+  "com/google/j2objc#j2objc-annotations/1.3": {
+   "jar": "sha256-Ia8wySJnvWEiwOC00gzMtmQaN+r5VsZUDsRx1YTmSns=",
+   "pom": "sha256-X6yoJLoRW+5FhzAzff2y/OpGui/XdNQwTtvzD6aj8FU="
+  },
+  "com/google/j2objc#j2objc-annotations/2.8": {
+   "jar": "sha256-8CqV+hpele2z7YWf0Pt99wnRIaNSkO/4t03OKrf01u0=",
+   "pom": "sha256-N/h3mLGDhRE8kYv6nhJ2/lBzXvj6hJtYAMUZ1U2/Efg="
+  },
+  "com/google/j2objc#j2objc-annotations/3.1": {
+   "jar": "sha256-hNOhUFGEhfgUDqmbiphWVnSWKfZDPJK4DHWzaro7CZs=",
+   "pom": "sha256-FFcIOFAANPwbR8ggXOHJ1rJVwczdLRr9zcv3XomySjM="
+  },
+  "com/google/protobuf#protobuf-java/2.4.1": {
+   "jar": "sha256-rZdpoimJ5oikavTTrMw0jMUBztIhGAMyMFQryRbjPws=",
+   "pom": "sha256-LiLFFf1PMYH6Ou1/cYM8G42vC+oG2ealxopFDfQ1/pg="
+  },
+  "com/google/protobuf#protobuf-java/2.6.1": {
+   "jar": "sha256-VapVSEOYP0Md9WFhEs9ojTiqF8EyNXr9HBCUNb/axOY=",
+   "pom": "sha256-ifwM0g2wMAM7oEuwDCg37+HlMLAPhpNdamRXF9FbuXg="
+  },
+  "com/google/protobuf#protobuf-java/3.25.5": {
+   "jar": "sha256-hUAkf62eBrrvqPtF6zE4AtAZ9IXxQwDg+da1Vu2I51M=",
+   "pom": "sha256-51IDIVeno5vpvjeGaEB1RSpGzVhrKGWr0z5wdWikyK8="
+  },
+  "com/google/protobuf#protobuf-java/3.25.6": {
+   "jar": "sha256-VJQ5F6859YMDyrfQX2zfYNk3yDBPSVYLWWvBSR7IPos=",
+   "pom": "sha256-soXBHKdm81Mi3VYI+nNuYaaFr5L4NWpMdVH5ySXYYY8="
+  },
+  "com/google/protobuf#protobuf-java/4.34.1": {
+   "jar": "sha256-rgRZAwtUpvMFitNJqgH8Lty7LUqEtzaZZ1u9El3y6W0=",
+   "pom": "sha256-r1MJ/JwGdZYKB61gE7SUTaP1bxHcRY3crTX0RmykvRQ="
+  },
+  "com/google/protobuf#protobuf-parent/3.25.5": {
+   "pom": "sha256-ZMwOOtboX1rsj53Pk0HRN56VJTZP9T4j4W2NWCRnPvc="
+  },
+  "com/google/protobuf#protobuf-parent/3.25.6": {
+   "pom": "sha256-AmCbfzuiZaQxcmjS6RfY03eOtrVE50GpugKp9JFm12E="
+  },
+  "com/google/protobuf#protobuf-parent/4.34.1": {
+   "pom": "sha256-f1DgrPUsF0kcTTNK45VWColDG33pAs8osyxNTAOEiZk="
+  },
+  "com/google/protobuf/nano#protobuf-javanano/3.0.0-alpha-5": {
+   "jar": "sha256-bTDx5meolS4ckKChJfDODt+E1rHVHJHYVVxPtUnj16E=",
+   "pom": "sha256-jUkZJly4Tuf7jCOuKvkvcme4GQm0ec7BmcOLUp2ae54="
+  },
+  "com/google/re2j#re2j/1.8": {
+   "jar": "sha256-e1LHIVbdf5izI3pbNcHTT7o4GyEEjIkgiROtgKRd+9c=",
+   "pom": "sha256-32JpkzXNRvxGX0wDuMWB09UHeSIS0ntlrbkjtMJ95Oc="
+  },
+  "com/googlecode/juniversalchardet#juniversalchardet/1.0.3": {
+   "jar": "sha256-dXv+kGGTuLZR553CbNZ9a1XQdwos37A4FZFQT3edSnY=",
+   "pom": "sha256-eEY5mzXHzWQqmzoADD4tYtBOs3pFR7aTPMixi8wvCGs="
+  },
+  "com/hazelcast#hazelcast-root/3.12.2": {
+   "pom": "sha256-LzR4rBzE8OpgMpGMW5IRObOH+315vFJO5IkSejidsq4="
+  },
+  "com/hazelcast#hazelcast-root/4.0.1": {
+   "pom": "sha256-nvN5VIWYztPVZ0A/aP3CO3GS9fuz/KBnZU2z3xk1U3w="
+  },
+  "com/hazelcast#hazelcast/3.12.2": {
+   "jar": "sha256-xQHUjwBl5LFMOrwEl0UCZ6qX736nQ+Ubki0BLZzwnuw=",
+   "pom": "sha256-pblX1JN5/Q9J8kl+H7+LWZp0nTifL1CJW87sGzYz82w="
+  },
+  "com/hazelcast#hazelcast/4.0.1": {
+   "jar": "sha256-yv0Nyewmkpc6ENa8AhIgzGuKEZiMt1d3vdscV/gV/gA=",
+   "pom": "sha256-4YhA4Xs9AjRP9BpTojl2NAZ1+UuVc7ZPhX8u5Cqb5JA="
+  },
+  "com/ibm/icu#icu4j/2.6.1": {
+   "jar": "sha256-kKgY7L0G21MZuOXboFguQixWTq0MHBwaM48CgFHqI4g=",
+   "pom": "sha256-5EmVXaVEHB2rtIA+0CAjQErEz6VW+8DtzMBWjG51u5M="
+  },
+  "com/influxdb#flux-dsl/8.0.0": {
+   "jar": "sha256-sknGTGK02vSh3wKRdN+shnYZVO/lFl9cQRu9yJib1Dk=",
+   "pom": "sha256-lGlG8t3HtiWQ5ueHkJJikzKgqLL/uy+1oEmgMNJVq8s="
+  },
+  "com/influxdb#influxdb-client-core/8.0.0": {
+   "jar": "sha256-sPbJrV0cmJ+N9G0SiCH6Scrf3BJGR3uqXyt52XR1+kc=",
+   "pom": "sha256-18NAuurJndisHAKUHAJTEgq537RlQrpNBQm4wXomC8Q="
+  },
+  "com/influxdb#influxdb-client-java/8.0.0": {
+   "jar": "sha256-TCRKMEloqm7s5Z2lbcTr/4fKwrBHn5hqjD6om6Omixo=",
+   "pom": "sha256-aokIFzmjDfd6ZDBC0F9hrhPdnsN57TrhwomFZ+jIjO8="
+  },
+  "com/influxdb#influxdb-client-utils/8.0.0": {
+   "jar": "sha256-dnPhMrlq+1UPIv1MQvLUaoybNZNzcnzLB87G2lmORbM=",
+   "pom": "sha256-eI5gnB9zr21Ujir4DigPTAX6forlqFhPeEx8k8VuNmc="
+  },
+  "com/influxdb#influxdb-client/8.0.0": {
+   "pom": "sha256-c9XHtImSC6xo31cCHFgsRm58EY+N/fmu25QsgxaWX+s="
+  },
+  "com/jcraft#jsch.agentproxy.connector-factory/0.0.6": {
+   "jar": "sha256-QuAs0NBt8wnCQaMOFigVI3PB92WI24pCrLr4wctt3q0=",
+   "pom": "sha256-tKtWbeiuK4oqA3YwDj2gB32rPENPxDTvwUzbLM/LCjA="
+  },
+  "com/jcraft#jsch.agentproxy.core/0.0.6": {
+   "jar": "sha256-x8J3PTv8Hg69C7AcIIplkWb5kE1BPJUAklr8qHjBZuE=",
+   "pom": "sha256-qZyKEBtlJHkXSTgT8Eno6ioM7W3YVfUMw2QlJ+Tt+dE="
+  },
+  "com/jcraft#jsch.agentproxy.jsch/0.0.6": {
+   "jar": "sha256-XBwIiFDrZQre6RrFJ/j3a0MBGooQOGrJ3hDaQNk4Ss0=",
+   "pom": "sha256-3qKvMfv7u85u5xKVZ+bq3JvvkBUzzLQ2R2MkEUTgE1w="
+  },
+  "com/jcraft#jsch.agentproxy.pageant/0.0.6": {
+   "jar": "sha256-hK7mkQnTNnhDC+vExOeSGZDUY1eFlG5yjj3PChOj9us=",
+   "pom": "sha256-b0gIAfFWN9x+0pC4bhYM77KIiAjX0uCFn1a+6GVH0h8="
+  },
+  "com/jcraft#jsch.agentproxy.sshagent/0.0.6": {
+   "jar": "sha256-075sh4rjkabXAnMESDH0VcyeH2reD1NVeIaNh08Vw6c=",
+   "pom": "sha256-2ew50IGrf6bbSvib4jN5eG5tFuKSiHpKM03CpG6HXjA="
+  },
+  "com/jcraft#jsch.agentproxy.usocket-jna/0.0.6": {
+   "jar": "sha256-22Ihg+PAJIaNHmxxbzJO8OauKtU3qcQ6nOKYxY37bQQ=",
+   "pom": "sha256-GIlz6eoaYKuFIgG3PHd3VvY1XOG4RmoA8zH16PT6gks="
+  },
+  "com/jcraft#jsch.agentproxy.usocket-nc/0.0.6": {
+   "jar": "sha256-LQYAArU8bNdsV1XROWzHPB3oL2eVAvN1xqPF3EWyetI=",
+   "pom": "sha256-UHUshR5Vr/PbPNZH53q05Z85QF+l+EUkzTpK8sYcWvg="
+  },
+  "com/jcraft#jsch.agentproxy/0.0.6": {
+   "pom": "sha256-8hyGPicnLqqpaInK7d2NAxQz0uvx1gs2/1Y86uRkKKs="
+  },
+  "com/jcraft#jsch/0.1.23": {
+   "jar": "sha256-3ZN1dEHkeu9rbNVfc1ghuuZO66rMOqgI6VGzNw6Olyo=",
+   "pom": "sha256-9U61BPLdCLbRutQ7Tihv3GK18IaUpXJmSVvf4NaszP8="
+  },
+  "com/jcraft#jsch/0.1.31": {
+   "jar": "sha256-gk5XFFy709OAuTrLaRyUkj0jL/8Imw5FBJ+0r5bBdnE=",
+   "pom": "sha256-uCf4OjAncpWVzvj1XqC8QltsFBWMsHD/IrYB94qgfqU="
+  },
+  "com/jcraft#jsch/0.1.42": {
+   "jar": "sha256-dCl1UK7MO1Zu4Z5Jvvuc1J4jJsnY1xrVBxusxlW3YNw=",
+   "pom": "sha256-OdqtbB1QYgnMWq94x7OZwIsWuu956MN5rxFbc/ulGWg="
+  },
+  "com/jcraft#jsch/0.1.49": {
+   "jar": "sha256-d1SB7ojXrf0GU8QT06Hk2f2M8EWGK173A+RLGkVz70Q=",
+   "pom": "sha256-uCiwasc1g0eXMvQxdl44kJn7expI3yEEMutJeLZTnl4="
+  },
+  "com/jcraft#jsch/0.1.50": {
+   "jar": "sha256-ffnn/OhPQpxaMT/7hrI6pV/8/DbU1QY14Xa8hG4XsZU=",
+   "pom": "sha256-U249mV/w3O2svEovYU+7q9T07QCc5kv72us5j+o3vbA="
+  },
+  "com/jcraft#jzlib/1.0.7": {
+   "jar": "sha256-Fr0OCCwSviinb/JuNWIZJGzVe+9SkOUARedaPPsSCBw=",
+   "pom": "sha256-uaAiXytdcSEnNEu6EQ2O2QaoB/oYYBdG/PCrJCOREQQ="
+  },
+  "com/jcraft#jzlib/1.1.3": {
+   "jar": "sha256-ibE2D0Bzgb9h/eQRAZ2MvQCeuxDP9xXzZpAXoDECdWA=",
+   "pom": "sha256-7bZyUWCFVq2VhNAORrXvOOzxJG1XHA+A8k9QsoWp9oI="
+  },
+  "com/lmax#disruptor/3.4.2": {
+   "jar": "sha256-9BLsuyNcJGC0XmNYQQlyPeqNlLgZx4yb/Dj1DLqFRsA=",
+   "pom": "sha256-cxHl4mHKYvJZstFObW8c43WmRxhzGnMP187AIo1Q9do="
+  },
+  "com/netflix/archaius#archaius-core/0.4.1": {
+   "jar": "sha256-J2d6KAsPMJ9hgVl57U2tn0ZTP5dJW+n5vEaOkK4pkF8=",
+   "pom": "sha256-jyzhpd7IR/+ibIRIfwS/Pa/MQvDML5bytnJ7L1PH2Eo="
+  },
+  "com/netflix/hystrix#hystrix-core/1.5.12": {
+   "jar": "sha256-GtXVuqGp1zVhS7kKyxJvqMYgWSK5yooBAZURa7ubjRo=",
+   "pom": "sha256-9U/fZAWD+BlPCJc38pKfAmOCbyxbmdRRSrJhHWNNMdw="
+  },
+  "com/ning#compress-lzf/1.0.3": {
+   "jar": "sha256-bPk72hwsr2GGUvl9LzbIg6Wpd0NFOEwF01k7FzcxvM0=",
+   "pom": "sha256-4r8KBDm2ZlZZ0hWytobfvX9bDfFNG4z6OgqaCgtrStE="
+  },
+  "com/opencsv#opencsv/5.9": {
+   "jar": "sha256-ICOWm4bOlorYrlSWSKxYfRQcGa5oSppcZ8kQXzerDRw=",
+   "pom": "sha256-l+UC78Xmwt0VZiGynKy8D0dEIowAmPaxafV/eukwMGA="
+  },
+  "com/oracle/labs/olcut#olcut-config-protobuf/5.3.1": {
+   "jar": "sha256-FIGMw6lK51IUFNSEVmarghBEJ47sGZucjwi3EYt0WvU=",
+   "pom": "sha256-aS58zbcGib1KYiaS4x1IXsdlMXmYnoYNYoUs9gl/FC0="
+  },
+  "com/oracle/labs/olcut#olcut-core/5.3.1": {
+   "jar": "sha256-QK2b7QJ9ZVh3aJPCoFkTTuf3RNOM3qZ49ZMSQXZOv4c=",
+   "pom": "sha256-KRNCc4ZA0LpfqQ6BoDfRl06uEx1g0hg3xD/F/YkYnE0="
+  },
+  "com/oracle/labs/olcut#olcut/5.3.1": {
+   "pom": "sha256-FozfcdoCOr6j5szCfuIaY4wzGJs1yTvYllDpSm1goao="
+  },
+  "com/puppycrawl/tools#checkstyle/11.1.0": {
+   "jar": "sha256-AdLE4WAjVbKjTd4UCI5lqv9OvhZ4FciGmQi1u/Cn88k=",
+   "pom": "sha256-CtCVc7hBSEy0ade4xc7J4onVgk2cv8WzlhhefWkK5A4="
+  },
+  "com/sleepycat#je/18.3.12": {
+   "jar": "sha256-CkK7fVPAz6fkRetXvCv3T+27jSLXIWoS2voqOu/lxz4=",
+   "pom": "sha256-v1lEMd0Ba64zO+KqHoRUibb8zURKdTqRIxtAdZbJXU4="
+  },
+  "com/squareup/okhttp3#logging-interceptor/4.12.0": {
+   "jar": "sha256-8+jV8JA8JQwrVdL0f8/gCOgGNDhdqDhRYcemOq7Qx0w=",
+   "pom": "sha256-MVkkh9X6euW87fZ4Bqy93Eh9zPROH9t/z3zlNkrPyFw="
+  },
+  "com/squareup/okhttp3#logging-interceptor/5.2.1": {
+   "jar": "sha256-lN7nfsXcSPbbDns9ewhvsVKgHzLUNL2mtnBxGSfjhtc=",
+   "pom": "sha256-apN7ppiy5L51v2qx0dHk3J3xfRJQewIcpwQtyO6d9Ds="
+  },
+  "com/squareup/okhttp3#logging-interceptor/5.3.2": {
+   "jar": "sha256-hldKXjX0g+bWupe+r4RCCZbf/KGfTVzzpBY2Nl1AMjk=",
+   "pom": "sha256-bgv6aBRFxNW573A3GuZC3/3T+uxpCqc8+/yRzf5EM7Y="
+  },
+  "com/squareup/okhttp3#okhttp-jvm/5.2.1": {
+   "jar": "sha256-ljLAhWfbshxWmxPXkxB4NMhYDUTk7qdLLq4HIvBQYXk=",
+   "pom": "sha256-pqjW6KSkFlTifoZbuONbCthMZ7goSaoBZJLrUHughwo="
+  },
+  "com/squareup/okhttp3#okhttp-jvm/5.3.2": {
+   "jar": "sha256-x3H0gHW3Y/bDIgVeIRKalLfeTB+vP49YrOMgsMlRejA=",
+   "pom": "sha256-ruhxl7v7LXQktiQdMA6wy/+xhEycqwEpyuU5BAizP6Q="
+  },
+  "com/squareup/okhttp3#okhttp/3.14.4": {
+   "jar": "sha256-WMyzdU8VzELfjxaHs7qGMw7ZfH5S5cPoP+ETG4DOPg8=",
+   "pom": "sha256-QFJXf3jyyKzFQuezmsJ652hAnGGUqgu/H+LXG8KPGsQ="
+  },
+  "com/squareup/okhttp3#okhttp/3.14.9": {
+   "jar": "sha256-JXD6tVUVy/iB16TO70n8UVSQvAJwV+Zmd2ooMkZa7KA=",
+   "pom": "sha256-Ye3zxHZOqV8SEsot+8bqXUEzxxxOjEC9JH7IPnxrfOc="
+  },
+  "com/squareup/okhttp3#okhttp/4.12.0": {
+   "jar": "sha256-sQUAgbFLt6On5VpNPvAbXc+rxFO0VzpPwBl2cZHV9OA=",
+   "pom": "sha256-fHNwQKlBlSLnxQzAJ0FqcP58dinlKyGZNa3mtBGcfTg="
+  },
+  "com/squareup/okhttp3#okhttp/4.5.0": {
+   "jar": "sha256-Ze/SINNPmZ3wZdbHIRD0bDmTXeLmNZyqSQ2AkCoDc6A=",
+   "pom": "sha256-MfniHonnAuwaQNDPij/HoZ4qeVgiMy4QrODCRA3NfZo="
+  },
+  "com/squareup/okhttp3#okhttp/5.2.1": {
+   "jar": "sha256-5yCjg/3D6x30qsd6CF5ht3MINzZBUd6GcJP9vK/LRKo=",
+   "pom": "sha256-4kGTtJ/Cuen8UOAo/iNBkpjg7NKTkP1YU2pFbnPS8JI="
+  },
+  "com/squareup/okhttp3#parent/3.14.4": {
+   "pom": "sha256-fBV8WZeNnFGxxl0zA2HZWmof2CWTzaZHDtHxnvuvpDc="
+  },
+  "com/squareup/okhttp3#parent/3.14.9": {
+   "pom": "sha256-tfEB3PLMfzLsPXtovcB4536sGXm7hmTo+H92IojD3OU="
+  },
+  "com/squareup/okio#okio-jvm/3.16.0": {
+   "jar": "sha256-xzfANcpnUYe/EaZ925WBlUvw1cqfPgSOg4syZ88ytcM=",
+   "pom": "sha256-UZpRemxp4bmF6BsNm3XT3kWjg4aI46CUjnpTYeVHOPM="
+  },
+  "com/squareup/okio#okio-jvm/3.16.1": {
+   "jar": "sha256-MfSOZGPsWH1tJi0ELJHaAGWcmDtq0g1Zgr8x6FIiaTw=",
+   "pom": "sha256-1wyYqvTCQWzB2U0v2EfZtO3jya7+DDKUl7x9ohyJ52Y="
+  },
+  "com/squareup/okio#okio-jvm/3.16.4": {
+   "jar": "sha256-IZa5k800272Rnn4B9XpHgbWL7oD4YQYWPih8IDQ6lqc=",
+   "pom": "sha256-ZnePTQWXvOY/kewADFdcwCmzIB990JLLgIh1FVs+hqE="
+  },
+  "com/squareup/okio#okio-jvm/3.17.0": {
+   "jar": "sha256-OxPcw+FXMEfC1Qf8T3/LC7DLzZ05XaIdIOCUBuLNanM=",
+   "pom": "sha256-5ORCN6ZvQJG8D1sdWiu+IorAFKs8D5GM1vwCujGZkDA="
+  },
+  "com/squareup/okio#okio-jvm/3.6.0": {
+   "jar": "sha256-Z1Q/Bzb8QirpJ+0OUEuYvF4mn9oNNQBXkzfLcT2ihBI=",
+   "pom": "sha256-YbTXxRWgiU/62SX9cFJiDBQlqGQz/TURO1+rDeiQpX8="
+  },
+  "com/squareup/okio#okio-parent/1.17.2": {
+   "pom": "sha256-6B9AFG8qDrOUsQ+joXXIWrn751eqQYqkTUt2Dv4W8CQ="
+  },
+  "com/squareup/okio#okio/1.17.2": {
+   "jar": "sha256-+AzkLS/6xHrUxH4db5gNYE0kfOsaiGcFz0WBqwyf4rg=",
+   "pom": "sha256-zVf3VEOranFLID2lGZTuZO0OkZ/qgfBOT0tTJOS7A/A="
+  },
+  "com/squareup/okio#okio/2.5.0": {
+   "jar": "sha256-fJ3wApksX7Ag0PA3ZzBBp8W9uUGPkanvNHIeXM/W/5I=",
+   "pom": "sha256-sRTi1nkkkBlrJvS+Fpo1XDcYr1yScGqZyX6UtLxMLfs="
+  },
+  "com/squareup/okio#okio/3.16.0": {
+   "jar": "sha256-4XEN4rNrO7xuYQYj24Bip/v9BlnX7IOgenG2PtHkMzc=",
+   "pom": "sha256-tJcqa4qGXc5rxH+v5ti5P+aSiWMf5z34e7S0XDdcHOY="
+  },
+  "com/squareup/okio#okio/3.16.1": {
+   "jar": "sha256-yZZPOUxM0yt5vzOK+/ovIpciHu4IMReHBhzqVfh91g4=",
+   "pom": "sha256-VyKCs83XFMD89kpofp99UZDiJ0+VbhijKsPsntT9iF4="
+  },
+  "com/squareup/okio#okio/3.6.0": {
+   "jar": "sha256-jmMpLlxTu5PEprDCE+efFZkP7SUME0Dxw0OIDhycObU=",
+   "pom": "sha256-rrO3CiTBA+0MVFQfNfXFEdJ85gyuN2pZbX1lNpf4zJU="
+  },
+  "com/squareup/retrofit2#adapter-rxjava3/2.11.0": {
+   "jar": "sha256-1k2GPQIjvUHtg6MGB3YPW5BUbSeRVd0zm9j2G2bulFA=",
+   "pom": "sha256-2xk9SHUgYzXMEonhZIzX5vsz3xe6HaQYEhnUqwtT/0w="
+  },
+  "com/squareup/retrofit2#adapter-rxjava3/3.0.0": {
+   "jar": "sha256-R9GBPS7Mfn/W8s0mlYTHJQAQ6PdoBRSbuzFu2VL4o8c=",
+   "pom": "sha256-rVbmrhZBmDm+FYKxpMMErYbDl5pbB301/XB6cSktS2E="
+  },
+  "com/squareup/retrofit2#converter-gson/2.11.0": {
+   "jar": "sha256-PStLZokJRoRlxXdkMLVyMiddAWVRPyD8lrDP5KpTEyY=",
+   "pom": "sha256-ADLLB9ymbvDJES3YkDwn6rYQQY8+ygsFZaaRjU8T5To="
+  },
+  "com/squareup/retrofit2#converter-gson/3.0.0": {
+   "jar": "sha256-raY0uxIDkDdV0h/z3p7MyxOQYfzgWqYYI0XUyXw2ngc=",
+   "pom": "sha256-s2CVzCZ9SrFpiZiUV12WrfN0DoPl7LqFIz2Dd2Mquto="
+  },
+  "com/squareup/retrofit2#converter-scalars/2.11.0": {
+   "jar": "sha256-ZH1+gaxh7t9pG6adgvDVaFCHq/DVj+fYa2Q9AoCNqRE=",
+   "pom": "sha256-s9ShAXMYUHQencArE1u4FRHlM0wUe74tqtL1afVmNkU="
+  },
+  "com/squareup/retrofit2#converter-scalars/3.0.0": {
+   "jar": "sha256-uXzwaSmoDUm8Yy5E8hnPCnGF/Ezuhh7JCtHQ5IIIQCM=",
+   "pom": "sha256-B42x+Kgsb48K0vzzn7ia4bfUf1XQIlGEksToSN1QL8c="
+  },
+  "com/squareup/retrofit2#retrofit/2.11.0": {
+   "jar": "sha256-n0+7znByhYT77tONQGHzbUR36JvKdLTirIrraBmw/kM=",
+   "pom": "sha256-3iKB4huk2YSrrxPcBn84C8WBaXBoxlaKu5uZjZ13cF4="
+  },
+  "com/squareup/retrofit2#retrofit/3.0.0": {
+   "jar": "sha256-acai00UbbflUmpP6t0QJTr8HpLDOT0U9bI9XXvD+yaE=",
+   "pom": "sha256-/BaPqJcZiIc331OurA9JgLP07z5hIeMww2YGHJlrBoA="
+  },
+  "com/sun/activation#all/1.2.0": {
+   "pom": "sha256-HYUY46x1MqEE5Pe+d97zfJguUwcjxr2z1ncIzOKwwsQ="
+  },
+  "com/sun/activation#all/1.2.1": {
+   "pom": "sha256-NgiDv2RIbs7xYbjygvZQNTbdGmcNU6Coccj7IBcOZ5U="
+  },
+  "com/sun/activation#javax.activation/1.2.0": {
+   "jar": "sha256-mTMCsWzXBW8h53nMV30XWoELtJAO9zzY+/K1D5KLqc4=",
+   "pom": "sha256-+Hm26UWFTGkAsNvuHIOE16s95+FX/XrISTdAXEFtKl4="
+  },
+  "com/sun/istack#istack-commons-runtime/3.0.7": {
+   "jar": "sha256-ZEPhC6LiWfuCHZtr7PENtTFihfwwxTzsnXsZo4d+f98=",
+   "pom": "sha256-bXBORQqBakW86Aa6IsIv6D2Ojc96cVF2A95jChcmgJ8="
+  },
+  "com/sun/istack#istack-commons/3.0.7": {
+   "pom": "sha256-b4PTyF/cqe8kAQyy9lKqsaUIv/YzHAh7YNAwF4K3jG8="
+  },
+  "com/sun/mail#all/1.4.3": {
+   "pom": "sha256-bzdym4PSLmScPWlUDOD88uPQTi2PBuYMdKTgXCOGITg="
+  },
+  "com/sun/mail#all/1.4.7": {
+   "pom": "sha256-WWVyZBVPF2+UWc9Fwk0H9Olm8sXpxRCtoS1lTHxbxU4="
+  },
+  "com/sun/mail#all/1.6.2": {
+   "pom": "sha256-S36Dqpt31l4AfpfLUPm4nNt1T6rxZBHl/ZTR49q3brM="
+  },
+  "com/sun/mail#javax.mail/1.6.2": {
+   "jar": "sha256-RbUV5xBJRMCeRbnHuxzl3/ZASGN0hS3SsugMw3Ut+hE=",
+   "pom": "sha256-xCKcBbWDbwAlITY9NDXz0HJmJ0RUi/F+fnreyv5ouf0="
+  },
+  "com/sun/xml/bind#jaxb-bom-ext/2.3.1": {
+   "pom": "sha256-wiBPVLQ1k4CMmvZQKGXucWeYIxVtq97zQecdNWYseqA="
+  },
+  "com/sun/xml/bind/mvn#jaxb-parent/2.3.1": {
+   "pom": "sha256-9pnvN+x5ZuKEdC38qDB1IhF5BBqaSa73mRKAGSYERi0="
+  },
+  "com/sun/xml/bind/mvn#jaxb-runtime-parent/2.3.1": {
+   "pom": "sha256-tWOD601DSYsUXTeeKpPV/NzY/5KR+JtYuCy5Fljb8Uw="
+  },
+  "com/sun/xml/bind/mvn#jaxb-txw-parent/2.3.1": {
+   "pom": "sha256-eoRz6TVQSEHGBmhthOnAF6c5rCwUT95oeqADp91E3n8="
+  },
+  "com/sun/xml/fastinfoset#FastInfoset/1.2.15": {
+   "jar": "sha256-eFhh2xHKG9DRlWaCuXStc+sZzT4BpLP6gtYuypchCuw=",
+   "pom": "sha256-u8eWq4Smd4p1HC7/ETYHir0rTTW1BHBigE81gu88Qsg="
+  },
+  "com/sun/xml/fastinfoset#fastinfoset-project/1.2.15": {
+   "pom": "sha256-z7jNrUwN0F7YysvhRr8XGHZEA5R7neg0jhv9QvYupz4="
+  },
+  "com/thoughtworks/qdox#qdox/1.12.1": {
+   "jar": "sha256-IfuiL4MOkmjwfPSrLZnoGBq73LDLke4CKOs8uRjc3R0=",
+   "pom": "sha256-xSpmFtBO+zDJ7eq57oKwWR5NBNOOAwv4HiUHdlUtIV0="
+  },
+  "com/thoughtworks/xstream#xstream-parent/1.4.2": {
+   "pom": "sha256-7hKsOsAqeHDP1xDJA10xxVeVlNn7h84mYV8ri0NTTdM="
+  },
+  "com/thoughtworks/xstream#xstream-parent/1.4.7": {
+   "pom": "sha256-D2FAB1cg+H0LhsTLuD4nwaQAyy0NxEwnR4bjHOYgfyI="
+  },
+  "com/thoughtworks/xstream#xstream/1.4.2": {
+   "jar": "sha256-3CfgY4hohlHabMPhxrTxKAkoqwKofAnXvehODyTv4hI=",
+   "pom": "sha256-3JaO4nHQwlChdh5UUtZUdAZ89Px5+TGO2NgvfsiZIK8="
+  },
+  "com/thoughtworks/xstream#xstream/1.4.7": {
+   "jar": "sha256-f4A5wO5yhPnCqVVLXivCC/JrdLN/aQYzp1/xmTE282Q=",
+   "pom": "sha256-gsIbzilnJCVAEQExN2aG5OabOqpO9VjMj/rEyLh4RmM="
+  },
+  "com/zaxxer#HikariCP/7.0.2": {
+   "jar": "sha256-8eYS+ic0W+MQeoVDHoqK6yBcFTZKsvLUEeQKnXuwgJU=",
+   "pom": "sha256-ZiqH+ASHvom9dyliE+kRCP+fAe0NmpD5pOISY8xJ5z4="
+  },
+  "commons-beanutils#commons-beanutils/1.11.0": {
+   "jar": "sha256-nkS6aOyaPyEob6Kou7ADtzXA9pEBu0MUS3n0+KqnRwk=",
+   "pom": "sha256-z/nqsddRJkvXdbbj6+0WUHlMrJzYvhxBa0jjpcYTnZM="
+  },
+  "commons-beanutils#commons-beanutils/1.7.0": {
+   "jar": "sha256-JLyqIMy9x8hWzgwK6hRFZpQ0A+Lp8nvZd5zaHXaCPvQ=",
+   "pom": "sha256-tqymRloosCdobwJdV3AvkK0NEo4U0c/OygvYcfAIStk="
+  },
+  "commons-beanutils#commons-beanutils/1.8.0": {
+   "jar": "sha256-E1Q5ObhuO7gzkBnWrMCOywTksJWoK6+YTlBbOvtUdCo=",
+   "pom": "sha256-RcBZb/rd9e7HOaIIBH3OId+bsawhwa/owNoMsOj/yO4="
+  },
+  "commons-beanutils#commons-beanutils/1.8.3": {
+   "jar": "sha256-4UB7gdgTj7nB/HMbh7XgBo3cyr+8Zd7lnNs3ipDF6Bo=",
+   "pom": "sha256-VSrVaAC8YBDx5uqMdjjyTHQjDpmRpSVo3yDVtapcSyA="
+  },
+  "commons-beanutils#commons-beanutils/1.9.4": {
+   "jar": "sha256-fZOMgXiQKARcCMBl6UvnX8KAUnYg1b1itRnVg4UyNoo=",
+   "pom": "sha256-w1zKe2HUZ42VeMvAuQG4cXtTmr+SVEQdp4uP5g3gZNA="
+  },
+  "commons-codec#commons-codec/1.10": {
+   "jar": "sha256-QkHfqU5xHUNfKaRgSj4t5cSqPBZeI70Ga+b8H8QwlWk=",
+   "pom": "sha256-vbjbcBLREqbj6o/bfFELMA2Z7/CBnSfd26nEM5fqTPs="
+  },
+  "commons-codec#commons-codec/1.11": {
+   "jar": "sha256-5ZnVMY6Xqkj0ITaikn5t+k6Igd/w5sjjEJ3bv/Ude30=",
+   "pom": "sha256-wecUDR3qj981KLwePFRErAtUEpcxH0X5gGwhPsPumhA="
+  },
+  "commons-codec#commons-codec/1.15": {
+   "jar": "sha256-s+n21jp5AQm/DQVmEfvtHPaQVYJt7+uYlKcTadJG7WM=",
+   "pom": "sha256-yG7hmKNaNxVIeGD0Gcv2Qufk2ehxR3eUfb5qTjogq1g="
+  },
+  "commons-codec#commons-codec/1.19.0": {
+   "jar": "sha256-XDiB5PVWhV6cUykn7gyd/elMxmdg1YBcAxpZiHBwr18=",
+   "pom": "sha256-4PMmn6I94MgxMMVln1+VFMxUIsC830Xy6uAEp4ufyjQ="
+  },
+  "commons-codec#commons-codec/1.2": {
+   "jar": "sha256-mJijs4V2dhKJh7l10LDwNb7PPaXPZ3Jmo01mNvK4BUI=",
+   "pom": "sha256-KNbAiTVUh/0ulz4JGhUnJ6wnrSssHsnLz5FqEPyGMUg="
+  },
+  "commons-codec#commons-codec/1.5": {
+   "jar": "sha256-x5Vv5iFwjkUxTr32o141xX8v+AupyF36+x5DYgr2x5c=",
+   "pom": "sha256-DAXGK5NrrXQ2C/v+OZPTpdGhnxJ6Oj3z91NDcbPAzK4="
+  },
+  "commons-collections#commons-collections/3.1": {
+   "jar": "sha256-wVR9GFumiAvMLaJhxfdTNRK2/9u8GJjbW3k8DLgw/PA=",
+   "pom": "sha256-Wcnl/HXleQ5Wl2wWaonyy9rZn3bEm5L3ShdJaJr3JqI="
+  },
+  "commons-collections#commons-collections/3.2.1": {
+   "jar": "sha256-hzY6TJTqq+79i5MMsFn2a2TJ99Yyhi8j3jAS2nZgBHs=",
+   "pom": "sha256-H5Ymy6pYTtXYYCGGbk42fib+Xvwkg4JlK+aL7rQ+dBY="
+  },
+  "commons-collections#commons-collections/3.2.2": {
+   "jar": "sha256-7urpF5FxRKaKdB1MDf9mqlxcX9hVk/8he87T/Iyng7g=",
+   "pom": "sha256-1dgfzCiMDYxxHDAgB8raSqmiJu0aES1LqmTLHWMiFws="
+  },
+  "commons-configuration#commons-configuration/1.8": {
+   "jar": "sha256-4inPH+lfcUfLwfjTGv/AcIfCBryNx+WwW2vmcJEPh7o=",
+   "pom": "sha256-l5oEsNYZGcijVt4563Jg1dcS1fFa2KS2ULfxO/ar8QQ="
+  },
+  "commons-digester#commons-digester/1.8.1": {
+   "jar": "sha256-uXtytCARNyYiFdymDOuE5rZkv3/kKKTWJyneAjnK/bY=",
+   "pom": "sha256-mfgZ9LBEzRf8pUM4hh4yCvlnhTJIdkURZ9AiQg/MA6o="
+  },
+  "commons-fileupload#commons-fileupload/1.6.0": {
+   "jar": "sha256-k4MnLJNWmv6r7bFpI6lKbcilvXovn4O/Mmr07mhDRik=",
+   "pom": "sha256-5WCT0Gr1rCOC2q5GC2Etp5JvSj0GsergjEyzLfQ8/nQ="
+  },
+  "commons-httpclient#commons-httpclient/2.0.2": {
+   "jar": "sha256-/Cr/FL+CtnHM3C0lHlYFlRiBMQZAK8SWGLczwT1dnYQ=",
+   "pom": "sha256-3y7go+0ugpj59MasHrj2GzWsQjdrdge8XcdC90Hix1o="
+  },
+  "commons-httpclient#commons-httpclient/3.0": {
+   "jar": "sha256-ev0Y8w6YySv4c7ZLr+6kO0q96rpipOUOG2stAEBe9+8=",
+   "pom": "sha256-84yodRd/RBCO4n6hhqyiSP8FRQiIRp0eev78xMeSe5A="
+  },
+  "commons-httpclient#commons-httpclient/3.1": {
+   "jar": "sha256-29SVPQE+EOfBzDcBo+bM2MlQyJLwjYBPq/rCFwWTBEM=",
+   "pom": "sha256-ipsH1FjT5zAiHb7N+vpzU+wbq9O5TIQyJ8RxBKkMbWw="
+  },
+  "commons-io#commons-io/2.19.0": {
+   "jar": "sha256-gkJokZtLYvn0DwjFQ4HeWZOwePWGZ+My0XNIrgGdcrk=",
+   "pom": "sha256-VCt6UC7WGVDRuDEStRsWF9NAfjpN9atWqY12Dg+MWVA="
+  },
+  "commons-io#commons-io/2.20.0": {
+   "jar": "sha256-35C7oP48tYa38WTnj+j49No/LdXCf6ZF+IgQDMwl3XI=",
+   "pom": "sha256-vb34EHLBkO6aixgaXFj1vZF6dQ+xOiVt679T9dvTOio="
+  },
+  "commons-jelly#commons-jelly-tags-log/1.0": {
+   "jar": "sha256-q9DjrvOxN+YXAcTLtymSN3QEKv098cT81AhfjCIV1so=",
+   "pom": "sha256-KXoMiPxN8+vYWiAdQP05IyRIwH8d2gACnP2HxbsdK/8="
+  },
+  "commons-jxpath#commons-jxpath/1.3": {
+   "jar": "sha256-/LwK2RfZ1qc8bfIfrDIuANIT7xnNlIFaAHxAeoo/9Ek=",
+   "pom": "sha256-fMIYjwKvcuA7wqWFcaBH4e6Us+IFAJEWW+db/VDJiE0="
+  },
+  "commons-lang#commons-lang/2.6": {
+   "jar": "sha256-UPEbCfh3wpTVbyRGP0fSj5Kc9QRPZIZhwPDPuumi9Jw=",
+   "pom": "sha256-7Xa4iRwwtWYonHQ2Vvik1DWYaYJDjUDFZ8YmIzJH5xE="
+  },
+  "commons-logging#commons-logging/1.0.3": {
+   "jar": "sha256-vPoCPa6oUl1tsCnqguj1jb8aBgBttlJtn5hNvyFdinU=",
+   "pom": "sha256-jCPG6S8d9/WLRVzSyqAJ3Mh6L+ZJdubORhUi5jWupB4="
+  },
+  "commons-logging#commons-logging/1.0.4": {
+   "jar": "sha256-6Ur0l0k4TBH1qlDo0PX+Z5vncSlbUgMDONMoQ8mANR4=",
+   "pom": "sha256-ZdMQUJNStUJRGCJe5gCgH4O6chQtA1AUtdFkvASy0oQ="
+  },
+  "commons-logging#commons-logging/1.1.1": {
+   "jar": "sha256-zm+RPK0fDbOq1wGG1lxbx//Mmpnj/o4LE3MSgZ98Ni8=",
+   "pom": "sha256-0PLhbQVOi7l63ZyiZSXrI0b2koCfzSooeH2ozrPDXug="
+  },
+  "commons-logging#commons-logging/1.1.3": {
+   "jar": "sha256-cJA/b8gumQjI2p8gRD9h2Q8IcKMSZCmR/oRioLk5F4Q=",
+   "pom": "sha256-MlCsOsa9YO0GMfXNAzUDKymT1j5AWmrgVV0np+SGWEk="
+  },
+  "commons-logging#commons-logging/1.2": {
+   "jar": "sha256-2t3qHqC+D1aXirMAa4rJKDSv7vvZt+TmMW/KV98PpjY=",
+   "pom": "sha256-yRq1qlcNhvb9B8wVjsa8LFAIBAKXLukXn+JBAHOfuyA="
+  },
+  "commons-net#commons-net/1.4.1": {
+   "jar": "sha256-BaNhHe35DQqz6O2D3sTuSSABSMCUJUN+uTSFYv3n2Dw=",
+   "pom": "sha256-1REvVdum8eRbaz00zlvhox9BBFkwbbksME/spDBP7Ko="
+  },
+  "commons-net#commons-net/2.2": {
+   "jar": "sha256-oI04Qlm/AwNMRyCNW5VgYizqvOWA7u/YB+74ki7bT4c=",
+   "pom": "sha256-0WsNPkR4nP1M1V/fGG0rF6tieIemZWDiA1Zlj/yacNc="
+  },
+  "commons-vfs#commons-vfs/1.0": {
+   "jar": "sha256-pX6Wn4tWIiE8kF2odBmhtuTCIGVDX87bMpKv4qoHG30=",
+   "pom": "sha256-/dVxkP6iIjEFlKvSQ/2VJQa5ug8xuX9RZFq8SM2G9kQ="
+  },
+  "dom4j#dom4j/1.4": {
+   "jar": "sha256-F8PAywzQueUSY/IVCxbw/+EQ4N6jBlz5Dgqe7ZDhj6Q=",
+   "pom": "sha256-sCbTxrgOEuR6KFhFkr91ga3IDyh10hVOxzcdgV8uGrk="
+  },
+  "dom4j#dom4j/1.5.2": {
+   "jar": "sha256-5qAmt6o0PhT16tsyoImVStiVSABoRczRDv+yNMyL4Zw=",
+   "pom": "sha256-YbGvvseaTm1xC9j3YU6UhHVOl0sPuFG0V5MOD+affk8="
+  },
+  "dom4j#dom4j/1.6.1": {
+   "jar": "sha256-WTVS/+o8WCPGYCR4tQAqfFJf2QSjxE8avkBlwi7frHM=",
+   "pom": "sha256-RHc4ylNC2hqy4Mg19waD4Mk4GMIqSUwuUWFlb4aQbBY="
+  },
+  "eu/chargetime/ocpp#OCPP-J/1.0.2": {
+   "jar": "sha256-KJMpR7OCJgL7CiDa4JTYaG8+hXR5kcySh6b5YQYB5qo=",
+   "pom": "sha256-ygCju6WNDjGfT1A9ffYyAlMux4AwKFlZtdguH2no8V8="
+  },
+  "eu/chargetime/ocpp#common/1.0.2": {
+   "jar": "sha256-CTStCWRNURDQdl5UStQjN2H8hKOg6Ix1oaBH76tcGlo=",
+   "pom": "sha256-ev5thxFpggsdQ7Z6/FOcU8+onLQWoTvMu/J0t8jD+eI="
+  },
+  "eu/chargetime/ocpp#v1_6/1.1.0": {
+   "jar": "sha256-p/Z7Wn/roLeX8knYKKOLTZgs6phiCx+DrTwgXji5+qg=",
+   "pom": "sha256-LDpRLjxN13sr22GvuJta50cXzKSUhHubxvbLtBUZVnc="
+  },
+  "findbugs#annotations/1.0.0": {
+   "jar": "sha256-4EyLT8ZFv3c8hmrQrSxuqKeiC0gAShGPIJESL6/30vE=",
+   "pom": "sha256-yWSFaImNV0y6HYorFM0osmX8gOAV3bjsHJa4/dORl8Q="
+  },
+  "findbugs#bcel/5.1": {
+   "jar": "sha256-RyjS6/8VhyQZTSGwDaLxQyo5qisO16I6fgFCFhTE7oQ=",
+   "pom": "sha256-CAW2TUcoY6nHLhrBYTqUcfz1C6Qy4qtQI4NRptKKTyw="
+  },
+  "findbugs#coreplugin/1.0.0": {
+   "jar": "sha256-rX/AtIPqiX099HR7XzQd3oeiLK6x3NIDEupRyn0DCcs=",
+   "pom": "sha256-s1YvIs8yr7QuFQc0x7u3d0TtQTo5TkAJR7UHLKWbXnY="
+  },
+  "findbugs#findbugs-ant/1.0.0": {
+   "jar": "sha256-Of27keTYNe3PTGrmCFVjYgANp32AJPMHvk4eUC3B7X8=",
+   "pom": "sha256-uTbFekzZGcbLGgnnA0Id0OZtCfdXSD2DNLAPLQ5LUqw="
+  },
+  "findbugs#findbugs/1.0.0": {
+   "jar": "sha256-KgqUiG/g41fVpadAF8gwf47QOtZoVt9pXz3/qrwozyI=",
+   "pom": "sha256-yalNEGJKAqwT8yUEogcdZAn44ye5x+kZhV4XpNyFd2Q="
+  },
+  "findbugs#findbugsGUI/1.0.0": {
+   "jar": "sha256-570INWJppp7bQsl3077XmAPny1XFipKJwaeysME/MwI=",
+   "pom": "sha256-ZvF2cCFozthJc9GsR8lup7Bjzl+nUo8nxwgClwW1ssE="
+  },
+  "fr/turri#aXMLRPC/1.17.0": {
+   "jar": "sha256-eENwLdf+ktF0m4YHtejgS7zNVXZFWvKGb5IVHYFIdi8=",
+   "pom": "sha256-OR1238bGdpE+MNju2nwilGlPxyYSIDTg0+e2kB9hAWs="
+  },
+  "fr/turri#jISO8601/0.2": {
+   "jar": "sha256-69S9E4F0Y3pp5aFuncjoM5oxheHyN1soy36bj3oYsJg=",
+   "pom": "sha256-wrC7jGOU2TYkSBhf0ZG6rl4ifONStRnThLrilMtGB20="
+  },
+  "info/faljse#SDNotify/1.6": {
+   "jar": "sha256-joAyRLuW6xVah+JiuYfRAnpZIJ94mqF4GWtKBfs1dJE=",
+   "pom": "sha256-u5w0az4hSYPlJk7FhN4iF1nJ2im/dCqtATOfniS0Bts="
+  },
+  "info/picocli#picocli/4.7.7": {
+   "jar": "sha256-+G4w//0Q0rE7jKqNSyN6fuYfL/zPWxlB3nGLdl0jW/g=",
+   "pom": "sha256-GxjTYxNN9mYx0rn3R1Bo1zQiW6OJzfkIKhvYvakNV9M="
+  },
+  "io/dropwizard/metrics#metrics-core/4.0.6": {
+   "jar": "sha256-Zlun2F/79A4OhFLJyJG5aH7gdAZPPuC5XbE/yDsSGsA=",
+   "pom": "sha256-MyFjQrS6+r6P1N4o/fnT4TSzp15Wqz1FqMlvKSZebUo="
+  },
+  "io/dropwizard/metrics#metrics-core/4.0.7": {
+   "jar": "sha256-OCoPD2tGT6iBrcuSSWpWX+AmsTq9i+ZgdTWV4gZEbzo=",
+   "pom": "sha256-NRn8L7ZrlEqje9gf5MkJ9tvxmgHUWR3pS6ZCSEYjqK8="
+  },
+  "io/dropwizard/metrics#metrics-parent/4.0.6": {
+   "pom": "sha256-uQ3H3moy8YhiAaE+fOqqmMKa2gsEV6P6wQxoA2bs1D4="
+  },
+  "io/dropwizard/metrics#metrics-parent/4.0.7": {
+   "pom": "sha256-/g6FEOdVKXV0QMD+Yuwq14pO7Rysk1nE1fs9WJmb54E="
+  },
+  "io/github/hakky54#ayza-bom/10.0.2": {
+   "pom": "sha256-gXw+F0EB49hDuuZaExMNrY4bkzluE1W1rWdpQQRdjdI="
+  },
+  "io/github/hakky54#ayza-parent/10.0.2": {
+   "pom": "sha256-8CGZPgOkhKi9HQbcbH8qYAepKsEQK9XdrJvhMFnfHN8="
+  },
+  "io/github/hakky54#ayza/10.0.2": {
+   "jar": "sha256-mqBjBJk6/1Z326dpxnfleDZPV5PLrxVpsrXzm3ERmns=",
+   "pom": "sha256-RBE2IyFz1etTP+/8ltqgNT+PDLaVAzypYx7Mjmjd0zU="
+  },
+  "io/github/hakky54#sude/2.0.2": {
+   "jar": "sha256-+I49Ax270v6huYSB3wZGoluNY9knltbzD5B9UYdZWzk=",
+   "pom": "sha256-w4owIG6ouVgRgFNI7Lecs9NRffg1uhDGYNOV7HYYFEE="
+  },
+  "io/helins#linux-common/0.1.4": {
+   "jar": "sha256-s6+sPTmOBnG2XRN8+wrbomd7nS6Oreom5qVQ8r5HPzc=",
+   "pom": "sha256-heooEVWS+33hnvR6UPH1SQZO203UjTGqbLUrLmNnUhc="
+  },
+  "io/helins#linux-errno/1.0.2": {
+   "jar": "sha256-xDzrJos/XW9j92k1JX18gjANt1GniDQG55LqeMWPxwU=",
+   "pom": "sha256-RZ0JVGaGiLFzj+z2ndweRz4O1tDW6lqLMwpY9Pmsvrc="
+  },
+  "io/helins#linux-i2c/1.0.2": {
+   "jar": "sha256-0Wv+n3Oay8QTmaZZbH2i0OFn/kwp7j3fKTXq+Ey3ogc=",
+   "pom": "sha256-D7O21SGjOtcn0G2J63+Ltk/9zpw/BSj+PFzduHgKwVQ="
+  },
+  "io/helins#linux-io/0.0.4": {
+   "jar": "sha256-mIha++lUrohF7EPAOO70Nq4NZUQEgkWDL/AHvJWtlLE=",
+   "pom": "sha256-ZSF4pfG5HtqRC5mXV1lgQDspY7YZQd0EyCm/P2xyUDE="
+  },
+  "io/jenetics#jenetics/8.3.0": {
+   "jar": "sha256-GyksDUmLTerSziuqJ+RC/Vy4YZqFAJSn6xmKxaUKpS8=",
+   "pom": "sha256-m2MKQbIhCJFKO07vnR8VopNbhLMw2JI2mOW50e8ohR4="
+  },
+  "io/micrometer#micrometer-core/1.3.0": {
+   "jar": "sha256-p9+gk7nKvVfyIWzqJ462h7TcF11xEGqtNY1hfq3AV6Q=",
+   "pom": "sha256-s6SvCAjrCX2/4+96Mxgbsnoi4P92NaY4L0Py+lC8B3U="
+  },
+  "io/micrometer#micrometer-core/1.5.10": {
+   "jar": "sha256-Keh9LGiTbLD13dVW+XyDCEeF3YiX3/BUckfqD2Z6hgQ=",
+   "pom": "sha256-Fiz/giAHilphb3YCWZ4ATbbvcHT8eWYeTlSJd/hZIwY="
+  },
+  "io/netty#netty-buffer/4.1.17.Final": {
+   "jar": "sha256-skoo4hKfwR4fYSTr+Tcl0fnAkE6medJh2nsuIdTIYV4=",
+   "pom": "sha256-hyEmdgcPxr/Em/MpIFCtcnjNgTiAxjFobAGz7XB3Brg="
+  },
+  "io/netty#netty-buffer/4.1.39.Final": {
+   "jar": "sha256-oVRFR8J1z/6LPv6xHD/y553NpnW80XUJaOHR4dYOp2A=",
+   "pom": "sha256-4TK4HLnG37pieb26hH41gJdRI4IspJU8W6rzwnPS/hU="
+  },
+  "io/netty#netty-buffer/4.1.56.Final": {
+   "jar": "sha256-eLXbND+bsJOxfa44oTcQIDklTXDR/046Hyt5z5sS22M=",
+   "pom": "sha256-G6LrvADRMZRY7l8sNWZYxBiWrNpFADlvuQpT0vlLGkY="
+  },
+  "io/netty#netty-codec-haproxy/4.1.39.Final": {
+   "jar": "sha256-krD/MyGheyfNRfv2HfnPMVEjPBduN7mCUt10iEx1fpU=",
+   "pom": "sha256-5gCggQrE05ZfER1FUaZVU3PLL0e8l3AQ+kV9dOy4QK4="
+  },
+  "io/netty#netty-codec-haproxy/4.1.56.Final": {
+   "jar": "sha256-/Z1SumNJNo7I5D6yiOxqMcfSmwJZ5OIrflyUcATGvq4=",
+   "pom": "sha256-naoMN1Fe/vCzatfF3FuQGUBuKT2ciBbrK0BiLqAE1T0="
+  },
+  "io/netty#netty-codec-http/4.1.39.Final": {
+   "jar": "sha256-6S7MvzefmL4B4YXRQnVFBcF8+VwapE04P/ep6MQhEGM=",
+   "pom": "sha256-uopsjq9o8BsZbSdR4jpHkGr1loT8GoG+hJcksUHB0d0="
+  },
+  "io/netty#netty-codec-http/4.1.56.Final": {
+   "jar": "sha256-i8rn53HDiUqsqMy9vTS1526PCrWaOZ+dspZ18Fav+tc=",
+   "pom": "sha256-PfrQadZxAioYzRsty69oHol1Lk95Ww8rLDsWHxjAsr8="
+  },
+  "io/netty#netty-codec-http2/4.1.39.Final": {
+   "jar": "sha256-3G8+reoGXrrXI0tePiZ6c9qI2m1cUF3fu7k3IhltM54=",
+   "pom": "sha256-slgBkb23piNdHXTeA/UnFdRsxrBs2rgF5ePZ0KxoFaU="
+  },
+  "io/netty#netty-codec-http2/4.1.56.Final": {
+   "jar": "sha256-YvyvXF4lq+0CK3NJ65cahSKKpxhwZzjIDtvUoSUAhkk=",
+   "pom": "sha256-Ygo0L/Rb4TSLBqIQwJVNXMExifY/3Ul0dc7vd1qMqsM="
+  },
+  "io/netty#netty-codec-socks/4.1.39.Final": {
+   "jar": "sha256-uTRySWLzN34r8qwvCriUWVqsf0sovoDy8pTSHpbJFSY=",
+   "pom": "sha256-W2HbgfhdaTf0b16DdKbIi0kPYFJrHNO5djKqY3WQ6C0="
+  },
+  "io/netty#netty-codec-socks/4.1.56.Final": {
+   "jar": "sha256-NvgXq76zZwaSjazKWwLIJVyK2eIRisufEAjEzm0yl3g=",
+   "pom": "sha256-ND/mGfNlW4fnJEwhhG7TE9zAbKLN8qykyHTH2g8XDfo="
+  },
+  "io/netty#netty-codec/4.1.17.Final": {
+   "jar": "sha256-eQzht2lPxBZjExV513ajcOMy47P+L+ZUNmL9WkCpSOE=",
+   "pom": "sha256-Im3RBojQ9y+k0RSdqsiIXUg5XOo1k+mqV+YNdcCiuBs="
+  },
+  "io/netty#netty-codec/4.1.39.Final": {
+   "jar": "sha256-YceHQJoZEXonUhrneEgIcLBM9uSWKSRDDau5XpCpvNo=",
+   "pom": "sha256-40lEEpJxfzSbXsJUr6lGtO1Zg4PotnGrZ3pN6us5SO4="
+  },
+  "io/netty#netty-codec/4.1.56.Final": {
+   "jar": "sha256-203UUni+zIy5juWtKWw7QPJXEiCpOM1FQ39i5xZkoNU=",
+   "pom": "sha256-Jt/8CqbUP/sTS4Eu/i+5yYIfQViJNc9AhH/kL1zTT+0="
+  },
+  "io/netty#netty-common/4.1.17.Final": {
+   "jar": "sha256-3dq97AGVkYDaRBKdEwMBuEwjtHNBEojxQ9XingsJjSY=",
+   "pom": "sha256-GSq9MOoshbA2Pu1Plv4z+MEBhvPCwZPORPyzX3GOs90="
+  },
+  "io/netty#netty-common/4.1.39.Final": {
+   "jar": "sha256-Z6AA2Zpx5P2iY5GtTfqYVx40zadzrsAHpfRSQui+9m8=",
+   "pom": "sha256-CN9EkPt9Eo9pYSdFKbUIoP5ryWeyCW3jypBMllda2As="
+  },
+  "io/netty#netty-common/4.1.56.Final": {
+   "jar": "sha256-64EhiTMWjKDMctybM8yfXUOYaYt/AbGQRIzt3zBmcB0=",
+   "pom": "sha256-JwZM+ejxBloGm9I1WoeEYuWjUhMy4fV0JIaYPijmiMQ="
+  },
+  "io/netty#netty-handler-proxy/4.1.39.Final": {
+   "jar": "sha256-EVcCF4vv5QDaxu28D3Mk3YT5PsHk4JQ8gIPTmpE+SiI=",
+   "pom": "sha256-8IzSsRhkJ8v5IQm82VMgBydOzi/HQsXN6Lbxa07TTco="
+  },
+  "io/netty#netty-handler-proxy/4.1.56.Final": {
+   "jar": "sha256-4pRTbJz29g53DDFia8/qUNJp3xqW/lCyUyVri3uGhf4=",
+   "pom": "sha256-SWYJBtKiCN2FlQKE1ZfDXiNJKhH0zAMFiY1/TLuYw5k="
+  },
+  "io/netty#netty-handler/4.1.17.Final": {
+   "jar": "sha256-hbraYE/hS8NY2nsUBYMmSojXpFyhLauhIWxCJarbDHs=",
+   "pom": "sha256-/5gJRLOSUkCMvfFGV2CsdHfta8pknbm7wdZFcUaFEfA="
+  },
+  "io/netty#netty-handler/4.1.39.Final": {
+   "jar": "sha256-sDEZV/KLKEc5uYL9zfHVALDZnwR7GV+3TPHYd9BF/F0=",
+   "pom": "sha256-wc038IRHPiUKkkfyQuTkuOWY1OEoRnIJIPdrun/yEN8="
+  },
+  "io/netty#netty-handler/4.1.56.Final": {
+   "jar": "sha256-eR9yqXQnyZ3aAMV8GG1wtubu1lNgdB0A9pgcUjpTPjU=",
+   "pom": "sha256-KgDb+xpyCNirhXI2cs+sKaei7VljH7PttK6yiW8xlaY="
+  },
+  "io/netty#netty-parent/4.0.18.Final": {
+   "pom": "sha256-+9F/TjuAl6Up4s1dKvVX18VPwHVomwwDqcckUhaE3jw="
+  },
+  "io/netty#netty-parent/4.0.29.Final": {
+   "pom": "sha256-N6VDvlB+miEeR3LmJUlUsdKY1nqYdgpyiBCpK1aGBlU="
+  },
+  "io/netty#netty-parent/4.1.17.Final": {
+   "pom": "sha256-hAZ9/L8VpGjxCiZJQ371/tYDXdLrKYk/NRCn/JRE7Zo="
+  },
+  "io/netty#netty-parent/4.1.39.Final": {
+   "pom": "sha256-cwBNIGZniSkr9gD6k1eAFTmcN0jCBiXjduGXUtWKBWg="
+  },
+  "io/netty#netty-parent/4.1.56.Final": {
+   "pom": "sha256-VBHPijI6p++99RVoGzdWEi90SVN/P5XPL9YiLatP5/E="
+  },
+  "io/netty#netty-resolver/4.1.17.Final": {
+   "jar": "sha256-CCrEkUnLcsZ1x+0WFbo1kj0xZ+Zb+zfEoUIuxJkTfLE=",
+   "pom": "sha256-7+T7BOPVY3GumeGkfgNrCxKHpZey3/mubvYhayuHgHU="
+  },
+  "io/netty#netty-resolver/4.1.39.Final": {
+   "jar": "sha256-YbgNzsjJXM9sihNBQ+N9byYlG4Bw5femiG/9XdaeSnI=",
+   "pom": "sha256-k0cketO66JNB8GuE7fCuoc97mhHtxGR6Lq8wDB/dmN4="
+  },
+  "io/netty#netty-resolver/4.1.56.Final": {
+   "jar": "sha256-KikuyolE1l7sk8NRPD/6CQwgL6inMlF7cRaS6VpF++k=",
+   "pom": "sha256-ujuwbu5iYFmCBYTJjdECmQkJ0bGvGqva9NuS/hO1A2Y="
+  },
+  "io/netty#netty-tcnative-parent/2.0.25.Final": {
+   "pom": "sha256-2gXRIRlzv9B+EA1JCiJGc+9ZB+Kw78xxDUuPKRo9TG8="
+  },
+  "io/netty#netty-tcnative-parent/2.0.35.Final": {
+   "pom": "sha256-XbE/2euQ4sYyi9kUb45IA4L2uz3EA9DHdZv1eGMI0hI="
+  },
+  "io/netty#netty-tcnative-parent/2.0.7.Final": {
+   "pom": "sha256-M/iJmDZ2bfir26ntx0125pOIDitlsjolsWGASgY+iUw="
+  },
+  "io/netty#netty-tcnative/2.0.25.Final": {
+   "pom": "sha256-qm3nNMKJJvi5FoeDdU4yTsNIRVGAYfkNLW40DYei1tY="
+  },
+  "io/netty#netty-tcnative/2.0.35.Final": {
+   "pom": "sha256-eeHdug+lHfVqC26wfKRa2bsBB6H1B2gNDVSvmoCUjl0="
+  },
+  "io/netty#netty-tcnative/2.0.7.Final": {
+   "pom": "sha256-oD4PGlBu/wH+ox1pAbo6tALPyip3P8PqPLCfAv+TYt4="
+  },
+  "io/netty#netty-transport-native-epoll/4.1.39.Final": {
+   "pom": "sha256-XbAOwPcUSKrZixgrHUfD69qnCTyDVgF619+Y/xTNRrs="
+  },
+  "io/netty#netty-transport-native-epoll/4.1.39.Final/linux-x86_64": {
+   "jar": "sha256-HnJKjSinkzzmc0qoH6X7o/vzWOWAtAxeAPQtxw3LWQs="
+  },
+  "io/netty#netty-transport-native-epoll/4.1.56.Final": {
+   "pom": "sha256-EqzwHzbsd8JGEbPtDJzlywa0ANIC5qiDKkSygP7LalE="
+  },
+  "io/netty#netty-transport-native-epoll/4.1.56.Final/linux-x86_64": {
+   "jar": "sha256-f9KpHLLR7Xn/qjRX5hn6FFAQyeorwmVjWjmP5RnCdkU="
+  },
+  "io/netty#netty-transport-native-kqueue/4.1.39.Final": {
+   "jar": "sha256-4gsKXn/1pJ8WEY1GGdW6VySrtsodwqDdphDK0Fcvbno=",
+   "pom": "sha256-CiQdM9eKe26VamOtI1mJkEmJjpA0GqMoyiD5Wkfok1k="
+  },
+  "io/netty#netty-transport-native-kqueue/4.1.56.Final": {
+   "jar": "sha256-6jxP8ZrYYW0SrIg8QApIuKd97778f/Z8A8Yb7Aq0zzA=",
+   "pom": "sha256-evPDiqEK+fMYwyvWg7XQpivv3+zd2PcegB6Z/oXwNac="
+  },
+  "io/netty#netty-transport-native-unix-common/4.1.39.Final": {
+   "jar": "sha256-OcS6UJ8CsHXzu9J3+i1xx6gf2OKAClKWadaHanh2h4g=",
+   "pom": "sha256-psymLNsKE2ESbsdwuC3/XupWeu+CogdFTAyAHH/Wli4="
+  },
+  "io/netty#netty-transport-native-unix-common/4.1.56.Final": {
+   "jar": "sha256-xeFXoG3ZJ0ZzarPKB3nERNhMYv+3BM7zog5c2ZB0AN4=",
+   "pom": "sha256-fzX6D3OOm4iSUu6Xa68QG48tLdcNgKlhB8iNYGO5b/g="
+  },
+  "io/netty#netty-transport/4.1.17.Final": {
+   "jar": "sha256-YHY0Jsed2TDHDQ2pXkdPZivReljT1XszJpbQic8ggIk=",
+   "pom": "sha256-nenFGwZVN2iD8E53eFcfdS87x6wGlUuO878yLPivLAo="
+  },
+  "io/netty#netty-transport/4.1.39.Final": {
+   "jar": "sha256-zwGLfl8HOf9flydh3Mo9YoJaVCa9BPVW0kJACTSyRfU=",
+   "pom": "sha256-mR2L3kZREzhia9HftXB0qDWWh1MOkq+R6PDlW9r0F9Y="
+  },
+  "io/netty#netty-transport/4.1.56.Final": {
+   "jar": "sha256-IJrzAkCRd6HpFLgUrCIMjTSHd706j2riudI2fHbXFXY=",
+   "pom": "sha256-9tP1Vx2SGl27k0jTnV09RZ4oYjdUqG0FCbJ8i+lJgkc="
+  },
+  "io/openems#j2mod/3.3.0-openems.2": {
+   "jar": "sha256-Q9CHmrR8Gn0ehIE9CU1XMGlMxfSvElSdGil5zOLHwKM=",
+   "pom": "sha256-ERaJ5jiIsT5fYSBH4nt9sgSG7Fkexga9/acYi2GcFvs="
+  },
+  "io/projectreactor#reactor-core/3.3.0.RELEASE": {
+   "jar": "sha256-ol8EM9X2Hs0kwvRKcXEHkQH/1KGfK/qkI68Axz/roTY=",
+   "pom": "sha256-Aer/8kRZAAzSqpxYov0HYAJ4ZaBS7C2M1F4raI+toZM="
+  },
+  "io/projectreactor#reactor-core/3.3.13.RELEASE": {
+   "jar": "sha256-8loQ5KHDJU04wZnOfvz6qcTVlS4e7LK+TbUo+5VdRTU=",
+   "pom": "sha256-iie4wfbD7Q0tilKQxkc08nrXA/4xoOSusK2IZlbHl5Y="
+  },
+  "io/projectreactor/addons#reactor-pool/0.1.0.RELEASE": {
+   "jar": "sha256-UAcFgvw3tHSuLiUzSkeBR2K7Rr2uAuGtJTUTzDbVgRE=",
+   "pom": "sha256-D75UY4aQPh9zuoGPzRghW405IFNWktdwVhwHt1pDkoQ="
+  },
+  "io/projectreactor/netty#reactor-netty/0.9.0.RELEASE": {
+   "jar": "sha256-eOzsJ/Q2wAcgoaFAYim9cmEW4HxtifoeO0OXhno/2Kw=",
+   "pom": "sha256-aOOsfcJaVMP0hoGQKpI4QNRtxWWJA/oedAZGgluCWfI="
+  },
+  "io/projectreactor/netty#reactor-netty/0.9.16.RELEASE": {
+   "jar": "sha256-5RZvLkhSHtdZm1PtpKGWaWJkdpY9FvdFdj2LWmKLp8Q=",
+   "pom": "sha256-ZwN80iHwoCUfkvvrq1hHf/YN53otmVmN5b5+HL84cy4="
+  },
+  "io/projectreactor/tools#blockhound/1.0.3.RELEASE": {
+   "jar": "sha256-4RtnuhX/y0sDOeL6IStYHzh7LsUGqjhouczcjJ1ZScc=",
+   "pom": "sha256-kp8y6+Oq6TqN1enqpIZdGaJrzIpL/g0WVWF21wtpOUU="
+  },
+  "io/prometheus#client_java/1.3.2": {
+   "pom": "sha256-uAhbKWIdihoxn83L3qZAiLXnX9Fuqnjo7R9MiZzIYZY="
+  },
+  "io/prometheus#client_java/1.3.8": {
+   "pom": "sha256-60owtJle0lT10JLQF+TQJ08RepqVy5FnHXlVmKuQOD8="
+  },
+  "io/prometheus#client_java_parent/1.3.8": {
+   "pom": "sha256-+q6XtUqTBosc3cL80aGDyosENCMSTah/uVJyBpPT1Hs="
+  },
+  "io/prometheus#prometheus-metrics-config/1.3.2": {
+   "jar": "sha256-/rfc0lY+izRjaT9CUv9YeC2lemFWAxGKPo4zoxWTPIk=",
+   "pom": "sha256-Bn3Jgj4v7BDlE4+G9XBAkSCrdCvdV0S6o9eqLy++obo="
+  },
+  "io/prometheus#prometheus-metrics-config/1.3.8": {
+   "jar": "sha256-x3FguIgdaQbFtBRCesG/8cZAGfXrBocYjRE4yGFI6P8=",
+   "pom": "sha256-rzgEM1T3GWFU0WVM83hCXFfhvqRsKYE+AkpBWBKaykg="
+  },
+  "io/prometheus#prometheus-metrics-core/1.3.8": {
+   "jar": "sha256-YEgaSBVhlaXJ8h2+7ItK/5C6JTJ+xmo9zQ+qW/aYIp0=",
+   "pom": "sha256-Y0oFLLJ+K5r+htElwu5Z6v0FheHpDroKGx7T8+8rWfM="
+  },
+  "io/prometheus#prometheus-metrics-exporter-common/1.3.2": {
+   "jar": "sha256-ywjmrP8ebW8LVRC0vqnMTtDGAQ93Y7z2gZtbKGf/ur8=",
+   "pom": "sha256-A7O+oMz+mpIO6Ijhffn965HFUsg++M3uhH5oY53iBQY="
+  },
+  "io/prometheus#prometheus-metrics-exporter-httpserver/1.3.2": {
+   "jar": "sha256-5Wep/h6F/J7cEhXSXVd/8M1MoaRzdvLlo9NFgeNP1fE=",
+   "pom": "sha256-bP4KAwzTmXhCUOYYKGbJcvvAVQ7ezD8FBLMf5kU+5mc="
+  },
+  "io/prometheus#prometheus-metrics-exposition-formats/1.3.2": {
+   "jar": "sha256-y6BRpzHwaCDHZWQDG6eyGqpRSVVetq/40NxrogDbLOc=",
+   "pom": "sha256-8TXddZmwLyIJpQGTDDHsUku0YpdVzGz+nVkr3PJrRh8="
+  },
+  "io/prometheus#prometheus-metrics-instrumentation-jvm/1.3.8": {
+   "jar": "sha256-DcLjrDqas4mYJGJrriWHZ9P37zRXsU/hDjP1ColbPZE=",
+   "pom": "sha256-Nh/Vf/3stHYESR8Y9mhyS2nrBTK9tFTJrItnxXVFT2A="
+  },
+  "io/prometheus#prometheus-metrics-model/1.3.2": {
+   "jar": "sha256-xucZbCBLkSJVg+qBnWb3KeZysP7E0j62pR/tAXUhY8g=",
+   "pom": "sha256-0jF5d0Snzlm97EHwIX/W8kCTyt99g+lqxNTZALZTPiI="
+  },
+  "io/prometheus#prometheus-metrics-model/1.3.8": {
+   "jar": "sha256-poZ8sEKZ4+Ro4mWIVI6SFRYzc+CljxtzAd1Z/m82SPo=",
+   "pom": "sha256-cqktzkjOAhfng+WYEo651v5/qxPaqzqNh929IjvBwF4="
+  },
+  "io/prometheus#prometheus-metrics-tracer-common/1.3.8": {
+   "jar": "sha256-zqcUY/XxrQCe8D0atgaTqU3kmOYwbzr37YFCCT8JP6s=",
+   "pom": "sha256-gbwK058pcQpHF9lkUs03tIIxa3b5SBrUuH2NXnkHF3U="
+  },
+  "io/prometheus#prometheus-metrics-tracer-initializer/1.3.8": {
+   "jar": "sha256-oRThWd/4mzw79NhjKvP4GGMG/w0UYViyOYAV8TPL66k=",
+   "pom": "sha256-Drogh7ObQ5oU2u+GJ11E+7hhkDvf8b6BWJ5xfcr1cCY="
+  },
+  "io/prometheus#prometheus-metrics-tracer-otel-agent/1.3.8": {
+   "jar": "sha256-w9hxFy3WWdAD4nPdxfgudejWRv8/5X7OKU/eEhyEu9c=",
+   "pom": "sha256-wh9zzpwPP5Tgy2HBRQogh+8XSs/GyioeR4t4tVPKnBk="
+  },
+  "io/prometheus#prometheus-metrics-tracer-otel/1.3.8": {
+   "jar": "sha256-ZCvlIBVAAfgZkmJkXJFRF8VXYl7bosiZzel3WH+3VV8=",
+   "pom": "sha256-Ugk3Gt12LDltg0/lj8BC7epwjGG7SysVNFkFllOLnLM="
+  },
+  "io/prometheus#prometheus-metrics-tracer/1.3.8": {
+   "pom": "sha256-jawNvVgxQ0HmyEB4Cryp4hj8mvhJz+lOZ2kzgjY/ZUk="
+  },
+  "io/reactivex#rxjava/1.2.0": {
+   "jar": "sha256-K2w2wdRtmuzMBAjLjTfY4TONgAZdCs4mdo0e3c5hlnA=",
+   "pom": "sha256-krrFobHHnksfYzxn7DTzFG9FbXn/XVj4BfDa1V8S+lE="
+  },
+  "io/reactivex/rxjava3#rxjava/3.1.10": {
+   "jar": "sha256-6fJW+egFVy3V/UWxQNs2DX3ERNDDgwSbLT1+vwXYSqs=",
+   "pom": "sha256-EeldzI+ywwumAH/f9GxW+HF2/lwwLFGEQThZEk1Tq60="
+  },
+  "io/reactivex/rxjava3#rxjava/3.1.12": {
+   "jar": "sha256-GAikM+9V3MKWVSPlEquRSl0NcnIoomg+11WdfMz0Tjc=",
+   "pom": "sha256-chJrr7gKEse1WFJNCRkj5pYSODxHQay34Aw1ybBUazQ="
+  },
+  "io/reactivex/rxjava3#rxjava/3.1.8": {
+   "jar": "sha256-aJC+y9RkY0eSh0akQhzFWfyp800G7yp6lHvXrfdHMkY=",
+   "pom": "sha256-b/0PLh8jVTB1tjJzZ+JXCv26DFaGgo2yrWx+YSYUsbY="
+  },
+  "isorelax#isorelax/20020414": {
+   "jar": "sha256-9tvLt+mKmCw/kU7pwSwcl9t+wHYY2zxr2UjUBH4hKkM=",
+   "pom": "sha256-UaPbgNvEdhVBU4XyKJ+MrQOeRDMufPiIxuAbibGvu3Q="
+  },
+  "jakarta/activation#jakarta.activation-api/1.2.1": {
+   "jar": "sha256-iwoPUvqLBcVDGSGgY+2GbvqkHa3y46fuPhlh8rDZZFs=",
+   "pom": "sha256-QlhcsH3afyOqBOteCUAGGUSiRqZ609FpQvvlaf8DzTE="
+  },
+  "jakarta/annotation#jakarta.annotation-api/2.1.0": {
+   "jar": "sha256-RI8qv1Ow+z6W7tyP4Nr7YoSvElLdGqS9Pmd06R/UGmo=",
+   "pom": "sha256-zcRoNzZCWA3SwJ5DKFosnl3+AAqtCuT5ZCs53iGdONU="
+  },
+  "jakarta/annotation#jakarta.annotation-api/2.1.1": {
+   "jar": "sha256-X2X9r0JO7itV4diCupuzdr6T+wmze4CL5uIuiFHJCf4=",
+   "pom": "sha256-r2UOyh3huYdBAGrNglB+RAjP/t0v7jOg6kY9YVCNt+w="
+  },
+  "jakarta/el#jakarta.el-api/5.0.0": {
+   "jar": "sha256-V7giOAIHkA9RRcKmhzhMUP1BSV04iiNXkdlq47m/020=",
+   "pom": "sha256-PblMqd6cOIfLGWR4VZj/D+Qalf2X5njfXexSzWpHaVg="
+  },
+  "jakarta/enterprise#jakarta.enterprise.cdi-api/4.0.1": {
+   "jar": "sha256-vq90xPJhgYkwnj9KCcQ+/6tjPdlqofbcWKa6fuAEJxc=",
+   "pom": "sha256-i0Hh01UQWPe+A2ChrlfpMlAuFqDjiKAluthwW4FjUUY="
+  },
+  "jakarta/enterprise#jakarta.enterprise.cdi-parent/4.0.1": {
+   "pom": "sha256-X0kLdPY9vWy/0VpVeWSRzAP0tapSl5qJMxwQq/a13Bc="
+  },
+  "jakarta/enterprise#jakarta.enterprise.lang-model/4.0.1": {
+   "jar": "sha256-U6yv5ltu8Blfobig7yZQ5aoCTDLLQFnE3zctazIInNM=",
+   "pom": "sha256-HIxXS33140lAhNJHF5lO798m0rnh6DppQbUJb07KicE="
+  },
+  "jakarta/inject#jakarta.inject-api/2.0.1": {
+   "jar": "sha256-99yYBi/M8UEmq7dRtk+rEsMSVm6MvchINZi//OqTr3w=",
+   "pom": "sha256-5/1yMuljB6V1sklMk2fWjPQ+yYJEqs48zCPhdz/6b9o="
+  },
+  "jakarta/interceptor#jakarta.interceptor-api/2.1.0": {
+   "jar": "sha256-73h9P3E/xv9PAs1LDb7Qj5PYrzQAyQy7Q/tLXAWDcQs=",
+   "pom": "sha256-0RTaY7IJPwvZwqllegFs5w/ro3YFCAalxZldiRPffV8="
+  },
+  "jakarta/servlet#jakarta.servlet-api/6.0.0": {
+   "jar": "sha256-wDTrGvsViYfbtTpf6gyt9hHI2ujardWcRNnVq3ASnO8=",
+   "pom": "sha256-PVolnfvSuUDklcMFy6K2BhWSPcgXjgMrfvYMuyQThDk="
+  },
+  "jakarta/servlet#jakarta.servlet-api/6.1.0": {
+   "jar": "sha256-ijH0ZfNZO/I1FTGlyVIBTrg52pamBbWCW5PdVHFMSMQ=",
+   "pom": "sha256-G6+Lb6bQIYAwINCXDqQ/sH32beZskNKZohZ3Dwsz5K4="
+  },
+  "jakarta/transaction#jakarta.transaction-api/2.0.1": {
+   "jar": "sha256-UMCnx2DBOubAQqzxgrKPAEdBPblbRjb7iHm8/6tbqHU=",
+   "pom": "sha256-X+NJmBwVb7viY4jVmUn9rBa7jXh57mGzTEnHtc4PLyM="
+  },
+  "jakarta/websocket#jakarta.websocket-all/2.1.1": {
+   "pom": "sha256-J9vJgkpicx4a2/XKfTEkJS+MAjPlVs7aiACjDNGPO7U="
+  },
+  "jakarta/websocket#jakarta.websocket-api/2.1.1": {
+   "jar": "sha256-vq25LCbQTaZT9tLbJTK1Sbeg2+WcbiLCPlW9A2F/ASA=",
+   "pom": "sha256-3xb6ydroxTIAIOJWDJUBbENAFYK5eFyIE8Sv33At610="
+  },
+  "jakarta/websocket#jakarta.websocket-client-api/2.1.1": {
+   "jar": "sha256-6P6MHf+Ug4WkYdvIXexUZ8vjUPBl7BoPO/7VO3nnsQI=",
+   "pom": "sha256-OC2FVbzLdeOu+epfSndOuByFpSs2SlKdkyah59L0jdo="
+  },
+  "jakarta/xml/bind#jakarta.xml.bind-api-parent/2.3.2": {
+   "pom": "sha256-FaVbfVN8n5lwrq0o0q+XwFn2X/YQL3a70p8SR92Kbfs="
+  },
+  "jakarta/xml/bind#jakarta.xml.bind-api/2.3.2": {
+   "jar": "sha256-aRVjBAeb3u2fwK47OTifGbPMS6REO8gFCJlTlOrXQuo=",
+   "pom": "sha256-tTeziNurTMBpC50vsMdBJNZyUxc0VnrPblMTDqsTGtY="
+  },
+  "javax/activation#activation/1.1": {
+   "jar": "sha256-KIHHnJ1u8BxY5ivuoT6dGsi4uqFvL8GYrW5ndt79zdM=",
+   "pom": "sha256-1JDlQKEVBLnXFxixyF/vez3mgCNhKQgkU5sHbVj6qKA="
+  },
+  "javax/activation#javax.activation-api/1.2.0": {
+   "jar": "sha256-Q/3vC1ts6zGwQksgi5MMdKtY+sLO63s/b9OuuLXKQ5M=",
+   "pom": "sha256-2ikm88i+iYZDzBCs3sbeCwNRpX+yc1dw+gF3sGrecbk="
+  },
+  "javax/cache#cache-api/1.1.1": {
+   "jar": "sha256-nzTgB+36gqeyouG5aUd9z1CZzn9Pkm+1TOfifEoM1Us=",
+   "pom": "sha256-gyoEyfAvHkJ/HkM9pjtvdNQKKQKjx4ceGoHDzBACGhM="
+  },
+  "javax/jcr#jcr/1.0": {
+   "jar": "sha256-gZJm+0wWeAlvmfYlldMVuErskgT8SAlAJiZMAoBmCtc=",
+   "pom": "sha256-nixkO6t6PvdZc7UGUgSjjwAZv1hW4mdDaV0jSd+hg7c="
+  },
+  "javax/mail#mail/1.4": {
+   "jar": "sha256-loaPgiZOvZt9QfBNeMvoerddaKe7+O37gkFqq+m1S2w=",
+   "pom": "sha256-8KOlpN2T6O4sebiv8YcGPHZGLXNXkQwz2B9LkHr1pkU="
+  },
+  "javax/mail#mail/1.4.1": {
+   "jar": "sha256-KU8LP7xV4Pz3sgNwpXhG9dft+fXPp9+uoB6xqtF46sM=",
+   "pom": "sha256-dWWDY5QNC3eC6WGgy1T1dLg4ebw0ytw7WG86AqXibQY="
+  },
+  "javax/mail#mail/1.4.3": {
+   "jar": "sha256-EBO9twFARn75odfdnRtx1OguaifzYb5BtFmKPBsanxI=",
+   "pom": "sha256-8MDcN43MgeCC3V4zDhJA7uEqzpZaGMf1THtO4dVuwso="
+  },
+  "javax/mail#mail/1.4.7": {
+   "jar": "sha256-eMM7T3x7YPS2gPLSQFsfBj1xkpzxpPvDKIiDefNl/Ps=",
+   "pom": "sha256-lhCZpCD2wx3rczQQwKJGLAZpJzI1+ljFcNYay9udjYo="
+  },
+  "javax/persistence#javax.persistence-api/2.2": {
+   "jar": "sha256-VXi3GzeZml6u0/6g0UqmHGDG7GMoJW8rY0cvM2MYuvQ=",
+   "pom": "sha256-ngY2SG0fI1an80W035u5XlhC8KsmvXYVsHt76Zs8hwo="
+  },
+  "javax/servlet#javax.servlet-api/3.1.0": {
+   "jar": "sha256-r0VrLdQcToLPVPPnQ7xniXPZ/jW9TTBx+gXH5TM7hII=",
+   "pom": "sha256-sxEJ4i6j8t8a15VUMucYo13vUK5sGWmANK+ooM+ekGk="
+  },
+  "javax/servlet#servlet-api/2.5": {
+   "jar": "sha256-xljqNgpw+u6ttm+zyQpwLkFCoKt3aPmumChnjg2a1Nw=",
+   "pom": "sha256-aXcVBvPNhDIlLWpsqHCHxmlJf+v8oCr7mnL8vZQ/qh4="
+  },
+  "javax/ws/rs#javax.ws.rs-api/2.1.1": {
+   "jar": "sha256-LDCesslFX/7p2oUYxwo7bUa+KiabLioQHIBqU37+eaQ=",
+   "pom": "sha256-TNFZAxKy0M9D2K2aOndOdUAxCq3elu0OTUOVIL0u5lc="
+  },
+  "javax/xml/bind#jaxb-api-parent/2.3.1": {
+   "pom": "sha256-zRvqpFYNxN/bgmudgJ5GTbIlJt+1QmS654pv9++wjh8="
+  },
+  "javax/xml/bind#jaxb-api/2.1": {
+   "jar": "sha256-Lp3ImaeFVE6KgmIEfNNwY29zTuAkbjYmPuApXD867ZQ=",
+   "pom": "sha256-p/PnACu2vwyLwPRuNY3uew4jHjxzg2e/UwSikOvwXmE="
+  },
+  "javax/xml/bind#jaxb-api/2.2.12": {
+   "jar": "sha256-aKYh7BhIX5UdCax29D5X7uOU2+QsuPKkxZyTKW+p3MY=",
+   "pom": "sha256-Gs08hdTP48Sa4eKsKXdCujnaW7swo60OQXbqbGNI/O8="
+  },
+  "javax/xml/bind#jaxb-api/2.3.1": {
+   "jar": "sha256-iLlVoN9XiAomp0cIvDT3Tcr46/TniEOii1Dq6UVzKwY=",
+   "pom": "sha256-ErIM+SJ3NEXDRFwog8v2cfqYIRHpv5+HUCD5MTs4FLE="
+  },
+  "javax/xml/soap#javax.xml.soap-api/1.4.0": {
+   "jar": "sha256-FBN04zvpl2hhGi1CudM1caDFuXY77KnC3JCQDYzI92c=",
+   "pom": "sha256-f0QbXEpuotXviFh1zw4wrbjDy4+dCpK+cJVMc7kGwK0="
+  },
+  "javax/xml/stream#stax-api/1.0-2": {
+   "jar": "sha256-6McOvXb5gslYKoLvgs9s4Up9WKSk3KXLe3/JiMgAibc=",
+   "pom": "sha256-KGTxnahP1Sdj11oZenF3my3svMqsPrTkdg/8iExa9KI="
+  },
+  "jaxen#jaxen/1.0-FCS": {
+   "jar": "sha256-7cw+W/Z1bQPzFrtag4AzsNTsvfppdkgLaGqixoyOZ+o=",
+   "pom": "sha256-uZE2uSLm62ozIugB/Qtc/tLRA3plXauGtBMGkYeWiGI="
+  },
+  "jaxen#jaxen/1.1-beta-4": {
+   "jar": "sha256-ta9S+K1kLo7VRWLzf/J8aBUdiLeaqTKTHecn2BElfRM=",
+   "pom": "sha256-bKuiEvuqDkEu3jyDB4Iwlo0r1k3de+10fZaPZ0PAHPw="
+  },
+  "jaxen#jaxen/1.1-beta-6": {
+   "jar": "sha256-BTE4ibDtYVWNHqiHCxhXi+r/qD+KC9hjt8OMR20mM+k=",
+   "pom": "sha256-2Ya5nugz4AuoIj8Lk4jQtq/Y/VwjOlLGNOyDwnlG+Fw="
+  },
+  "jaxen#jaxen/1.1-beta-8": {
+   "jar": "sha256-sHtHaFnjcGbvBPzZjvh0vL9YlsBI7Jl4fneqFcwH4HM=",
+   "pom": "sha256-VN9wv/ClleAbwih4UFZQoPE/wQpqphxUtd6gib+oiqA="
+  },
+  "jaxen#jaxen/1.1.3": {
+   "jar": "sha256-PkUes1NYjjDa0iMG1RzXXL9rzxGlXmYkd6PcrOjueTs=",
+   "pom": "sha256-49D6Php4CmTbO4XlGUmzLgueDOB5No42OqxeTAAilkI="
+  },
+  "jaxen#jaxen/1.1.4": {
+   "jar": "sha256-XabDv8Kq8P19Q9x2gpFkqBX7mpVn7Km3zPZ5mPpw47U=",
+   "pom": "sha256-2Pa5My4NLPGDTOF6NWS8s6t26rI/TjTsOkRbrDWqWKg="
+  },
+  "jaxen#jaxen/1.1.6": {
+   "jar": "sha256-WsnHS7s5ZLNKiGumsbbAsNw+vuvB3EpElCp2Y0SQs+s=",
+   "pom": "sha256-0M3yuBthXWkj8Z/9hyenIlpNZQaWbfzQI32st04Es6o="
+  },
+  "jaxme#jaxme-api/0.3": {
+   "jar": "sha256-GkWUS3NHXOIletPi9lcLYQcxwvi68Bm8X2FFRqWi+Qo=",
+   "pom": "sha256-FAtT0WyPiaDMa0erj2bLWG7YKT0YtE2mzIBJefN+UlY="
+  },
+  "jdom#jdom/1.0": {
+   "jar": "sha256-OyO8OXmuwUqVKhKq/EgwENxXV5d18v/KzvUlapDu2gI=",
+   "pom": "sha256-NwGGZJV1WjLlDCBDupfvxYeBJfxa+c5ScmMCRlzxfw0="
+  },
+  "jdom#jdom/b10": {
+   "jar": "sha256-6fv5vps8gc3DQ5osGyg4V33dKeIVlRupwymytAasEUc=",
+   "pom": "sha256-Y8DWyjy5mEyVKWrBSi/6jTC137M1FeoQfroDGPUDhCQ="
+  },
+  "jline#jline/1.0": {
+   "jar": "sha256-sNiEmA+rHfL5SMVo9XbDZfM3nci8kwJy+lCIQ9HzZSs=",
+   "pom": "sha256-2MdGmx9WZI0QDSLfFW+8lkIBJF2xmmcWldV8to9dKlw="
+  },
+  "jline#jline/2.12": {
+   "jar": "sha256-00tFyMpDWcZa5h5AYzkCLkcxxzm8NEjOOZmmBEC6qnI=",
+   "pom": "sha256-STOMd6Nr7ImL+sJKgvbl0qvWuXUQNNDbLdRa4EyCTqU="
+  },
+  "jmock#jmock/1.0.1": {
+   "jar": "sha256-ir5gt5/Mz9q4ugig4qxkBcggOJCOrunhL+C4XI2MqAY=",
+   "pom": "sha256-NFq5tY2xc2+UA94QlRN00t8cUOj+03womkyqLhVbmGI="
+  },
+  "jmock#jmock/1.1.0": {
+   "jar": "sha256-wO8lnaz4XKQskF37VYwTS9w7er/uo0UsFzGW2TP2Aqs=",
+   "pom": "sha256-DUbJb7KeTXPeexB9MUdQYsEBPdr2wnDXBaFV4AX7wbI="
+  },
+  "joda-time#joda-time/1.6": {
+   "jar": "sha256-vJbb58VvT+Nn6jPmbfzxi1iePI7dz/UqeDI8Xm2iOH4=",
+   "pom": "sha256-ThV2ms8Fn1vjBU/RF5j6YDR4ui6uULDMKi4RFTuWxqY="
+  },
+  "joda-time#joda-time/2.12.7": {
+   "jar": "sha256-OFKCsAWBjPrM2+i9JCmBHn5kF4LyuIkyprj/UdZo9hY=",
+   "pom": "sha256-hf3b+kfCmf2OzhyT//1H2cLTyQNaM7XbAXswTGd+hCg="
+  },
+  "junit#junit/3.8.1": {
+   "jar": "sha256-tY5FlQnhkL7XN/NZK8GVBIUyKEbPEOeN7R0GUVMBLXA=",
+   "pom": "sha256-5o8zND2DI5jzyKp4r82AjVa3wQIN5NOtjOR5CQle6QQ="
+  },
+  "junit#junit/3.8.2": {
+   "jar": "sha256-7NzAgYNwjqP3sN3Jbxlnig24rx+zl3kdSErtYyAFWLA=",
+   "pom": "sha256-rt5nmZ8CrIUcKirozsWPnYAfgmuiCZTfI6HZ++zEfw8="
+  },
+  "junit#junit/4.0": {
+   "jar": "sha256-TM7ty4OCTbCGIDnT4M81+Vjo2++xBtCjCpM9t8uImFY=",
+   "pom": "sha256-GvlzB9hfbGy+CTrHvFP/t2piJBfryNTjZAriorGJVvE="
+  },
+  "junit#junit/4.10": {
+   "jar": "sha256-NqdHyh4LhvbqiAVbhyO7hwMNYndm2mKIvwd6/e6w91o=",
+   "pom": "sha256-IqG/C6rothBretgCbs8nxZ5+R920nWKXUDa+rbLGLrU="
+  },
+  "junit#junit/4.11": {
+   "jar": "sha256-kKjhYD7spI5+h586+8lWBxUyKYXzmidPb2BwtD+dBv4=",
+   "pom": "sha256-GK2LCunmWpGV0E4lQn3+i1gXWrza6HWlpAau44vd+yY="
+  },
+  "junit#junit/4.12": {
+   "jar": "sha256-WXIfCAXiI9hLkGd4h9n/Vn3FNNfFAsqQPAwrF/BcEWo=",
+   "pom": "sha256-kPFj944/+28cetl96efrpO6iWAcUG4XW0SvmfKJUScQ="
+  },
+  "junit#junit/4.13.2": {
+   "jar": "sha256-jklbY0Rp1k+4rPo0laBly6zIoP/1XOHjEAe+TBbcV9M=",
+   "pom": "sha256-Vptpd+5GA8llwcRsMFj6bpaSkbAWDraWTdCSzYnq3ZQ="
+  },
+  "junit#junit/4.8.1": {
+   "jar": "sha256-79jPk7V9Aej1++++HxeuOebiJVNhWSbgCm7vwwfaIeY=",
+   "pom": "sha256-PKbJzP49s3/l685JbtO1Cg5vVr3nkRHgpKJmhDymqOU="
+  },
+  "log4j#log4j/1.2.12": {
+   "jar": "sha256-3Gc3jPQowGQI55Weg73BUY3SLM0xPnwoqYZhLWXCdsc=",
+   "pom": "sha256-y1Te3F2MRRAUjfp5JwHLrBqEw4OoT0j1oy5tfkYLu3I="
+  },
+  "log4j#log4j/1.2.16": {
+   "jar": "sha256-euP93nqwyuRzWirsBDga2bbiXJPSQgXz7TFdmGbxL+E=",
+   "pom": "sha256-Kx6fEFXPC0pGWar0dLZehC1cHcWAtcTgI472NHDREP0="
+  },
+  "log4j#log4j/1.2.17": {
+   "jar": "sha256-HTFpZEVpdyBScJF1Q2kIKmZRvUl4G2AF3rlOVnU0Bvk=",
+   "pom": "sha256-O5Wj083TqkuRqzJ921ob/gPYHic3lONqoUQEcdXXDl4="
+  },
+  "log4j#log4j/1.2.6": {
+   "jar": "sha256-3pY5u/QXm/iA6WSfx+krj6aHUhLp0by7Wd7ocHyxeDI=",
+   "pom": "sha256-dNrNjUYw8Y2+UaFypGn9cStRq5Bea6le9jMcrG3Dh9Q="
+  },
+  "log4j#log4j/1.2.8": {
+   "jar": "sha256-wxZZWmj3vHTuCTHgxENUgc3t3JHJXSy3jq2hB8WwGmU=",
+   "pom": "sha256-6z5htd6Rw5IXfsUYFeB4ujt08CKUIXYeBz2MYTMjUF8="
+  },
+  "log4j#log4j/1.2.9": {
+   "jar": "sha256-0rnfspe8qnvh/N1wJkKpyXE9eEfcqHBOnBW9gp8Ksb8=",
+   "pom": "sha256-rE5NJGOOHa+sSYCplCpWEv+pttCCIMsyewRWXHIhJQA="
+  },
+  "logkit#logkit/1.0.1": {
+   "jar": "sha256-fqk7T8IfPQXtIksWigJfhk23Xd/dwjQ+HsKaOG11AeA=",
+   "pom": "sha256-PeMo36G1Y7pt/Fgpd0zy+Nqw3JUo7Scxw1JRq3/WxMY="
+  },
+  "maven-plugins#maven-cobertura-plugin/1.3": {
+   "pom": "sha256-XV18GU1y0xuhsfErnLhAhzyYaSF3o+uLlGrOzMJkkUw="
+  },
+  "maven-plugins#maven-findbugs-plugin/1.3.1": {
+   "pom": "sha256-LDUXXuc+EyfVsAs8fomFSpAdLT8UMBRDZoElVhULbNw="
+  },
+  "msv#msv/20020414": {
+   "jar": "sha256-aNAfixbKnNserd6pDG64DNAxIio5QU642DmevVYA27E=",
+   "pom": "sha256-VKoWsn3zxAE2nzeY8e548QPcapkv3dQqe432FxtuPg0="
+  },
+  "msv#relaxngDatatype/20030807": {
+   "jar": "sha256-TUWpPrXNwyYxlmZzyVS4P8m2CgaBu93O+ixJdtBM3fI=",
+   "pom": "sha256-ni6X5T98oTT8HqPyVMnbwnl2IQpT/qFW4DT32mzmXQo="
+  },
+  "msv#xsdlib/20030807": {
+   "jar": "sha256-J7ehwLjlyv5n+BJhbS3wmANY1frvtZNW9eoel9mOG/w=",
+   "pom": "sha256-GQdnGaJMmYeYCGIlD23NgeritPZTum7M4StDcQezTBA="
+  },
+  "net/bytebuddy#byte-buddy-agent/1.17.7": {
+   "jar": "sha256-qbqIfcolKtYbfVFTKU805vO99LJzawQ3PRNhWmlfwP8=",
+   "pom": "sha256-gU7kLWsBF/S40etrHWLBbbTAtZfYOzrY2qV4HrFF19w="
+  },
+  "net/bytebuddy#byte-buddy-agent/1.18.8": {
+   "jar": "sha256-4wNZTVl94JCry1RYCqeIR4/F5Y8lnmrpFKERXyB8Q68=",
+   "pom": "sha256-sHRrW0C9UDn3YcSvW3ny4wpd5Vf0nfE3rw2EyI3JooU="
+  },
+  "net/bytebuddy#byte-buddy-agent/1.6.5": {
+   "jar": "sha256-hAPk8aUoc7Pcd0eLtFto/E7mWRCuetuw1HyfrdZEs/o=",
+   "pom": "sha256-k8URHMZMUw8SVlQZvPmE/sASQ3L+S/GBwJ7Bx6MWBm0="
+  },
+  "net/bytebuddy#byte-buddy-agent/1.8.5": {
+   "jar": "sha256-gE4Nhb/580EQVkMYv7NOxiYExHBNvMc0Zoq9aNWMu3o=",
+   "pom": "sha256-PoOAGS2wB/vcwy2+ELycNADM3dXZKppDdq7R/YGlKpA="
+  },
+  "net/bytebuddy#byte-buddy-parent/1.17.7": {
+   "pom": "sha256-ilfiDczgDaccM+8+GdndhY/p0gQsouK8onhxcA1SaYw="
+  },
+  "net/bytebuddy#byte-buddy-parent/1.18.8": {
+   "pom": "sha256-ETFe9B64oi9hLmMJew9vrUfi0596nqy3SvXphu3e8r8="
+  },
+  "net/bytebuddy#byte-buddy-parent/1.6.5": {
+   "pom": "sha256-bdz+/XHok/TkOsbQARIk+TyHC5UoKnCcY5LWTeQ5ADg="
+  },
+  "net/bytebuddy#byte-buddy-parent/1.8.5": {
+   "pom": "sha256-yNmgc1BPOq6BeJUPtMWsicPG7Nb5M/EN5wB3+9Upehc="
+  },
+  "net/bytebuddy#byte-buddy-parent/1.9.11": {
+   "pom": "sha256-G0at+N6LuKxUc+oSMDW21u6ka8nUX/azYZjeT5kR6Oo="
+  },
+  "net/bytebuddy#byte-buddy/1.17.7": {
+   "jar": "sha256-NXXcuKmPr5Q9PBWVxHoWBHxPzoqD67smJi8aL2dUY1c=",
+   "pom": "sha256-7n+6hWnDu1wekeWBL9n0oPMb4n5WjVNU4a39GRGfl7M="
+  },
+  "net/bytebuddy#byte-buddy/1.18.8": {
+   "jar": "sha256-In0+CtUZFYCRQ/anRKwPTLIfAyFNqyjlLucAfFrX6dk=",
+   "pom": "sha256-KNSDF8boOXZoN7Ruew7Ub9hmB05LzPrJ03QbZ3hzJ8U="
+  },
+  "net/bytebuddy#byte-buddy/1.6.5": {
+   "jar": "sha256-RF6hB1TpbgsC5H7GhonnTKquum3z43cuTFqAiXXTg6U=",
+   "pom": "sha256-pCriwtikHxNCDY3r3n1wxdAZj+nhSmL2SJlzSfY+I40="
+  },
+  "net/bytebuddy#byte-buddy/1.8.5": {
+   "jar": "sha256-XN8430HSIk5mg4Ld6dhpi0Q3adjSD0ozd7ApxnGdaB4=",
+   "pom": "sha256-u87G5auj5bOW7HryeyUMa5ccyH72N5oDNOfm2hTFBuc="
+  },
+  "net/bytebuddy#byte-buddy/1.9.11": {
+   "jar": "sha256-HCvxVmc6iY4OEmAQF0LAGDHlmsuhN6vQeb9Vt/du5lk=",
+   "pom": "sha256-H1okhX1V6jBcBZeDIt37+IS1hDq7RZ/jBTYs7p5tEF4="
+  },
+  "net/java#jvnet-parent/1": {
+   "pom": "sha256-KBRAgRJo5l2eJms8yJgpfiFOBPCXQNA4bO60qJI9Y78="
+  },
+  "net/java#jvnet-parent/3": {
+   "pom": "sha256-MPV4nvo53b+WCVqto/wSYMRWH68vcUaGcXyy3FBJR1o="
+  },
+  "net/java#jvnet-parent/4": {
+   "pom": "sha256-RxOVc1VJSVKXyP+Tm5oy4IuRMCAg/3c1htJ+SXq7j7s="
+  },
+  "net/java#jvnet-parent/5": {
+   "pom": "sha256-GvaZ+Nndq2f5oNIC+9eRXrA2Klpt/V/8VMr6NGXJywo="
+  },
+  "net/java/dev/jna#jna-platform/4.5.1": {
+   "jar": "sha256-hMhmdVXujdkf70S0UUGfbxb3H3J9X8R1oQwmY+uoOrs=",
+   "pom": "sha256-r/fass5t5es1nwGSEdaYWztZCsIgGbvE5FwklA6ZXoo="
+  },
+  "net/java/dev/jna#jna/3.4.0": {
+   "jar": "sha256-O/9qFIm45UzxMDRLxeh0TbMxBFrS/HNmElduHYDrH0g=",
+   "pom": "sha256-z0YFgivVbRNd1wMWA/EioRoOx3I3P0ZqTyqsct2aF2E="
+  },
+  "net/java/dev/jna#jna/4.5.1": {
+   "jar": "sha256-+8nelqDMGToSW0AI28NI6e1U5eE/xnuO1A5kXTA8xRs=",
+   "pom": "sha256-orrgS7Rp4UITzmyUvkE2hGRuAJZa2oXsA1Y4Ab8MJAg="
+  },
+  "net/java/dev/jna#jna/4.5.2": {
+   "jar": "sha256-DI63rPZyYWVteQBRkd66ujtr9d1gpDc1okVCk4Hb7P8=",
+   "pom": "sha256-nfQrTM73BF1uT7ZLg3bdCS3XTZc3zGSVx2mO7MvTxE8="
+  },
+  "net/java/dev/jna#jna/5.11.0": {
+   "jar": "sha256-4rzpnkrv1NqwlwGaeZ0xfLO11Ww93XmExpp3Lc7tDdM=",
+   "pom": "sha256-X94a6YowvOtlFtyPfhmj7lBBQ87rmyukrhBxBd/jwyY="
+  },
+  "net/java/dev/jna#jna/5.16.0": {
+   "jar": "sha256-P1IzWJp5nrZtwpaa+jQz+1aFnT14fFi5vH3Z6G8KJQw=",
+   "pom": "sha256-9h/SxEqlg/Kiy8X8Z7DxmpIDyofV8OGNPVAwy+OQgIM="
+  },
+  "net/java/dev/jna#jna/5.18.1": {
+   "jar": "sha256-JgxLHiKx254RDuRBxPE84RX4QfpIxB14dQmGIUs5VVc=",
+   "pom": "sha256-mLYq5v8oDXR/s1n8QuSP7RE9Rbw3Kagj3DC4MIqAZkU="
+  },
+  "net/java/dev/jna#jna/5.7.0": {
+   "jar": "sha256-w04+ACzKbhlzecEFtVQlXMBjgQHtegnvADNNreABNiE=",
+   "pom": "sha256-3shrJr+W+f7VvM5M2WRoxpf8IIJBFNpB9MjJHHwuQr4="
+  },
+  "net/java/dev/jna#platform/3.4.0": {
+   "jar": "sha256-6onVCQyDA7pOmgBW5tiiBCnz4CFBHpUL/Z66O25s8Vw=",
+   "pom": "sha256-jwwU9ikSwInYE4YBXnjPIS+elvZ1s7wOUZweLZKqiVA="
+  },
+  "net/java/dev/msv#msv/2013.6.1": {
+   "pom": "sha256-wy3e52tI9Jo4wT4xxGX5mHaWfu6xfKiQFO1hQE5BSpc="
+  },
+  "net/java/dev/msv#xsdlib/2013.6.1": {
+   "jar": "sha256-YkcqIR5LmcmgU81lbpZihSFlsesjKsxCWFtxh+qtRXU=",
+   "pom": "sha256-1ug8EkQ2BJ2DI4/FMqJsXYzNfkqxDrptlgQ8hQrILzw="
+  },
+  "net/jodah#failsafe/2.4.4": {
+   "jar": "sha256-rD+RblNtuaafk3Bvd46Q4r5Ha96+oMRcym2Wde6Z7DA=",
+   "pom": "sha256-UzEN+yfGV3Wq9d5TKaL2+HNVBjaEYZD3cmHLy/KAf1o="
+  },
+  "net/jpountz/lz4#lz4/1.3.0": {
+   "jar": "sha256-uHek1KOgFASG09D4PZBY58D/bKgLANL3t3FFk1s4W1Y=",
+   "pom": "sha256-aHFQYx7Z3AwEIJHhLO6inGuFYNeXPBAs+Ta0KNHbfOg="
+  },
+  "net/sf/ehcache#ehcache-parent/2.22": {
+   "pom": "sha256-B4P76pwehqGUml4BP1h9v547/P2bCNszn2aHaZejMwM="
+  },
+  "net/sf/ehcache#ehcache-root/2.10.6": {
+   "pom": "sha256-vHBpu4QxQj8SSZD/mg7306OdHhRkeZz8XzNfwdJPVYc="
+  },
+  "net/sf/ehcache#ehcache/2.10.6": {
+   "jar": "sha256-xv9m9t4sWkmoNQ0DYhIWa9TZCJkwkrgnNoYEGohoOvY=",
+   "pom": "sha256-EkdZlhfvqrCb0b1fnN+vi1d+z+PcSAq/odKnwphr5iY="
+  },
+  "net/sf/kxml#kxml2-min/2.3.0": {
+   "jar": "sha256-EuoYiBssAhItBIvYpPc+DzsQ8SaUIgeJ2xDWSx9g500=",
+   "pom": "sha256-3ga+PVYBx6FVknDUBe47zMR4iTIVMGbwWj11LjE4XoY="
+  },
+  "net/sf/kxml#kxml2/2.2.2": {
+   "jar": "sha256-1QyPkkGSXMIv4GoO8MI9efGROCQ6qhNQ35h1L5I5l4Q=",
+   "pom": "sha256-v4nJY6tMpCpUmBFzThKukA+3Zftl7VC6SQnFf3USISU="
+  },
+  "net/sf/kxml#kxml2/2.3.0": {
+   "jar": "sha256-8mTdn3mh/eEM5ezFMiHv8kvkyTMcgwt9UvLwintjPeI=",
+   "pom": "sha256-Mc5gb06VGJNimbsNJ8l4+mHhhf0d58mHT+lZpT40poU="
+  },
+  "net/sf/saxon#Saxon-HE/12.9": {
+   "jar": "sha256-jzqSFqU3NnEyKT6su6nfBi6s6PixahhK9Z4uSDnUzUE=",
+   "pom": "sha256-+IDp0dQAyZwYkvWWTl/JIN0d7wViI1m5sFjzK1tCaXU="
+  },
+  "org/antlr#antlr4-master/4.13.2": {
+   "pom": "sha256-Ct2gJmhYc/ZRNgF4v/xEbO7kgzCBc5466dbo8H6NkCo="
+  },
+  "org/antlr#antlr4-runtime/4.13.2": {
+   "jar": "sha256-3T6KE6LWab+E+42DTeNc5IdfJxV2mNIGJB7ISIqtyvc=",
+   "pom": "sha256-A84HonlsURsMlNwU/YbM3W44KMV5Z60jg94wTg0Runk="
+  },
+  "org/apache#apache/1": {
+   "pom": "sha256-Gnh6bkCFbIvv4eNfY4gBJtnUHXpu1MDjQIQC+FBysPs="
+  },
+  "org/apache#apache/13": {
+   "pom": "sha256-/1E9sDYf1BI3vvR4SWi8FarkeNTsCpSW+BEHLMrzhB0="
+  },
+  "org/apache#apache/15": {
+   "pom": "sha256-NsLy+XmsZ7RQwMtIDk6br2tA86aB8iupaSKH0ROa1JQ="
+  },
+  "org/apache#apache/16": {
+   "pom": "sha256-n4X/L9fWyzCXqkf7QZ7n8OvoaRCfmKup9Oyj9J50pA4="
+  },
+  "org/apache#apache/18": {
+   "pom": "sha256-eDEwcoX9R1u8NrIK4454gvEcMVOx1ZMPhS1E7ajzPBc="
+  },
+  "org/apache#apache/19": {
+   "pom": "sha256-kfejMJbqabrCy69tAf65NMrAAsSNjIz6nCQLQPHsId8="
+  },
+  "org/apache#apache/21": {
+   "pom": "sha256-rxDBCNoBTxfK+se1KytLWjocGCZfoq+XoyXZFDU3s4A="
+  },
+  "org/apache#apache/23": {
+   "pom": "sha256-vBBiTgYj82V3+sVjnKKTbTJA7RUvttjVM6tNJwVDSRw="
+  },
+  "org/apache#apache/29": {
+   "pom": "sha256-PkkDcXSCC70N9jQgqXclWIY5iVTCoGKR+mH3J6w1s3c="
+  },
+  "org/apache#apache/3": {
+   "pom": "sha256-OTxQr7S3qm61flN3pVoaBhCxn3W1Ls4BMI2wShGHog4="
+  },
+  "org/apache#apache/30": {
+   "pom": "sha256-Y91KOTqcDfyzFO/oOHGkHSQ7yNIAy8fy0ZfzDaeCOdg="
+  },
+  "org/apache#apache/31": {
+   "pom": "sha256-VV0MnqppwEKv+SSSe5OB6PgXQTbTVe6tRFIkRS5ikcw="
+  },
+  "org/apache#apache/33": {
+   "pom": "sha256-14vYUkxfg4ChkKZSVoZimpXf5RLfIRETg6bYwJI6RBU="
+  },
+  "org/apache#apache/34": {
+   "pom": "sha256-NnGunU0GKuO7mFcxx2CIuy9vfXJU4tME7p9pC5dlEyg="
+  },
+  "org/apache#apache/35": {
+   "pom": "sha256-6il9zRFBNui46LYwIw1Sp2wvxp9sXbJdZysYVwAHKLg="
+  },
+  "org/apache#apache/4": {
+   "pom": "sha256-npMjomuo6yOU7+8MltMbcN9XCAhjDcFHyrHnNUHMUZQ="
+  },
+  "org/apache#apache/5": {
+   "pom": "sha256-GTOmA3Q5s4m9ov6sz8AROID9jYj30kDSBSuREI3Vrok="
+  },
+  "org/apache#apache/6": {
+   "pom": "sha256-Eu21CW4T9Aw2LQvUCQJYn6lYZQUSP6Jnmc5QsRb6W7M="
+  },
+  "org/apache#apache/7": {
+   "pom": "sha256-E5fOHbQzrcnyI9vwdJbRM2gUSHUfSuKeWPaOePtLbCU="
+  },
+  "org/apache#apache/9": {
+   "pom": "sha256-SUbmClR8jtpp87wjxbbw2tz4Rp6kmx0dp940rs/PGN0="
+  },
+  "org/apache/ant#ant-antlr/1.8.4": {
+   "jar": "sha256-wky4SMDAd8E/HbbshT4ZiN2wUl0+SeaiwMRHktEEU3I=",
+   "pom": "sha256-Bt2pvfO5N0LdWTIIb3NKyQqtP20Tb2ztqD6m9mTILxM="
+  },
+  "org/apache/ant#ant-antlr/1.9.4": {
+   "jar": "sha256-zu/vuhigd6Tm1SukS8E2osydTZqFsyKSVJnQbmBdX00=",
+   "pom": "sha256-AHAzomwJbGPoWq/ZUbEzjCkpsmIJPN5PemrtlT5riPc="
+  },
+  "org/apache/ant#ant-junit/1.8.4": {
+   "jar": "sha256-ADPN6WDRXQ8Ch0XQVZky1YvtAHmL20nfLjKdZWeZeEA=",
+   "pom": "sha256-xNv7qZZyGAP+WHn4UrvBv5XcRYjIrhLWhm8Cs178oBI="
+  },
+  "org/apache/ant#ant-junit/1.9.4": {
+   "jar": "sha256-eKAzHAPSJARiPtUz/e8C1fXqCUFQUw/Ml9y3gpCKnwo=",
+   "pom": "sha256-rJRaRfMzBEVM+tcGGkxGnVxcYSECx3Z7DFAQNsdaMq4="
+  },
+  "org/apache/ant#ant-launcher/1.7.0": {
+   "jar": "sha256-crPQPg19hqVlE+w43UzWq+PaZiAYm+IiqyVTUstuuko=",
+   "pom": "sha256-0p0myykG6cOYOBvUhz7KuwTWMO9hNDXssUmoWirvyvQ="
+  },
+  "org/apache/ant#ant-launcher/1.7.1": {
+   "jar": "sha256-JetZJsl1rG9BJv7rnQBPU/nr8H3BF/XbmVimv7MRB4M=",
+   "pom": "sha256-FxZqkci30Kh9pWNCZiuZA2BUxydyLjlJJY4vtVltezg="
+  },
+  "org/apache/ant#ant-launcher/1.8.4": {
+   "jar": "sha256-Q5SVHo2FM3Mr9XRfTnv/pyEijH1UdaLV8UPLNe2cKUE=",
+   "pom": "sha256-ANtTWjWQlZniVM64rj4IluObR0jm5Ve/FURxJopDsTU="
+  },
+  "org/apache/ant#ant-launcher/1.9.4": {
+   "jar": "sha256-e8zqILQYAcoXvLyQmnjINdD0Q/EtY5x3vWrj0FhhYI0=",
+   "pom": "sha256-yRk+1gCtxseUOmxtxr2VLty18Q+yzaWUtxmXZv3u9pg="
+  },
+  "org/apache/ant#ant-nodeps/1.7.1": {
+   "jar": "sha256-5baKwBwuoVfJSFSw12xvCfkONsrcyBrjUeBcrHYXVHI=",
+   "pom": "sha256-lMWXsMTLw3WGbyrQFIk6UiLhwFRFi7Wtn+hCzqusC1g="
+  },
+  "org/apache/ant#ant-parent/1.7.0": {
+   "pom": "sha256-GlLYNxpsvG4F7b8CZGcXEX3SNERZvulnAU8EH9zzCJM="
+  },
+  "org/apache/ant#ant-parent/1.7.1": {
+   "pom": "sha256-z9CX1uuetTBvQVXo/39PeARGGQN6EP/FSV4xNC2H6mA="
+  },
+  "org/apache/ant#ant-parent/1.8.4": {
+   "pom": "sha256-vcUEkR6uTeSE1a/gzcmlctQmdcb1xNldPJX6gFrsgH8="
+  },
+  "org/apache/ant#ant-parent/1.9.4": {
+   "pom": "sha256-qTqpxmZlhysOUTYMFa4oKXHjaoqph7QO9NgtmlqhUcQ="
+  },
+  "org/apache/ant#ant-trax/1.7.1": {
+   "jar": "sha256-MyXIkSSKQBKX9RwE+Upq/2DwoRgRwLwsWZzqqpPgXec=",
+   "pom": "sha256-6el2E1gMO2hSB5eXPhkftfmjW9oOfxIFDC3lvJJjMiI="
+  },
+  "org/apache/ant#ant/1.7.0": {
+   "jar": "sha256-kvcjB+dEDx41LJFvJDjSu6s//Sz3MMcTFhF60Eq63qg=",
+   "pom": "sha256-fAIXQD9XogDLgNSJiSzgTqdi8qEzq+PdOEcGUUNM+vI="
+  },
+  "org/apache/ant#ant/1.7.1": {
+   "jar": "sha256-6+WSya+f22xV8ObG+rx29uDuyO/exTU5jobDqINofr8=",
+   "pom": "sha256-osMPlvHZ6beGa5cfDNPmAFTIAVl3HNsJfBcFeAwAloU="
+  },
+  "org/apache/ant#ant/1.8.4": {
+   "jar": "sha256-/8WBjKjN4u0RHZ1sZ2PTAUKa2Yl1gvCWi4DBoTbp26Q=",
+   "pom": "sha256-saa0ySl4FnCgog3F1rYxnzh7hz5dcZ0Gikq2GcupPvg="
+  },
+  "org/apache/ant#ant/1.9.4": {
+   "jar": "sha256-ZJrgcwJR3ge4kT9JKG1Gu6e5LUfF8zJhCqQmxPAhYdg=",
+   "pom": "sha256-XOI6GPKNBL41H4YwINoBNiFCGK+s4FVgUWuXVVpQd/0="
+  },
+  "org/apache/commons#commons-collections4/4.4": {
+   "jar": "sha256-Hfi5QwtcjtFD14FeQD4z71NxskAKrb6b2giDdi4IRtE=",
+   "pom": "sha256-JxvWc4Oa9G5zr/lX4pGNS/lvWsT2xs9NW+k/0fEnHE0="
+  },
+  "org/apache/commons#commons-compress/1.18": {
+   "jar": "sha256-Xy3x5GeCXkysWZbUSJDEIBwAC0PAsjz/wHgtKKC+ubA=",
+   "pom": "sha256-Zyxf6SvT6rQ+jVMzjK1coHO2Up3k6ys4hZo+qmyegRk="
+  },
+  "org/apache/commons#commons-compress/1.19": {
+   "jar": "sha256-/y1Z+tdOhnYw+8faqxTEMmVHEqxiTb7kaNIgZ3sSTdU=",
+   "pom": "sha256-nVppDR3qanR+DdjnTmREcWfzlcuPFIAQuCQTNPWLUls="
+  },
+  "org/apache/commons#commons-compress/1.28.0": {
+   "jar": "sha256-4VIpRSGEVvNkmjm8Sv1wzkvUZiIVGdun03jyFBpGQso=",
+   "pom": "sha256-Az9MeNYy2ojQ646tl0/BSiZDks6/EqtsaNbOp63wxko="
+  },
+  "org/apache/commons#commons-csv/1.14.1": {
+   "jar": "sha256-Mr4OHnZnMJL10Sy3kL0qy2wqsExOpu/GnqXuF5EcJP4=",
+   "pom": "sha256-ld9zUwLAq5LOwForUeInB1jhXwpkGG3mVmLrFI69l/0="
+  },
+  "org/apache/commons#commons-csv/1.6": {
+   "jar": "sha256-fRVg/iw1ZBKPL/P3wPyfBmZziqDnBPPXi4lU+eDsOt8=",
+   "pom": "sha256-DDVY6Nz+AQ7o8afv9D3/BQlnKMfF4/kC0cTCwmikN2E="
+  },
+  "org/apache/commons#commons-csv/1.7": {
+   "jar": "sha256-JfXnkUcpo8ucu4ORi18RFmJcymPOOKUPD+WW+De5pSQ=",
+   "pom": "sha256-e+EjHW19bNw/sBB32+GLAVQ4XSrfALfGY46o+yn1JFU="
+  },
+  "org/apache/commons#commons-jexl/2.1.1": {
+   "jar": "sha256-A8mp+uXaeM5SwL8kRnzDc1W34jGW3/SDniwP8BigEwY=",
+   "pom": "sha256-rXwKqnzmeFCcyZx5v/Esn1m6oqAtnOiRmcoKLOTYuQc="
+  },
+  "org/apache/commons#commons-lang3/3.12.0": {
+   "jar": "sha256-2RnZBEhsA3+NGTQS2gyS4iqfokIwudZ6V4VcXDHH6U4=",
+   "pom": "sha256-gtMfHcxFg+/9dE6XkWWxbaZL+GvKYj/F0bA+2U9FyFo="
+  },
+  "org/apache/commons#commons-lang3/3.13.0": {
+   "jar": "sha256-gvUoz3GMejwvMPxbx4TjxqChCxdgXa254WyC7eEeYGQ=",
+   "pom": "sha256-/3zqTrI53WIRdRDavlGo1fDJ5MxCa8PowsIhpxj4ZIQ="
+  },
+  "org/apache/commons#commons-lang3/3.18.0": {
+   "jar": "sha256-Tu6ujSDAeKu2SwFewVit04OsWBVxzdxFxo8MmuAjByA=",
+   "pom": "sha256-qiVLNztvbUa8ncqGMxsHKoq4brJeqZIf1Dlhg5LpihY="
+  },
+  "org/apache/commons#commons-lang3/3.20.0": {
+   "jar": "sha256-aeXJ+jXaelGl/SCZ3+VqLY0yzyM+L213DnlhRkQCY/Q=",
+   "pom": "sha256-fKg7JwnB56ngO1ds1BQiGQN5SJqAhm5UL4yLlVQRoqo="
+  },
+  "org/apache/commons#commons-lang3/3.8.1": {
+   "jar": "sha256-2sgH9lsHaY/zmxsHv+89h64/1G2Ru/iivAKyqDFhb2g=",
+   "pom": "sha256-7I4J91QRaFIFvQ2deHLMNiLmfHbfRKCiJ7J4vqBEWNU="
+  },
+  "org/apache/commons#commons-math3/3.6.1": {
+   "jar": "sha256-HlbXsFjSi2Wr0la4RY44hbZ0wdWI+kPNfRy7nH7yswg=",
+   "pom": "sha256-+tcjNup9fdBtoQMUTjdA21CPpLF9nFTXhHc37cJKfmA="
+  },
+  "org/apache/commons#commons-parent/11": {
+   "pom": "sha256-ueAwbzk0YBBbij+lEFJQxSkbHvqpmVSs4OwceDEJoCo="
+  },
+  "org/apache/commons#commons-parent/14": {
+   "pom": "sha256-JPLlK95l4tyc/Ouy/CLY3g7bNyaSXM+AsT207rUVowI="
+  },
+  "org/apache/commons#commons-parent/17": {
+   "pom": "sha256-lucYuvU0h07mLOTULeJl8t2s2IORpUDgMNWdmPp8RAg="
+  },
+  "org/apache/commons#commons-parent/20": {
+   "pom": "sha256-7cEfBOcgFjBhzYgsILqRscOuGlmwx5ypcTN2UzVkIVs="
+  },
+  "org/apache/commons#commons-parent/21": {
+   "pom": "sha256-JDheHi6oWwZGvI5IPraHc6DEgEm28GhMnwkdevaO8ek="
+  },
+  "org/apache/commons#commons-parent/22": {
+   "pom": "sha256-+4xeVeMKet20/yEIWKDo0klO1nV7vhkBLamdUVhsPLs="
+  },
+  "org/apache/commons#commons-parent/23": {
+   "pom": "sha256-rxBTFUEEUtEBbap8I9BMHAoAFr5QT4/ivEQez59Mc3s="
+  },
+  "org/apache/commons#commons-parent/28": {
+   "pom": "sha256-FHM6aOixILad5gzZbSIhRtzzLwPBxsxqdQsSabr+hsc="
+  },
+  "org/apache/commons#commons-parent/34": {
+   "pom": "sha256-Oi5p0G1kHR87KTEm3J4uTqZWO/jDbIfgq2+kKS0Et5w="
+  },
+  "org/apache/commons#commons-parent/35": {
+   "pom": "sha256-cJihq4M27NTJ3CHLvKyGn4LGb2S4rE95iNQbT8tE5Jo="
+  },
+  "org/apache/commons#commons-parent/39": {
+   "pom": "sha256-h80n4aAqXD622FBZzphpa7G0TCuLZQ8FZ8ht9g+mHac="
+  },
+  "org/apache/commons#commons-parent/42": {
+   "pom": "sha256-zTE0lMZwtIPsJWlyrxaYszDlmPgHACNU63ZUefYEsJw="
+  },
+  "org/apache/commons#commons-parent/45": {
+   "pom": "sha256-nIhiPs+pHwEsZz7kYiwO60Nn5eDSItlg92zSCLGk/aY="
+  },
+  "org/apache/commons#commons-parent/47": {
+   "pom": "sha256-io7LVwVTv58f+uIRqNTKnuYwwXr+WSkzaPunvZtC/Lc="
+  },
+  "org/apache/commons#commons-parent/48": {
+   "pom": "sha256-Hh996TcKe3kB8Sjx2s0UIr504/R/lViw954EwGN8oLQ="
+  },
+  "org/apache/commons#commons-parent/5": {
+   "pom": "sha256-i9YywAvfgKfeNsIrYPEkUsFH2Oyi8A151maZ6+faoCo="
+  },
+  "org/apache/commons#commons-parent/52": {
+   "pom": "sha256-ddvo806Y5MP/QtquSi+etMvNO18QR9VEYKzpBtu0UC4="
+  },
+  "org/apache/commons#commons-parent/58": {
+   "pom": "sha256-LUsS4YiZBjq9fHUni1+pejcp2Ah4zuy2pA2UbpwNVZA="
+  },
+  "org/apache/commons#commons-parent/64": {
+   "pom": "sha256-bxljiZToNXtO1zRpb5kgV++q+hI1ZzmYEzKZeY4szds="
+  },
+  "org/apache/commons#commons-parent/81": {
+   "pom": "sha256-NI1OfBMb5hFMhUpxnOekQwenw5vTZghJd7JP0prQ7bQ="
+  },
+  "org/apache/commons#commons-parent/84": {
+   "pom": "sha256-kjn7lxAdsnBw5Jg9ENM6DpHPZ2ytkb9TgVQiw1Ye+bE="
+  },
+  "org/apache/commons#commons-parent/85": {
+   "pom": "sha256-0Yn/LAAn6Wu2XTHm8iftKvlmFps2rx6XPdW6CJJtx7U="
+  },
+  "org/apache/commons#commons-parent/9": {
+   "pom": "sha256-UzG30+Cu1ZcoyA8RGOTb94Vl1BCegdFmAsnK29sjoSg="
+  },
+  "org/apache/commons#commons-parent/92": {
+   "pom": "sha256-lPbAJ7FfZAKZXdGyx+o1v+HryItoMrMTQ2i0GZhyGVM="
+  },
+  "org/apache/commons#commons-text/1.11.0": {
+   "jar": "sha256-Ks8woHCxkWPVpIDq5BGigTQehwAg41NMbV1MhHJznjA=",
+   "pom": "sha256-O0AZecBkEoXYUM8Ri04Y8EmsIj3Hherk0LNXKPxTTRE="
+  },
+  "org/apache/commons#commons-text/1.3": {
+   "jar": "sha256-gYWzpTEQktg+0fGEwtCTsxBdcmu9doZ8MrNRFUK7mag=",
+   "pom": "sha256-3usrqXAeSV3DHTJjPrhrlLJLCpbg3Gf7h+cGLxUwJ6o="
+  },
+  "org/apache/commons#commons-vfs2-project/2.0": {
+   "pom": "sha256-wHAvebBW0ptCdtzZy9KiEaJ2pKeNJAqq6uOFsVddPz4="
+  },
+  "org/apache/commons#commons-vfs2/2.0": {
+   "jar": "sha256-WvN7xH9rzOlOdAuXkxFf8TXdpU+cz5jgV5OMLJh2X00=",
+   "pom": "sha256-6lENrZAoUmQcKd4E+55rQHmI0C8qWn+a/9qlVNdKDc8="
+  },
+  "org/apache/felix#felix-parent/1.2.0": {
+   "pom": "sha256-aBxM+iH1tsF7vuRKG9hL7fOJk22jsGFqhd5Rlf8h50M="
+  },
+  "org/apache/felix#felix-parent/6": {
+   "pom": "sha256-Ngi2sgD2yPSIx3zBWYR9UV5pZugzO4XY4E45Sgk7VZU="
+  },
+  "org/apache/felix#felix-parent/7": {
+   "pom": "sha256-awCuFheRYztQ4CA9r45aeSzTGchG3fWgAhjlUINvaVc="
+  },
+  "org/apache/felix#felix-parent/8": {
+   "pom": "sha256-wGLQC5PeBQmOCOMI1geSrl3SpB0XEaB9woU7nCKw2Lg="
+  },
+  "org/apache/felix#felix-parent/9": {
+   "pom": "sha256-zFjbS1HkV+GmkvkgdMTHnwYM/NqiTRsa4UwDM9qFEoI="
+  },
+  "org/apache/felix#felix/1.0.0": {
+   "pom": "sha256-TIZhxJ8XzFYmrHadjsVcKHuggFFUKvay9mVpUJdA4hA="
+  },
+  "org/apache/felix#felix/1.0.2": {
+   "pom": "sha256-kNdLQvBLf1DR3seoxmy844V3gXMAPIF8WK4HcyN/HzY="
+  },
+  "org/apache/felix#javax.servlet/1.0.0": {
+   "jar": "sha256-U7zkvSynalSwIZiFT6pqtXe89Mj1ozxAb23ni5aGEhk=",
+   "pom": "sha256-OlEnMo4Cu8EGuSrhKxS1K4MjApv59SVuKK6EV7XLHUs="
+  },
+  "org/apache/felix#org.apache.felix.configadmin/1.9.26": {
+   "jar": "sha256-U4aKWBk4lpUG4gj+CWsNNZJArjWPFPl5s/VzrvMK8JQ=",
+   "pom": "sha256-mW6jdcM5iWd2afGmu9KaLOIZC1CzVrz+MDi3uA+Ou80="
+  },
+  "org/apache/felix#org.apache.felix.eventadmin/1.6.4": {
+   "jar": "sha256-BqsnN1Q9fquTK9wgp64Nrb2QL9bmh6lYct1X94s3VVw=",
+   "pom": "sha256-tD+utWpzOEPYNSBOAiuPLw2WC8ODAB/fTwSxKqtxdEc="
+  },
+  "org/apache/felix#org.apache.felix.fileinstall/3.7.4": {
+   "jar": "sha256-MsjWq23t3eC2veCOke54EX5mUYzm92+svqUw3/ZYpzM=",
+   "pom": "sha256-Jz57p9y9gtS1KulcblheM1/TeuuaKSUj/8ckmswq/aA="
+  },
+  "org/apache/felix#org.apache.felix.framework/7.0.5": {
+   "jar": "sha256-q6cpMsX/5S0a6ftzVBVHS8gwX9BPBQ6FHzqPZ9oYNP0=",
+   "pom": "sha256-CBAm1JP4dt+OsPPxyPhdpyy+N99VeDPpaLQMMNrL/Kk="
+  },
+  "org/apache/felix#org.apache.felix.http.base/5.1.16": {
+   "jar": "sha256-juq1JlTMoa8mIjA+pzYCHMP2VcU0nyOnepOhpOW1/BE=",
+   "pom": "sha256-EJDA5cStAsxGvIieVKClABRapYzPAdiwNiFOcA1dKmc="
+  },
+  "org/apache/felix#org.apache.felix.http.jetty12/1.1.8": {
+   "jar": "sha256-YxhlqpBir6x8umU2KCbSpCxghJbkEO0Y0P10m6nBZLE=",
+   "pom": "sha256-jNFk7f/gVFvtWn+wIB34U4EBCdJfZcHHzJ2d/S0QT90="
+  },
+  "org/apache/felix#org.apache.felix.http.servlet-api/6.1.0": {
+   "jar": "sha256-jsa20SnKLPfAnzMpQNYC9J+eXEwx+ll+bvEyOGt5QWk=",
+   "pom": "sha256-bslmnhefjS96XpgFsztSqcVyUJ+p0OoWJ7/2cS8dRr4="
+  },
+  "org/apache/felix#org.apache.felix.http.wrappers/6.1.0": {
+   "jar": "sha256-CBqPNMmEROqien7iWsuWVaDSNUDK5ppkxApxfTAUAgk=",
+   "pom": "sha256-UNpSUOM8Yd0Fz/huIyvttCFrjA5uiO8DlDcZggmhXIw="
+  },
+  "org/apache/felix#org.apache.felix.inventory/2.0.0": {
+   "jar": "sha256-Mutjesp6MVJjPSEMNu83dZIJ1YyGoQ9jcNhH3+DINJ4=",
+   "pom": "sha256-h/E8gLEqE/rVt+my7o7T8ePD3tpEeM93Y5X+LRrUE+I="
+  },
+  "org/apache/felix#org.apache.felix.metatype/1.2.4": {
+   "jar": "sha256-7ya/kwFvRiI0cKtWYYK+Wp/jTGhD7+kpRaZZLae8Y4Y=",
+   "pom": "sha256-gFwYqxRV+CdoebZ6EpMS5yrG01w2ZP3xxJrKDgJS0x4="
+  },
+  "org/apache/felix#org.apache.felix.scr/2.2.18": {
+   "jar": "sha256-xb2IfI/V7EzVYySedVK7GhocpX4FofHvhCWnt7e9L74=",
+   "pom": "sha256-x9lBVXht4K/qgLjFM08mN2h2WLu+SIEVR7L5tTybAbU="
+  },
+  "org/apache/felix#org.apache.felix.webconsole.plugins.ds/2.3.0": {
+   "jar": "sha256-yrxfrU8xsPGKu758nqN2iSGQlpGPDcrnZu6Pikd3nj4=",
+   "pom": "sha256-vyHsa8aQCwWCGuJ70mxIM6egC1q//spZ4OedqkgVM6A="
+  },
+  "org/apache/felix#org.apache.felix.webconsole/5.0.18": {
+   "jar": "sha256-8PvTUDga2umZMww7L78BmmxJj6+ryrScXuNNrNCGk/4=",
+   "pom": "sha256-gTFvALrjBbB0dckcgkjkcMPfJpOGB3eMOLpr2fEUSC8="
+  },
+  "org/apache/felix#org.osgi.compendium/1.4.0": {
+   "jar": "sha256-lG+PzuIBLwO4A3CcZTvjVTSkU4fK9TeyBh5rO4tv2Q4=",
+   "pom": "sha256-VVXsIxOsd3Y6mH4SJJfDWsFJN3q1cg3njMURM6+7Wsg="
+  },
+  "org/apache/felix#org.osgi.core/1.4.0": {
+   "jar": "sha256-oRzUlCKIN6k+2ACpJwe/hvdisD+FYZ/KPPLKCkuS9Pg=",
+   "pom": "sha256-w4A8hCHbXBDIw8HZre2zsCBfJfFrk4npH2lh5KCzaS4="
+  },
+  "org/apache/felix#org.osgi.foundation/1.2.0": {
+   "jar": "sha256-pKVqRz9L5U377dICl+VjsMmCNKS+QrMthBlRIWinHrc=",
+   "pom": "sha256-R8P6ojMBYs45kn8yP19ITjlqv9kVzX783eBC+IgJ0PA="
+  },
+  "org/apache/geronimo/genesis#genesis-default-flava/2.0": {
+   "pom": "sha256-CObhRvTiRSZt/53YALEodd0jZ9P2ejSrZgoSbIESFfg="
+  },
+  "org/apache/geronimo/genesis#genesis-java5-flava/2.0": {
+   "pom": "sha256-58U1i7u8J9qlsyf2O8EmUKdd3J+axtS/oSeJvh8sKds="
+  },
+  "org/apache/geronimo/genesis#genesis/2.0": {
+   "pom": "sha256-ue0vndQ0YxFY13MI7lZIYiwinM7OFyLF43ekKWkj2uY="
+  },
+  "org/apache/geronimo/specs#geronimo-jms_1.1_spec/1.0": {
+   "jar": "sha256-KTGAr+1HpydrIYDNN7ryyJ1BRSuYLYubEfsCcTA+G8E=",
+   "pom": "sha256-ySK4WUSVvIMxOB0JQJhRluXo8gHlo6i2a/rRgIU3If8="
+  },
+  "org/apache/httpcomponents#httpasyncclient/4.1.4": {
+   "jar": "sha256-UOmBqOVnoW69rRBGBbFWVAqGNFn6EnuLpkfzEN/IPvg=",
+   "pom": "sha256-NPJO+Ya4nVG4CgkDh6o9DIJNQPCHrlzPrUf/PCYsLkc="
+  },
+  "org/apache/httpcomponents#httpclient/4.5.12": {
+   "jar": "sha256-vF8GWrpd2BXuVZ3STZvLeX+xAv+c+gNvUJHrxSm9O5M=",
+   "pom": "sha256-QZrRskp3uqIoirYK4Fe0z3jbwsEdJ8cgTVy2d5pFFSc="
+  },
+  "org/apache/httpcomponents#httpclient/4.5.13": {
+   "jar": "sha256-b+kCalZsalABYIzz/DIZZkH2weXhmG0QN8zb1fMe90M=",
+   "pom": "sha256-eOua2nSSn81j0HrcT0kjaEGkXMKdX4F79FgB9RP9fmw="
+  },
+  "org/apache/httpcomponents#httpclient/4.5.6": {
+   "jar": "sha256-wD+BMZXnqA42CNDd2NqAshaWpMkqaiKYhlvxSQcVUcc=",
+   "pom": "sha256-fvwSQec+f7smi/0zJC0R69PKBwYdfYXyli3DKg8LiFU="
+  },
+  "org/apache/httpcomponents#httpcomponents-asyncclient/4.1.4": {
+   "pom": "sha256-6WXrNprx2LWmi31LeGHVOlJhaugD4TFi6N+EImFwAYA="
+  },
+  "org/apache/httpcomponents#httpcomponents-client/4.5.12": {
+   "pom": "sha256-j4iaU1k8AnvqAD/b6JOZVG177vofYOF1YBXxD1ArAWo="
+  },
+  "org/apache/httpcomponents#httpcomponents-client/4.5.13": {
+   "pom": "sha256-nLpZTAjbcnHQwg6YRdYiuznmlYORC0Xn1d+C9gWNTdk="
+  },
+  "org/apache/httpcomponents#httpcomponents-client/4.5.6": {
+   "pom": "sha256-sEK0HyOR7bANNff05Qmu0hI2SMHSRs5Y0Pe5Bcn+H3M="
+  },
+  "org/apache/httpcomponents#httpcomponents-core/4.4.10": {
+   "pom": "sha256-YelCfUvjJsMHp/FrqCjRyzsUcTybBPyLqZKljzdsMTY="
+  },
+  "org/apache/httpcomponents#httpcomponents-core/4.4.13": {
+   "pom": "sha256-xVTnAI5FF8fvVOAFzIt09Mh6VKDqLG9Xvl0Fad9Rk2s="
+  },
+  "org/apache/httpcomponents#httpcomponents-core/4.4.14": {
+   "pom": "sha256-IJ7ZMctXmYJS3+AnyqnAOtpiBhNkIylnkTEWX4scutE="
+  },
+  "org/apache/httpcomponents#httpcomponents-parent/10": {
+   "pom": "sha256-yq+WfZSvshdT82CCxghiBr0fSIJf9ZaTLM66crZdOfo="
+  },
+  "org/apache/httpcomponents#httpcomponents-parent/11": {
+   "pom": "sha256-qQH4exFcVQcMfuQ+//Y+IOewLTCvJEOuKSvx9OUy06o="
+  },
+  "org/apache/httpcomponents#httpcore-nio/4.4.10": {
+   "jar": "sha256-3r7n6VcsAqFs4Mqk9WWp7OsSkNM816HjKXCHvUZ9r/Q=",
+   "pom": "sha256-pMmVtzjRBLdcyLEWTbYAUzFWwEfsy0yO5dknshoX7HM="
+  },
+  "org/apache/httpcomponents#httpcore/4.4.10": {
+   "jar": "sha256-eLoQllYZV9sbVSAKFZtkiHZDA0LRXUYSd+YjYNoZ9v0=",
+   "pom": "sha256-xcEgZt8rO4iomiyGArgeqaYWJ+l25RKe6hiZ67rqOSs="
+  },
+  "org/apache/httpcomponents#httpcore/4.4.13": {
+   "jar": "sha256-4G6J1AlDJF/Po57FN82/zjdirs3o+cWXeA0rAMK0NCQ=",
+   "pom": "sha256-j4Etn6e3Kj1Kp/glJ4kypd80S0Km2DmJBYeUMaG/mpc="
+  },
+  "org/apache/httpcomponents#httpcore/4.4.14": {
+   "jar": "sha256-+VYgnkUMsdDFF3bfvSPlPp3Y25oSmO1itwvwlEumOyg=",
+   "pom": "sha256-VXFjmKl48QID+eJciu/AWA2vfwkHxu0K6tgexftrf9g="
+  },
+  "org/apache/httpcomponents#project/7": {
+   "pom": "sha256-PW66QoVVpVjeBGtddurMH1pUtPXyC4TWNu16/xiqSMM="
+  },
+  "org/apache/ivy#ivy/2.2.0": {
+   "jar": "sha256-nQpWAmaAmZmGyjPVPRLW8o97/148nm4MZjOjZ3ygDxg=",
+   "pom": "sha256-g0ov+TFyjkI+JhkJs9UknqTJJ4H7uughRqgPFE6QcEE="
+  },
+  "org/apache/ivy#ivy/2.4.0": {
+   "jar": "sha256-zoHLI0QGsJO1uN6fb1sqUO0IJNaiNYkTU+jT6UGlOXA=",
+   "pom": "sha256-9dXPwEmY2gcwC2LT27XjiM+wQ/2GwV0REUTsrkY+KnM="
+  },
+  "org/apache/jackrabbit#jackrabbit-jcr-commons/1.5.2": {
+   "jar": "sha256-faMV/NGf2FCtoQWZeCAEDrfLWAlnI6pNPweY0mxcuoY=",
+   "pom": "sha256-HE42OXwxCWivVCxQiofZD73p98bxZwBdiIiHnub/MBM="
+  },
+  "org/apache/jackrabbit#jackrabbit-parent/1.5.0": {
+   "pom": "sha256-5WXkNsMXRhqdsg1zrj690S10GGEwAsCFv78DlwkLYds="
+  },
+  "org/apache/jackrabbit#jackrabbit-webdav/1.5.2": {
+   "jar": "sha256-sJc40UvoUFk1gMu8+WLEIMEG3czV3C1GIh9UArth7ak=",
+   "pom": "sha256-VvbVACoIK1rIC0CZ6rqBtXS9jN8ZK+p/tO1sAR+eD9c="
+  },
+  "org/apache/kafka#connect-api/2.5.0": {
+   "jar": "sha256-V4jVry3Zqq49OhKrA2K6Hc1svCokKw/nVAlcGS7Tkg4=",
+   "pom": "sha256-xMDvmjUhXPLj0Q/KVG126laFsyL+C2yhmEDtzejpj5I="
+  },
+  "org/apache/kafka#connect-json/2.5.0": {
+   "jar": "sha256-I45XFlA6NQQKELCQ2HxTQcMIiwHndVnX9XM/v0alnXY=",
+   "pom": "sha256-K2U12M1wrv1wOtcVRZXaPxUKTNfXRYln3Ofnp20j4kg="
+  },
+  "org/apache/kafka#kafka-clients/1.1.1": {
+   "jar": "sha256-qS3Rx2vgYa1A4dJCHIpqPxSMbDuCry8iWa1A58QA17w=",
+   "pom": "sha256-FP8Ix702Ia5kIwxifzOdmdogWukXypFXP49Of/jjQHA="
+  },
+  "org/apache/kafka#kafka-clients/2.5.0": {
+   "jar": "sha256-iB7FQ0sROQ7bfsEbtbO7DTfv5KA9h02a3DAWUDUrggo=",
+   "pom": "sha256-Jrr9Xiyr1bJ2Ke9U3WqJejKI/GDvHR68iX2o4WH1hgY="
+  },
+  "org/apache/kafka#kafka-streams/2.5.0": {
+   "jar": "sha256-O2AsAvOo1WjGIseQBPR5QYEPzc42kNTnd5olTU5HEbg=",
+   "pom": "sha256-+JX5/SBKnF6Hoe/Ez/m/Dy4qUgYkGWp1Yf5jsymZeCk="
+  },
+  "org/apache/logging/log4j#log4j-api/2.6.2": {
+   "jar": "sha256-p85Od0sBAP+g+HokVupnaMQstQeV6TG7UdvNu86XTsg=",
+   "pom": "sha256-EBmop2vgauf7OpyaTyoO86kr3MYJgOv1eBgssOjSHaM="
+  },
+  "org/apache/logging/log4j#log4j-core/2.12.1": {
+   "jar": "sha256-iF4xoU/HHLSEnpNWTSaiIcaFp4k3nvY8stCCzt88IjU=",
+   "pom": "sha256-mqcRk2UaFw09lbfPaChxIRyLSwcLaV2PMKYyAILrxwk="
+  },
+  "org/apache/logging/log4j#log4j-core/2.13.2": {
+   "jar": "sha256-Jo3BfTc5mS1NHKLCf5RjD7IDpA0H6a1d+uEx1OP6l2Q=",
+   "pom": "sha256-hmP93rGiQ6mhTT4KORBpPZkJXHnr26S5NQhg+bNYhFI="
+  },
+  "org/apache/logging/log4j#log4j/2.12.1": {
+   "pom": "sha256-dfE2PPUgtrEaz2qF78ZR+pUVL0e+YBGQQN1NTbVXzHA="
+  },
+  "org/apache/logging/log4j#log4j/2.13.2": {
+   "pom": "sha256-RzwcYDXUNKHJEA2SSNrH1YUQFiM/hWV8jprX9bfgMoc="
+  },
+  "org/apache/logging/log4j#log4j/2.6.2": {
+   "pom": "sha256-cQPwMfF/p30FA8tGLaUnMBdG2uGzrOQY68AQxNj1udo="
+  },
+  "org/apache/maven#maven-parent/16": {
+   "pom": "sha256-cM74PSRjCaKqNVw48gBO3aNiGuC8XFWnoTnq7vTRIxo="
+  },
+  "org/apache/maven#maven-parent/34": {
+   "pom": "sha256-Go+vemorhIrLJqlZlU7hFcDXnb51piBvs7jHwvRaI38="
+  },
+  "org/apache/maven/doxia#doxia-core/1.12.0": {
+   "jar": "sha256-XknNgnvrvOpYKdOziD0XrRzhXr1jlK61CtUNff2Tn80=",
+   "pom": "sha256-sDiPdIoIheE+fCxFOSH4u53U+1sZBb50VoVHbPNFbqM="
+  },
+  "org/apache/maven/doxia#doxia-logging-api/1.12.0": {
+   "jar": "sha256-mFMGFiwKn0wwnUYQlEfzDwK/b8m8FqPgOdWeHavQGS8=",
+   "pom": "sha256-ndmbQ1AiOEZYUxBpTERjGLFpK6dG7XFzdtWWGaJxI7Q="
+  },
+  "org/apache/maven/doxia#doxia-module-xdoc/1.12.0": {
+   "jar": "sha256-6HMboApO3TSyDv+eSnKcIEXGLLeWw+SRaSYH3kR2qwE=",
+   "pom": "sha256-+2nZW+S1WvLzsKm2jj6OYgY+aVlMH86+cFpaTbCZbSU="
+  },
+  "org/apache/maven/doxia#doxia-modules/1.12.0": {
+   "pom": "sha256-q4/2u0eTz7pZsU+zg/81GjSbEJHQccZrH8vKco1QW9w="
+  },
+  "org/apache/maven/doxia#doxia-sink-api/1.12.0": {
+   "jar": "sha256-XcpqqqnnDYoHZuFD3c+dsJ3l/eD7zHjLY11052TfzKU=",
+   "pom": "sha256-JrUf3babXKbgRM2ii40cGje2+v0M+5v7FakZ3lfGcdU="
+  },
+  "org/apache/maven/doxia#doxia/1.12.0": {
+   "pom": "sha256-LQKgvWTzMbdnzudFWzGTxvuCEQFDoRmFiryWh5il/Ck="
+  },
+  "org/apache/maven/scm#maven-scm-api/1.4": {
+   "jar": "sha256-hgO0O39s09EXhazZ8tUHq2vczaXL0sMWojl554Iv5k8=",
+   "pom": "sha256-EQm9Mv6TeIlBZdJsk0k+4OfKic0rRB07xLU7djsEQSM="
+  },
+  "org/apache/maven/scm#maven-scm-provider-svn-commons/1.4": {
+   "jar": "sha256-385OXz5Sc98kHxhI6qfBjXPedm8SfUprVycZPEww1A0=",
+   "pom": "sha256-TzD7Y7QpcXrZxRdwqzD49ZD9xwlnCO3QRHzA7aiWwgg="
+  },
+  "org/apache/maven/scm#maven-scm-provider-svnexe/1.4": {
+   "jar": "sha256-A1gNjX+MAGG8eEqszblGDD29ijHBlERT+jCpjivX020=",
+   "pom": "sha256-u5gMFSDIYCThGMvVUS4dxdHv0qYR3t0pBt0CHrLjEM4="
+  },
+  "org/apache/maven/scm#maven-scm-providers-svn/1.4": {
+   "pom": "sha256-xICIXwjTmvHYXCwCesBEslRjZuoUHhDHosbBmRi7bAo="
+  },
+  "org/apache/maven/scm#maven-scm-providers/1.4": {
+   "pom": "sha256-Mgs3gcVbVmYndmtHiDX/weDBSbHI6fiHm5YQ+kPuICI="
+  },
+  "org/apache/maven/scm#maven-scm/1.4": {
+   "pom": "sha256-LwUCm5Lm2MEW8UAcnAaXGH2w5vBPi1/rWfSKzFRBAjM="
+  },
+  "org/apache/servicemix#servicemix-pom/5": {
+   "pom": "sha256-AP/z19rYSafO4CuymYOWKShYqsmWRXuiD0DIX2G4glI="
+  },
+  "org/apache/servicemix/bundles#bundles-pom/14": {
+   "pom": "sha256-XKQk5hQRTDNskk2VumXMGcr2Fcn2o2PVXxH75oJBDHw="
+  },
+  "org/apache/servicemix/bundles#org.apache.servicemix.bundles.junit/4.13.2_1": {
+   "jar": "sha256-CGy1LQ4j9ELAVCJTJ2lR7NTsJ+KR6mDdilIOiXxRn+M=",
+   "pom": "sha256-PKpM8jELQG8nhM61oB2abwbzGXhE1NI7gqSMb5vGUvM="
+  },
+  "org/apache/tomcat#tomcat-annotations-api/8.5.46": {
+   "jar": "sha256-amtG0OaVhkRRTAyjZYs7B+YSOmgqIO4203lSQnNfq8M=",
+   "pom": "sha256-A/ycWQ+GPbBHjZE0OPNTNDYKObzI9YSr6PU5O/w0Hlk="
+  },
+  "org/apache/tomcat#tomcat-annotations-api/8.5.54": {
+   "jar": "sha256-OJyN0kdksod8tM/HiQqMqI6Gq6MgqFAMMU5U61Lq83o=",
+   "pom": "sha256-fYLs2uJYoEPDeruVCOJPh3ODCg4Z/rIH7xcQWDfiwkA="
+  },
+  "org/apache/tomcat#tomcat-servlet-api/9.0.102": {
+   "jar": "sha256-hzkOqSqZl9YMfNTGn8skBqwjjjLmQIBHS2UsCPss870=",
+   "pom": "sha256-3tAxFrRr8C0Nk+KFCoXUagLYkQZoWYsdbfkcue/iazM="
+  },
+  "org/apache/tomcat/embed#tomcat-embed-core/8.5.46": {
+   "jar": "sha256-vl+FREjS7l1uADb+srT3ExYweaG2uaepdQjlWRetNcI=",
+   "pom": "sha256-cHINdlbSZAS7i0H8GOB4nHDJx/J+mX3fv9QDyokqTP8="
+  },
+  "org/apache/tomcat/embed#tomcat-embed-core/8.5.54": {
+   "jar": "sha256-hATsiEEwIr55X2F4zGxFDqG6sp538K4cbKY603VwniU=",
+   "pom": "sha256-+Zx/4tMHb0E6muNbKuWz9e0kDdyHcahBESSmMpTF9Kc="
+  },
+  "org/apache/xbean#xbean-reflect/3.7": {
+   "jar": "sha256-EE5em7WmafhnIvMigZYHAPfsjjIJ71GyPrm20j0WKcs=",
+   "pom": "sha256-l5XBUyLF0ZrzNu69nhZPp9WJfEsASn1m4hY1oXPnSKk="
+  },
+  "org/apache/xbean#xbean/3.7": {
+   "pom": "sha256-6nFxMt6EBLYvyQl6HzIVxwXVJdRXvppfEmU63GjDOrc="
+  },
+  "org/apiguardian#apiguardian-api/1.1.2": {
+   "jar": "sha256-tQlEisUG1gcxnxglN/CzXXEAdYLsdBgyofER5bW3Czg=",
+   "pom": "sha256-MjVQgdEJCVw9XTdNWkO09MG3XVSemD71ByPidy5TAqA="
+  },
+  "org/aspectj#aspectjweaver/1.8.14": {
+   "jar": "sha256-sPGSWYCwsYUI5NYGBwum4zFGQyWSz1uph0DGw1iXb4g=",
+   "pom": "sha256-yDfintdUeb13tAWmxrx82yo+bgjx2Mu7QHlD52nKGew="
+  },
+  "org/beanshell#beanshell/2.0b4": {
+   "pom": "sha256-B5LlgfFZJDEnZhxlhZ0U9PC2b8d01HjaKodCkrtHuHQ="
+  },
+  "org/beanshell#bsh/2.0b4": {
+   "jar": "sha256-kTlcB4hYOajGmG1bfFd82brPAb8SnIkUHzXo6oWEJ7Y=",
+   "pom": "sha256-nASP3fKWY9k4Cmj0FNCJcXrj4wuRXmyWAVv0pkqC8Y8="
+  },
+  "org/bouncycastle#bcpg-jdk14/1.45": {
+   "jar": "sha256-ZFUfoEFPzelCQ0UsfavQ8OqgSjxdO1w9CxHeIQtm+Pc=",
+   "pom": "sha256-DVqHe6yELHT0rJ3EEzUwdfs+xhJd8hjOl5yYLSAGKPU="
+  },
+  "org/bouncycastle#bcpkix-jdk15on/1.54": {
+   "jar": "sha256-1hjc+/Aze5EBWyHUs5gXWuljgqgsfh1ujGV/zSNkY8c=",
+   "pom": "sha256-MhrBi4+GWen8BMkv+Xre9PJ+Cy57KhqI05uTtJdHb7o="
+  },
+  "org/bouncycastle#bcpkix-jdk15on/1.65": {
+   "jar": "sha256-JoxH6npF/9rq0sKkhAokn++egL+daYFaGjidk4Yvh54=",
+   "pom": "sha256-OwbJBaLBlT0h79dxf55CJl5z6YFxbqUm3A2DPPGufuo="
+  },
+  "org/bouncycastle#bcpkix-jdk18on/1.84": {
+   "jar": "sha256-yH8W7Z5exhvJQVHp82RqxE5QzUSBIc6ENn+kt+x+wbs=",
+   "pom": "sha256-wSge1er48+QFVX56UgXLbzzfdT+E3psagVx16965mSo="
+  },
+  "org/bouncycastle#bcprov-jdk14/1.45": {
+   "jar": "sha256-d/O0HsP/MdcJ1yllwf3UBGDDaH48dOaTqhL+2e/TNec=",
+   "pom": "sha256-k4pw29C2i5H3yvb+fyjdBHsGeIPkHa7svVqpboe4hDQ="
+  },
+  "org/bouncycastle#bcprov-jdk15on/1.54": {
+   "jar": "sha256-0K4UWY+cUo0qt7uO0A54WlRA9pJxLNNi1pMoq6Je+1c=",
+   "pom": "sha256-aBLcCCXOg/qwuFh4Dxyjr+SkXYT2ETT04HusakgmkT8="
+  },
+  "org/bouncycastle#bcprov-jdk15on/1.65": {
+   "pom": "sha256-niMbZunXFLzaKR5qenJd5O9k+lHw3kexFUwfeZgSDiY="
+  },
+  "org/bouncycastle#bcprov-jdk18on/1.83": {
+   "jar": "sha256-gs86Kvdmw7yHT202ufIKi5mo8Jdi3HduiiJ6Rdjaqvs=",
+   "pom": "sha256-yHzwb1qsRlY4Dx1EGyRZ++Bm7IErKUab0LP8uLsgV0o="
+  },
+  "org/bouncycastle#bcprov-jdk18on/1.84": {
+   "jar": "sha256-ZNbFphIfzZJxUt0YLL7Tmv4P2mQalw2bzAycsYWLJzE=",
+   "pom": "sha256-znq7SpG6XSpz/fF6PfR2LjYFoDksx5g+8vGuFs04TMM="
+  },
+  "org/bouncycastle#bcutil-jdk18on/1.84": {
+   "jar": "sha256-s3ThaWNCH7nPsBzCDXrY/S+LgYjj7vDsColl4kX3YZo=",
+   "pom": "sha256-Cwy4GmXuFzfVEoY1Cp5WSJM2uPmQgZj+vQSUJD7qKXg="
+  },
+  "org/brotli#dec/0.1.2": {
+   "jar": "sha256-YVwMPv75kNd4MRBEdfumofeXE4hpHUutFHGthBAfbVI=",
+   "pom": "sha256-HT2yjgAeuaAXMtDJi+Bir5r1NtlCiXoMk3mEr4tCKMA="
+  },
+  "org/brotli#parent/0.1.2": {
+   "pom": "sha256-EW+dZjLBPNScPzMzd2UHX876GrkR6eK3dic2ytSo9Wk="
+  },
+  "org/ccil/cowan/tagsoup#tagsoup/0.9.7": {
+   "jar": "sha256-qFvARGBGyPtFTqeA6jTeac/jZc4sUobbZtcdDbksE8Q=",
+   "pom": "sha256-iV9yytz98N8Xkf0vU8+/0/plt55kTUYkA3OYPw2nkHE="
+  },
+  "org/checkerframework#checker-qual/2.10.0": {
+   "jar": "sha256-0mH94l1ZD2tp23ch1GmsGwoZoXzKqqdRwx8Ni4JguJQ=",
+   "pom": "sha256-JG5H45X416jBK3IisWa8Oh04Cbw6PTDel0cKo42VKks="
+  },
+  "org/checkerframework#checker-qual/2.11.1": {
+   "jar": "sha256-AVIkpLHcbebaBTJz1Np9Oc/qIOYwOBafxFrA0dycWTg=",
+   "pom": "sha256-zy4MkNj3V0VfSiWOpglzkFNmO9XaannZvVP5NaR955w="
+  },
+  "org/checkerframework#checker-qual/2.8.1": {
+   "jar": "sha256-kQNJkAi87NTpSNopsXhkq7ZDBOFXBkRK4gnRfr4Fdd8=",
+   "pom": "sha256-8jN2tY7XlfL/R0Jqx2uZbUnjkYRC5dhxPjkl+Imnd5k="
+  },
+  "org/checkerframework#checker-qual/3.3.0": {
+   "jar": "sha256-gmTsS77L+5Id9ETWZsRVA4PiZw3AtU64eNaCUrpUOoo=",
+   "pom": "sha256-v+xfjT/7y22ePre9KQZDigcUNSHbyJfRzwD90MYhSTs="
+  },
+  "org/checkerframework#checker-qual/3.33.0": {
+   "jar": "sha256-4xYlW7/Nn+UNFlMUuFq7KzPLKmapPEkdtkjkmKgsLeE=",
+   "pom": "sha256-9VqSICenj92LPqFaDYv+P+xqXOrDDIaqivpKW5sN9gM="
+  },
+  "org/checkerframework#checker-qual/3.51.0": {
+   "jar": "sha256-jpFnbckWgEvRL3kJ5/XcB2RsyYIgFHqLX+p/9CvW/0o=",
+   "module": "sha256-MNCupC4IPfcNa/P5WAA0Mhj4nPn6G8MkN6XqcHrvg+w=",
+   "pom": "sha256-VyZA+ycbWVVBeR7+2+Ch8reFA3M8t1/BglkO3QcbxMs="
+  },
+  "org/checkerframework#checker-qual/3.52.0": {
+   "jar": "sha256-C1uxpL3E5LEhdIL+WY78qrTh+6ezf5QSY5F4/IEW/AU=",
+   "pom": "sha256-CWX2sKmMP6+NvCpu9x2GAWyeJKGQVwp3Gb2kq2CHkmU="
+  },
+  "org/codehaus#codehaus-parent/3": {
+   "pom": "sha256-UOslOs0LbuBI9DLZ/Do7NiZO+z2h/6f7B/bE1LeoyjE="
+  },
+  "org/codehaus#codehaus-parent/4": {
+   "pom": "sha256-a4cjfejC4XQM+AYnx/POPhXeGTC7JQxVoeypT6PgFN8="
+  },
+  "org/codehaus/gpars#gpars/1.0.0": {
+   "jar": "sha256-glYHHp10DPe/4deDeNXDuZvNeVdpDxMEUOBC9ovBiSA=",
+   "pom": "sha256-2oNr7M1ZkGu++Lov7npeIsXUBGiCWUegWhdMo3Xwnfo="
+  },
+  "org/codehaus/gpars#gpars/1.2.1": {
+   "jar": "sha256-+eCL+WTzTRKTREBMAWZiduxDxnBN106NTKMtzR0vtKg=",
+   "pom": "sha256-QoGa4DFjcSPJS8c9bvANBfh29tSixUiztj722uw4gw4="
+  },
+  "org/codehaus/groovy#groovy-all/2.1.9": {
+   "jar": "sha256-f2/NnCjWmbkqdMq+HzEcHL5F2q+r3XgVMcGXLf1nAxA=",
+   "pom": "sha256-AGzfvQ6+LrXz2C+oNUBuf27pB3vJj5I24sSyDr09k/k="
+  },
+  "org/codehaus/groovy#groovy-all/2.4.0": {
+   "jar": "sha256-pwK0bswdbPlfmnsX/7qtiVnse3wLGhTvQESN9tqM3PQ=",
+   "pom": "sha256-yJBGcCz9XeDpWWjelEtrEWnlK3ctAutrFEBF5VFqKzw="
+  },
+  "org/codehaus/janino#commons-compiler/3.0.6": {
+   "jar": "sha256-GQAGpjg98udbCSpacT4wzC9MVnMlUI3x07UsvjoUCoM=",
+   "pom": "sha256-ijeIVNb+w0fH2nbfNLh4ndy1TrZcVbthTKNOQ52Yvkg="
+  },
+  "org/codehaus/janino#janino-parent/3.0.6": {
+   "pom": "sha256-bHL9BHepZN9ORQLVgIaKxOoCa4Z+Q/uoRjvvyq9SjY8="
+  },
+  "org/codehaus/janino#janino/3.0.6": {
+   "jar": "sha256-urc/H1jX04BxrjTcIDR3CRCdiAwL3doIh/gmZWt3gNs=",
+   "pom": "sha256-lEqew5Pcfr4wZa/4ULi+QWoQXVTSCjUds3YrNFYdxis="
+  },
+  "org/codehaus/jcsp#jcsp/1.1-rc5": {
+   "jar": "sha256-HM0ZcwcVn/J5WX5dm9Q0VEhSBxKhCAn7uhkc26AdmQY=",
+   "pom": "sha256-Tg2OU773WhFwltLi7we6z/rOWG+GBPlmyRGJ/SosUxo="
+  },
+  "org/codehaus/jettison#jettison/1.2": {
+   "jar": "sha256-VEog3Lcye+8IsCkq/fKhMSvzAEub3hvwbqUrmd6kFOk=",
+   "pom": "sha256-UguAxi5jwz966RpqNoTuxP2wAH20YXZHGQ1o0Ke8s6Y="
+  },
+  "org/codehaus/jsr166-mirror#jsr166y/1.7.0": {
+   "jar": "sha256-TU50Uy6BvGpU5MvahlmZ9KspiF6FDwuDXqN0gAuE0LI=",
+   "pom": "sha256-tmtSb0df2k3Oi5X/8P7ukkqPBZKYwzrgyTS3fYkJBkM="
+  },
+  "org/codehaus/mojo#animal-sniffer-annotations/1.10": {
+   "jar": "sha256-A63rPUzI63BKrURGRxCxzDVdfIsS+9KzvqJn5uFDa5M=",
+   "pom": "sha256-CtyBblelq5dgFNLA2hk0xLo9HbrhHLW1tVPwp1cFEso="
+  },
+  "org/codehaus/mojo#animal-sniffer-annotations/1.14": {
+   "jar": "sha256-IGgyC9a610TDZzqwSPZ+ML749RiZb6OAAzVWYAZpkF0=",
+   "pom": "sha256-GHnxmgWZHj7ZWRC5ZokzM5awxGeiFdxNH5ABhAS3KiY="
+  },
+  "org/codehaus/mojo#animal-sniffer-annotations/1.18": {
+   "jar": "sha256-R/BYUrSO6brv74D6PYzqYO+kdTwAExId1/5e7y5ccp0=",
+   "pom": "sha256-rfUi9IOcNfUynql8QHrr6/qIB7ZEhS3E1c18l7em0uA="
+  },
+  "org/codehaus/mojo#animal-sniffer-annotations/1.9": {
+   "jar": "sha256-zZb+60fzSyVZcEcV23sXmgOjch+dxAksNFxxjim0LeQ=",
+   "pom": "sha256-/nEJDiNXjdGapqj+9Rhvz6WPSPgHBnKprIlFhis7fz0="
+  },
+  "org/codehaus/mojo#animal-sniffer-parent/1.10": {
+   "pom": "sha256-pjpcqTpCDBd6I/jwgjHD7LFlZsWPQeSwFSzn5Atr4+o="
+  },
+  "org/codehaus/mojo#animal-sniffer-parent/1.14": {
+   "pom": "sha256-9RVQoGsUEL1JYssOcd8Lkhpgp+9Hv6nEgloUvnIxbuo="
+  },
+  "org/codehaus/mojo#animal-sniffer-parent/1.18": {
+   "pom": "sha256-Tp31RqR89jBKExfEaHAQCocm++oRsN0YMi+VfkBwlzw="
+  },
+  "org/codehaus/mojo#animal-sniffer-parent/1.9": {
+   "pom": "sha256-nyDSRN5e5OZQmbJ3tpiE7xr4EROcAJcl3TzPqPsaxjs="
+  },
+  "org/codehaus/mojo#mojo-parent/28": {
+   "pom": "sha256-WrbfH5JfxhOX3y0XNSu8mK8UZOhT7SF+CeU9IKMm9wc="
+  },
+  "org/codehaus/mojo#mojo-parent/32": {
+   "pom": "sha256-8l6Ivz6x/hjo/CT8/HoQ3aMUL8C4nrHNXlrhWvoWISU="
+  },
+  "org/codehaus/mojo#mojo-parent/34": {
+   "pom": "sha256-Pjldb7xDwJo3dMrIaUzlJzmDBeo/1UktgOJa8n04Kpw="
+  },
+  "org/codehaus/mojo#mojo-parent/50": {
+   "pom": "sha256-+BnK0bFbaneRyLYB6WveM3ZeRoE5WAfbRTfS8N7dSTs="
+  },
+  "org/codehaus/plexus#plexus-classworlds/2.6.0": {
+   "jar": "sha256-Uvd8XsSfeHycQX6+1dbv2ZIvRKIC8hc3bk+UwNdPNUk=",
+   "pom": "sha256-RppsWfku/6YsB5fOfVLSwDz47hA0uSPDYN14qfUFp7o="
+  },
+  "org/codehaus/plexus#plexus-component-annotations/2.1.0": {
+   "jar": "sha256-veNhfOm1vPlYQSYEYIAEOvaks7rqQKOxU/Aue7wyrKw=",
+   "pom": "sha256-BnC2BSVffcmkVNqux5EpGMzxtUdcv8o3Q2O1H8/U6gA="
+  },
+  "org/codehaus/plexus#plexus-container-default/2.1.0": {
+   "jar": "sha256-bc6xJGsYgVO9y2+WLVQ9Ud22csygfK2Up4+6vJ7fCjk=",
+   "pom": "sha256-i4wg5jC9zHlcyYUCTEwQRcFHvhFgUsLJdeMMYI9/O0U="
+  },
+  "org/codehaus/plexus#plexus-containers/2.1.0": {
+   "pom": "sha256-lNWu2zxGAjJlOWUnz4zn/JRLe9eeTrq5BzhkGOtaCNc="
+  },
+  "org/codehaus/plexus#plexus-utils/1.5.6": {
+   "jar": "sha256-aZDsGwXJeMmUDr9+wbTdkR0WxSTun0o4ahTsCwcBarQ=",
+   "pom": "sha256-DUc/heea6ENWm5MC9jT8P3C98TUgCrKkhncPV97dvzk="
+  },
+  "org/codehaus/plexus#plexus-utils/3.3.0": {
+   "jar": "sha256-dtF0eSVA4nda+U0D0Q+y08d24s0KwOv0J9PlcAcruc4=",
+   "pom": "sha256-ecl5IHP97jzb69YadrqMLdEWJKn4XRKLrla9oZ4gR1w="
+  },
+  "org/codehaus/plexus#plexus/1.0.12": {
+   "pom": "sha256-4/6xaUeKIeqOOvJ/kLLYVRMJ7ncfJBduN61Iu9e9rQQ="
+  },
+  "org/codehaus/plexus#plexus/5.1": {
+   "pom": "sha256-o0PkT/V5au0OpgvhFFTJNc4gqxxfFkrMjaV0SC3Lx+k="
+  },
+  "org/codehaus/woodstox#stax2-api/3.1.4": {
+   "jar": "sha256-htfAt3WnybRUzGumHUCo6zuZzBKfgy65uXejdVtLM44=",
+   "pom": "sha256-pqp2WMFCXURHe4Lq7+RCt+v+NyWxYyw7PMWK6NthaqE="
+  },
+  "org/codehaus/woodstox#stax2-api/4.1": {
+   "jar": "sha256-PpnGeMQs41NZW2zHHmLyW9bliGCzz3m2CtySQKlnkk8=",
+   "pom": "sha256-ZvXSkQCjCgsGw2qfWjtQ9F7xY1K+NHuj4iUVqInaX8U="
+  },
+  "org/codehaus/woodstox#stax2-api/4.2": {
+   "jar": "sha256-ut9ggaC7Um/SwBlR3++tkbaEa23Q6wBIWH4w0d0zTmg=",
+   "pom": "sha256-YhW0dL03FPG5z0216ig39LqvO42vkSEOh+qM6mWlCXw="
+  },
+  "org/codehaus/woodstox#stax2-api/4.2.2": {
+   "jar": "sha256-phxI1VPvrXi8Af/8SsUovruuZMuuwXCypeOc9h61Gr4=",
+   "pom": "sha256-TpAuxVb8ZZi0HClS7BVz7cgVA35zMOxJIuq2GUImhuI="
+  },
+  "org/codehaus/woodstox#wstx-asl/3.2.7": {
+   "jar": "sha256-k59ZG0Rcg/KFGRzvdgNzHtNz6vAA2gBfSXaaKDEQ3S0=",
+   "pom": "sha256-hfiH+o33MbrNHF5j8rqwHHvY0z8k2qiTOWv7SC8y+pw="
+  },
+  "org/conscrypt#conscrypt-openjdk-uber/1.0.0.RC11": {
+   "jar": "sha256-SX6H/ibgwDAaRZRndp88BJrYGqAbw+TDVRJL8rROl/U=",
+   "pom": "sha256-S5rzGAb44nAfeGCMiGcnBDY5GkgJjK2LVXRtjlo7SYU="
+  },
+  "org/conscrypt#conscrypt-openjdk-uber/1.3.0": {
+   "jar": "sha256-P7J+tvHfOTKq6j/2b3L2a5v/kSgBHdeWbqELJ/H5cxg=",
+   "pom": "sha256-oCsYizvlsxiqG76hpRxqzDwh2YyU6/CxOPiN9ARn33U="
+  },
+  "org/conscrypt#conscrypt-openjdk-uber/2.5.1": {
+   "jar": "sha256-AfnHQstZKhUeLmK9U5eomAYoqWcAH82s1KpHRGeGhfM=",
+   "pom": "sha256-XivA41GARnUwxVpnqvq+XvmOBg7raY6a9tCw3N26lc0="
+  },
+  "org/dhatim#fastexcel-parent/0.20.0": {
+   "pom": "sha256-tfzZXDvkepleLr0Aijso3uevgMk/ZhPuRBZZD+uum74="
+  },
+  "org/dhatim#fastexcel-reader/0.20.0": {
+   "jar": "sha256-gy9PoRvQ3BY+4A1dxa6nd/+cejcspfANfJMq9L8HVW8=",
+   "pom": "sha256-Qe5oGjJTdruqNYA+JXgPT0GX+nRKt8CxrNrfUGK/WTc="
+  },
+  "org/dhatim#fastexcel/0.20.0": {
+   "jar": "sha256-iUVI68p2S+lX2aP+M9nLwXXf6H5ewHqSregF4QR5Wbc=",
+   "pom": "sha256-j3VJERSBodkOQOZWycYn+sjv++/jNs9zPSh1A6rjuU8="
+  },
+  "org/dom4j#dom4j/2.1.1": {
+   "jar": "sha256-ou9ftJkLkUoxF2xR9hN/bwQlPdFlQgmFBR+f1PsDISg=",
+   "pom": "sha256-xZJw7GReqkRcgsxn1FOum02rjY78KZgwC6FLFqJ/nIs="
+  },
+  "org/easymock#easymock/2.2": {
+   "jar": "sha256-yvqbebcUYFzGvnTfnNYTOmwUAVgLxC27XLRMLnAl7r4=",
+   "pom": "sha256-DCZwrQ0RewVNZrXj9YJ/55MNElUhU6jSk9VIMgGhaqI="
+  },
+  "org/eclipse/ee4j#project/1.0.2": {
+   "pom": "sha256-dJWgenl+iOQ8O8GodCG9ix/FXjIpH6GOTjLYAx3chz8="
+  },
+  "org/eclipse/ee4j#project/1.0.5": {
+   "pom": "sha256-kWtHlNjYIgpZo/32pk2+eUrrIzleiIuBrjaptaLFkaY="
+  },
+  "org/eclipse/ee4j#project/1.0.6": {
+   "pom": "sha256-Tn2DKdjafc8wd52CQkG+FF8nEIky9aWiTrkHZ3vI1y0="
+  },
+  "org/eclipse/ee4j#project/1.0.7": {
+   "pom": "sha256-IFwDmkLLrjVW776wSkg+s6PPlVC9db+EJg3I8oIY8QU="
+  },
+  "org/eclipse/ee4j#project/1.0.8": {
+   "pom": "sha256-DQx7blSjXq9sJG4QfrGox6yP8KC4TEibB6NXcTrfZ0s="
+  },
+  "org/eclipse/ee4j#project/1.0.9": {
+   "pom": "sha256-glN5k0oc8pJJ80ny0Yra95p7LLLb4jFRiXTh7nCUHBc="
+  },
+  "org/eclipse/jetty#jetty-alpn-client/12.0.32": {
+   "jar": "sha256-fzHpSo/DhXeMeM/bJnSL/FPE6qAZoBAcQDbai/DfGgw=",
+   "pom": "sha256-3bKXONz79bAWqZR3Ybgff1vRJcnzKaw54qs5PSylzMY="
+  },
+  "org/eclipse/jetty#jetty-alpn-server/12.0.32": {
+   "jar": "sha256-OViP9WlQUU+pKLgvKX2CHPJsgZoD0YF4yqYTJQwH8n4=",
+   "pom": "sha256-RCuYEX61rawshuJQeEqRa4jUj/UjaY5rk2s1PXxa8r0="
+  },
+  "org/eclipse/jetty#jetty-alpn/12.0.32": {
+   "pom": "sha256-MQaBn8zQkwm65knCEHlqnco92BhZaoncdGM57e7x6IM="
+  },
+  "org/eclipse/jetty#jetty-client/12.0.32": {
+   "jar": "sha256-VjJP9SeAhjtANPFztrfZ0TRMpu5tDr6ANXFIRlvOdzk=",
+   "pom": "sha256-UB1bZTuiMoDWuZSpA7Aw7ruGxVuEjuX7c2blnYKR3+Q="
+  },
+  "org/eclipse/jetty#jetty-client/9.4.28.v20200408": {
+   "jar": "sha256-+3To0AcrOIQ5/oHmpQVEGNfuLbqDo0Mcybt3U93wNTU=",
+   "pom": "sha256-1/w8f0vRsBJ6WW8sfZHhckQrRJuv4yofFKpBDClCpG4="
+  },
+  "org/eclipse/jetty#jetty-core/12.0.32": {
+   "pom": "sha256-DXOhdE3rpHiexQczIu4FSSatpMmgZAKNbCtmr6o/TNM="
+  },
+  "org/eclipse/jetty#jetty-ee/12.0.32": {
+   "jar": "sha256-VGkqjbQ9MzaaJekpixCcP6q01NYpAsYepDB00jR0ank=",
+   "pom": "sha256-10ZZTNohI4NtWHrgUHVibcTedyCmywsPZDlm7wz/nB8="
+  },
+  "org/eclipse/jetty#jetty-http/12.0.32": {
+   "jar": "sha256-W5onczsBim4+g7UNKfhQWIrs1zlAB5pjMHqca4RT0Z0=",
+   "pom": "sha256-U/oU+UZREVz3reV5E6FYS33JJCZ/XtC9AVFSB6rXW+s="
+  },
+  "org/eclipse/jetty#jetty-http/9.2.28.v20190418": {
+   "jar": "sha256-tcz5TVdtXkiFh//HbSFe+kqRoluIxzK2Mqt4Str+gdU=",
+   "pom": "sha256-d7Db7XsY+GdcHHPYmEpkyT4tj4Yt+UIc/H8N30NoMY8="
+  },
+  "org/eclipse/jetty#jetty-http/9.4.28.v20200408": {
+   "jar": "sha256-p1xebpKTvqutmn9sNvFjGkFM+fRloYGNxgb17hNwfOQ=",
+   "pom": "sha256-zi2/2NBP2cNHzDh41nrSCenFZbjCPGiwuJr4bNWR8U8="
+  },
+  "org/eclipse/jetty#jetty-io/12.0.32": {
+   "jar": "sha256-COJ4mRptbDsbY2VFglCG73s2iZVj1qojyiwBt+GUuBo=",
+   "pom": "sha256-9kLLDOVLGTLytc3oJaNYFAcrBtZC7duuQAqNZ2rSgwY="
+  },
+  "org/eclipse/jetty#jetty-io/9.2.28.v20190418": {
+   "jar": "sha256-S8nb3DQpN9JNzHrOcj4WzgQJ710viNxHuns9NcxjD/o=",
+   "pom": "sha256-mUFOVXucjBHK3xlnx+fez5xhWFi5C4GerwSU6/A+f0o="
+  },
+  "org/eclipse/jetty#jetty-io/9.4.28.v20200408": {
+   "jar": "sha256-3PdH2CgRYLCkTndrTQEbkIBTgf8+GlNW/BMucgHxosY=",
+   "pom": "sha256-Zbv6iyOsnVeOxFXI7nnfQdIaAJYiw1OUnwQPqrB5oGE="
+  },
+  "org/eclipse/jetty#jetty-jmx/12.0.32": {
+   "jar": "sha256-o+srGHLXt5oHahK9qC8WEVkkSte147jKajmG6IUtkd8=",
+   "pom": "sha256-Cu8JKf5/RuqlRNWH05e3dQsWx/sP+d0eKJTjbnLXhRg="
+  },
+  "org/eclipse/jetty#jetty-jmx/9.2.28.v20190418": {
+   "jar": "sha256-n0oAA3AKzt09ialWXK3GCdhOumjkqrA1FUVCZcAU6ck=",
+   "pom": "sha256-evoc0qzwD3D9Ib0fcmYyNTon+tBCIbRH/XMLQVPXrfE="
+  },
+  "org/eclipse/jetty#jetty-jmx/9.4.28.v20200408": {
+   "jar": "sha256-wxgwoJy2ro+hBoUmnaCoWXJQMN8NMWyPVipk5771FXc=",
+   "pom": "sha256-6hQ4YN0mLd9u/dI/QLaDfxnhUp78U9EuVlmZUAULv/c="
+  },
+  "org/eclipse/jetty#jetty-jndi/12.0.32": {
+   "jar": "sha256-Q6E5tXI6fwoB1mv+uv2fKi+p+T9yeBSFjlrBEflslaE=",
+   "pom": "sha256-cjDb0nD9dfRsLPUAAOkR0Ad6G9BYgNX3NfnJAHT/9+M="
+  },
+  "org/eclipse/jetty#jetty-parent/20": {
+   "pom": "sha256-ytF4magqY0+0hwYIdetm37r25BJ6ureGVdQwKN5K8oQ="
+  },
+  "org/eclipse/jetty#jetty-parent/21": {
+   "pom": "sha256-eXLp7G84UqjuHuXU0Q3Mnc1gd7El+TWqlrNnpsgjN/U="
+  },
+  "org/eclipse/jetty#jetty-parent/23": {
+   "pom": "sha256-/yKdivNzLGYsYj/kA/fnrBAv5UVVrQHzgkMuCd7ajFE="
+  },
+  "org/eclipse/jetty#jetty-plus/12.0.32": {
+   "jar": "sha256-3h0n4SYwGdlQG/K6QepnuZp6JSf/Q3Fiia4cJPDdgS0=",
+   "pom": "sha256-kqQLMTjD5us3gAP5lFWMUVo9gr7iubPepj7sJIkEp3I="
+  },
+  "org/eclipse/jetty#jetty-project/12.0.32": {
+   "pom": "sha256-Pm0xp7KvyC4zwkvv3s0DKgTcqeaJl+fQPMACRT9Z9bs="
+  },
+  "org/eclipse/jetty#jetty-project/9.2.28.v20190418": {
+   "pom": "sha256-NfNUjHFMZHve3+CCNt7MvSoVrRxFN+f8lJQx0sJfAJw="
+  },
+  "org/eclipse/jetty#jetty-project/9.4.28.v20200408": {
+   "pom": "sha256-mTScThPr7LtDY1IVvUqpo/E6w3uyjRpG8pSCIttxLTk="
+  },
+  "org/eclipse/jetty#jetty-security/12.0.32": {
+   "jar": "sha256-OAueRDYCSuRs79DhhjhcW67r/WqiumqFl768kUcp2PA=",
+   "pom": "sha256-9IJHcX9jyEfNE2Ch17dslMyqBa23rRXFby55fXl7b+o="
+  },
+  "org/eclipse/jetty#jetty-server/12.0.32": {
+   "jar": "sha256-BLDZ85VDYguxsQMr+P8PgJURnU5GIToaPWNE+goHtyg=",
+   "pom": "sha256-XNMOYDdrGyrKef0L6qdSkDpzJYclmg9hJ5V12VxqA7U="
+  },
+  "org/eclipse/jetty#jetty-server/9.2.28.v20190418": {
+   "jar": "sha256-/EjsGmi7QiAN4kLOSqNaDeslMepmlRaXMs9bnq+LP5Y=",
+   "pom": "sha256-I63dKaOx9deqLggYO6+Oz/eyatTPynMZjK1zjyIXfsE="
+  },
+  "org/eclipse/jetty#jetty-server/9.4.28.v20200408": {
+   "jar": "sha256-N2b5ESqUaejvMJftMhvysxySWTr7FUKf5ONLFE4iL0M=",
+   "pom": "sha256-+az+39kM4boNwfZNhlLdNxZciDicp3sidUrYSj2fMtI="
+  },
+  "org/eclipse/jetty#jetty-session/12.0.32": {
+   "jar": "sha256-OYLs6nuxIgKwnKBRy0HVpnZgw/P8XRHOYTSXXzY4z1Y=",
+   "pom": "sha256-Dr4T3U19DrMbW4xDd8RjRZ48pjuH5sT98MbuXzsSQxU="
+  },
+  "org/eclipse/jetty#jetty-util-ajax/12.0.32": {
+   "jar": "sha256-1/2uYnD6++7uqGGJLjHsxWsuvpNhu055h3I8V3ziitM=",
+   "pom": "sha256-z8jjbCBOi4mqfhNgTH9WD8hQqAXSJQp3QolJ6AVSiAQ="
+  },
+  "org/eclipse/jetty#jetty-util/12.0.32": {
+   "jar": "sha256-78o05RuprsVMaVkVfNM7q2Q35ZsDQUTpEyxMfbl3Occ=",
+   "pom": "sha256-Qt9QAMSjJsBYIv+cUb8Zx0oQT8UiwQPl/T9DQhyHa/g="
+  },
+  "org/eclipse/jetty#jetty-util/9.2.28.v20190418": {
+   "jar": "sha256-vbKu4UvZvIVcUc2ngHEGSxB3dw3isigzjwD5H5yx3kQ=",
+   "pom": "sha256-YZJlM0rVq+Pn7TpPkANK59l5zSdlAazguphpwFN6ZY0="
+  },
+  "org/eclipse/jetty#jetty-util/9.4.28.v20200408": {
+   "jar": "sha256-wOjlXAs2iyUObsk/hfOjaP6AFJZbx/Mumu+kgYrFUmM=",
+   "pom": "sha256-mwlvpXHENRHfisDAoWhDJUHsu40IwjkYF3sRrj8Xmao="
+  },
+  "org/eclipse/jetty#jetty-xml/12.0.32": {
+   "jar": "sha256-mao5awOGuZMgPlc9cgfTwBn8nORcQKNRTJlYccxz0gk=",
+   "pom": "sha256-UZtMzbKVpop7A+/yjiamYyH2YcbDdNFTFq6ncUXz4v8="
+  },
+  "org/eclipse/jetty/alpn#alpn-api/1.1.2.v20150522": {
+   "jar": "sha256-xb45kBumnrvoYj5j1XDnOqFHdWY7GQzZmE3VxIbvAnQ=",
+   "pom": "sha256-CWGoxJXcfzLgqBog6ALReXDWekaH53wNW+/hk6XESik="
+  },
+  "org/eclipse/jetty/ee10#jetty-ee10-annotations/12.0.32": {
+   "jar": "sha256-dSpCprmw3CIY29mYdpePvrpEXmDqYs3BHMb8uAfNlYA=",
+   "pom": "sha256-vHzGuaskCc9QrGzNIqXudyAjc8/VPvXWE11DSTv0JFA="
+  },
+  "org/eclipse/jetty/ee10#jetty-ee10-plus/12.0.32": {
+   "jar": "sha256-SL/wOqZYqST2NIYjTP53stIJnJJOaeJjVEj+fJy+poQ=",
+   "pom": "sha256-Zm8dTJCiigD18CzvG2J0vzL/E+e1DNRm2lg/b5gzBCk="
+  },
+  "org/eclipse/jetty/ee10#jetty-ee10-servlet/12.0.32": {
+   "jar": "sha256-keAMv9Zd2THzYyZv4rP6bCik3oXZ7YCJpgoxc/ncf6A=",
+   "pom": "sha256-klfojfk6Yc+dQTLk22e2yhICssp041tiDCryqrCXyM8="
+  },
+  "org/eclipse/jetty/ee10#jetty-ee10-webapp/12.0.32": {
+   "jar": "sha256-44QryCNsBkSNcjZmIY+QEzPTotBFg0ZUc7H1Ql/OoqI=",
+   "pom": "sha256-bgYpcElVIHFBQ2iigiVkJH40gsnr0UdNv95CGWpI35k="
+  },
+  "org/eclipse/jetty/ee10#jetty-ee10/12.0.32": {
+   "pom": "sha256-JCdkRk3t8Sb/TmFs1Ofkfx2E9rnWot2XOvluVRr3ZSs="
+  },
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-client/12.0.32": {
+   "jar": "sha256-g/7GRff6BSuMj1Wo9zz16jFibksvlMIV4ALsgyJ143U=",
+   "pom": "sha256-9aIS7kVLhETir4xirxJvKyTx7WVWMabBKPyKuUpkb8M="
+  },
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-common/12.0.32": {
+   "jar": "sha256-raD6X29O9qP6p1gzmpWBXthoMHsQpDlwooqDWMeO7Mc=",
+   "pom": "sha256-rMcx7cY0+Hr1C490uq0U/zLfip/GOy1qGH7XQu1wb2c="
+  },
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jakarta-server/12.0.32": {
+   "jar": "sha256-TfMCuflQql60BmDdrwdQY5cmXxJY5RHOgLWFrJSVdhI=",
+   "pom": "sha256-EX7pgFVCOSseq4Xd6kKzPiNqFOzP4di0WpC1Ixa5XZM="
+  },
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-jetty-server/12.0.32": {
+   "jar": "sha256-uvCgM60aWQbmM8VF33YFm9CPr6i6/egqT1pYplOnUaY=",
+   "pom": "sha256-D3OCyK9RfC7HR4Z36fTrLmrwedMy0j6JnLeqDsjNbxI="
+  },
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket-servlet/12.0.32": {
+   "jar": "sha256-tNt/nTEiYngFc5aBOyu7Cs+oLnPMl+NH7TXkqoPYpQk=",
+   "pom": "sha256-ta7Wn5g1jwo6sqr831b8ofc77EYjFUEnO7WJzL6IeDE="
+  },
+  "org/eclipse/jetty/ee10/websocket#jetty-ee10-websocket/12.0.32": {
+   "pom": "sha256-c3BnHrVC7Ik8KXhRU2ZT00iOuZZvRDnBm9zS1+OO6R8="
+  },
+  "org/eclipse/jetty/http2#jetty-http2-common/12.0.32": {
+   "jar": "sha256-tXXdXqZJ3xEEydD20gaPbCNxQsqtxWnts1guG6YTxUU=",
+   "pom": "sha256-q/KslQMFpcScMfY1FJ3uH04NrxtNAq09AX0O4Qkvzmk="
+  },
+  "org/eclipse/jetty/http2#jetty-http2-hpack/12.0.32": {
+   "jar": "sha256-fA/tTYaO27ZlP9qzLjdJJNzH3za5+N/tVN7rFQV4FMk=",
+   "pom": "sha256-oDtQPLQxUGqig+BCPDUnegdhSR5jGGSLKjI4wHGP+tg="
+  },
+  "org/eclipse/jetty/http2#jetty-http2-server/12.0.32": {
+   "jar": "sha256-ByEklVo+K4uQOSPZ9PaWdVw77CHibbOdkvE7pLZ+VsQ=",
+   "pom": "sha256-+XRqXt/UKMUCLA8gscaW5eBAD2pMkIYF1cE4xOkMoOg="
+  },
+  "org/eclipse/jetty/http2#jetty-http2/12.0.32": {
+   "pom": "sha256-J/ORjc9d81IyPTsjxvxA60Azr9isNHrNobxByg4Uh/4="
+  },
+  "org/eclipse/jetty/npn#npn-api/1.1.1.v20141010": {
+   "jar": "sha256-AYf5qsNhS+8GG/g6US9wDNucCbhzEjL3SwyzgE/2tGk=",
+   "pom": "sha256-qVLDAiYT4oQfGEifI5WqwqdJlPhDN28dDrEJ9rCQogw="
+  },
+  "org/eclipse/jetty/websocket#jetty-websocket-core-client/12.0.32": {
+   "jar": "sha256-X9KhGk9QNz7REsqeGZqt4RwS63fElsJYJxwakHD1Oow=",
+   "pom": "sha256-0mnN814JKx5tcWXSUvuDCMXq7HnhudF++in30t5aLk8="
+  },
+  "org/eclipse/jetty/websocket#jetty-websocket-core-common/12.0.32": {
+   "jar": "sha256-Zo/CloAsZ6MqkwVSqVAPqo8S2hVuTuwKeCHSmm4vCVQ=",
+   "pom": "sha256-QErEEHMZpAkPLT8L6fdZ9e/N7MSY0hJ0WTjZbPnuHzU="
+  },
+  "org/eclipse/jetty/websocket#jetty-websocket-core-server/12.0.32": {
+   "jar": "sha256-hAGSnS7WBfr9/hQTx9ofWt1gqnFURPDbREbwVQSczhI=",
+   "pom": "sha256-/HNPrIRvwQw0VpSo38EPfusHV5IV/6NEX3eils12H70="
+  },
+  "org/eclipse/jetty/websocket#jetty-websocket-jetty-api/12.0.32": {
+   "jar": "sha256-d4wS/tsCozBfn7DQpTn5MldxwDzCVhshOJIjfTLhbC4=",
+   "pom": "sha256-kVOiVNpIIiK/4z6/gwSpQ7ugb0Y4WSDJFSJQAJnLtRQ="
+  },
+  "org/eclipse/jetty/websocket#jetty-websocket-jetty-common/12.0.32": {
+   "jar": "sha256-58eCv1rNXbACuZy7bocGjGa7JE8nDD5njkBbAO5Zesg=",
+   "pom": "sha256-Z3Ivi+aRsOpcKqPTmFpilq+rpWeiJ11pQZT/mzLV0gM="
+  },
+  "org/eclipse/jetty/websocket#jetty-websocket-jetty-server/12.0.32": {
+   "jar": "sha256-FnoeEkXAnOvAWn//FNYy1/rI98/BTNJGkaRbDoKQuto=",
+   "pom": "sha256-N44mpQLFSQxEB5seynwlwnCgu8MfsM9p6BKqB/rpZ0g="
+  },
+  "org/eclipse/jetty/websocket#jetty-websocket/12.0.32": {
+   "pom": "sha256-4aSMemmo10VT0tvO62CnRtJ6CdB4ONZbPCS9ZwbHd8Q="
+  },
+  "org/eclipse/paho#java-parent/1.2.5": {
+   "pom": "sha256-dam4wXrhuGfLMubkVU1XS0f7nr3h6wGwP1fPfzDVAuM="
+  },
+  "org/eclipse/paho#org.eclipse.paho.client.mqttv3/1.2.5": {
+   "jar": "sha256-WZFCh62sUGoo1egXLu0mKiJgXz301Ca52S9B2uJEgYU=",
+   "pom": "sha256-a5Vo3szHkbzJX0gGuj84g9qTbMlAnky9tJaWBtsKA5A="
+  },
+  "org/eclipse/paho#org.eclipse.paho.mqttv5.client/1.2.5": {
+   "jar": "sha256-1x/n/NY9vrUkG0FcJa9iGsxV/F5uxlwDYRXRao55AYg=",
+   "pom": "sha256-ZoYTU4cZkn78e9ObloNKkvhMR+aAy1sgy2bGJEnOVEI="
+  },
+  "org/fusesource#fusesource-pom/1.11": {
+   "pom": "sha256-aV24M14z3j1AOz0fBCWXDzcQqdtKUo7EYBmQVe8eirg="
+  },
+  "org/fusesource#fusesource-pom/1.12": {
+   "pom": "sha256-xA2WDarc73sBwbHGZXr7rE//teUxaPj8sLKLhOb9zKE="
+  },
+  "org/fusesource#fusesource-pom/1.5": {
+   "pom": "sha256-WzO5ZH0tEYFeBBmWbSnJhlyusJMrCfr9HOxLPtk1kuo="
+  },
+  "org/fusesource#fusesource-pom/1.8": {
+   "pom": "sha256-sfAD8ow84XU+oNoipvAokZeiw2nnBWsy4XCveQTv8sE="
+  },
+  "org/fusesource/jansi#jansi-project/1.11": {
+   "pom": "sha256-i6nEm1X5ec9OBNSHEJLrUOg0s4j8oDoidMyt/xLMnOg="
+  },
+  "org/fusesource/jansi#jansi-project/1.17.1": {
+   "pom": "sha256-1zmA70A2Wcbeu9zwUc2ewo8yEmcLh+mIVmG+3yZWltQ="
+  },
+  "org/fusesource/jansi#jansi-project/1.6": {
+   "pom": "sha256-Ld8vvYP3sKsDe3ifIWOJuvfnCsVPCg0X7bOl2Y2UoRA="
+  },
+  "org/fusesource/jansi#jansi/1.11": {
+   "jar": "sha256-noIWPtL8Ylf+YnEyzlVHJueW7e5OXv6dnlI67iF9YLg=",
+   "pom": "sha256-sJda3HRQaYAz895Hkt1uunKpgMK1bY6NNtOBOFs3pck="
+  },
+  "org/fusesource/jansi#jansi/1.17.1": {
+   "jar": "sha256-siNL+w2PJFVi1k7ZMl32uQcJP02qcCyQgtR5bbKi2JQ=",
+   "pom": "sha256-nRwmvMSYxA6dqskQpCxUxY7I1h1FMaRcnnFxrAPJIpQ="
+  },
+  "org/fusesource/jansi#jansi/1.6": {
+   "jar": "sha256-AecetsfsrhB0rMV9GHASV9qxBBCB/p4CPcnKyJDIxgw=",
+   "pom": "sha256-hGyq4CtbEoW5ixVPP/mD8nf7xe7i5VdIkyqzy2Lix8Q="
+  },
+  "org/fusesource/jansi#jansi/2.4.1": {
+   "jar": "sha256-Ll53Wp3Fj/prvWqm8JnWL4ti3N60w8O7vlzyMBvC3ME=",
+   "pom": "sha256-P5jZeaTTVZ+HefuwBLNK51Fq+t9RDhHffMPNBz6xuzs="
+  },
+  "org/glassfish/jaxb#jaxb-bom/2.3.1": {
+   "pom": "sha256-bMEmbPMGVXtPLQnL2M1udbXvDFdzyk73Y9T3MN+Ue2Q="
+  },
+  "org/glassfish/jaxb#jaxb-runtime/2.3.1": {
+   "jar": "sha256-Rf7PpcghfOHzZSq5UXl5DsjMDewDhLylHL65Sik9ny8=",
+   "pom": "sha256-+BAbhhV/v8AZSf/cfFnqccojt+ziX2p5Bh/gHLdQ/wA="
+  },
+  "org/glassfish/jaxb#txw2/2.3.1": {
+   "jar": "sha256-NJdd3hxpIPGjl5EUIjVom8PNNX4k0F7dj/k7iFvWjWA=",
+   "pom": "sha256-RxTUbKz3Aqss1HjWBIxdnMV6vbVfTAe2t6pyeZ4C02w="
+  },
+  "org/hamcrest#hamcrest-core/1.1": {
+   "jar": "sha256-A2HRST/w2U+GE1nv6pEgByBjUHITR5LvtyF/bgnVz/s=",
+   "pom": "sha256-OXOH9AbGjMtAP0d8y+wcgYz8a4/0+tpaM+Jhg6hBfIM="
+  },
+  "org/hamcrest#hamcrest-core/1.3": {
+   "jar": "sha256-Zv3vkelzk0jfeglqo4SlaF9Oh1WEzOiThqekclHE2Ok=",
+   "pom": "sha256-/eOGp5BRc6GxA95quCBydYS1DQ4yKC4nl3h8IKZP+pM="
+  },
+  "org/hamcrest#hamcrest-parent/1.1": {
+   "pom": "sha256-FOaVChpimMvLg8+UKcrEFf8nMWf28Vh2hZQTsNbAfjo="
+  },
+  "org/hamcrest#hamcrest-parent/1.3": {
+   "pom": "sha256-bVNflO+2Y722gsnyelAzU5RogAlkK6epZ3UEvBvkEps="
+  },
+  "org/hdrhistogram#HdrHistogram/2.1.11": {
+   "jar": "sha256-lmceCJizXWAoae/ZM5sZKc2shV0rxkki77vN0iCYFrw=",
+   "pom": "sha256-vXvBoZk0AQrqYTMgnOydwYcgo7KdSM//VNpNFr78BIw="
+  },
+  "org/hdrhistogram#HdrHistogram/2.1.12": {
+   "jar": "sha256-m0f7rkRP6qxLfgTw6ilFaeS8KCvGnYws4qw/I1dygeI=",
+   "pom": "sha256-f7PnkMFU0bXiMXC7jL9/cO8ICa8XIp8dywENd5llEIA="
+  },
+  "org/hdrhistogram#HdrHistogram/2.1.8": {
+   "jar": "sha256-J3a3Vbr+PdyLTX57ZL/xY1035IDITjM39NBbYqAFUpk=",
+   "pom": "sha256-YrZPd4ptEKc0dylfCmvHh7xXqOuYjTvxjfdKu9laU+k="
+  },
+  "org/hdrhistogram#HdrHistogram/2.1.9": {
+   "jar": "sha256-ldQJE74o39Q5zv6pFwxAiY6oTxHyXm/43lAzm4p7Xj4=",
+   "pom": "sha256-1XD003w8yjaGYlEsUXLCjXsdZDt0oyB+AHK2SDORuAI="
+  },
+  "org/hibernate#hibernate-core/5.4.6.Final": {
+   "jar": "sha256-8nMMUZScURFs9/eFYmao8Ssylrc/5VydA4UZ82yqXrs=",
+   "pom": "sha256-coHORMa5lVT4ocz26fjDix127tXDsaXTvKNl0s98iEw="
+  },
+  "org/hibernate#hibernate-entitymanager/5.4.6.Final": {
+   "jar": "sha256-8jvVDYM7J2uf5SOikapis4tOiEwKTikSOXCZi9m9DCU=",
+   "pom": "sha256-Fh5x7h0OcmnaaWXqc1KE73ebKw03y4tLa1kWDK3jKH8="
+  },
+  "org/hibernate#hibernate-entitymanager/6.0.0.Alpha5": {
+   "pom": "sha256-FruRv/lAp7I+3Spm5wlEDNc9aAkbLxQBNwR5I1AFLgM="
+  },
+  "org/hibernate/common#hibernate-commons-annotations/5.1.0.Final": {
+   "jar": "sha256-Hjv8/p79tA6dPAhMm8+Fl+SS4wKUx+QLVu0YpnwoOM0=",
+   "pom": "sha256-jsoYyP1RB7FEADgc9zd0Qnbb6hOkeDPthybK5Mw+gHo="
+  },
+  "org/jacoco#org.jacoco.agent/0.8.14": {
+   "jar": "sha256-IL6YUzhb38ZaWSlkNBLQkkPRRRQwS4m6I6JlFYzIeSs=",
+   "pom": "sha256-lD537VzLma7rP+VkP+paY29vgo45WPhgX0Jt3Jr6uMk="
+  },
+  "org/jacoco#org.jacoco.ant/0.8.14": {
+   "jar": "sha256-n/9olU1d46rSv4OOr4hu1n0sIqLWxvCVVIut6MRcrq4=",
+   "pom": "sha256-L8jktUIWP+7zRetZ6Ji8697hb2XfQDAwMtkgYkJ7FaU="
+  },
+  "org/jacoco#org.jacoco.build/0.8.14": {
+   "pom": "sha256-h9BZs1hJ35d3kUj9flL2Px/NA6Tn5kwqYabJzOYajec="
+  },
+  "org/jacoco#org.jacoco.core/0.8.14": {
+   "jar": "sha256-KKu/DupaCOTyQJfy+6xmPKF8NBwlw6BNkNbNMllDyZU=",
+   "pom": "sha256-e3W64sF3mvVENpgzr+HWj1o5VekdFmyxnf+IZTSxrWw="
+  },
+  "org/jacoco#org.jacoco.report/0.8.14": {
+   "jar": "sha256-o+ICYGCri41cZQcGQGI0u0wDPf1Tdq/rixZm6O0nxFM=",
+   "pom": "sha256-4uvyxYD4avp/dfQ6KBCd2JTEJGOSi8mRF3fjUnUQjlg="
+  },
+  "org/java-websocket#Java-WebSocket/1.5.2": {
+   "jar": "sha256-/4adGYqNxdAJZzkuGHrtqTuDO3zdO8zvs9f7WDQJi4U=",
+   "pom": "sha256-d7KDTuPCPfu461vn9lfXP8FEZ0u0DfqEb9UlSiNClEM="
+  },
+  "org/javassist#javassist/3.24.0-GA": {
+   "jar": "sha256-q6ge+meLYhID+4mu/4HW8Sb3qd1wlAHlYJxCl2aEriM=",
+   "pom": "sha256-ydN5DwMCdlQdEYoRvmf9Jxv4HjAblieA5ULC5fY2wbE="
+  },
+  "org/javassist#javassist/3.28.0-GA": {
+   "jar": "sha256-V9Cp6ShvgvTqqFESUYaZf4Eb784OIGD/ChWnf1qd2ac=",
+   "pom": "sha256-w2p8E9o6SFKqiBvfnbYLnk0a8UbsKvtTmPltWYP21d0="
+  },
+  "org/javassist#javassist/3.29.2-GA": {
+   "jar": "sha256-qQ3bJRNd+eV+qb1OIk4hlVSSl1j5uumWXyn4HWCjKT8=",
+   "pom": "sha256-Ehu5fA3qc0LXSJInrCe/8J2hJ6TkS14Vy09YyeccbIk="
+  },
+  "org/jboss#jandex/2.0.5.Final": {
+   "jar": "sha256-kRKpwzF1uMZLmZ7PR7ZJ/fHNb6gmLQZ3iV6XbtKJHws=",
+   "pom": "sha256-sCTV0iV8JLwY/KRen6prMSjJp3td0OGbHINSZRXCxAM="
+  },
+  "org/jboss#jboss-parent/11": {
+   "pom": "sha256-XylkrqGr0yxYIhKAXML+JzRLM59tVs5km32YbSSyUi4="
+  },
+  "org/jboss#jboss-parent/12": {
+   "pom": "sha256-nlb1shiYpucR6FdiGsHvts88PeFlpKowfbmYgmrU/98="
+  },
+  "org/jboss#jboss-parent/15": {
+   "pom": "sha256-LqMCMZY22mXuRWb5Vv6fgyjK/4T7Tusfn0coIafkvCk="
+  },
+  "org/jboss#jboss-parent/25": {
+   "pom": "sha256-9mKiCtvm/VdfN5drCnzsgdLwoENd1JCGut7MDvyQGgs="
+  },
+  "org/jboss#jboss-parent/5": {
+   "pom": "sha256-CFAMQ1aaETqF6lFnlr+xRj33KzlcIBlAMp11zr5mj3Q="
+  },
+  "org/jboss#jboss-parent/9": {
+   "pom": "sha256-FMdH0KO7ovUps/hgsHiA+xzvICZW5mSc2iy5jbY+x54="
+  },
+  "org/jboss/logging#jboss-logging-spi/2.1.2.GA": {
+   "jar": "sha256-qmp4WlLZ3sjTa0+EIZykp8II3LAY9EcrRxH1uabHQCg=",
+   "pom": "sha256-exV3WqQX/YDy0GOot9fFdMgCBQ6XSq248y/JVlZ9W+8="
+  },
+  "org/jboss/logging#jboss-logging/3.3.2.Final": {
+   "jar": "sha256-y5FL/oiNp9kWLpZayLDW8o8vMuypRKAPu/bdPPGqzBM=",
+   "pom": "sha256-3zs5e4AqyjZPMwLCC5J70fmuad1YG+FYdIVo71HgrHk="
+  },
+  "org/jboss/marshalling#jboss-marshalling-parent/1.4.11.Final": {
+   "pom": "sha256-gbOjRgLbDpPI1pMzqGddl7vywccAD3Lb/Nn6UoG8v/Q="
+  },
+  "org/jboss/marshalling#jboss-marshalling/1.4.11.Final": {
+   "jar": "sha256-LwUrqqHDmI//T9W8gCvOS0Nqds8MMn9pIz/vX7HFYaw=",
+   "pom": "sha256-wDA4PSz5er7i3Jv3ykIxqPs1GdCEaXysJ0E8+LhmH7U="
+  },
+  "org/jboss/netty#netty/3.2.7.Final": {
+   "jar": "sha256-mtuWf+0R5JpBUJiUmj7b5ZsHO+12GSOScdlHcyJGrR4=",
+   "pom": "sha256-K3PW4ABkUtkxzflLJYO8sctGmROjzj4nILCDW/Rl4P4="
+  },
+  "org/jboss/netty#netty/3.2.9.Final": {
+   "jar": "sha256-/W0LkjCAGeIJH5vSiCBHzvJ3fcHx7gAYsufMcS/ZDDc=",
+   "pom": "sha256-+GNHqg8SQjzvxtey5ADsJjZd+YhPIMOo5/KgIXPh3e8="
+  },
+  "org/jboss/spec/javax/transaction#jboss-transaction-api_1.2_spec/1.1.1.Final": {
+   "jar": "sha256-oxClC5vcRKrzY2Lcm7ISI1oUf/qO9y3JVEo5wynqu8M=",
+   "pom": "sha256-oS8U6QAjtSUCFi1TLszHhtwnpQxEz7gdxy+7VTp9UwQ="
+  },
+  "org/jctools#jctools-core/1.2.1": {
+   "jar": "sha256-yB5o757uEwjOfKVoERkCWOMdFiBzZAETyVAgJ/yi63Q=",
+   "pom": "sha256-EkRNx74eoeG1Nh9Lufua4EGXtkhGw86RWzY8+vvN+Nk="
+  },
+  "org/jdom#jaxen-core/1.0-FCS": {
+   "jar": "sha256-JZP3YH5oOF36T5PWXgR1M5VqY0oQvLmVJ40HsAzKLk4=",
+   "pom": "sha256-wSvSCk7PiRhQErNPlETwWdBpBOhXOHVvrUfp3acC7rM="
+  },
+  "org/jdom#jaxen-jdom/1.0-FCS": {
+   "jar": "sha256-aHsxqSv0Ru7yKYCZwhw6QQDtB5oOoRM1tiWUNcTxDt4=",
+   "pom": "sha256-24z2xK0VjPiWGJP8QH97B5MRcUDn2Cf0m7dAwUtVSnM="
+  },
+  "org/jdom#jdom/1.1": {
+   "jar": "sha256-PBZ2VEmUNu6cGWdLUZ0E5zZAhVM/b6ytob+QsWrTSJc=",
+   "pom": "sha256-rEHD+xdmiWvSV9kq+9qopTY82+ZYA4P/0+ycULOmw7c="
+  },
+  "org/jdom#jdom/1.1.3": {
+   "jar": "sha256-Ar1hpyXor5sBdrQ78pgW0MdIuKuVE4W9EnvjdIkyWgo=",
+   "pom": "sha256-WWNuz8OmbAwUgcH9AK+hMYAhGyBXHrszBjRUPEqZ6iA="
+  },
+  "org/jdom#jdom2/2.0.5": {
+   "jar": "sha256-Mu0JPznEao2Z+AEkAGlHjqyTs18HNRwAHyzvQzDpe0o=",
+   "pom": "sha256-66wna1rWLp0xL7bOZj1V/eurqbrckYFm59YLH/0b1HU="
+  },
+  "org/jdom#saxpath/1.0-FCS": {
+   "jar": "sha256-jpP5ChDjxJTWonhMiz7Ivxgwl20484gCNYZ3Ak+FY7g=",
+   "pom": "sha256-2EVzc8mOGQTfcO96M//of63kP/miWqR1Ans84gdOi5s="
+  },
+  "org/jetbrains#annotations/13.0": {
+   "jar": "sha256-rOKhDcji1f00kl7KwD5JiLLA+FFlDJS4zvSbob0RFHg=",
+   "pom": "sha256-llrrK+3/NpgZvd4b96CzuJuCR91pyIuGN112Fju4w5c="
+  },
+  "org/jetbrains#annotations/23.0.0": {
+   "jar": "sha256-ew8ZckCCy/y8ZuWr6iubySzwih6hHhkZM+1DgB6zzQU=",
+   "pom": "sha256-yUkPZVEyMo3yz7z990P1P8ORbWwdEENxdabKbjpndxw="
+  },
+  "org/jetbrains/kotlin#kotlin-osgi-bundle/2.3.21": {
+   "jar": "sha256-R9osKxOM/QsPpflOZPliynO7foXeSkDz7q1QYAyEujk=",
+   "pom": "sha256-b3SNmyNSVBXrK5grI6MrQgiIf0CDEkyDOWWvQ13gB/s="
+  },
+  "org/jetbrains/kotlin#kotlin-project/2.3.21": {
+   "pom": "sha256-cp4AH/yEN/SxDTdiqakQ7KkHIYuCrG3vH5dacI/4Hw0="
+  },
+  "org/jetbrains/kotlin#kotlin-reflect/1.8.10": {
+   "jar": "sha256-mWckEEWQRQkNBioBlO2HAI4jcfBpRra/pyh8aX+SS+o=",
+   "pom": "sha256-hTDQcHET6iC/b08VYhGaMbznYKVpEKwVXxbK6BiZfRc="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-common/1.3.31": {
+   "jar": "sha256-1unFTB5sTfIb6Tld5VhmVUTGvcj4B26nUY8In4LNNPw=",
+   "pom": "sha256-Q/EYujqnKlMdZtZM3UIj+mErf6xXAwzpFI/7SlXMOvw="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-common/1.3.70": {
+   "jar": "sha256-biN3z8SJjy+yRCmVGxM7VwslDj+GCoRYsqH4pjz1OlA=",
+   "pom": "sha256-dhYr/Kp1aJf9P2MQGTU+E7Eo3yMYza1brst+fUKKKOM="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-common/1.7.0": {
+   "jar": "sha256-Wcb/ZP6aZgSvzgPoqqdfg1hsYDCscfsLNO583v7TYY8=",
+   "pom": "sha256-JhqZ5S596dKySKuJmKUEbOZB/h4oI39p3xUOxL6aMBo="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-common/1.8.10": {
+   "jar": "sha256-OFAx3kxt2emQ1qREVdeVg1cqSQo0ZNf+fxCl7MoyJag=",
+   "pom": "sha256-0naS2+IzkEoRlTD+8UJheAYNUkvHRf82zsyLN88UB0Y="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-common/1.8.21": {
+   "jar": "sha256-akTJ7MnXdU2elD+x41iMdNSj8Xhb5RB09J1sVyNoKnM=",
+   "pom": "sha256-4ZpVd8vOqJcolw21MzyCZMjGmuci7recv0HV8LDJrmU="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-common/1.9.10": {
+   "jar": "sha256-zeM0G6GKK6JisLfPbFWyDJDo1DTkLJoT5qP3cNuWWog=",
+   "pom": "sha256-fUtwVHkQZ2s738iSWojztr+yRYLJeEVCgFVEzu9JCpI="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/1.8.10": {
+   "jar": "sha256-qEOq4LcjJEivxq8FdHzU3kFrnCt24QChsHsfeIM3su0=",
+   "pom": "sha256-CbhtjWD4DuC7yA/Ta0GdjZpkD6ztwQTR6NTE3rhwJPo="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/1.8.21": {
+   "jar": "sha256-M9FI2w4R3r0NkGd9KCQrztkH+cd3MAAP1ZeGcIkDnYY=",
+   "pom": "sha256-m7EH1dXjkwvFl38AekPNILfSTZGxweUo6m7g8kjxTTY="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/1.9.10": {
+   "jar": "sha256-rGNhv5rR7TgsIQPZcSxHzewWYjK0kD7VluiHawaBybc=",
+   "pom": "sha256-x/pnx5YTILidhaPKWaLhjCxlhQhFWV3K5LRq9pRe3NU="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/1.8.10": {
+   "jar": "sha256-liL2fL5B6IrSV8G4AYBU3QIaYEQWJHSnixvs1E8VoWk=",
+   "pom": "sha256-yqJfrLoU1MPoGQgFaQD30hRCEVeqvU/R1l325zTrML8="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/1.8.21": {
+   "jar": "sha256-PbdSowB08G7mxXmEqm8n2kT00rvH9UQmUfaYjxyyt9c=",
+   "pom": "sha256-ODnXKNfDCaXDaLAnC0S08ceHj/XKXTKpogT6o0kUWdg="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/1.9.10": {
+   "jar": "sha256-pMdNlNZM4avlN2D+A4ndlB9vxVjQ2rNeR8CFoR7IDyg=",
+   "pom": "sha256-X0uU3TBlp3ZMN/oV3irW2B9A1Z+Msz8X0YHGOE+3py4="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/1.3.31": {
+   "jar": "sha256-84yEMmVD5m7UiVsg+z6g/KUn/VoEDh9J0JRuzz0rOyM=",
+   "pom": "sha256-k4GCVV+Hqr2qv6fqIvKSSagB0Iglh/2zbv1raattlIM="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/1.3.70": {
+   "jar": "sha256-MgQ8DqMqKBzeKI1qvrmyjmZmANW2vF7Lyrjw6Tn5MjM=",
+   "pom": "sha256-/0ELFcVzjC4JJKuWEcpZWFt9vsMW3H9Hp9Rmdr/RUEg="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/1.7.0": {
+   "jar": "sha256-qojpYlV3lX8ySaRstuFm7gmzaeYA96EdFI0WsKbYfwU=",
+   "pom": "sha256-CsWfu0zZGIqggUYASiUpXDdSCe+rkxJad/UDfpVldk4="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/1.8.10": {
+   "jar": "sha256-F+EHYTHNB8lYqUL/igh8+GWx7z3lhGPh5d1v11FUBrA=",
+   "pom": "sha256-qWw7icVP1E7MLkCH5dWF0K3kmGtC1Oc1JYAPmwkoXlg="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/1.8.21": {
+   "jar": "sha256-BCoc0ayXbNz+XrY/HY4LC4kskkjhWmnIz7pJXVRupSo=",
+   "pom": "sha256-/gzZ4yGT5FMzP9Kx9XfmYvtavGkHECu5Z4F7wTEoD9c="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/1.9.10": {
+   "jar": "sha256-VemJxRK4CQd5n4VDCfO8d4LFs9E5MkQtA3nVxHJxFQQ=",
+   "pom": "sha256-fin79z/fceBnnT3ufmgP1XNGT6AWRKT1irgZ0sCI09I="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/2.1.0": {
+   "jar": "sha256-1vkbew8wbMopn+x0+3w05IdNb17FuSWgtN4hkB4RnD8=",
+   "pom": "sha256-E05IwXeWwcECfsvmyfHHXHkvU1mHq4nh4d2kP4w2b14="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/2.1.21": {
+   "jar": "sha256-JjvcZ54fYgEtt7CReWJ5ttcc829Hl6mP8azgWDXyAcg=",
+   "pom": "sha256-xVJAhso+SaZ5ht+P3M1mA3uvXzxaNYt2+d1gm+57tjg="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/2.2.0": {
+   "jar": "sha256-ZdEthaO4ZcFg25FHhRcSpksQ2t1osi7qIqlb+KhnDco=",
+   "pom": "sha256-jDyCEAfBNBFVhzm589U4LrgVUds4lc/7iVYeVsD03BY="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/2.2.20": {
+   "jar": "sha256-iDbM/9NYX63amQEkSyDUKQHS881YEFjYQ04v+rzzo+c=",
+   "pom": "sha256-SosIbmQxvPYjY39Ssv8ZLhrbkTg4dC5cDupwqN7kKcQ="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/2.2.21": {
+   "jar": "sha256-ZVij0jPaVqIJNLMhWfnbX4btWBbvCY94osIj3Gq7ed0=",
+   "pom": "sha256-zzH5IxlsY67ezQpXwkJpvTcCpOR8C/C9ZLWtpd5SInI="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.10.2": {
+   "jar": "sha256-XKF1s43zMf1kFVs1zYyuElH6nuNpcJs21C4KKIzM4/0=",
+   "pom": "sha256-ZY9Xa5bIMuc4JAatsZfWTY4ul94Q6W36NwDez6KmDe8="
+  },
+  "org/jetbrains/kotlinx#kotlinx-datetime-jvm/0.4.0": {
+   "jar": "sha256-B1ynWhbjVkhMB948x7znnankrbxnC7zyPF4T9OEu5uc=",
+   "pom": "sha256-6x1TsBUqNd7nZsj0pO4IlCfXw36ZVAC83V4Qhdo9RYE="
+  },
+  "org/jfree#jfreechart/1.5.6": {
+   "jar": "sha256-vnrmMQygBayY7Ot0+lFK+IytCYyAiEV4b3YsoIpbS7M=",
+   "pom": "sha256-WUS/vorn9r2otsbpOl12Hm3pdn27MvUj1MuBYxdBbXE="
+  },
+  "org/jline#jline-builtins/3.27.1": {
+   "jar": "sha256-LVpkkgHcgCr+XrYGwYMNe/6lULQmbbk2cqTXtUyNjYc=",
+   "pom": "sha256-d3HzvwShWSuwQg0igPp3GMVyWRvUzus89EPLg8aBcq4="
+  },
+  "org/jline#jline-native/3.27.1": {
+   "jar": "sha256-Y2ZG2kBBPnSWOz9LQMnF3PtC89Ds8bk9bd9ciV7/5CI=",
+   "pom": "sha256-n/4orsyfVG7JaV8tUh9nRZtLNpFxSMCNFvRVazg9Mo8="
+  },
+  "org/jline#jline-parent/3.27.1": {
+   "pom": "sha256-6WT9B2wgziTdtI3XN6CNYFA0cAXj5u7IL/XrBD1WFYE="
+  },
+  "org/jline#jline-reader/3.27.1": {
+   "jar": "sha256-/t2xgKq9Bb+gTgEzefaTjPj5+vHlo0KZF2K4/NMzRXg=",
+   "pom": "sha256-GuNUfW3zBFrpM5y9olcYaCY74bc8dnPRcFelBcrPHwg="
+  },
+  "org/jline#jline-style/3.27.1": {
+   "jar": "sha256-P7GYcbJZhNaYMHQgXHpKE5v6wuYJm3sa6KSJWLKCMTo=",
+   "pom": "sha256-L9kzNG0hqyqy0EujYO0z8bODID00dMsk00pkl9Z0ExE="
+  },
+  "org/jline#jline-terminal-jansi/3.27.1": {
+   "jar": "sha256-mWvM6OpUHXH3Du3/+dEHpIJ39lVzReIdHzDGDmZIRnQ=",
+   "pom": "sha256-XWrgbTzxQG2C+kk2K8yZxImpu4l3c9baUiJnTT+K/+g="
+  },
+  "org/jline#jline-terminal/3.27.1": {
+   "jar": "sha256-Qre3VlBrypi1BZOEJqNcmQgveBnDM+0lvUEUv7DjtfI=",
+   "pom": "sha256-hHjnmqIupq95eWRD+O0w//pdxkfrPS0YYLrC4j800pc="
+  },
+  "org/jmdns#jmdns/3.6.3": {
+   "jar": "sha256-a26xYjyx2eUUZzEupixWfaAFwqpalTR/VmoRuHA8DvE=",
+   "pom": "sha256-ifvCssUCnnW/tUn4dV2a9YLDG+KW4WdKXG50FOJW7j8="
+  },
+  "org/joda#joda-convert/1.9.2": {
+   "jar": "sha256-a0Edzg+ihuvwMyTwrXoztLHzBCdpq+8EyZMZzZB18xM=",
+   "pom": "sha256-KoolkoW4rL1+JVTS+Qxehjamx+KVaNndYSX/3IEfTVQ="
+  },
+  "org/jooq#jooq-parent/3.13.1": {
+   "pom": "sha256-0ZGbvarG/l/R6Qvvay8djohCls5aXZKc4c7bkTLPz68="
+  },
+  "org/jooq#jooq/3.13.1": {
+   "jar": "sha256-h+7+KZF59m12CJdxg9vKAxtLhqPLf41glvZbB6jo67Q=",
+   "pom": "sha256-1nbVHhMbe7WTj4yj4bHWyyggQh+TaSX9swPEv/vN13E="
+  },
+  "org/json#json/20080701": {
+   "jar": "sha256-A6zWrastpEf0mBR1Gw6VP7YqahAj+dKnBcMKbj5GOOs=",
+   "pom": "sha256-sncQnYWT9blQcZwmkSFCfXXmgSd1qER2/vp0SPfiGZ8="
+  },
+  "org/jsoup#jsoup/1.22.2": {
+   "jar": "sha256-WWeFmW08bfFvVEwjLRCpodiHg7KkdAz1JRy2FvK+cE0=",
+   "pom": "sha256-VPq5kKDvVilwiMJSIT+oM5T6/O+lFgWQRMCeOo4F5VI="
+  },
+  "org/jspecify#jspecify/1.0.0": {
+   "jar": "sha256-H61ua+dVd4Hk0zcp1Jrhzcj92m/kd7sMxozjUer9+6s=",
+   "module": "sha256-0wfKd6VOGKwe8artTlu+AUvS9J8p4dL4E+R8J4KDGVs=",
+   "pom": "sha256-zauSmjuVIR9D0gkMXi0N/oRllg43i8MrNYQdqzJEM6Y="
+  },
+  "org/junit#junit-bom/5.12.2": {
+   "module": "sha256-3nCsXZGlJlbYiQptI7ngTZm5mxoEAlMN7K1xvzGyc14=",
+   "pom": "sha256-zvgP7IZFT2gGv7DfJGabXG8y4styhTnqhZ9H39ybvBc="
+  },
+  "org/junit#junit-bom/5.13.1": {
+   "module": "sha256-M8B6uXJHkKblhZugfWkResUwQ5ckVFqBxBeeMnLHXeg=",
+   "pom": "sha256-+mhFHqgwVy7UP/5R11tqBfel5mWmAqUfSda+AgY6ZfM="
+  },
+  "org/junit#junit-bom/5.13.4": {
+   "module": "sha256-6Vkoj94bGwUNm8CC/HhniRKNpdKFMJFGj8pQQQS99AA=",
+   "pom": "sha256-16CKmbJQLwu2jNTh+YTwv2kySqogi9D3M2bAP8NUikI="
+  },
+  "org/junit#junit-bom/5.14.1": {
+   "module": "sha256-J4rLEczJmYaUIkOG+W+0lBoi7bQstEbJLg8fMwFLa0g=",
+   "pom": "sha256-AbAd+jZlULQKxXYFSKfXKLYQnRfEUeg4ZNHl4M6GLJQ="
+  },
+  "org/junit#junit-bom/5.7.1": {
+   "module": "sha256-mFTjiU1kskhSB+AEa8oHs9QtFp54L0+oyc4imnj67gQ=",
+   "pom": "sha256-C5sUo9YhBvr+jGinF7h7h60YaFiZRRt1PAT6QbaFd4Q="
+  },
+  "org/junit/jupiter#junit-jupiter-api/5.13.4": {
+   "jar": "sha256-0buBq/2eA0GDBrTmozkMjbUsWDcudJwpgKwp8MCCePE=",
+   "pom": "sha256-xWBTV9MRgTZCxABEHgR7ynF8rcFXs/5+GJhbxv8jLls="
+  },
+  "org/junit/jupiter#junit-jupiter-api/6.0.3": {
+   "jar": "sha256-1lXX5vDHrgfxCi87uq67bTDpsmIEoGitnps5UKooeSw=",
+   "pom": "sha256-dmyA+zGOFgDr9smpId6AGIexVIqigtataRiLdgjVbUc="
+  },
+  "org/junit/jupiter#junit-jupiter-engine/6.0.3": {
+   "jar": "sha256-Hi+rYa0n6gj8fHDdlnfPjG0a5UNNQtz91jOxLH58BNA=",
+   "pom": "sha256-uvvAmTJsGIPw7hywVtMbQiLiYWX5+aqbiW89P3ijFTg="
+  },
+  "org/junit/jupiter#junit-jupiter-params/6.0.3": {
+   "jar": "sha256-zylH4jArn4yKBZJZoneIHBytro+8JRTBapJc/re+suU=",
+   "pom": "sha256-mVtk7KoiJ8S1Xz6453c19URDSi7Cz+7QYF6LrxCCY94="
+  },
+  "org/junit/platform#junit-platform-commons/1.13.4": {
+   "jar": "sha256-HCXKZB66rkT/OtIcobLvaNDdhL/rB8SAW6eECJm3dAg=",
+   "pom": "sha256-RKWQ1nrsTSdskMUVj+EEePITPwoj7DLPqzqlXUK4aIM="
+  },
+  "org/junit/platform#junit-platform-commons/6.0.3": {
+   "jar": "sha256-OfJi0Jw9UnGf4Ld/CA6Qo2leKF13mkGyMuF5Y65dogA=",
+   "pom": "sha256-vbjiS+l+Dll2nyFktTYfVSJ5WN9BA9aGgvh3mtLKjX0="
+  },
+  "org/junit/platform#junit-platform-engine/6.0.3": {
+   "jar": "sha256-SR6eT3RfFhuKjkGGoafGpFDqEscJMMmu2uQnIVMB2Uc=",
+   "pom": "sha256-eofYxqCn2wJgsAzjAxgPb0HQQFYoldaARhnV227iMr4="
+  },
+  "org/junit/platform#junit-platform-launcher/6.0.3": {
+   "jar": "sha256-MVYINy5NxEvKDMs66KB+zCBrM2cDP6BXSKA8zVY/EwE=",
+   "pom": "sha256-TTngPyCTd29BkwccjN8ZgTa5YWbHtDteN+fWFWudmO0="
+  },
+  "org/junit/vintage#junit-vintage-engine/6.0.3": {
+   "jar": "sha256-4JNfC0QpbnP+SH3t5IoOfPp8PN0Gb4NF+Jph7VG1gTI=",
+   "pom": "sha256-gs0XiUf12cL0pbAFSOLDK9ta3fI7+UqYYEyuDCr464k="
+  },
+  "org/jvnet/staxex#stax-ex/1.8": {
+   "jar": "sha256-lbBdlZCvQVTGUTucXcH7LlW1OZcroKnvKOmgwB2DrXc=",
+   "pom": "sha256-CoTCDPcfaj0h/iJrDViDMvx64+kMtYPGCkgzF+ufNkQ="
+  },
+  "org/latencyutils#LatencyUtils/2.0.3": {
+   "jar": "sha256-oyqf+gay9OAcU2D4+d97xdlFSl03PNjzYTR/paVxZew=",
+   "pom": "sha256-jwwBU3kLhK9sCTFtVpvRBu4PAIuTk+gLpHj1v2Vziig="
+  },
+  "org/lz4#lz4-java/1.4.1": {
+   "jar": "sha256-8O+lzhMY8OPnNPNSONrMRBxlEMtvP+5tHP0+uuFeK+8=",
+   "pom": "sha256-Vig2NEoy0Fbmqt30mLSREhQfpAj0CQ71bIBnP+5ZgUs="
+  },
+  "org/lz4#lz4-java/1.7.1": {
+   "jar": "sha256-8RZ6RdS4ACBTZw72mRymbRurncwD5O8AGDZ00vP7nKw=",
+   "pom": "sha256-LLcm2JCYwUGHnM6tzuUyrJmpwBbVQp5EASOqES/JagI="
+  },
+  "org/mockito#mockito-core/2.18.3": {
+   "jar": "sha256-wFsuT+E6Df7ajyu26xhx8CB2EYmC/aws/NpA1mzaCRA=",
+   "pom": "sha256-NvuZ0VV4kT+H1WS9Vl7KQxjJQf3tz+qXS9I+PRG3/rg="
+  },
+  "org/mockito#mockito-core/2.7.2": {
+   "jar": "sha256-do1fRBdoxIpMvtLg8azk/u3VZJME9bPpXbYbkuHQO70=",
+   "pom": "sha256-7oX6PVmUrRwSmNCo8w5p7cbN+HT02AcZkzZCu8Qb8aI="
+  },
+  "org/mockito#mockito-core/5.23.0": {
+   "jar": "sha256-rilb69XRH6uXqyl4Fdx2FxiLhgA8vOPf1cDVw6bMSgw=",
+   "pom": "sha256-wC4pALknetv+EnVtfQuUcua55Zcq4fKNGaQaplE3d+M="
+  },
+  "org/mockito#mockito-junit-jupiter/5.23.0": {
+   "jar": "sha256-ZZOFJv3DEbs6HAAV6xyKC+gVFaqZjyK59OkvG2aOT2M=",
+   "pom": "sha256-tm0N+BqrLtL6U8mQ6pDC8fkVAxvIXkGGAt5M+40q1+g="
+  },
+  "org/mongodb#bson-kotlin/5.6.2": {
+   "jar": "sha256-PdwhzzYbKO0/1wgab8hwxRZUA13tuvw5+bGUOGeJ+FQ=",
+   "pom": "sha256-l7JfOEqfUOzZRlp+iGCrP04PVRGBklceiLOXOSfeaoE="
+  },
+  "org/mongodb#bson-kotlinx/5.6.2": {
+   "jar": "sha256-2HXei27adNZi0WUupDkP224k8+Xs9RsJlUsRVupt/OQ=",
+   "pom": "sha256-CZS/jQFh2UKoj7Ywp2oDWKtoGLsVjyZ3otBw7F7MUZQ="
+  },
+  "org/mongodb#bson-record-codec/5.6.2": {
+   "jar": "sha256-X0AnRJmXuK/Ae5W7E5aQeq3upyF4rF6PvMpkB3xNzq4=",
+   "pom": "sha256-G+epnOIp16xA4Aci1oQyD0fBpCyWUisWTGgBsaB4BOg="
+  },
+  "org/mongodb#bson/3.12.14": {
+   "jar": "sha256-2wXF/wA7tAkfvHQB5rtQMvII/gaP/4cKQG+6psleOY4=",
+   "pom": "sha256-ZCj7ky2WzLulEihtPXpcuDONGb4hsHWAqhn0UgM6GyA="
+  },
+  "org/mongodb#bson/5.0.0-beta0": {
+   "jar": "sha256-GTGUHD0kc6L6EHe1MaTLa+DwVDPKc25sxafd1OdVGj8=",
+   "pom": "sha256-sJCsfpOLT3E5Rt+MjM4ICLmnH5ogy3ZmqQQ9p9CJBRU="
+  },
+  "org/mongodb#bson/5.6.2": {
+   "jar": "sha256-+Ke8RWyNb/4VhJae+mBK8Uo4luUKxyFDUsQy3R/ObUU=",
+   "pom": "sha256-nZpQJ+e0TEx7TJ6M2RLft5EV+qIR1gA158vD1UkyEYs="
+  },
+  "org/mongodb#mongo-java-driver/3.11.0": {
+   "jar": "sha256-QkyMubVB90fk8GgRWHzsI1fl5AJYYqKV8VnlFmxN27U=",
+   "pom": "sha256-GsM1J+D/RHfcPjInXXin11YqScwAuFOd5mYrRbSQbvE="
+  },
+  "org/mongodb#mongo-java-driver/3.12.3": {
+   "jar": "sha256-ZduuU1k/wzJ9AesU20TEIflADzyE+DLF0WaRjU+Y7Fc=",
+   "pom": "sha256-4Yqxot5ZxlDH5fmtr8zNxvrqfncQUvSfoTqvBrtaxHQ="
+  },
+  "org/mongodb#mongodb-crypt/1.0.0-beta4": {
+   "jar": "sha256-+LjppO9iYnPVHq7H0fxQFg8L68IiSHfWNc1IrogTOjI=",
+   "pom": "sha256-xqs8X6mtu9AYma/1iKtxvfVLn9TzG0QCNzYCDevt4e8="
+  },
+  "org/mongodb#mongodb-crypt/1.0.1": {
+   "jar": "sha256-BbzphjTjBc33PKs5D79dUUAi+TKxomYftQWqcGWwFFk=",
+   "pom": "sha256-CMexdYieVLxRQ5oeWHjutwW1sl4ZWW1UHhP0Pb9Kk0Y="
+  },
+  "org/mongodb#mongodb-crypt/5.6.2": {
+   "jar": "sha256-sq9Lj3Sbu+BDKGiVzNFajmGsfBLbZin1Tkir5ypQWH8=",
+   "pom": "sha256-GPLiYjNVFVCQi5od3OIJ15k6EC3C9fJJUdMdkiEwinM="
+  },
+  "org/mongodb#mongodb-driver-core/3.12.14": {
+   "jar": "sha256-+7iQUAZTlfI3EFd8XulbutWbAElCiBdeL5LSQ4wiXWM=",
+   "pom": "sha256-LOYyXLFUq2G8/+Bpzi1j9/pFbJ+AYVhfLKlHBY1Znqo="
+  },
+  "org/mongodb#mongodb-driver-core/5.6.2": {
+   "jar": "sha256-Lyn/lFZnZQ/RNd3LQnWpMPy4orvVUae0ZiTXN/hUp30=",
+   "pom": "sha256-l0eMTRSOQkAqWNRoCSJ+tw7Docb6itg/eajXuaYEzIc="
+  },
+  "org/mongodb#mongodb-driver-legacy/3.12.14": {
+   "jar": "sha256-9xyAbdBKdCNywitEoVN1NowTyXzJ3xrBZ39oSlWJWP0=",
+   "pom": "sha256-1uOu4VZHkFlaJXC8GJYOiILXy5vtGUJM2zOGIITTY5w="
+  },
+  "org/mongodb#mongodb-driver-sync/3.12.14": {
+   "jar": "sha256-g2R8poc3oHlksdO1wfUbrw1IPuz+2DjqGmGkg3+S6Lc=",
+   "pom": "sha256-rQ2fLhxtVqy7u8Wc/3RWY46JI0lJ0h6sR0eo6xp8FrY="
+  },
+  "org/mongodb#mongodb-driver-sync/5.6.2": {
+   "jar": "sha256-SRUZ7x4a/x+RyuyGcTgcmvRIFnhpwl7tNFer/AD24LQ=",
+   "pom": "sha256-slh9z8xF3/BxjoEni/qHCuO/FO3XmxivXQ5n+90QOi4="
+  },
+  "org/mongodb/bson/maven-metadata": {
+   "xml": {
+    "groupId": "org.mongodb",
+    "lastUpdated": "20260430174400",
+    "release": "5.7.0"
+   }
+  },
+  "org/multiverse#multiverse-beta/0.7-RC-1": {
+   "jar": "sha256-0OsmDjda+7j9xYn9EX9bxigXjq+sQDhfIrS3CIHk17E=",
+   "pom": "sha256-gsnkxvnLn/gVVjda2FvDIMrKQyF4oDW5vOA2U5LZR9I="
+  },
+  "org/multiverse#multiverse-core/0.7.0": {
+   "jar": "sha256-xUOY8CKAVLf65lInQzrp2oflsqluuoJOZqkkkS0Q/FA=",
+   "pom": "sha256-p7gugArForuaPFPIf328LPcE45XMMnNRC6OAd9PrURQ="
+  },
+  "org/multiverse#multiverse/0.7.0": {
+   "pom": "sha256-7eh88cQ59oa9lF8cRiz8//VQg6HnKxjCjmP050MEohg="
+  },
+  "org/objenesis#objenesis-parent/2.5": {
+   "pom": "sha256-jx9IN/9uYXDdp/9Tv0kki9wCMIynBUI4p99dFFn8ASg="
+  },
+  "org/objenesis#objenesis-parent/2.6": {
+   "pom": "sha256-OCX+yio8F2QAsGPex8awZD4rUla7v9Tgp8EeDdCYO6o="
+  },
+  "org/objenesis#objenesis-parent/3.3": {
+   "pom": "sha256-MFw4SqLx4cf+U6ltpBw+w1JDuX1CjSSo93mBjMEL5P8="
+  },
+  "org/objenesis#objenesis-parent/3.5": {
+   "pom": "sha256-up+Z3fcpbWwF5EKdhEN52gFxrVboJ2RNdtVHu3PBz0o="
+  },
+  "org/objenesis#objenesis/2.5": {
+   "jar": "sha256-KTMo4bDTHtMLuJ/KVCtsUvrACYm7DmLrnZjWMMTda3w=",
+   "pom": "sha256-HMpFX8US3pJ2vu1t2mD+S4ZvMcenwghhbsaPBKyar5A="
+  },
+  "org/objenesis#objenesis/2.6": {
+   "jar": "sha256-XhaDaPvCUK88eapf7ww0Z6LWTlp710AF8l2Dma6wcI0=",
+   "pom": "sha256-TBMHkJ3GLfG9kfB1UD+L3vWuRF4TNT8XUq+USL6h0/E="
+  },
+  "org/objenesis#objenesis/3.3": {
+   "jar": "sha256-At/QsEOaVZHjW3CO0vVHTrCUj1Or90Y36Vm45O9pv+s=",
+   "pom": "sha256-ugxA2iZpoEi24k73BmpHHw+8v8xQnmo+hWyk3fphStM="
+  },
+  "org/objenesis#objenesis/3.5": {
+   "jar": "sha256-b1q9Qs8+vA8r2uc9vFeCD8Shy4kwSShB4p6an53MhuA=",
+   "pom": "sha256-BSjmTxaXywaZOnlRcXd8bSSkJcmuDdKY7GQBhO30Zag="
+  },
+  "org/openmuc#jmbus/3.3.0": {
+   "jar": "sha256-H5Eek4yLoaCwD36hCTHP37tXkP9TrxbEHE966YgPFI0=",
+   "pom": "sha256-JlT4jhsuCJhr62zHUuvMFcFCLQPuntW45U85tSQ6woA="
+  },
+  "org/openmuc#jrxtx/1.0.1": {
+   "jar": "sha256-pRi9B9Nn/BKKnpncSJsCHYR5odIYGt4ZvFrh3TXN04Y=",
+   "pom": "sha256-a4VBSaqekimcnRxWyvDDpRwTTAI1qxSV93QG/NinCUY="
+  },
+  "org/opentest4j#opentest4j/1.3.0": {
+   "jar": "sha256-SOLfY2yrZWPO1k3N/4q7I1VifLI27wvzdZhoLd90Lxs=",
+   "pom": "sha256-m/fP/EEPPoNywlIleN+cpW2dQ72TfjCUhwbCMqlDs1U="
+  },
+  "org/ops4j#master/4.3.0": {
+   "pom": "sha256-j7pc+vZORRwlikcL5illCUzfrFzuDy+aqVBO4NUy88s="
+  },
+  "org/ops4j/pax#logging/2.3.3": {
+   "pom": "sha256-KmTewrU4ljxdhjxWaTgJGNR7VesHgW+GUnZFddPc14w="
+  },
+  "org/ops4j/pax/logging#pax-logging-api/2.3.3": {
+   "jar": "sha256-HnNwCpkTduhVyoMk8W0unoZGKscSoH9ewRf98BWs5VA=",
+   "pom": "sha256-iF+KCB7FjtMWBiVwhTgXOYFTVsmBiks2jJnFzn+gcFQ="
+  },
+  "org/ops4j/pax/logging#pax-logging-log4j2/2.3.3": {
+   "jar": "sha256-h6+dGIHo4xE739FZht0UfXAeAdvQvkQzpdsJ0dtmKU8=",
+   "pom": "sha256-NrUaMSD1ok9G7N4IxhF+EJV+lgYaJc+jUEwvSljwkxU="
+  },
+  "org/osgi#org.osgi.dto/1.0.0": {
+   "jar": "sha256-y3Xzx+SOWjGjHfIuJoczRvW/ZZ4tyrI2ngMeSFDS/0M=",
+   "pom": "sha256-XDHfk5LAR5tfgS9/hIDPsvcrbUmu8oVLfZFuBrCxDKw="
+  },
+  "org/osgi#org.osgi.framework/1.10.0": {
+   "jar": "sha256-4AcAssB6aNb3CntCvSnVmbvna9EelqNLYeTeRamKsb4=",
+   "pom": "sha256-hLZkCUkh3RWhQKjsvcOzwojhAAO0QJxbuOY2Jta25h0="
+  },
+  "org/osgi#org.osgi.framework/1.8.0": {
+   "jar": "sha256-7BlLeHGvJ2gXFv8FJZMZpcPJuXJ+gADp6DJJm5NIS04=",
+   "pom": "sha256-Z9tZJwa+xs7fS932a6ZJrVEkDN8SnjSQXm78j5AhCTM="
+  },
+  "org/osgi#org.osgi.namespace.extender/1.0.1": {
+   "jar": "sha256-k9eYvef6dglhQIyKEKllynuh2/mKOnBshtgpD1KK1Rk=",
+   "pom": "sha256-XvcolKmjGtQibGHcShBfm3VnLT1BzjrKXomn1pHgAoM="
+  },
+  "org/osgi#org.osgi.namespace.implementation/1.0.0": {
+   "jar": "sha256-uFgwXl5apoO4NmKX3bsuEfiPwq9KAMlvpyLNpSW7izQ=",
+   "pom": "sha256-ZDqZeo/endaa5WhiNj94zOJ5ikEGKssF75BzTsC2+QE="
+  },
+  "org/osgi#org.osgi.resource/1.0.0": {
+   "jar": "sha256-gfxQ8fHTikryjhMZB9Sv4hMkmqsFBgSE7coOYMSvm0o=",
+   "pom": "sha256-g6zfIl/7mkp7xYL1OkFFofLDvbtCjgM8AJZvY8YQ6CA="
+  },
+  "org/osgi#org.osgi.service.cm/1.6.1": {
+   "jar": "sha256-Up2ntoBq9NeIrMCu8AecnJIPbLHSZ5yPOSylUvsuHTU=",
+   "pom": "sha256-ey1426s52iAvTyUoNQuwFrtFfM92SjXwMVfikjuX/cg="
+  },
+  "org/osgi#org.osgi.service.component.annotations/1.5.1": {
+   "jar": "sha256-QsCA3gkIlvRdKk6YCiYdW2rd7uB+xLIB8B3pWrVitEg=",
+   "pom": "sha256-d+NdJtSU77JNnp83yxJOpcDjdjCFJ6ml2dtIdnthGjc="
+  },
+  "org/osgi#org.osgi.service.component/1.5.1": {
+   "jar": "sha256-BlOFLeq1xvbpyE46qPcucrnOffr3pkMfPYD2+dekM60=",
+   "pom": "sha256-ntwXphSPKgFenLpb8KuCSJDGI+xYs3Plx9R11t/emYk="
+  },
+  "org/osgi#org.osgi.service.coordinator/1.0.2": {
+   "jar": "sha256-sA3LUHuCQ/vlTubn+FNEmoRa+OfYQxPH1JdJSf2qsis=",
+   "pom": "sha256-DR2KkKB+CBsBIewegopVu51NRK7SK9qUKZEqIQFGi2o="
+  },
+  "org/osgi#org.osgi.service.event/1.4.1": {
+   "jar": "sha256-nxHGiYDb2TGFDz8n/Hw14dcQ7Mco/ocr1teGzX5Le14=",
+   "pom": "sha256-UUlc5UDzg+9j8ZEYOZnd9D+B9zV7ERt/LLcGp7vhyvg="
+  },
+  "org/osgi#org.osgi.service.jdbc/1.1.0": {
+   "jar": "sha256-wdFMs012vtxLSM+YWeXY1LhI0PtA/HAPK+ZviCnK1CQ=",
+   "pom": "sha256-sI2WI8DM5co2YCballdbMF/PUmtYk7F1IO9BPE2iTEI="
+  },
+  "org/osgi#org.osgi.service.log/1.3.0": {
+   "jar": "sha256-/2cQxIVtMmhM8+vcRSSPQQNv9zTysDu8CMRgmmH+z6A=",
+   "pom": "sha256-IcKVDBCS/bOOwIRYa471pU5dHQSV9UqCR+Auuu1EMos="
+  },
+  "org/osgi#org.osgi.service.metatype.annotations/1.4.1": {
+   "jar": "sha256-TGRbCjlSwfZWFWpjYaKNgtRi7VIzRM2Bq26EkLjNBNU=",
+   "pom": "sha256-a0vLdJ6CiCyJQtoMSxhrZK5DjcECcS98ldXqr/u8I3E="
+  },
+  "org/osgi#org.osgi.service.metatype/1.4.1": {
+   "jar": "sha256-g9nMK2JQDS5Di+kcFXZZwtaTomLP0U65uRYobKYn7QA=",
+   "pom": "sha256-xey3BzR6GxkEZ5L1QpIPG1fJcdg/DMfniob8HLaGFdo="
+  },
+  "org/osgi#org.osgi.service.repository/1.1.0": {
+   "jar": "sha256-xVU+lbRZUpGSQzSG1MTMIv9FourkloSE+fcXMZJkpTI=",
+   "pom": "sha256-QGb8pxWqwy/jzgvHv4Epe/1xMOu2CQzJZSrfeyqAfxk="
+  },
+  "org/osgi#org.osgi.service.resolver/1.1.1": {
+   "jar": "sha256-0hLyvLRc++yQcxDXj1MNmJjeDM97B5Os8Ys4bwPH3jk=",
+   "pom": "sha256-uPMUllLomdnRY/zyBKSD1Cq79OoT/+zI2aMyLIF84cI="
+  },
+  "org/osgi#org.osgi.service.serviceloader/1.0.0": {
+   "jar": "sha256-j4ds4qmqTpWx8ZUpUCVRA+JIdCUFCmVPMoVEe6YBwVQ=",
+   "pom": "sha256-dVdRq2w3oaMa+1ueSllcDdLv0rUNcDshJVuCfFDtYVM="
+  },
+  "org/osgi#org.osgi.util.function/1.0.0": {
+   "jar": "sha256-T/kykBLAGgxpwFchpr0LkQ1AoNMhCChOWcGmIVzuekM=",
+   "pom": "sha256-/rMDeejecNgCtzWqw8FaveP/s4pP7n2CnqFQOfamsPI="
+  },
+  "org/osgi#org.osgi.util.function/1.1.0": {
+   "jar": "sha256-g9UtGY+L3UzZoC7LfwXgHg1Z0clgJW223M0Wli9518U=",
+   "pom": "sha256-PRTZoKoXJk/voMJNImQK8Pf8R+D1YUIXjiJc7iU+Amw="
+  },
+  "org/osgi#org.osgi.util.function/1.2.0": {
+   "jar": "sha256-IIgZx8cWkMFaa7ixh0dOf50BR5RraAGCpiufIirgFOw=",
+   "pom": "sha256-9O3YQYEVfUNoGNRlZdSAN5wbBwAdXLEwtAZxlykRXqg="
+  },
+  "org/osgi#org.osgi.util.promise/1.0.0": {
+   "jar": "sha256-fWGcklcW8hrhdlRSlUPQDqVoEHhAQPbtjG1vkBUm7mc=",
+   "pom": "sha256-tNcKlK0qBiuq5lWNHNG2hL16I8E3Ii5tDkrvTmVQ8kU="
+  },
+  "org/osgi#org.osgi.util.promise/1.3.0": {
+   "jar": "sha256-cFPFfn19iP7GuQl5o68SXh0ruEcmijKKLx7WWtCkwYU=",
+   "pom": "sha256-rcyK9ce+Z7BSEF4Mncq43ibaxvGbxamrcpRqMydscQA="
+  },
+  "org/osgi#org.osgi.util.tracker/1.5.4": {
+   "jar": "sha256-fXjCzJvLZCHCTxeqCXhmzo2RFcIZpPjWzHU7xN+5fvo=",
+   "pom": "sha256-L3oSGrysdT5csPguP+4NpHlZV5hp4wTYwvtuh2PkMSk="
+  },
+  "org/osgi#osgi.annotation/7.0.0": {
+   "jar": "sha256-1fQIPMTHgaOxKDKl+v18VTa6S90x9BGozVyTtzNw1ww=",
+   "pom": "sha256-9H5EZpzGE7XBPTh2gXHQ0jRK+D/jzH8z6l+uFGr9/LU="
+  },
+  "org/osgi#osgi.annotation/8.0.1": {
+   "jar": "sha256-oOikw2K9NgCBLzew6kX7qWbHvASdAf7Vagnsx0CCdZ4=",
+   "pom": "sha256-iC0Hao4lypIH95ywk4DEcvazxBUIFivSuqBpF74d7XM="
+  },
+  "org/osgi#osgi.annotation/8.1.0": {
+   "jar": "sha256-aK/rhqUyJnXU3+PfWGPH2KN7NMGOOo5BVT8as6wV148=",
+   "pom": "sha256-Ipp+DGAj5pPlC5O80w5J0c0Q5RnZYV4YaW3Q7Pobndc="
+  },
+  "org/osgi#osgi.cmpn/7.0.0": {
+   "jar": "sha256-jmRFr+Grs9zUPGDIzWwPFbBSqPQiiBJVm6Uhxc6R2zQ=",
+   "pom": "sha256-84XsLBkJVboOPwqqanx2EQ/2bZlUMyFFIk1vFxa2wVU="
+  },
+  "org/osgi#osgi.core/7.0.0": {
+   "jar": "sha256-qSGPm+5opBxN29ks37LuiuZg+iWzcveNAYErF3DkUls=",
+   "pom": "sha256-1R1f0j4ebg07q9vYKiuSLjp92+GdrcDgBQSv+5CQCY4="
+  },
+  "org/osgi#osgi.core/8.0.0": {
+   "jar": "sha256-QcJNGH9nqq9HRfq3j9HaZt5/N92CWB27vJuolkW6AWY=",
+   "pom": "sha256-ZR92uim7Q5LTaupW99CwyC/EkXAk2eaoQ3dLulAV61M="
+  },
+  "org/ow2#ow2/1.3": {
+   "pom": "sha256-USFcZ9LAaNi30vb4D1E3KgmAdd7MxEjUvde5h7qDKPs="
+  },
+  "org/ow2#ow2/1.5": {
+   "pom": "sha256-D4obEW52C4/mOJxRuE5LB6cPwRCC1Pk25FO1g91QtDs="
+  },
+  "org/ow2#ow2/1.5.1": {
+   "pom": "sha256-Mh3bt+5v5PU96mtM1tt0FU1r+kI5HB92OzYbn0hazwU="
+  },
+  "org/ow2/asm#asm-analysis/5.0.3": {
+   "jar": "sha256-6PoqY0YsllV9zTbCVSXhJkt3Nm/4Uc8LlOt1krKQhJ0=",
+   "pom": "sha256-n/wCobw9hGKTrZ+Inbn0LQkg6VOsxMSCVyb/AxQFp9A="
+  },
+  "org/ow2/asm#asm-analysis/9.2": {
+   "jar": "sha256-h4++UhcxwHLRTS1luYOxvq5q0G/aAAe2qLroH3P0M8Q=",
+   "pom": "sha256-dzzBor/BTGxKl5xRoHXAI0oL9pT8Or5PrPRU83oUXxs="
+  },
+  "org/ow2/asm#asm-bom/9.9": {
+   "pom": "sha256-D6JzNvp7YpI8qb3GlSbr5xKjv7H37ov3bEoLP4XxnWI="
+  },
+  "org/ow2/asm#asm-commons/5.0.3": {
+   "jar": "sha256-GMHgkiMCM8nSnkbyGUPXab20gTDMJ55LDmY/QjlIwto=",
+   "pom": "sha256-6H6kgj7PLdhWkB2jWScL6QQja+WcJ+J4HrjXjJfkWyo="
+  },
+  "org/ow2/asm#asm-commons/9.2": {
+   "jar": "sha256-vkzlMTiiOLtSLNeBz5Hzulzi9sqT7GLUahYqEnIl4KY=",
+   "pom": "sha256-AoJOg58qLw5ylZ/dMLSJckDwWvxD3kLXugsYQ3YBwHA="
+  },
+  "org/ow2/asm#asm-commons/9.9": {
+   "jar": "sha256-2y9vJhULvnwSZga0oRUYNrzCKh4FpCOzWFaYvs6ZX/g=",
+   "pom": "sha256-GKXT7xN351RLPKMhDyYTlrmH9gEO9ZHThyra5jEZ7kM="
+  },
+  "org/ow2/asm#asm-parent/5.0.3": {
+   "pom": "sha256-wu2r9BKKU030uLSwubVi6U8kK6lawk3GFIVDK4oYjjI="
+  },
+  "org/ow2/asm#asm-tree/5.0.3": {
+   "jar": "sha256-NHp6lAD5lk6HyR05gOSO69yNAkvDs29/IhicZihTpRw=",
+   "pom": "sha256-ZYGcp8WiGP9J+OvnLzs5IZyB8TfQF6zBrsFbEFTPUjY="
+  },
+  "org/ow2/asm#asm-tree/9.2": {
+   "jar": "sha256-qr+b0jCRpOv8EJwfPufPPkuJ9rotP1HFJD8Ws8/64BE=",
+   "pom": "sha256-9h8+vqVSDd8Z9FKwPEJscjG92KgdesKHZctScSJaw3g="
+  },
+  "org/ow2/asm#asm-tree/9.9": {
+   "jar": "sha256-QhePN3XJxj+eXhRGdH0ptOyk2RvW515cQ8+jcqR9OMY=",
+   "pom": "sha256-0BeI7Y5ujiSsr2y0p73MJzNBYlL6oAIylZ4+Lp3xv0Q="
+  },
+  "org/ow2/asm#asm-util/5.0.3": {
+   "jar": "sha256-J2jtv6JoG1B38IFR3lhqbWa5FnA82jqyl+WLQa6PI2I=",
+   "pom": "sha256-WuIOj99Um5zt4JCDRyX2RUosrG9RkBMH60UmF35ON1U="
+  },
+  "org/ow2/asm#asm-util/9.2": {
+   "jar": "sha256-/1s80zGuipqAR2goDamPUPQk/vI908eIuzIOCMlO5Zg=",
+   "pom": "sha256-3dBpE/FH1wrmjnpuQ1alWzPxTd5hYtv/K9DiiVgfGtI="
+  },
+  "org/ow2/asm#asm/5.0.3": {
+   "jar": "sha256-ccT3jkN7j9zZzA39Kr6owInrZ3AFpqXP8yAgbMUrRsw=",
+   "pom": "sha256-fTRlP/5ivncU0vGWlmChffnsGxnYJQxPA9sRI8grpqA="
+  },
+  "org/ow2/asm#asm/9.2": {
+   "jar": "sha256-udT+TXGTjfOIOfDspCqqpkz4sxPWeNoDbwyzyhmbR/U=",
+   "pom": "sha256-37EqGyJL8Bvh/WBAIEZviUJBvLZF3M45Xt2M1vilDfQ="
+  },
+  "org/ow2/asm#asm/9.8": {
+   "jar": "sha256-h26raoPa7K1cpn65/KuwY8l7WuuM8fynqYns3hdSIFE=",
+   "pom": "sha256-wTZ8O7OD12Gef3l+ON91E4hfLu8ErntZCPaCImV7W6o="
+  },
+  "org/ow2/asm#asm/9.9": {
+   "jar": "sha256-A9madK0e5ccTNO9nQ39O9P40iMqnyW2GRavHPI4gF9Q=",
+   "pom": "sha256-z4Ye8edF1XFUr3muFN80DtU0Hl3NAVfO/NLrfxqgXFc="
+  },
+  "org/owasp/encoder#encoder-parent/1.4.0": {
+   "pom": "sha256-P8okzcWIihgMvOJi+61NBkeyyPN8qKACrJMnAGw+RGo="
+  },
+  "org/owasp/encoder#encoder/1.4.0": {
+   "jar": "sha256-kPmGCSWQXdl/MTz/rgZYNesCrMPi6bAFFiFpPv0JAlw=",
+   "pom": "sha256-UchD3Z4a7vlLOJWRXJk7aN+WG2pwB7TBOcAHbeJ4l7E="
+  },
+  "org/postgresql#postgresql/42.7.10": {
+   "jar": "sha256-yrHNZ8+iXCXeQ0jlMimAKCiKh3ugHHfRYZ/kVBYZM4c=",
+   "pom": "sha256-KTQ79/n1Jz41ElfEm8EDoHXwsf9SS5tivYSUKZVmsb8="
+  },
+  "org/reactivestreams#reactive-streams/1.0.2": {
+   "jar": "sha256-zAmrCxQODQSWwhZdSzLOJPTWRGwKJsXcd7Br35nuj64=",
+   "pom": "sha256-W2JqmeVzS6jQwMjD/GJYr6BiT0zmGuEZIkfQPFdGPe0="
+  },
+  "org/reactivestreams#reactive-streams/1.0.3": {
+   "jar": "sha256-He4EgQctGckptiPhVeFNL2CF3AEVKaCg2+/ITPVx2GU=",
+   "pom": "sha256-zO1GcXX0JXgz9ssHUQ/5ezx1oG4aWNiCo515hT1RxgI="
+  },
+  "org/reactivestreams#reactive-streams/1.0.4": {
+   "jar": "sha256-91yll3ibPaxY9hhXuawuEDSmj6Zy2zUFWo+0UJ4yXyg=",
+   "pom": "sha256-VLoj2HotQ4VAyZ74eUoIVvxXOiVrSYZ4KDw8Z+8Yrag="
+  },
+  "org/reflections#reflections/0.10.2": {
+   "jar": "sha256-k4otCP5UBQ12ELlE2N3DoJNVcQ2ea+CqyDjbwE6aKCU=",
+   "pom": "sha256-tsqj6301vXVu1usKKoGGi408D29CJE/q5BdgrGYwbYc="
+  },
+  "org/rocksdb#rocksdbjni/5.18.3": {
+   "jar": "sha256-YgmRFpD0ZRORR/L4bsVEvFMJcVdnd2En6X/ZRbevn78=",
+   "pom": "sha256-/rAA31rgAv+05L9Zw9tlfTmK7QQTQAvRay1KoVi7pBI="
+  },
+  "org/rrd4j#rrd4j/3.10": {
+   "jar": "sha256-nK4LvQs1iWpVqMjvT13DCLG8gifK9YQLNpnr1+75ZpQ=",
+   "pom": "sha256-UnFsrCGkS353xOBXXLxJCPkdaSLruJIajOJx3OlyVOU="
+  },
+  "org/slf4j#jcl-over-slf4j/1.7.25": {
+   "jar": "sha256-XpOEV+ee/L+zq2S8KcQ+xsO5X//No8FV9KhswyDBHhQ=",
+   "pom": "sha256-8xiXbT1L0/Nqm6tHr0sX6vZxYD49epLmxnsgBEYuDy0="
+  },
+  "org/slf4j#slf4j-api/1.5.3": {
+   "jar": "sha256-z3lo2hv0OuJsDaEhIXmphn3syvxKmqcSgdH0YfBddBc=",
+   "pom": "sha256-3yRRKeY7NWzehZz2WPmnjT5tc7RK2yYMjKSMAzVRr6o="
+  },
+  "org/slf4j#slf4j-api/1.6.4": {
+   "jar": "sha256-NnuQkDD3FO4RdqsJa2geBjSPAzhemNG84O2AG1RSNX4=",
+   "pom": "sha256-1A3yrVI+j/dGHu3VoOfCHo8F8Oj5mDOHs1iFOKVWRUA="
+  },
+  "org/slf4j#slf4j-api/1.7.0": {
+   "jar": "sha256-JV7CfbxUMy+pTSbxBabbYmAbYHcg2t/IlnX5BG0Tbsg=",
+   "pom": "sha256-2YhR1xxwjzv2T3NDsfH/jEcg7iZbX2A60rHcMdKs3vg="
+  },
+  "org/slf4j#slf4j-api/1.7.12": {
+   "jar": "sha256-Cu6ad6SUDXKTKw0NlVd5P4cuZqA/WY5HP0Xn7+zcz5k=",
+   "pom": "sha256-XoH/aRJeXs3bu+5c7iiqXWXPyzZu1mUBvGeOud1mpPw="
+  },
+  "org/slf4j#slf4j-api/1.7.13": {
+   "jar": "sha256-INaNDC5PuYT/wWSFK4to30miuHFgdvV2iBvO92SaDjU=",
+   "pom": "sha256-WqsK2NDuSTP1er2+3Io8Kh1qX3vXE177xAeinYhyq64="
+  },
+  "org/slf4j#slf4j-api/1.7.21": {
+   "jar": "sha256-HVrra9mLD90VEmnq6UHAX2Rop5HqDx5o2Of+UYrz598=",
+   "pom": "sha256-XyvfJv+i2uhK8snfhDhTKmxwOl6ff5mOmxzWAP3VT9w="
+  },
+  "org/slf4j#slf4j-api/1.7.25": {
+   "jar": "sha256-GMSgCV1cHaa4F1kudnuyPSndL1YK1033X/OWHb3iW3k=",
+   "pom": "sha256-fNnXoLXZPf1GGhSIkbQ1Cc9AOpx/n7SQYNNVTfHIHh4="
+  },
+  "org/slf4j#slf4j-api/1.7.26": {
+   "jar": "sha256-bZ5bhs/R3UTGdomShbW7T6DTcc9YPoFk+cigNmVTJCs=",
+   "pom": "sha256-g5K4CDDtDWpxQjXrmgbMJuRmGe9L7FOiIz4dw0uNuUk="
+  },
+  "org/slf4j#slf4j-api/1.7.30": {
+   "jar": "sha256-zboHlk0btAoHYUhcax6ML4/Z6x0ZxTkorA1/lRAQXFc=",
+   "pom": "sha256-fgdHdR6bZ+Gdy1IG8E6iLMA9JQxCJCZALq3QNRPywxQ="
+  },
+  "org/slf4j#slf4j-api/1.7.6": {
+   "jar": "sha256-BZqEOD+teNhdnDlRvrr6tyAMcExBGp0lyRM0DDh3YEo=",
+   "pom": "sha256-ep5ydsHTU9KyAUu07iBEbvAWqZ5y2be3rDs4DL0MNoU="
+  },
+  "org/slf4j#slf4j-api/1.8.0-beta4": {
+   "jar": "sha256-YCtxIynIS0qDxARk9P39D+QjjFPvOXE5qGcGRznb9OA=",
+   "pom": "sha256-+DFtKKzyUrIbHp6O7ZqEwq+9yOBA9p06ELq4E9PYWoU="
+  },
+  "org/slf4j#slf4j-api/2.0.17": {
+   "jar": "sha256-e3UdlSBhlU1av+1xgcH2RdM2CRtnmJFZHWMynGIuuDI=",
+   "pom": "sha256-FQxAKH987NwhuTgMqsmOkoxPM8Aj22s0jfHFrJdwJr8="
+  },
+  "org/slf4j#slf4j-api/2.0.7": {
+   "jar": "sha256-XWKYuToZBcMs2mR4gIrBTC1KR+kVNeU8Qff+64XZRvQ=",
+   "pom": "sha256-LUA8zw4KAtXBqGZ7DiozyN/GA4qyh7lnHdaBwgUmeYE="
+  },
+  "org/slf4j#slf4j-api/2.0.9": {
+   "jar": "sha256-CBiTDcjX3rtAMgRhFpHaWOSdQsULb/z9zgLa23w8K2w=",
+   "pom": "sha256-nDplT50KoaNLMXjr5TqJx2eS4dgfwelznL6bFhBSM4U="
+  },
+  "org/slf4j#slf4j-bom/2.0.17": {
+   "pom": "sha256-940ntkK0uIbrg5/BArXNn+fzDzdZn/5oGFvk4WCQMek="
+  },
+  "org/slf4j#slf4j-bom/2.0.9": {
+   "pom": "sha256-6u9FhIB9gSxqC2z4OdXkf1DHVDJ3GbnOCB4nHRXaYkM="
+  },
+  "org/slf4j#slf4j-parent/1.5.3": {
+   "pom": "sha256-7D/aFPJYpF9LkYKSQhOOYOho2rMKsC1SzxgOrWTaKtQ="
+  },
+  "org/slf4j#slf4j-parent/1.6.4": {
+   "pom": "sha256-dqBiUy8KJQOITzPOVX6uPK4vLTj9jbDEPjpwQFYGzIU="
+  },
+  "org/slf4j#slf4j-parent/1.7.0": {
+   "pom": "sha256-iTZf6dZOxqEs0I1xzOsjmrc4QD5pu9SeDoCv8+bJHmQ="
+  },
+  "org/slf4j#slf4j-parent/1.7.12": {
+   "pom": "sha256-RiMP+voM+kt9xQ8xsTzWtGjDf+i8Mv5/hBixgM/ukh8="
+  },
+  "org/slf4j#slf4j-parent/1.7.13": {
+   "pom": "sha256-EgXx0cG3q0ws7feknUVQg/7q0pg9Tx5m2SB0UM2sYxg="
+  },
+  "org/slf4j#slf4j-parent/1.7.21": {
+   "pom": "sha256-eqolf13tUWyTwHWGwe0TntUO5aT/YZ5vWLuhf0nRO64="
+  },
+  "org/slf4j#slf4j-parent/1.7.25": {
+   "pom": "sha256-GPXFISDbA26I1hNviDnIMtB0vdqVx1bG9CkknS21SsY="
+  },
+  "org/slf4j#slf4j-parent/1.7.26": {
+   "pom": "sha256-NdEVs8mXMOyKCLD8LLMc++Yz55M8T7Y4BeAaEgv0F14="
+  },
+  "org/slf4j#slf4j-parent/1.7.30": {
+   "pom": "sha256-EWR5VuSKDFv7OsM/bafoPzQQAraFfv0zWlBbaHvjS3U="
+  },
+  "org/slf4j#slf4j-parent/1.7.6": {
+   "pom": "sha256-adgFJi7eTqw8DxWCXIsTQ6b3Qa2WiSw8TwTxlthP4gY="
+  },
+  "org/slf4j#slf4j-parent/1.8.0-beta4": {
+   "pom": "sha256-uvujCoPVOpRVAZZEdWKqjNrRRWFcKJMsaku0QcNVMQE="
+  },
+  "org/slf4j#slf4j-parent/2.0.17": {
+   "pom": "sha256-lc1x6FLf2ykSbli3uTnVfsKy5gJDkYUuC1Rd7ggrvzs="
+  },
+  "org/slf4j#slf4j-parent/2.0.7": {
+   "pom": "sha256-wYK7Ns068ck8FgPN/v54iRV9swuotYT0pEU1/NIuRec="
+  },
+  "org/slf4j#slf4j-parent/2.0.9": {
+   "pom": "sha256-wwfwQkFB8cUArlzw04aOSGbLIZ7V45m2bFoHxh6iH9U="
+  },
+  "org/slf4j#slf4j-reload4j/2.0.9": {
+   "jar": "sha256-iWsGOaXw6x/ELEU77oPOr4u+bLcbJJ3xJMlkXf0VoOU=",
+   "pom": "sha256-KQFQVyhiLF6rCuIi1dQ7FZp1JvSUiKpDmkad7Ae8Q28="
+  },
+  "org/slf4j#slf4j-simple/1.7.25": {
+   "jar": "sha256-CWbob/+lvlLT2ee4ndZ02YoD7tCkVPuvfBvZSTvZ2HQ=",
+   "pom": "sha256-pTyky/yMwRnWkG7aKwMR5yYX+cKBVxMqViqVRkuVsfg="
+  },
+  "org/sonarsource/parent#parent/85.0.0.3035": {
+   "pom": "sha256-z80fvEj+pbl0y5PUNrj3NgA0Cs3uofPnH+cKu+sqlgw="
+  },
+  "org/sonarsource/scanner/lib#sonar-scanner-download-cache/4.0.0.1577": {
+   "jar": "sha256-mqsVdXH3rbjkD0z0aMKiy+UY1L0B3LykidOF4R56r2c=",
+   "pom": "sha256-R1a6fP1Srg5M49OCQJJtz7k/rBH3PFQaOrIwkVpt0mI="
+  },
+  "org/sonarsource/scanner/lib#sonar-scanner-java-library-batch-interface/4.0.0.1577": {
+   "jar": "sha256-d8W5NnfCNWI2xkYnP81iT1b4Tb/lp3W+ksjs8tVdOTQ=",
+   "pom": "sha256-Cd7bSA2gUxAiNxfKdG3t+a6vN2EBgv5DgrgBXoG9vj8="
+  },
+  "org/sonarsource/scanner/lib#sonar-scanner-java-library-parent/4.0.0.1577": {
+   "pom": "sha256-MY1Tes0fLfOX05nuxX2QaHVKaTF7dbJXQopbg6J4jio="
+  },
+  "org/sonarsource/scanner/lib#sonar-scanner-java-library/4.0.0.1577": {
+   "jar": "sha256-gwOoNxs6Y3FSb2ghMjihnxgR9Z28yAEWbHxNvOBMudI=",
+   "pom": "sha256-SwdWjAxh27BqPZ6b8rdYuxTuFvpi5vu9zRDesbiWD1E="
+  },
+  "org/sonatype/oss#oss-parent/3": {
+   "pom": "sha256-DCeIkmfAlGJEYRaZcJPGcVzMAMKzqVTmZDRDDY9Nrt4="
+  },
+  "org/sonatype/oss#oss-parent/6": {
+   "pom": "sha256-tDBtE+j1OSRYobMIZvHP8WGz0uaZmojQWe6jkyyKhJk="
+  },
+  "org/sonatype/oss#oss-parent/7": {
+   "pom": "sha256-tR+IZ8kranIkmVV/w6H96ne9+e9XRyL+kM5DailVlFQ="
+  },
+  "org/sonatype/oss#oss-parent/9": {
+   "pom": "sha256-+0AmX5glSCEv+C42LllzKyGH7G8NgBgohcFO8fmCgno="
+  },
+  "org/testng#testng/6.8": {
+   "jar": "sha256-wPKEWnzIfhCEXW+Z1B3b7aWQlyrq2D5nJxT/exZCzQM=",
+   "pom": "sha256-+BhEcQKe2bHpEKiIaHpR5zXGaisIvgtaBE/5rdT/YHA="
+  },
+  "org/testng#testng/6.8.13": {
+   "jar": "sha256-3XoqtJS0+7bPPMfYDhUxXBNF+5rkYrshs+b8oWTA1Cg=",
+   "pom": "sha256-noydzjPuum19tX6e2SOYwQNcGKg1fEGpn2dYjTR+8NU="
+  },
+  "org/tribuo#tribuo-common-tree/4.3.2": {
+   "jar": "sha256-gq3JMkn++IZ1vWmEZahNXN4NIIy53juZRK/tYjGsE9U=",
+   "pom": "sha256-q7JajDLUkTrYKjMO8oObUOyXDSx8k2d4cLkviUnVvHs="
+  },
+  "org/tribuo#tribuo-common/4.3.2": {
+   "pom": "sha256-hiltnKeKpv52QCc2IN3rF9+m0FRS+q+jeRa8KaQg78w="
+  },
+  "org/tribuo#tribuo-core/4.3.2": {
+   "jar": "sha256-+O9DqjbzespMNGzR5i4p5J6cE4YLTlbJzQXio1/YXzQ=",
+   "pom": "sha256-aydJMUgOYOMr/rtPdzI8u/f19cAioZYBadX7slj5oH0="
+  },
+  "org/tribuo#tribuo-data/4.3.2": {
+   "jar": "sha256-JVpXdz9erThtkSVoERbm1NH3/AgzjhQebXdGphOQsBM=",
+   "pom": "sha256-vE1xWTQfLGsxGllRvPELe06GcEWCs06N3eOV0c+l3iI="
+  },
+  "org/tribuo#tribuo-math/4.3.2": {
+   "jar": "sha256-afXYcsMsFWRJcFG7hZyIgVPKlhxvxFlVVVOgfVw423I=",
+   "pom": "sha256-O/PROvFihfwD+FPNH0jVR+7PZDvpSL2aDrAEB06d/OM="
+  },
+  "org/tribuo#tribuo-regression-core/4.3.2": {
+   "jar": "sha256-wNEbO5unCOXNkjI08NwXUicuKn4WCXaXM+hLbc0Qm1w=",
+   "pom": "sha256-9Y4IJKmg/jVOGJP+i+Wgv4hmfehxXKVzWP6+QTCeFgI="
+  },
+  "org/tribuo#tribuo-regression-tree/4.3.2": {
+   "jar": "sha256-23ClURWEKAKORrzj0lR3c7Cn3TL8w3Lk5rraJzufOqo=",
+   "pom": "sha256-Utuk2CO2xfKivmpSWnztfcgqHK7ynrLNL4C1DhbSaJM="
+  },
+  "org/tribuo#tribuo-regression/4.3.2": {
+   "pom": "sha256-hIB1BCT0ttlcmvOW5oOkGqymdQK7R05Ad9YcchJRfcE="
+  },
+  "org/tribuo#tribuo-util-onnx/4.3.2": {
+   "jar": "sha256-hgk9baHLThi3IOw0XAdubvXZpSrRIIU2yE6w5w8HwU8=",
+   "pom": "sha256-JOYWUtcwPJb1d4cGb0nT6xf0+Swj5nRD+UN4pCTP+kw="
+  },
+  "org/tribuo#tribuo-util-tokenization/4.3.2": {
+   "jar": "sha256-/F1cZ9T6zvGbSNkjEU2WTg8vTV69nn0itSuhBMBItgo=",
+   "pom": "sha256-Os30qk9dYYOphA45ZuzcN1n1UDDWnboeVBwuPXlRnaQ="
+  },
+  "org/tribuo#tribuo-util/4.3.2": {
+   "pom": "sha256-OOmW/aFp4KTTqRC/gAOAEPPbp88xkCGcs4KWDFJ3If0="
+  },
+  "org/tribuo#tribuo/4.3.2": {
+   "pom": "sha256-mGb8n49lef22KoyhH7hb1pXJRCcu/+8ixeQlar8JB04="
+  },
+  "org/tukaani#xz/1.10": {
+   "jar": "sha256-lcY8GlWyLdZFOJCkGcwaZA95C799iugtseMK7++wiIg=",
+   "pom": "sha256-72CLg8O7bI4+azvqo4hCuhWWO0ZJXkr5GwdGyLdQ87k="
+  },
+  "org/tukaani#xz/1.8": {
+   "jar": "sha256-jHlks2/j8MvmRLBPy/+E5JHOgZF9svW/oMuo6VSK/10=",
+   "pom": "sha256-8p51y4jrSsv35apcCe1V6sLLrmAdY6nzdSMfRUUsEBM="
+  },
+  "org/xerial/snappy#snappy-java/1.1.10.3": {
+   "jar": "sha256-+ntdb5nZekKOUxTZgjtYbGbI+0aVYBf92R/FnAKvewU=",
+   "pom": "sha256-vZ4g6iMjXGZk6AJhhpMFAZZFUqwdn+pM+fXn8OH/mlw="
+  },
+  "org/xerial/snappy#snappy-java/1.1.4": {
+   "jar": "sha256-917A+pyEPiNsbhUSwXwJXP/9F18y4h6g4+zLVA138AI=",
+   "pom": "sha256-L5NU/A9hXQ9Mk+FmgCo27qTMtE6lj0GKzRE9rSSevzM="
+  },
+  "org/xerial/snappy#snappy-java/1.1.7.1": {
+   "jar": "sha256-u1KFR1P+sZGfEwmaU0daKo62XbzNIoOam5suGiGQuVE=",
+   "pom": "sha256-eA0rCPtQk6YXR4Fpny0wQm4eDYS5Crr+5Rrd3ifqDfs="
+  },
+  "org/xerial/snappy#snappy-java/1.1.7.3": {
+   "jar": "sha256-fuoxwKJdNc0JLYrsCL7QTyIVJAm1jWPUODkHSpq3q5c=",
+   "pom": "sha256-B84SNmF8jBt0qd4jtaCd+aWYkw34KDg9sqz6O/FhdQU="
+  },
+  "org/xmlresolver#xmlresolver/5.3.3": {
+   "jar": "sha256-H+TVuS9wjc24LbzhKRngFx5rXKYsbcpiIEg2JQmP618=",
+   "module": "sha256-DeilBgQ5G2UDnI/6PxQRiSJ+x5rFMyPhPiunKIy3no4=",
+   "pom": "sha256-JhradtnmZ2AI3Kw3ek1FiXSRZrYGVZ9Z8uRepi2Ldew="
+  },
+  "org/xmlresolver#xmlresolver/5.3.3/data": {
+   "jar": "sha256-sMSHrS8+VYvo2CnJFtJFjRCspqW6+npNBSS3CEXkilw="
+  },
+  "org/yaml#snakeyaml/1.12": {
+   "jar": "sha256-BpnICdFkS2qCCecAdjv1lJffPmN1a7IvUuMx4sfnUKg=",
+   "pom": "sha256-jnTfOajvWS+3BGSBXdx64kTsbr/lupoyA9qgcnU5UWA="
+  },
+  "org/yaml#snakeyaml/1.23": {
+   "jar": "sha256-EwCfte3jzyvlqNDxYCFVrqoM5e9fk2aJK9JY2NPU0rE=",
+   "pom": "sha256-HhvrIsqQYglwASK1ys9vJxkyRTjFsePCe/kVZMjTHb0="
+  },
+  "org/yaml#snakeyaml/1.24": {
+   "jar": "sha256-0/fwmYnVsM5cR5GBjvk37nZj8eNZwu8tMS+Tiq0HY9o=",
+   "pom": "sha256-F01CNyIlaCPtvir41+M4XEZFz3I4KiLaBIWztnQ5Tzc="
+  },
+  "org/yaml#snakeyaml/1.6": {
+   "jar": "sha256-WnuzU3GsM8NczH8EygSIyxXVc9yN8W3KkJAofXTTWUs=",
+   "pom": "sha256-E2ABG4BVusQPcZo87LBjDeoU+e91K+Qk+1obA/UVjq0="
+  },
+  "org/zeromq#jeromq/0.4.3": {
+   "jar": "sha256-G2Ij6K+omqxDNR5ti1iXoAuazFkUD897cv4K1e7eaZw=",
+   "pom": "sha256-UCNhyjI+ee6/iib+uUZeY5wxwOQ/7zXjLzWz3W3Ws+w="
+  },
+  "org/zeromq#jnacl/0.1.0": {
+   "jar": "sha256-Xkg21fCKIugz+c8crb21r2DAc10I3YglagTV3yW1TyY=",
+   "pom": "sha256-GoGQVEMrzzH4jkXVPMFqkjR5jLmIvz/jqNaFxeU3WdU="
+  },
+  "oro#oro/2.0.8": {
+   "jar": "sha256-4AzNrV3360P97kQjLvZGAr9jgHwtEzp76Dugn9Sa8m4=",
+   "pom": "sha256-mqnf6y6F4dXnkyyHFAaXzswrD63ZM9Z5/UIKLkODGoI="
+  },
+  "pull-parser#pull-parser/2": {
+   "jar": "sha256-sgweVlE/rv+5sB2dA7oaNhKKw/m+ObLQ7b4uJAsCnT8=",
+   "pom": "sha256-SCNndnB5fCtx6Ou+VDfEEVH06O23xsDUcyeXFQcPNtM="
+  },
+  "regexp#regexp/1.2": {
+   "jar": "sha256-nHryeMSrtwIcPMnlRK5lA9V7nkR0xClmceFzyasanlg=",
+   "pom": "sha256-s/pr8LTOdI9NBp91JGRoxrd00VcRLhMBuUbm5MME3og="
+  },
+  "regexp#regexp/1.3": {
+   "jar": "sha256-J5mHMuzVdFkkZE+JH0Gtr3Nzb+JZoKIIQ5eUUldPA4U=",
+   "pom": "sha256-UB/ubteenULX0eC5Qgfxnt3DO4kN8d4kRLbu2pclL9w="
+  },
+  "relaxngDatatype#relaxngDatatype/20020414": {
+   "jar": "sha256-KiVj78kR9DElAhQiBXD6yOw/Q8PsHkcyjO54Bi+Bshg=",
+   "pom": "sha256-Jrh5kTUm4Ig+iRSYusy3o3RDq+5O32LSsAEMqu+rpck="
+  },
+  "saxpath#saxpath/1.0-FCS": {
+   "jar": "sha256-JyTzLc6B0guVg5WISs6AvZkriEEww1dBHZaR0ZAD86E=",
+   "pom": "sha256-5lolPzJ1qWHO8NwlbKROrDAh6m7KK2yD2Ej1uGWZntE="
+  },
+  "software/amazon/awssdk#annotations/2.30.31": {
+   "jar": "sha256-w2VfG0H4u3dg9qczNxRbi22k12/Bu6dPOnuCpfj6Jts=",
+   "pom": "sha256-ItTVpiTyS9JvfdQ7ct7QeL2GeVcAFk6sS7uVB5JcjpQ="
+  },
+  "software/amazon/awssdk#apache-client/2.30.31": {
+   "jar": "sha256-kEbf+NgNUGYlqWesJhF2jMOFW6pWJxRclQWwNtxcfqM=",
+   "pom": "sha256-f06AcP/ZCbzxTYUmYnsk6yPwgelaIh/UTOlx2A8gRUI="
+  },
+  "software/amazon/awssdk#auth/2.30.31": {
+   "jar": "sha256-GdxW4FRGElVg3FWLjCwxCyhQBOX3+OlNMZf68CVIFO8=",
+   "pom": "sha256-Fe5Vp/HAtEyis95iimbjQH7tdEP8x5Li56hdgoOpFVw="
+  },
+  "software/amazon/awssdk#aws-core/2.30.31": {
+   "jar": "sha256-KN2XC3eyuN0JyTt6ygAQuYNIx66YvjQsV5p2Gl+eu94=",
+   "pom": "sha256-unRx1Ho0GFGxeJ/mAe7jc6gPIfPFr1qd484TZbG5wek="
+  },
+  "software/amazon/awssdk#aws-query-protocol/2.30.31": {
+   "jar": "sha256-j/NLOHBQh6HvLg4gCbMM92ep6+r6QXFuzimoVUACtVo=",
+   "pom": "sha256-TYu0SLL4HvUpgZX8Om+xzfu+oCdQTZ/ISFtAs5ag+6Y="
+  },
+  "software/amazon/awssdk#aws-sdk-java-pom/2.30.31": {
+   "pom": "sha256-VOYayCsrMmNVeAgWWiDM2dCXSGAMeyTLRo0S2sasFPs="
+  },
+  "software/amazon/awssdk#checksums-spi/2.30.31": {
+   "jar": "sha256-oMpSsWqxwC2hSXj88gR2I7/2leKLRFzwNtC6YhrdXN0=",
+   "pom": "sha256-GZ3/zQUaMprZW+3zsSO3D+fBd6VjcsZKRRlZhJKAY30="
+  },
+  "software/amazon/awssdk#checksums/2.30.31": {
+   "jar": "sha256-hI/dkZ3S+FMjvrv9G4hd/C50vfsm3F5grRUGucwxLuc=",
+   "pom": "sha256-QMx9/RpttMwE8sLUH9tsy10lRCnDNcVy/BtJf0ZpyLM="
+  },
+  "software/amazon/awssdk#core/2.30.31": {
+   "pom": "sha256-30FRO3BB1DoTFfShfJFn+Ek5WTNRW7FtHN73qxidOyc="
+  },
+  "software/amazon/awssdk#endpoints-spi/2.30.31": {
+   "jar": "sha256-d+5RQHL+iGdQ5OM3m7aVTUJBAtiaO5PCsBd542r1RgM=",
+   "pom": "sha256-nMf6kC/tigx7eJxV4N0SZSClhXIh2Sl/T2hL1n3Dq+g="
+  },
+  "software/amazon/awssdk#http-auth-aws-crt/2.30.31": {
+   "jar": "sha256-Wt8nYc/LJzi3CJcQdxA8kVUoxnDRAEL1Ml6jHbIl30o=",
+   "pom": "sha256-FFi1yXb6VsPw3OetGC/oeedV65cdSmyr5oYapZnHR0Y="
+  },
+  "software/amazon/awssdk#http-auth-aws-eventstream/2.30.31": {
+   "jar": "sha256-F0UMOvqqIkJiSS5lJg+Sq8QoQYwpp1zn0cOgma/7CdE=",
+   "pom": "sha256-ZAGV2spE2P6JqC8Fy+x7OMcvE6OpSYxn1ClO/vN2vis="
+  },
+  "software/amazon/awssdk#http-auth-aws/2.30.31": {
+   "jar": "sha256-wesL/9yjpb0vi6AFIxU73dqZvWDM0FhLIN3Cyb/a0os=",
+   "pom": "sha256-xJeqBIKsS87Y0Sme18UuHkDJO4NbH7/EyaWoZA4mfV4="
+  },
+  "software/amazon/awssdk#http-auth-spi/2.30.31": {
+   "jar": "sha256-Kjx1hXBNyyOakFGK4YVY/Fu4XF+FSO1jqvyNxVaO8s4=",
+   "pom": "sha256-KjxtQOZSU/2mEsMtac1GkSU+Q5JRO7rleYiVIkSwa0k="
+  },
+  "software/amazon/awssdk#http-auth/2.30.31": {
+   "jar": "sha256-bCkQIt6xVgJBQeeCJ0atJEJmaZ7J6djDjq2pav2h5mE=",
+   "pom": "sha256-n2oBDtASO1bLXdC4+XnWN5txvAxDvrxWJ5Yba7ArXa0="
+  },
+  "software/amazon/awssdk#http-client-spi/2.30.31": {
+   "jar": "sha256-KkJrPPxP0ez7otjlExIndXpNz30KUCs3yRGR8wstvuA=",
+   "pom": "sha256-7YkngBkq5jyWy5OpxRqBHyfjSUlsX46aeRH9ED540iU="
+  },
+  "software/amazon/awssdk#http-clients/2.30.31": {
+   "pom": "sha256-/UXAWr4A2x81xrigxRUr1qYU+p86Cbu1Q/+TAHp5ywE="
+  },
+  "software/amazon/awssdk#identity-spi/2.30.31": {
+   "jar": "sha256-R8lAxzwoDiUgPMiT0XVqFRLblcwHfD5JUYa3xv7d4jM=",
+   "pom": "sha256-QJyGt/CZYpy18Odq6JRt2VOSLI3u37uinqIr6+vlEYE="
+  },
+  "software/amazon/awssdk#json-utils/2.30.31": {
+   "jar": "sha256-Ut3JIp/j4U6k8bqnqKPv/6qm0JwU8VEsXKBN97+GT0M=",
+   "pom": "sha256-qKAYpdPaLe2LcuG06buB2iq2JEQpV5nKOAlf4mX+ieg="
+  },
+  "software/amazon/awssdk#metrics-spi/2.30.31": {
+   "jar": "sha256-BhVvfoqqtTsNA5BMoA8rKZWdVq+kVhBeI01X71QZ03M=",
+   "pom": "sha256-0olsxKMtOamFQ2D50Qh0j3mFx5R6gnsg2Pp7/2up0pc="
+  },
+  "software/amazon/awssdk#netty-nio-client/2.30.31": {
+   "jar": "sha256-p0Xnx5cr1xYmK2G6mVkXanrTBa+/2SG71Nn6+fcYadM=",
+   "pom": "sha256-/77QkZY+iORCH3fJ0pN+NzJIAxFlZkezekWziCMaWv0="
+  },
+  "software/amazon/awssdk#profiles/2.30.31": {
+   "jar": "sha256-hUMTsxnTV1TsyCxpfbUZkmgWZ7KmIBIFYs9Lz5gZcj4=",
+   "pom": "sha256-Kkk6kFkhUdCTKQG221SBTWSXIet3RCf780G9jcalxt0="
+  },
+  "software/amazon/awssdk#protocol-core/2.30.31": {
+   "jar": "sha256-+n2qFmL3APHxFKuNwtU2HuR6XyLdut9KDW1YhtxX8G0=",
+   "pom": "sha256-tspvFfYV40hYN93AW9WrxNVxwksQ96P2wVLLnvqPobU="
+  },
+  "software/amazon/awssdk#protocols/2.30.31": {
+   "pom": "sha256-3iFIplUweGWATjdDxjSF7bGdugZTCgVGAaJ2jmnrYqU="
+  },
+  "software/amazon/awssdk#regions/2.30.31": {
+   "jar": "sha256-t0R5QYBJ8uvBzR0S6wC8fr1AYYTSeJNfjhCWInW7UWA=",
+   "pom": "sha256-P8S/x2KG7eOuWpy3T2rTPHzq9EiQzgnTgxy9OLf8I/0="
+  },
+  "software/amazon/awssdk#retries-spi/2.30.31": {
+   "jar": "sha256-ZuFU3coSraKhYIT+75W59QKP3h96aoe9TjJi1rIDxjM=",
+   "pom": "sha256-kf6ilaMCBEHOrjegRhBLZH5w6ifKEsGA/m1FZOqxsbQ="
+  },
+  "software/amazon/awssdk#retries/2.30.31": {
+   "jar": "sha256-CYX5Ho1QH4ph3BAJSM3taAw7rVOm/CbYbbrv3QYZFas=",
+   "pom": "sha256-NMpG8n26P0H/Ah4umX4K3kQwm1n8elifuHJCo0eCGgs="
+  },
+  "software/amazon/awssdk#sdk-core/2.30.31": {
+   "jar": "sha256-xS+Grop2U0ePtPEhPjquBB5LehY9V5H8fMwkBbJzzzU=",
+   "pom": "sha256-7CyaOCEjWOh+5AqC2nRyQ6LadUiJX2jVxeocbyohEyo="
+  },
+  "software/amazon/awssdk#services/2.30.31": {
+   "pom": "sha256-1dZF+kXOsjNRs0sVJ61XMUjF8zO7+VO47jkhCEhNYQI="
+  },
+  "software/amazon/awssdk#sts/2.30.31": {
+   "jar": "sha256-S/UNt/soYisw3Phs7HCIUV1m9J+A5ZGMpt6MH7lCtl8=",
+   "pom": "sha256-rvyox/WAJoiGoSHPZboHgo+tBkcrPjtAcLDpfcfnXZU="
+  },
+  "software/amazon/awssdk#third-party-jackson-core/2.30.31": {
+   "jar": "sha256-vxK2Puu/CFpcMGVhEmlhRoqoih8H+9eRWy8t7degrGY=",
+   "pom": "sha256-9UlpguwryChDaPmk5A2JKRdURajnVkDw47Ti08ub3ro="
+  },
+  "software/amazon/awssdk#third-party/2.30.31": {
+   "pom": "sha256-IvmJlgK7OQZx13Ju+slJJ1i9JmNqc0dSWWjlxUAjeTo="
+  },
+  "software/amazon/awssdk#utils/2.30.31": {
+   "jar": "sha256-48iTg/68kl9v619lVTJ5m8puwBfjpkHyenzfoT0CWO0=",
+   "pom": "sha256-3Mwz/iDlLGFinP5WAmHEJHSNeRQ5/XIUeXKscnc7tqA="
+  },
+  "software/amazon/awssdk/crt#aws-crt/0.34.1": {
+   "jar": "sha256-yXpwwGv5TOsEyxqA2yPj+HIfQwzWhqxqirOBLSfFyi8=",
+   "pom": "sha256-Z3xzCe36HneW1x/SfL7ba+Z0xK1RKSO5OBi/lJv+kV0="
+  },
+  "software/amazon/eventstream#eventstream/1.0.1": {
+   "jar": "sha256-DDfY5pYRfwLDAhkbgRCw0Osg+kEvzjTDomnsc8Fs6CI=",
+   "pom": "sha256-+UYMt5Sgp69oJ377V2lWno5mUVJQJ2w35ip+i9SyV8w="
+  },
+  "stax#stax-api/1.0": {
+   "jar": "sha256-hIimMGqp4eIrIEW8Kd7D4igFORgpD2qRFubFZvFoYDk=",
+   "pom": "sha256-0pxGGBh2cB0XzmQCcOwY23r6ti1YjCozHre+BbEXZwQ="
+  },
+  "stax#stax-api/1.0.1": {
+   "jar": "sha256-0ZaENvwhbJAfubgsfoeLUP0dMAkWdtqVsu3TqcDM+S4=",
+   "pom": "sha256-h7E64Taiu5KZJxoN/ow1H3ZmG2VO2P3gNcLKuxmM8lk="
+  },
+  "stax#stax/1.2.0": {
+   "jar": "sha256-32kFoEewXiO8kfA7pXrC+Hwd34PgSKoOW9ExadXr8Nk=",
+   "pom": "sha256-pu5SlwjCYff7ousMf3gPr4eWF3zQReYkZZtZvTand6M="
+  },
+  "xalan#serializer/2.7.1": {
+   "jar": "sha256-oVB40kPUogtrTori9h7UZV41IFThIarab3RB8e1EWjw=",
+   "pom": "sha256-sPPEvPJgTJA+tF6sn7DE3lDziVBZzsTGrIjq4VYT8IE="
+  },
+  "xalan#xalan/2.5.0": {
+   "jar": "sha256-a8ueGIuGiJgolWUbQZ2brg0n9k+gXS+RG7iJhtYccHM=",
+   "pom": "sha256-tLbWfwzyrhhxOnTVyBPOJYmCyX05pW2vnJ+ShKYzbx4="
+  },
+  "xalan#xalan/2.5.D1": {
+   "jar": "sha256-DBvha9/zagW35EpLfPh1h2A9jArHjXlyBYQMizxljEI=",
+   "pom": "sha256-KBkkDaatf9+92yYKbemmuSx5JIc6JTkUiF3IRSNEY2U="
+  },
+  "xalan#xalan/2.6.0": {
+   "jar": "sha256-0H4/1iduwdXu6lo76RkmEEmTC6IU1Qvk4xXymI3I17E=",
+   "pom": "sha256-rPzPnPMbRJo8UiK58YLRcozcokFrb42U04LK3izQYbU="
+  },
+  "xalan#xalan/2.7.0": {
+   "jar": "sha256-vx8GXv1uPVy5ZNtBMIFXUgFYczOJmdI9yvwtvIn8fZs=",
+   "pom": "sha256-L7q+eT/7PENONRm7RN//UrnU7QBPds5kArLMNRR7PIA="
+  },
+  "xalan#xalan/2.7.1": {
+   "jar": "sha256-VaLpUUSs8avkT+qRwpSFJcmx8A/KodEOdT6Shy/73R4=",
+   "pom": "sha256-246IcesIRTAnO64H4vfKpK83D4zxbCpZgIeuPDrFVCk="
+  },
+  "xerces#xercesImpl/2.10.0": {
+   "jar": "sha256-lhTSMxLVY8FNspTkmuA8+p7z9CWd8nMm5CeqrnOBmls=",
+   "pom": "sha256-EtCUNMAandLG0AwSb649ae+mfIluv5av2IfVeLHpwVg="
+  },
+  "xerces#xercesImpl/2.12.2": {
+   "jar": "sha256-b8mRgprxcI0VrqUMZvC+rc0s/raWjgsvVcGwkJiD/hY=",
+   "pom": "sha256-sJjGPfGmz+qIy1vzxrrZAu1CH69xKOL5IIO6E1F3KNk="
+  },
+  "xerces#xercesImpl/2.2.1": {
+   "jar": "sha256-KKlWkftUE6r/+OqwnHt7fOx3JGC87gO6idFvWKL2W1U=",
+   "pom": "sha256-SanLbhKV+XGY+JwqSb1NaBINjzBAJNTp31zokmYRFbM="
+  },
+  "xerces#xercesImpl/2.6.0": {
+   "jar": "sha256-NUfpU2zufVN9f0+DGtNkhYurmCH2IyQEkZFjDAoIEAA=",
+   "pom": "sha256-zijBv6TbKdAfTin+Af2CGZZ0yALZK7z5chEflj2wMtI="
+  },
+  "xerces#xercesImpl/2.6.1": {
+   "jar": "sha256-/462HlTpDh56DwNpWXVSkThFv6qDy98Pr4dlz58aXt4=",
+   "pom": "sha256-5iRMZeGIEv4bRiFYItdmke7LqN0BdUpj+/sqKGmOPV8="
+  },
+  "xerces#xercesImpl/2.6.2": {
+   "jar": "sha256-dRKVc0LcNCkPJ8DV/UMT4ArLHm2+KZL9TKZrRtcgADU=",
+   "pom": "sha256-qWBiYBrBfyhE0AiJYu66eqKJGx2quHd0hne2kEBDdM8="
+  },
+  "xerces#xercesImpl/2.8.1": {
+   "jar": "sha256-+V860UG9/1pkli9sJrTxjs8Jdc06aIAnEihLnm2zfhs=",
+   "pom": "sha256-ER1ntTGjP6+QwG6aL5zEHK6l8dlInk1UcxPNYEKmE1A="
+  },
+  "xerces#xercesImpl/2.9.0": {
+   "jar": "sha256-nFUFHZRz8ajSewDu6xOf2JmDzZOouNoYerrVPqqEw9Q=",
+   "pom": "sha256-XEiHd/V4DWDgbjr+w/ggh22xcsVtS3rQnfQ6mUH1uMM="
+  },
+  "xerces#xmlParserAPIs/2.6.1": {
+   "jar": "sha256-HChnvh+qc8Z+kjJjEkHrHfTNB2MEhkbnu1damYDp1+U=",
+   "pom": "sha256-mAXYyFWGLzul9ieC+9AeFp0OzXV1t0onmjAe+F62Mi4="
+  },
+  "xerces#xmlParserAPIs/2.6.2": {
+   "jar": "sha256-HChnvh+qc8Z+kjJjEkHrHfTNB2MEhkbnu1damYDp1+U=",
+   "pom": "sha256-t/WRHR88z594/qy0vj8n8J1ZAYCOhemT9dlLLUerIsE="
+  },
+  "xml-apis#xml-apis/1.0.b2": {
+   "jar": "sha256-gjLzSCw0bYQ+Xj+zYQVXccGswQW22KGJ65AYxVlIz58=",
+   "pom": "sha256-e8OOeg+MogsMrtYH4Ay7FE3I0Abr7Eqhk/VdzzkbrVA="
+  },
+  "xml-apis#xml-apis/1.3.02": {
+   "jar": "sha256-uYocZM+7krWRVw09MA+KSRzrYbN7/zR7OG/h6mBMb7E=",
+   "pom": "sha256-sHArqgP27CiZy6mQ1GI4b+9yWXYm9XZAiWXWbZ6Ipss="
+  },
+  "xml-apis#xml-apis/1.3.03": {
+   "jar": "sha256-7CJaHGbUUF/s0a12RM5Ed+Ym9Dn9kjDb+DOM69/DoOU=",
+   "pom": "sha256-xg0hd5GFnkugyf99pBdVzfnO/j8KJh6KqWocRNMJb60="
+  },
+  "xml-apis#xml-apis/1.3.04": {
+   "jar": "sha256-1ASqiB65xfek+1RuhOoRUGzUF6crWXLojv8X9D+fimQ=",
+   "pom": "sha256-NaH9SdRLQcYW1IypkJejLvorZOGzc5+6xvvzbjw7V7E="
+  },
+  "xml-apis#xml-apis/1.4.01": {
+   "jar": "sha256-qECWgXZkVoS7Aa7TduBnqzlhSIX57uRKvjWl8g6+f60=",
+   "pom": "sha256-Cagv8VCshr+jEUXgpq/YmgLkUEeF9doRLk+uFCUCDpI="
+  },
+  "xml-apis#xml-apis/2.0.2": {
+   "jar": "sha256-gjLzSCw0bYQ+Xj+zYQVXccGswQW22KGJ65AYxVlIz58=",
+   "pom": "sha256-qQLZYkAsAvTBpXxaIwOmCKisOu9c0UXhmAVjRHYD1gY="
+  },
+  "xml-resolver#xml-resolver/1.1": {
+   "jar": "sha256-zXIrRqnKS/gghnoVu0Zbo+i7F2CK7MHN/qnRcG49z9c=",
+   "pom": "sha256-QjyqM2ZT7XYYuim6ZXHkA58014JjKOpLO0JCCFsNEbk="
+  },
+  "xml-resolver#xml-resolver/1.2": {
+   "jar": "sha256-R9zeiYYBkxTveK5ygKlJc6IdLtlQdaQKAAtC2pVkKeE=",
+   "pom": "sha256-WB1eF4Pd17XaE2W3eNwS95ZxpDCddCIcT72TWYiYeps="
+  },
+  "xmlpull#xmlpull/1.1.3.1": {
+   "jar": "sha256-NOCO5iEWBxy7acDtcNFaelsgjWJ5jFnyEgu4kpMky2M=",
+   "pom": "sha256-jxD/2N8NPpgZyMyEAnCcaySLxTqVTvbkVHDZrjpXNfs="
+  },
+  "xom#xom/1.0": {
+   "jar": "sha256-x0ncx8p1bmW6fjN24I/PnQt7RKWqhCzzBv/n4wgO22Q=",
+   "pom": "sha256-oQn/1DHxoRv1W+vniHCk4l3+LjD3+ngH+RnKgZHwrxM="
+  },
+  "xom#xom/1.0b3": {
+   "jar": "sha256-A3RUgAekqOBYfcdIz0bbqJK4LlzFwg4cBTj6Qbdjigk=",
+   "pom": "sha256-BgYLPy4t/LKJ/NHXR/w7yojMBza704irpCuxvi9u+so="
+  },
+  "xom#xom/1.1": {
+   "jar": "sha256-BdUTzOPxnBvEsGxUVDHaENvS+WtOg6pxXS/pKwbZUac=",
+   "pom": "sha256-eI5Vo08olKgvBclzRicTlbwdY3QLK5ZZT89bqy3UIt0="
+  },
+  "xpp3#xpp3/1.1.3.3": {
+   "jar": "sha256-sUpnFt74NBdULVUVZ32Uf+zSWXwSXyyCqpvoeS9mte4=",
+   "pom": "sha256-E3Jmg7gN7wUsuEOnRszlr406FwPoRb1AEx1NBgtEcEU="
+  },
+  "xpp3#xpp3/1.1.4c": {
+   "jar": "sha256-A0E5WkgbuIeAOVcUWmo3h5hT3WJekkTC6iUJ2bt1Mbk=",
+   "pom": "sha256-TlRiL13A+LbFHihlAmjwAeO1XQdsjjqdlzHAUIIMCj0="
+  },
+  "xpp3#xpp3_min/1.1.4c": {
+   "jar": "sha256-v8kOnjLQ6rHzl/uXS18VCoFRiDgqxB83KnFJ1bwXgAg=",
+   "pom": "sha256-tbRqwMCdpBsE28dTRWtIkShWp/+7FJBnaRC1EMRx0T8="
+  }
+ }
+}

--- a/pkgs/by-name/op/openems-edge/deps.json
+++ b/pkgs/by-name/op/openems-edge/deps.json
@@ -2749,6 +2749,7 @@
    "pom": "sha256-aBLcCCXOg/qwuFh4Dxyjr+SkXYT2ETT04HusakgmkT8="
   },
   "org/bouncycastle#bcprov-jdk15on/1.65": {
+   "jar": "sha256-54+W61kGbJTJT7LWteuA9S/qxvX5d2iYY0+K3exuITc=",
    "pom": "sha256-niMbZunXFLzaKR5qenJd5O9k+lHw3kexFUwfeZgSDiY="
   },
   "org/bouncycastle#bcprov-jdk18on/1.83": {
@@ -4095,7 +4096,6 @@
    "pom": "sha256-ep5ydsHTU9KyAUu07iBEbvAWqZ5y2be3rDs4DL0MNoU="
   },
   "org/slf4j#slf4j-api/1.8.0-beta4": {
-   "jar": "sha256-YCtxIynIS0qDxARk9P39D+QjjFPvOXE5qGcGRznb9OA=",
    "pom": "sha256-+DFtKKzyUrIbHp6O7ZqEwq+9yOBA9p06ELq4E9PYWoU="
   },
   "org/slf4j#slf4j-api/2.0.17": {

--- a/pkgs/by-name/op/openems-edge/package.nix
+++ b/pkgs/by-name/op/openems-edge/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gradle_9,
+  jre,
+  makeWrapper,
+  bash,
+  writableTmpDirAsHomeHook,
+  ...
+}:
+stdenv.mkDerivation (finalAttrs: {
+
+  pname = "openems-edge";
+  version = "2026.5.0";
+
+  src = fetchFromGitHub {
+    owner = "OpenEMS";
+    repo = "openems";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-BQzkjq+rvYuPGthU1okgAO89FRIU3x+8jYW20hbGuLk=";
+  };
+
+  mitmCache = gradle_9.fetchDeps {
+    inherit (finalAttrs) pname;
+    data = ./deps.json;
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+  __darwinAllowLocalNetworking = true;
+
+  nativeBuildInputs = [
+    gradle_9
+    makeWrapper
+    writableTmpDirAsHomeHook
+  ];
+
+  gradleBuildTask = "buildEdge";
+
+  postPatch = ''
+    # This directory contains PDF files that causes a gradle build failure,
+    # likely due to characters in the file names.
+    rm -r io.openems.edge.*/doc/
+
+    substituteInPlace io.openems.edge.core/src/io/openems/edge/core/host/Bash.java \
+      --replace-fail '/bin/bash' '${bash}/bin/bash'
+
+    substituteInPlace io.openems.edge.core/src/io/openems/edge/core/host/OperatingSystemDebianSystemd.java \
+      --replace-fail '/usr/bin/systemctl' 'systemctl'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 build/openems-edge.jar -t $out/share/openems-edge
+    mkdir -p $out/bin
+    makeWrapper ${lib.getExe jre} $out/bin/openems-edge \
+      --add-flags "\$JAVA_OPTS" \
+      --add-flags "-jar $out/share/openems-edge/openems-edge.jar"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Open energy management system (IoT edge device runtime)";
+    license = lib.licenses.epl20;
+    homepage = "https://openems.io/";
+    changelog = "https://github.com/openems/openems/releases/tag/${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ mrcjkb ];
+    mainProgram = "openems-edge";
+    platforms = lib.platforms.all;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode # mitm cache
+    ];
+  };
+
+})

--- a/pkgs/by-name/op/openems-ui/package.nix
+++ b/pkgs/by-name/op/openems-ui/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  buildNpmPackage,
+  pkg-config,
+  vips,
+  openems-edge,
+  websocket-port ? 8082,
+  ...
+}:
+buildNpmPackage (finalAttrs: {
+
+  pname = "openems-ui";
+
+  inherit (openems-edge)
+    version
+    src
+    ;
+
+  sourceRoot = "${finalAttrs.src.name}/ui";
+
+  strictDeps = true;
+
+  __structuredAttrs = true;
+
+  npmDepsHash = "sha256-PNAU5MYJTjjUaqYG4Y10YhEQmT79TCpByezItHRb7qc=";
+
+  nativeBuildInputs = [
+    pkg-config
+    vips
+  ];
+
+  buildInputs = [
+    vips
+  ];
+
+  dontNpmBuild = true;
+
+  postPatch = ''
+    # Disable font inlining, which is impure
+    substituteInPlace angular.json \
+      --replace-fail '"fonts": true' '"fonts": false'
+  ''
+  # The openems-ui build configurations hardcode the websocket ports.
+  # To allow for customisation, we have to replace it in the source.
+  # 8082 is the default port of the openems,openems-backend-prod,prod configuration.
+  + (lib.optionalString (websocket-port != 8082) ''
+    substituteInPlace src/themes/openems/environments/backend-prod.ts \
+      --replace-fail ':8082' ':${toString websocket-port}'
+  '');
+
+  buildPhase = ''
+    runHook preBuild
+    mkdir -p $out/share/openems-ui
+    node_modules/.bin/ng build \
+      --configuration "openems,prod" \
+      --output-path $out/share/openems-ui
+    runHook postBuild
+  '';
+
+  doInstall = false;
+
+  meta = {
+    description = "Open energy management system (UI component)";
+    license = lib.licenses.agpl3Only;
+    homepage = "https://openems.io/";
+    changelog = "https://github.com/openems/openems/releases/tag/${finalAttrs.version}";
+    maintainers = [ lib.maintainers.mrcjkb ];
+    mainProgram = "openems-ui";
+    platforms = lib.platforms.all;
+  };
+
+})


### PR DESCRIPTION
@ners and I have been playing around with packaging [OpenEMS](https://openems.io/) ("Open Energy Management System") [[GitHub repo](https://github.com/OpenEMS/openems)] and deploying it as a NixOS module.

Since OpenEMS is quite cumbersome to deploy without Nix, I figured it could be useful to contribute our work to nixpkgs.

This PR adds:

- Packages:
  - `openems-edge`
  - `openems-backend`
  - `openems-ui`
- NixOS module: `services.openems.{edge,backend,ui}`
- NixOS test for the edge and backend.
  The UI requires JavaScript, so we haven't put any effort into test automation for it yet.
  We've only tested it manually using `nixos-shell`.
- Some documentation.

Disclaimer: I used an LLM for the following tasks:

- Troubleshooting the NixOS test (finding the right curl commands to configure the edge-backend connection at runtime).
- Tweaking the `openems.md` documentation (wrote it myself, then fed it to an LLM for initial feedback).

Note: There exists another `openems` ("Open Electromagnetic Field Solver") package.
The names of the packages I've added don't clash, but it might be worth adding a prefix to avoid confusion. I'm open to suggestions.

It's been a while since I've packaged a NixOS module, and I'm not up-to-date on the conventions, so please roast my PR :sweat_smile: 

I haven't added release notes yet, because I expect change requests and want to avoid having to resolve conflicts until we're ready to merge.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
