### PR TITLE
gharial: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -31074,5 +31074,11 @@
     githubId = 59917878;
     name = "Mathias Zhang";
   };
+  gusahlg = {
+    name = "Gustav Ahlgren";
+    email = "gustav@ahlgren.nu";
+    github = "gusahlg";
+    githubId = 209215577;
+  };
   # keep-sorted end
 }

--- a/pkgs/by-name/gh/gharial/package.nix
+++ b/pkgs/by-name/gh/gharial/package.nix
@@ -1,9 +1,9 @@
-{ lib
-, rustPlatform
-, fetchFromGitHub
-, pkg-config
-, wayland
-,
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  wayland,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "gharial";
@@ -35,4 +35,3 @@ rustPlatform.buildRustPackage rec {
     platforms = lib.platforms.linux;
   };
 }
-

--- a/pkgs/by-name/gh/gharial/package.nix
+++ b/pkgs/by-name/gh/gharial/package.nix
@@ -1,0 +1,38 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, wayland
+,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "gharial";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "gusahlg";
+    repo = "gharial";
+    rev = "v${version}";
+    hash = "sha256-Xlu4KxN4jo7msCWFXE7iQCMipe7XTsQRNkP7bDPfzVo=";
+  };
+
+  cargoHash = "sha256-Fqhgdqs7xXmd6Bpg7kYLWLiu+Yn4JTbMtJo4iLLFcIs=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    wayland
+  ];
+
+  meta = {
+    description = "Minimal external window manager for the river Wayland compositor";
+    homepage = "https://github.com/gusahlg/gharial";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gusahlg ];
+    mainProgram = "gharial";
+    platforms = lib.platforms.linux;
+  };
+}
+


### PR DESCRIPTION
Adds `gharial`, a River-based Wayland window manager, as a new package.

Gharial is intendended to act as a minimal and highly 'hackable' window manager layer on top of the non-monolithic river compositor. The package builds the Rust project from the upstream `v0.2.0` release and exposes the resulting binaries through nixpkgs.

Homepage: https://github.com/gusahlg/gharial

## Things done

* Built on platform:

  * [x] x86_64-linux
  * [ ] aarch64-linux
  * [ ] x86_64-darwin
  * [ ] aarch64-darwin
* Tested, as applicable:

  * [ ] [NixOS tests] in [nixos/tests].
  * [ ] [Package tests] at `passthru.tests`.
  * [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
* [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
* [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
* Nixpkgs Release Notes

  * [ ] Package update: when the change is major or breaking.
* NixOS Release Notes

  * [ ] Module addition: when adding a new NixOS module.
  * [ ] Module update: when the change is significant.
* [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
* [x] Follows the [automation/AI policy].
