### PR TITLE
ycwd: 0-unstable-2025-07-09 -> 0-unstable-2026-05-10

### DIFF
--- a/pkgs/by-name/yc/ycwd/package.nix
+++ b/pkgs/by-name/yc/ycwd/package.nix
@@ -2,20 +2,23 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage {
   pname = "ycwd";
-  version = "0-unstable-2025-07-09";
+  version = "0-unstable-2026-05-10";
 
   src = fetchFromGitHub {
     owner = "blinry";
     repo = "ycwd";
-    rev = "5676dafe3700ac76e071424a47407186a08d1c77";
-    hash = "sha256-HFRS+cNHKloASKXB/Tlrvpsmbg78V4lrNx9WehyzMxE=";
+    rev = "6e8b14be2ee1bf6194f69f9e127d21113656c345";
+    hash = "sha256-7NwMeH2QWNOUna/Zu0RGcfLzX/103rN+3xqyQXx+62c=";
   };
 
-  cargoHash = "sha256-HTlIcrn/QtyY2vLxfeC2RXD1mniWYE7m/rV1QBI4PZc=";
+  cargoHash = "sha256-gZpLBsS6b7l5EkPvn5CHqlwfZvKKLIZFMEC51T9GQFU=";
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = {
     description = "Helps replace xcwd on Wayland compositors";


### PR DESCRIPTION
Also added update script for future auto-updates. 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
