### PR TITLE
ghidra: various fixes for aarch64-darwin

### DIFF
--- a/pkgs/tools/security/ghidra/0001-Use-protobuf-gradle-plugin.patch
+++ b/pkgs/tools/security/ghidra/0001-Use-protobuf-gradle-plugin.patch
@@ -2,7 +2,7 @@ diff --git a/Ghidra/Debug/Debugger-isf/build.gradle b/Ghidra/Debug/Debugger-isf/
 index 2db94ed67e..925f394cf0 100644
 --- a/Ghidra/Debug/Debugger-isf/build.gradle
 +++ b/Ghidra/Debug/Debugger-isf/build.gradle
-@@ -18,11 +18,17 @@ apply from: "${rootProject.projectDir}/gradle/javaProject.gradle"
+@@ -18,11 +18,23 @@ apply from: "${rootProject.projectDir}/gradle/javaProject.gradle"
  apply from: "${rootProject.projectDir}/gradle/jacocoProject.gradle"
  apply from: "${rootProject.projectDir}/gradle/javaTestProject.gradle"
  apply from: "${rootProject.projectDir}/gradle/distributableGhidraModule.gradle"
@@ -18,6 +18,12 @@ index 2db94ed67e..925f394cf0 100644
 +	}
 +}
 +
++protobuf {
++	protoc {
++		path = '@protoc@'
++	}
++}
++
  dependencies {
  	api project(':ProposedUtils')
  }
@@ -25,7 +31,7 @@ diff --git a/Ghidra/Debug/Debugger-rmi-trace/build.gradle b/Ghidra/Debug/Debugge
 index 4fa3b9a539..2663aeaeb0 100644
 --- a/Ghidra/Debug/Debugger-rmi-trace/build.gradle
 +++ b/Ghidra/Debug/Debugger-rmi-trace/build.gradle
-@@ -20,12 +20,17 @@ apply from: "${rootProject.projectDir}/gradle/jacocoProject.gradle"
+@@ -20,12 +20,23 @@ apply from: "${rootProject.projectDir}/gradle/jacocoProject.gradle"
  apply from: "${rootProject.projectDir}/gradle/javaTestProject.gradle"
  apply from: "${rootProject.projectDir}/gradle/distributableGhidraModule.gradle"
  apply from: "${rootProject.projectDir}/gradle/javadoc.gradle"
@@ -39,6 +45,12 @@ index 4fa3b9a539..2663aeaeb0 100644
 +buildscript {
 +	dependencies {
 +		classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.18'
++	}
++}
++
++protobuf {
++	protoc {
++		path = '@protoc@'
 +	}
 +}
 +

--- a/pkgs/tools/security/ghidra/0004-Add-workerless-Sleigh-grammar-generation.patch
+++ b/pkgs/tools/security/ghidra/0004-Add-workerless-Sleigh-grammar-generation.patch
@@ -1,0 +1,72 @@
+diff --git a/Ghidra/Framework/SoftwareModeling/build.gradle b/Ghidra/Framework/SoftwareModeling/build.gradle
+index 2a1d0e2..770e33f 100644
+--- a/Ghidra/Framework/SoftwareModeling/build.gradle
++++ b/Ghidra/Framework/SoftwareModeling/build.gradle
+@@ -108,3 +108,67 @@ generateGrammarSource {
+ }
+ // must generate grammar before zipping if we want to include it in the source zip
+ zipSourceSubproject.dependsOn generateGrammarSource
++
++if (project.hasProperty('NIX_GENERATE_GRAMMAR_WITHOUT_WORKER')) {
++	tasks.register('generateGrammarSourceWithoutWorker') {
++		def antlrInputDir = file('src/main/antlr')
++		def generatedDir = file(buildDir.toString() + '/' + genSrcDir)
++		def grammarPaths = [
++			'ghidra/sleigh/grammar/BooleanExpression.g',
++			'ghidra/sleigh/grammar/SleighLexer.g',
++			'ghidra/sleigh/grammar/BaseLexer.g',
++			'ghidra/sleigh/grammar/DisplayLexer.g',
++			'ghidra/sleigh/grammar/SemanticLexer.g',
++			'ghidra/sleigh/grammar/SleighParser.g',
++			'ghidra/sleigh/grammar/SleighEcho.g',
++			'ghidra/sleigh/grammar/SleighCompiler.g',
++		]
++
++		inputs.files(grammarPaths.collect { file('src/main/antlr/' + it) })
++		outputs.dir(generatedDir)
++
++		doFirst {
++			delete file(generatedDir.toString() + '/ghidra/sleigh/grammar/SleighLexer.tokens')
++		}
++
++		doLast {
++			generatedDir.mkdirs()
++			def loader = new URLClassLoader(configurations.antlr.files.collect { it.toURI().toURL() } as URL[], (ClassLoader) null)
++			try {
++				def tool = loader.loadClass('org.antlr.Tool').getDeclaredConstructor().newInstance()
++				tool.setInputDirectory(antlrInputDir.absolutePath)
++				tool.setForceRelativeOutput(true)
++				def antlrArgs = ['-o', generatedDir.absolutePath] + grammarPaths
++				tool.processArgs(antlrArgs as String[])
++				tool.process()
++				if (tool.getNumErrors() != 0) {
++					throw new GradleException("ANTLR failed with " + tool.getNumErrors() + " errors")
++				}
++			}
++			finally {
++				loader.close()
++			}
++
++			delete fileTree(generatedDir.toString() + '/ghidra/sleigh/grammar') {
++				include 'SleighLexer*.java'
++			}
++			fileTree(generatedDir.toString() + '/ghidra/sleigh/grammar') {
++				include '*.java'
++			}.each { File src ->
++				def lines = src.readLines()
++				if (lines.get(0) != 'package ghidra.sleigh.grammar;') {
++					src.withWriter { wr ->
++						wr.println('package ghidra.sleigh.grammar;')
++						lines.each { line ->
++							wr.println line
++						}
++					}
++				}
++			}
++		}
++	}
++
++	generateGrammarSource.enabled = false
++	compileJava.dependsOn generateGrammarSourceWithoutWorker
++	zipSourceSubproject.dependsOn generateGrammarSourceWithoutWorker
++}

--- a/pkgs/tools/security/ghidra/build-extension.nix
+++ b/pkgs/tools/security/ghidra/build-extension.nix
@@ -5,6 +5,7 @@
   jdk,
   gradle,
   ghidra,
+  replaceVars,
 }:
 
 let
@@ -39,6 +40,17 @@ let
         ];
 
         preBuild = ''
+          ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+            gradleJvmArgs="-Xms64m -Xmx2G -Dfile.encoding=UTF-8 -Duser.language=en -Duser.country=US -Duser.variant"
+            if [[ -n "''${MITM_CACHE_KEYSTORE-}" ]]; then
+              gradleJvmArgs+=" -Dhttp.proxyHost=$MITM_CACHE_HOST -Dhttp.proxyPort=$MITM_CACHE_PORT"
+              gradleJvmArgs+=" -Dhttps.proxyHost=$MITM_CACHE_HOST -Dhttps.proxyPort=$MITM_CACHE_PORT"
+              gradleJvmArgs+=" -Djavax.net.ssl.trustStore=$MITM_CACHE_KEYSTORE -Djavax.net.ssl.trustStorePassword=$MITM_CACHE_KS_PWD"
+            fi
+            echo "org.gradle.jvmargs=$gradleJvmArgs" >> gradle.properties
+            export GRADLE_OPTS="$gradleJvmArgs ''${GRADLE_OPTS:-}"
+          ''}
+
           # Set project name, otherwise defaults to directory name
           echo -e '\nrootProject.name = "${pname}"' >> settings.gradle
           # A config directory needs to exist when ghidra's GHelpBuilder is run
@@ -48,9 +60,18 @@ let
 
         # Needed to run gradle on darwin
         __darwinAllowLocalNetworking = true;
+        enableParallelBuilding = args.enableParallelBuilding or (!stdenv.hostPlatform.isDarwin);
 
         gradleBuildTask = args.gradleBuildTask or "buildExtension";
-        gradleFlags = args.gradleFlags or [ ] ++ [ "-PGHIDRA_INSTALL_DIR=${ghidra}/lib/ghidra" ];
+        gradleFlags =
+          (args.gradleFlags or [ ])
+          ++ [ "-PGHIDRA_INSTALL_DIR=${ghidra}/lib/ghidra" ]
+          ++ lib.optionals stdenv.hostPlatform.isDarwin [
+            "--max-workers=1"
+            "--init-script"
+            "${./darwin-javac-init.gradle}"
+            "-PNIX_JAVAC=${jdk}/bin/javac"
+          ];
 
         installPhase =
           args.installPhase or ''
@@ -80,6 +101,13 @@ let
         meta ? { },
         ...
       }@args:
+      let
+        extensionProperties = replaceVars ./script-extension.properties.in {
+          inherit pname;
+          description = meta.description or "";
+          version = lib.getVersion ghidra;
+        };
+      in
       {
         installPhase = ''
           runHook preInstall
@@ -89,14 +117,7 @@ let
           cp -r . $GHIDRA_HOME/ghidra_scripts
 
           touch $GHIDRA_HOME/Module.manifest
-          cat <<'EOF' > extension.properties
-          name=${pname}
-          description=${meta.description or ""}
-          author=
-          createdOn=
-          version=${lib.getVersion ghidra}
-
-          EOF
+          cp ${extensionProperties} "$GHIDRA_HOME/extension.properties"
 
           runHook postInstall
         '';

--- a/pkgs/tools/security/ghidra/build.nix
+++ b/pkgs/tools/security/ghidra/build.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   lib,
   callPackage,
+  cmake,
   gradle,
   makeBinaryWrapper,
   openjdk21,
@@ -15,6 +16,7 @@
   ghidra-extensions,
   python3,
   python3Packages,
+  zulu8,
 }:
 
 let
@@ -23,6 +25,8 @@ let
   version = "12.1.2";
 
   isMacArm64 = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64;
+  zulu8Include = lib.makeIncludePath [ zulu8 ];
+  zulu8DarwinInclude = "${zulu8Include}/darwin";
 
   releaseName = "NIX";
   distroPrefix = "ghidra_${version}_${releaseName}";
@@ -43,6 +47,14 @@ let
       date -u -d "@$(git log -1 --pretty=%ct)" "+%Y%m%d" > $out/SOURCE_DATE_EPOCH_SHORT
       find "$out" -name .git -print0 | xargs -0 rm -rf
     '';
+  };
+
+  # https://github.com/NationalSecurityAgency/ghidra/blob/Ghidra_12.1.2_build/Ghidra/Features/FileFormats/build.gradle#L49-L50
+  sevenzipjbindingSrc = fetchFromGitHub {
+    owner = "borisbrodski";
+    repo = "sevenzipjbinding";
+    rev = "Release-16.02-2.01";
+    hash = "sha256-MtdPBjXUNFc9KwMNMtxmQ1R+cW6dhum73d3KX76GjG0=";
   };
 
   patches = [
@@ -162,6 +174,42 @@ stdenv.mkDerivation (finalAttrs: {
     f=("${pkg_path}"/*)
     mv "${pkg_path}"/*/* "${pkg_path}"
     rmdir "''${f[@]}"
+
+    ${lib.optionalString isMacArm64 ''
+      # sevenzipjbinding-all-platforms jar only ships a macOS x86_64 dylib.
+      # Leaving that in the output makes the whole native Ghidra install ask for
+      # Rosetta 2 just for 7-Zip support.
+      cp -R ${sevenzipjbindingSrc} sevenzipjbinding-src
+      chmod -R u+w sevenzipjbinding-src
+      substituteInPlace sevenzipjbinding-src/CMakeLists.txt \
+        --replace-fail "cmake_policy(SET CMP0026 OLD)" "# cmake_policy(SET CMP0026 OLD)" \
+        --replace-fail "GET_TARGET_PROPERTY(SEVENZIP_JBINDING_LIB 7-Zip-JBinding LOCATION)" \
+          "SET(SEVENZIP_JBINDING_LIB_FILENAME \"lib7-Zip-JBinding.dylib\")" \
+        --replace-fail "GET_FILENAME_COMPONENT(SEVENZIP_JBINDING_LIB_FILENAME \"\''${SEVENZIP_JBINDING_LIB}\" NAME)" ""
+      # Call CMake directly so its setup hook does not try to configure Ghidra's
+      # Gradle source tree as a CMake project.
+      ${lib.getExe cmake} -S sevenzipjbinding-src -B sevenzipjbinding-build \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+        -DJAVA_SYSTEM=Mac \
+        -DJAVA_ARCH=arm64 \
+        -DJAVA_JDK=${zulu8.home} \
+        -DJAVA_INCLUDE_PATH=${zulu8Include} \
+        -DJAVA_INCLUDE_PATH2=${zulu8DarwinInclude} \
+        -DCMAKE_CXX_FLAGS="-std=gnu++98" \
+        -DCMAKE_BUILD_TYPE=Release
+      ${lib.getExe cmake} --build sevenzipjbinding-build --parallel "$NIX_BUILD_CORES"
+
+      rm -f "${pkg_path}/Ghidra/Features/FileFormats/lib"/sevenzipjbinding-all-platforms-*.jar
+      rm -rf "${pkg_path}/Ghidra/Features/FileFormats/data/sevenzipnativelibs"
+      install -Dm444 sevenzipjbinding-build/sevenzipjbinding-Mac-arm64.jar \
+        "${pkg_path}/Ghidra/Features/FileFormats/lib/sevenzipjbinding-Mac-arm64.jar"
+      substituteInPlace "${pkg_path}/Ghidra/Features/FileFormats/Module.manifest" \
+        --replace-fail "lib/sevenzipjbinding-all-platforms-16.02-2.01.jar LGPL 2.1" \
+          "lib/sevenzipjbinding-Mac-arm64.jar LGPL 2.1"
+      mkdir -p "${pkg_path}/Ghidra/Features/FileFormats/data/sevenzipnativelibs"
+      unzip -q sevenzipjbinding-build/sevenzipjbinding-Mac-arm64.jar "Mac-arm64/*" \
+        -d "${pkg_path}/Ghidra/Features/FileFormats/data/sevenzipnativelibs"
+    ''}
 
     for f in Ghidra/Framework/Gui/src/main/resources/images/GhidraIcon*.png; do
       res=$(basename "$f" ".png" | cut -d"_" -f3 | cut -c11-)

--- a/pkgs/tools/security/ghidra/build.nix
+++ b/pkgs/tools/security/ghidra/build.nix
@@ -1,6 +1,7 @@
 {
   stdenv,
   fetchFromGitHub,
+  fetchurl,
   lib,
   callPackage,
   cmake,
@@ -30,6 +31,7 @@ let
 
   releaseName = "NIX";
   distroPrefix = "ghidra_${version}_${releaseName}";
+
   src = fetchFromGitHub {
     owner = "NationalSecurityAgency";
     repo = "Ghidra";
@@ -57,6 +59,12 @@ let
     hash = "sha256-MtdPBjXUNFc9KwMNMtxmQ1R+cW6dhum73d3KX76GjG0=";
   };
 
+  # Bootstrap dependency for gradle/support/fetchDependencies.gradle.
+  commonsIoJar = fetchurl {
+    url = "https://repo.maven.apache.org/maven2/commons-io/commons-io/2.21.0/commons-io-2.21.0.jar";
+    hash = "sha256-fWQ6Kv6osFi3YqpvuQ5bJW9scpc5+LN4TDNw3cYJ6I0=";
+  };
+
   patches = [
     # Use our own protoc binary instead of the prebuilt one
     ./0001-Use-protobuf-gradle-plugin.patch
@@ -66,6 +74,9 @@ let
 
     # Remove build dates from output filenames for easier reference
     ./0003-Remove-build-datestamp.patch
+
+    # Avoid Gradle's worker daemon for Sleigh grammar generation on Darwin.
+    ./0004-Add-workerless-Sleigh-grammar-generation.patch
   ];
 
   postPatch = ''
@@ -77,14 +88,26 @@ let
     echo "application.build.date.short=$(cat SOURCE_DATE_EPOCH_SHORT)" >> Ghidra/application.properties
     echo "application.revision.ghidra=$(cat COMMIT)" >> Ghidra/application.properties
 
-    # Tells ghidra to use our own protoc binary instead of the prebuilt one.
-    tee -a Ghidra/Debug/Debugger-{isf,rmi-trace}/build.gradle <<HERE
-    protobuf {
-      protoc {
-        path = '${protobuf}/bin/protoc'
-      }
-    }
-    HERE
+    substituteInPlace gradle.properties \
+      --replace-fail 'org.gradle.jvmargs=-Xmx2G -Duser.language=en -Duser.country=US' \
+        'org.gradle.jvmargs=-Xms64m -Xmx2G -Dfile.encoding=UTF-8 -Duser.language=en -Duser.country=US -Duser.variant'
+    substituteInPlace gradle/support/fetchDependencies.gradle \
+      --replace-fail "dependencies { classpath 'commons-io:commons-io:2.21.0' }" \
+        "dependencies { classpath files('${commonsIoJar}') }"
+    substituteInPlace Ghidra/Debug/Debugger-{isf,rmi-trace}/build.gradle \
+      --replace-fail '@protoc@' '${protobuf}/bin/protoc'
+
+    ${lib.optionalString isMacArm64 ''
+      # Upstream wires each platform-specific distribution task to each native
+      # module's `assemble`, and Java/native modules also wire the generic
+      # distribution task to `assemble`. Gradle's native `assemble` builds
+      # every declared target platform, so use the Java jar plus Ghidra's
+      # platform-specific native rule instead. This keeps a mac_arm_64
+      # distribution from trying to link mac_x86_64 binaries.
+      substituteInPlace gradle/distributableGhidraModule.gradle \
+        --replace-fail 'dependsOn assemble' "dependsOn ((plugins.hasPlugin('cpp') || plugins.hasPlugin('c')) ? jar : assemble)" \
+        --replace-fail 't.dependsOn this.assemble' 't.dependsOn "''${project.path}:buildNatives_''${platform.name}"'
+    ''}
   '';
 
 in
@@ -139,25 +162,56 @@ stdenv.mkDerivation (finalAttrs: {
     data = ./deps.json;
   };
 
-  gradleFlags = [
-    "-Dorg.gradle.java.home=${openjdk21}"
-  ]
-  ++ lib.optionals isMacArm64 [
-    # For some reason I haven't been able to figure out yet, ghidra builds for
-    # arm64 seems to build the x64 binaries of the decompiler. These fail to
-    # build due to trying to link the x64 object files with arm64 stdc++
-    # library, which obviously fails.
-    #
-    # Those binaries are entirely unnecessary anyways, since we're targeting
-    # arm64 build here, so let's exclude them from the build.
-    "-x"
-    "Decompiler:linkSleighMac_x86_64Executable"
-    "-x"
-    "Decompiler:linkDecompileMac_x86_64Executable"
+  enableParallelBuilding = !stdenv.hostPlatform.isDarwin;
+
+  gradleFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+    "--max-workers=1"
+    "--init-script"
+    "${./darwin-javac-init.gradle}"
+    "-PNIX_JAVAC=${openjdk21}/bin/javac"
+    "-PNIX_GENERATE_GRAMMAR_WITHOUT_WORKER=true"
   ];
 
+  env.JAVA_HOME = openjdk21;
+
   preBuild = ''
-    export JAVA_TOOL_OPTIONS="-Duser.home=$NIX_BUILD_TOP/home"
+    export JAVA_HOME=${openjdk21}
+    export PATH="$JAVA_HOME/bin:$PATH"
+    java -XshowSettings:properties -version 2>&1 \
+      | sed -n 's/^[[:space:]]*java.home = /Using java.home = /p'
+
+    javaToolOptions="-Duser.home=$NIX_BUILD_TOP/home"
+    gradleJvmArgs="-Xms64m -Xmx2G -Dfile.encoding=UTF-8 -Duser.language=en -Duser.country=US -Duser.variant"
+    if [[ -n "''${MITM_CACHE_KEYSTORE-}" ]]; then
+      javaToolOptions+=" -Dhttp.proxyHost=$MITM_CACHE_HOST -Dhttp.proxyPort=$MITM_CACHE_PORT"
+      javaToolOptions+=" -Dhttps.proxyHost=$MITM_CACHE_HOST -Dhttps.proxyPort=$MITM_CACHE_PORT"
+      javaToolOptions+=" -Djavax.net.ssl.trustStore=$MITM_CACHE_KEYSTORE -Djavax.net.ssl.trustStorePassword=$MITM_CACHE_KS_PWD"
+      gradleJvmArgs+=" -Dhttp.proxyHost=$MITM_CACHE_HOST -Dhttp.proxyPort=$MITM_CACHE_PORT"
+      gradleJvmArgs+=" -Dhttps.proxyHost=$MITM_CACHE_HOST -Dhttps.proxyPort=$MITM_CACHE_PORT"
+      gradleJvmArgs+=" -Djavax.net.ssl.trustStore=$MITM_CACHE_KEYSTORE -Djavax.net.ssl.trustStorePassword=$MITM_CACHE_KS_PWD"
+    fi
+    export JAVA_TOOL_OPTIONS="$javaToolOptions"
+    substituteInPlace gradle.properties \
+      --replace-fail 'org.gradle.jvmargs=-Xms64m -Xmx2G -Dfile.encoding=UTF-8 -Duser.language=en -Duser.country=US -Duser.variant' \
+        "org.gradle.jvmargs=$gradleJvmArgs"
+
+    if [[ -n "''${IN_GRADLE_UPDATE_DEPS-}" ]]; then
+      mavenRepository="https://repo.maven.apache.org/maven2"
+    else
+      mavenRepository="file://${finalAttrs.mitmCache}/https/repo.maven.apache.org/maven2"
+      mkdir -p dependencies/downloads
+      while IFS= read -r -d "" dep; do
+        ln -sf "$dep" "dependencies/downloads/$(basename "$dep")"
+      done < <(find -L ${finalAttrs.mitmCache} -type f -print0)
+      ln -sf \
+        ${finalAttrs.mitmCache}/https/sourceforge.net/projects/pydev/files/pydev/PyDev%209.3.0/PyDev%209.3.0.zip \
+        "dependencies/downloads/PyDev 9.3.0.zip"
+    fi
+
+    substituteInPlace build.gradle \
+      --replace-fail 'mavenCentral()' \
+        "maven { url = uri(\"$mavenRepository\") }"
+    export GRADLE_OPTS="$gradleJvmArgs ''${GRADLE_OPTS:-}"
     gradle -I gradle/support/fetchDependencies.gradle
   '';
 

--- a/pkgs/tools/security/ghidra/build.nix
+++ b/pkgs/tools/security/ghidra/build.nix
@@ -296,6 +296,10 @@ stdenv.mkDerivation (finalAttrs: {
       ;
 
     withExtensions = callPackage ./with-extensions.nix { ghidra = finalAttrs.finalPackage; };
+
+    tests.headless-analysis = callPackage ./tests/headless-analysis.nix {
+      ghidra = finalAttrs.finalPackage;
+    };
   };
 
   meta = {

--- a/pkgs/tools/security/ghidra/darwin-javac-init.gradle
+++ b/pkgs/tools/security/ghidra/darwin-javac-init.gradle
@@ -1,0 +1,6 @@
+allprojects {
+	tasks.withType(org.gradle.api.tasks.compile.JavaCompile).configureEach {
+		options.fork = true
+		options.forkOptions.executable = gradle.startParameter.projectProperties['NIX_JAVAC']
+	}
+}

--- a/pkgs/tools/security/ghidra/extensions/ghidra-delinker-extension/default.nix
+++ b/pkgs/tools/security/ghidra/extensions/ghidra-delinker-extension/default.nix
@@ -25,17 +25,29 @@ ghidra.buildGhidraExtension (finalAttrs: {
     # The vendored-in dependency does not work for us because maven
     # needs to download dependencies while building.
     ./local-binary-file-toolkit.patch
+    ./use-gradle-dependency-cache.patch
   ];
 
   postPatch = ''
+    if [[ -n "''${IN_GRADLE_UPDATE_DEPS-}" ]]; then
+      gradlePluginRepository="https://plugins.gradle.org/m2"
+      mavenRepository="https://repo.maven.apache.org/maven2"
+    else
+      gradlePluginRepository="file://${finalAttrs.mitmCache}/https/plugins.gradle.org/m2"
+      mavenRepository="file://${finalAttrs.mitmCache}/https/repo.maven.apache.org/maven2"
+    fi
+
+    substituteInPlace settings.gradle \
+      --replace-fail '@gradle-plugin-repository@' "$gradlePluginRepository" \
+      --replace-fail '@maven-repository@' "$mavenRepository"
+
     substituteInPlace build.gradle \
+      --replace-fail '@maven-repository@' "$mavenRepository" \
       --replace-fail '"GIT_VERSION", gitVersionProvider' '"GIT_VERSION", "v${finalAttrs.version}"' \
       --replace-fail '"@binary-file-toolkit@"' '"${binary-file-toolkit}"'
   '';
 
   gradleBuildTask = "buildExtension";
-
-  __darwinAllowLocalNetworking = true;
 
   mitmCache = gradle.fetchDeps {
     pkg = finalAttrs.finalPackage;
@@ -48,5 +60,9 @@ ghidra.buildGhidraExtension (finalAttrs: {
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.jchw ];
     platforms = lib.platforms.unix;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode # mitm cache
+    ];
   };
 })

--- a/pkgs/tools/security/ghidra/extensions/ghidra-delinker-extension/local-binary-file-toolkit.patch
+++ b/pkgs/tools/security/ghidra/extensions/ghidra-delinker-extension/local-binary-file-toolkit.patch
@@ -5,7 +5,8 @@ index 48da640..bca1958 100644
 @@ -84,16 +84,8 @@ tasks.register("installStandaloneDeps") {
  repositories {
  	mavenLocal()
- 	mavenCentral()
+-	mavenCentral()
++	maven { url = uri("@maven-repository@") }
 -	maven {
 -		name = "boricj's binary-file-toolkit"
 -		url = uri("https://maven.pkg.github.com/boricj/binary-file-toolkit")

--- a/pkgs/tools/security/ghidra/extensions/ghidra-delinker-extension/use-gradle-dependency-cache.patch
+++ b/pkgs/tools/security/ghidra/extensions/ghidra-delinker-extension/use-gradle-dependency-cache.patch
@@ -1,0 +1,11 @@
+diff --git a/settings.gradle b/settings.gradle
+index e69de29..a0daecb 100644
+--- a/settings.gradle
++++ b/settings.gradle
+@@ -0,0 +1,6 @@
++pluginManagement {
++	repositories {
++		maven { url = uri("@gradle-plugin-repository@") }
++		maven { url = uri("@maven-repository@") }
++	}
++}

--- a/pkgs/tools/security/ghidra/extensions/gnudisassembler/default.nix
+++ b/pkgs/tools/security/ghidra/extensions/gnudisassembler/default.nix
@@ -6,8 +6,8 @@
   ghidra,
   flex,
   bison,
+  gnumake,
   texinfo,
-  perl,
   zlib,
   xcbuild,
 }:
@@ -20,6 +20,13 @@ let
     url = "mirror://gnu/binutils/binutils-${binutils-version}.tar.bz2";
     sha256 = "sha256-9mOQpmH6oRfQD6suec8tydCXtCzClr8/hnfR57RS3Do=";
   };
+  gdisPlatform =
+    if stdenv.hostPlatform.isDarwin then
+      if stdenv.hostPlatform.isAarch64 then "mac_arm_64" else "mac_x86_64"
+    else if stdenv.hostPlatform.isAarch64 then
+      "linux_arm_64"
+    else
+      "linux_x86_64";
 in
 buildGhidraExtension {
   pname = "gnudisassembler";
@@ -27,23 +34,29 @@ buildGhidraExtension {
 
   src = "${ghidra}/lib/ghidra/Extensions/Ghidra/${ghidra.distroPrefix}_GnuDisassembler.zip";
 
+  patches = [ ./fix-platform-build.patch ];
+
   postPatch = ''
     ln -s ${binutils-src} binutils-${binutils-version}.tar.bz2
+
     substituteInPlace build.gradle \
       --replace-fail 'ext.binutils = "binutils-2.41"' 'ext.binutils = "binutils-${binutils-version}"'
+
+    substituteInPlace buildGdis.gradle \
+      --replace-fail "ext.supportedPlatforms = ['mac_x86_64', 'mac_arm_64', 'linux_x86_64', 'linux_arm_64']" \
+                     "ext.supportedPlatforms = ['${gdisPlatform}']" \
+      --replace-fail '@gdis-platform@' '${gdisPlatform}'
   '';
 
   # Don't modify ELF stub resources
   dontPatchELF = true;
   dontStrip = true;
 
-  __darwinAllowLocalNetworking = true;
-
   nativeBuildInputs = [
     flex
     bison
+    gnumake
     texinfo
-    perl
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ xcbuild ];
 

--- a/pkgs/tools/security/ghidra/extensions/gnudisassembler/fix-platform-build.patch
+++ b/pkgs/tools/security/ghidra/extensions/gnudisassembler/fix-platform-build.patch
@@ -1,0 +1,26 @@
+--- a/buildGdis.gradle
++++ b/buildGdis.gradle
+@@ -48,12 +47,0 @@
+-	tasks.compileGdisMac_x86_64ExecutableGdisC {
+-		dependsOn 'copyBinutilsArtifcats_mac_x86_64'
+-	}
+-	tasks.compileGdisLinux_x86_64ExecutableGdisC {
+-		dependsOn 'copyBinutilsArtifcats_linux_x86_64'
+-	}
+-	tasks.compileGdisMac_arm_64ExecutableGdisC {
+-		dependsOn 'copyBinutilsArtifcats_mac_arm_64'
+-	}
+-	tasks.compileGdisLinux_arm_64ExecutableGdisC {
+-		dependsOn 'copyBinutilsArtifcats_linux_arm_64'
+-	}
+@@ -62,0 +51,4 @@
++tasks.matching { it.name.startsWith('compileGdis') && it.name.endsWith('ExecutableGdisC') }.configureEach {
++    dependsOn 'copyBinutilsArtifcats_@gdis-platform@'
++}
++
+@@ -94,0 +87,5 @@
++        def zutilHeader = file("${binutilsUnpackDir}/zlib/zutil.h")
++        zutilHeader.text = zutilHeader.text.replace(
++            "#if defined(MACOS) || defined(TARGET_OS_MAC)",
++            "#if defined(MACOS)"
++        )

--- a/pkgs/tools/security/ghidra/extensions/kaiju/default.nix
+++ b/pkgs/tools/security/ghidra/extensions/kaiju/default.nix
@@ -38,9 +38,44 @@ let
       z3_lib
     ];
 
+    patches = [
+      ./use-gradle-dependency-cache.patch
+      ./disable-groovy-worker-daemon.patch
+    ];
+
+    postPatch = ''
+      if [[ -n "''${IN_GRADLE_UPDATE_DEPS-}" ]]; then
+        gradlePluginRepository="https://plugins.gradle.org/m2"
+        mavenRepository="https://repo.maven.apache.org/maven2"
+      else
+        gradlePluginRepository="file://${finalAttrs.mitmCache}/https/plugins.gradle.org/m2"
+        mavenRepository="file://${finalAttrs.mitmCache}/https/repo.maven.apache.org/maven2"
+      fi
+
+      substituteInPlace settings.gradle \
+        --replace-fail '@gradle-plugin-repository@' "$gradlePluginRepository" \
+        --replace-fail '@maven-repository@' "$mavenRepository"
+
+      substituteInPlace build.gradle buildSrc/build.gradle \
+        --replace-fail '@maven-repository@' "$mavenRepository"
+    '';
+
     # used to copy java bindings from nixpkgs z3 package instead of having kaiju's build.gradle build gradle from source
     # https://github.com/CERTCC/kaiju/blob/c9dbb55484b3d2a6abd9dfca2197cd00fb7ee3c1/build.gradle#L189
     preBuild = ''
+      ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+        kaijuJavacModuleArgs="--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED"
+        kaijuJavacModuleArgs+=" --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED"
+        kaijuJavacModuleArgs+=" --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED"
+        kaijuJavacModuleArgs+=" --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED"
+        kaijuJavacModuleArgs+=" --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
+        kaijuJavacModuleArgs+=" --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED"
+
+        substituteInPlace gradle.properties \
+          --replace-fail 'org.gradle.jvmargs=' "org.gradle.jvmargs=$kaijuJavacModuleArgs "
+        export GRADLE_OPTS="$kaijuJavacModuleArgs ''${GRADLE_OPTS:-}"
+      ''}
+
       mkdir -p build/cmake/z3/java-bindings
       ln -s ${lib.getOutput "java" z3_lib}/share/java/com.microsoft.z3.jar build/cmake/z3/java-bindings
       mkdir -p os/${ghidraPlatformName}
@@ -64,6 +99,10 @@ let
         "x86_64-linux"
         "aarch64-linux"
         "aarch64-darwin"
+      ];
+      sourceProvenance = with lib.sourceTypes; [
+        fromSource
+        binaryBytecode # mitm cache
       ];
     };
   });

--- a/pkgs/tools/security/ghidra/extensions/kaiju/disable-groovy-worker-daemon.patch
+++ b/pkgs/tools/security/ghidra/extensions/kaiju/disable-groovy-worker-daemon.patch
@@ -1,0 +1,12 @@
+diff --git a/buildSrc/build.gradle b/buildSrc/build.gradle
+index 26e0515..1913e3e 100644
+--- a/buildSrc/build.gradle
++++ b/buildSrc/build.gradle
+@@ -51,3 +51,7 @@ gradlePlugin {
+         }
+     }
+ }
++
++tasks.withType(org.gradle.api.tasks.compile.GroovyCompile).configureEach {
++    groovyOptions.fork = false
++}

--- a/pkgs/tools/security/ghidra/extensions/kaiju/use-gradle-dependency-cache.patch
+++ b/pkgs/tools/security/ghidra/extensions/kaiju/use-gradle-dependency-cache.patch
@@ -1,0 +1,26 @@
+diff --git a/build.gradle b/build.gradle
+index b35e3f5..81b3f21 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -120 +120 @@ repositories {
+-    mavenCentral()
++    maven { url = uri("@maven-repository@") }
+diff --git a/buildSrc/build.gradle b/buildSrc/build.gradle
+index 26e0515..ab6763e 100644
+--- a/buildSrc/build.gradle
++++ b/buildSrc/build.gradle
+@@ -39 +39 @@ repositories {
+-    mavenCentral()
++    maven { url = uri("@maven-repository@") }
+diff --git a/settings.gradle b/settings.gradle
+index 505fa1f..253ec71 100644
+--- a/settings.gradle
++++ b/settings.gradle
+@@ -0,0 +1,7 @@
++pluginManagement {
++    repositories {
++        maven { url = uri("@gradle-plugin-repository@") }
++        maven { url = uri("@maven-repository@") }
++    }
++}
++

--- a/pkgs/tools/security/ghidra/script-extension.properties.in
+++ b/pkgs/tools/security/ghidra/script-extension.properties.in
@@ -1,0 +1,5 @@
+name=@pname@
+description=@description@
+author=
+createdOn=
+version=@version@

--- a/pkgs/tools/security/ghidra/tests/CheckAnalysis.java
+++ b/pkgs/tools/security/ghidra/tests/CheckAnalysis.java
@@ -1,0 +1,52 @@
+// Ghidra post-analysis script run by tests/headless-analysis.nix. It emits
+// NIX_TEST_* markers that the surrounding derivation greps for. Running it
+// exercises the parts of a native Ghidra build that "does the GUI launch" does
+// not: the processor's Sleigh specification and the native decompiler process.
+//
+// Written in Java rather than Python: Ghidra 12 dropped bundled Jython, and
+// Python scripts now require the PyGhidra runtime, which the package does not
+// ship. Java scripts are compiled in-process by analyzeHeadless with no extra
+// runtime. The class name must match the file name.
+import ghidra.app.script.GhidraScript;
+import ghidra.app.decompiler.DecompInterface;
+import ghidra.app.decompiler.DecompileResults;
+import ghidra.program.model.listing.Function;
+import ghidra.program.model.listing.FunctionManager;
+import ghidra.program.model.listing.Listing;
+import ghidra.util.task.ConsoleTaskMonitor;
+
+public class CheckAnalysis extends GhidraScript {
+    @Override
+    public void run() throws Exception {
+        FunctionManager fm = currentProgram.getFunctionManager();
+        Listing listing = currentProgram.getListing();
+
+        Function marker = null;
+        for (Function f : fm.getFunctions(true)) {
+            // Mach-O prefixes C symbols with an underscore, while ELF does not.
+            if (f.getName().equals("nix_ghidra_marker") ||
+                f.getName().equals("_nix_ghidra_marker")) {
+                marker = f;
+            }
+        }
+
+        println("NIX_TEST_ARCH=" + currentProgram.getLanguageID().getIdAsString());
+        println("NIX_TEST_INSTRS=" + listing.getNumInstructions());
+        println("NIX_TEST_HASMARKER=" + (marker != null ? 1 : 0));
+
+        // Decompile the marker function. This spawns the native decompiler
+        // binary, which is the component that was previously cross-built for the
+        // wrong architecture on aarch64-darwin.
+        int declen = 0;
+        if (marker != null) {
+            DecompInterface ifc = new DecompInterface();
+            ifc.openProgram(currentProgram);
+            DecompileResults res = ifc.decompileFunction(marker, 60, new ConsoleTaskMonitor());
+            if (res.decompileCompleted() && res.getDecompiledFunction() != null) {
+                String c = res.getDecompiledFunction().getC();
+                declen = c == null ? 0 : c.length();
+            }
+        }
+        println("NIX_TEST_DECOMPILED_LEN=" + declen);
+    }
+}

--- a/pkgs/tools/security/ghidra/tests/headless-analysis.nix
+++ b/pkgs/tools/security/ghidra/tests/headless-analysis.nix
@@ -1,0 +1,59 @@
+{
+  runCommandCC,
+  ghidra,
+}:
+
+runCommandCC "ghidra-headless-analysis-test"
+  {
+    nativeBuildInputs = [ ghidra ];
+    meta = {
+      description = "Import, analyse and decompile a native binary with headless Ghidra";
+      inherit (ghidra.meta) maintainers;
+    };
+  }
+  ''
+    export HOME="$TMPDIR"
+    # Java does not consistently derive user.home from HOME (notably on
+    # Darwin), and Ghidra persists its selected JDK below user.home.
+    export JAVA_TOOL_OPTIONS="-Duser.home=$HOME"
+
+    # A tiny host-native program with a distinctive symbol to look for after
+    # analysis. Building it here means the binary matches the platform Ghidra was
+    # built for, so on aarch64-darwin this analyses an arm64 Mach-O.
+    cat > marker.c <<'EOF'
+    int nix_ghidra_marker(int a, int b) { return a * b + 7; }
+    int main(void) { return nix_ghidra_marker(3, 4); }
+    EOF
+    $CC -O0 -o marker marker.c
+
+    mkdir -p scripts project
+    cp ${./CheckAnalysis.java} scripts/CheckAnalysis.java
+
+    # Import with default analysis, then run the post-script. analyzeHeadless is
+    # noisy and its exit status is unreliable, so assert on the NIX_TEST_*
+    # markers rather than on $?. GhidraScript.println prefixes its output, so
+    # match the markers anywhere on the line rather than anchoring.
+    ghidra-analyzeHeadless project ghidra-test \
+      -import ./marker \
+      -scriptPath ./scripts \
+      -postScript CheckAnalysis.java \
+      -deleteProject \
+      2>&1 | tee analysis.log
+
+    field() { grep -oE "$1=[^ ]+" analysis.log | tail -1 | cut -d= -f2; }
+    arch=$(field NIX_TEST_ARCH)
+    instrs=$(field NIX_TEST_INSTRS)
+    marker=$(field NIX_TEST_HASMARKER)
+    declen=$(field NIX_TEST_DECOMPILED_LEN)
+
+    echo "language=$arch instructions=$instrs marker=$marker decompiled_len=$declen"
+
+    [[ -n "$instrs" && "$instrs" -gt 0 ]] \
+      || { echo "FAIL: no instructions were disassembled"; exit 1; }
+    [[ "$marker" == "1" ]] \
+      || { echo "FAIL: nix_ghidra_marker not recovered by analysis"; exit 1; }
+    [[ -n "$declen" && "$declen" -gt 0 ]] \
+      || { echo "FAIL: decompiler produced no output (native decompiler broken?)"; exit 1; }
+
+    touch "$out"
+  ''


### PR DESCRIPTION
Build `sevenzipjbinding` from source _(for `aarch64-darwin`)_, so Ghidra on `aarch64-darwin` doesn't need Rosetta 2

Disclosure: all commits that are not `ghidra: build sevenzipjbinding on aarch64-darwin` were done with assistance of LLM (GPT-5.5)

Before:

<details>

<img width="592" height="353" alt="image" src="https://github.com/user-attachments/assets/5eb1bff4-93aa-42b2-96b4-65886e9aa6a0" />

</details>

After:

<details>

<img width="852" height="496" alt="image" src="https://github.com/user-attachments/assets/95e53562-c3e4-4aa5-bd10-26d23e7179f9" />

<img width="550" height="851" alt="image" src="https://github.com/user-attachments/assets/bd8c43a6-6b80-41e2-9f5e-c3a841cc3f92" />

<img width="912" height="712" alt="image" src="https://github.com/user-attachments/assets/ec512353-70f8-41d7-9725-809615a787e6" />

<img width="1627" height="974" alt="image" src="https://github.com/user-attachments/assets/1f20e3ae-b91f-4ab0-a03b-d957e509fd70" />

</details>

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
