### PR TITLE
nocturne: init at 1.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20371,17 +20371,17 @@
     email = "nyu@nyuku.ru";
     githubId = 97425873;
   };
-  nyxonios = {
-    name = "nyxonios";
-    github = "Nyxonios";
-    email = "martin.n.seller@gmail.com";
-    githubId = 18164197;
-  };
   nyxar77 = {
     name = "nyxar77";
     github = "nyxar77";
     email = "nyxar49@gmail.com";
     githubId = 153492661;
+  };
+  nyxonios = {
+    name = "nyxonios";
+    github = "Nyxonios";
+    email = "martin.n.seller@gmail.com";
+    githubId = 18164197;
   };
   nzbr = {
     email = "nixos@nzbr.de";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20377,6 +20377,12 @@
     email = "martin.n.seller@gmail.com";
     githubId = 18164197;
   };
+  nyxar77 = {
+    name = "nyxar77";
+    github = "nyxar77";
+    email = "nyxar49@gmail.com";
+    githubId = 153492661;
+  };
   nzbr = {
     email = "nixos@nzbr.de";
     github = "nzbr";

--- a/pkgs/by-name/no/nocturne/disable-navidrome-setup.patch
+++ b/pkgs/by-name/no/nocturne/disable-navidrome-setup.patch
@@ -1,0 +1,14 @@
+--- a/src/integrations/navidrome.py
++++ b/src/integrations/navidrome.py
+@@ -556,11 +556,6 @@
+     process = None
+ 
+     def check_if_ready(self, row) -> bool:
+-        if get_navidrome_path():
+-            return True
+-        else:
+-            row.get_root().main_stack.set_visible_child_name('setup')
+-            row.get_root().main_stack.get_child_by_name('setup').set_integration(self)
+         return False
+ 
+     def start_instance(self) -> bool:

--- a/pkgs/by-name/no/nocturne/package.nix
+++ b/pkgs/by-name/no/nocturne/package.nix
@@ -22,7 +22,8 @@
   wrapGAppsHook4,
   xdg-user-dirs,
   cmake,
-}: let
+}:
+let
   mpris-server = python3.pkgs.buildPythonPackage {
     pname = "mpris_server";
     version = "0.9.1";
@@ -31,76 +32,81 @@
       url = "https://github.com/Jeffser/mpris_server/releases/download/v0.9.1/mpris_server-0.10.0.tar.gz";
       hash = "sha256-0+nYgTzLLlIWNcW/iAaQtbsoMDF44BqZrq3+6ZGTjnY=";
     };
-    build-system = with python3.pkgs; [hatchling];
-    propagatedBuildInputs = with python3.pkgs; [pydbus strenum unidecode emoji];
+    build-system = with python3.pkgs; [ hatchling ];
+    propagatedBuildInputs = with python3.pkgs; [
+      pydbus
+      strenum
+      unidecode
+      emoji
+    ];
     doCheck = false;
   };
 in
-  stdenv.mkDerivation (finalAttrs: {
-    pname = "nocturne";
-    version = "1.2.1";
-    src = fetchFromGitHub {
-      owner = "Jeffser";
-      repo = "Nocturne";
-      tag = finalAttrs.version;
-      hash = "sha256-CfrPmpkjcmKMB66kdFL4HqVukaIWAkIzOkwtBqZ65k4=";
-    };
-    __structuredAttrs = true;
-    dontUseCmakeConfigure = true;
-    strictDeps = true;
-    nativeBuildInputs = [
-      meson
-      ninja
-      pkg-config
-      gettext
-      desktop-file-utils
-      appstream
-      blueprint-compiler
-      gobject-introspection
-      wrapGAppsHook4
-      glib
-      cmake
-      gtk4
-      python3
-    ];
-    buildInputs = [
-      libadwaita
-      gtk4
-      glib
-      glib-networking
-      gst_all_1.gstreamer
-      gst_all_1.gst-plugins-base
-      gst_all_1.gst-plugins-good
-      gst_all_1.gst-plugins-bad
-      libsecret
-    ];
-    pythonDependencies = [
-      python3Packages.pygobject3
-      python3Packages.tinytag
-      python3Packages.requests
-      python3Packages.pillow
-      python3Packages.syncedlyrics
-      python3Packages.colorthief
-      mpris-server
-    ];
-    preFixup = ''
-      gappsWrapperArgs+=(
-        --prefix PATH : ${lib.makeBinPath [xdg-user-dirs]}
-        --prefix PYTHONPATH : ${python3.pkgs.makePythonPath finalAttrs.pythonDependencies}
-      )
-    '';
-    postPatch = ''
-      sed -i '/if get_navidrome_path():/,/set_integration(self)/d' src/integrations/navidrome.py
-      sed -i "s/tag\.artist\.split(';')\[0\] or \"\"/\(tag.artist or ''\).split(';')[0]/" src/integrations/local.py
-    '';
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nocturne";
+  version = "1.2.1";
+  src = fetchFromGitHub {
+    owner = "Jeffser";
+    repo = "Nocturne";
+    tag = finalAttrs.version;
+    hash = "sha256-CfrPmpkjcmKMB66kdFL4HqVukaIWAkIzOkwtBqZ65k4=";
+  };
+  __structuredAttrs = true;
+  dontUseCmakeConfigure = true;
+  strictDeps = true;
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    gettext
+    desktop-file-utils
+    appstream
+    blueprint-compiler
+    gobject-introspection
+    wrapGAppsHook4
+    glib
+    cmake
+    gtk4
+    python3
+  ];
+  buildInputs = [
+    libadwaita
+    gtk4
+    glib
+    glib-networking
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    libsecret
+  ];
+  pythonDependencies = [
+    python3Packages.pygobject3
+    python3Packages.tinytag
+    python3Packages.requests
+    python3Packages.pillow
+    python3Packages.syncedlyrics
+    python3Packages.colorthief
+    mpris-server
+  ];
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : ${lib.makeBinPath [ xdg-user-dirs ]}
+      --prefix PYTHONPATH : ${python3.pkgs.makePythonPath finalAttrs.pythonDependencies}
+    )
+  '';
 
-    meta = {
-      description = "Adwaita music player for OpenSubsonic servers like Navidrome";
-      homepage = "https://github.com/Jeffser/Nocturne";
-      license = lib.licenses.gpl3Plus;
-      maintainers = with lib.maintainers; [nyxar77 pbsds];
-      mainProgram = "nocturne";
-      platforms = lib.platforms.linux;
-    };
-  })
+  patches = [ ./disable-navidrome-setup.patch ];
 
+  meta = {
+    description = "Adwaita music player for OpenSubsonic servers like Navidrome";
+    homepage = "https://github.com/Jeffser/Nocturne";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      nyxar77
+      pbsds
+    ];
+    mainProgram = "nocturne";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/no/nocturne/package.nix
+++ b/pkgs/by-name/no/nocturne/package.nix
@@ -2,95 +2,105 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  meson,
-  ninja,
-  blueprint-compiler,
-  wrapGAppsHook4,
-  gettext,
-  desktop-file-utils,
-  appstream,
-  glib,
-  glib-networking,
-  pkg-config,
-  cmake,
-  gtk4,
+  fetchurl,
   python3,
   python3Packages,
   libadwaita,
-  gobject-introspection,
-  libsecret,
+  gtk4,
+  glib,
+  glib-networking,
   gst_all_1,
+  libsecret,
+  blueprint-compiler,
+  meson,
+  ninja,
+  pkg-config,
+  gettext,
+  desktop-file-utils,
+  appstream,
+  gobject-introspection,
+  wrapGAppsHook4,
   xdg-user-dirs,
-}:
-
-stdenv.mkDerivation (finalAttrs: {
-  pname = "nocturne";
-  version = "1.1.1";
-
-  src = fetchFromGitHub {
-    owner = "Jeffser";
-    repo = "Nocturne";
-    tag = finalAttrs.version;
-    hash = "sha256-7B9wtuxfsF6brtLkIEeWII4IvXwdJHnZ1Wr3uLfoqHU=";
+  cmake,
+}: let
+  mpris-server = python3.pkgs.buildPythonPackage {
+    pname = "mpris_server";
+    version = "0.9.1";
+    pyproject = true;
+    src = fetchurl {
+      url = "https://github.com/Jeffser/mpris_server/releases/download/v0.9.1/mpris_server-0.10.0.tar.gz";
+      hash = "sha256-0+nYgTzLLlIWNcW/iAaQtbsoMDF44BqZrq3+6ZGTjnY=";
+    };
+    build-system = with python3.pkgs; [hatchling];
+    propagatedBuildInputs = with python3.pkgs; [pydbus strenum unidecode emoji];
+    doCheck = false;
   };
+in
+  stdenv.mkDerivation (finalAttrs: {
+    pname = "nocturne";
+    version = "1.2.1";
+    src = fetchFromGitHub {
+      owner = "Jeffser";
+      repo = "Nocturne";
+      tag = finalAttrs.version;
+      hash = "sha256-CfrPmpkjcmKMB66kdFL4HqVukaIWAkIzOkwtBqZ65k4=";
+    };
+    __structuredAttrs = true;
+    dontUseCmakeConfigure = true;
+    strictDeps = true;
+    nativeBuildInputs = [
+      meson
+      ninja
+      pkg-config
+      gettext
+      desktop-file-utils
+      appstream
+      blueprint-compiler
+      gobject-introspection
+      wrapGAppsHook4
+      glib
+      cmake
+      gtk4
+      python3
+    ];
+    buildInputs = [
+      libadwaita
+      gtk4
+      glib
+      glib-networking
+      gst_all_1.gstreamer
+      gst_all_1.gst-plugins-base
+      gst_all_1.gst-plugins-good
+      gst_all_1.gst-plugins-bad
+      libsecret
+    ];
+    pythonDependencies = [
+      python3Packages.pygobject3
+      python3Packages.tinytag
+      python3Packages.requests
+      python3Packages.pillow
+      python3Packages.syncedlyrics
+      python3Packages.colorthief
+      mpris-server
+    ];
+    preFixup = ''
+      gappsWrapperArgs+=(
+        --prefix PATH : ${lib.makeBinPath [xdg-user-dirs]}
+        --prefix PYTHONPATH : ${python3.pkgs.makePythonPath finalAttrs.pythonDependencies}
+      )
+    '';
+    postPatch = ''
+      sed -i '/if get_navidrome_path():/,/set_integration(self)/d' src/integrations/navidrome.py
+      sed -i "s/tag\.artist\.split(';')\[0\] or \"\"/\(tag.artist or ''\).split(';')[0]/" src/integrations/local.py
+    '';
 
-  __structuredAttrs = true;
+    meta = {
+      description = "Adwaita music player for OpenSubsonic servers like Navidrome";
+      homepage = "https://github.com/Jeffser/Nocturne";
+      license = lib.licenses.gpl3Plus;
+      maintainers = with lib.maintainers; [nyxar77 pbsds];
+      mainProgram = "nocturne";
+      platforms = lib.platforms.linux;
+    };
+  })
 
-  dontUseCmakeConfigure = true;
-
-  strictDeps = true;
-  nativeBuildInputs = [
-    meson
-    ninja
-    blueprint-compiler
-    gobject-introspection
-    wrapGAppsHook4
-    gettext # for msgfmt
-    desktop-file-utils # for desktop-file-validate
-    appstream
-    glib
-    pkg-config
-    cmake
-    gtk4
-    python3
-  ];
-
-  buildInputs = [
-    gtk4
-    libadwaita
-    libsecret
-    python3
-    glib-networking
-    gst_all_1.gstreamer
-    gst_all_1.gst-plugins-base
-    gst_all_1.gst-plugins-good
-  ];
-
-  pythonDependencies = [
-    python3Packages.pygobject3
-    python3Packages.tinytag
-    python3Packages.requests
-    python3Packages.syncedlyrics
-    python3Packages.pycairo
-    python3Packages.colorthief
-    python3Packages.favicon
-    python3Packages.mpris-server
-    python3Packages.pillow
-  ];
-
-  preFixup = ''
-    gappsWrapperArgs+=(
-      --prefix PATH : ${lib.makeBinPath [ xdg-user-dirs ]}
-      --prefix PYTHONPATH : ${python3.pkgs.makePythonPath finalAttrs.pythonDependencies}
-    )
-  '';
-
-  meta = {
-    description = "Adwaita Music Player and Library Manager";
-    homepage = "https://jeffser.com/nocturne/";
-    license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ pbsds ];
-    mainProgram = "nocturne";
-    platforms = lib.platforms.linux;
-  };
-})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
  - Packages Jeffser's fork of mpris-server as an internal let binding since it diverges from the upstream PyPI package already in nixpkgs, The fork is maintained by the same developer
  - Disables the managed Navidrome setup/download prompt, which would install binaries outside the Nix store

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
