### PR TITLE
dune_3: 3.21.1 -> 3.24.0

### DIFF
--- a/pkgs/by-name/du/dune/package.nix
+++ b/pkgs/by-name/du/dune/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   buildPackages,
-  version ? "3.21.1",
+  version ? "3.24.0_alpha0",
 }:
 let
   # needed for pkgsStatic
@@ -17,11 +17,14 @@ stdenv.mkDerivation {
     url =
       let
         sfx = lib.optionalString (lib.versions.major version == "2") "site-";
+        # Pre-release tarballs are named with a "." separator (dune-3.24.0.alpha0.tbz)
+        # while the git tag uses "_" (3.24.0_alpha0).
+        filenameVersion = builtins.replaceStrings [ "_" ] [ "." ] version;
       in
-      "https://github.com/ocaml/dune/releases/download/${version}/dune-${sfx}${version}.tbz";
+      "https://github.com/ocaml/dune/releases/download/${version}/dune-${sfx}${filenameVersion}.tbz";
     hash =
       {
-        "3.21.1" = "sha256-hPeoLG2ApxJPOEfppInoDPvq+3vtNXOsAShu9W/QjZQ=";
+        "3.24.0_alpha0" = "sha256-hH6Rhac4ehY+OahA8wC2A53CxXiHT72KH00LYUA3mFw=";
         "2.9.3" = "sha256:1ml8bxym8sdfz25bx947al7cvsi2zg5lcv7x9w6xb01cmdryqr9y";
       }
       ."${version}";


### PR DESCRIPTION
Alpha: https://github.com/ocaml/dune/releases/tag/3.24.0_alpha0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
