### PR TITLE
python3Packages.insightface: 0.7.3 -> 1.0.1

### DIFF
--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -380,8 +380,6 @@ in
       MACHINE_LEARNING_WORKERS = "1";
       MACHINE_LEARNING_WORKER_TIMEOUT = "120";
       MACHINE_LEARNING_CACHE_FOLDER = "/var/cache/immich";
-      # TODO: drop when insightface no longer unconditionally imports matplotlib
-      MPLCONFIGDIR = "/var/cache/immich";
       XDG_CACHE_HOME = "/var/cache/immich";
       IMMICH_HOST = "localhost";
       IMMICH_PORT = "3003";

--- a/pkgs/by-name/im/immich-machine-learning/package.nix
+++ b/pkgs/by-name/im/immich-machine-learning/package.nix
@@ -18,6 +18,7 @@ python.pkgs.buildPythonApplication rec {
 
   pythonRelaxDeps = [
     "huggingface-hub"
+    "insightface"
     "numpy"
     "pillow"
     "pydantic-settings"

--- a/pkgs/development/python-modules/insightface/default.nix
+++ b/pkgs/development/python-modules/insightface/default.nix
@@ -3,7 +3,6 @@
   albumentations,
   buildPythonPackage,
   cython,
-  easydict,
   fetchPypi,
   insightface,
   matplotlib,
@@ -11,9 +10,10 @@
   numpy,
   onnx,
   onnxruntime,
-  opencv4,
+  opencv-python,
   pillow,
-  prettytable,
+  pyside6,
+  reportlab,
   requests,
   setuptools,
   scipy,
@@ -26,12 +26,12 @@
 
 buildPythonPackage rec {
   pname = "insightface";
-  version = "0.7.3";
+  version = "1.0.1";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-8ZH3GWEuuzcBj0GTaBRQBUTND4bm/NZ2wCPzVMZo3fc=";
+    hash = "sha256-J68kiRu7pHDLNXOzZqD8yomJ/IUDyfjygejLpv1xYHU=";
   };
 
   build-system = [
@@ -40,22 +40,29 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
-    albumentations
-    easydict
-    matplotlib
     mxnet # used in insightface/commands/rec_add_mask_param.py
     numpy
     onnx
     onnxruntime
-    opencv4
-    pillow
-    prettytable
+    opencv-python
     requests
-    scikit-learn
     scikit-image
     scipy
     tqdm
   ];
+
+  optional-dependencies = {
+    gui = [
+      pillow
+      pyside6
+      reportlab
+      scikit-learn
+    ];
+    face3d = [
+      albumentations
+      matplotlib
+    ];
+  };
 
   # aarch64-linux tries to get cpu information from /sys, which isn't available
   # inside the nix build sandbox.


### PR DESCRIPTION
This should solve the matplotlib warning muted in https://github.com/NixOS/nixpkgs/pull/522428 for good.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
