### PR TITLE
katago: 1.15.3 -> 1.16.4

### DIFF
--- a/pkgs/by-name/ka/katago/package.nix
+++ b/pkgs/by-name/ka/katago/package.nix
@@ -29,10 +29,8 @@ assert lib.assertOneOf "backend" backend [
   "eigen"
 ];
 
-# N.b. older versions of cuda toolkit (e.g. 10) do not support newer versions
-# of gcc.  If you need to use cuda10, please override stdenv with gcc8Stdenv
 let
-  githash = "cd0ed6c0712088ddb901be68189ba7fa1439a9e7";
+  githash = "ba938676d7f42d70950b3a535af2466fb642008c";
   fakegit = writeShellScriptBin "git" "echo ${githash}";
   stdenv' =
     if
@@ -47,13 +45,13 @@ let
 in
 stdenv'.mkDerivation rec {
   pname = "katago";
-  version = "1.15.3";
+  version = "1.16.5";
 
   src = fetchFromGitHub {
     owner = "lightvector";
     repo = "katago";
     rev = "v${version}";
-    sha256 = "sha256-hZc8LlOxnVqJqyqOSIWKv3550QOaGr79xgqsAQ8B8SM=";
+    sha256 = "sha256-+s4JO6+UMyeSHUqyRFEhJD2kmsdhcydanFWjTqxC1Tc=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Update package katago to newest released version 1.16.4

I know release is soon, so I'm not sure if this should be in a different branch, please let me know if so.  Otherwise, I'll probably have to figure out where the proper backport is.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
