### PR TITLE
material-design-icons: use installFonts

### DIFF
--- a/pkgs/by-name/ma/material-design-icons/package.nix
+++ b/pkgs/by-name/ma/material-design-icons/package.nix
@@ -3,11 +3,17 @@
   fetchFromGitHub,
   stdenvNoCC,
   nix-update-script,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "material-design-icons";
   version = "7.4.47";
+
+  outputs = [
+    "out"
+    "webfont"
+  ];
 
   src = fetchFromGitHub {
     owner = "Templarian";
@@ -17,17 +23,7 @@ stdenvNoCC.mkDerivation rec {
     sparseCheckout = [ "fonts" ];
   };
 
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p "$out/share/fonts/"{eot,truetype,woff,woff2}
-    cp fonts/*.eot "$out/share/fonts/eot/"
-    cp fonts/*.ttf "$out/share/fonts/truetype/"
-    cp fonts/*.woff "$out/share/fonts/woff/"
-    cp fonts/*.woff2 "$out/share/fonts/woff2/"
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/ma/material-design-icons/package.nix
+++ b/pkgs/by-name/ma/material-design-icons/package.nix
@@ -6,7 +6,7 @@
   installFonts,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "material-design-icons";
   version = "7.4.47";
 
@@ -18,7 +18,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "Templarian";
     repo = "MaterialDesign-Webfont";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-7t3i3nPJZ/tRslLBfY+9kXH8TR145GC2hPFYJeMHRL8=";
     sparseCheckout = [ "fonts" ];
   };
@@ -42,4 +42,4 @@ stdenvNoCC.mkDerivation rec {
       dixslyf
     ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- https://github.com/NixOS/nixpkgs/issues/495640

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
