### PR TITLE
Autorecon: init at  0-unstable-2025-11-16

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6143,6 +6143,11 @@
     github = "DarkOnion0";
     githubId = 68606322;
   };
+  Darks1de42 = {
+    name = "Darks1de42";
+    github = "Darks1de42";
+    githubId = 48830356;
+  };
   darkyzhou = {
     name = "darkyzhou";
     email = "me@zqy.io";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6143,6 +6143,13 @@
     github = "DarkOnion0";
     githubId = 68606322;
   };
+  Darks1de42 = {
+    name = "Darks1de42";
+    github = "Darks1de42";
+    githubId = 48830356;
+    email = "git@darks1de.de";
+    matrix = "@darks1de:matrix.darks1.de";
+  };
   darkyzhou = {
     name = "darkyzhou";
     email = "me@zqy.io";

--- a/pkgs/by-name/au/autorecon/package.nix
+++ b/pkgs/by-name/au/autorecon/package.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  dnsrecon,
+  enum4linux-ng,
+  whatweb,
+  nikto,
+  nbtscan,
+  onesixtyone,
+  pkgs,
+  seclists,
+  curl,
+  smbmap,
+  sslscan,
+}:
+# the following optional deps are not packaged in nix
+# oscanner
+# oracle-scanner
+# redis-tools
+#smbclient smbclient-ng?
+#snmpwalk
+#svwar
+#tnscmd10g
+
+python3Packages.buildPythonPackage (finalAttrs: {
+  pname = "autorecon";
+  version = "0-unstable-2025-11-16";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "AutoRecon";
+    repo = "AutoRecon";
+    rev = "e7e98f60bdc5fb1695159c1bbcdfdf2746d30fa6";
+    hash = "sha256-xSRfsfLRYt7jS5Jpp6fz5/Kj2DiNI3hgUbUI9w3AHkw=";
+  };
+
+  postPatch = ''
+    substituteInPlace autorecon/global.toml \
+      --replace-fail "/usr/share/seclists" "${seclists}/share/wordlists/seclists"
+
+    substituteInPlace autorecon/config.toml \
+      --replace-fail "/usr/share/seclists" "${seclists}/share/wordlists/seclists"
+
+    substituteInPlace autorecon/default-plugins/*.py \
+      --replace-quiet "/usr/share/seclists" "${seclists}/share/wordlists/seclists"
+  '';
+
+  pythonRelaxDeps = [
+    "impacket"
+    "psutil"
+  ];
+
+  build-system = [ python3Packages.poetry-core ];
+
+  dependencies = with python3Packages; [
+    unidecode
+    colorama
+    impacket
+    platformdirs
+    psutil
+    requests
+    toml
+  ];
+
+  __structuredAttrs = true; # RFC 140
+
+  preFixup = ''
+    wrapProgram $out/bin/autorecon \
+      --suffix PATH : ${
+        lib.makeBinPath [
+          dnsrecon
+          enum4linux-ng
+          whatweb
+          onesixtyone
+          nbtscan
+          nikto
+          curl
+          smbmap
+          sslscan
+        ]
+      }
+  '';
+
+  pythonImportsCheck = [ "autorecon" ];
+
+  meta = {
+    description = "AutoRecon is a multi-threaded network reconnaissance tool which performs automated enumeration of services. ";
+    license = lib.licenses.gpl3;
+    homepage = "https://github.com/AutoRecon/AutoRecon";
+    maintainers = with lib.maintainers; [
+      Darks1de42
+    ];
+    mainProgram = "autorecon";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds the autorecon package. AutoRecon is a multi-threaded network reconnaissance tool which performs automated enumeration of services.    
It scans with nmap one or multiple targets and then based on the results starts other programms like feroxbuster for directory bruteforcing and other scans.    
It is a penetration testing tool and developed for CTFs.
**Not all tools that autorecon is using are available in nixpkgs, but the most important are.**     
So when running it fails, to disable this check a special flag must be used, as seen in this example command:
```bash
autorecon --ignore-plugin-checks scanme.nmap.org
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
