### PR TITLE
migu: use installFonts

### DIFF
--- a/pkgs/by-name/mi/migu/package.nix
+++ b/pkgs/by-name/mi/migu/package.nix
@@ -1,10 +1,11 @@
 {
   lib,
-  stdenv,
+  stdenvNoCC,
   fetchzip,
+  installFonts,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "migu";
   version = "20150712";
 
@@ -12,30 +13,26 @@ stdenv.mkDerivation (finalAttrs: {
     (fetchzip {
       url = "mirror://osdn/mix-mplus-ipa/63545/migu-1p-${finalAttrs.version}.zip";
       sha256 = "04wpbk5xbbcv2rzac8yzj4ww7sk2hy2rg8zs96yxc5vzj9q7svf6";
+      name = "migu-1p-${finalAttrs.version}.zip";
     })
     (fetchzip {
       url = "mirror://osdn/mix-mplus-ipa/63545/migu-1c-${finalAttrs.version}.zip";
       sha256 = "1k7ymix14ac5fb44bjvbaaf24784zzpyc1jj2280c0zdnpxksyk6";
+      name = "migu-1c-${finalAttrs.version}.zip";
     })
     (fetchzip {
       url = "mirror://osdn/mix-mplus-ipa/63545/migu-1m-${finalAttrs.version}.zip";
       sha256 = "07r8id83v92hym21vrqmfsfxb646v8258001pkjhgfnfg1yvw8lm";
+      name = "migu-1m-${finalAttrs.version}.zip";
     })
     (fetchzip {
       url = "mirror://osdn/mix-mplus-ipa/63545/migu-2m-${finalAttrs.version}.zip";
       sha256 = "1pvzbrawh43589j8rfxk86y1acjbgzzdy5wllvdkpm1qnx28zwc2";
+      name = "migu-2m-${finalAttrs.version}.zip";
     })
   ];
-
-  dontUnpack = true;
-
-  installPhase = ''
-    find $srcs -name '*.ttf' | xargs install -m644 --target $out/share/fonts/truetype/migu -D
-  '';
-
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-  outputHash = "0nbpn21cxdd6gsgr3fadzjsnz84f2swpf81wmscmjgvd56ngndzh";
+  sourceRoot = ".";
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     description = "High-quality Japanese font based on modified M+ fonts and IPA fonts";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Part of #495640
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
