### PR TITLE
nixos/forgejo: allow extra arguments to service commands

### DIFF
--- a/nixos/modules/services/misc/forgejo.nix
+++ b/nixos/modules/services/misc/forgejo.nix
@@ -162,6 +162,13 @@ in
         description = "Group under which Forgejo runs.";
       };
 
+      extraArgs = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = [ "--verbose" ];
+        description = "List of extra arguments passed to the `forgejo web` command.";
+      };
+
       database = {
         type = mkOption {
           type = types.enum [
@@ -297,6 +304,13 @@ in
             The format is described in
             {manpage}`tmpfiles.d(5)`.
           '';
+        };
+
+        extraArgs = mkOption {
+          type = types.listOf types.str;
+          default = [ ];
+          example = [ "--skip-repo-archives" ];
+          description = "List of extra arguments passed to the `forgejo dump` command.";
         };
       };
 
@@ -737,7 +751,9 @@ in
         User = cfg.user;
         Group = cfg.group;
         WorkingDirectory = cfg.stateDir;
-        ExecStart = "${exe} web --pid /run/forgejo/forgejo.pid";
+        ExecStart =
+          "${exe} web --pid /run/forgejo/forgejo.pid"
+          + optionalString (cfg.extraArgs != [ ]) " ${lib.strings.escapeShellArgs cfg.extraArgs}";
         Restart = "always";
         # Runtime directory and mode
         RuntimeDirectory = "forgejo";
@@ -835,7 +851,8 @@ in
         User = cfg.user;
         ExecStart =
           "${exe} dump --type ${cfg.dump.type}"
-          + optionalString (cfg.dump.file != null) " --file ${cfg.dump.file}";
+          + optionalString (cfg.dump.file != null) " --file ${cfg.dump.file}"
+          + optionalString (cfg.dump.extraArgs != [ ]) " ${lib.strings.escapeShellArgs cfg.dump.extraArgs}";
         WorkingDirectory = cfg.dump.backupDir;
       };
     };


### PR DESCRIPTION
My usecase is passing `--skip-repo-archives --skip-package-data` to `forgejo dump` to reduce archive size. Added it to the `forgejo web` command for good measure.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. (**On top of nixos-unstable at `64c08a7ca051951c8eae34e3e3cb1e202fe36786`** (no rebuild caused), on master the tests fail but they do even without this change)
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
