### PR TITLE
cudaPackages.cuda_cccl: fix cpp syntax error on CUDA 13.2

### DIFF
--- a/pkgs/development/cuda-modules/packages/cuda_cccl.nix
+++ b/pkgs/development/cuda-modules/packages/cuda_cccl.nix
@@ -25,17 +25,29 @@ buildRedist {
     rmdir -v "$PWD/include/cccl"
   '';
 
-  patches = lib.optionals (cudaAtLeast "12.9" && cudaOlder "13.0") [
-    # Fix missing _CCCL_PP_SPLICE_WITH_IMPL20 in preprocessor.h
-    # https://github.com/NVIDIA/cccl/issues/4967
-    # https://github.com/NVIDIA/cccl/pull/4972
-    (fetchpatch {
-      name = "fix-missing-_CCCL_PP_SPLICE_WITH_IMPL20";
-      url = "https://github.com/NVIDIA/cccl/commit/2c2276d8b19d737cb16811ce2eb761030f472e60.patch";
-      stripLen = 1;
-      hash = "sha256-hYfMFsd7Y8CwuNGaPYG6uEB+lg1TmWSIIU5ToVMULKY=";
-    })
-  ];
+  patches =
+    lib.optionals (cudaAtLeast "12.9" && cudaOlder "13.0") [
+      # Fix missing _CCCL_PP_SPLICE_WITH_IMPL20 in preprocessor.h
+      # https://github.com/NVIDIA/cccl/issues/4967
+      # https://github.com/NVIDIA/cccl/pull/4972
+      (fetchpatch {
+        name = "fix-missing-_CCCL_PP_SPLICE_WITH_IMPL20";
+        url = "https://github.com/NVIDIA/cccl/commit/2c2276d8b19d737cb16811ce2eb761030f472e60.patch";
+        stripLen = 1;
+        hash = "sha256-hYfMFsd7Y8CwuNGaPYG6uEB+lg1TmWSIIU5ToVMULKY=";
+      })
+    ]
+    ++ lib.optionals (cudaAtLeast "13.2") [
+      # Fix onnxruntime compilation error: https://github.com/microsoft/onnxruntime/issues/28023
+      # Backport: https://github.com/NVIDIA/cccl/pull/8771
+      (fetchpatch {
+        name = "fix-invalid-cpp-syntax";
+        url = "https://github.com/NVIDIA/cccl/commit/8e41eeabe54ab9ae48ad5640cfa7153b0a1071af.patch";
+        stripLen = 2;
+        extraPrefix = "include/";
+        hash = "sha256-eko1GSD2NPSLtbQ3diwgKMbuS6wU9lHDOajLJy5lBwM=";
+      })
+    ];
 
   # NVIDIA, in their wisdom, expect CCCL to be a directory inside include.
   # https://github.com/NVIDIA/cutlass/blob/087c84df83d254b5fb295a7a408f1a1d554085cf/CMakeLists.txt#L773


### PR DESCRIPTION
## Things done

https://github.com/NVIDIA/cccl/pull/8771

Fixes onnxruntime: https://github.com/microsoft/onnxruntime/issues/28023

```
/nix/store/9bvirxizyiq3pg5rmgpz2f6aw6y7c1fm-cuda13.2-cuda_cccl-13.2.27/include/cub/device/device_transform.cuh:44:111: error: global qualification of class name is invalid before ':' token
   44 | struct ::cuda::proclaims_copyable_arguments<CUB_NS_QUALIFIER::detail::__return_constant<T>> : ::cuda::std::true_type
      |                                                                                                               ^
/nix/store/9bvirxizyiq3pg5rmgpz2f6aw6y7c1fm-cuda13.2-cuda_cccl-13.2.27/include/cub/device/device_transform.cuh:44:111: error: expected '{' before ':' token
make[2]: *** [CMakeFiles/onnxruntime_providers_cuda.dir/build.make:8382: CMakeFiles/onnxruntime_providers_cuda.dir/build/source/onnxruntime/contrib_ops/cuda/math/bias_softmax_impl.cu.o] Error 1
make[2]: *** Waiting for unfinished jobs....
In file included from /nix/store/54yzskzwmapls2awvih149wyzci717gw-onnx-src/onnx/version_converter/convert.cc:5:
/nix/store/54yzskzwmapls2awvih149wyzci717gw-onnx-src/onnx/version_converter/convert.h: In constructor 'onnx::version_conversion::DefaultVersionConverter::DefaultVersionConverter()':
/nix/store/54yzskzwmapls2awvih149wyzci717gw-onnx-src/onnx/version_converter/convert.h:110:3: note: variable tracking size limit exceeded with '[-fvar-tracking-assignments](https://gcc.gnu.org/onlinedocs/gcc-15.2.0/gcc/Debugging-Options.html#index-fno-var-tracking-assignments)', retrying without
  110 |   DefaultVersionConverter() {
      |   ^~~~~~~~~~~~~~~~~~~~~~~
/nix/store/9bvirxizyiq3pg5rmgpz2f6aw6y7c1fm-cuda13.2-cuda_cccl-13.2.27/include/cub/device/device_transform.cuh:44:111: error: global qualification of class name is invalid before ':' token
   44 | struct ::cuda::proclaims_copyable_arguments<CUB_NS_QUALIFIER::detail::__return_constant<T>> : ::cuda::std::true_type
      |                                                                                                               ^
/nix/store/9bvirxizyiq3pg5rmgpz2f6aw6y7c1fm-cuda13.2-cuda_cccl-13.2.27/include/cub/device/device_transform.cuh:44:111: error: expected '{' before ':' token
make[2]: *** [CMakeFiles/onnxruntime_providers_cuda.dir/build.make:8562: CMakeFiles/onnxruntime_providers_cuda.dir/build/source/onnxruntime/contrib_ops/cuda/moe/ft_moe/moe_kernel.cu.o] Error 1
```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
