### PR TITLE
krunkit: install missing firmware; krunkit: add boot regression test; podman-desktop: add krunkit to closure on darwin

### DIFF
--- a/pkgs/by-name/kr/krunkit/boot-test.nix
+++ b/pkgs/by-name/kr/krunkit/boot-test.nix
@@ -1,0 +1,126 @@
+{
+  krunkit,
+  lib,
+  nixos,
+  pkgs,
+  runCommand,
+}:
+
+let
+  linuxPkgs = import pkgs.path {
+    system = "aarch64-linux";
+  };
+
+  nixosConfig =
+    (nixos {
+      nixpkgs.pkgs = linuxPkgs;
+
+      imports = [ "${pkgs.path}/nixos/modules/profiles/qemu-guest.nix" ];
+
+      boot = {
+        kernelParams = [ "console=hvc0" ];
+        loader = {
+          efi.canTouchEfiVariables = false;
+          systemd-boot.enable = true;
+        };
+      };
+
+      documentation.enable = false;
+      environment.defaultPackages = [ ];
+
+      fileSystems = {
+        "/" = {
+          device = "/dev/disk/by-label/nixos";
+          fsType = "ext4";
+        };
+
+        "/boot" = {
+          device = "/dev/disk/by-label/ESP";
+          fsType = "vfat";
+        };
+      };
+
+      systemd.services.krunkit-boot-ok = {
+        wantedBy = [ "multi-user.target" ];
+        after = [ "multi-user.target" ];
+        serviceConfig.Type = "oneshot";
+        script = ''
+          echo krunkit-boot-ok >/dev/hvc0
+        '';
+      };
+
+      system.stateVersion = lib.trivial.release;
+    }).config;
+
+  image = import "${pkgs.path}/nixos/lib/make-disk-image.nix" {
+    inherit lib;
+    config = nixosConfig;
+    pkgs = linuxPkgs;
+
+    additionalSpace = "64M";
+    baseName = "krunkit-nixos";
+    bootSize = "128M";
+    copyChannel = false;
+    format = "raw";
+    partitionTableType = "efi";
+  };
+in
+runCommand "krunkit-nixos-boot-test"
+  {
+    requiredSystemFeatures = [ "apple-virt" ];
+
+    meta.platforms = [ "aarch64-darwin" ];
+  }
+  ''
+    image=${image}/krunkit-nixos.img
+    disk=$TMPDIR/disk.img
+    console=$TMPDIR/console.log
+    log=$TMPDIR/krunkit.log
+
+    cp "$image" "$disk"
+    chmod u+w "$disk"
+    touch "$console" "$log"
+
+    cleanup() {
+      set +e
+      if [ -n "''${pid:-}" ]; then
+        kill "$pid" >/dev/null 2>&1
+        for _ in $(seq 1 20); do
+          kill -0 "$pid" >/dev/null 2>&1 || break
+          sleep 1
+        done
+        kill -KILL "$pid" >/dev/null 2>&1
+      fi
+    }
+    trap cleanup EXIT
+
+    ${krunkit}/bin/krunkit \
+      --cpus 1 \
+      --memory 1024 \
+      --log-file "$log" \
+      --device "virtio-blk,path=$disk,format=raw" \
+      --device "virtio-serial,logFilePath=$console" &
+    pid=$!
+
+    for _ in $(seq 1 120); do
+      if grep -q krunkit-boot-ok "$console"; then
+        touch "$out"
+        exit 0
+      fi
+
+      if ! kill -0 "$pid" >/dev/null 2>&1; then
+        echo "krunkit exited before the guest reached multi-user.target"
+        wait "$pid"
+        cat "$log"
+        cat "$console"
+        exit 1
+      fi
+
+      sleep 1
+    done
+
+    echo "timed out waiting for krunkit guest boot marker"
+    cat "$log"
+    cat "$console"
+    exit 1
+  ''

--- a/pkgs/by-name/kr/krunkit/package.nix
+++ b/pkgs/by-name/kr/krunkit/package.nix
@@ -43,6 +43,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];
 
+  postInstall = ''
+    install -Dm444 edk2/KRUN_EFI.silent.fd $out/share/krunkit/KRUN_EFI.silent.fd
+  '';
+
   # This is necessary in order for the binary to keep its entitlements
   dontStrip = true;
 

--- a/pkgs/by-name/kr/krunkit/package.nix
+++ b/pkgs/by-name/kr/krunkit/package.nix
@@ -1,4 +1,5 @@
 {
+  callPackage,
   cargo,
   darwin,
   pkg-config,
@@ -50,7 +51,12 @@ stdenv.mkDerivation (finalAttrs: {
   # This is necessary in order for the binary to keep its entitlements
   dontStrip = true;
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    tests.boot = callPackage ./boot-test.nix {
+      krunkit = finalAttrs.finalPackage;
+    };
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Launch configurable virtual machines with libkrun";

--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -18,6 +18,7 @@
   jq,
   gnugrep,
   podman,
+  krunkit,
 }:
 
 let
@@ -124,7 +125,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   installPhase =
     let
-      commonWrapperArgs = "--prefix PATH : ${lib.makeBinPath [ podman ]}";
+      prefixPackages = lib.makeBinPath (
+        [ podman ] ++ lib.optional (lib.meta.availableOn stdenv.hostPlatform krunkit) krunkit
+      );
+      commonWrapperArgs = "--prefix PATH : ${prefixPackages}";
     in
     (
       ''


### PR DESCRIPTION
This PR should fix krunkit failing to boot anything, including podman machine of krunkit type. It also adds krunkit to podman-desktop closure because in recent versions the app started to call to krunkit directly.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
