### PR TITLE
pnpm_10: 10.34.0 -> 10.34.4

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -56,6 +56,8 @@
 
 - `librest` providing 0.7 ABI was removed. `librest_1_0` providing 1.0 ABI was renamed to `librest` and `librest_1_0` was kept as an alias.
 
+- `pnpm_10` was upgraded to version 10.34.1+, which introduced stricter integrity checks. If you encounter `ERR_PNPM_MISSING_TARBALL_INTEGRITY`, you can fall back to the older `pnpm_10_34_0`.
+
 - `fetchPnpmDeps`' `fetcherVersion = 1` and `fetcherVersion = 2` have been
   removed, as announced in the 26.05 release. Packages still using them now
   throw an evaluation error and must migrate to `fetcherVersion = 3` (or later)

--- a/pkgs/by-name/sh/sharkey/package.nix
+++ b/pkgs/by-name/sh/sharkey/package.nix
@@ -15,7 +15,7 @@
   pango,
   pixman,
   pkg-config,
-  pnpm_10,
+  pnpm_10_34_0,
   fetchPnpmDeps,
   pnpmConfigHook,
   python3,
@@ -24,7 +24,7 @@
 }:
 
 let
-  pnpm = pnpm_10.override { nodejs-slim = nodejs-slim_22; };
+  pnpm = pnpm_10_34_0.override { nodejs-slim = nodejs-slim_22; };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "sharkey";

--- a/pkgs/by-name/vu/vue-language-server/package.nix
+++ b/pkgs/by-name/vu/vue-language-server/package.nix
@@ -4,13 +4,13 @@
   fetchFromGitHub,
   fetchPnpmDeps,
   pnpmConfigHook,
-  pnpm_10,
+  pnpm_10_34_0,
   nodejs,
   nix-update-script,
   makeBinaryWrapper,
 }:
 let
-  pnpm = pnpm_10;
+  pnpm = pnpm_10_34_0;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "vue-language-server";

--- a/pkgs/development/tools/pnpm/default.nix
+++ b/pkgs/development/tools/pnpm/default.nix
@@ -30,6 +30,18 @@ let
         "CVE-2026-55699"
       ];
     };
+    # 10.34.1 made a breaking change that causes
+    # ERR_PNPM_MISSING_TARBALL_INTEGRITY error for some packages.
+    "10_34_0" = {
+      version = "10.34.0";
+      hash = "sha256-WOFDJYhx31FYm2UcBiBdq+xIdmpdu6PCWZm2m1C+WY4=";
+      knownVulnerabilities = [
+        "CVE-2026-55487"
+        "CVE-2026-55698"
+        "CVE-2026-55180"
+        "CVE-2026-55697"
+      ];
+    };
     "10" = {
       version = "10.34.0";
       hash = "sha256-WOFDJYhx31FYm2UcBiBdq+xIdmpdu6PCWZm2m1C+WY4=";

--- a/pkgs/development/tools/pnpm/default.nix
+++ b/pkgs/development/tools/pnpm/default.nix
@@ -43,8 +43,8 @@ let
       ];
     };
     "10" = {
-      version = "10.34.0";
-      hash = "sha256-WOFDJYhx31FYm2UcBiBdq+xIdmpdu6PCWZm2m1C+WY4=";
+      version = "10.34.4";
+      hash = "sha256-mM1XGNvYxLJokVZJO5WWzs9rZLGpjUoIfoITWhdbQOs=";
     };
     "11" = {
       version = "11.9.0";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2813,6 +2813,7 @@ with pkgs;
     pnpm_8
     pnpm_9
     pnpm_10_29_2
+    pnpm_10_34_0
     pnpm_10
     pnpm_11
     ;


### PR DESCRIPTION
Releases:
- https://github.com/pnpm/pnpm/releases/tag/v10.34.1
- https://github.com/pnpm/pnpm/releases/tag/v10.34.2
- https://github.com/pnpm/pnpm/releases/tag/v10.34.3
- https://github.com/pnpm/pnpm/releases/tag/v10.34.4

closes https://github.com/NixOS/nixpkgs/pull/532571
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
