### PR TITLE
maven: add mvnGoal and mvnOffline parameters to buildMavenPackage

### DIFF
--- a/pkgs/by-name/ma/maven/build-maven-package.nix
+++ b/pkgs/by-name/ma/maven/build-maven-package.nix
@@ -20,6 +20,15 @@ let
       version,
       mvnJdk ? jdk,
       mvnHash ? "",
+      /**
+        Maven goal to execute. Normally the the default should be used, but some special cases need other goals.
+      */
+      mvnGoal ? "package",
+      /**
+        Set the Maven offline argument, `-o`. Normally the default is preferred, but to call `mvn deploy` with
+        a directory destination `-o` must be removed. In that case we rely on the Nix sandbox to keep things hermetic.
+      */
+      mvnOffline ? true,
       mvnFetchExtraArgs ? { },
       mvnDepsParameters ? "",
       manualMvnArtifacts ? [ ],
@@ -143,7 +152,9 @@ let
 
           mvnDeps=$(cp -dpR ${fetchedMavenDeps}/.m2 ./ && chmod +w -R .m2 && pwd)
           runHook afterDepsSetup
-          mvn package -o -nsu "-Dmaven.repo.local=$mvnDeps/.m2" ${mvnSkipTests} ${mvnParameters}
+          mvn ${mvnGoal} ${
+            if mvnOffline then "-o" else ""
+          } -nsu "-Dmaven.repo.local=$mvnDeps/.m2" ${mvnSkipTests} ${mvnParameters}
 
           runHook postBuild
         '';


### PR DESCRIPTION
mvnGoal allows overriding the main Maven goal used in the derivation.

mvnOffline allows defaults to `true`, but allows the offline (`-o`) argument to `mvn` to be removed for special cases (e.g. `deploy` goal) where we will just rely on the Nix sandbox enforcing offline operation.


- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
