### PR TITLE
kronometer: migrate to pkgs/by-name

### DIFF
--- a/pkgs/by-name/kr/kronometer/package.nix
+++ b/pkgs/by-name/kr/kronometer/package.nix
@@ -3,13 +3,8 @@
   stdenv,
   lib,
   cmake,
-  extra-cmake-modules,
-  kdoctools,
-  wrapQtAppsHook,
-  kconfig,
-  kcrash,
-  kwidgetsaddons,
-  kxmlgui,
+  kdePackages,
+  qt6,
 }:
 
 stdenv.mkDerivation {
@@ -26,16 +21,16 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     cmake
-    extra-cmake-modules
-    kdoctools
-    wrapQtAppsHook
+    kdePackages.extra-cmake-modules
+    kdePackages.kdoctools
+    qt6.wrapQtAppsHook
   ];
 
   buildInputs = [
-    kconfig
-    kcrash
-    kwidgetsaddons
-    kxmlgui
+    kdePackages.kconfig
+    kdePackages.kcrash
+    kdePackages.kwidgetsaddons
+    kdePackages.kxmlgui
   ];
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2580,8 +2580,6 @@ with pkgs;
     inherit (darwin) sigtool;
   };
 
-  kronometer = kdePackages.callPackage ../tools/misc/kronometer { };
-
   limine-full = limine.override { enableAll = true; };
 
   logstash7 = callPackage ../tools/misc/logstash/7.x.nix {


### PR DESCRIPTION
Also drops one of the 4 remaining `kdePackages.callPackage` in pkgs/top-level/all-packages.nix.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
