### PR TITLE
cling: fix regression from Nixpkgs upgrading to GCC 15

### DIFF
--- a/pkgs/by-name/cl/cling/package.nix
+++ b/pkgs/by-name/cl/cling/package.nix
@@ -20,8 +20,9 @@
   # build Cling against.
   clangStdenv,
 
-  # For runtime C++ standard library
-  gcc-unwrapped,
+  # For runtime C++ standard library.
+  # Cling's embedded clang 18 can't handle GCC 15+ headers, so pin to GCC 14.
+  gcc14,
 
   # Build with debug symbols
   debug ? false,
@@ -33,6 +34,7 @@
 
 let
   stdenv = clangStdenv;
+  gcc-unwrapped = gcc14.cc;
 
   version = "1.2";
 


### PR DESCRIPTION
Nixpkgs master bumped the default GCC to 15.x. Cling's embedded clang 18 crashes when parsing GCC 15's C++ headers, which use attributes like `__externally_visible__` that clang 18 doesn't recognize. Pinning to GCC 14 (the default on release-25.11) fixes the incompatibility.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
