### PR TITLE
rsibreak: migrate to pkgs/by-name

### DIFF
--- a/pkgs/by-name/rs/rsibreak/package.nix
+++ b/pkgs/by-name/rs/rsibreak/package.nix
@@ -3,15 +3,8 @@
   lib,
   stdenv,
   cmake,
-  extra-cmake-modules,
-  kdoctools,
-  wrapQtAppsHook,
-  knotifyconfig,
-  kidletime,
-  kwindowsystem,
-  kstatusnotifieritem,
-  ktextwidgets,
-  kcrash,
+  kdePackages,
+  qt6,
 }:
 
 stdenv.mkDerivation rec {
@@ -25,17 +18,17 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    extra-cmake-modules
-    kdoctools
-    wrapQtAppsHook
+    kdePackages.extra-cmake-modules
+    kdePackages.kdoctools
+    qt6.wrapQtAppsHook
   ];
   propagatedBuildInputs = [
-    knotifyconfig
-    kidletime
-    kwindowsystem
-    kstatusnotifieritem
-    ktextwidgets
-    kcrash
+    kdePackages.knotifyconfig
+    kdePackages.kidletime
+    kdePackages.kwindowsystem
+    kdePackages.kstatusnotifieritem
+    kdePackages.ktextwidgets
+    kdePackages.kcrash
   ];
 
   meta = {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3154,8 +3154,6 @@ with pkgs;
     lua = lua5_4;
   };
 
-  rsibreak = kdePackages.callPackage ../applications/misc/rsibreak { };
-
   rubocop = rubyPackages.rubocop;
 
   ruby-lsp = rubyPackages.ruby-lsp;


### PR DESCRIPTION
Also drops one of the 7 remaining `kdePackages.callPackage` in pkgs/top-level/all-packages.nix.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
