### PR TITLE
ungoogled-chromium: 148.0.7778.178-1 -> 148.0.7778.215-1

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -828,7 +828,7 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "148.0.7778.178",
+    "version": "148.0.7778.215",
     "deps": {
       "depot_tools": {
         "rev": "41c40cfaec7ee3bf0423c59925d8b23982a601f1",
@@ -840,16 +840,16 @@
         "hash": "sha256-BTPD8WM1pVAMkFDlHekMdWFGyf63KdhKkKwsqikqoBQ="
       },
       "ungoogled-patches": {
-        "rev": "148.0.7778.178-1",
-        "hash": "sha256-s4zTU4rQUcrfpg7CWFdvEn3JYNqhHGsAFcYmQGS64fc="
+        "rev": "148.0.7778.215-1",
+        "hash": "sha256-Rp+PuyOQ26Cqiu+8sNlJkjp/3bO968NYNX1AgHOyYOA="
       },
       "npmHash": "sha256-JuVcY8iFRDWcPcP4Pg+qm5rnTXkiVfNsqSkXbDWqsE8="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "d096af1c9e98c45c3596e59620622b1a049bfecb",
-        "hash": "sha256-XRalekzeALnDh9KiGqhYdhXvkGkjO3TOIZeqwpPLO+U=",
+        "rev": "7c855c70efe3f6ade6663c1520913fa7f63a0b2b",
+        "hash": "sha256-uDVYgSjxQ+xw8DHVd5UNkqnUrJ6P5ZWxL2tZToBhgQg=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -919,8 +919,8 @@
       },
       "src/third_party/angle": {
         "url": "https://chromium.googlesource.com/angle/angle.git",
-        "rev": "50fd896fb21cca91f325812d01d1e971593efc73",
-        "hash": "sha256-HcfKm7UQmg3wMDOytmaYzm7Z7gRdOrRoqAKaE0ZdI4E="
+        "rev": "a101e2d1db6da927325273566fe8f5404fa3a9bd",
+        "hash": "sha256-uIqodvHxEY9xNse2IHNns2Mz9zLAUZSSIN7pAXB8cPs="
       },
       "src/third_party/angle/third_party/glmark2/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glmark2/glmark2",
@@ -959,8 +959,8 @@
       },
       "src/third_party/dawn": {
         "url": "https://dawn.googlesource.com/dawn.git",
-        "rev": "19696dd088b8ed5804e2f02a8f83f5afdb3e99e3",
-        "hash": "sha256-ihnVPCk9412UzCmoABWVUhiGaIdIYxiYMkk43KDqpg8="
+        "rev": "78a9030d63048d832c4b822839bffe38ad4f20e5",
+        "hash": "sha256-ZknkLN64TYAN5j9WsgtKlRBrAc3iCM084zpc8Zui8Ts="
       },
       "src/third_party/dawn/third_party/glfw3/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glfw/glfw",
@@ -1094,8 +1094,8 @@
       },
       "src/third_party/devtools-frontend/src": {
         "url": "https://chromium.googlesource.com/devtools/devtools-frontend",
-        "rev": "6efd6eb1d85fd67fdcc2385c54fa56c524bec3f7",
-        "hash": "sha256-1pr3+RK519m+wtcacJB3PcDTL+qSHlOn1ctxpoLzTf8="
+        "rev": "1fb83ff123c44ab59a480056c8c1ba3d33c2caf0",
+        "hash": "sha256-S6agM7HMZ2g2W6e9tYdLSXr0Lc6zeQF9hAYLIeImAYQ="
       },
       "src/third_party/dom_distiller_js/dist": {
         "url": "https://chromium.googlesource.com/chromium/dom-distiller/dist.git",
@@ -1159,8 +1159,8 @@
       },
       "src/third_party/freetype/src": {
         "url": "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git",
-        "rev": "99b479dc34728936b006679a31e12b8cf432fc55",
-        "hash": "sha256-H5RzBFYWIp/QYKyeBM2wfuX7FvXHPbhCAp7qne5Zvhw="
+        "rev": "6d9fc45fc4bca8aef0b8f65592520673638c3334",
+        "hash": "sha256-A21ONLz8HxoBkOL/jHfs5YwePmOnFyNdlNYSJa9wers="
       },
       "src/third_party/fxdiv/src": {
         "url": "https://chromium.googlesource.com/external/github.com/Maratyszcza/FXdiv.git",
@@ -1169,8 +1169,8 @@
       },
       "src/third_party/harfbuzz/src": {
         "url": "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git",
-        "rev": "f027b8e9039f73bf803eae684fee2eb2d30e4180",
-        "hash": "sha256-HWb3QbPl+RE2oI/Jwv5BjKwv9UnJ8VcJvk+uGy9cAqM="
+        "rev": "67bb413f586f36ba44d740319cb7a28b3d283ea6",
+        "hash": "sha256-WCPEkbiiU8dENM+ik0KokW9Uxmz0xlsRFVVPPOEOZXw="
       },
       "src/third_party/ink/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/ink.git",
@@ -1259,8 +1259,8 @@
       },
       "src/third_party/libaom/source/libaom": {
         "url": "https://aomedia.googlesource.com/aom.git",
-        "rev": "b63f30b6d30028a3d7d9c5223def8f3ad97dcc4c",
-        "hash": "sha256-LaBEcVcSB8WB9ZNRgPSiGaKdQL5f3wll2sPb9OhN5SE="
+        "rev": "343cee0a952f8c7d329e59ff3ac2c8bdbe70ec6a",
+        "hash": "sha256-H8Eu3BiUIiZcyReGDyFq9UvjdMJOX00ERjru8+I0zL8="
       },
       "src/third_party/crabbyavif/src": {
         "url": "https://chromium.googlesource.com/external/github.com/webmproject/CrabbyAvif.git",
@@ -1439,8 +1439,8 @@
       },
       "src/third_party/pdfium": {
         "url": "https://pdfium.googlesource.com/pdfium.git",
-        "rev": "a78c62d93a8f514ea2cd98a70bd1d21226be9d93",
-        "hash": "sha256-qd3Oa/JFzoI5hKDY2/OQAzdr2z9srUj0H6oKz0R516U="
+        "rev": "72ea487e4399c44c3a53a48b104f9612ca772008",
+        "hash": "sha256-0VgmDPyF5k81nBXdo88CcIIbz6XRhaiADnG8gwDGZZk="
       },
       "src/third_party/perfetto": {
         "url": "https://chromium.googlesource.com/external/github.com/google/perfetto.git",
@@ -1489,8 +1489,8 @@
       },
       "src/third_party/skia": {
         "url": "https://skia.googlesource.com/skia.git",
-        "rev": "a2888b27a98e4ff30085d4d2dba8a1a99baf6dfb",
-        "hash": "sha256-eOjFuMmXr9YtZ0e4yDB8JMjTrNWEg5OlTkAMGuHZIWE="
+        "rev": "03c3234e64f9fbbbcf6a7b9c79e94059df49dbfe",
+        "hash": "sha256-e0MSCbqv4u4995nowzipKorkn6mPpO7tf8+ygj3/nFY="
       },
       "src/third_party/smhasher/src": {
         "url": "https://chromium.googlesource.com/external/smhasher.git",
@@ -1624,8 +1624,8 @@
       },
       "src/third_party/webrtc": {
         "url": "https://webrtc.googlesource.com/src.git",
-        "rev": "9a7f650bcd14f241d20f88f4e1ea3b7300de72ac",
-        "hash": "sha256-k5cHE4XURJQrPURmXk4MMNV5k8+ryKfjmsVTzARRro4="
+        "rev": "e3ee86921c57b9f8921045e77f098604803cb66c",
+        "hash": "sha256-n39HENOXmatsZLF6jdYRsb+wl2cM0i6ngT4Zbyu5ayE="
       },
       "src/third_party/wuffs/src": {
         "url": "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git",
@@ -1649,8 +1649,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "ad6e4525c418a92147c8247ef9d144ce4c242a38",
-        "hash": "sha256-+cQdsWTgIohd3yOCsNCprSr4Ctes77fWGdmPxN2tQlM="
+        "rev": "5e24a1fd6ffb840b93ee90a800897fcb4d60eeab",
+        "hash": "sha256-JcBGaXhqNRIA4NPPV4eANVM93wsQ9QxSLO/Ecz3wklU="
       }
     }
   }


### PR DESCRIPTION
Same underlying changes as #525221

https://chromereleases.googleblog.com/2026/05/stable-channel-update-for-desktop_0877304591.html

This update includes 151 security fixes.

CVEs:
CVE-2026-9872 CVE-2026-9873 CVE-2026-9874 CVE-2026-9875 CVE-2026-9876
CVE-2026-9877 CVE-2026-9878 CVE-2026-9879 CVE-2026-9880 CVE-2026-9881
CVE-2026-9882 CVE-2026-9883 CVE-2026-9884 CVE-2026-9885 CVE-2026-9886
CVE-2026-9887 CVE-2026-9888 CVE-2026-9889 CVE-2026-9890 CVE-2026-9891
CVE-2026-9892 CVE-2026-9893 CVE-2026-9894 CVE-2026-9895 CVE-2026-9896
CVE-2026-9897 CVE-2026-9898 CVE-2026-9899 CVE-2026-9900 CVE-2026-9901
CVE-2026-9902 CVE-2026-9903 CVE-2026-9904 CVE-2026-9905 CVE-2026-9906
CVE-2026-9907 CVE-2026-9908 CVE-2026-9909 CVE-2026-9910 CVE-2026-9911
CVE-2026-9912 CVE-2026-9913 CVE-2026-9914 CVE-2026-9915 CVE-2026-9916
CVE-2026-9917 CVE-2026-9918 CVE-2026-9919 CVE-2026-9920 CVE-2026-9921
CVE-2026-9922 CVE-2026-9923 CVE-2026-9924 CVE-2026-9925 CVE-2026-9926
CVE-2026-9927 CVE-2026-9928 CVE-2026-9929 CVE-2026-9930 CVE-2026-9931
CVE-2026-9932 CVE-2026-9933 CVE-2026-9934 CVE-2026-9935 CVE-2026-9936
CVE-2026-9937 CVE-2026-9938 CVE-2026-9939 CVE-2026-9940 CVE-2026-9941
CVE-2026-9942 CVE-2026-9943 CVE-2026-9944 CVE-2026-9945 CVE-2026-9946
CVE-2026-9947 CVE-2026-9948 CVE-2026-9949 CVE-2026-9950 CVE-2026-9951
CVE-2026-9952 CVE-2026-9953 CVE-2026-9954 CVE-2026-9955 CVE-2026-9956
CVE-2026-9957 CVE-2026-9958 CVE-2026-9959 CVE-2026-9960 CVE-2026-9961
CVE-2026-9962 CVE-2026-9963 CVE-2026-9964 CVE-2026-9965 CVE-2026-9966
CVE-2026-9967 CVE-2026-9968 CVE-2026-9969 CVE-2026-9970 CVE-2026-9971
CVE-2026-9972 CVE-2026-9973 CVE-2026-9974 CVE-2026-9975 CVE-2026-9976
CVE-2026-9977 CVE-2026-9978 CVE-2026-9979 CVE-2026-9980 CVE-2026-9981
CVE-2026-9982 CVE-2026-9983 CVE-2026-9984 CVE-2026-9985 CVE-2026-9986
CVE-2026-9987 CVE-2026-9988 CVE-2026-9989 CVE-2026-9990 CVE-2026-9991
CVE-2026-9992 CVE-2026-9993 CVE-2026-9994 CVE-2026-9995 CVE-2026-9996
CVE-2026-9997 CVE-2026-9998 CVE-2026-9999 CVE-2026-10000 CVE-2026-10001
CVE-2026-10002 CVE-2026-10003 CVE-2026-10004 CVE-2026-10005
CVE-2026-10006 CVE-2026-10007 CVE-2026-10008 CVE-2026-10009
CVE-2026-10010 CVE-2026-10011 CVE-2026-10012 CVE-2026-10013
CVE-2026-10014 CVE-2026-10015 CVE-2026-10016 CVE-2026-10017
CVE-2026-10018 CVE-2026-10019 CVE-2026-10020 CVE-2026-10021
CVE-2026-10022

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
