### PR TITLE
fido2-hid-bridge: init at 0.1.0-unstable-2026-06-29

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -22,6 +22,8 @@
 
 - [Stump](https://www.stumpapp.dev/), a free and open source comics, manga and digital book server with OPDS support. Available as [services.stump](#opt-services.stump.enable).
 
+- [fido2-hid-bridge], a driver that allows for PC/SC cards to be used as passkeys. Available as [services.fido2-hid-bridge](#opt-services.fido2-hid-bridge.enable).
+
 - [Freescout](https://freescout.net/), a free, open source Helpdesk and shared mailbox. Available as [services.freescout](#opt-services.freescout.enable).
 
 - [FlapAlerted](https://github.com/Kioubit/FlapAlerted), detects BGP flapping events and provides statistics based on BGP update messages. Available as [services.flap-alerted](#opt-services.flap-alerted.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -670,6 +670,7 @@
   ./services/hardware/dell-bios-fan-control.nix
   ./services/hardware/display.nix
   ./services/hardware/fancontrol.nix
+  ./services/hardware/fido2-hid-bridge.nix
   ./services/hardware/framework-control.nix
   ./services/hardware/freefall.nix
   ./services/hardware/fwupd.nix

--- a/nixos/modules/services/hardware/fido2-hid-bridge.nix
+++ b/nixos/modules/services/hardware/fido2-hid-bridge.nix
@@ -1,0 +1,74 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.fido2-hid-bridge;
+  desc = "PC/SC to FIDO2 over USB HID bridge";
+in
+{
+  options.services.fido2-hid-bridge = {
+    enable = lib.mkEnableOption desc;
+
+    package = lib.mkPackageOption pkgs "fido2-hid-bridge" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    boot.kernelModules = [ "uhid" ];
+
+    services.pcscd.enable = lib.mkDefault true;
+
+    systemd.services.fido2-hid-bridge = {
+      enable = lib.mkDefault true;
+
+      description = desc;
+
+      after = [ "pcscd.socket" ];
+      requires = [ "pcscd.socket" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        ExecStart = lib.getExe cfg.package;
+        Restart = "on-failure";
+        RestartSec = "5s";
+
+        # DynamicUser = true not possible since access control needs to be set up ahead of time
+        User = "fido2-hid-bridge";
+        Group = "fido2-hid-bridge";
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        NoNewPrivileges = true;
+
+        DevicePolicy = "closed";
+        DeviceAllow = [ "/dev/uhid rw" ];
+
+        BindPaths = [ "/run/pcscd/pcscd.comm" ];
+      };
+      unitConfig.ConditionPathExists = "/dev/uhid";
+    };
+
+    services.udev.extraRules = ''
+      KERNEL=="uhid", RUN+="${lib.getExe' pkgs.acl "setfacl"} -m g:fido2-hid-bridge:rw /dev/uhid"
+    '';
+
+    security.polkit.extraConfig = ''
+      polkit.addRule(function(action, subject) {
+        if ((action.id == "org.debian.pcsc-lite.access_pcsc" || action.id == "org.debian.pcsc-lite.access_card") && subject.isInGroup("fido2-hid-bridge")) {
+          return polkit.Result.YES;
+        }
+      });
+    '';
+
+    users.users.fido2-hid-bridge = {
+      description = "fido2-hid-bridge system service user";
+      isSystemUser = true;
+      group = "fido2-hid-bridge";
+    };
+    users.groups.fido2-hid-bridge = { };
+  };
+
+  meta.maintainers = with lib.maintainers; [ pandapip1 ];
+}

--- a/pkgs/by-name/fi/fido2-hid-bridge/package.nix
+++ b/pkgs/by-name/fi/fido2-hid-bridge/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "fido2-hid-bridge";
+  version = "0.1.0-unstable-2026-06-29";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "BryanJacobs";
+    repo = "fido2-hid-bridge";
+    rev = "1f3cad668a37105ea7db484f2f15af88617fa5a7";
+    hash = "sha256-DWxnMhGEfH/hDriFKZB3j4tImPUvKq2npG1ulf/Q2wo=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  build-system = with python3Packages; [ poetry-core ];
+  dependencies =
+    with python3Packages;
+    (
+      [
+        uhid
+        fido2
+        pyscard
+      ]
+      ++ fido2.optional-dependencies.pcsc
+    );
+
+  doCheck = false;
+
+  dontCheckRuntimeDeps = true; # pyinstaller version is out of date
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "HID to PC/SC bridge allowing browsers to use FIDO2 smartcards";
+    homepage = "https://github.com/BryanJacobs/fido2-hid-bridge";
+    license = lib.licenses.mit;
+    mainProgram = "fido2-hid-bridge";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ pandapip1 ];
+  };
+}

--- a/pkgs/development/python-modules/uhid/default.nix
+++ b/pkgs/development/python-modules/uhid/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  nix-update-script,
+}:
+
+buildPythonPackage {
+  pname = "uhid";
+  version = "0-unstable-2021-04-08";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "FFY00";
+    repo = "python-uhid";
+    rev = "99f459aef3934a146d1954ae372b1a107b1f34eb";
+    hash = "sha256-QTTlSYaDciWc9I/MUvR9YJ9z4oxHeN/PLJ3rcJhRd/w=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "uhid" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "Pure Python typed Linux UHID wrapper";
+    homepage = "https://github.com/FFY00/python-uhid";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ pandapip1 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21085,6 +21085,8 @@ self: super: with self; {
 
   uhi = callPackage ../development/python-modules/uhi { };
 
+  uhid = callPackage ../development/python-modules/uhid { };
+
   uhooapi = callPackage ../development/python-modules/uhooapi { };
 
   uiprotect = callPackage ../development/python-modules/uiprotect { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fully E2E tested; works.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
