### PR TITLE
python3Packages.unittestCheckHook: add some structural flag support

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -1539,21 +1539,49 @@ automatically add `pythonRelaxDepsHook` if either `pythonRelaxDeps` or
 
 #### Using unittestCheckHook {#using-unittestcheckhook}
 
-`unittestCheckHook` is a hook which will set up (or configure) a [`checkPhase`](#ssec-check-phase) to run `python -m unittest discover`:
+`unittestCheckHook` is a hook which sets up (or configure) a [`checkPhase`](#ssec-check-phase) to run `python -m unittest discover`.
+
+For better overridability, `unittestCheckHook` supports the following variables:
+
+`unittestStartDir` (String)
+
+: Directory to start test discovery.
+  The value will pass via `--start-directory` if specified, or `unittest` falls back to the current working directory (`.`).
+
+`unittestFilePattern` (String)
+
+: Glob pattern to match test files.
+  The value will pass via `--pattern` if specified, or `unittest` falls back to `test*.py`.
+
+`unittestTopDir` (String)
+
+: Top-level directory of the package to be tested.
+  The value will pass via `--top-level-directory` if specified.
+
+`enabledTests` (`null` or list of strings)
+
+: White-listed test name patterns (sub-strings or globs)
+  Each specified pattern is passed via the `-k` flag.
+  The default value of the Nix attribute is `null`, which opts out the white-listing.
 
 ```nix
 {
   nativeCheckInputs = [ unittestCheckHook ];
 
+  unittestStartDir = "tests";
   unittestFlags = [
-    "-s"
-    "tests"
     "-v"
   ];
 }
 ```
 
-`pytest` is compatible with `unittest`, so in most cases you can use `pytestCheckHook` instead.
+`pytest` is compatible with test cases defined by `unittest`, so in most cases you can use `pytestCheckHook` instead for more fine-grained control over which tests to include/exclude.
+On the other hand, `unittestCheckHook` has a smaller dependency closure as `unittests` is part of the Python Standard Library.
+
+::: {.note}
+There are subtle differences between `unittest` and `pytest`.
+For example, the default filename pattern for `unittest` is `test*.py`, while `pytest` defaults to `test_*.py` or `*_test.py`.
+:::
 
 #### Using sphinxHook {#using-sphinxhook}
 

--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -1564,6 +1564,14 @@ For better overridability, `unittestCheckHook` supports the following variables:
   Each specified pattern is passed via the `-k` flag.
   The default value of the Nix attribute is `null`, which opts out the white-listing.
 
+`disabledTests` (list of strings)
+
+: Black-listed test name patterns.
+  It constructs a `-k` pattern that matches anything but the patterns listed on `disabledTests`.
+  ::: {.note}
+  `disabledTests` will be ignored if `enabledTests` is specified.
+  :::
+
 ```nix
 {
   nativeCheckInputs = [ unittestCheckHook ];

--- a/pkgs/development/interpreters/python/hooks/unittest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/unittest-check-hook.sh
@@ -9,11 +9,11 @@ unittestCheckPhase() {
 
     local -a flagsArray=()
 
-    # Compatibility layer to the obsolete unittestFlagsArray
     if [[ -z "${dontUseUnittestDiscover-}" ]]; then
       flagsArray+=("discover")
     fi
 
+    # Compatibility layer to the obsolete unittestFlagsArray
     eval "flagsArray+=(${unittestFlagsArray[*]-})"
 
     concatTo flagsArray unittestFlags

--- a/pkgs/development/interpreters/python/hooks/unittest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/unittest-check-hook.sh
@@ -25,15 +25,23 @@ unittestCheckPhase() {
         flagsArray+=(--top-level-directory="$unittestTopDir")
     fi
 
-    if [[ -n "${enabledTests[*]-}" ]]; then
-        local -a _patterns=()
-        concatTo _patterns enabledTests
-        local _pattern
-        for _pattern in "${_patterns[@]}"; do
-            flagsArray+=(-k"$_pattern")
-        done
-        unset _pattern _patterns
+    if [[ -n "${enabledTests[*]-}" ]] && [[ -n "${disabledTests[*]-}" ]]; then
+        echo "WARNING: unittestCheckHook: ignoring disabledTests as enabledTests is specified." >&2
+        echo "  disabledTests: $(concatStringsSep ", " disabledTests)" >&2
+        echo "  enabledTests: $(concatStringsSep ", " enabledTests)" >&2
     fi
+
+    local -a _patterns=()
+    if [[ -n "${enabledTests[*]-}" ]]; then
+        concatTo _patterns enabledTests
+    elif [[ -n "${disabledTests[*]-}" ]]; then
+        _patterns=("[!($(concatStringsSep "|" disabledTests))]")
+    fi
+    local _pattern
+    for _pattern in "${_patterns[@]}"; do
+        flagsArray+=(-k"$_pattern")
+    done
+    unset _pattern _patterns
 
     # Compatibility layer to the obsolete unittestFlagsArray
     eval "flagsArray+=(${unittestFlagsArray[*]-})"

--- a/pkgs/development/interpreters/python/hooks/unittest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/unittest-check-hook.sh
@@ -13,6 +13,28 @@ unittestCheckPhase() {
       flagsArray+=("discover")
     fi
 
+    if [[ -n "${unittestStartDir-}" ]]; then
+        flagsArray+=(--start-directory="$unittestStartDir")
+    fi
+
+    if [[ -n "${unittestFilePattern-}" ]]; then
+        flagsArray+=(--pattern="$unittestFilePattern")
+    fi
+
+    if [[ -n "${unittestTopDir-}" ]]; then
+        flagsArray+=(--top-level-directory="$unittestTopDir")
+    fi
+
+    if [[ -n "${enabledTests[*]-}" ]]; then
+        local -a _patterns=()
+        concatTo _patterns enabledTests
+        local _pattern
+        for _pattern in "${_patterns[@]}"; do
+            flagsArray+=(-k"$_pattern")
+        done
+        unset _pattern _patterns
+    fi
+
     # Compatibility layer to the obsolete unittestFlagsArray
     eval "flagsArray+=(${unittestFlagsArray[*]-})"
 

--- a/pkgs/development/python-modules/clize/default.nix
+++ b/pkgs/development/python-modules/clize/default.nix
@@ -43,23 +43,16 @@ buildPythonPackage (finalAttrs: {
     repeated-test
   ];
 
-  unittestFlags =
-    let
-      disabledTests = [
-        "test_help.ElementsFromAutodetectedDocstringTests.test_sphinx_has_sphinx_error_in_param_desc"
-        "test_help.ElementsFromAutodetectedDocstringTests.test_sphinx_has_sphinx_error_in_free_text"
-        "test_help.ElementsFromAutodetectedDocstringTests.test_clize_sphinx_error"
-        "test_help.ElementsFromAutodetectedDocstringTests.test_clize_has_sphinx_error"
-      ]
-      ++ lib.optionals (pythonAtLeast "3.14") [
-        "test_help.ClizeWholeHelpTests.test_custom_param_help"
-      ];
-      matchingPattern = builtins.concatStringsSep "|" disabledTests;
-    in
-    [
-      "-s clize/tests"
-      "-k [!(${matchingPattern})]"
-    ];
+  unittestStartDir = "clize/tests";
+  disabledTests = [
+    "test_help.ElementsFromAutodetectedDocstringTests.test_sphinx_has_sphinx_error_in_param_desc"
+    "test_help.ElementsFromAutodetectedDocstringTests.test_sphinx_has_sphinx_error_in_free_text"
+    "test_help.ElementsFromAutodetectedDocstringTests.test_clize_sphinx_error"
+    "test_help.ElementsFromAutodetectedDocstringTests.test_clize_has_sphinx_error"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    "test_help.ClizeWholeHelpTests.test_custom_param_help"
+  ];
 
   pythonImportsCheck = [ "clize" ];
 

--- a/pkgs/development/python-modules/khanaa/default.nix
+++ b/pkgs/development/python-modules/khanaa/default.nix
@@ -28,10 +28,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ unittestCheckHook ];
 
-  unittestFlagsArray = [
-    "-s"
-    "tests"
-  ];
+  unittestStartDir = "tests";
 
   pythonImportsCheck = [ "khanaa" ];
 

--- a/pkgs/development/python-modules/kneaddata/default.nix
+++ b/pkgs/development/python-modules/kneaddata/default.nix
@@ -22,7 +22,8 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ unittestCheckHook ];
 
-  unittestFlagsArray = [ "kneaddata/tests/ '*.py'" ];
+  unittestStartDir = "kneaddata/tests/";
+  unittestFilePattern = "*.py";
 
   pythonImportsCheck = [ "kneaddata" ];
 

--- a/pkgs/development/python-modules/sigtools/default.nix
+++ b/pkgs/development/python-modules/sigtools/default.nix
@@ -33,10 +33,10 @@ buildPythonPackage (finalAttrs: {
     unittestCheckHook
   ];
 
-  unittestFlags = lib.optionals (pythonAtLeast "3.14") [
-    "-s sigtools/tests"
+  unittestStartDir = "sigtools/tests";
+  disabledTests = lib.optionals (pythonAtLeast "3.14") [
     # python314 only: NameError: name 'o' is not defined
-    "-k [!RoundTripTests.test_locals]"
+    "RoundTripTests.test_locals"
   ];
 
   pythonImportsCheck = [ "sigtools" ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
