### PR TITLE
sherlock: 0.16.0 -> 0.16.0-unstable-2026-05-09

### DIFF
--- a/pkgs/by-name/sh/sherlock/package.nix
+++ b/pkgs/by-name/sh/sherlock/package.nix
@@ -7,14 +7,14 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "sherlock";
-  version = "0.16.0";
+  version = "0.16.0-unstable-2026-05-09";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "sherlock-project";
     repo = "sherlock";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-MP/INeD/dkS0lwACa9g3JqROuOinfr3LKmxjHnVUOdk=";
+    rev = "206068dc7842665130c87e16e1535572d3d1a907";
+    hash = "sha256-QM0vHvZ1w9FtM0bGPGvMhhobPKOGQNPacVWB0caoPTw=";
   };
 
   patches = [
@@ -24,20 +24,28 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   postPatch = ''
     substituteInPlace tests/sherlock_interactives.py \
-      --replace @sherlockBin@ "$out/bin/sherlock"
+      --replace-fail @sherlockBin@ "$out/bin/sherlock"
+    substituteInPlace sherlock_project/__init__.py \
+      --replace-fail "__version__     = get_version()" "__version__ = \"${finalAttrs.version}\""
   '';
 
   nativeBuildInputs = [ makeWrapper ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  dependencies = with python3.pkgs; [
     certifi
     colorama
+    openpyxl
     pandas
     pysocks
     requests
     requests-futures
     stem
     torrequest
+    tomli
+  ];
+
+  build-system = with python3.pkgs; [
+    poetry-core
   ];
 
   installPhase = ''
@@ -59,15 +67,11 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   nativeCheckInputs = with python3.pkgs; [
     rstr
     pytestCheckHook
-    poetry-core
     jsonschema
-    openpyxl
-    stem
   ];
 
-  pythonRelaxDeps = [ "stem" ];
-
   disabledTestMarks = [
+    # tests require internet access
     "online"
   ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Closes #525288

This PR updates sherlock to current HEAD which contains a commit https://github.com/sherlock-project/sherlock/commit/6eaec5cccd59d6c17f9ed7802b002ffb990131f5 which resolved upstream security issue.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
