### PR TITLE
aws-workspaces: 2025.0.5296 -> 2025.1.5524-1

### DIFF
--- a/pkgs/by-name/aw/aws-workspaces/package.nix
+++ b/pkgs/by-name/aw/aws-workspaces/package.nix
@@ -5,7 +5,11 @@
   buildFHSEnv,
   webkitgtk_4_1,
   ffmpeg_7,
-  gtk3,
+  gtk4,
+  libepoxy,
+  wayland,
+  libxcb,
+  libxi,
   pango,
   atk,
   cairo,
@@ -48,7 +52,10 @@ buildFHSEnv {
     workspacesclient
     custom_lsb_release
     webkitgtk_4_1
-    gtk3
+    gtk4
+    libepoxy
+    libxcb
+    libxi
     ffmpeg_7
     pango
     atk
@@ -56,6 +63,7 @@ buildFHSEnv {
     gdk-pixbuf
     protobufc
     cyrus_sasl
+    wayland
   ];
 
   extraBwrapArgs = [

--- a/pkgs/by-name/aw/aws-workspaces/workspacesclient.nix
+++ b/pkgs/by-name/aw/aws-workspaces/workspacesclient.nix
@@ -5,25 +5,28 @@
   dpkg,
   makeBinaryWrapper,
   glib-networking,
+  wrapGAppsHook4,
+  glib,
 }:
 
 let
-  dcv-path = "lib/x86_64-linux-gnu/workspacesclient/dcv";
+  dcv-path = "lib/x86_64-linux-gnu/workspacesclient";
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "workspacesclient";
-  version = "2025.0.5296";
+  version = "2025.1.5526-1";
 
   src = fetchurl {
     urls = [
-      "https://d3nt0h4h6pmmc4.cloudfront.net/ubuntu/dists/jammy/main/binary-amd64/workspacesclient_${finalAttrs.version}_amd64.deb"
+      "https://d3nt0h4h6pmmc4.cloudfront.net/ubuntu/dists/noble/main/binary-amd64/workspacesclient_${finalAttrs.version}_amd64.ubuntu2404.deb"
     ];
-    hash = "sha256-VPNZN9AsrGJ56O8B5jxlgLMvrUViTv6yto8c5pGQc0A=";
+    hash = "sha256-iGYKpbpzGNeEUKgozhSwVd9dWRgQEbozIAWRu7wu2D8=";
   };
 
   nativeBuildInputs = [
     dpkg
     makeBinaryWrapper
+    wrapGAppsHook4
   ];
 
   installPhase = ''
@@ -38,6 +41,12 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  preFixup = ''
+    schemadir=${glib.makeSchemaPath "$out" "$name"}
+    mv $out/share/workspacesclient/schemas/* $schemadir
+    glib-compile-schemas $schemadir
+  '';
+
   postFixup = ''
     # provide network support
     wrapProgram "$out/bin/workspacesclient" \
@@ -45,8 +54,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     # dcvclient does not setup the environment correctly.
     # Instead wrap the binary directly the correct environment paths
-    mv $out/${dcv-path}/dcvclientbin $out/${dcv-path}/dcvclient
-    wrapProgram $out/${dcv-path}/dcvclient \
+    mv $out/${dcv-path}/dcvviewer $out/${dcv-path}/workspacesclientdcv
+    wrapProgram $out/${dcv-path}/workspacesclientdcv \
       --suffix LD_LIBRARY_PATH : $out/${dcv-path} \
       --suffix GIO_EXTRA_MODULES : ${dcv-path}/gio/modules \
       --set DCV_SASL_PLUGIN_DIR $out/${dcv-path}/sasl2 \


### PR DESCRIPTION
Status: Working ! (Thanks Rohan!!!)

- The previous version does not exist any longer upstream
  - Switch to the new version
- This new version's installation steps must be updated to match the new binary names (e.g., `dcv` does not exist as such any longer)
  - Fixed in this PR
- I can provide a `strace` log if needed, but there's so much log that I don't really know how to fix it yet 
  - Ronan fixed it correctly within this PR as well.
- Should we use the Jammy or Noble version ?
  - We use the very latest `Noble` version

There's a comment on Archlinux from someone that succeeded to get it working (the Noble version): https://aur.archlinux.org/packages/amazon-workspaces-bin#comment-1071974

@RohanHart I might need your help on this one

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
