### PR TITLE
nixos/qui: serve config from the Nix store

### DIFF
--- a/nixos/modules/services/torrent/qui.nix
+++ b/nixos/modules/services/torrent/qui.nix
@@ -16,6 +16,7 @@ let
     ;
   inherit (lib.types)
     bool
+    externalPath
     path
     port
     str
@@ -72,6 +73,18 @@ in
         type = submodule {
           freeformType = configFormat.type;
           options = {
+            dataDir = mkOption {
+              type = externalPath;
+              default = stateDir;
+              description = ''
+                Directory where qui stores its SQLite database `qui.db` and other runtime data.
+
+                Must be an absolute path outside the Nix store, writable by the qui service user.
+                At the default location, the service provisions and owns this directory via systemd's `StateDirectory=`.
+                If set to a different location, the directory must already exist and be writable by `services.qui.user`.
+              '';
+            };
+
             host = mkOption {
               type = str;
               default = "127.0.0.1";
@@ -123,12 +136,9 @@ in
 
         LoadCredential = "sessionSecret:${cfg.secretFile}";
         Environment = [ "QUI__SESSION_SECRET_FILE=%d/sessionSecret" ];
-        StateDirectory = "qui";
+        StateDirectory = mkIf (cfg.settings.dataDir == stateDir) "%N";
 
-        ExecStartPre = ''
-          ${pkgs.coreutils}/bin/install -m 600 '${configFile}' '%S/qui/config.toml'
-        '';
-        ExecStart = "${getExe cfg.package} serve --config-dir %S/qui";
+        ExecStart = "${getExe cfg.package} serve --config-dir ${configFile}";
         Restart = "on-failure";
 
         # Based on qbittorrent and nemorosa hardening settings

--- a/nixos/tests/qui.nix
+++ b/nixos/tests/qui.nix
@@ -17,12 +17,29 @@
         secretFile = testSecretFile;
       };
 
-      # Use port other than default to test if settings options work.
-      specialisation.settingsPort.configuration = {
-        services.qui = {
-          enable = true;
-          secretFile = testSecretFile;
-          settings.port = 7777;
+      specialisation = {
+        # Use port other than default to test if settings options work.
+        settingsPort.configuration = {
+          services.qui = {
+            enable = true;
+            secretFile = testSecretFile;
+            settings.port = 7777;
+          };
+        };
+
+        # Use dataDir other than default to test if the wiring is correct
+        relocatedDataDir.configuration = {
+          services.qui = {
+            enable = true;
+            secretFile = testSecretFile;
+            settings.dataDir = "/var/lib/qui-data";
+          };
+
+          systemd.tmpfiles.settings."10-qui"."/var/lib/qui-data".d = {
+            user = "qui";
+            group = "qui";
+            mode = "0750";
+          };
         };
       };
     };
@@ -31,6 +48,7 @@
     { nodes, ... }:
     let
       settingsPort = "${nodes.machine.system.build.toplevel}/specialisation/settingsPort";
+      relocatedDataDir = "${nodes.machine.system.build.toplevel}/specialisation/relocatedDataDir";
     in
     # python
     ''
@@ -40,8 +58,15 @@
         machine.wait_until_succeeds(f"curl --fail http://localhost:{port}")
 
       test_webui(7476)
+      machine.succeed("test -f /var/lib/qui/qui.db")
+      machine.succeed('systemctl show qui.service --property=StateDirectory --value | grep -qx qui')
 
       machine.succeed("${settingsPort}/bin/switch-to-configuration test")
       test_webui(7777)
+
+      machine.succeed("${relocatedDataDir}/bin/switch-to-configuration test")
+      test_webui(7476)
+      machine.succeed("test -f /var/lib/qui-data/qui.db")
+      machine.succeed('test -z "$(systemctl show qui.service --property=StateDirectory --value)"')
     '';
 }


### PR DESCRIPTION
This serves qui's generated config directly from the Nix store instead of copying it into the state directory on every start.

- `ExecStartPre`'s `install` step is completely dropped, removing an unnecessary dep and write on every service start.
- `ExecStart` now passes `--config-dir ${configFile}` directly. qui only reads its config, so serving it read-only from the Nix store is safe.
- With this change, an unset `dataDir` defaults to the config directory. This is a conflict since the `dataDir` needs to be writable. To ameliorate this, `dataDir` now defaults to `/var/lib/qui` with type `externalPath` so that it can never be empty or resolve into the store.
- `StateDirectory` is only created when `dataDir` is left default. Otherwise it's in the user's hands to configure the location they want.

Behavior is unchanged for default configurations. Existing installs keep a now-unused `/var/lib/qui/config.toml` which can be deleted.

The test gain a `relocatedDataDir` specialisation, asserting that the `dataDir` option works correctly and that the `StateDirectory` is created/dropped appropriately.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
