### PR TITLE
grcov: 0.9.1 -> 0.10.7

### DIFF
--- a/pkgs/by-name/gr/grcov/package.nix
+++ b/pkgs/by-name/gr/grcov/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "grcov";
-  version = "0.9.1";
+  version = "0.10.7";
 
   src = fetchFromGitHub {
     owner = "mozilla";
     repo = "grcov";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-e3RQn6wKvVm40UK8ZlgIi2gRS9eEFBnEXdmXtCgv0Go=";
+    hash = "sha256-64c8byxQDEE9eRS+YAd9BaGSjGm+cl2XTAy3l3Utrws=";
   };
 
-  cargoHash = "sha256-v4laGVbWmK8WFJXX5ChtViyKyMtmwpehSgNG6F31Mn0=";
+  cargoHash = "sha256-JTIYfAatMg9L597pRLywgCQmQO9sbuq/En0wNUx8QUo=";
 
   # tests do not find grcov path correctly
   checkFlags =
@@ -29,6 +29,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
         "test_integration_guess_single_file"
         "test_integration_zip_dir"
         "test_integration_zip_zip"
+        "test_llvm_aggregate_profraws"
+        "test_profdatas_to_lcov"
+        "test_profraws_to_lcov"
+        "test_wrong_binary_file"
       ];
     in
     builtins.map (x: "--skip=" + x) skipList;


### PR DESCRIPTION
update to 0.10.7

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
