### PR TITLE
dutctl: init at 0-unstable-2026-05-21

### DIFF
--- a/pkgs/by-name/du/dutctl/package.nix
+++ b/pkgs/by-name/du/dutctl/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+
+  # tests
+  callPackage,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "dutctl";
+  version = "0-unstable-2026-05-21";
+
+  src = fetchFromGitHub {
+    owner = "BlindspotSoftware";
+    repo = "dutctl";
+    rev = "710bbcd16264e62af932698a229f9be2f83f6286";
+    hash = "sha256-SJfnUUo5vmmwa8qFLY4KaVyjyVnlEcVqLU1Yo3PjWug=";
+  };
+
+  vendorHash = "sha256-vOBz9gi/cnUJ04ns1ZOgfNqzbVBE3Fd3oOfV04VSmFQ=";
+
+  ldflags = [
+    "-s"
+  ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [ "--version=branch" ];
+    };
+
+    tests = callPackage ./test.nix {
+      dutctl = finalAttrs.finalPackage;
+    };
+  };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Unified device management for open firmware development";
+    longDescription = ''
+      dutctl stands for "Device-under-Test Control" and is an open-source
+      command-line utility and service ecosystem for managing development and
+      test devices in firmware environments.
+
+      By providing a unified interface to interact with boards and test
+      fixtures across platforms, dutctl eliminates the fragmentation of device
+      management tools that has long plagued firmware workflows.
+
+      The project features remote device control, command streaming,
+      multi-architecture testing, and a flexible plugin architecture for
+      extensibility.
+    '';
+    homepage = "https://github.com/BlindspotSoftware/dutctl";
+    changelog = "https://github.com/BlindspotSoftware/dutctl/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    mainProgram = "dutctl";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/by-name/du/dutctl/test.nix
+++ b/pkgs/by-name/du/dutctl/test.nix
@@ -1,0 +1,78 @@
+{
+  runCommand,
+  writeScriptBin,
+  expect,
+
+  dutctl,
+}:
+let
+  dutctl-test =
+    runCommand "test-dutctl-basic"
+      {
+        nativeBuildInputs = [
+          dutctl
+          interactive-repeat-test
+        ];
+      }
+      ''
+        cfg="${dutctl.src}/contrib/dutagent-cfg-example.yaml"
+
+        # start agent
+        dutagent -a localhost:1024 -c "$cfg" &
+        agent_pid=$!
+        trap 'kill "$agent_pid" 2>/dev/null || true' EXIT
+
+        # wait for agent to become ready
+        for i in $(seq 1 10); do
+          dutctl list 2>/dev/null | grep -q device1 && break
+          [ "$i" -eq 10 ] && { echo "FAIL: agent timed out"; exit 1; }
+          sleep 1
+        done
+        echo "PASS: agent ready"
+
+        # verify device status
+        dutctl device1 status > status.out
+        grep -q "Hello from dummy status module" status.out
+        echo "PASS: device1 status"
+
+        # run interactive repeat test
+        repeat-test
+
+        touch $out
+      '';
+
+  interactive-repeat-test = writeScriptBin "repeat-test" ''
+    #!${expect}/bin/expect -f
+
+    spawn dutctl device2 repeat
+
+    expect {
+      "Hello from dummy repeat module!" {}
+      timeout { puts "FAIL: no greeting"; exit 1 }
+    }
+
+    send "hello\r"
+    expect {
+      "hello" {}
+      timeout { puts "FAIL: no echo"; exit 1 }
+    }
+
+    send "stop now\r"
+    expect {
+      "Oh no! Can only handle one word per line." {}
+      timeout { puts "FAIL: no termination msg"; exit 1 }
+    }
+
+    # wait for the process to finish and collect its exit code
+    expect eof
+    lassign [wait] pid spawnid os_error exit_code
+
+    if {$exit_code != 0} {
+      puts "FAIL: exit $exit_code"
+      exit 1
+    }
+
+    puts "PASS: interactive repeat"
+  '';
+in
+dutctl-test


### PR DESCRIPTION
[DUT-Control](https://github.com/BlindspotSoftware/dutctl) is a command-line utility and service ecosystem for managing development and test devices in firmware environments.

- closes: https://github.com/ngi-nix/projects/issues/1000
- tracking: https://github.com/ngi-nix/projects/issues/331

Assisted-By: nix-init
Assisted-By: Claude Sonnet 4.6 and MiniMax M2.5 (passthru tests)

> [!NOTE]
> Work done as part of the [Nix@NGI](https://nixos.org/community/teams/ngi) packaging effort 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
