### PR TITLE
incus-lts: backport 7.1 security fixes

### DIFF
--- a/pkgs/by-name/in/incus/lts.nix
+++ b/pkgs/by-name/in/incus/lts.nix
@@ -79,6 +79,26 @@ import ./generic.nix {
       url = "https://github.com/lxc/incus/commit/5b29ecc164ef28239d2e2a874a7c871a2e419083.patch?full_index=1";
       hash = "sha256-jpyJYjiZvRw/aOGsykEx8uotRBF7p1q5O08PVhyQtvk=";
     })
+    (fetchpatch2 {
+      name = "incusd-storage_Fix-unsafe-access-to-backup-data.patch";
+      url = "https://github.com/lxc/incus/commit/d71c5053a4c8318e6eb07337a7a4a07a6608ef73.patch?full_index=1";
+      hash = "sha256-/mH0/KmX9sG8HZTcdk8MT+QZtNqZa934wcHptvdVtXM=";
+    })
+    (fetchpatch2 {
+      name = "incusd-storage_Guard-nil-ExpiresAt-in-CreateCustomVolumeFromBackup.patch";
+      url = "https://github.com/lxc/incus/commit/ab6b7dff0c770044875d9d26a6254a7075b4d00b.patch?full_index=1";
+      hash = "sha256-d7VUetQzUTBq3GLYM1JKy2KDbBxOW5Lg7Di1/JPNzSE=";
+    })
+    (fetchpatch2 {
+      name = "incusd-storage_Guard-nil-fields-in-createDependentVolumesFromBackup.patch";
+      url = "https://github.com/lxc/incus/commit/98e64f0a6fcfdc9676eea0246418d490c53297bf.patch?full_index=1";
+      hash = "sha256-+lB7eHsGZ/dW7aL4/wIWD4AF6t7s4QYfAld1bQOw2tQ=";
+    })
+    (fetchpatch2 {
+      name = "incusd-storage-s3_Confine-multipart-uploads-with-os.Root.patch";
+      url = "https://github.com/lxc/incus/commit/a6012422b45c86f3b1956788cff5d75c604ad838.patch?full_index=1";
+      hash = "sha256-u3NLKE8Rh8i6HMbJ0KNhH7gbuwIpJ1SPqiyVoiuw9Sc=";
+    })
   ];
   nixUpdateExtraArgs = [
     "--version-regex=^v(7\\.0\\.[0-9]+)$"


### PR DESCRIPTION
Backport of the security patches from version 7.1 to our LTS package.

This isn't something that has happened upstream yet.

Hoewer, it's the same thing Debian did: https://salsa.debian.org/go-team/packages/incus/-/commit/acc2df6adf97018df26999195d4067222fdaa498 (which seems to have happened in cooperation with the incus project)

Advisories:
- https://github.com/lxc/incus/security/advisories/GHSA-8g7m-96c8-8wwc (Low)
- https://github.com/lxc/incus/security/advisories/GHSA-xhqx-mgh3-3h7q (Low)
- https://github.com/lxc/incus/security/advisories/GHSA-4xg6-52mh-fpw8 (Low)
- https://github.com/lxc/incus/security/advisories/GHSA-ccjc-4qc3-jxqc (Critical)

The 25.11 backport should instead happen to the incus package. I don't think we should bump that one beyond 7.0.x.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
