### PR TITLE
python3Packages.python-fontconfig: fix build issue with dejavu

### DIFF
--- a/pkgs/development/python-modules/python-fontconfig/default.nix
+++ b/pkgs/development/python-modules/python-fontconfig/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  runCommand,
 
   # build-system
   cython,
@@ -9,7 +10,6 @@
 
   # dependencies
   fontconfig,
-  freefont_ttf,
   makeFontsConf,
 
   # testing
@@ -18,7 +18,11 @@
 }:
 
 let
-  fontsConf = makeFontsConf { fontDirectories = [ freefont_ttf ]; };
+  dejavuSerifRegular = runCommand "dejavu-serif-regular" { } ''
+    mkdir -p $out/share/fonts/truetype
+    cp ${dejavu_fonts}/share/fonts/truetype/DejaVuSerif.ttf $out/share/fonts/truetype/
+  '';
+  fontsConf = makeFontsConf { fontDirectories = [ dejavuSerifRegular ]; };
 in
 buildPythonPackage rec {
   pname = "python-fontconfig";
@@ -42,8 +46,6 @@ buildPythonPackage rec {
   preBuild = ''
     ${python.pythonOnBuildForHost.interpreter} setup.py build_ext -i
   '';
-
-  nativeCheckInputs = [ dejavu_fonts ];
 
   preCheck = ''
     export FONTCONFIG_FILE=${fontsConf};


### PR DESCRIPTION
Fix for: https://github.com/NixOS/nixpkgs/issues/525135

One of the tests expects dejavu normal font but was getting the bold version, thus failing.   The tests expect fonts[0] to be the regular-weight DejaVu Serif, but when all variants are available DejaVuSerif-Bold.ttf sorts before DejaVuSerif.ttf, returning the bold variant first. Expose only the regular file so the query is unambiguous.

since python3Packages.python-fontconfig is without maintainers, maybe previous contributors could have a look at the fix? @ethancedwards8 
or fontconfig maintainer? @jtojnar 

Assisted by: copilot

- Built on platform:
  - [ x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ x] Follows the [automation/AI policy].