### PR TITLE
rsync: remove failing darwin test

### DIFF
--- a/pkgs/by-name/rs/rsync/package.nix
+++ b/pkgs/by-name/rs/rsync/package.nix
@@ -83,9 +83,15 @@ stdenv.mkDerivation (finalAttrs: {
     python3
   ];
 
-  # Test fails when built in a chroot store
   preCheck = ''
+    # Test fails when built in a chroot store
     rm testsuite/chgrp.test
+  ''
+  + lib.optionalString (stdenv.hostPlatform.isDarwin) ''
+    # Fails with: [tester] exceeded --max-alloc=0 setting (file=syscall.c, line=1857)
+    rm testsuite/chmod-symlink-race.test
+    # Fails with: ERROR: dir/file failed verification -- update discarded.
+    rm testsuite/symlink-dirlink-basis.test
   '';
 
   doCheck = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Building rsync currently on staging errors with the following two failed tests:
```
----- chmod-symlink-race log follows
Testing for symlinks using 'test -h'
[tester] exceeded --max-alloc=0 setting (file=syscall.c, line=1857)
exit(22): util2.c(80)
t_chmod_secure reported failures (see stderr above)
----- chmod-symlink-race log ends
<snip>
----- symlink-dirlink-basis log follows
Testing for symlinks using 'test -h'
dir/file

sent 32,871 bytes  received 31 bytes  65,804.00 bytes/sec
total size is 32,768  speedup is 1.00
dir/file
WARNING: dir/file failed verification -- update discarded (will try again).
dir/file
ERROR: dir/file failed verification -- update discarded.

sent 1,687 bytes  received 1,278 bytes  5,930.00 bytes/sec
total size is 32,784  speedup is 11.06
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1347) [sender=3.4.3]
test 1: update through directory symlink failed
```
Homebrew has released the latest version, so this seems to be a nixpkgs specific issue. I haven't had proper time to diagnose it, nor does the standard failed builds reports really seem to cover staging, so I just made a quick patch to skip the test on darwin and thus fix the build. Might actually be a deeper problem, I'm not sure. Both new tests were added in 3.4.3 after the recent CVEs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
