### PR TITLE
rocqPackages.micromega-plugin: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/development/rocq-modules/micromega-plugin/default.nix
+++ b/pkgs/development/rocq-modules/micromega-plugin/default.nix
@@ -15,11 +15,11 @@ mkRocqDerivation {
     in
     with lib.versions;
     lib.switch rocq-core.rocq-version [
-      (case (range "9.0" "9.2") "1.0.0")
+      (case (range "9.0" "9.2") "1.1.0")
     ] null;
 
   release = {
-    "1.0.0".sha256 = "sha256-srDOrGC4h21O9MIHfmOMJ0BKQhamaWyzQT72TwgfDYc=";
+    "1.1.0".sha256 = "sha256-OszFXGLnm0rGAZVRCq/riQUK1DuhPyfv49GBePkQWAI=";
   };
   releaseRev = v: "v${v}";
 
@@ -39,11 +39,11 @@ mkRocqDerivation {
   '';
 
   buildPhase = ''
-    etc/with-rocq-wrap.sh dune build -p micromega-plugin @install ''${enableParallelBuilding:+-j $NIX_BUILD_CORES}
+    etc/with-rocq-wrap.sh dune build -p rocq-micromega-plugin @install ''${enableParallelBuilding:+-j $NIX_BUILD_CORES}
   '';
 
   installPhase = ''
-    etc/with-rocq-wrap.sh dune install --root . micromega-plugin --prefix=$out --libdir $OCAMLFIND_DESTDIR
+    etc/with-rocq-wrap.sh dune install --root . rocq-micromega-plugin --prefix=$out --libdir $OCAMLFIND_DESTDIR
     mkdir $out/lib/coq/
     mv $OCAMLFIND_DESTDIR/coq $out/lib/coq/${rocq-core.rocq-version}
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
