### PR TITLE
idplug-classic: init at 4.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27239,6 +27239,12 @@
     githubId = 280235;
     name = "Terje Larsen";
   };
+  termozour = {
+    email = "stefanpruneanu@gmail.com";
+    github = "TermoZour";
+    githubId = 16005294;
+    name = "Stefan Pruneanu";
+  };
   terrorjack = {
     email = "astrohavoc@gmail.com";
     github = "TerrorJack";

--- a/pkgs/by-name/id/idplug-classic/cei-nssdb.in
+++ b/pkgs/by-name/id/idplug-classic/cei-nssdb.in
@@ -1,0 +1,98 @@
+#!@shell@
+
+rootdb="/etc/pki/nssdb"
+userdb="$HOME/.pki/nssdb"
+dbentry="Romanian CEI"
+libfile="@libfile@"
+certurl="https://hub.mai.gov.ro/cei/info/descarca-cert"
+root_ca_name="MAI Root CA"
+sub_ca_name="MAI Sub CA"
+
+dbdir="$userdb"
+
+while true; do
+	case "$1" in
+	--help|"")	cat <<EOF
+(Un)register $dbentry with NSS-compatible browsers.
+
+Usage: $(basename "$0") [OPTION] ACTION [LIBRARY]
+
+Options:
+  --db PATH   use custom NSS database directory PATH
+  --user      use user NSS database $userdb (default)
+  --system    use system NSS database $rootdb
+  --help      show this message
+
+Actions:
+  add           add $dbentry PKCS#11 module to NSS database
+  remove        remove $dbentry PKCS#11 module from NSS database
+  show          show $dbentry NSS database entry
+  add-certs     download and trust MAI CA certificates in NSS database
+  remove-certs  remove MAI CA certificates from NSS database
+
+Default library if unspecified: $libfile
+EOF
+		exit ;;
+	--db)		dbdir="$2"
+			shift 2 ;;
+	--user)		dbdir="$userdb"
+			shift ;;
+	--system)	dbdir="$rootdb"
+			shift ;;
+	-*)		echo "$0: unknown option: '$1'" >&2
+			echo "Try --help for usage information."
+			exit 1 ;;
+	*)		break ;;
+	esac
+done
+
+if [ "${2+set}" = set ]; then
+	libfile="$2"
+	if ! [ -f "$libfile" ]; then
+		echo "$0: error: '$libfile' not found" >&2
+		exit 1
+	fi
+fi
+
+mkdir -p "$dbdir"
+if ! [ -d "$dbdir" ]; then
+	echo "$0: error: '$dbdir' must be a writable directory" >&2
+	exit 1
+fi
+
+if ! [ -f "$dbdir/cert9.db" ]; then
+	echo "Initializing NSS database at $dbdir"
+	@certutil@ -d "sql:$dbdir" -N --empty-password
+fi
+
+dbdir="sql:$dbdir"
+
+echo "NSS database: $dbdir"
+case "$1" in
+add)		echo "Adding $dbentry PKCS#11 module:"
+		@modutil@ -dbdir "$dbdir" -add "$dbentry" -libfile "$libfile" -force ||
+			echo "Tip: try removing the module before adding it again."
+		@modutil@ -dbdir "$dbdir" -list "$dbentry" 2>/dev/null ;;
+remove)		echo "Removing $dbentry PKCS#11 module:"
+		@modutil@ -dbdir "$dbdir" -delete "$dbentry" -force ;;
+show)		echo "Displaying $dbentry database entry, if any:"
+		@modutil@ -dbdir "$dbdir" -list "$dbentry" 2>/dev/null ;;
+add-certs)	tmpdir=$(mktemp -d)
+		trap 'rm -rf "$tmpdir"' EXIT
+		echo "Downloading MAI CA certificates from $certurl"
+		@curl@ -fsSL "$certurl" -o "$tmpdir/certs.zip"
+		@unzip@ -q "$tmpdir/certs.zip" -d "$tmpdir"
+		echo "Importing $root_ca_name:"
+		@certutil@ -d "$dbdir" -A -n "$root_ca_name" -t "CT,C,C" -i "$tmpdir/ro_cei_mai_root-ca.cer"
+		echo "Importing $sub_ca_name:"
+		@certutil@ -d "$dbdir" -A -n "$sub_ca_name" -t "CT,C,C" -i "$tmpdir/ro_cei_mai_sub-ca.cer" ;;
+remove-certs)	echo "Removing MAI CA certificates:"
+		@certutil@ -d "$dbdir" -D -n "$root_ca_name" 2>/dev/null || true
+		@certutil@ -d "$dbdir" -D -n "$sub_ca_name" 2>/dev/null || true ;;
+"")		exec "$0" --help ;;
+*)		echo "$0: unknown action: '$1'" >&2
+		echo "Try --help for usage information."
+		exit 1 ;;
+esac
+
+exit $?

--- a/pkgs/by-name/id/idplug-classic/package.nix
+++ b/pkgs/by-name/id/idplug-classic/package.nix
@@ -1,0 +1,103 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+  autoPatchelfHook,
+  pcsclite,
+  openssl,
+  glib,
+  nssTools,
+  curl,
+  unzip,
+  pango,
+  libpng,
+  fontconfig,
+  gtk3,
+  gdk-pixbuf,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "idplug-classic";
+  version = "4.5.0";
+
+  src = fetchurl {
+    url = "https://hub.mai.gov.ro/cei/info/descarca-middleware?versiune=450linux";
+    hash = "sha256-TQhEANzYBTX8v14rMZTplgOeyWGZJBVzsdY697/rBIQ=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    pcsclite
+    openssl
+    glib
+    stdenv.cc.cc.lib
+    pango
+    libpng
+    fontconfig
+    gtk3
+    gdk-pixbuf
+  ];
+
+  dontBuild = true;
+
+  unpackPhase = ''
+    runHook preUnpack
+    dpkg-deb -x "$src" .
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 usr/lib/idplugclassic/libidplug-pkcs11.so $out/lib/idplugclassic/libidplug-pkcs11.so
+    install -Dm755 usr/lib/idplugclassic/libidplug-civapi.so $out/lib/idplugclassic/libidplug-civapi.so
+    install -Dm755 usr/lib/idplugclassic/libidplug-pivapi.so $out/lib/idplugclassic/libidplug-pivapi.so
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    install -Dm755 ${./cei-nssdb.in} $out/bin/cei-nssdb
+    substituteInPlace $out/bin/cei-nssdb \
+      --replace-fail "@shell@"   "${stdenv.shell}" \
+      --replace-fail "@libfile@" "$out/lib/idplugclassic/libidplug-pkcs11.so" \
+      --replace-fail "@modutil@" "${lib.getExe' nssTools "modutil"}" \
+      --replace-fail "@certutil@" "${lib.getExe' nssTools "certutil"}" \
+      --replace-fail "@curl@"    "${lib.getExe curl}" \
+      --replace-fail "@unzip@"   "${lib.getExe unzip}"
+  '';
+
+  meta = {
+    description = "Romanian eID PKCS#11 middleware for DGEP ID-A cards (CEI)";
+    longDescription = ''
+      Provides the PKCS#11 library for Romanian electronic ID cards (CEI, issued by DGEP/MAI).
+      Also requires a running pcscd service and compatible card reader.
+
+      To register the PKCS#11 module and trust the MAI CA certificates in NSS-compatible
+      browsers (Firefox, Chromium, Okular, etc.), run as a regular user:
+        $ cei-nssdb add
+        $ cei-nssdb add-certs
+
+      To register system-wide for all users (run as root):
+        # cei-nssdb --system add
+        # cei-nssdb --system add-certs
+
+      Before uninstalling, remove the registrations:
+        $ cei-nssdb remove
+        $ cei-nssdb remove-certs
+    '';
+    homepage = "https://hub.mai.gov.ro/aplicatie-cei";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.unfree;
+    maintainers = [ lib.maintainers.termozour ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
The goal of this package is to provide the pkcs#11 .so used by IDPLUGMANAGER app from MAI in order to sign documents using the Romanian EID card.

Homepage: https://hub.mai.gov.ro/aplicatie-cei

The .so used for NSS is extracted from the official .deb provided by MAI.

The package also provides a script based on [eid-mw](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/ei/eid-mw/eid-nssdb.in) package which will install the .so and certificate files to their correct places so they can be used by other programs.

I could not find a license in the .deb file provided by MAI nor a restriction of redistributing the package from the MAI portal. When building, everything is fetched directly from the MAI portal so I am not sure if this counts as redistributing the package or not.

I tried to package the entire program but I couldn't get it to communicate with the EID. I will test on an Ubuntu VM and see if maybe the GUI has a bug in it or not.

I did not know how the entire OpenSC and NSS system works or how Okular renders PDFs. The entire project started from a "_How can I sign a pdf using Okular on KDE using my Romanian EID card?_" kind of prompt. Code was mostly taken from eid-mw but adapted for my usecase. 

Assisted-by: Claude Sonnet 4.6

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
