### PR TITLE
nixos/nvidia: simplify udev rules, cleanup, refactor

### DIFF
--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -774,20 +774,26 @@ in
               "L+ /run/nvidia-docker/extras/bin/nvidia-persistenced - - - - ${cfg.package.persistenced}/origBin/nvidia-persistenced";
 
           hardware.nvidia.moduleParams = lib.mkMerge (
-            lib.optional (offloadCfg.enable || cfg.modesetting.enable) { nvidia-drm.modeset = 1; }
-            ++ lib.optional (
-              (offloadCfg.enable || cfg.modesetting.enable) && lib.versionAtLeast cfg.package.version "545"
-            ) { nvidia-drm.fbdev = 1; }
-            ++ lib.optional (cfg.powerManagement.enable && cfg.powerManagement.kernelSuspendNotifier) {
-              nvidia.NVreg_UseKernelSuspendNotifiers = 1;
+            lib.optional (cfg.modesetting.enable && lib.versionOlder cfg.package.version "595") {
+              nvidia-drm.modeset = 1;
             }
-            ++ lib.optional cfg.powerManagement.enable { nvidia.NVreg_PreserveVideoMemoryAllocations = 1; }
+            ++ lib.optional (
+              cfg.modesetting.enable
+              && lib.versionAtLeast cfg.package.version "545"
+              && lib.versionOlder cfg.package.version "570"
+            ) { nvidia-drm.fbdev = 1; }
+            ++ lib.optional cfg.powerManagement.enable (
+              if cfg.powerManagement.kernelSuspendNotifier then
+                { nvidia.NVreg_UseKernelSuspendNotifiers = 1; }
+              else
+                { nvidia.NVreg_PreserveVideoMemoryAllocations = 1; }
+            )
             ++ lib.optional (
               useOpenModules
               && lib.versionAtLeast cfg.package.version "515.43.04"
               && lib.versionOlder cfg.package.version "545.23.06"
             ) { nvidia.NVreg_OpenRmEnableUnsupportedGpus = 1; }
-            ++ lib.optional cfg.powerManagement.finegrained { nvidia.NVreg_DynamicPowerManagement = "0x02"; }
+            ++ lib.optional cfg.powerManagement.finegrained { nvidia.NVreg_DynamicPowerManagement = 2; }
           );
 
           boot = {

--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -458,12 +458,8 @@ in
             "L+ /run/nvidia-docker/bin - - - - ${nvidia_x11.bin}/origBin"
           ];
           services.udev.extraRules = ''
-            # Create /dev/nvidia-uvm when the nvidia-uvm module is loaded.
-            KERNEL=="nvidia", RUN+="${pkgs.runtimeShell} -c 'mknod -m 666 /dev/nvidiactl c 195 255'"
-            KERNEL=="nvidia", RUN+="${pkgs.runtimeShell} -c 'for i in $$(cat /proc/driver/nvidia/gpus/*/information | grep Minor | cut -d \  -f 4); do mknod -m 666 /dev/nvidia$${i} c 195 $${i}; done'"
-            KERNEL=="nvidia_modeset", RUN+="${pkgs.runtimeShell} -c 'mknod -m 666 /dev/nvidia-modeset c 195 254'"
-            KERNEL=="nvidia_uvm", RUN+="${pkgs.runtimeShell} -c 'mknod -m 666 /dev/nvidia-uvm c $$(grep nvidia-uvm /proc/devices | cut -d \  -f 1) 0'"
-            KERNEL=="nvidia_uvm", RUN+="${pkgs.runtimeShell} -c 'mknod -m 666 /dev/nvidia-uvm-tools c $$(grep nvidia-uvm /proc/devices | cut -d \  -f 1) 1'"
+            KERNEL=="nvidia", RUN+="${nvidia_x11.bin}/bin/nvidia-smi -L"
+            KERNEL=="nvidia_modeset", RUN+="${pkgs.nvidia-modprobe}/bin/nvidia-modprobe -m"
           '';
           hardware.graphics =
             let

--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -432,18 +432,22 @@ in
               '';
             }
           ];
-          boot.blacklistedKernelModules = [
-            "nouveau"
-            "nova_core"
-            "nvidiafb"
-          ];
-          systemd.tmpfiles.rules = lib.mkIf config.virtualisation.docker.enableNvidia [
-            "L+ /run/nvidia-docker/bin - - - - ${cfg.package.bin}/origBin"
-          ];
+
+          boot = {
+            extraModulePackages = if useOpenModules then [ cfg.package.open ] else [ cfg.package.mod ];
+
+            blacklistedKernelModules = [
+              "nouveau"
+              "nova_core"
+              "nvidiafb"
+            ];
+          };
+
           services.udev.extraRules = ''
             KERNEL=="nvidia", RUN+="${cfg.package.bin}/bin/nvidia-smi -L"
             KERNEL=="nvidia_modeset", RUN+="${pkgs.nvidia-modprobe}/bin/nvidia-modprobe -m"
           '';
+
           hardware.graphics =
             let
               icd = [
@@ -460,433 +464,424 @@ in
               ];
               combineIcdPkgs =
                 icd: pkgs:
-                pkgs.symlinkJoin {
-                  name = "nvidia-egl-external-platforms${lib.optionalString pkgs.stdenv.is32bit "-x32"}";
-                  paths = lib.attrVals icd pkgs;
-                  # Remediate reversed priorities in pre-595 drivers,
-                  # https://github.com/NixOS/nixpkgs/pull/497342#issuecomment-4034876793
-                  postBuild = lib.optionalString (lib.versionOlder cfg.package.version "595") ''
-                    pushd $out/share/egl/egl_external_platform.d
-                    for f in [0-9][0-9]_*; do
-                      num=''${f:0:2}
-                      rest=''${f:2}
-                      new=$(printf "%02d" $((99 - 10#$num)))
-                      mv -- "$f" "tmp-$new$rest"
-                    done
-                    for f in tmp-*; do
-                      mv -- "$f" "''${f#tmp-}"
-                    done
-                    popd
-                  '';
-                };
+                # Remediate reversed priorities in pre-595 drivers,
+                # https://github.com/NixOS/nixpkgs/pull/497342#issuecomment-4034876793
+                if lib.versionOlder cfg.package.version "595" then
+                  [
+                    (pkgs.symlinkJoin {
+                      name = "nvidia-egl-external-platforms${lib.optionalString pkgs.stdenv.is32bit "-x32"}";
+                      paths = lib.attrVals icd pkgs;
+                      postBuild = ''
+                        pushd $out/share/egl/egl_external_platform.d
+                        for f in [0-9][0-9]_*; do
+                          num=''${f:0:2}
+                          rest=''${f:2}
+                          new=$(printf "%02d" $((99 - 10#$num)))
+                          mv -- "$f" "tmp-$new$rest"
+                        done
+                        for f in tmp-*; do
+                          mv -- "$f" "''${f#tmp-}"
+                        done
+                        popd
+                      '';
+                    })
+                  ]
+                else
+                  lib.attrVals icd pkgs;
             in
             {
               extraPackages = [
                 cfg.package.out
-                (combineIcdPkgs icd pkgs)
-              ];
+              ]
+              ++ (combineIcdPkgs icd pkgs);
               extraPackages32 = [
                 cfg.package.lib32
-                (combineIcdPkgs icd pkgs.pkgsi686Linux)
-              ];
-            };
-          environment.systemPackages = [ cfg.package.bin ];
-        }
-
-        # X11
-        (lib.mkIf nvidiaEnabled {
-          assertions = [
-            {
-              assertion = primeEnabled -> pCfg.intelBusId == "" || pCfg.amdgpuBusId == "";
-              message = "You cannot configure both an Intel iGPU and an AMD APU. Pick the one corresponding to your processor.";
-            }
-
-            {
-              assertion = offloadCfg.enableOffloadCmd -> offloadCfg.enable || reverseSyncCfg.enable;
-              message = "Offload command requires offloading or reverse prime sync to be enabled.";
-            }
-
-            {
-              assertion =
-                primeEnabled -> pCfg.nvidiaBusId != "" && (pCfg.intelBusId != "" || pCfg.amdgpuBusId != "");
-              message = "When NVIDIA PRIME is enabled, the GPU bus IDs must be configured.";
-            }
-
-            {
-              assertion = offloadCfg.enable -> lib.versionAtLeast cfg.package.version "435.21";
-              message = "NVIDIA PRIME render offload is currently only supported on versions >= 435.21.";
-            }
-
-            {
-              assertion =
-                (reverseSyncCfg.enable && pCfg.amdgpuBusId != "") -> lib.versionAtLeast cfg.package.version "470.0";
-              message = "NVIDIA PRIME render offload for AMD APUs is currently only supported on versions >= 470 beta.";
-            }
-
-            {
-              assertion = !(syncCfg.enable && offloadCfg.enable);
-              message = "PRIME Sync and Offload cannot be both enabled";
-            }
-
-            {
-              assertion = !(syncCfg.enable && reverseSyncCfg.enable);
-              message = "PRIME Sync and PRIME Reverse Sync cannot be both enabled";
-            }
-
-            {
-              assertion = !(syncCfg.enable && cfg.powerManagement.finegrained);
-              message = "Sync precludes powering down the NVIDIA GPU.";
-            }
-
-            {
-              assertion = cfg.powerManagement.finegrained -> offloadCfg.enable;
-              message = "Fine-grained power management requires offload to be enabled.";
-            }
-
-            {
-              assertion = cfg.powerManagement.enable -> lib.versionAtLeast cfg.package.version "430.09";
-              message = "Required files for driver based power management only exist on versions >= 430.09.";
-            }
-
-            {
-              assertion = cfg.gsp.enable -> (cfg.package ? firmware);
-              message = "This version of NVIDIA driver does not provide a GSP firmware.";
-            }
-
-            {
-              assertion = useOpenModules -> (cfg.package ? open);
-              message = "This version of NVIDIA driver does not provide a corresponding opensource kernel driver.";
-            }
-
-            {
-              assertion = useOpenModules -> cfg.gsp.enable;
-              message = "The GSP cannot be disabled when using the opensource kernel driver.";
-            }
-
-            {
-              assertion = cfg.dynamicBoost.enable -> lib.versionAtLeast cfg.package.version "510.39.01";
-              message = "NVIDIA's Dynamic Boost feature only exists on versions >= 510.39.01";
-            }
-
-            {
-              assertion =
-                cfg.powerManagement.kernelSuspendNotifier
-                -> (useOpenModules && lib.versionAtLeast cfg.package.version "595");
-              message = "NVIDIA driver support for kernel suspend notifiers requires NVIDIA driver version 595 or newer, and the open source kernel modules.";
-            }
-
-            {
-              assertion =
-                removeAttrs cfg.moduleParams [
-                  "nvidia"
-                  "nvidia-drm"
-                  "nvidia-modeset"
-                  "nvidia-uvm"
-                ] == { };
-              message = "You can only use `hardware.nvidia.moduleParams` to set parameters for the kernel modules of NVIDIA drivers.";
-            }
-          ];
-
-          # If Optimus/PRIME is enabled, we:
-          # - Specify the configured NVIDIA GPU bus ID in the Device section for the
-          #   "nvidia" driver.
-          # - Add the AllowEmptyInitialConfiguration option to the Screen section for the
-          #   "nvidia" driver, in order to allow the X server to start without any outputs.
-          # - Add a separate Device section for the Intel GPU, using the "modesetting"
-          #   driver and with the configured BusID.
-          # - OR add a separate Device section for the AMD APU, using the "amdgpu"
-          #   driver and with the configures BusID.
-          # - Reference that Device section from the ServerLayout section as an inactive
-          #   device.
-          # - Configure the display manager to run specific `xrandr` commands which will
-          #   configure/enable displays connected to the Intel iGPU / AMD APU.
-
-          services.xserver.drivers =
-            lib.optional primeEnabled {
-              name = igpuDriver;
-              display = offloadCfg.enable;
-              modules = lib.optional (igpuDriver == "amdgpu") pkgs.xf86-video-amdgpu;
-              deviceSection = ''
-                BusID "${igpuBusId}"
-              ''
-              + lib.optionalString (syncCfg.enable && igpuDriver != "amdgpu") ''
-                Option "AccelMethod" "none"
-              '';
-            }
-            ++ lib.singleton {
-              name = "nvidia";
-              modules = [ cfg.package.bin ];
-              display = !offloadCfg.enable;
-              deviceSection = ''
-                Option "SidebandSocketPath" "/run/nvidia-xdriver/"
-              ''
-              + lib.optionalString primeEnabled ''
-                BusID "${pCfg.nvidiaBusId}"
-              ''
-              + lib.optionalString pCfg.allowExternalGpu ''
-                Option "AllowExternalGpus"
-              '';
-              screenSection = ''
-                Option "RandRRotation" "on"
-              ''
-              + lib.optionalString syncCfg.enable ''
-                Option "AllowEmptyInitialConfiguration"
-              ''
-              + lib.optionalString cfg.forceFullCompositionPipeline ''
-                Option         "metamodes" "nvidia-auto-select +0+0 {ForceFullCompositionPipeline=On}"
-                Option         "AllowIndirectGLXProtocol" "off"
-                Option         "TripleBuffer" "on"
-              '';
+              ]
+              ++ (combineIcdPkgs icd pkgs.pkgsi686Linux);
             };
 
-          services.xserver.serverLayoutSection =
-            lib.optionalString syncCfg.enable ''
-              Inactive "Device-${igpuDriver}[0]"
-            ''
-            + lib.optionalString reverseSyncCfg.enable ''
-              Inactive "Device-nvidia[0]"
-            ''
-            + lib.optionalString offloadCfg.enable ''
-              Option "AllowNVIDIAGPUScreens"
-            '';
-
-          services.xserver.displayManager.setupCommands =
-            let
-              gpuProviderName =
-                if igpuDriver == "amdgpu" then
-                  # find the name of the provider if amdgpu
-                  "`${lib.getExe pkgs.xrandr} --listproviders | ${lib.getExe pkgs.gnugrep} -i AMD | ${lib.getExe pkgs.gnused} -n 's/^.*name://p'`"
-                else
-                  igpuDriver;
-              providerCmdParams =
-                if syncCfg.enable then "\"${gpuProviderName}\" NVIDIA-0" else "NVIDIA-G0 \"${gpuProviderName}\"";
-            in
-            lib.optionalString
-              (syncCfg.enable || (reverseSyncCfg.enable && reverseSyncCfg.setupCommands.enable))
-              ''
-                # Added by nvidia configuration module for Optimus/PRIME.
-                ${lib.getExe pkgs.xrandr} --setprovideroutputsource ${providerCmdParams}
-                ${lib.getExe pkgs.xrandr} --auto
-              '';
-
-          environment.etc = {
-            "nvidia/nvidia-application-profiles-rc" = lib.mkIf cfg.package.useProfiles {
-              source = "${cfg.package.bin}/share/nvidia/nvidia-application-profiles-rc";
-            };
-
-            # 'cfg.package' installs it's files to /run/opengl-driver/...
-            "egl/egl_external_platform.d".source = "/run/opengl-driver/share/egl/egl_external_platform.d/";
-          };
-
-          hardware.graphics.extraPackages = lib.optional cfg.videoAcceleration pkgs.nvidia-vaapi-driver;
-
-          environment.systemPackages =
-            lib.optional cfg.nvidiaSettings cfg.package.settings
-            ++ lib.optional cfg.nvidiaPersistenced cfg.package.persistenced
-            ++ lib.optional offloadCfg.enableOffloadCmd (
-              pkgs.writeShellScriptBin cfg.prime.offload.offloadCmdMainProgram ''
-                export __NV_PRIME_RENDER_OFFLOAD=1
-                export __NV_PRIME_RENDER_OFFLOAD_PROVIDER=NVIDIA-G0
-                export __GLX_VENDOR_LIBRARY_NAME=nvidia
-                export __VK_LAYER_NV_optimus=NVIDIA_only
-                exec "$@"
-              ''
-            );
-
-          systemd.packages = lib.optional (
-            cfg.powerManagement.enable && !cfg.powerManagement.kernelSuspendNotifier
-          ) cfg.package.out;
-
-          systemd.services =
-            let
-              nvidiaService = state: {
-                description = "NVIDIA system ${state} actions";
-                path = [ pkgs.kbd ];
-                serviceConfig = {
-                  Type = "oneshot";
-                  ExecStart = "${cfg.package.out}/bin/nvidia-sleep.sh '${state}'";
-                };
-                before = [ "systemd-${state}.service" ];
-                requiredBy = [ "systemd-${state}.service" ];
-              };
-            in
-            lib.mkMerge [
-              (lib.mkIf (cfg.powerManagement.enable && !cfg.powerManagement.kernelSuspendNotifier) {
-                nvidia-suspend = nvidiaService "suspend";
-                nvidia-hibernate = nvidiaService "hibernate";
-                nvidia-resume = (nvidiaService "resume") // {
-                  before = [ ];
-                  after = [
-                    "systemd-suspend.service"
-                    "systemd-hibernate.service"
-                  ];
-                  requiredBy = [
-                    "systemd-suspend.service"
-                    "systemd-hibernate.service"
-                  ];
-                };
-              })
-              (lib.mkIf cfg.nvidiaPersistenced {
-                "nvidia-persistenced" = {
-                  description = "NVIDIA Persistence Daemon";
-                  wantedBy = [ "multi-user.target" ];
-                  serviceConfig = {
-                    Type = "forking";
-                    Restart = "always";
-                    PIDFile = "/var/run/nvidia-persistenced/nvidia-persistenced.pid";
-                    ExecStart = "${lib.getExe cfg.package.persistenced} --verbose";
-                    ExecStopPost = "${pkgs.coreutils}/bin/rm -rf /var/run/nvidia-persistenced";
-                  };
-                };
-              })
-              (lib.mkIf cfg.dynamicBoost.enable {
-                "nvidia-powerd" = {
-                  description = "nvidia-powerd service";
-                  path = [
-                    pkgs.util-linux # nvidia-powerd wants lscpu
-                  ];
-                  wantedBy = [ "multi-user.target" ];
-                  serviceConfig = {
-                    Type = "dbus";
-                    BusName = "nvidia.powerd.server";
-                    ExecStart = "${cfg.package.bin}/bin/nvidia-powerd";
-                  };
-                };
-              })
-            ];
-
-          services.acpid.enable = true;
-
-          services.dbus.packages = lib.optional cfg.dynamicBoost.enable cfg.package.bin;
-
-          hardware.firmware = lib.optional cfg.gsp.enable cfg.package.firmware;
-
-          systemd.tmpfiles.rules = [
-            # Remove the following log message:
-            #    (WW) NVIDIA: Failed to bind sideband socket to
-            #    (WW) NVIDIA:     '/var/run/nvidia-xdriver-b4f69129' Permission denied
-            #
-            # https://bbs.archlinux.org/viewtopic.php?pid=1909115#p1909115
-            "d /run/nvidia-xdriver 0770 root users"
+          environment.systemPackages = [
+            cfg.package.bin
           ]
-          ++
-            lib.optional (cfg.package.persistenced != null && config.virtualisation.docker.enableNvidia)
-              "L+ /run/nvidia-docker/extras/bin/nvidia-persistenced - - - - ${cfg.package.persistenced}/origBin/nvidia-persistenced";
-
-          hardware.nvidia.moduleParams = lib.mkMerge (
-            lib.optional (cfg.modesetting.enable && lib.versionOlder cfg.package.version "595") {
-              nvidia-drm.modeset = 1;
-            }
-            ++ lib.optional (
-              cfg.modesetting.enable
-              && lib.versionAtLeast cfg.package.version "545"
-              && lib.versionOlder cfg.package.version "570"
-            ) { nvidia-drm.fbdev = 1; }
-            ++ lib.optional cfg.powerManagement.enable (
-              if cfg.powerManagement.kernelSuspendNotifier then
-                { nvidia.NVreg_UseKernelSuspendNotifiers = 1; }
-              else
-                { nvidia.NVreg_PreserveVideoMemoryAllocations = 1; }
-            )
-            ++ lib.optional (
-              useOpenModules
-              && lib.versionAtLeast cfg.package.version "515.43.04"
-              && lib.versionOlder cfg.package.version "545.23.06"
-            ) { nvidia.NVreg_OpenRmEnableUnsupportedGpus = 1; }
-            ++ lib.optional cfg.powerManagement.finegrained { nvidia.NVreg_DynamicPowerManagement = 2; }
-          );
-
-          boot = {
-            extraModulePackages = if useOpenModules then [ cfg.package.open ] else [ cfg.package.mod ];
-
-            kernelParams = lib.optional (
-              config.boot.kernelPackages.kernel.kernelAtLeast "6.2" && !ibtSupport
-            ) "ibt=off";
-
-            extraModprobeConfig =
-              let
-                mergeParams = lib.concatMapAttrsStringSep " " (k: v: "${k}=${toString v}");
-                genModprobeLine = module: params: "options ${module} ${mergeParams params}";
-              in
-              lib.concatMapAttrsStringSep "\n" genModprobeLine cfg.moduleParams;
-          };
-          services.udev.extraRules = lib.optionalString cfg.powerManagement.finegrained (
-            lib.optionalString (lib.versionOlder config.boot.kernelPackages.kernel.version "5.5") ''
-              # Remove NVIDIA USB xHCI Host Controller devices, if present
-              ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x0c0330", ATTR{remove}="1"
-
-              # Remove NVIDIA USB Type-C UCSI devices, if present
-              ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x0c8000", ATTR{remove}="1"
-
-              # Remove NVIDIA Audio devices, if present
-              ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x040300", ATTR{remove}="1"
-            ''
-            + ''
-              # Enable runtime PM for NVIDIA VGA/3D controller devices on driver bind
-              ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x03[0-9]*", TEST=="power/control", ATTR{power/control}="auto"
-
-              # Disable runtime PM for NVIDIA VGA/3D controller devices on driver unbind
-              ACTION=="unbind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x03[0-9]*", TEST=="power/control", ATTR{power/control}="on"
-            ''
-          );
-        })
-        # Data Center
-        (lib.mkIf (cfg.datacenter.enable) {
-          boot.extraModulePackages = if useOpenModules then [ cfg.package.open ] else [ cfg.package.mod ];
+          ++ lib.optional cfg.nvidiaPersistenced cfg.package.persistenced;
 
           systemd = {
             tmpfiles.rules =
-              lib.optional (cfg.package.persistenced != null && config.virtualisation.docker.enableNvidia)
-                "L+ /run/nvidia-docker/extras/bin/nvidia-persistenced - - - - ${cfg.package.persistenced}/origBin/nvidia-persistenced";
+              lib.optional config.virtualisation.docker.enableNvidia "L+ /run/nvidia-docker/bin - - - - ${cfg.package.bin}/origBin"
+              ++
+                lib.optional (cfg.package.persistenced != null && config.virtualisation.docker.enableNvidia)
+                  "L+ /run/nvidia-docker/extras/bin/nvidia-persistenced - - - - ${cfg.package.persistenced}/origBin/nvidia-persistenced";
 
-            services = lib.mkMerge [
-              {
-                nvidia-fabricmanager = {
-                  enable = true;
-                  description = "Start NVIDIA NVLink Management";
-                  wantedBy = [ "multi-user.target" ];
-                  unitConfig.After = [ "network-online.target" ];
-                  unitConfig.Requires = [ "network-online.target" ];
-                  serviceConfig = {
-                    Type = "forking";
-                    TimeoutStartSec = 240;
-                    ExecStart =
-                      let
-                        # Since these rely on the `cfg.package.fabricmanager` derivation, they're
-                        # unsuitable to be mentioned in the configuration defaults, but they _can_
-                        # be overridden in `cfg.datacenter.settings` if needed.
-                        fabricManagerConfDefaults = {
-                          TOPOLOGY_FILE_PATH = "${cfg.package.fabricmanager}/share/nvidia-fabricmanager/nvidia/nvswitch";
-                          DATABASE_PATH = "${cfg.package.fabricmanager}/share/nvidia-fabricmanager/nvidia/nvswitch";
-                        };
-                        nv-fab-conf = settingsFormat.generate "fabricmanager.conf" (
-                          fabricManagerConfDefaults // cfg.datacenter.settings
-                        );
-                      in
-                      "${lib.getExe cfg.package.fabricmanager} -c ${nv-fab-conf}";
-                    LimitCORE = "infinity";
-                  };
+            services.nvidia-persistenced = lib.mkIf cfg.nvidiaPersistenced {
+              description = "NVIDIA Persistence Daemon";
+              wantedBy = [ "multi-user.target" ];
+              serviceConfig = {
+                Type = "forking";
+                Restart = "always";
+                PIDFile = "/var/run/nvidia-persistenced/nvidia-persistenced.pid";
+                ExecStart = "${lib.getExe cfg.package.persistenced} --verbose";
+                ExecStopPost = "${pkgs.coreutils}/bin/rm -rf /var/run/nvidia-persistenced";
+              };
+            };
+          };
+        }
+
+        # X11
+        (lib.mkIf nvidiaEnabled (
+          lib.mkMerge [
+            {
+              assertions = [
+                {
+                  assertion = cfg.powerManagement.enable -> lib.versionAtLeast cfg.package.version "430.09";
+                  message = "Required files for driver based power management only exist on versions >= 430.09.";
+                }
+
+                {
+                  assertion = cfg.gsp.enable -> (cfg.package ? firmware);
+                  message = "This version of NVIDIA driver does not provide a GSP firmware.";
+                }
+
+                {
+                  assertion = useOpenModules -> (cfg.package ? open);
+                  message = "This version of NVIDIA driver does not provide a corresponding opensource kernel driver.";
+                }
+
+                {
+                  assertion = useOpenModules -> cfg.gsp.enable;
+                  message = "The GSP cannot be disabled when using the opensource kernel driver.";
+                }
+
+                {
+                  assertion = cfg.dynamicBoost.enable -> lib.versionAtLeast cfg.package.version "510.39.01";
+                  message = "NVIDIA's Dynamic Boost feature only exists on versions >= 510.39.01";
+                }
+
+                {
+                  assertion =
+                    cfg.powerManagement.kernelSuspendNotifier
+                    -> (useOpenModules && lib.versionAtLeast cfg.package.version "595");
+                  message = "NVIDIA driver support for kernel suspend notifiers requires NVIDIA driver version 595 or newer, and the open source kernel modules.";
+                }
+
+                {
+                  assertion =
+                    removeAttrs cfg.moduleParams [
+                      "nvidia"
+                      "nvidia-drm"
+                      "nvidia-modeset"
+                      "nvidia-uvm"
+                    ] == { };
+                  message = "You can only use `hardware.nvidia.moduleParams` to set parameters for the kernel modules of NVIDIA drivers.";
+                }
+              ];
+
+              environment.etc = {
+                "nvidia/nvidia-application-profiles-rc" = lib.mkIf cfg.package.useProfiles {
+                  source = "${cfg.package.bin}/share/nvidia/nvidia-application-profiles-rc";
                 };
-              }
-              (lib.mkIf cfg.nvidiaPersistenced {
-                "nvidia-persistenced" = {
-                  description = "NVIDIA Persistence Daemon";
-                  wantedBy = [ "multi-user.target" ];
-                  serviceConfig = {
-                    Type = "forking";
-                    Restart = "always";
-                    PIDFile = "/var/run/nvidia-persistenced/nvidia-persistenced.pid";
-                    ExecStart = "${lib.getExe cfg.package.persistenced} --verbose";
-                    ExecStopPost = "${pkgs.coreutils}/bin/rm -rf /var/run/nvidia-persistenced";
+
+                # 'cfg.package' installs it's files to /run/opengl-driver/...
+                "egl/egl_external_platform.d".source = "/run/opengl-driver/share/egl/egl_external_platform.d/";
+              };
+
+              hardware.graphics.extraPackages = lib.optional cfg.videoAcceleration pkgs.nvidia-vaapi-driver;
+
+              environment.systemPackages = lib.optional cfg.nvidiaSettings cfg.package.settings;
+
+              systemd.packages = lib.optional (
+                cfg.powerManagement.enable && !cfg.powerManagement.kernelSuspendNotifier
+              ) cfg.package.out;
+
+              systemd.services =
+                let
+                  nvidiaService = state: {
+                    description = "NVIDIA system ${state} actions";
+                    path = [ pkgs.kbd ];
+                    serviceConfig = {
+                      Type = "oneshot";
+                      ExecStart = "${cfg.package.out}/bin/nvidia-sleep.sh '${state}'";
+                    };
+                    before = [ "systemd-${state}.service" ];
+                    requiredBy = [ "systemd-${state}.service" ];
                   };
+                in
+                lib.mkMerge [
+                  (lib.mkIf (cfg.powerManagement.enable && !cfg.powerManagement.kernelSuspendNotifier) {
+                    nvidia-suspend = nvidiaService "suspend";
+                    nvidia-hibernate = nvidiaService "hibernate";
+                    nvidia-resume = (nvidiaService "resume") // {
+                      before = [ ];
+                      after = [
+                        "systemd-suspend.service"
+                        "systemd-hibernate.service"
+                      ];
+                      requiredBy = [
+                        "systemd-suspend.service"
+                        "systemd-hibernate.service"
+                      ];
+                    };
+                  })
+                  (lib.mkIf cfg.dynamicBoost.enable {
+                    "nvidia-powerd" = {
+                      description = "nvidia-powerd service";
+                      path = [
+                        pkgs.util-linux # nvidia-powerd wants lscpu
+                      ];
+                      wantedBy = [ "multi-user.target" ];
+                      serviceConfig = {
+                        Type = "dbus";
+                        BusName = "nvidia.powerd.server";
+                        ExecStart = "${cfg.package.bin}/bin/nvidia-powerd";
+                      };
+                    };
+                  })
+                ];
+
+              services.acpid.enable = true;
+
+              services.dbus.packages = lib.optional cfg.dynamicBoost.enable cfg.package.bin;
+
+              hardware.firmware = lib.optional cfg.gsp.enable cfg.package.firmware;
+
+              hardware.nvidia.moduleParams = lib.mkMerge (
+                lib.optional (cfg.modesetting.enable && lib.versionOlder cfg.package.version "595") {
+                  nvidia-drm.modeset = 1;
+                }
+                ++ lib.optional (
+                  cfg.modesetting.enable
+                  && lib.versionAtLeast cfg.package.version "545"
+                  && lib.versionOlder cfg.package.version "570"
+                ) { nvidia-drm.fbdev = 1; }
+                ++ lib.optional cfg.powerManagement.enable (
+                  if cfg.powerManagement.kernelSuspendNotifier then
+                    { nvidia.NVreg_UseKernelSuspendNotifiers = 1; }
+                  else
+                    { nvidia.NVreg_PreserveVideoMemoryAllocations = 1; }
+                )
+                ++ lib.optional (
+                  useOpenModules
+                  && lib.versionAtLeast cfg.package.version "515.43.04"
+                  && lib.versionOlder cfg.package.version "545.23.06"
+                ) { nvidia.NVreg_OpenRmEnableUnsupportedGpus = 1; }
+                ++ lib.optional cfg.powerManagement.finegrained { nvidia.NVreg_DynamicPowerManagement = 2; }
+              );
+
+              boot = {
+                kernelParams = lib.optional (
+                  config.boot.kernelPackages.kernel.kernelAtLeast "6.2" && !ibtSupport
+                ) "ibt=off";
+
+                extraModprobeConfig =
+                  let
+                    mergeParams = lib.concatMapAttrsStringSep " " (k: v: "${k}=${toString v}");
+                    genModprobeLine = module: params: "options ${module} ${mergeParams params}";
+                  in
+                  lib.concatMapAttrsStringSep "\n" genModprobeLine cfg.moduleParams;
+              };
+              services.udev.extraRules = lib.optionalString cfg.powerManagement.finegrained (
+                lib.optionalString (config.boot.kernelPackages.kernel.kernelOlder "5.5") ''
+                  # Remove NVIDIA USB xHCI Host Controller devices, if present
+                  ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x0c0330", ATTR{remove}="1"
+
+                  # Remove NVIDIA USB Type-C UCSI devices, if present
+                  ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x0c8000", ATTR{remove}="1"
+
+                  # Remove NVIDIA Audio devices, if present
+                  ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x040300", ATTR{remove}="1"
+                ''
+                + ''
+                  # Enable runtime PM for NVIDIA VGA/3D controller devices on driver bind
+                  ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x03[0-9]*", TEST=="power/control", ATTR{power/control}="auto"
+
+                  # Disable runtime PM for NVIDIA VGA/3D controller devices on driver unbind
+                  ACTION=="unbind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x03[0-9]*", TEST=="power/control", ATTR{power/control}="on"
+                ''
+              );
+            }
+
+            (lib.mkIf config.services.xserver.enable {
+              assertions = [
+                {
+                  assertion = primeEnabled -> pCfg.intelBusId == "" || pCfg.amdgpuBusId == "";
+                  message = "You cannot configure both an Intel iGPU and an AMD APU. Pick the one corresponding to your processor.";
+                }
+
+                {
+                  assertion = offloadCfg.enableOffloadCmd -> offloadCfg.enable || reverseSyncCfg.enable;
+                  message = "Offload command requires offloading or reverse prime sync to be enabled.";
+                }
+
+                {
+                  assertion =
+                    primeEnabled -> pCfg.nvidiaBusId != "" && (pCfg.intelBusId != "" || pCfg.amdgpuBusId != "");
+                  message = "When NVIDIA PRIME is enabled, the GPU bus IDs must be configured.";
+                }
+
+                {
+                  assertion = offloadCfg.enable -> lib.versionAtLeast cfg.package.version "435.21";
+                  message = "NVIDIA PRIME render offload is currently only supported on versions >= 435.21.";
+                }
+
+                {
+                  assertion =
+                    (reverseSyncCfg.enable && pCfg.amdgpuBusId != "") -> lib.versionAtLeast cfg.package.version "470.0";
+                  message = "NVIDIA PRIME render offload for AMD APUs is currently only supported on versions >= 470 beta.";
+                }
+
+                {
+                  assertion = !(syncCfg.enable && offloadCfg.enable);
+                  message = "PRIME Sync and Offload cannot be both enabled";
+                }
+
+                {
+                  assertion = !(syncCfg.enable && reverseSyncCfg.enable);
+                  message = "PRIME Sync and PRIME Reverse Sync cannot be both enabled";
+                }
+
+                {
+                  assertion = !(syncCfg.enable && cfg.powerManagement.finegrained);
+                  message = "Sync precludes powering down the NVIDIA GPU.";
+                }
+
+                {
+                  assertion = cfg.powerManagement.finegrained -> offloadCfg.enable;
+                  message = "Fine-grained power management requires offload to be enabled.";
+                }
+              ];
+
+              # If Optimus/PRIME is enabled, we:
+              # - Specify the configured NVIDIA GPU bus ID in the Device section for the
+              #   "nvidia" driver.
+              # - Add the AllowEmptyInitialConfiguration option to the Screen section for the
+              #   "nvidia" driver, in order to allow the X server to start without any outputs.
+              # - Add a separate Device section for the Intel GPU, using the "modesetting"
+              #   driver and with the configured BusID.
+              # - OR add a separate Device section for the AMD APU, using the "amdgpu"
+              #   driver and with the configures BusID.
+              # - Reference that Device section from the ServerLayout section as an inactive
+              #   device.
+              # - Configure the display manager to run specific `xrandr` commands which will
+              #   configure/enable displays connected to the Intel iGPU / AMD APU.
+
+              services.xserver.drivers =
+                lib.optional primeEnabled {
+                  name = igpuDriver;
+                  display = offloadCfg.enable;
+                  modules = lib.optional (igpuDriver == "amdgpu") pkgs.xf86-video-amdgpu;
+                  deviceSection = ''
+                    BusID "${igpuBusId}"
+                  ''
+                  + lib.optionalString (syncCfg.enable && igpuDriver != "amdgpu") ''
+                    Option "AccelMethod" "none"
+                  '';
+                }
+                ++ lib.singleton {
+                  name = "nvidia";
+                  modules = [ cfg.package.bin ];
+                  display = !offloadCfg.enable;
+                  deviceSection = ''
+                    Option "SidebandSocketPath" "/run/nvidia-xdriver/"
+                  ''
+                  + lib.optionalString primeEnabled ''
+                    BusID "${pCfg.nvidiaBusId}"
+                  ''
+                  + lib.optionalString pCfg.allowExternalGpu ''
+                    Option "AllowExternalGpus"
+                  '';
+                  screenSection = ''
+                    Option "RandRRotation" "on"
+                  ''
+                  + lib.optionalString syncCfg.enable ''
+                    Option "AllowEmptyInitialConfiguration"
+                  ''
+                  + lib.optionalString cfg.forceFullCompositionPipeline ''
+                    Option         "metamodes" "nvidia-auto-select +0+0 {ForceFullCompositionPipeline=On}"
+                    Option         "AllowIndirectGLXProtocol" "off"
+                    Option         "TripleBuffer" "on"
+                  '';
                 };
-              })
-            ];
+
+              services.xserver.serverLayoutSection =
+                lib.optionalString syncCfg.enable ''
+                  Inactive "Device-${igpuDriver}[0]"
+                ''
+                + lib.optionalString reverseSyncCfg.enable ''
+                  Inactive "Device-nvidia[0]"
+                ''
+                + lib.optionalString offloadCfg.enable ''
+                  Option "AllowNVIDIAGPUScreens"
+                '';
+
+              services.xserver.displayManager.setupCommands =
+                let
+                  gpuProviderName =
+                    if igpuDriver == "amdgpu" then
+                      # find the name of the provider if amdgpu
+                      "`${lib.getExe pkgs.xrandr} --listproviders | ${lib.getExe pkgs.gnugrep} -i AMD | ${lib.getExe pkgs.gnused} -n 's/^.*name://p'`"
+                    else
+                      igpuDriver;
+                  providerCmdParams =
+                    if syncCfg.enable then "\"${gpuProviderName}\" NVIDIA-0" else "NVIDIA-G0 \"${gpuProviderName}\"";
+                in
+                lib.optionalString
+                  (syncCfg.enable || (reverseSyncCfg.enable && reverseSyncCfg.setupCommands.enable))
+                  ''
+                    # Added by nvidia configuration module for Optimus/PRIME.
+                    ${lib.getExe pkgs.xrandr} --setprovideroutputsource ${providerCmdParams}
+                    ${lib.getExe pkgs.xrandr} --auto
+                  '';
+
+              environment.systemPackages = lib.optional offloadCfg.enableOffloadCmd (
+                pkgs.writeShellScriptBin cfg.prime.offload.offloadCmdMainProgram ''
+                  export __NV_PRIME_RENDER_OFFLOAD=1
+                  export __NV_PRIME_RENDER_OFFLOAD_PROVIDER=NVIDIA-G0
+                  export __GLX_VENDOR_LIBRARY_NAME=nvidia
+                  export __VK_LAYER_NV_optimus=NVIDIA_only
+                  exec "$@"
+                ''
+              );
+
+              systemd.tmpfiles.rules = [
+                # Remove the following log message:
+                #    (WW) NVIDIA: Failed to bind sideband socket to
+                #    (WW) NVIDIA:     '/var/run/nvidia-xdriver-b4f69129' Permission denied
+                #
+                # https://bbs.archlinux.org/viewtopic.php?pid=1909115#p1909115
+                "d /run/nvidia-xdriver 0770 root users"
+              ];
+            })
+          ]
+        ))
+
+        # Data Center
+        (lib.mkIf cfg.datacenter.enable {
+          systemd.services.nvidia-fabricmanager = {
+            description = "Start NVIDIA NVLink Management";
+            wantedBy = [ "multi-user.target" ];
+            unitConfig.After = [ "network-online.target" ];
+            unitConfig.Requires = [ "network-online.target" ];
+            serviceConfig = {
+              Type = "forking";
+              TimeoutStartSec = 240;
+              ExecStart =
+                let
+                  # Since these rely on the `cfg.package.fabricmanager` derivation, they're
+                  # unsuitable to be mentioned in the configuration defaults, but they _can_
+                  # be overridden in `cfg.datacenter.settings` if needed.
+                  fabricManagerConfDefaults = {
+                    TOPOLOGY_FILE_PATH = "${cfg.package.fabricmanager}/share/nvidia-fabricmanager/nvidia/nvswitch";
+                    DATABASE_PATH = "${cfg.package.fabricmanager}/share/nvidia-fabricmanager/nvidia/nvswitch";
+                  };
+                  nv-fab-conf = settingsFormat.generate "fabricmanager.conf" (
+                    fabricManagerConfDefaults // cfg.datacenter.settings
+                  );
+                in
+                "${lib.getExe cfg.package.fabricmanager} -c ${nv-fab-conf}";
+              LimitCORE = "infinity";
+            };
           };
 
-          environment.systemPackages =
-            lib.optional cfg.datacenter.enable cfg.package.fabricmanager
-            ++ lib.optional cfg.nvidiaPersistenced cfg.package.persistenced;
+          environment.systemPackages = [ cfg.package.fabricmanager ];
         })
       ]
     );

--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -208,14 +208,19 @@ in
         configuring X to allow external NVIDIA GPUs when using Prime [Reverse] sync optimus
       '';
 
-      prime.offload.enable = lib.mkEnableOption ''
-        render offload support using the NVIDIA proprietary driver via PRIME.
+      prime.offload.enable =
+        lib.mkEnableOption ''
+          render offload support using the NVIDIA proprietary driver via PRIME.
 
-        If this is enabled, then the bus IDs of the NVIDIA and Intel/AMD GPUs have to
-        be specified ({option}`hardware.nvidia.prime.nvidiaBusId` and
-        {option}`hardware.nvidia.prime.intelBusId` or
-        {option}`hardware.nvidia.prime.amdgpuBusId`)
-      '';
+          If this is enabled, then the bus IDs of the NVIDIA and Intel/AMD GPUs have to
+          be specified ({option}`hardware.nvidia.prime.nvidiaBusId` and
+          {option}`hardware.nvidia.prime.intelBusId` or
+          {option}`hardware.nvidia.prime.amdgpuBusId`)
+        ''
+        // {
+          default = reverseSyncCfg.enable;
+          defaultText = lib.literalExpression "config.hardware.nvidia.prime.reverseSync.enable";
+        };
 
       prime.offload.enableOffloadCmd = lib.mkEnableOption ''
         adding a `nvidia-offload` convenience script to {option}`environment.systemPackages`
@@ -595,9 +600,6 @@ in
           #   device.
           # - Configure the display manager to run specific `xrandr` commands which will
           #   configure/enable displays connected to the Intel iGPU / AMD APU.
-
-          # reverse sync implies offloading
-          hardware.nvidia.prime.offload.enable = lib.mkDefault reverseSyncCfg.enable;
 
           services.xserver.drivers =
             lib.optional primeEnabled {

--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -6,7 +6,6 @@
 }:
 let
   nvidiaEnabled = lib.elem "nvidia" config.services.xserver.videoDrivers;
-  nvidia_x11 = if cfg.enabled then cfg.package else null;
 
   cfg = config.hardware.nvidia;
 
@@ -20,7 +19,7 @@ let
   reverseSyncCfg = pCfg.reverseSync;
   primeEnabled = syncCfg.enable || reverseSyncCfg.enable || offloadCfg.enable;
   busIDType = lib.types.strMatching "([[:print:]]+:[0-9]{1,3}(@[0-9]{1,10})?:[0-9]{1,2}:[0-9])?";
-  ibtSupport = useOpenModules || (nvidia_x11.ibtSupport or false);
+  ibtSupport = useOpenModules || (cfg.package.ibtSupport or false);
   settingsFormat = pkgs.formats.keyValue { };
 in
 {
@@ -103,7 +102,7 @@ in
           Requires NVIDIA driver version 595 or newer, and the open source kernel modules.
         ''
         // {
-          default = useOpenModules && lib.versionAtLeast nvidia_x11.version "595";
+          default = useOpenModules && lib.versionAtLeast cfg.package.version "595";
           defaultText = lib.literalExpression ''
             config.hardware.nvidia.open == true && lib.versionAtLeast config.hardware.nvidia.package.version "595"
           '';
@@ -362,7 +361,7 @@ in
         example = true;
         description = "Whether to enable the open source NVIDIA kernel module.";
         type = lib.types.nullOr lib.types.bool;
-        default = if lib.versionOlder nvidia_x11.version "560" then false else null;
+        default = if lib.versionOlder cfg.package.version "560" then false else null;
         defaultText = lib.literalExpression ''
           if lib.versionOlder config.hardware.nvidia.package.version "560" then false else null
         '';
@@ -373,7 +372,7 @@ in
           the GPU System Processor (GSP) on the video card
         ''
         // {
-          default = useOpenModules || lib.versionAtLeast nvidia_x11.version "555";
+          default = useOpenModules || lib.versionAtLeast cfg.package.version "555";
           defaultText = lib.literalExpression ''
             config.hardware.nvidia.open == true || lib.versionAtLeast config.hardware.nvidia.package.version "555"
           '';
@@ -421,7 +420,7 @@ in
               '';
             }
             {
-              assertion = !cfg.open || (nvidia_x11.open != null);
+              assertion = !cfg.open || (cfg.package.open != null);
               message = ''
                 The selected NVIDIA package does not provide open kernel modules.
                 Set hardware.nvidia.open = false or choose a package branch with open module support.
@@ -434,10 +433,10 @@ in
             "nvidiafb"
           ];
           systemd.tmpfiles.rules = lib.mkIf config.virtualisation.docker.enableNvidia [
-            "L+ /run/nvidia-docker/bin - - - - ${nvidia_x11.bin}/origBin"
+            "L+ /run/nvidia-docker/bin - - - - ${cfg.package.bin}/origBin"
           ];
           services.udev.extraRules = ''
-            KERNEL=="nvidia", RUN+="${nvidia_x11.bin}/bin/nvidia-smi -L"
+            KERNEL=="nvidia", RUN+="${cfg.package.bin}/bin/nvidia-smi -L"
             KERNEL=="nvidia_modeset", RUN+="${pkgs.nvidia-modprobe}/bin/nvidia-modprobe -m"
           '';
           hardware.graphics =
@@ -446,11 +445,11 @@ in
                 "egl-wayland"
               ]
               # GBM support was added in 495.
-              ++ lib.optionals (lib.versionAtLeast nvidia_x11.version "495") [
+              ++ lib.optionals (lib.versionAtLeast cfg.package.version "495") [
                 "egl-gbm"
               ]
               # ICDs below use a new driver interface, which is added in the 560 series drivers.
-              ++ lib.optionals (lib.versionAtLeast nvidia_x11.version "560") [
+              ++ lib.optionals (lib.versionAtLeast cfg.package.version "560") [
                 "egl-wayland2"
                 "egl-x11"
               ];
@@ -461,7 +460,7 @@ in
                   paths = lib.attrVals icd pkgs;
                   # Remediate reversed priorities in pre-595 drivers,
                   # https://github.com/NixOS/nixpkgs/pull/497342#issuecomment-4034876793
-                  postBuild = lib.optionalString (lib.versionOlder nvidia_x11.version "595") ''
+                  postBuild = lib.optionalString (lib.versionOlder cfg.package.version "595") ''
                     pushd $out/share/egl/egl_external_platform.d
                     for f in [0-9][0-9]_*; do
                       num=''${f:0:2}
@@ -478,15 +477,15 @@ in
             in
             {
               extraPackages = [
-                nvidia_x11.out
+                cfg.package.out
                 (combineIcdPkgs icd pkgs)
               ];
               extraPackages32 = [
-                nvidia_x11.lib32
+                cfg.package.lib32
                 (combineIcdPkgs icd pkgs.pkgsi686Linux)
               ];
             };
-          environment.systemPackages = [ nvidia_x11.bin ];
+          environment.systemPackages = [ cfg.package.bin ];
         }
 
         # X11
@@ -509,13 +508,13 @@ in
             }
 
             {
-              assertion = offloadCfg.enable -> lib.versionAtLeast nvidia_x11.version "435.21";
+              assertion = offloadCfg.enable -> lib.versionAtLeast cfg.package.version "435.21";
               message = "NVIDIA PRIME render offload is currently only supported on versions >= 435.21.";
             }
 
             {
               assertion =
-                (reverseSyncCfg.enable && pCfg.amdgpuBusId != "") -> lib.versionAtLeast nvidia_x11.version "470.0";
+                (reverseSyncCfg.enable && pCfg.amdgpuBusId != "") -> lib.versionAtLeast cfg.package.version "470.0";
               message = "NVIDIA PRIME render offload for AMD APUs is currently only supported on versions >= 470 beta.";
             }
 
@@ -540,7 +539,7 @@ in
             }
 
             {
-              assertion = cfg.powerManagement.enable -> lib.versionAtLeast nvidia_x11.version "430.09";
+              assertion = cfg.powerManagement.enable -> lib.versionAtLeast cfg.package.version "430.09";
               message = "Required files for driver based power management only exist on versions >= 430.09.";
             }
 
@@ -560,14 +559,14 @@ in
             }
 
             {
-              assertion = cfg.dynamicBoost.enable -> lib.versionAtLeast nvidia_x11.version "510.39.01";
+              assertion = cfg.dynamicBoost.enable -> lib.versionAtLeast cfg.package.version "510.39.01";
               message = "NVIDIA's Dynamic Boost feature only exists on versions >= 510.39.01";
             }
 
             {
               assertion =
                 cfg.powerManagement.kernelSuspendNotifier
-                -> (useOpenModules && lib.versionAtLeast nvidia_x11.version "595");
+                -> (useOpenModules && lib.versionAtLeast cfg.package.version "595");
               message = "NVIDIA driver support for kernel suspend notifiers requires NVIDIA driver version 595 or newer, and the open source kernel modules.";
             }
 
@@ -614,7 +613,7 @@ in
             }
             ++ lib.singleton {
               name = "nvidia";
-              modules = [ nvidia_x11.bin ];
+              modules = [ cfg.package.bin ];
               display = !offloadCfg.enable;
               deviceSection = ''
                 Option "SidebandSocketPath" "/run/nvidia-xdriver/"
@@ -669,19 +668,19 @@ in
               '';
 
           environment.etc = {
-            "nvidia/nvidia-application-profiles-rc" = lib.mkIf nvidia_x11.useProfiles {
-              source = "${nvidia_x11.bin}/share/nvidia/nvidia-application-profiles-rc";
+            "nvidia/nvidia-application-profiles-rc" = lib.mkIf cfg.package.useProfiles {
+              source = "${cfg.package.bin}/share/nvidia/nvidia-application-profiles-rc";
             };
 
-            # 'nvidia_x11' installs it's files to /run/opengl-driver/...
+            # 'cfg.package' installs it's files to /run/opengl-driver/...
             "egl/egl_external_platform.d".source = "/run/opengl-driver/share/egl/egl_external_platform.d/";
           };
 
           hardware.graphics.extraPackages = lib.optional cfg.videoAcceleration pkgs.nvidia-vaapi-driver;
 
           environment.systemPackages =
-            lib.optional cfg.nvidiaSettings nvidia_x11.settings
-            ++ lib.optional cfg.nvidiaPersistenced nvidia_x11.persistenced
+            lib.optional cfg.nvidiaSettings cfg.package.settings
+            ++ lib.optional cfg.nvidiaPersistenced cfg.package.persistenced
             ++ lib.optional offloadCfg.enableOffloadCmd (
               pkgs.writeShellScriptBin cfg.prime.offload.offloadCmdMainProgram ''
                 export __NV_PRIME_RENDER_OFFLOAD=1
@@ -694,7 +693,7 @@ in
 
           systemd.packages = lib.optional (
             cfg.powerManagement.enable && !cfg.powerManagement.kernelSuspendNotifier
-          ) nvidia_x11.out;
+          ) cfg.package.out;
 
           systemd.services =
             let
@@ -703,7 +702,7 @@ in
                 path = [ pkgs.kbd ];
                 serviceConfig = {
                   Type = "oneshot";
-                  ExecStart = "${nvidia_x11.out}/bin/nvidia-sleep.sh '${state}'";
+                  ExecStart = "${cfg.package.out}/bin/nvidia-sleep.sh '${state}'";
                 };
                 before = [ "systemd-${state}.service" ];
                 requiredBy = [ "systemd-${state}.service" ];
@@ -733,7 +732,7 @@ in
                     Type = "forking";
                     Restart = "always";
                     PIDFile = "/var/run/nvidia-persistenced/nvidia-persistenced.pid";
-                    ExecStart = "${lib.getExe nvidia_x11.persistenced} --verbose";
+                    ExecStart = "${lib.getExe cfg.package.persistenced} --verbose";
                     ExecStopPost = "${pkgs.coreutils}/bin/rm -rf /var/run/nvidia-persistenced";
                   };
                 };
@@ -748,7 +747,7 @@ in
                   serviceConfig = {
                     Type = "dbus";
                     BusName = "nvidia.powerd.server";
-                    ExecStart = "${nvidia_x11.bin}/bin/nvidia-powerd";
+                    ExecStart = "${cfg.package.bin}/bin/nvidia-powerd";
                   };
                 };
               })
@@ -756,9 +755,9 @@ in
 
           services.acpid.enable = true;
 
-          services.dbus.packages = lib.optional cfg.dynamicBoost.enable nvidia_x11.bin;
+          services.dbus.packages = lib.optional cfg.dynamicBoost.enable cfg.package.bin;
 
-          hardware.firmware = lib.optional cfg.gsp.enable nvidia_x11.firmware;
+          hardware.firmware = lib.optional cfg.gsp.enable cfg.package.firmware;
 
           systemd.tmpfiles.rules = [
             # Remove the following log message:
@@ -769,13 +768,13 @@ in
             "d /run/nvidia-xdriver 0770 root users"
           ]
           ++
-            lib.optional (nvidia_x11.persistenced != null && config.virtualisation.docker.enableNvidia)
-              "L+ /run/nvidia-docker/extras/bin/nvidia-persistenced - - - - ${nvidia_x11.persistenced}/origBin/nvidia-persistenced";
+            lib.optional (cfg.package.persistenced != null && config.virtualisation.docker.enableNvidia)
+              "L+ /run/nvidia-docker/extras/bin/nvidia-persistenced - - - - ${cfg.package.persistenced}/origBin/nvidia-persistenced";
 
           hardware.nvidia.moduleParams = lib.mkMerge (
             lib.optional (offloadCfg.enable || cfg.modesetting.enable) { nvidia-drm.modeset = 1; }
             ++ lib.optional (
-              (offloadCfg.enable || cfg.modesetting.enable) && lib.versionAtLeast nvidia_x11.version "545"
+              (offloadCfg.enable || cfg.modesetting.enable) && lib.versionAtLeast cfg.package.version "545"
             ) { nvidia-drm.fbdev = 1; }
             ++ lib.optional (cfg.powerManagement.enable && cfg.powerManagement.kernelSuspendNotifier) {
               nvidia.NVreg_UseKernelSuspendNotifiers = 1;
@@ -783,14 +782,14 @@ in
             ++ lib.optional cfg.powerManagement.enable { nvidia.NVreg_PreserveVideoMemoryAllocations = 1; }
             ++ lib.optional (
               useOpenModules
-              && lib.versionAtLeast nvidia_x11.version "515.43.04"
-              && lib.versionOlder nvidia_x11.version "545.23.06"
+              && lib.versionAtLeast cfg.package.version "515.43.04"
+              && lib.versionOlder cfg.package.version "545.23.06"
             ) { nvidia.NVreg_OpenRmEnableUnsupportedGpus = 1; }
             ++ lib.optional cfg.powerManagement.finegrained { nvidia.NVreg_DynamicPowerManagement = "0x02"; }
           );
 
           boot = {
-            extraModulePackages = if useOpenModules then [ nvidia_x11.open ] else [ nvidia_x11.mod ];
+            extraModulePackages = if useOpenModules then [ cfg.package.open ] else [ cfg.package.mod ];
 
             kernelParams = lib.optional (
               config.boot.kernelPackages.kernel.kernelAtLeast "6.2" && !ibtSupport
@@ -825,12 +824,12 @@ in
         })
         # Data Center
         (lib.mkIf (cfg.datacenter.enable) {
-          boot.extraModulePackages = if useOpenModules then [ nvidia_x11.open ] else [ nvidia_x11.mod ];
+          boot.extraModulePackages = if useOpenModules then [ cfg.package.open ] else [ cfg.package.mod ];
 
           systemd = {
             tmpfiles.rules =
-              lib.optional (nvidia_x11.persistenced != null && config.virtualisation.docker.enableNvidia)
-                "L+ /run/nvidia-docker/extras/bin/nvidia-persistenced - - - - ${nvidia_x11.persistenced}/origBin/nvidia-persistenced";
+              lib.optional (cfg.package.persistenced != null && config.virtualisation.docker.enableNvidia)
+                "L+ /run/nvidia-docker/extras/bin/nvidia-persistenced - - - - ${cfg.package.persistenced}/origBin/nvidia-persistenced";
 
             services = lib.mkMerge [
               {
@@ -845,18 +844,18 @@ in
                     TimeoutStartSec = 240;
                     ExecStart =
                       let
-                        # Since these rely on the `nvidia_x11.fabricmanager` derivation, they're
+                        # Since these rely on the `cfg.package.fabricmanager` derivation, they're
                         # unsuitable to be mentioned in the configuration defaults, but they _can_
                         # be overridden in `cfg.datacenter.settings` if needed.
                         fabricManagerConfDefaults = {
-                          TOPOLOGY_FILE_PATH = "${nvidia_x11.fabricmanager}/share/nvidia-fabricmanager/nvidia/nvswitch";
-                          DATABASE_PATH = "${nvidia_x11.fabricmanager}/share/nvidia-fabricmanager/nvidia/nvswitch";
+                          TOPOLOGY_FILE_PATH = "${cfg.package.fabricmanager}/share/nvidia-fabricmanager/nvidia/nvswitch";
+                          DATABASE_PATH = "${cfg.package.fabricmanager}/share/nvidia-fabricmanager/nvidia/nvswitch";
                         };
                         nv-fab-conf = settingsFormat.generate "fabricmanager.conf" (
                           fabricManagerConfDefaults // cfg.datacenter.settings
                         );
                       in
-                      "${lib.getExe nvidia_x11.fabricmanager} -c ${nv-fab-conf}";
+                      "${lib.getExe cfg.package.fabricmanager} -c ${nv-fab-conf}";
                     LimitCORE = "infinity";
                   };
                 };
@@ -869,7 +868,7 @@ in
                     Type = "forking";
                     Restart = "always";
                     PIDFile = "/var/run/nvidia-persistenced/nvidia-persistenced.pid";
-                    ExecStart = "${lib.getExe nvidia_x11.persistenced} --verbose";
+                    ExecStart = "${lib.getExe cfg.package.persistenced} --verbose";
                     ExecStopPost = "${pkgs.coreutils}/bin/rm -rf /var/run/nvidia-persistenced";
                   };
                 };
@@ -878,8 +877,8 @@ in
           };
 
           environment.systemPackages =
-            lib.optional cfg.datacenter.enable nvidia_x11.fabricmanager
-            ++ lib.optional cfg.nvidiaPersistenced nvidia_x11.persistenced;
+            lib.optional cfg.datacenter.enable cfg.package.fabricmanager
+            ++ lib.optional cfg.nvidiaPersistenced cfg.package.persistenced;
         })
       ]
     );

--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -428,32 +428,11 @@ in
               '';
             }
           ];
-          boot = {
-            blacklistedKernelModules = [
-              "nouveau"
-              "nova_core"
-              "nvidiafb"
-            ];
-
-            # Don't add `nvidia-uvm` to `kernelModules`, because we want
-            # `nvidia-uvm` be loaded only after the GPU device is available, i.e. after `udev` rules
-            # for `nvidia` kernel module are applied.
-            # This matters on Azure GPU instances: https://github.com/NixOS/nixpkgs/pull/267335
-            #
-            # Instead, we use `softdep` to lazily load `nvidia-uvm` kernel module
-            # after `nvidia` kernel module is loaded and `udev` rules are applied.
-            extraModprobeConfig = ''
-              softdep nvidia post: nvidia-uvm
-            '';
-
-            # Exception is the open-source kernel module failing to load nvidia-uvm using softdep
-            # for unknown reasons.
-            # It affects CUDA: https://github.com/NixOS/nixpkgs/issues/334180
-            # Previously nvidia-uvm was explicitly loaded only when xserver was enabled:
-            # https://github.com/NixOS/nixpkgs/pull/334340/commits/4548c392862115359e50860bcf658cfa8715bde9
-            # We are now loading the module eagerly for all users of the open driver (including headless).
-            kernelModules = lib.optionals useOpenModules [ "nvidia_uvm" ];
-          };
+          boot.blacklistedKernelModules = [
+            "nouveau"
+            "nova_core"
+            "nvidiafb"
+          ];
           systemd.tmpfiles.rules = lib.mkIf config.virtualisation.docker.enableNvidia [
             "L+ /run/nvidia-docker/bin - - - - ${nvidia_x11.bin}/origBin"
           ];
@@ -812,12 +791,6 @@ in
 
           boot = {
             extraModulePackages = if useOpenModules then [ nvidia_x11.open ] else [ nvidia_x11.mod ];
-            # nvidia-uvm is required by CUDA applications.
-            kernelModules = lib.optionals config.services.xserver.enable [
-              "nvidia"
-              "nvidia_modeset"
-              "nvidia_drm"
-            ];
 
             kernelParams = lib.optional (
               config.boot.kernelPackages.kernel.kernelAtLeast "6.2" && !ibtSupport

--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -843,12 +843,10 @@ in
             ''
             + ''
               # Enable runtime PM for NVIDIA VGA/3D controller devices on driver bind
-              ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030000", TEST=="power/control", ATTR{power/control}="auto"
-              ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030200", TEST=="power/control", ATTR{power/control}="auto"
+              ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x03[0-9]*", TEST=="power/control", ATTR{power/control}="auto"
 
               # Disable runtime PM for NVIDIA VGA/3D controller devices on driver unbind
-              ACTION=="unbind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030000", TEST=="power/control", ATTR{power/control}="on"
-              ACTION=="unbind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x030200", TEST=="power/control", ATTR{power/control}="on"
+              ACTION=="unbind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{class}=="0x03[0-9]*", TEST=="power/control", ATTR{power/control}="on"
             ''
           );
         })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Running `sudo nvidia-smi -L` will load kernel modules and create device files, except the `nvidia-modeset` file.

```
❯ nvidia-smi -L
GPU 0: NVIDIA GeForce GTX 1650 Ti (UUID: GPU-dba9c788-0930-b476-97a6-3ab75f765397)

~ 
❯ nvidia-smi --version
NVIDIA-SMI version  : 595.71.05
NVML version        : 595.71
DRIVER version      : 595.71.05
CUDA Version        : 13.2

~ 
❯ lsmod | grep nvidia
nvidia_uvm           2461696  0
nvidia_drm            147456  3
nvidia_modeset       2187264  3 nvidia_drm
nvidia              16297984  39 nvidia_uvm,nvidia_modeset
drm_ttm_helper         20480  1 nvidia_drm
ecc                    49152  2 ecdh_generic,nvidia
video                  81920  3 asus_wmi,i915,nvidia_modeset

~ 
❯ ll /dev/nvidia*
crw-rw-rw- 195,254 root 29 5月  15:08 󰡯 /dev/nvidia-modeset
crw-rw-rw-   510,0 root 29 5月  15:08 󰡯 /dev/nvidia-uvm
crw-rw-rw-   510,1 root 29 5月  15:08 󰡯 /dev/nvidia-uvm-tools
crw-rw-rw-   195,0 root 29 5月  15:08 󰡯 /dev/nvidia0
crw-rw-rw- 195,255 root 29 5月  15:08 󰡯 /dev/nvidiactl

/dev/nvidia-caps:
cr-------- 237,1 root 29 5月  15:08 󰡯 nvidia-cap1
cr--r--r-- 237,2 root 29 5月  15:08 󰡯 nvidia-cap2
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
