### PR TITLE
salt: 3007.13 -> 3008.0

### DIFF
--- a/pkgs/by-name/sa/salt/package.nix
+++ b/pkgs/by-name/sa/salt/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   python3,
-  fetchpatch,
   fetchPypi,
   openssl,
   # Many Salt modules require various Python modules to be installed,
@@ -12,36 +11,31 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "salt";
-  version = "3007.13";
+  version = "3008.0";
   format = "setuptools";
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-xmOnOGy9R6/pSm2LCxrx/M3DUFnM7CuTMQ55IHBTRPs=";
+    hash = "sha256-az5PJTHJnD2wZtgds1KDnHdn3oRsk94/+UZRoX054tE=";
   };
 
   patches = [
     ./fix-libcrypto-loading.patch
-    (fetchpatch {
-      name = "urllib.patch";
-      url = "https://src.fedoraproject.org/rpms/salt/raw/1c6e7b7a88fb81902f5fcee32e04fa80713b81f8/f/urllib.patch";
-      hash = "sha256-yldIurafduOAYpf2X0PcTQyyNjz5KKl/N7J2OTEF/c0=";
-    })
   ];
 
   postPatch = ''
     substituteInPlace "salt/utils/rsax931.py" \
       --subst-var-by "libcrypto" "${lib.getLib openssl}/lib/libcrypto${stdenv.hostPlatform.extensions.sharedLibrary}"
-    substituteInPlace requirements/base.txt \
-      --replace contextvars ""
 
     # Don't require optional dependencies on Darwin, let's use
     # `extraInputs` like on any other platform
     echo -n > "requirements/darwin.txt"
 
-    # Remove windows-only requirement
-    substituteInPlace "requirements/zeromq.txt" \
-      --replace 'pyzmq==25.0.2 ; sys_platform == "win32"' ""
+    # Fix duplicated script in bin and scripts:
+    # FileExistsError: File already exists: /nix/store/...-salt-3008.0/bin/salt
+    # See https://github.com/pypa/installer/pull/170 and https://github.com/saltstack/salt/issues/65083
+    substituteInPlace "tools/pkg/salt_build_backend.py" \
+      --replace-fail 'get_scripts(dist=None):' $'get_scripts(dist=None):\n    return []'
   '';
 
   propagatedBuildInputs =


### PR DESCRIPTION
Changelog: https://docs.saltproject.io/en/latest/topics/releases/3008.0.html

Major release, no CVEs this time as far as I can see (except for dependencies, but that shouldn’t be a problem in nixpkgs).

The urllib patch seems to be included now, so removed that.
The pypa install fails with an obscure error, I added a workaround.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
