### PR TITLE
nixos/gpgsmartcards: some tlc and adoption

### DIFF
--- a/nixos/modules/hardware/gpgsmartcards.nix
+++ b/nixos/modules/hardware/gpgsmartcards.nix
@@ -5,37 +5,18 @@
   ...
 }:
 let
-  # gnupg's manual describes how to setup ccid udev rules:
-  #   https://www.gnupg.org/howtos/card-howto/en/ch02s03.html
-  # gnupg folks advised me (https://dev.gnupg.org/T5409) to look at debian's rules:
-  # https://salsa.debian.org/debian/gnupg2/-/blob/debian/main/debian/scdaemon.udev
-
-  # the latest rev of the entire debian gnupg2 repo as of 2021-04-28
-  # the scdaemon.udev file was last committed on 2021-01-05 (7817a03):
-  scdaemonUdevRev = "01898735a015541e3ffb43c7245ac1e612f40836";
-
-  scdaemonRules = pkgs.fetchurl {
-    url = "https://salsa.debian.org/debian/gnupg2/-/raw/${scdaemonUdevRev}/debian/scdaemon.udev";
-    sha256 = "08v0vp6950bz7galvc92zdss89y9vcwbinmbfcdldy8x72w6rqr3";
-  };
-
-  # per debian's udev deb hook (https://man7.org/linux/man-pages/man1/dh_installudev.1.html)
-  destination = "60-scdaemon.rules";
-
-  scdaemonUdevRulesPkg = pkgs.runCommand "scdaemon-udev-rules" { } ''
-    loc="$out/lib/udev/rules.d/"
-    mkdir -p "''${loc}"
-    cp "${scdaemonRules}" "''${loc}/${destination}"
-  '';
-
   cfg = config.hardware.gpgSmartcards;
 in
 {
   options.hardware.gpgSmartcards = {
     enable = lib.mkEnableOption "udev rules for gnupg smart cards";
+
+    package = lib.mkPackageOption pkgs "scdaemon-udev-rules-debian" { };
   };
 
   config = lib.mkIf cfg.enable {
-    services.udev.packages = [ scdaemonUdevRulesPkg ];
+    services.udev.packages = [ cfg.package ];
   };
+
+  meta.maintainers = with lib.maintainers; [ pandapip1 ];
 }

--- a/pkgs/by-name/sc/scdaemon-udev-rules-debian/package.nix
+++ b/pkgs/by-name/sc/scdaemon-udev-rules-debian/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitLab,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "scdaemon-udev-rules-debian";
+  version = "2.4.9-4";
+
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "debian";
+    repo = "gnupg2";
+    tag = "debian/${finalAttrs.version}";
+    hash = "sha256-3xeEoQLBTmwgJQkYYAM6Ctx9TAq+YTTXlANUl/zOM0k=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  preferLocalBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/udev/rules.d
+    cp debian/scdaemon.udev $out/lib/udev/rules.d/60-scdaemon.rules
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "udev rules for scdaemon as packaged by Debian";
+    homepage = "https://salsa.debian.org/debian/gnupg2";
+    license = with lib.licenses; [ gpl3Plus ];
+    maintainers = with lib.maintainers; [ pandapip1 ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
