### PR TITLE
ut1999: provide ISO file sources as passthru

### DIFF
--- a/pkgs/by-name/ut/ut1999/package.nix
+++ b/pkgs/by-name/ut/ut1999/package.nix
@@ -43,15 +43,21 @@ let
     # fat binary
     aarch64-darwin = x86_64-darwin;
   };
+  # This upload of the game is officially sanctioned by OldUnreal (who has received permission from Epic Games to link to archive.org) and the UT99.org community
+  # This is a copy of the original Unreal Tournament: Game of the Year Edition (also known as UT or UT99). The first ISO contains the base game.
+  iso1 = fetchurl {
+    url = "https://archive.org/download/ut-goty/UT_GOTY_CD1.iso";
+    hash = "sha256-4YSYTKiPABxd3VIDXXbNZOJm4mx0l1Fhte1yNmx0cE8=";
+  };
+  # The second ISO contains bonus maps and game modes
+  iso2 = fetchurl {
+    url = "https://archive.org/download/ut-goty/UT_GOTY_CD2.iso";
+    hash = "sha256-2V2O4c+VVi7gI/1UA17IgT1CdfY9GEdCMiCYbtyNANg=";
+  };
   baseGame =
     runCommand "ut1999-iso1"
       {
-        # This upload of the game is officially sanctioned by OldUnreal (who has received permission from Epic Games to link to archive.org) and the UT99.org community
-        # This is a copy of the original Unreal Tournament: Game of the Year Edition (also known as UT or UT99). The first ISO contains the base game.
-        src = fetchurl {
-          url = "https://archive.org/download/ut-goty/UT_GOTY_CD1.iso";
-          hash = "sha256-4YSYTKiPABxd3VIDXXbNZOJm4mx0l1Fhte1yNmx0cE8=";
-        };
+        src = iso1;
         nativeBuildInputs = [ libarchive ];
       }
       ''
@@ -62,11 +68,7 @@ let
   bonusPacks =
     runCommand "ut1999-iso2"
       {
-        # The second ISO contains bonus maps and game modes
-        src = fetchurl {
-          url = "https://archive.org/download/ut-goty/UT_GOTY_CD2.iso";
-          hash = "sha256-2V2O4c+VVi7gI/1UA17IgT1CdfY9GEdCMiCYbtyNANg=";
-        };
+        src = iso2;
         nativeBuildInputs = [ libarchive ];
       }
       ''
@@ -218,6 +220,14 @@ stdenv.mkDerivation (finalAttrs: {
       categories = [ "Game" ];
     })
   ];
+
+  passthru = {
+    # The ISOs can be appended to `system.extraDependencies` in order to prevent them from getting garbage collected and redownloaded during rebuilds.
+    isos = [
+      iso1
+      iso2
+    ];
+  };
 
   meta = {
     description = "Unreal Tournament GOTY (1999) with the OldUnreal patch";


### PR DESCRIPTION
It itches me that the Unreal Tournament 99 ISOs are redownloaded for many system updates and disscussed the issue on [discourse](https://discourse.nixos.org/t/preventing-ut1999-iso-redownloads/77870). The solution is to add the ISOs as dependencies to prevent them from getting garbage collected. However one has to repeat the `fetchurl` from the `package.nix`. In order to avoid this repetition, this commit provides them as `passthru`.

Note this commit does not change the hash of the `ut1999` derivation and therefore does not trigger a rebuilt of the package.

## Things done

Added the `nixpkgs` fork to my flake, adapted my `gaming.nix` (see [commit](https://github.com/Borgvall/nixos/commit/13153d70c7a99a436c028855cc09ac5a4a7bb6b3)), run `nixos-rebuild switch` and started `ut1999`.

- Built on platform:
  - [x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
