### PR TITLE
nixos/pcscd: expose package as option; pcsclite: enable structuredAttrs, separateDebugInfo, strictDeps

### DIFF
--- a/nixos/modules/services/hardware/pcscd.nix
+++ b/nixos/modules/services/hardware/pcscd.nix
@@ -10,8 +10,6 @@ let
     builtins.concatStringsSep "\n\n" config.services.pcscd.readerConfigs
   );
 
-  package = if config.security.polkit.enable then pkgs.pcscliteWithPolkit else pkgs.pcsclite;
-
   pluginEnv = pkgs.buildEnv {
     name = "pcscd-plugins";
     paths = map (p: "${p}/pcsc/drivers") config.services.pcscd.plugins;
@@ -35,6 +33,11 @@ in
 
   options.services.pcscd = {
     enable = lib.mkEnableOption "PCSC-Lite daemon, to access smart cards using SCard API (PC/SC)";
+
+    package = (lib.mkPackageOption pkgs "pcsclite" { }) // {
+      default = if config.security.polkit.enable then pkgs.pcscliteWithPolkit else pkgs.pcsclite;
+      defaultText = lib.literalExpression "if config.security.polkit.enable then pkgs.pcscliteWithPolkit else pkgs.pcsclite";
+    };
 
     plugins = lib.mkOption {
       type = lib.types.listOf lib.types.package;
@@ -101,8 +104,8 @@ in
   config = lib.mkIf config.services.pcscd.enable {
     environment.etc."reader.conf".source = cfgFile;
 
-    environment.systemPackages = [ package ];
-    systemd.packages = [ package ];
+    environment.systemPackages = [ cfg.package ];
+    systemd.packages = [ cfg.package ];
 
     services.pcscd.plugins = [ pkgs.ccid ];
 
@@ -133,7 +136,7 @@ in
       # https://github.com/NixOS/nixpkgs/issues/121088
       serviceConfig.ExecStart = [
         ""
-        "${lib.getExe package} -f -x -c ${cfgFile} ${lib.escapeShellArgs cfg.extraArgs}"
+        "${lib.getExe cfg.package} -f -x -c ${cfgFile} ${lib.escapeShellArgs cfg.extraArgs}"
       ];
     };
 

--- a/pkgs/by-name/pc/pcsclite/package.nix
+++ b/pkgs/by-name/pc/pcsclite/package.nix
@@ -88,6 +88,10 @@ stdenv.mkDerivation (finalAttrs: {
     moveToOutput bin/pcsc-spy "$dev"
   '';
 
+  __structuredAttrs = true;
+  separateDebugInfo = true;
+  strictDeps = true;
+
   nativeBuildInputs = [
     meson
     ninja


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
