### PR TITLE
panix: init at 0.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17957,6 +17957,11 @@
     githubId = 323199;
     name = "Mihai Maruseac";
   };
+  mihakrumpestar = {
+    name = "Miha Krumpestar";
+    github = "mihakrumpestar";
+    githubId = 70652456;
+  };
   mihnea-s = {
     email = "mihn.stn@gmail.com";
     github = "mihnea-s";

--- a/pkgs/by-name/pa/panix/package.nix
+++ b/pkgs/by-name/pa/panix/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "panix";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "mihakrumpestar";
+    repo = "panix";
+    rev = "v${version}";
+    hash = "sha256-Nran1Kop3BXYcUFoAb97WUOOL20PqAFA4sq3N/utv2U=";
+  };
+
+  subPackages = [ "cmd/panix" ];
+
+  flags = [ "-trimpath" ];
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  env.CGO_ENABLED = 0;
+
+  vendorHash = "sha256-S1lLVTo03NH3beLeduyyHBdPZohntCAD05E6myHIwj0=";
+
+  meta = with lib; {
+    description = "Universal NixOS Deployment Tool";
+    homepage = "https://github.com/mihakrumpestar/panix";
+    changelog = "https://github.com/mihakrumpestar/panix/releases/tag/v${version}";
+    license = licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ mihakrumpestar ];
+    platforms = platforms.all;
+    mainProgram = "panix";
+  };
+}

--- a/pkgs/by-name/pa/panix/package.nix
+++ b/pkgs/by-name/pa/panix/package.nix
@@ -8,6 +8,8 @@ buildGoModule rec {
   pname = "panix";
   version = "0.7.0";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "mihakrumpestar";
     repo = "panix";


### PR DESCRIPTION
I would like to add package Panix and act as the maintainer for it.

Panix is a _Universal NixOS Deployment Tool_.
Description: _Stateless, phase-oriented deployment with real-time visibility across multi-flake fleets_.

Homepage: https://github.com/mihakrumpestar/panix

Assisted-by: OpenCode: GLM 5.1
If you are curious of the exact setup I use, it is available on https://github.com/mihakrumpestar/infrastructure/tree/9f776bf62004fc826509e944cc660b2eac9e04ba/modules/home/llm.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
