### PR TITLE
python3Packages.apex: fix CUDA capabilities selection in setup.py

### DIFF
--- a/pkgs/development/python-modules/apex/default.nix
+++ b/pkgs/development/python-modules/apex/default.nix
@@ -57,16 +57,25 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
     ./fix-cuda-capabilities-selection.patch
   ];
 
-  # Don't use git submodules for cuda dependencies
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace-fail \
-        'subprocess.run(["git", "submodule", "update", "--init", "apex/contrib/csrc/multihead_attn/cutlass"])' \
-        "" \
-      --replace-fail \
-        'subprocess.run(["git", "submodule", "update", "--init", "apex/contrib/csrc/cudnn-frontend/"])' \
-        ""
-  '';
+  postPatch =
+    # Don't use git submodules for cuda dependencies
+    ''
+      substituteInPlace setup.py \
+        --replace-fail \
+          'subprocess.run(["git", "submodule", "update", "--init", "apex/contrib/csrc/multihead_attn/cutlass"])' \
+          "" \
+        --replace-fail \
+          'subprocess.run(["git", "submodule", "update", "--init", "apex/contrib/csrc/cudnn-frontend/"])' \
+          ""
+    ''
+    # Disambiguate apex's local `lerp` from `std::lerp`, which is now reachable through ATen/torch
+    # headers with CUDA 13's C++20 standard and gcc 15's <cmath>.
+    + ''
+      substituteInPlace apex/contrib/csrc/optimizers/multi_tensor_distopt_adam_kernel.cu \
+        --replace-fail \
+          "lerp(" \
+          "apex_lerp("
+    '';
 
   env = {
     APEX_CPP_EXT = 1;

--- a/pkgs/development/python-modules/apex/default.nix
+++ b/pkgs/development/python-modules/apex/default.nix
@@ -49,6 +49,11 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
     # Fix incompatibility with more recent versions of cudnn to de-vendor it:
     #   error: ‘throw_if’ is not a member of ‘cudnn_frontend’
     ./fix-cudnn-frontend-compat.patch
+
+    # By default apex's setup.py will taget all capabilities instead of using TORCH_CUDA_ARCH_LIST
+    # This result in the build failing on recent versions of CUDA.
+    # Instead, use TORCH_CUDA_ARCH_LIST as the source of truth for selecting capabilities
+    ./fix-cuda-capabilities-selection.patch
   ];
 
   # Don't use git submodules for cuda dependencies

--- a/pkgs/development/python-modules/apex/default.nix
+++ b/pkgs/development/python-modules/apex/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
 
   # build-system
+  ninja,
   setuptools,
   torch,
 
@@ -92,6 +93,7 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
   '';
 
   build-system = [
+    ninja
     setuptools
     torch
   ];

--- a/pkgs/development/python-modules/apex/fix-cuda-capabilities-selection.patch
+++ b/pkgs/development/python-modules/apex/fix-cuda-capabilities-selection.patch
@@ -1,0 +1,164 @@
+diff --git a/setup.py b/setup.py
+index fa61b72..c31d1e0 100644
+--- a/setup.py
++++ b/setup.py
+@@ -405,24 +405,8 @@ if has_flag("--cuda_ext", "APEX_CUDA_EXT"):
+     )
+ 
+     if bare_metal_version >= Version("11.0"):
+-
+-        cc_flag = []
+-        cc_flag.append("-gencode")
+-        cc_flag.append("arch=compute_70,code=sm_70")
+-        cc_flag.append("-gencode")
+-        cc_flag.append("arch=compute_80,code=sm_80")
+-        if bare_metal_version >= Version("11.1"):
+-            cc_flag.append("-gencode")
+-            cc_flag.append("arch=compute_86,code=sm_86")
+-        if bare_metal_version >= Version("11.8"):
+-            cc_flag.append("-gencode")
+-            cc_flag.append("arch=compute_90,code=sm_90")
+-        if bare_metal_version >= Version("12.8"):
+-            cc_flag.append("-gencode")
+-            cc_flag.append("arch=compute_100,code=sm_100")
+-            cc_flag.append("-gencode")
+-            cc_flag.append("arch=compute_120,code=sm_120")
+-
++        # Architectures are selected via TORCH_CUDA_ARCH_LIST (torch appends the
++        # matching -gencode flags) instead of a hard-coded list.
+         ext_modules.append(
+             CUDAExtension(
+                 name="fused_weight_gradient_mlp_cuda",
+@@ -441,7 +425,7 @@ if has_flag("--cuda_ext", "APEX_CUDA_EXT"):
+                         "--expt-relaxed-constexpr",
+                         "--expt-extended-lambda",
+                         "--use_fast_math",
+-                    ] + version_dependent_macros + cc_flag,
++                    ] + version_dependent_macros,
+                 },
+             )
+         )
+@@ -530,14 +514,7 @@ if has_flag("--group_norm", "APEX_GROUP_NORM"):
+         sys.argv.remove("--group_norm")
+     raise_if_cuda_home_none("--group_norm")
+ 
+-    # CUDA group norm supports from SM70
+-    arch_flags = []
+-    # FIXME: this needs to be done more cleanly
+-    for arch in [70, 75, 80, 86, 90, 100, 120]:
+-        arch_flag = f"-gencode=arch=compute_{arch},code=sm_{arch}"
+-        arch_flags.append(arch_flag)
+-    arch_flags.append(arch_flag)
+-
++    # Architectures are selected via TORCH_CUDA_ARCH_LIST instead of a hard-coded list.
+     ext_modules.append(
+         CUDAExtension(
+             name="group_norm_cuda",
+@@ -549,7 +526,7 @@ if has_flag("--group_norm", "APEX_GROUP_NORM"):
+                 "cxx": ["-O3", "-std=c++17"] + version_dependent_macros,
+                 "nvcc": [
+                     "-O3", "-std=c++17", "--use_fast_math", "--ftz=false",
+-                ] + arch_flags + version_dependent_macros,
++                ] + version_dependent_macros,
+             },
+         )
+     )
+@@ -651,22 +628,7 @@ if has_flag("--fast_layer_norm", "APEX_FAST_LAYER_NORM"):
+         sys.argv.remove("--fast_layer_norm")
+     raise_if_cuda_home_none("--fast_layer_norm")
+ 
+-    cc_flag = []
+-    cc_flag.append("-gencode")
+-    cc_flag.append("arch=compute_70,code=sm_70")
+-
+-    if bare_metal_version >= Version("11.0"):
+-        cc_flag.append("-gencode")
+-        cc_flag.append("arch=compute_80,code=sm_80")
+-    if bare_metal_version >= Version("11.8"):
+-        cc_flag.append("-gencode")
+-        cc_flag.append("arch=compute_90,code=sm_90")
+-    if bare_metal_version >= Version("12.8"):
+-        cc_flag.append("-gencode")
+-        cc_flag.append("arch=compute_100,code=sm_100")
+-        cc_flag.append("-gencode")
+-        cc_flag.append("arch=compute_120,code=sm_120")
+-
++    # Architectures are selected via TORCH_CUDA_ARCH_LIST instead of a hard-coded list.
+     ext_modules.append(
+         CUDAExtension(
+             name="fast_layer_norm",
+@@ -689,7 +651,7 @@ if has_flag("--fast_layer_norm", "APEX_FAST_LAYER_NORM"):
+                     "--expt-relaxed-constexpr",
+                     "--expt-extended-lambda",
+                     "--use_fast_math",
+-                ] + version_dependent_macros + generator_flag + cc_flag,
++                ] + version_dependent_macros + generator_flag,
+             },
+             include_dirs=[os.path.join(this_dir, "apex/contrib/csrc/layer_norm")],
+         )
+@@ -703,17 +665,18 @@ if has_flag("--fmha", "APEX_FMHA"):
+     if bare_metal_version < Version("11.0"):
+         raise RuntimeError("--fmha only supported on sm_80 and sm_90 GPUs")
+ 
++    # The fmha kernels use sm_80 MMA instructions, so select architectures from
++    # TORCH_CUDA_ARCH_LIST but drop anything below 8.0 (torch would otherwise also
++    # try to build the unsupported sm_75 target).
+     cc_flag = []
+-    cc_flag.append("-gencode")
+-    cc_flag.append("arch=compute_80,code=sm_80")
+-    if bare_metal_version >= Version("11.8"):
+-        cc_flag.append("-gencode")
+-        cc_flag.append("arch=compute_90,code=sm_90")
+-    if bare_metal_version >= Version("12.8"):
+-        cc_flag.append("-gencode")
+-        cc_flag.append("arch=compute_100,code=sm_100")
+-        cc_flag.append("-gencode")
+-        cc_flag.append("arch=compute_120,code=sm_120")
++    for arch in os.environ["TORCH_CUDA_ARCH_LIST"].replace(" ", ";").split(";"):
++        capability = arch.removesuffix("+PTX")
++        if not capability or Version(capability) < Version("8.0"):
++            continue
++        num = capability.replace(".", "")
++        cc_flag += ["-gencode", f"arch=compute_{num},code=sm_{num}"]
++        if arch.endswith("+PTX"):
++            cc_flag += ["-gencode", f"arch=compute_{num},code=compute_{num}"]
+ 
+     ext_modules.append(
+         CUDAExtension(
+@@ -755,25 +718,7 @@ if has_flag("--fast_multihead_attn", "APEX_FAST_MULTIHEAD_ATTN"):
+         sys.argv.remove("--fast_multihead_attn")
+     raise_if_cuda_home_none("--fast_multihead_attn")
+ 
+-    cc_flag = []
+-    cc_flag.append("-gencode")
+-    cc_flag.append("arch=compute_70,code=sm_70")
+-
+-    if bare_metal_version >= Version("11.0"):
+-        cc_flag.append("-gencode")
+-        cc_flag.append("arch=compute_80,code=sm_80")
+-    if bare_metal_version >= Version("11.1"):
+-        cc_flag.append("-gencode")
+-        cc_flag.append("arch=compute_86,code=sm_86")
+-    if bare_metal_version >= Version("11.8"):
+-        cc_flag.append("-gencode")
+-        cc_flag.append("arch=compute_90,code=sm_90")
+-    if bare_metal_version >= Version("12.8"):
+-        cc_flag.append("-gencode")
+-        cc_flag.append("arch=compute_100,code=sm_100")
+-        cc_flag.append("-gencode")
+-        cc_flag.append("arch=compute_120,code=sm_120")
+-
++    # Architectures are selected via TORCH_CUDA_ARCH_LIST instead of a hard-coded list.
+     subprocess.run(["git", "submodule", "update", "--init", "apex/contrib/csrc/multihead_attn/cutlass"])
+     ext_modules.append(
+         CUDAExtension(
+@@ -800,8 +745,7 @@ if has_flag("--fast_multihead_attn", "APEX_FAST_MULTIHEAD_ATTN"):
+                     "--use_fast_math",
+                 ]
+                 + version_dependent_macros
+-                + generator_flag
+-                + cc_flag,
++                + generator_flag,
+             },
+             include_dirs=[
+                 os.path.join(this_dir, "apex/contrib/csrc/multihead_attn/cutlass/include/"),


### PR DESCRIPTION
## Things done

On CUDA 13.2, building `python3Packages.apex` with `cudaCapabilities = [ "8.9" ]` (for example) fails with:
```
FAILED: [code=1] /build/apex/build/temp.linux-x86_64-cpython-313/fused_weight_gradient_mlp_cuda/csrc/megatron/fused_weight_gradient_dense_cuda.o
/nix/store/4afn4zvw26zcfl1ch0551qb731m38ccr-cuda13.2-cuda_nvcc-13.2.78/bin/nvcc -MD -MF /build/apex/build/temp.linux-x86_64-cpython-313/fused_weight_gradient_mlp_cuda/csrc/megatron/fused_weight_gradient_dense_cuda.o.d -I/build/apex/csrc -I/nix/store/n9078b8f3gn72xjhdg0m4s57lz21x6wd-python3.13-torch-2.11.0/lib/python3.13/site-packages/torch/include -I/nix/store/n9078b8f3gn72xjhdg0m4s57lz21x6wd-python3.13-torch-2.11.0/lib/python3.13/site-packages/torch/include/torch/csrc/api/include -I/nix/store/4afn4zvw26zcfl1ch0551qb731m38ccr-cuda13.2-cuda_nvcc-13.2.78/include -I/nix/store/60m4rxhg2fldqaak400c0lry96ijrzqn-python3-3.13.13/include/python3.13 -c -c /build/apex/csrc/megatron/fused_weight_gradient_dense_cuda.cu -o /build/apex/build/temp.linux-x86_64-cpython-313/fused_weight_gradient_mlp_cuda/csrc/megatron/fused_weight_gradient_dense_cuda.o -D__CUDA_NO_HALF_OPERATORS__ -D__CUDA_NO_HALF_CONVERSIONS__ -D__CUDA_NO_BFLOAT16_CONVERSIONS__ -D__CUDA_NO_HALF2_OPERATORS__ --expt-relaxed-constexpr --compiler-options ''"'"'-fPIC'"'"'' -O3 -U__CUDA_NO_HALF_OPERATORS__ -U__CUDA_NO_HALF_CONVERSIONS__ --expt-relaxed-constexpr --expt-extended-lambda --use_fast_math -DVERSION_GE_1_1 -DVERSION_GE_1_3 -DVERSION_GE_1_5 -gencode arch=compute_70,code=sm_70 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_90,code=sm_90 -gencode arch=compute_100,code=sm_100 -gencode arch=compute_120,code=sm_120 -DTORCH_API_INCLUDE_EXTENSION_H -DTORCH_EXTENSION_NAME=fused_weight_gradient_mlp_cuda -ccbin gcc -std=c++17
nvcc fatal   : Unsupported gpu architecture 'compute_70'
```

This is because `setup.py` will make sure to target older architectures no matter the value of `TORCH_CUDA_ARCH_LIST`.
I'm still wondering whether this is the intended behavior or not.

cc @NixOS/cuda-maintainers

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
