### PR TITLE
liblognorm: 2.0.9 -> 2.1.0

### DIFF
--- a/pkgs/by-name/li/liblognorm/package.nix
+++ b/pkgs/by-name/li/liblognorm/package.nix
@@ -1,34 +1,48 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  autoreconfHook,
   pkg-config,
   libestr,
   json_c,
-  pcre,
+  pcre2,
   libfastjson,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "liblognorm";
-  version = "2.0.9";
+  version = "2.1.0";
 
-  src = fetchurl {
-    url = "https://www.liblognorm.com/files/download/liblognorm-${finalAttrs.version}.tar.gz";
-    hash = "sha256-dsfMLLdqPVjncy4M/yORgPg/O2NQAriqBIZciBKFd5M=";
+  src = fetchFromGitHub {
+    owner = "rsyslog";
+    repo = "liblognorm";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XHfTSLYjfGRNmPUQrLWK+Co4v4cCmtfhZ0wruAC0RNI=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  postPatch = ''
+    patchShebangs tests/*.sh
+  '';
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
   buildInputs = [
     libestr
     json_c
-    pcre
+    pcre2
     libfastjson
   ];
 
   configureFlags = [ "--enable-regexp" ];
 
+  doCheck = true;
+
   meta = {
+    changelog = "https://github.com/rsyslog/liblognorm/blob/${finalAttrs.src.tag}/ChangeLog";
     description = "Help to make sense out of syslog data, or, actually, any event data that is present in text form";
     homepage = "https://www.liblognorm.com/";
     license = lib.licenses.lgpl21;


### PR DESCRIPTION
https://github.com/rsyslog/liblognorm/blob/v2.1.0/ChangeLog

Part of #356387 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
