### PR TITLE
lib.types.nullOr: implement v2 check & merge

### DIFF
--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -227,7 +227,7 @@ checkConfigError 'In attrTag, each tag value must be an option, but tag int was 
 checkConfigOutput '"ok"' config.assertions ./types.nix
 
 # types.nullOr
-checkConfigError 'The option .nullableValue\.mixed. is defined both null and not null, in .* and .*\.' config.nullableValue.mixed ./types.nix
+checkConfigError 'A definition for option .nullableValue\.mixed. is not of type .*\. TypeError: The option .nullableValue\.mixed. is defined both null and not null, in .* and .*\.' config.nullableValue.mixed ./types.nix
 
 # types.pathInStore
 checkConfigOutput '".*/store/0lz9p8xhf89kb1c1kk6jxrzskaiygnlh-bash-5.2-p15.drv"' config.pathInStore.ok1 ./types.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -226,6 +226,9 @@ checkConfigError 'In attrTag, each tag value must be an option, but tag int was 
 # types
 checkConfigOutput '"ok"' config.assertions ./types.nix
 
+# types.nullOr
+checkConfigError 'The option .nullableValue\.mixed. is defined both null and not null, in .* and .*\.' config.nullableValue.mixed ./types.nix
+
 # types.pathInStore
 checkConfigOutput '".*/store/0lz9p8xhf89kb1c1kk6jxrzskaiygnlh-bash-5.2-p15.drv"' config.pathInStore.ok1 ./types.nix
 checkConfigOutput '".*/store/0fb3ykw9r5hpayd05sr0cizwadzq1d8q-bash-5.2-p15"' config.pathInStore.ok2 ./types.nix

--- a/lib/tests/modules/types.nix
+++ b/lib/tests/modules/types.nix
@@ -60,6 +60,10 @@ in
     };
     nullableValue.list = [ { bar = [ 1 ]; } ]; # list
     nullableValue.lambda = x: x; # Error
+    nullableValue.mixed = lib.mkMerge [
+      null
+      "foo"
+    ]; # Error
 
     # serializableValueWith { nullable = false; }
     structuredValue.null = null; # Error

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1261,18 +1261,44 @@ rec {
         optionDescriptionPhrase (class: class == "noun" || class == "conjunction") elemType
       }";
       descriptionClass = "conjunction";
-      check = x: x == null || elemType.check x;
-      merge =
-        loc: defs:
-        let
-          nulls = filter (def: def.value == null) defs;
-        in
-        if nulls == [ ] then
-          elemType.merge loc defs
-        else if length nulls == length defs then
-          null
-        else
-          throw "The option `${showOption loc}` is defined both null and not null, in ${showFiles (getFiles defs)}.";
+      check = {
+        __functor = _self: x: x == null || elemType.check x;
+        isV2MergeCoherent = true;
+      };
+      merge = {
+        __functor =
+          self: loc: defs:
+          let
+            inherit (self.v2 { inherit loc defs; }) headError value;
+          in
+          if headError.causedByMixedNulls or false then throw headError.message else value;
+        v2 =
+          { loc, defs }:
+          if all (def: def.value != null) defs then
+            # There are no null values
+            if elemType.merge ? v2 then
+              checkV2MergeCoherence loc elemType (elemType.merge.v2 { inherit loc defs; })
+            else
+              {
+                value = elemType.merge loc defs;
+                headError = checkDefsForError elemType.check loc defs;
+                valueMeta = { };
+              }
+          else
+            # There are some null values
+            {
+              headError =
+                if length defs == 1 || all (def: def.value == null) defs then
+                  null
+                else
+                  {
+                    message = "The option `${showOption loc}` is defined both null and not null, in ${showFiles (getFiles defs)}.";
+                    causedByMixedNulls = true;
+                  };
+              value = null;
+              valueMeta = { };
+            };
+      };
       emptyValue = {
         value = null;
       };


### PR DESCRIPTION
There are still a few types using v1 `check` and `merge` functions. When these types delegate to other types, we end up losing information from v2 `check` and `merge`, such as `valueMeta`.

This PR upgrades `types.nullOr` to support v2 `check` and `merge`.

The existing v1 merge function had a `throw` if some definitions are null and others are not. I've added a test for that assertion and maintained it in the v2 impl via an internal `headError.causedByMixedNulls` attr. Without that attr, `elemType` errors would leak out and throw early, causing other tests to fail.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
    - `nix-build lib/tests/release.nix`
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
  - No AI was used in this PR.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
