### PR TITLE
docs: fix various typos and grammar errors in release notes

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -53,7 +53,7 @@
 
 - `cardboard` has been removed due to the package having been broken since at least November 2024.
 
-- `carla` no longer support `gtk2` override.
+- `carla` no longer supports `gtk2` override.
 
 - `chatgpt-retrieval-plugin` has been removed due to the package having been broken since at least November 2024.
 
@@ -431,7 +431,7 @@ and [release notes for v18](https://goteleport.com/docs/changelog/#1800-070325).
 
 - The `dockerTools.streamLayeredImage` builder now uses a better algorithm for generating layered docker images, such that much more sharing is possible when the number of store paths exceeds the layer limit. It gives each of the largest store paths its own layer and adds dependencies to those layers when they aren't used elsewhere.
 
-- The `open-webui` package's postgres support have been moved to optional dependencies to comply with upstream changes in 0.6.26.
+- The `open-webui` package's postgres support has been moved to optional dependencies to comply with upstream changes in 0.6.26.
 
 - The systemd initrd will now respect `x-systemd.wants` and `x-systemd.requires` for reliably unlocking multi-disk bcachefs volumes.
 

--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -105,7 +105,7 @@
 
 - `spoof` has been removed, as there are many issues upstream with it working on modern OS versions, and it appears to be unmaintained.
 
-- `duckstation` package has been removed, as it was requested by upstream and build source were changed to be incompatible with NixOS.
+- `duckstation` package has been removed, as it was requested by upstream and build sources were changed to be incompatible with NixOS.
 
 - `nodePackages.coc-go` and `nodePackages.coc-tsserver`, along with their vim plugins, have been removed from nixpkgs due to being unmaintained.
 
@@ -163,7 +163,7 @@
 
 `minio_legacy_fs` has been removed. Users should migrate to alternatives such as Garage, SeaweedFS, or Ceph. S3-compatible clients such as rclone can be used to move data.
 
-- `mercure` has been update to `0.21.4` (or later). Version [0.21.0](https://github.com/dunglas/mercure/releases/v0.21.0) and [0.21.2](https://github.com/dunglas/mercure/releases/tag/v0.21.2) introduce breaking changes to the package.
+- `mercure` has been updated to `0.21.4` (or later). Version [0.21.0](https://github.com/dunglas/mercure/releases/v0.21.0) and [0.21.2](https://github.com/dunglas/mercure/releases/tag/v0.21.2) introduce breaking changes to the package.
 
 - `mozc` and `mozc-ut` no longer contains the IBus front-end, which are now provided by `ibus-engines.mozc` and `ibus-engines.mozc-ut`.
 
@@ -171,7 +171,7 @@
 
 - `n8n` has been updated to version 2. You can find the breaking changes here: https://docs.n8n.io/2-0-breaking-changes/.
 
-- `nomad` has been updated to v1.11. Refer to the [release note](https://developer.hashicorp.com/nomad/docs/release-notes/nomad/v1-11-x) for more details. Once a new Nomad version has started and upgraded it's data directory, it generally cannot be downgraded to the previous version.
+- `nomad` has been updated to v1.11. Refer to the [release note](https://developer.hashicorp.com/nomad/docs/release-notes/nomad/v1-11-x) for more details. Once a new Nomad version has started and upgraded its data directory, it generally cannot be downgraded to the previous version.
 
 - The default NVIDIA drivers no longer support Maxwell (GTX 1xxx) or older GPUs. Pin the nvidia package to ` config.boot.kernelPackages.nvidiaPackages.legacy_580` for continued support.
 
@@ -185,9 +185,9 @@
   Please use [`pytestFlags` and `(enabled|disabled)(TestPaths|Tests|TestMarks)`](#using-pytestcheckhook) instead.
   If modifying the Nix expression is not feasible, users can remediate the error by overriding `pytestFlagsArray` with `null` or `[ ]`.
 
-- `python3Packages.pygame` has been been renamed to `python3Packages.pygame-original`, the attribute `python3Packages.pygame` will from python 3.14 default to the more actively maintained `python3Packages.pygame-ce`
+- `python3Packages.pygame` has been renamed to `python3Packages.pygame-original`, the attribute `python3Packages.pygame` will from python 3.14 default to the more actively maintained `python3Packages.pygame-ce`.
 
-- `fastly` has been updated to major version 14. For more information, you can check the [release notes](https://github.com/fastly/cli/releases/tag/v14.0.0)
+- `fastly` has been updated to major version 14. For more information, you can check the [release notes](https://github.com/fastly/cli/releases/tag/v14.0.0).
 
 - `peertube` has been updated from `7.3.0` to `8.0.2`, introducing several breaking changes.
   Some notable new features include channel collaboration and video player redesign with a new theme.
@@ -274,7 +274,7 @@
     IMAP_CERTIFICATE_VALIDATION=false
     ```
 
-- `python3packages.pillow-avif-plugin` has been removed as the functionality is included in `python3packages.pillow` directly since version 11.3.
+- `python3Packages.pillow-avif-plugin` has been removed as the functionality is included in `python3Packages.pillow` directly since version 11.3.
 
 - `wasistlos` (previously known as `whatsapp-for-linux`) has been removed because it was unmaintained and archived upstream.
   Multiple alternatives exist: `karere`, `whatsie` and `zapzap` among others.
@@ -328,7 +328,7 @@
 
 - The packages `ibtool`, `actool` and `re-plistbuddy` have been added, providing reimplementations of the corresponding proprietary Apple tools. They are more compatible with the originals than the previously existing `xcbuild` package, and should enable more darwin software to be built from source.
 
-- Switch inhibitors were introduced, which add a pre-switch check that compares a list of strings between the previous and the new generation, and refuses to switch into the new generation when there is a difference between the two lists. This allows to avoid switching into a system when for instance the systemd version changed by adding `config.systemd.package.version` to the switch inhibitors for your system. You can still forcefully switch into any generation by setting `NIXOS_NO_CHECK=1`.
+- Switch inhibitors were introduced, which add a pre-switch check that compares a list of strings between the previous and the new generation, and refuses to switch into the new generation when there is a difference between the two lists. This allows avoiding switching into a system when for instance the systemd version changed by adding `config.systemd.package.version` to the switch inhibitors for your system. You can still forcefully switch into any generation by setting `NIXOS_NO_CHECK=1`.
 
 - GNU Taler has been updated to version 1.3.
   This release focuses on getting everything ready for a deployment of GNU Taler by Magnet bank.

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -4,7 +4,7 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Added `nixos-init`, a Rust-based bashless initialization system for systemd initrd. This allows to build NixOS systems without any interpreter. Enable via `system.nixos-init.enable = true;`.
+- Added `nixos-init`, a Rust-based bashless initialization system for systemd initrd. This allows building NixOS systems without any interpreter. Enable via `system.nixos-init.enable = true;`.
 
 - COSMIC DE has been updated to the beta version, bringing it closer to its first stable release. This includes updates to its core components, applications, and overall stability.
 
@@ -41,7 +41,7 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Added `nixos-init`, a Rust-based bashless initialization system for systemd initrd. This allows to build NixOS systems without any interpreter. Enable via `system.nixos-init.enable = true;`.
+- Added `nixos-init`, a Rust-based bashless initialization system for systemd initrd. This allows building NixOS systems without any interpreter. Enable via `system.nixos-init.enable = true;`.
 
 - [angrr](https://github.com/linyinfeng/angrr), a service that automatically cleans up old auto GC roots. Available as [services.angrr](#opt-services.angrr.enable).
 
@@ -49,7 +49,7 @@
 
 - [Beszel](https://beszel.dev), a lightweight server monitoring hub with historical data, docker stats, and alerts. Available as [`services.beszel.agent`](options.html#opt-services.beszel.agent.enable) and [`services.beszel.hub`](options.html#opt-services.beszel.hub.enable).
 
-- [boot.kernel.sysfs](options.html#opt-boot.kernel.sysfs), a new way to set of sysfs attributes.
+- [boot.kernel.sysfs](options.html#opt-boot.kernel.sysfs), a new way to set sysfs attributes.
 
 - [Broadcast Box](https://github.com/Glimesh/broadcast-box), a WebRTC broadcast server. Available as [services.broadcast-box](options.html#opt-services.broadcast-box.enable).
 
@@ -222,7 +222,7 @@
 
 - `miniflux` no longer uses the hstore PostgreSQL extension. Having the extension would prevent Miniflux from starting. In case you are managing your `miniflux` PostgreSQL database externally, disable the extension with `DROP EXTENSION IF EXISTS hstore;`.
 
-- `netbox-manage` script created by the `netbox` module no longer uses `sudo -u netbox` internally. It can be run as root and will change it's user to `netbox` using `runuser`.
+- `netbox-manage` script created by the `netbox` module no longer uses `sudo -u netbox` internally. It can be run as root and will change its user to `netbox` using `runuser`.
 
 - NixOS display manager modules now strictly use tty1, where many of them previously used tty7. Options to configure display managers' VT have been dropped. A configuration with a display manager enabled will not start `getty@tty1.service`, even if the system is forced to boot into `multi-user.target` instead of `graphical.target`.
 
@@ -254,7 +254,7 @@
 
 - `services.nextcloud.notify_push.enable` now installs the notify_push app. Therefore the appstore is now disabled when using `notify_push`. See `services.nextcloud.appstoreEnable`.
 
-- `services.nixseparatedebuginfod.enable = true;` has been replaced by `services.nixseparatedebuginfod2.enable = true`. If you only use the official binary cache `https://cache.nixos.org` then no further configuration should be needed. If you have other https substituters, you can add them to `services.nixseparatedebuginfod2.subsituters`. SSH substituters are not supported by nixseparatedebuginfod2. Consider running nixseparatedebuginfod2 on the substituter instead, and pointing to it with the new option `environment.debuginfodServers`.
+- `services.nixseparatedebuginfod.enable = true;` has been replaced by `services.nixseparatedebuginfod2.enable = true`. If you only use the official binary cache `https://cache.nixos.org` then no further configuration should be needed. If you have other https substituters, you can add them to `services.nixseparatedebuginfod2.substituters`. SSH substituters are not supported by nixseparatedebuginfod2. Consider running nixseparatedebuginfod2 on the substituter instead, and pointing to it with the new option `environment.debuginfodServers`.
 
 - `services.parsoid` and the `nodePackages.parsoid` package have been removed, as the JavaScript-based version this module uses is not compatible with modern MediaWiki versions.
 

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -274,7 +274,7 @@ of pulling the upstream container image from Docker Hub. If you want the old beh
   for further information.
 
   Please do note that there's no official way to rotate. On a single-node instance with the database and the secret-key being
-  on the same filesystem with the same permissions for Grafana only to read it's most likely OK to keep using the old key.
+  on the same filesystem with the same permissions for Grafana only to read its most likely OK to keep using the old key.
 
   If you need to rotate, a [3rd-party tool, `grafana-secretkey-rotation-tool`](https://github.com/erooke/grafana-secretkey-rotation-tool/tree/d9dc788902fa5185e15cb15ce6129f7237ab6138) is a tested option.
   When using a secret for this value, make sure to use [Grafana's variable expansion to inject secrets](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#variable-expansion).
@@ -312,7 +312,7 @@ of pulling the upstream container image from Docker Hub. If you want the old beh
 
 - `walker` has been updated to 2.0.0+, which is a complete rewrite in rust.
 
-  It now requires a running `elephant` application launcher backend service, which can be enabled using the new `services.elephpant.enable`.
+  It now requires a running `elephant` application launcher backend service, which can be enabled using the new `services.elephant.enable`.
 
   The way keybinds and actions are handled have been completely revamped. Please refer to the [default config](https://raw.githubusercontent.com/abenz1267/walker/refs/heads/master/resources/config.toml).
 


### PR DESCRIPTION
Fixes a few instances of incorrect grammar and typos in 25.11 and 26.05 changelogs.

I was looking for some incorrect entries that ended up in 25.11 docs, but found some typos and grammar errors instead. Decided to fix those anyway since people might still end up reading 25.11 docs when upgrading from earlier versions.

Change-Id: I51346308f175aabf51751cab517173286a6a6964
