### PR TITLE
rhodium-libre, vt323, ostrich-sans, zilla-slab, drafting-mono: use installFonts hook

### DIFF
--- a/pkgs/by-name/dr/drafting-mono/package.nix
+++ b/pkgs/by-name/dr/drafting-mono/package.nix
@@ -2,10 +2,17 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  installFonts,
 }:
+
 stdenvNoCC.mkDerivation {
   pname = "drafting-mono";
   version = "1.1-unstable-2024-06-04";
+
+  outputs = [
+    "out"
+    "webfont"
+  ];
 
   src = fetchFromGitHub {
     owner = "indestructible-type";
@@ -14,14 +21,7 @@ stdenvNoCC.mkDerivation {
     hash = "sha256-J64mmDOzTV4MRuZO3MB2SSX5agCRjLDjXAPXuDfdlOM=";
   };
 
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/share/fonts/truetype
-    cp fonts/*/*.otf $out/share/fonts/truetype
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     homepage = "https://indestructibletype.com/Drafting/";

--- a/pkgs/by-name/os/ostrich-sans/package.nix
+++ b/pkgs/by-name/os/ostrich-sans/package.nix
@@ -2,11 +2,17 @@
   lib,
   fetchFromGitHub,
   stdenvNoCC,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation {
   pname = "ostrich-sans";
   version = "2014-04-18";
+
+  outputs = [
+    "out"
+    "webfont"
+  ];
 
   src = fetchFromGitHub {
     owner = "theleagueof";
@@ -15,13 +21,7 @@ stdenvNoCC.mkDerivation {
     hash = "sha256-vvTNtl+fO2zWooH1EvCmO/dPYYgCkj8Ckg5xfg1gtnw=";
   };
 
-  installPhase = ''
-    runHook preInstall
-
-    install -D -m444 -t $out/share/fonts/opentype $src/*.otf
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     description = "Gorgeous modern sans-serif with a very long neck";

--- a/pkgs/by-name/rh/rhodium-libre/package.nix
+++ b/pkgs/by-name/rh/rhodium-libre/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -15,14 +16,7 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-YCQvUdjEAj4G71WCRCM0+NwiqRqwt1Ggeg9jb/oWEsY=";
   };
 
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm444 -t $out/share/fonts/opentype/ RhodiumLibre-Regular.otf
-    install -Dm444 -t $out/share/fonts/truetype/ RhodiumLibre-Regular.ttf
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     description = "F/OSS/Libre font for Latin and Devanagari";

--- a/pkgs/by-name/vt/vt323/package.nix
+++ b/pkgs/by-name/vt/vt323/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  installFonts,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -15,9 +16,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Abq0/hU/BXJMxQxzhZG1SEGIZYt+qofuXwy5/A9byQ8=";
   };
 
-  installPhase = ''
-    mkdir -p $out/share/fonts/truetype
-    cp fonts/ttf/VT323-Regular.ttf $out/share/fonts/truetype
+  nativeBuildInputs = [ installFonts ];
+
+  preInstall = ''
+    rm -r old
   '';
 
   meta = {

--- a/pkgs/by-name/zi/zilla-slab/package.nix
+++ b/pkgs/by-name/zi/zilla-slab/package.nix
@@ -2,11 +2,17 @@
   lib,
   stdenvNoCC,
   fetchzip,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "zilla-slab";
   version = "1.002";
+
+  outputs = [
+    "out"
+    "webfont"
+  ];
 
   src = fetchzip {
     url = "https://github.com/mozilla/zilla-slab/releases/download/v${version}/Zilla-Slab-Fonts-v${version}.zip";
@@ -14,14 +20,7 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-yOHu+dSWlyI7w1N1teED9R1Fphso2bKAlYDC1KdqBCc=";
   };
 
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/share/fonts/truetype
-    cp -v zilla-slab/ttf/*.ttf $out/share/fonts/truetype/
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     homepage = "https://github.com/mozilla/zilla-slab";


### PR DESCRIPTION
Part of #495640

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test