### PR TITLE
kmod: 31 -> 34.2

### DIFF
--- a/pkgs/os-specific/linux/kmod/default.nix
+++ b/pkgs/os-specific/linux/kmod/default.nix
@@ -2,22 +2,18 @@
   stdenv,
   lib,
   fetchzip,
-  fetchpatch,
-  autoconf,
-  automake,
-  docbook_xml_dtd_42,
-  docbook_xml_dtd_43,
   docbook_xsl,
   gtk-doc,
-  libtool,
   pkg-config,
-  libxslt,
   xz,
   zstd,
-  elf-header,
   withDevdoc ? stdenv.hostPlatform == stdenv.buildPlatform,
   withStatic ? stdenv.hostPlatform.isStatic,
   gitUpdater,
+  scdoc,
+  meson,
+  ninja,
+  zlib,
 }:
 
 let
@@ -26,21 +22,16 @@ let
     "/run/current-system/kernel-modules"
     ""
   ];
-  modulesDirs = lib.concatMapStringsSep ":" (x: "${x}/lib/modules") systems;
+  modulesDirs = lib.concatMapStringsSep "," (x: "${x}/lib/modules") systems;
 
 in
 stdenv.mkDerivation rec {
   pname = "kmod";
-  version = "31";
+  version = "34.2";
 
-  # autogen.sh is missing from the release tarball,
-  # and we need to run it to regenerate gtk_doc.make,
-  # because the version in the release tarball is broken.
-  # Possibly this will be fixed in kmod 30?
-  # https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git/commit/.gitignore?id=61a93a043aa52ad62a11ba940d4ba93cb3254e78
   src = fetchzip {
     url = "https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git/snapshot/kmod-${version}.tar.gz";
-    hash = "sha256-FNR015/AoYBbi7Eb1M2TXH3yxUuddKICCu+ot10CdeQ=";
+    hash = "sha256-+fSM9ver+Yg9YbKuqiheKbqkLaZBPRuu0dey6gXQHyE=";
   };
 
   outputs = [
@@ -53,69 +44,108 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
   nativeBuildInputs = [
-    autoconf
-    automake
+    meson
+    ninja
     docbook_xsl
-    libtool
-    libxslt
     pkg-config
 
-    docbook_xml_dtd_42 # for the man pages
+    scdoc # for the man pages
   ]
   ++ lib.optionals withDevdoc [
-    docbook_xml_dtd_43
     gtk-doc
   ];
   buildInputs = [
     xz
     zstd
-  ]
-  # gtk-doc is looked for with pkg-config
-  ++ lib.optionals withDevdoc [ gtk-doc ];
+    zlib
+  ];
 
-  preConfigure = ''
-    ./autogen.sh
-  '';
-
-  configureFlags = [
-    "--sysconfdir=/etc"
-    "--with-xz"
-    "--with-zstd"
-    "--with-modulesdirs=${modulesDirs}"
-    (lib.enableFeature withDevdoc "gtk-doc")
+  mesonFlags = [
+    (lib.mesonOption "sysconfdir" "/etc")
+    (lib.mesonEnable "xz" true)
+    (lib.mesonEnable "zstd" true)
+    (lib.mesonEnable "openssl" false)
+    (lib.mesonOption "modulesdirs" modulesDirs)
+    (lib.mesonBool "docs" withDevdoc)
+    (lib.mesonBool "manpages" true)
+    (lib.mesonBool "build-tests" doCheck)
   ]
-  ++ lib.optional withStatic "--enable-static";
+  ++ lib.optional withStatic (lib.mesonOption "default_library" "static");
 
   patches = [
     # Accept multiple default kernel module dirs at build-time, instead
-    # of hardcoding a single /lib/modules, and adjust module search logic
+    # of hardcoding a single (MODULE_DIRECTORY), and adjust module search logic
     # accordingly (to account for multiple default directories)
     ./module-dir.patch
-
-    # Use portable implementation for basename API
-    #
-    # musl has removed the non-prototype declaration of basename from string.h
-    # which now results in build errors with clang-17+ compiler
-    #
-    # Implement GNU basename behavior using strchr which is portable across libcs
-    #
-    # Fixes "call to undeclared function 'basename'" error on clang+musl
-    (fetchpatch {
-      name = "musl.patch";
-      url = "https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git/patch/?id=11eb9bc67c319900ab00523997323a97d2d08ad2";
-      hash = "sha256-CYG615elMWces6QGQRg2H/NL7W4XsG9Zvz5H+xsdFFo=";
-    })
+    # Don't create empty confdirs at install time
+    ./dont-create-empty-confdirs.patch
   ]
-  # Force configure.ac to accept --enable-static (no other changes necessary)
+  # Force meson.build to support static builds
+  # based on the patch from
+  # https://github.com/bottlerocket-os/bottlerocket-core-kit/commit/81edc05400b05080941faed66f8ae9d5babb7ab1
   ++ lib.optional withStatic ./enable-static.patch;
 
-  postInstall = ''
-    for prog in rmmod insmod lsmod modinfo modprobe depmod; do
-      ln -sv $out/bin/kmod $out/bin/$prog
+  postPatch = ''
+    patchShebangs scripts/
+  '';
+
+  doCheck = true;
+
+  # The upstream Meson suite mixes pure unit tests with checks that need a
+  # fake module playground and kernel-style filesystem state. Run the
+  # self-contained unit tests directly instead of the full Meson suite.
+  checkPhase = ''
+    runHook preCheck
+
+    ninja \
+      testsuite/test-array \
+      testsuite/test-blacklist \
+      testsuite/test-dependencies \
+      testsuite/test-depmod \
+      testsuite/test-hash \
+      testsuite/test-init \
+      testsuite/test-initstate \
+      testsuite/test-list \
+      testsuite/test-loaded \
+      testsuite/test-modinfo \
+      testsuite/test-modprobe \
+      testsuite/test-new-module \
+      testsuite/test-strbuf \
+      testsuite/test-util \
+      testsuite/test-weakdep
+
+    ./testsuite/test-array
+    ./testsuite/test-hash
+    ./testsuite/test-list
+    ./testsuite/test-strbuf
+
+    for testName in \
+      test_strchr_replace \
+      test_underscores \
+      test_path_ends_with_kmod_ext \
+      test_uadd32_overflow \
+      test_uadd64_overflow \
+      test_umul32_overflow \
+      test_umul64_overflow \
+      test_backoff_time
+    do
+      ./testsuite/test-util -n "$testName"
     done
 
-    # Backwards compatibility
-    ln -s bin $out/sbin
+    # The rest of the tests are disabled because they require extra setup
+    # ./testsuite/test-blacklist
+    # ./testsuite/test-dependencies
+    # ./testsuite/test-depmod
+    # ./testsuite/test-init
+    # ./testsuite/test-initstate
+    # ./testsuite/test-loaded
+    # ./testsuite/test-modinfo
+    # ./testsuite/test-modprobe
+    # ./testsuite/test-new-module
+    # ./testsuite/test-util
+    # ./testsuite/test-weakdep
+
+    runHook postCheck
   '';
 
   passthru.updateScript = gitUpdater {

--- a/pkgs/os-specific/linux/kmod/default.nix
+++ b/pkgs/os-specific/linux/kmod/default.nix
@@ -170,7 +170,10 @@ stdenv.mkDerivation rec {
       gpl2Plus
     ]; # GPLv2+ for tools
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ artturin ];
+    maintainers = with lib.maintainers; [
+      artturin
+      joaosreis
+    ];
     teams = [ lib.teams.security-review ];
     identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "kernel" version;
   };

--- a/pkgs/os-specific/linux/kmod/dont-create-empty-confdirs.patch
+++ b/pkgs/os-specific/linux/kmod/dont-create-empty-confdirs.patch
@@ -1,0 +1,16 @@
+diff --git a/meson.build b/meson.build
+index de85f05..c79b5af 100644
+--- a/meson.build
++++ b/meson.build
+@@ -245,11 +245,6 @@ endforeach
+ 
+ add_project_arguments('-DMODULESDIRS=' + modulesdirs_define, language : 'c')
+ 
+-foreach confdir : [sysconfdir, distconfdir]
+-  install_emptydir(confdir / 'depmod.d')
+-  install_emptydir(confdir / 'modprobe.d')
+-endforeach
+-
+ _completiondirs = [
+   ['bash', 'bash-completion', 'bash-completion' / 'completions', '@0@'],
+   ['fish', 'fish',            'fish' / 'vendor_functions.d',     '@0@.fish'],

--- a/pkgs/os-specific/linux/kmod/enable-static.patch
+++ b/pkgs/os-specific/linux/kmod/enable-static.patch
@@ -1,12 +1,63 @@
-diff --git a/configure.ac b/configure.ac
-index ee72283..b42c42a 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -19,7 +19,6 @@ AM_SILENT_RULES([yes])
- LT_INIT([disable-static pic-only])
- DOLT
+diff --git a/meson.build b/meson.build
+index a0cf675..5b1b70a 100644
+--- a/meson.build
++++ b/meson.build
+@@ -421,18 +421,29 @@ endif
  
--AS_IF([test "x$enable_static" = "xyes"], [AC_MSG_ERROR([--enable-static is not supported by kmod])])
- AS_IF([test "x$enable_largefile" = "xno"], [AC_MSG_ERROR([--disable-largefile is not supported by kmod])])
+ install_headers('libkmod/libkmod.h')
  
- #####################################################################
+-libkmod = shared_library(
+-  'kmod',
+-  libkmod_files,
+-  dependencies : libkmod_deps + cdeps,
+-  link_with : libshared,
+-  link_args : ['-Wl,--version-script', meson.current_source_dir() /
+-                                                  'libkmod/libkmod.sym'],
+-  link_depends : files('libkmod/libkmod.sym'),
+-  gnu_symbol_visibility : 'hidden',
+-  version : '2.5.1',
+-  install : true,
+-)
++if get_option('default_library') == 'static'
++  libkmod = static_library(
++    'kmod',
++    libkmod_files,
++    dependencies : libkmod_deps + cdeps,
++    link_with : libshared,
++    gnu_symbol_visibility : 'hidden',
++    install : true,
++  )
++else
++  libkmod = shared_library(
++    'kmod',
++    libkmod_files,
++    dependencies : libkmod_deps + cdeps,
++    link_with : libshared,
++    link_args : ['-Wl,--version-script', meson.current_source_dir() /
++                                                    'libkmod/libkmod.sym'],
++    link_depends : files('libkmod/libkmod.sym'),
++    gnu_symbol_visibility : 'hidden',
++    version : '2.5.1',
++    install : true,
++  )
++endif
+ 
+ pkg.generate(
+   name : 'libkmod',
+@@ -465,10 +476,16 @@ kmod_sources = files(
+   'tools/static-nodes.c',
+ )
+ 
++kmod_link_args = []
++if get_option('default_library') == 'static'
++  kmod_link_args += ['-static']
++endif
++
+ kmod = executable(
+   'kmod',
+   kmod_sources,
+   link_with : [libshared, libkmod_internal],
++  link_args : kmod_link_args,
+   gnu_symbol_visibility : 'hidden',
+   build_by_default : get_option('tools'),
+   install : get_option('tools'),

--- a/pkgs/os-specific/linux/kmod/module-dir.patch
+++ b/pkgs/os-specific/linux/kmod/module-dir.patch
@@ -1,41 +1,12 @@
-diff --git a/Makefile.am b/Makefile.am
-index d4eeb7e..5c9f603 100644
---- a/Makefile.am
-+++ b/Makefile.am
-@@ -19,6 +19,7 @@ AM_CPPFLAGS = \
- 	-include $(top_builddir)/config.h \
- 	-I$(top_srcdir) \
- 	-DSYSCONFDIR=\""$(sysconfdir)"\" \
-+	-DMODULESDIRS=\""$(shell echo $(modulesdirs) | $(SED) 's|:|\\",\\"|g')"\" \
- 	${zlib_CFLAGS}
- 
- AM_CFLAGS = $(OUR_CFLAGS)
-diff --git a/configure.ac b/configure.ac
-index 23510c8..66490cf 100644
---- a/configure.ac
-+++ b/configure.ac
-@@ -202,6 +202,12 @@ GTK_DOC_CHECK([1.14],[--flavour no-tmpl-flat])
- ], [
- AM_CONDITIONAL([ENABLE_GTK_DOC], false)])
- 
-+AC_ARG_WITH([modulesdirs],
-+	AS_HELP_STRING([--with-modulesdirs=DIRS], [Kernel modules directories, separated by :]),
-+	[],
-+	[with_modulesdirs=/lib/modules])
-+AC_SUBST([modulesdirs], [$with_modulesdirs])
-+
- 
- #####################################################################
- # Default CFLAGS and LDFLAGS
 diff --git a/libkmod/libkmod.c b/libkmod/libkmod.c
-index 69fe431..d37da32 100644
+index f4510d0..c94ff24 100644
 --- a/libkmod/libkmod.c
 +++ b/libkmod/libkmod.c
-@@ -206,12 +206,15 @@ static int log_priority(const char *priority)
+@@ -162,12 +162,15 @@ static int log_priority(const char *priority)
  	return 0;
  }
  
--static const char *dirname_default_prefix = "/lib/modules";
+-static const char *dirname_default_prefix = MODULE_DIRECTORY;
 +static const char *dirname_default_prefixes[] = {
 +	MODULESDIRS,
 +	NULL
@@ -49,7 +20,7 @@ index 69fe431..d37da32 100644
  
  	if (dirname != NULL)
  		return path_make_absolute_cwd(dirname);
-@@ -219,8 +222,42 @@ static char *get_kernel_release(const char *dirname)
+@@ -175,8 +178,42 @@ static char *get_kernel_release(const char *dirname)
  	if (uname(&u) < 0)
  		return NULL;
  
@@ -94,11 +65,59 @@ index 69fe431..d37da32 100644
  
  	return p;
  }
+diff --git a/meson.build b/meson.build
+index a0cf675..59975c5 100644
+--- a/meson.build
++++ b/meson.build
+@@ -193,6 +193,25 @@ datadir = prefixdir / get_option('datadir')
+ 
+ distconfdir = get_option('distconfdir')
+ moduledir = get_option('moduledir')
++modulesdirs = get_option('modulesdirs')
++
++modulesdirs_list = []
++foreach dir : modulesdirs
++  if not dir.startswith('/')
++    error('User provided modulesdirs, \'@0@\' is not an absolute path.'.format(dir))
++  endif
++  modulesdirs_list += ['/' + dir.strip('/')]
++endforeach
++
++modulesdirs_define = ''
++foreach dir : modulesdirs_list
++  if modulesdirs_define != ''
++    modulesdirs_define += ','
++  endif
++  modulesdirs_define += '"' + dir + '"'
++endforeach
++
++add_project_arguments('-DMODULESDIRS=' + modulesdirs_define, language : 'c')
+ 
+ bashcompletiondir = get_option('bashcompletiondir')
+ fishcompletiondir = get_option('fishcompletiondir')
+diff --git a/meson_options.txt b/meson_options.txt
+index 3d41fae..b58a7d2 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -12,6 +12,13 @@ option(
+   description : 'Directory to look for kernel modules. Default: /lib/modules',
+ )
+ 
++option(
++  'modulesdirs',
++  type : 'array',
++  value : ['/lib/modules'],
++  description : 'Kernel modules directories.',
++)
++
+ option(
+   'bashcompletiondir',
+   type : 'string',
 diff --git a/tools/static-nodes.c b/tools/static-nodes.c
-index 8d2356d..2ed306d 100644
+index 9af30eb..ae6ab07 100644
 --- a/tools/static-nodes.c
 +++ b/tools/static-nodes.c
-@@ -29,10 +29,11 @@
+@@ -17,10 +17,11 @@
  #include <unistd.h>
  #include <sys/stat.h>
  #include <sys/types.h>
@@ -111,17 +130,17 @@ index 8d2356d..2ed306d 100644
  #include "kmod.h"
  
  struct static_nodes_format {
-@@ -154,8 +155,8 @@ static void help(void)
+@@ -143,8 +144,8 @@ static void help(void)
  
  static int do_static_nodes(int argc, char *argv[])
  {
 -	struct utsname kernel;
- 	char modules[PATH_MAX], buf[4096];
+ 	char modules[PATH_MAX], buf[PATH_MAX];
 +	struct kmod_ctx *ctx;
- 	const char *output = "/dev/stdout";
+ 	const char *output = NULL;
  	FILE *in = NULL, *out = NULL;
  	const struct static_nodes_format *format = &static_nodes_format_human;
-@@ -206,22 +207,25 @@ static int do_static_nodes(int argc, char *argv[])
+@@ -193,35 +194,26 @@ static int do_static_nodes(int argc, char *argv[])
  		}
  	}
  
@@ -133,23 +152,33 @@ index 8d2356d..2ed306d 100644
  		ret = EXIT_FAILURE;
  		goto finish;
  	}
--
--	snprintf(modules, sizeof(modules), "/lib/modules/%s/modules.devname", kernel.release);
+ 
+-	r = snprintf(modules, sizeof(modules), MODULE_DIRECTORY "/%s/modules.devname",
+-		     kernel.release);
+-	if (r >= (int)sizeof(modules)) {
+-		fprintf(stderr,
+-			"Error: could not open " MODULE_DIRECTORY
+-			"/%s/modules.devname - path too long\n",
+-			kernel.release);
 +	if (snprintf(modules, sizeof(modules), "%s/modules.devname", kmod_get_dirname(ctx)) < 0) {
 +		fprintf(stderr, "Error: path to modules.devname is too long\n");
-+		ret = EXIT_FAILURE;
-+		goto finish;
-+	}
+ 		ret = EXIT_FAILURE;
+ 		goto finish;
+ 	}
 +	kmod_unref(ctx);
  	in = fopen(modules, "re");
  	if (in == NULL) {
  		if (errno == ENOENT) {
--			fprintf(stderr, "Warning: /lib/modules/%s/modules.devname not found - ignoring\n",
+-			fprintf(stderr,
+-				"Warning: " MODULE_DIRECTORY
+-				"/%s/modules.devname not found - ignoring\n",
 -				kernel.release);
 +			fprintf(stderr, "Warning: %s not found - ignoring\n", modules);
  			ret = EXIT_SUCCESS;
  		} else {
--			fprintf(stderr, "Error: could not open /lib/modules/%s/modules.devname - %m\n",
+-			fprintf(stderr,
+-				"Error: could not open " MODULE_DIRECTORY
+-				"/%s/modules.devname - %m\n",
 -				kernel.release);
 +			fprintf(stderr, "Error: could not open %s - %m\n", modules);
  			ret = EXIT_FAILURE;


### PR DESCRIPTION
Changelog: https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git/plain/NEWS?h=v34.2

This PR also enables running upstream kmod tests.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
