### PR TITLE
npins: 0.4.1 -> 0.5.0

### DIFF
--- a/pkgs/by-name/np/npins/package.nix
+++ b/pkgs/by-name/np/npins/package.nix
@@ -1,8 +1,10 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
   makeWrapper,
+  installShellFiles,
 
   # runtime dependencies
   nix-prefetch-git,
@@ -19,25 +21,44 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "npins";
-  version = "0.4.1";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "andir";
     repo = "npins";
     tag = finalAttrs.version;
-    sha256 = "sha256-XzJaDf5tlrYGTMJ+eS9hH9l79S4JA8h2KfbvKHF14xY=";
+    sha256 = "sha256-OkPEh0axWs3gUoUyplQexYpEXxyCDYWm5BQpwB2PIqA=";
   };
 
-  cargoHash = "sha256-Fiku3UULsm6HL1skjJA/UiW9VRFRWbnXULQFBiVDCJ0=";
+  cargoHash = "sha256-ZbdAvt2FRq5fHS0RRndeCrpY3j8Lvn2oTAECteIss5A=";
 
-  nativeBuildInputs = [ makeWrapper ];
+  cargoBuildFlags = [
+    "-p"
+    "npins"
+    "-p"
+    "npins-completions"
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    installShellFiles
+  ];
 
   # (Almost) all tests require internet
   doCheck = false;
 
-  postFixup = ''
-    wrapProgram $out/bin/npins --prefix PATH : "${runtimePath}"
-  '';
+  postFixup =
+    lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      installShellCompletion --cmd npins \
+        --bash <($out/bin/npins-completions bash) \
+        --fish <(cat <($out/bin/npins-completions fish) $src/completions/pin-completions.fish) \
+        --zsh <($out/bin/npins-completions zsh)
+
+      rm $out/bin/npins-completions
+    ''
+    + ''
+      wrapProgram $out/bin/npins --prefix PATH : "${runtimePath}"
+    '';
 
   meta = {
     description = "Simple and convenient dependency pinning for Nix";


### PR DESCRIPTION
Changelog: https://github.com/andir/npins/releases/tag/0.5.0
Diff: https://github.com/andir/npins/compare/0.4.1...0.5.0 (diff is bit a scuffed due to rebasing shenanigans involved in 0.4.1)

This release includes the completion support added to npins, so the necessary nix code for that has been copied over from its own packaging. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
