### PR TITLE
meshtastic-desktop: init at 2.7.14

### DIFF
--- a/pkgs/by-name/me/meshtastic-desktop/package.nix
+++ b/pkgs/by-name/me/meshtastic-desktop/package.nix
@@ -1,0 +1,64 @@
+{
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  dpkg,
+  makeBinaryWrapper,
+  gtk4,
+  alsa-lib,
+  lib,
+  libxtst,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "meshtastic-desktop";
+  version = "2.7.14";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchurl {
+    url = "https://github.com/meshtastic/Meshtastic-Android/releases/download/v${finalAttrs.version}-open.14/meshtastic-desktop_${finalAttrs.version}_amd64.deb";
+    hash = "sha256-zwXuOQ70gBlNgcE7yDKOxQ0SEbNvDfFxD5+pRcPW1wQ=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    dpkg
+    makeBinaryWrapper
+  ];
+
+  buildInputs = [
+    gtk4
+    alsa-lib
+    libxtst
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p {$out,$out/bin,$out/share}
+    cp -a opt/meshtastic-desktop $out/share/
+    ln -s "$out/share/meshtastic-desktop/bin/Meshtastic Desktop" $out/bin/
+
+    install -Dm644 opt/meshtastic-desktop/lib/meshtastic-desktop-Meshtastic_Desktop.desktop $out/share/applications/Meshtastic_Desktop.desktop
+
+    substituteInPlace $out/share/applications/Meshtastic_Desktop.desktop \
+      --replace-fail "/opt/meshtastic-desktop/bin/Meshtastic Desktop" "Meshtastic Desktop" \
+      --replace-fail "/opt/meshtastic-desktop/lib/Meshtastic_Desktop.png" "Meshtastic_Desktop.png"
+
+    install -Dm655 -t $out/share/icons/hicolor/scalable/apps opt/meshtastic-desktop/lib/Meshtastic_Desktop.png
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Desktop application for Meshtastic";
+    mainProgram = "Meshtastic Desktop";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ drupol ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
