### PR TITLE
docs: more fixes to release notes

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -44,7 +44,7 @@
 
 - `base16-builder` node package has been removed due to lack of upstream maintenance.
 
-- `budgie-desktop` has been updated [10.9.4](https://github.com/BuddiesOfBudgie/budgie-desktop/releases/tag/v10.9.4). This changes `XDG_CURRENT_DESKTOP` from `Budgie:GNOME` to `Budgie` and contains ABI bumps for libpeas2 migration.
+- `budgie-desktop` has been updated to [10.9.4](https://github.com/BuddiesOfBudgie/budgie-desktop/releases/tag/v10.9.4). This changes `XDG_CURRENT_DESKTOP` from `Budgie:GNOME` to `Budgie` and contains ABI bumps for libpeas2 migration.
 
 - `buildGoModule` removes the compatibility layer of `CGO_ENABLED` not specified via `env`.
   Specifying `CGO_ENABLED` directly now results in an error.
@@ -135,7 +135,7 @@
 
 - `linux` and all other Linux kernel packages have moved all in-tree kernel modules into a new `modules` output.
 
-- `lxde` scope has been removed, and its packages have been moved the top-level.
+- `lxde` scope has been removed, and its packages have been moved to the top-level.
 
 - `mariadb` now defaults to `mariadb_114` instead of `mariadb_1011`, meaning the default version was upgraded from 10.11.x to 11.4.x. See the [upgrade notes](https://mariadb.com/kb/en/upgrading-from-mariadb-10-11-to-mariadb-11-4/) for potential issues.
 
@@ -183,7 +183,7 @@
 - `pcp` has been removed because the upstream repo was archived and it hasn't been updated since 2021.
 
 - `podofo` has been updated from `0.9.8` to `1.0.0`. These releases are by nature very incompatible due to major API changes. The legacy versions can be found under `podofo_0_10` and `podofo_0_9`.
-  Changelog: https://github.com/podofo/podofo/blob/1.0.0/CHANGELOG.md, API-Migration-Guide: https://github.com/podofo/podofo/blob/1.0.0/API-MIGRATION.md.
+  Changelog: <https://github.com/podofo/podofo/blob/1.0.0/CHANGELOG.md>, API-Migration-Guide: <https://github.com/podofo/podofo/blob/1.0.0/API-MIGRATION.md>.
 
 - `privatebin` has been updated to `2.0.0`. This release changes configuration defaults including switching the template and removing legacy features. See the [v2.0.0 changelog entry](https://github.com/PrivateBin/PrivateBin/releases/tag/2.0.0) for details on how to upgrade.
 
@@ -246,7 +246,7 @@
 
 - `sublime-music` has been removed because upstream has announced it is no longer maintained. Upstream suggests using `supersonic` instead.
 
-- Support for bootstrapping native GHC compilers on 32‐bit ARM and little‐endian 64‐bit PowerPC has been dropped.
+- Support for bootstrapping native GHC compilers on 32‐bit ARM and little‐endian 64-bit PowerPC has been dropped.
   The latter was probably broken anyway.
   If there is interest in restoring support for these architectures, it should be possible to cross‐compile a bootstrap GHC binary.
 
@@ -359,7 +359,7 @@ and [release notes for v18](https://goteleport.com/docs/changelog/#1800-070325).
 
 - `ffmpeg_8`, `ffmpeg_8-headless`, and `ffmpeg_8-full` have been added. The default version of FFmpeg is now `ffmpeg_8`. You can install previous versions from package attributes such as `ffmpeg_7`.
 
-- `forgejo-runner` upgrading to version 11 brings a license change from MIT to GPLv3-or-later.
+- `forgejo-runner` has been upgraded to version 11, which brings a license change from MIT to GPLv3-or-later.
 
 - GIMP now defaults to version 3. Use `gimp2` for the old version.
 
@@ -405,8 +405,6 @@ and [release notes for v18](https://goteleport.com/docs/changelog/#1800-070325).
 
 - `prl-tools` has been moved out of `linuxPackages` because Parallels Guest Tools become driverless since 26.1.0.
 
-- `searx` was updated to use `envsubst` instead of `sed` for parsing secrets from environment variables.
-
 - `sftpman` has been updated to version 2, a rewrite in Rust which is mostly backward compatible but does include some changes to the CLI.
   For more information, [check the project's README](https://github.com/spantaleev/sftpman-rs#is-sftpman-v2-compatible-with-sftpman-v1).
 
@@ -440,6 +438,8 @@ and [release notes for v18](https://goteleport.com/docs/changelog/#1800-070325).
 - Packages using `versionCheckHook` that previously relied solely on `pname` to locate the program used to version check, but have a differing `meta.mainProgram` entry, might now fail.
 
 - `waydroid-nftables` is a new variant of `waydroid` that supports nftables instead of iptables.
+
+- `searx` was updated to use `envsubst` instead of `sed` for parsing secrets from environment variables.
   If your previous configuration included a secret reference like `server.secret_key = "@SEARX_SECRET_KEY@"`, you must migrate to the new envsubst syntax: `server.secret_key = "$SEARX_SECRET_KEY"`.
 
 ## Nixpkgs Library {#sec-nixpkgs-release-25.11-lib}
@@ -470,7 +470,7 @@ and [release notes for v18](https://goteleport.com/docs/changelog/#1800-070325).
 
 - `lib.sources.pathType`, `lib.sources.pathIsDirectory` and `lib.sources.pathIsRegularFile` have been replaced by `lib.filesystem.pathType`, `lib.filesystem.pathIsDirectory` and `lib.filesystem.pathIsRegularFile` respectively.
 
-- `lib.strings.isCoercibleToString` has been in favor of either `lib.strings.isStringLike` or `lib.strings.isConvertibleWithToString`. Only use the latter if it needs to return true for null, numbers, booleans, or a list of those.
+- `lib.strings.isCoercibleToString` has been replaced in favor of either `lib.strings.isStringLike` or `lib.strings.isConvertibleWithToString`. Only use the latter if it needs to return true for null, numbers, booleans, or a list of those.
 
 - `lib.types.string` has been removed. See [this pull request](https://github.com/NixOS/nixpkgs/pull/66346) for better alternative types like `lib.types.str`.
 

--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -89,7 +89,7 @@
 
 - `yarn2nix`/`yarn2nix-moretea` and its tooling(`mkYarnPackage`, `mkYarnModules`, and `fixup_yarn_lock`) have been removed as they were unmaintainable in nixpkgs. If you want to build with Yarn V1 going forward, use the hooks instead(`yarnBuildHook`, `yarnConfigHook`, and `yarnInstallHook`). See the yarn v1 documentation in the nixpkgs manual for more details.
 
-- `albert` has been updated to the version 34.0.5. This release redesigns the query system to support stateful asynchronous handlers and infinite scrolling, and adds internationalized tokenization.
+- `albert` has been updated to version 34.0.5. This release redesigns the query system to support stateful asynchronous handlers and infinite scrolling, and adds internationalized tokenization.
   This update introduces several breaking changes: the Python plugin interface is now v5.0, the `PATH` plugin has been renamed to `Commandline`, and the QStylesheets-based widgets box model frontend has been removed.
   For more information read the [changelog for 34.0.0](https://albertlauncher.github.io/2026/01/19/albert-v34.0.0-released/).
 
@@ -115,7 +115,7 @@
 
 - `nodePackages.browserify` has been removed, as it was unmaintained within nixpkgs.
 
-- `command-not-found` package will be enabled by default if the source of nixpkgs contains the file `programs.sqlite`. This is the case if a nixpkgs tarball from https://channels.nixos.org is used. This usage will also make the database of `command-not-found` stateless.
+- `command-not-found` package will be enabled by default if the source of nixpkgs contains the file `programs.sqlite`. This is the case if a nixpkgs tarball from <https://channels.nixos.org> is used. This usage will also make the database of `command-not-found` stateless.
 
 - `nodePackages.sass` has been removed, as it was unmaintained within nixpkgs.
 
@@ -128,7 +128,7 @@
 
 - Reloading or restarting systemd units from the NixOS activation script is deprecated, and will be removed in NixOS 26.11. This deprecation is part of a bigger effort to deprecate activation scripts altogether, which will take place over several releases. There are no in-tree usages of the now-deprecated reload/restart functionality.
 
-- Keycloak has been updated to 26.6.X, bringing a lot new features like federated client authentication, JWT authorization grants, workflows and the ability to do
+- Keycloak has been updated to 26.6.X, bringing a lot of new features like federated client authentication, JWT authorization grants, workflows and the ability to do
   zero-downtime patch releases. Read more about [all the exciting new capabilities in keycloak 26.6 here](https://github.com/keycloak/keycloak/releases/tag/26.6.0)
   and [consult the migration guide to 26.6](https://www.keycloak.org/docs/latest/upgrading/index.html#migrating-to-26-6-0) to find out whether this is a breaking
   change for your keycloak instance.
@@ -157,19 +157,17 @@
   This release contains breaking changes, see [Upgrading to Vinyl Cache 9.0](https://vinyl-cache.org/docs/9.0/whats-new/upgrading-9.0.html).
   The `varnish-modules` project is currently not packaged for Vinyl Cache, as it is incompatible.
 
-- `eslint` has been updated from version 9 to version 10. Please see https://eslint.org/blog/2026/02/eslint-v10.0.0-released/ for details about the breaking changes included in the update.
+- `eslint` has been updated from version 9 to version 10. Please see <https://eslint.org/blog/2026/02/eslint-v10.0.0-released/> for details about the breaking changes included in the update.
 
-- `minio` has been abandoned by upstream and security issues won't be fixed. It is scheduled to be removed for 26.11. Users should migrate to alternatives such as Garage, SeaweedFS, or Ceph. S3-compatible clients such as rclone can be used to move data.
-
-`minio_legacy_fs` has been removed. Users should migrate to alternatives such as Garage, SeaweedFS, or Ceph. S3-compatible clients such as rclone can be used to move data.
+- `minio` has been abandoned by upstream and security issues won't be fixed. `minio_legacy_fs` has also been removed. Both are scheduled for full removal in 26.11. Users should migrate to alternatives such as Garage, SeaweedFS, or Ceph. S3-compatible clients such as rclone can be used to move data.
 
 - `mercure` has been updated to `0.21.4` (or later). Version [0.21.0](https://github.com/dunglas/mercure/releases/v0.21.0) and [0.21.2](https://github.com/dunglas/mercure/releases/tag/v0.21.2) introduce breaking changes to the package.
 
-- `mozc` and `mozc-ut` no longer contains the IBus front-end, which are now provided by `ibus-engines.mozc` and `ibus-engines.mozc-ut`.
+- `mozc` and `mozc-ut` no longer contain the IBus front-end, which is now provided by `ibus-engines.mozc` and `ibus-engines.mozc-ut`.
 
 - `nemorosa` has been updated from `0.4.3` to `0.5.0`. Version [0.5.0](https://github.com/KyokoMiki/nemorosa/releases/tag/0.5.0) introduced breaking changes to the package configuration.
 
-- `n8n` has been updated to version 2. You can find the breaking changes here: https://docs.n8n.io/2-0-breaking-changes/.
+- `n8n` has been updated to version 2. You can find the breaking changes here: <https://docs.n8n.io/2-0-breaking-changes/>.
 
 - `nomad` has been updated to v1.11. Refer to the [release note](https://developer.hashicorp.com/nomad/docs/release-notes/nomad/v1-11-x) for more details. Once a new Nomad version has started and upgraded its data directory, it generally cannot be downgraded to the previous version.
 
@@ -193,7 +191,7 @@
   Some notable new features include channel collaboration and video player redesign with a new theme.
   For details on how to upgrade, see the `IMPORTANT NOTES` section of the [v8.0.0 CHANGELOG entry](https://docs.joinpeertube.org/CHANGELOG#v8-0-0).
 
-- `python3Packages.gradio` has been updated to version 6. See upstream's migration guide at https://www.gradio.app/main/guides/gradio-6-migration-guide.
+- `python3Packages.gradio` has been updated to version 6. See upstream's migration guide at <https://www.gradio.app/main/guides/gradio-6-migration-guide>.
 
 - `python3Packages.pikepdf` no longer builds with mupdf support by default, which may be nice in Jupyter and iPython. Build with `withMupdf = true` if this is required.
 
@@ -286,7 +284,7 @@
 
 - `shisho` has been removed because it's archived. `semgrep`, `opengrep`, and `ast-grep` provide similar functionality.
 
-- `services.openssh.settings.AcceptEnv` now explicitly defined as an option that takes a list of strings, to facilitate option merging. Setting it to a string value is no longer supported.
+- `services.openssh.settings.AcceptEnv` is now explicitly defined as an option that takes a list of strings, to facilitate option merging. Setting it to a string value is no longer supported.
 
 - All Xfce packages have been moved to top level (e.g. if you previously added `pkgs.xfce.xfce4-whiskermenu-plugin` to `environment.systemPackages`, you will need to change it to `pkgs.xfce4-whiskermenu-plugin`). The `xfce` scope will be removed in NixOS 26.11.
 
@@ -298,7 +296,7 @@
 
 - `vimPlugins.nvim-treesitter` has been updated to `main` branch, which is a full and incompatible rewrite. If you can't or don't want to update, you should use `vimPlugins.nvim-treesitter-legacy`.
 
-- `services.taskchampion-sync-server` module have been added an option `services.taskchampion-sync-server.dynamicUser` to use systemd's DynamicUser feature. This is enabled by default when stateVersion is at least 26.05, and disabled otherwise. If you need this feature, you need to set `services.taskchampion-sync-server.dynamicUser` to `true` and migrate `/var/lib/taskchampion-sync-server` to `/var/lib/private/taskchampion-sync-server`.
+- `services.taskchampion-sync-server` module has had an option `services.taskchampion-sync-server.dynamicUser` added to use systemd's DynamicUser feature. This is enabled by default when stateVersion is at least 26.05, and disabled otherwise. If you need this feature, you need to set `services.taskchampion-sync-server.dynamicUser` to `true` and migrate `/var/lib/taskchampion-sync-server` to `/var/lib/private/taskchampion-sync-server`.
 
 - Package `jellyseerr` has been renamed to `seerr` following the upstream rename.
 
@@ -351,7 +349,7 @@
 
 - Added `dell-bios-fan-control` package and service.
 
-- Added `lovr` package, a LUA-based game engine for VR and XR applications.
+- Added `lovr` package, a Lua-based game engine for VR and XR applications.
 
 - Updated `wsjtx` from 2.7.0 to 3.0.0 for amateur radio hobbyists who use FT8 and other related digital modes.
   See the [release notes](https://wsjt.sourceforge.io/Release_Notes.txt) for the changelog.
@@ -361,7 +359,7 @@
 
 - `wrapNeovimUnstable` now sets provider-related configuration in its generated config rather than as wrapper arguments. It should not affect configuration unless you set `wrapRc` to false or are using the `legacyWrapper`.
 
-- neovim lua dependencies are now set in the generated init.lua instead of
+- Neovim Lua dependencies are now set in the generated init.lua instead of
   modifying LUA_PATH in the wrapper. Commands run pre-vimrc via `nvim --cmd
   "require'LUA_MODULE'"` may
   not find their lua dependencies anymore. Use `nvim -c "lua require'LUA_MODULE'"` instead to run these commands after loading `init.lua`. If you use `wrapNeovim` with `wrapRc` set to `false`, you may lose the lua dependencies if you are not loading the generated `init.lua`.
@@ -404,7 +402,7 @@ gnuradioMinimal.override {
 
 - `nodejs` is now a simple wrapper for `nodejs-slim`+`nodejs-slim.npm`+`nodejs-slim.corepack`, meaning it is no longer possible to reference or override its attributes or outputs (e.g. `nodejs.libv8` must be replaced with `nodejs-slim.libv8`, `nodejs.nativeBuildInputs` with `nodejs-slim.nativeBuildInputs`, etc.).
 
-- `navidrome` has removed the built-in Spotify integration https://github.com/navidrome/navidrome/releases/tag/v0.61.0 has details on optional replacements
+- `navidrome` has removed the built-in Spotify integration. See [v0.61.0](https://github.com/navidrome/navidrome/releases/tag/v0.61.0) for details on optional replacements.
 
 - `mold` is now wrapped by default.
 
@@ -424,4 +422,4 @@ gnuradioMinimal.override {
 
 - The builder `php.buildComposerProject2` for PHP applications has been improved for better reliability and stability.
 
-- The `services.drupal` module has a few improvements aimed at making it better for installing custom Drupal instances, namely a new `webRoot` option for identifying custom webroots in source code, a new `configRoot` option for identifying and synchronizing config yamls onto NixOS, and a some new settings for managing variable content and filepaths.
+- The `services.drupal` module has a few improvements aimed at making it better for installing custom Drupal instances, namely a new `webRoot` option for identifying custom webroots in source code, a new `configRoot` option for identifying and synchronizing config yamls onto NixOS, and some new settings for managing variable content and filepaths.

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -4,7 +4,7 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Added `nixos-init`, a Rust-based bashless initialization system for systemd initrd. This allows building NixOS systems without any interpreter. Enable via `system.nixos-init.enable = true;`.
+- Added `nixos-init`, a Rust-based bashless initialization system for systemd initrd.
 
 - COSMIC DE has been updated to the beta version, bringing it closer to its first stable release. This includes updates to its core components, applications, and overall stability.
 
@@ -47,11 +47,13 @@
 
 - Auto-scrub support for Bcachefs filesystems can now be enabled through [services.bcachefs.autoScrub.enable](#opt-services.bcachefs.autoScrub.enable) to periodically check for data corruption. If there's a correct copy available, it will automatically repair corrupted blocks.
 
-- [Beszel](https://beszel.dev), a lightweight server monitoring hub with historical data, docker stats, and alerts. Available as [`services.beszel.agent`](options.html#opt-services.beszel.agent.enable) and [`services.beszel.hub`](options.html#opt-services.beszel.hub.enable).
+- [Beszel](https://beszel.dev), a lightweight server monitoring hub with historical data, docker stats, and alerts. Available as [`services.beszel.agent`](#opt-services.beszel.agent.enable) and [`services.beszel.hub`](#opt-services.beszel.hub.enable).
 
-- [boot.kernel.sysfs](options.html#opt-boot.kernel.sysfs), a new way to set sysfs attributes.
+- [boot.kernel.sysfs](#opt-boot.kernel.sysfs), a new way to set sysfs attributes.
 
-- [Broadcast Box](https://github.com/Glimesh/broadcast-box), a WebRTC broadcast server. Available as [services.broadcast-box](options.html#opt-services.broadcast-box.enable).
+- [Broadcast Box](https://github.com/Glimesh/broadcast-box), a WebRTC broadcast server. Available as [services.broadcast-box](#opt-services.broadcast-box.enable).
+
+- Drivers and utilities for [Tenstorrent](https://tenstorrent.com) have been added. Available as [hardware.tenstorrent](#opt-hardware.tenstorrent.enable).
 
 - [byedpi](https://github.com/hufrea/byedpi), a DPI bypass service. Available as [services.byedpi](#opt-services.byedpi.enable).
 
@@ -67,9 +69,7 @@
 
 - [crowdsec-firewall-bouncer](https://www.crowdsec.net/), the CrowdSec Remediation Component for fetching new and old decisions from a CrowdSec API and adding them to a blocklist used by supported firewalls. Available as [services.crowdsec-firewall-bouncer](#opt-services.crowdsec-firewall-bouncer.enable).
 
-- Docker now defaults to 28.x, because version 27.x stopped receiving security updates and bug fixes after [May 2, 2025](https://github.com/moby/moby/pull/49910).
-
-- [docuseal](https://github.com/docusealco/docuseal), a DocuSign alternative. Create, fill, and sign digital documents. Available at [services.docuseal](#opt-services.docuseal.enable).
+- [docuseal](https://github.com/docusealco/docuseal), a DocuSign alternative. Create, fill, and sign digital documents. Available as [services.docuseal](#opt-services.docuseal.enable).
 
 - [Draupnir](https://github.com/the-draupnir-project/draupnir), a Matrix moderation bot. Available as [services.draupnir](#opt-services.draupnir.enable).
 
@@ -93,14 +93,14 @@
 
 - [Homebridge](https://github.com/homebridge/homebridge), a lightweight Node.js server you can run on your home network that emulates the iOS HomeKit API. Available as [services.homebridge](#opt-services.homebridge.enable).
 
-- [IfState](https://ifstate.net), manage host interface settings in a declarative manner. Available as [networking.ifstate](options.html#opt-networking.ifstate.enable) and [boot.initrd.network.ifstate](options.html#opt-boot.initrd.network.ifstate.enable).
+- [IfState](https://ifstate.net), manage host interface settings in a declarative manner. Available as [networking.ifstate](#opt-networking.ifstate.enable) and [boot.initrd.network.ifstate](#opt-boot.initrd.network.ifstate.enable).
 
 - [KMinion](https://github.com/redpanda-data/kminion), feature-rich Prometheus exporter for Apache Kafka. Available as [services.prometheus.exporters.kafka](options.html#opt-services.prometheus.exporters.kafka).
 
 - [LACT](https://github.com/ilya-zlobintsev/LACT), a GPU monitoring and configuration tool, can now be enabled through [services.lact.enable](#opt-services.lact.enable).
   Note that for LACT to work properly on AMD GPU systems, you need to enable [hardware.amdgpu.overdrive.enable](#opt-hardware.amdgpu.overdrive.enable).
 
-- [lemurs](https://github.com/coastalwhite/lemurs), a customizable TUI display/login manager. Available at [services.displayManager.lemurs](#opt-services.displayManager.lemurs.enable).
+- [lemurs](https://github.com/coastalwhite/lemurs), a customizable TUI display/login manager. Available as [services.displayManager.lemurs](#opt-services.displayManager.lemurs.enable).
 
 - [LibreTranslate](https://libretranslate.com), a free and open source machine translation API. Available as [services.libretranslate](#opt-services.libretranslate.enable).
 
@@ -121,11 +121,11 @@
 
 - [nebula-lighthouse-service](https://github.com/manuels/nebula-lighthouse-service), a public Nebula VPN lighthouse service. Available as [services.nebula-lighthouse-service](#opt-services.nebula-lighthouse-service.enable).
 
-- [Newt](https://github.com/fosrl/newt), a fully user space WireGuard tunnel client and TCP/UDP proxy, designed to securely expose private resources controlled by Pangolin. Available as [services.newt](options.html#opt-services.newt.enable).
+- [Newt](https://github.com/fosrl/newt), a fully user space WireGuard tunnel client and TCP/UDP proxy, designed to securely expose private resources controlled by Pangolin. Available as [services.newt](#opt-services.newt.enable).
 
 - [nixbit](https://github.com/pbek/nixbit), a GUI application for updating your NixOS system from a Nix Flakes Git repository. Available as [programs.nixbit](#opt-programs.nixbit.enable).
 
-- [nix-store-veritysetup](https://github.com/nikstur/nix-store-veritysetup-generator), a systemd generator to unlock the Nix Store as a dm-verity protected block device. Available as [boot.initrd.nix-store-veritysetup](options.html#opt-boot.initrd.nix-store-veritysetup.enable).
+- [nix-store-veritysetup](https://github.com/nikstur/nix-store-veritysetup-generator), a systemd generator to unlock the Nix Store as a dm-verity protected block device. Available as [boot.initrd.nix-store-veritysetup](#opt-boot.initrd.nix-store-veritysetup.enable).
 
 - [nvme-rs](https://github.com/liberodark/nvme-rs), NVMe monitoring [services.nvme-rs](#opt-services.nvme-rs.enable).
 
@@ -139,7 +139,7 @@
 
 - [Pi-hole](https://pi-hole.net/), a DNS sinkhole for advertisements based on Dnsmasq. Available as [services.pihole-ftl](#opt-services.pihole-ftl.enable), and [services.pihole-web](#opt-services.pihole-web.enable) for the web GUI and API.
 
-- [pmount](https://salsa.debian.org/debian/pmount), a tool that allows normal users to mount removable devices without requiring root privileges Available at [programs.pmount](#opt-programs.pmount.enable).
+- [pmount](https://salsa.debian.org/debian/pmount), a tool that allows normal users to mount removable devices without requiring root privileges Available as [programs.pmount](#opt-programs.pmount.enable).
 
 - [postfix-tlspol](https://github.com/Zuplu/postfix-tlspol), a MTA-STS and DANE resolver and TLS policy server for Postfix. Available as [services.postfix-tlspol](#opt-services.postfix-tlspol.enable).
 
@@ -153,7 +153,7 @@
 
 - [radicle-native-ci](https://radicle.network/nodes/seed.radicle.dev/rad:z3qg5TKmN83afz2fj9z3fQjU8vaYE), an adapter for the [Radicle CI broker](https://radicle.network/nodes/seed.radicle.dev/rad:zwTxygwuz5LDGBq255RA2CbNGrz8), for performing CI runs locally. Available as [services.radicle.ci.adapters.native](#opt-services.radicle.ci.adapters.native.instances).
 
-- [rauc](https://rauc.io/) (the Robust Auto-Update Controller), a daemon that allows reliable and secure software updates in embedded Linux systems. Available at [services.rauc](#opt-services.rauc.enable).
+- [rauc](https://rauc.io/) (the Robust Auto-Update Controller), a daemon that allows reliable and secure software updates in embedded Linux systems. Available as [services.rauc](#opt-services.rauc.enable).
 
 - [ringboard](https://github.com/SUPERCILEX/clipboard-history), a fast, efficient, and composable clipboard manager for Linux. Available for x11 as [services.ringboard](#opt-services.ringboard.x11.enable) and for Wayland as [services.ringboard](#opt-services.ringboard.wayland.enable).
 
@@ -189,7 +189,7 @@
 
 - [tuwunel](https://matrix-construct.github.io/tuwunel/), a federated chat server implementing the Matrix protocol, forked from Conduwuit. Available as [services.matrix-tuwunel](#opt-services.matrix-tuwunel.enable).
 
-- [umami](https://github.com/umami-software/umami), a simple, fast, privacy-focused alternative to Google Analytics. Available with [services.umami](#opt-services.umami.enable).
+- [umami](https://github.com/umami-software/umami), a simple, fast, privacy-focused alternative to Google Analytics. Available as [services.umami](#opt-services.umami.enable).
 
 - [wayvnc](https://github.com/any1/wayvnc), a VNC server for wlroots based Wayland compositors. Available as [programs.wayvnc](#opt-programs.wayvnc.enable).
 
@@ -373,7 +373,7 @@
 
 - `boot.plymouth` now has a [`package`](#opt-boot.plymouth.package) option to specify the package used in the module.
 
-- Drivers and utilities for [Tenstorrent](https://tenstorrent.com) have been added. Available as [hardware.tenstorrent](#opt-hardware.tenstorrent.enable).
+- Docker now defaults to 28.x, because version 27.x stopped receiving security updates and bug fixes after [May 2, 2025](https://github.com/moby/moby/pull/49910).
 
 - Due to [deprecation of gnome-session X11 support](https://blogs.gnome.org/alatiera/2025/06/08/the-x11-session-removal/), `services.desktopManager.pantheon` now defaults to pantheon-wayland session. The X11 session has been removed, see [this issue](https://github.com/elementary/session-settings/issues/91) for details.
 
@@ -436,9 +436,9 @@
 - `services.k3s` now shares most of its code with `services.rke2`. The merge resulted in both modules providing more options, with `services.rke2` receiving the most improvements.
   Existing configurations for either module should not be affected.
 
-- [services.libvirtd.autoSnapshot](options.html#opt-services.libvirtd.autoSnapshot.enable) has been added as a backup service for libvirt managed VMs.
+- [services.libvirtd.autoSnapshot](#opt-services.libvirtd.autoSnapshot.enable) has been added as a backup service for libvirt managed VMs.
 
-- `services.limesurvey` now supports nginx as reverse-proxy. Available through [services.limesurvey.webserver](#opt-services.limesurvey.webserver).
+- `services.limesurvey` now supports nginx as reverse-proxy. Available as [services.limesurvey.webserver](#opt-services.limesurvey.webserver).
 
 - `services.mattermost` has been updated to use the 10.11 ESR instead of 10.5. While this shouldn't break anyone, we also now package Mattermost 11 as mattermostLatest. Note that Mattermost 11 drops support for MySQL. The Mattermost module will assertion fail if you try to use MySQL with Mattermost 11; support for using MySQL with Mattermost will fully be removed in NixOS 26.
 

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -14,7 +14,7 @@
   - The `cryptsetup-askpass` program is not available; use `systemctl default` instead, which will prompt for passphrases as necessary. If you pipe password responses into SSH over stdin, use `ssh -o RequestTTY=force` to ensure `systemctl default` gets a TTY to prompt on.
   - Many kernel parameters have been replaced with native systemd versions; see [](#sec-boot-problems).
 
-- The system.nix file has been added as an alternative entry point to configuration.nix (and flake.nix) that allows to configure NixOS without using `nix-channel`.
+- The system.nix file has been added as an alternative entry point to configuration.nix (and flake.nix) that allows configuring NixOS without using `nix-channel`.
   This file must evaluate to a NixOS system derivation or an attribute set of such derivations, in which case the attribute to build has to be selected with the `--attr` option of `nixos-rebuild` or `nixos-install`.
   For example,
   ```nix
@@ -65,12 +65,11 @@
 - [Atuin](https://atuin.sh), magical shell history — sync, search and backup your terminal history. Available as [programs.atuin](#opt-programs.atuin.enable).
 
 - [Meshtastic](https://meshtastic.org), an open-source, off-grid, decentralised mesh network
-  designed to run on affordable, low-power devices. Available as [services.meshtasticd]
-  (#opt-services.meshtasticd.enable).
+  designed to run on affordable, low-power devices. Available as [services.meshtasticd](#opt-services.meshtasticd.enable).
 
 - [Goupile](https://goupile.org/en), an open-source design tool for secure forms including Clinical Report Forms (eCRF). Available as [services.goupile](#opt-services.goupile.enable).
 
-- [knot-resolver](https://www.knot-resolver.cz/) in version 6. Available as `services.knot-resolver`. A module for knot-resolver 5 was already available as `services.kresd`.
+- [knot-resolver](https://www.knot-resolver.cz/), in version 6. Available as `services.knot-resolver`. A module for knot-resolver 5 was already available as `services.kresd`.
 
 - [ImmichFrame](https://immichframe.dev/), display your photos from Immich as a digital photo frame. Available as `services.immichframe`.
 
@@ -80,7 +79,7 @@
 
 - [reaction](https://reaction.ppom.me/), a daemon that scans program outputs for repeated patterns, and takes action. A common usage is to scan ssh and webserver logs, and to ban hosts that cause multiple authentication errors. A modern alternative to fail2ban. Available as [services.reaction](#opt-services.reaction.enable).
 
-- [vinyl-cache] as the Varnish Cache project renamed itself. Available as [services.vinyl-cache](#opt-services.vinyl-cache.enable). To aid the migration, the old `services.varnish` module is still available.
+- [vinyl-cache](https://vinyl-cache.org) as the Varnish Cache project renamed itself. Available as [services.vinyl-cache](#opt-services.vinyl-cache.enable). To aid the migration, the old `services.varnish` module is still available.
 
 - [papra](https://papra.app/), an open-source document management platform designed to help you organize, secure, and archive your files effortlessly. Available as [services.papra](#opt-services.papra.enable).
 
@@ -98,29 +97,29 @@
 
 - [LibreChat](https://www.librechat.ai/), open-source self-hostable ChatGPT clone with Agents and RAG APIs. Available as [services.librechat](#opt-services.librechat.enable).
 
-- [nohang](https://github.com/hakavlad/nohang), a daemon for Linux that prevents out of memory (OOM) situations from affecting system responsiveness. Available as [services.nohang](#opt-services.nohang.enable)
+- [nohang](https://github.com/hakavlad/nohang), a daemon for Linux that prevents out of memory (OOM) situations from affecting system responsiveness. Available as [services.nohang](#opt-services.nohang.enable).
 
 - [clevis-luks-askpass](https://github.com/latchset/clevis), automatic LUKS unlocking in initrd using clevis token bindings stored in LUKS headers. Available as [boot.initrd.clevisLuksAskpass](#opt-boot.initrd.clevisLuksAskpass.enable).
 
 - [bentopdf](https://github.com/alam00000/bentopdf), a privacy-first PDF toolkit running completely in-browser. Available as [services.bentopdf](#opt-services.bentopdf.enable).
 
-- [hyprwhspr-rs](https://github.com/better-slop/hyprwhspr-rs), a keybind activated speech-to-text voice dictation utility built for use with Hyprland. Available as `services.hyprwhspr-rs`
+- [hyprwhspr-rs](https://github.com/better-slop/hyprwhspr-rs), a keybind activated speech-to-text voice dictation utility built for use with Hyprland. Available as `services.hyprwhspr-rs`.
 
 - [DankMaterialShell](https://danklinux.com), a complete desktop shell for Wayland compositors built with Quickshell. Available as [programs.dms-shell](#opt-programs.dms-shell.enable).
 
-- [pyroscope](https://github.com/grafana/pyroscope), a continuous profiling platform. that allows for performance debugging. Available as [services.pyroscope](#opt-services.pyroscope.enable)
+- [pyroscope](https://github.com/grafana/pyroscope), a continuous profiling platform that allows for performance debugging. Available as [services.pyroscope](#opt-services.pyroscope.enable).
 
 - [dms-greeter](https://danklinux.com), a modern display manager greeter for DankMaterialShell that works with greetd and supports multiple Wayland compositors. Available as [services.displayManager.dms-greeter](#opt-services.displayManager.dms-greeter.enable).
 
 - [dsearch](https://github.com/AvengeMedia/danksearch), a fast filesystem search service with fuzzy matching. Available as [programs.dsearch](#opt-programs.dsearch.enable).
 
-- [Rustical](https://github.com/lennart-k/rustical), a CalDav/CardDav server aiming to be simple, fast and passwordless. Available as [services.rustical](options.html#opt-services.rustical.enable).
+- [Rustical](https://github.com/lennart-k/rustical), a CalDav/CardDav server aiming to be simple, fast and passwordless. Available as [services.rustical](#opt-services.rustical.enable).
 
 - [Elephant](https://github.com/abenz1267/elephant), a data provider service and backend for building custom application launchers. Available as [services.elephant](#opt-services.elephant.enable).
 
 - [Dunst](https://github.com/dunst-project/dunst), a lightweight and customizable notification daemon. Available as [services.dunst](#opt-services.dunst.enable).
 
-- [cocoon](https://github.com/haileyok/cocoon), is a PDS (personal data server) that is a alternative to the bluesky pds. Available as [services.cocoon](#opt-services.cocoon.enable).
+- [cocoon](https://github.com/haileyok/cocoon), a PDS (personal data server) that is an alternative to the Bluesky PDS. Available as [services.cocoon](#opt-services.cocoon.enable).
 
 - [Ente Auth](https://ente.io/auth/), an open source 2FA authenticator, with end-to-end encrypted backups. Available as [programs.ente-auth](#opt-programs.ente-auth.enable).
 
@@ -140,7 +139,7 @@
 
 - [udp-over-tcp](https://github.com/mullvad/udp-over-tcp), a tunnel for proxying UDP traffic over a TCP stream. Available as `services.udp-over-tcp`.
 
-- [turborepo-remote-cache](https://ducktors.github.io/turborepo-remote-cache/), an open-source implementation of the [Turborepo custom remote cache server](https://turbo.build/repo/docs/core-concepts/remote-caching#self-hosting). Available as [services.turborepo-remote-cache](options.html#opt-services.turborepo-remote-cache).
+- [turborepo-remote-cache](https://ducktors.github.io/turborepo-remote-cache/), an open-source implementation of the [Turborepo custom remote cache server](https://turbo.build/repo/docs/core-concepts/remote-caching#self-hosting). Available as [services.turborepo-remote-cache](#opt-services.turborepo-remote-cache.enable).
 
 - [RSSHub](https://github.com/DIYgod/RSSHub), a service to convert many sources into rss. Available as `services.rsshub`.
 
@@ -164,7 +163,7 @@
 
 - [porxie](https://codeberg.org/Blooym/porxie), a correct and efficient ATProto blob proxy for secure content delivery. Available as [services.porxie](#opt-services.porxie.enable).
 
-- [LogiOps](https://github.com/PixlOne/logiops), a unofficial userspace driver for HID++ Logitech devices. Available as [services.logiops](#opt-services.logiops.enable).
+- [LogiOps](https://github.com/PixlOne/logiops), an unofficial userspace driver for HID++ Logitech devices. Available as [services.logiops](#opt-services.logiops.enable).
 
 ## Backward Incompatibilities {#sec-release-26.05-incompatibilities}
 
@@ -274,7 +273,7 @@ of pulling the upstream container image from Docker Hub. If you want the old beh
   for further information.
 
   Please do note that there's no official way to rotate. On a single-node instance with the database and the secret-key being
-  on the same filesystem with the same permissions for Grafana only to read its most likely OK to keep using the old key.
+  on the same filesystem with the same permissions for Grafana only to read, it is most likely OK to keep using the old key.
 
   If you need to rotate, a [3rd-party tool, `grafana-secretkey-rotation-tool`](https://github.com/erooke/grafana-secretkey-rotation-tool/tree/d9dc788902fa5185e15cb15ce6129f7237ab6138) is a tested option.
   When using a secret for this value, make sure to use [Grafana's variable expansion to inject secrets](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#variable-expansion).
@@ -459,7 +458,7 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - `systemd.network.*` has been updated to support all configuration options from upstream `networkd` version 259.
 
-- `networking.resolvconf.enable` now defaults to `true` unconditionally instead of `!(config.environment.etc ? "resolv.conf")`.If you set `environment.etc."resolv.conf"` yourself, then you should also set `networking.resolvconf.enable = false`.
+- `networking.resolvconf.enable` now defaults to `true` unconditionally instead of `!(config.environment.etc ? "resolv.conf")`. If you set `environment.etc."resolv.conf"` yourself, then you should also set `networking.resolvconf.enable = false`.
 
 - `services.openssh` now supports generating host SSH keys by setting `services.openssh.generateHostKeys = true` while leaving `services.openssh.enable` disabled.  This is particularly useful for systems that have no need of an SSH daemon but want SSH host keys for other purposes such as using agenix or sops-nix.
 


### PR DESCRIPTION
Followup to #525521 

Fixes a few Markdown lint warnings (which my editor helpfully displays) and organizes some incorrect bulletpoints. Also fixes more grammar errors and inconsistencies I've missed in the previous PR. Hopefully the last fixup PR.

