### PR TITLE
repoconductor, himitsu-bako: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25143,6 +25143,12 @@
     github = "shgew";
     githubId = 5584672;
   };
+  shichirouji21 = {
+    name = "shichirouji21";
+    email = "shichirouji21@proton.me";
+    github = "shichirouji21";
+    githubId = 189993052;
+  };
   shift = {
     name = "Vincent Palmer";
     email = "shift@someone.section.me";

--- a/pkgs/by-name/hi/himitsu-bako/package.nix
+++ b/pkgs/by-name/hi/himitsu-bako/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  fzf,
+  makeWrapper,
+  stdenv,
+  wl-clipboard,
+  xclip,
+  xsel,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "himitsu-bako";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "shichirouji21";
+    repo = "himitsu-bako";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8wQ0n3Xy5nnouDGMUfeM5eCiz+nthKzHvYa/Z+L43Go=";
+  };
+
+  vendorHash = "sha256-jwQvAIS8XCWjZtP9pKt1RRSaKBZ9dgDc2SD6q0K+sEs=";
+
+  __structuredAttrs = true;
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/himitsu-bako \
+      --prefix PATH : ${
+        lib.makeBinPath (
+          [ fzf ]
+          ++ lib.optionals stdenv.hostPlatform.isLinux [
+            wl-clipboard
+            xclip
+            xsel
+          ]
+        )
+      }
+  '';
+
+  meta = {
+    description = "Encrypted clipboard-backed secret storage using age";
+    homepage = "https://github.com/shichirouji21/himitsu-bako";
+    changelog = "https://github.com/shichirouji21/himitsu-bako/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ shichirouji21 ];
+    mainProgram = "himitsu-bako";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/re/repoconductor/package.nix
+++ b/pkgs/by-name/re/repoconductor/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  haskell,
+  haskellPackages,
+  fetchFromGitHub,
+  installShellFiles,
+}:
+
+let
+  inherit (haskell.lib.compose) justStaticExecutables overrideCabal;
+
+  raw = haskellPackages.callPackage (
+    {
+      mkDerivation,
+      async,
+      base,
+      containers,
+      directory,
+      filepath,
+      mtl,
+      optparse-applicative,
+      process,
+      stm,
+      text,
+      unix,
+    }:
+    mkDerivation {
+      pname = "repoconductor";
+      version = "1.4.0";
+      src = fetchFromGitHub {
+        owner = "shichirouji21";
+        repo = "RepoConductor";
+        rev = "v1.4.0";
+        hash = "sha256-kUUxfscSwgd6xFFyWxVSzrkuyzXWIvyon6CRTZHclg8=";
+      };
+      isLibrary = false;
+      isExecutable = true;
+      executableHaskellDepends = [
+        async
+        base
+        containers
+        directory
+        filepath
+        mtl
+        optparse-applicative
+        process
+        stm
+        text
+        unix
+      ];
+      license = lib.licenses.bsd2;
+      maintainers = with lib.maintainers; [ shichirouji21 ];
+      mainProgram = "repoconductor";
+      description = "Terminal dashboard for managing multiple git repositories";
+      homepage = "https://github.com/shichirouji21/RepoConductor";
+      changelog = "https://github.com/shichirouji21/RepoConductor/blob/v1.4.0/CHANGELOG.md";
+    }
+  ) { };
+
+  withCompletions = overrideCabal (drv: {
+    buildTools = (drv.buildTools or [ ]) ++ [ installShellFiles ];
+    postInstall = (drv.postInstall or "") + ''
+      installShellCompletion --cmd repoconductor \
+        --bash $src/completions/repoconductor.bash \
+        --zsh  $src/completions/_repoconductor \
+        --fish $src/completions/repoconductor.fish
+    '';
+  }) raw;
+in
+(justStaticExecutables withCompletions).overrideAttrs (_oldAttrs: {
+  strictDeps = true;
+  __structuredAttrs = true;
+})


### PR DESCRIPTION
## Description

Adds two command-line tools maintained by `shichirouji21`:

- `repoconductor` 1.4.0: terminal dashboard for managing multiple git repositories
- `himitsu-bako` 1.1.0: encrypted clipboard-backed secret storage using age

Also adds `shichirouji21` to the maintainer list.

## Things done

- Built on platform(s): x86_64-linux
- `nix-build -A repoconductor`
- `./result/bin/repoconductor --version`
- `nix-build -A himitsu-bako`
- `./result/bin/himitsu-bako --version`
- `nix-build lib/tests/maintainers.nix`
