### PR TITLE
tuxclocker: 1.5.1 -> 1.5.1-unstable-2026-08-19

### DIFF
--- a/pkgs/applications/misc/tuxclocker/default.nix
+++ b/pkgs/applications/misc/tuxclocker/default.nix
@@ -18,14 +18,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tuxclocker";
-  version = "1.5.1";
+  version = "1.5.1-unstable-2026-05-15";
 
   src = fetchFromGitHub {
     owner = "Lurkki14";
     repo = "tuxclocker";
     fetchSubmodules = true;
-    rev = finalAttrs.version;
-    hash = "sha256-QLKLqTCpVMWxlDINa8Bo1vgCDcjwovoaXUs/PdMnxv0=";
+    rev = "e244b4465a52d41932c7350779a0058a8a6fd4ae";
+    hash = "sha256-Fp+iVdAXwIR6Or9JGA/W4cAcePbmSqrB3iSOP41v3qw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/tuxclocker/default.nix
+++ b/pkgs/applications/misc/tuxclocker/default.nix
@@ -9,23 +9,22 @@
   ninja,
   pkg-config,
   python3,
-  qtbase,
-  qtcharts,
+  qt5,
   tuxclocker-plugins,
   tuxclocker-without-unfree,
-  wrapQtAppsHook,
+  unstableGitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tuxclocker";
-  version = "1.5.1";
+  version = "1.5.1-unstable-2026-08-19";
 
   src = fetchFromGitHub {
     owner = "Lurkki14";
     repo = "tuxclocker";
     fetchSubmodules = true;
-    rev = finalAttrs.version;
-    hash = "sha256-QLKLqTCpVMWxlDINa8Bo1vgCDcjwovoaXUs/PdMnxv0=";
+    rev = "c7c9021e6c32f3df581f266ccab4275d29810be1";
+    hash = "sha256-FMLpzt/VFzzFdn2b8MUxjPowLJu+tHiJhCDum5I6kSU=";
   };
 
   nativeBuildInputs = [
@@ -34,13 +33,13 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
     pkg-config
-    wrapQtAppsHook
+    qt5.wrapQtAppsHook
   ];
 
   buildInputs = [
     boost
-    qtbase
-    qtcharts
+    qt5.qtbase
+    qt5.qtcharts
   ];
 
   postInstall = ''
@@ -54,8 +53,11 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dplugins=false"
   ];
 
-  passthru.tests = {
-    inherit tuxclocker-without-unfree;
+  passthru = {
+    tests = {
+      inherit tuxclocker-without-unfree;
+    };
+    updateScript = unstableGitUpdater { };
   };
 
   meta = {

--- a/pkgs/development/python-modules/hwdata/default.nix
+++ b/pkgs/development/python-modules/hwdata/default.nix
@@ -20,8 +20,11 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [ setuptools ];
 
-  patchPhase = ''
-    substituteInPlace hwdata.py --replace "/usr/share/hwdata" "${pkgs.hwdata}/share/hwdata"
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail "2.4.3" "2.4.3-1"
+    substituteInPlace hwdata.py \
+      --replace-fail "/usr/share/hwdata" "${pkgs.hwdata}/share/hwdata"
   '';
 
   pythonImportsCheck = [ "hwdata" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9285,11 +9285,11 @@ with pkgs;
     wlroots = wlroots_0_20;
   };
 
-  tuxclocker = libsForQt5.callPackage ../applications/misc/tuxclocker {
+  tuxclocker = callPackage ../applications/misc/tuxclocker {
     tuxclocker-plugins = tuxclocker-plugins-with-unfree;
   };
 
-  tuxclocker-without-unfree = libsForQt5.callPackage ../applications/misc/tuxclocker { };
+  tuxclocker-without-unfree = callPackage ../applications/misc/tuxclocker { };
 
   linphonePackages = recurseIntoAttrs (
     callPackage ../applications/networking/instant-messengers/linphone { }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes `tuxclocker-plugins` build failure ([hydra](<https://hydra.nixos.org/job/nixpkgs/unstable/tuxclocker-plugins.x86_64-linux>))

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
