### PR TITLE
nixos/logrotate: Fix the config file check phase regex for create/createolddir

### DIFF
--- a/nixos/modules/services/logging/logrotate.nix
+++ b/nixos/modules/services/logging/logrotate.nix
@@ -91,9 +91,9 @@ let
       # files required to exist also won't be present, so missingok is forced.
       user=$(${pkgs.buildPackages.coreutils}/bin/id -un)
       group=$(${pkgs.buildPackages.coreutils}/bin/id -gn)
-      sed -e "s/\bsu\s.*/su $user $group/" \
-          -e "s/\b\(create\s\+[0-9]*\s*\|createolddir\s\+[0-9]*\s\+\).*/\1$user $group/" \
-          -e "1imissingok" -e "s/\bnomissingok\b//" \
+      sed -E -e "s/\bsu\s.*/su $user $group/" \
+             -e "s/\b((create|createolddir)\b(\s+[0-9]+)?).*/\1 $user $group/" \
+             -e "1imissingok" -e "s/\bnomissingok\b//" \
           $out > logrotate.conf
       # Since this makes for very verbose builds only show real error.
       # There is no way to control log level, but logrotate hardcodes

--- a/nixos/tests/logrotate.nix
+++ b/nixos/tests/logrotate.nix
@@ -66,8 +66,10 @@ in
             checkConf = {
               su = "root utmp";
               createolddir = "0750 root utmp";
+              "createolddir " = "0750";
               create = "root utmp";
               "create " = "0750 root utmp";
+              "create  " = "0750";
             };
             # multiple paths should be aggregated
             multipath = {


### PR DESCRIPTION
The check phase for the config file has to replace any instances of user and group with the current ones, since logrotate checks whether they actually exist. However, the create/createolddir substitution expressions didn't take all different parameter formats into account. Mainly, if the mode was specified, but not user and group, the result would be something like

```
  create 0644nixbld nixbld
```

since it relies on matching a space at the end of the mode specification.

To fix this, always append a space before the substituted user and group.

Also, simplify the formatting by using extended regex and check for word boundaries after create/createolddir to exclude any incorrect or unsupported suffixes.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
