### PR TITLE
python3Packages.proxmoxer: 2.3.0 correct revision & hash

### DIFF
--- a/pkgs/development/python-modules/proxmoxer/default.nix
+++ b/pkgs/development/python-modules/proxmoxer/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "proxmoxer";
     repo = "proxmoxer";
-    rev = "99fe9814d6212c614a944ce7b3d907e05042c4fa";
+    tag = finalAttrs.version;
     hash = "sha256-v/QqNCzkcYk2pqr9tTeyvEEeXt4nzqooHAQEIiJitZ4=";
   };
 

--- a/pkgs/development/python-modules/proxmoxer/default.nix
+++ b/pkgs/development/python-modules/proxmoxer/default.nix
@@ -10,7 +10,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "proxmoxer";
   version = "2.3.0";
   pyproject = true;
@@ -53,8 +53,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python wrapper for Proxmox API v2";
     homepage = "https://github.com/proxmoxer/proxmoxer";
-    changelog = "https://github.com/proxmoxer/proxmoxer/releases/tag/${version}";
-    license = with lib.licenses; [ bsd3 ];
+    changelog = "https://github.com/proxmoxer/proxmoxer/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/proxmoxer/default.nix
+++ b/pkgs/development/python-modules/proxmoxer/default.nix
@@ -18,8 +18,8 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "proxmoxer";
     repo = "proxmoxer";
-    rev = "cf1bcde696537c74ef00d8e71fb86735fb4c2c79";
-    hash = "sha256-h5Sla7/4XiZSGwKstyiqs/T2Qgi13jI9YMVPqDcF3sA=";
+    rev = "99fe9814d6212c614a944ce7b3d907e05042c4fa";
+    hash = "sha256-v/QqNCzkcYk2pqr9tTeyvEEeXt4nzqooHAQEIiJitZ4=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
Commit 3dee50b updated the nix metadata not source information. This commit updates the target revision to the commit that is currently tagged as 2.3.0 on the  [Proxmoxer Repository](https://github.com/proxmoxer/proxmoxer).

From what I could tell there were no automated tests for this module but I did test it using version 2.0.0 of the [community.proxmox Ansible Collection](https://docs.ansible.com/projects/ansible/latest/collections/community/proxmox/index.html) and it worked as expected. The collection has a hard dependency on version 2.3.0 of proxmoxer.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
