### PR TITLE
stylelint-config-{standard,recommended}: init at {40.0.0,18.0.0}

### DIFF
--- a/pkgs/by-name/st/stylelint-config-recommended/package.nix
+++ b/pkgs/by-name/st/stylelint-config-recommended/package.nix
@@ -1,0 +1,33 @@
+{
+  buildNpmPackage,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+}:
+buildNpmPackage rec {
+  pname = "stylelint-config-recommended";
+  version = "18.0.0";
+
+  src = fetchFromGitHub {
+    owner = "stylelint";
+    repo = "stylelint-config-recommended";
+    tag = version;
+    hash = "sha256-bwWPP5uVRQCqNd5SU4P0pXuqx7M/ccwSLaXTfxNb/Cg=";
+  };
+
+  npmDepsHash = "sha256-7DTZX95SWlYGyScerTzQjOcl/PcneoS/FxypAaLgY+s=";
+
+  dontNpmBuild = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  __structuredAtts = true;
+
+  meta = {
+    description = "Recommended shareable config for Stylelint";
+    mainProgram = "stylelint";
+    homepage = "https://github.com/stylelint/stylelint-config-recommended";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ mib ];
+  };
+}

--- a/pkgs/by-name/st/stylelint-config-standard/package.nix
+++ b/pkgs/by-name/st/stylelint-config-standard/package.nix
@@ -1,0 +1,33 @@
+{
+  buildNpmPackage,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+}:
+buildNpmPackage rec {
+  pname = "stylelint-config-standard";
+  version = "40.0.0";
+
+  src = fetchFromGitHub {
+    owner = "stylelint";
+    repo = "stylelint-config-standard";
+    tag = version;
+    hash = "sha256-tiT3m2v98kfKnzpTEyrapboawSFPbrrxWDilOKXDlrI=";
+  };
+
+  npmDepsHash = "sha256-IFqm0lJ3Pzr2qVBmGLIzi5PMqHN5pf4RkLAKGqMU5HQ=";
+
+  dontNpmBuild = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Standard shareable config for Stylelint";
+    mainProgram = "stylelint";
+    homepage = "https://github.com/stylelint/stylelint-config-standard";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ mib ];
+  };
+}


### PR DESCRIPTION
The two common/default stylelint configs, for making available to stylelint.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
