### PR TITLE
ffmpeg-headless: fix riscv64-linux build

### DIFF
--- a/pkgs/development/libraries/ffmpeg/fix-fate-ffmpeg-filter-in-eof-8.1.patch
+++ b/pkgs/development/libraries/ffmpeg/fix-fate-ffmpeg-filter-in-eof-8.1.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/fate/ffmpeg.mak b/tests/fate/ffmpeg.mak
+index cd00275638..d9458b7e1f 100644
+--- a/tests/fate/ffmpeg.mak
++++ b/tests/fate/ffmpeg.mak
+@@ -257,7 +257,7 @@ fate-ffmpeg-filter-in-eof: CMD = framecrc
+     -f rawvideo -s 352x288 -pix_fmt yuv420p -t 1 -i $(TARGET_PATH)/tests/data/vsynth1.yuv  \
+     -f rawvideo -s 352x288 -pix_fmt yuv420p -t 1 -i $(TARGET_PATH)/tests/data/vsynth1.yuv  \
+     -filter_complex "[0][1]concat" -c:v rawvideo
+-FATE_FFMPEG-$(call FRAMECRC, RAWVIDEO, RAWVIDEO, CONCAT_FILTER) += fate-ffmpeg-filter-in-eof
++FATE_SAMPLES_FFMPEG-$(call FRAMECRC, RAWVIDEO, RAWVIDEO, CONCAT_FILTER) += fate-ffmpeg-filter-in-eof
+ 
+ # Test termination on streamcopy with -t as an output option.
+ fate-ffmpeg-streamcopy-t: tests/data/vsynth1.yuv

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -498,6 +498,19 @@ stdenv.mkDerivation (
           hash = "sha256-OLiQHKBNp2p63ZmzBBI4GEGz3WSSP+rMd8ITfZSVRgY=";
         })
       ]
+      ++ optionals (lib.versionAtLeast version "7.1" && lib.versionOlder version "7.1.1") [
+        ./fix-fate-ffmpeg-spec-disposition-7.1.patch
+      ]
+      ++
+        optionals
+          (
+            lib.versionAtLeast version "8.1"
+            && lib.versionOlder version "8.1.1"
+            && stdenv.hostPlatform.isRiscV64
+          )
+          [
+            ./fix-fate-ffmpeg-filter-in-eof-8.1.patch
+          ]
       ++ optionals (lib.versionAtLeast version "7.1.1") [
         # Expose a private API for Chromium / Qt WebEngine.
         (fetchpatch2 {


### PR DESCRIPTION
Fix this issue : 

```
       > TEST    ffmpeg-streamcopy-t
       > TEST    ffmpeg-loopback-decoding
       > TEST    acodec-pcm-alaw
       > TEST    acodec-pcm-mulaw
       > TEST    acodec-pcm-s16be
       > TEST    acodec-pcm-s16le
       > TEST    acodec-pcm-u16be
       > TEST    acodec-pcm-u16le
       > TEST    acodec-pcm-s8
       > --- ./tests/ref/fate/ffmpeg-filter-in-eof       1970-01-01 00:00:01.000000000 +0000
       > +++ tests/data/fate/ffmpeg-filter-in-eof    2026-05-29 14:03:33.034874712 +0000
       > @@ -47,7 +47,7 @@
       >  0,         41,         41,        1,   152064, 0x8e364e18
       >  0,         42,         42,        1,   152064, 0xb15d38c8
       >  0,         43,         43,        1,   152064, 0xf25f6acc
       > -0,         44,         44,        1,   152064, 0xf34ddbff
       > +0,         44,         44,        1,   152064, 0x9b995435
       >  0,         45,         45,        1,   152064, 0xfc7bf570
       >  0,         46,         46,        1,   152064, 0x9dc72412
       >  0,         47,         47,        1,   152064, 0x445d1d59
       > TEST    acodec-pcm-u8
       > Test ffmpeg-filter-in-eof failed. Look at tests/data/fate/ffmpeg-filter-in-eof.err for details.
       > make: *** [tests/Makefile:322: fate-ffmpeg-filter-in-eof] Error 1
       > make: *** Waiting for unfinished jobs....
       > TEST    acodec-pcm-s24be
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
