### PR TITLE
concord-tui: init at 2.2.2

### DIFF
--- a/pkgs/by-name/co/concord-tui/package.nix
+++ b/pkgs/by-name/co/concord-tui/package.nix
@@ -1,0 +1,46 @@
+{
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  alsa-lib,
+  cmake,
+  opus,
+  lib,
+  stdenv,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "concord-tui";
+  version = "2.2.2";
+
+  src = fetchFromGitHub {
+    owner = "chojs23";
+    repo = "concord";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-oKaP5ff19RYg73LsilD1Hxaz7nSr8QK/08jM1TylbWU=";
+  };
+
+  cargoHash = "sha256-jJkAXzmZAUHLIO2uVeR3KNTBYAnp31m49mk66/lKHHY=";
+
+  buildInputs = [
+    opus
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    alsa-lib
+  ];
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Feature-rich TUI client for Discord, written in Rust";
+    homepage = "https://github.com/chojs23/concord";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ Simon-Weij ];
+    mainProgram = "concord";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/chojs23/concord
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
