### PR TITLE
waytrogen: 0.9.5 -> 0.9.8

### DIFF
--- a/pkgs/by-name/wa/waytrogen/package.nix
+++ b/pkgs/by-name/wa/waytrogen/package.nix
@@ -4,7 +4,6 @@
   rustPlatform,
   pkg-config,
   wrapGAppsHook4,
-  glib,
   nix-update-script,
   stdenv,
   meson,
@@ -14,22 +13,37 @@
   sqlite,
   openssl,
   desktop-file-utils,
+  bash,
+  dbus,
+  gtk4,
+  ffmpeg,
+  libx11,
+  libxcursor,
+  libxrandr,
+  libxi,
+  libxcb,
+  libxkbcommon,
+  vulkan-loader,
+  wayland,
+  xdg-utils,
+  xdg-desktop-portal,
+  libGL,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "waytrogen";
-  version = "0.9.5";
+  version = "0.9.8";
 
   src = fetchFromGitHub {
     owner = "nikolaizombie1";
     repo = "waytrogen";
     tag = finalAttrs.version;
-    hash = "sha256-+1HiTmJAkhd+zbLAyRRk9tHDbR7qcslkfJ2HyGipZCo=";
+    hash = "sha256-Nf1qPIFlhQl5T3RYVK4GMinO2vOJDNoYBrrVY93VF0Q=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-UKd/h/O9EE7gZ8B+QtFVGJEit0BIQ0OC0CG/GLYzMEo=";
+    hash = "sha256-EXP6Mt04Z+2ag2BhihzAtjwPGE82Ig6GoD1Vgor7oHc=";
   };
 
   nativeBuildInputs = [
@@ -41,30 +55,62 @@ stdenv.mkDerivation (finalAttrs: {
     cargo
     rustc
     desktop-file-utils
+    bash
+    dbus
+    sqlite
+    gtk4
+    dbus
+    xdg-utils
+    xdg-desktop-portal
   ];
 
   buildInputs = [
-    glib
     sqlite
     openssl
+    gtk4
+    ffmpeg
+    libx11
+    libxcursor
+    libxrandr
+    libxi
+    libxcb
+    libxkbcommon
+    vulkan-loader
+    wayland
+    dbus
+    xdg-utils
+    xdg-desktop-portal
   ];
-
-  preBuild = "export OUT_PATH=$out";
 
   env = {
     OPENSSL_NO_VENDOR = 1;
   };
 
-  mesonFlags = [ "-Dcargo_features=nixos" ];
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = { };
+  };
 
-  passthru.updateScript = nix-update-script { };
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --suffix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          wayland
+          libxkbcommon
+          vulkan-loader
+          libGL
+          dbus
+        ]
+      }
+    )
+  '';
 
   meta = {
     description = "Lightning fast wallpaper setter for Wayland";
     longDescription = ''
       A GUI wallpaper setter for Wayland that is a spiritual successor
       for the minimalistic wallpaper changer for X11 nitrogen. Written purely
-      in the Rust 🦀 programming language. Supports hyprpaper, swaybg, mpvpaper and swww wallpaper changers.
+      in the Rust 🦀 programming language. Supports hyprpaper, swaybg, mpvpaper, swww  and gSlapper wallpaper changers.
     '';
     homepage = "https://github.com/nikolaizombie1/waytrogen";
     changelog = "https://github.com/nikolaizombie1/waytrogen/releases/tag/${finalAttrs.version}";
@@ -75,5 +121,6 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     mainProgram = "waytrogen";
     platforms = lib.platforms.linux;
+    badPlatforms = lib.platforms.darwin;
   };
 })


### PR DESCRIPTION
<!--
GTK4 to iced migration and swaybg bug fixes.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
