### PR TITLE
nixos/prometheus-elasticsearch-exporter: init

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -62,6 +62,7 @@ let
         "domain"
         "dovecot"
         "ebpf"
+        "elasticsearch"
         "fail2ban"
         "fastly"
         "flow"

--- a/nixos/modules/services/monitoring/prometheus/exporters/elasticsearch.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/elasticsearch.nix
@@ -1,0 +1,62 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkIf
+    mkOption
+    types
+    ;
+
+  inherit (utils) escapeSystemdExecArgs;
+
+  cfg = config.services.prometheus.exporters.elasticsearch;
+in
+{
+  port = 9114;
+  extraOpts = {
+    package = lib.mkPackageOption pkgs "prometheus-elasticsearch-exporter" { };
+
+    url = mkOption {
+      type = types.str;
+      default = "http://localhost:9200";
+      example = "https://localhost:9200";
+      description = ''
+        URI of the Elasticsearch (or OpenSearch) node to scrape, passed as
+        `--es.uri`. Any credentials embedded here are overridden by the
+        `ES_USERNAME`/`ES_PASSWORD` or `ES_API_KEY` environment variables when
+        {option}`environmentFile` is set.
+      '';
+    };
+
+    environmentFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/run/secrets/elasticsearch-exporter.env";
+      description = ''
+        Path to an environment file, as defined in {manpage}`systemd.exec(5)`,
+        used to pass credentials to the exporter without exposing them in the
+        process arguments. It should contain either `ES_USERNAME` and
+        `ES_PASSWORD`, or `ES_API_KEY`.
+      '';
+    };
+  };
+  serviceOpts = {
+    serviceConfig = {
+      EnvironmentFile = mkIf (cfg.environmentFile != null) cfg.environmentFile;
+      ExecStart = escapeSystemdExecArgs (
+        [
+          (lib.getExe cfg.package)
+          "--web.listen-address=${cfg.listenAddress}:${toString cfg.port}"
+          "--es.uri=${cfg.url}"
+        ]
+        ++ cfg.extraFlags
+      );
+    };
+  };
+}

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -436,6 +436,30 @@ let
         '';
       };
 
+    elasticsearch =
+      { ... }:
+      {
+        exporterConfig = {
+          enable = true;
+          url = "http://localhost:9200";
+        };
+        metricProvider = {
+          # `services.elasticsearch` is unmaintained; OpenSearch is the same
+          # engine class and is explicitly supported by the exporter.
+          services.opensearch.enable = true;
+          virtualisation.memorySize = 2048;
+        };
+        exporterTest = ''
+          wait_for_unit("opensearch.service")
+          wait_for_open_port(9200)
+          wait_for_unit("prometheus-elasticsearch-exporter.service")
+          wait_for_open_port(9114)
+          succeed(
+              "curl -sSf localhost:9114/metrics | grep 'elasticsearch_cluster_health_status'"
+          )
+        '';
+      };
+
     fail2ban =
       { ... }:
       {

--- a/pkgs/by-name/pr/prometheus-elasticsearch-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-elasticsearch-exporter/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  nixosTests,
 }:
 buildGoModule (finalAttrs: {
   pname = "elasticsearch_exporter";
@@ -15,6 +16,8 @@ buildGoModule (finalAttrs: {
   };
 
   vendorHash = "sha256-8y0M1b34eJpuHOuXPemhB5kKwBSgU7cMFxOaIZFS/bo=";
+
+  passthru.tests = { inherit (nixosTests.prometheus-exporters) elasticsearch; };
 
   meta = {
     description = "Elasticsearch stats exporter for Prometheus";


### PR DESCRIPTION
Add a `services.prometheus.exporters.elasticsearch` module wrapping `pkgs.prometheus-elasticsearch-exporter`, which also supports OpenSearch.

Credentials are kept out of the process arguments and the store via an `environmentFile` carrying `ES_USERNAME`/`ES_PASSWORD` or `ES_API_KEY`, which override any auth embedded in `--es.uri`. Collector toggles go through the framework's `extraFlags`.

A NixOS test exercises the exporter against a single-node OpenSearch instance - which is also added to `passthru.tests` of `pkgs.prometheus-elasticsearch-exporter`.

Disclaimer: I used a coding agent in the creation of this patch.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
