### PR TITLE
mautrix-discord: make registration file owned by mautrix-discord

### DIFF
--- a/nixos/modules/services/matrix/mautrix-discord.nix
+++ b/nixos/modules/services/matrix/mautrix-discord.nix
@@ -378,6 +378,7 @@ in
     };
 
     users.groups.mautrix-discord = { };
+    # this group is only needed for installs before 26.05
     users.groups.mautrix-discord-registration = {
       members = lib.lists.optional config.services.matrix-synapse.enable "matrix-synapse";
     };
@@ -392,7 +393,10 @@ in
 
     systemd.services = {
       matrix-synapse = lib.mkIf cfg.registerToSynapse {
-        serviceConfig.SupplementaryGroups = [ "mautrix-discord-registration" ];
+        serviceConfig.SupplementaryGroups = [
+          "mautrix-discord"
+          "mautrix-discord-registration"
+        ];
         # Make synapse depend on the registration service when auto-registering
         wants = [ "mautrix-discord-registration.service" ];
         after = [ "mautrix-discord-registration.service" ];
@@ -472,14 +476,13 @@ in
           mv '${registrationFile}.tmp' '${registrationFile}'
 
           umask $old_umask
-          chown :mautrix-discord-registration '${registrationFile}'
           chmod 640 '${registrationFile}'
         '';
 
         serviceConfig = {
           Type = "oneshot";
           RemainAfterExit = true;
-          UMask = 27;
+          UMask = "027";
 
           User = "mautrix-discord";
           Group = "mautrix-discord";
@@ -535,6 +538,8 @@ in
           ProtectKernelLogs = true;
           ProtectHostname = true;
           ProtectClock = true;
+
+          UMask = "027";
 
           SystemCallArchitectures = "native";
           SystemCallErrorNumber = "EPERM";


### PR DESCRIPTION
instead of mautrix-discord-registration

The directory containing the registration file
(/var/lib/mautrix-discord) is declared as StateDirectory for a systemd service with User=mautrix-discord and Group=mautrix-discord. It seems that this causes systemd to occasionnaly changing the perms of /var/lib/mautrix-discord (just the directory, not necessarily its content) to 750 mautrix-discord:mautrix-discord. As a result, if synapse is only in the mautrix-discord-registration group, it cannot traverse the directory to the registration file and fails to start.

I have experienced this issue about once a month, every time when nixos-rebuild switch restarts the service. (I have daily upgrades). I am quite surprised that most of the time, the current module works, but occasionnaly it breaks as I describe above. The documentation is quite clear that it cannot work:

         Except  in  case  of  ConfigurationDirectory=, the innermost specified directories will be
         owned by the user and group specified in User= and Group=. If  the  specified  directories
         already  exist  and their owning user or group do not match the configured ones, all files
         and directories below the specified directories as well as the directories themselves will
         have their file ownership recursively changed to match what is configured. As an optimiza‐
         tion, if the specified directories are already owned by the right user  and  group,  files
         and directories below of them are left as-is, even if they do not match what is requested.
         The  innermost  specified  directories will have their access mode adjusted to the what is
         specified in RuntimeDirectoryMode=, StateDirectoryMode=, CacheDirectoryMode=, LogsDirecto‐
         ryMode= and ConfigurationDirectoryMode=.

It might use to work sometimes because of the "as an optimization" part.

This commit changes the registration file to be owned by mautrix-discord instead of mautrix-discord-registration and synapse to be in the mautrix-discord group. For backward compat with people who already have a mautrix-discord-registration owned registration file, the mautrix-discord-registration group is kept and synapse is still in this group as well.



cc @Mistyttm 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
