### PR TITLE
nocturne: clean up dependencies for version 1.2.1

### DIFF
--- a/pkgs/by-name/no/nocturne/disable-navidrome-setup.patch
+++ b/pkgs/by-name/no/nocturne/disable-navidrome-setup.patch
@@ -1,0 +1,14 @@
+--- a/src/integrations/navidrome.py
++++ b/src/integrations/navidrome.py
+@@ -556,11 +556,6 @@
+     process = None
+ 
+     def check_if_ready(self, row) -> bool:
+-        if get_navidrome_path():
+-            return True
+-        else:
+-            row.get_root().main_stack.set_visible_child_name('setup')
+-            row.get_root().main_stack.get_child_by_name('setup').set_integration(self)
+         return False
+ 
+     def start_instance(self) -> bool:

--- a/pkgs/by-name/no/nocturne/package.nix
+++ b/pkgs/by-name/no/nocturne/package.nix
@@ -12,7 +12,6 @@
   glib,
   glib-networking,
   pkg-config,
-  cmake,
   gtk4,
   python3,
   python3Packages,
@@ -50,7 +49,6 @@ stdenv.mkDerivation (finalAttrs: {
     appstream
     glib
     pkg-config
-    cmake
     gtk4
     python3
   ];
@@ -64,6 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
     gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
   ];
 
   pythonDependencies = [
@@ -73,7 +72,6 @@ stdenv.mkDerivation (finalAttrs: {
     python3Packages.syncedlyrics
     python3Packages.pycairo
     python3Packages.colorthief
-    python3Packages.favicon
     python3Packages.mpris-server
     python3Packages.pillow
   ];
@@ -85,8 +83,11 @@ stdenv.mkDerivation (finalAttrs: {
     )
   '';
 
+  # avoid installing Navidrome at runtime if not available, incompatible with the nix store
+  patches = [ ./disable-navidrome-setup.patch ];
+
   meta = {
-    description = "Adwaita Music Player and Library Manager";
+    description = "Adwaita music player for OpenSubsonic servers like Navidrome";
     homepage = "https://jeffser.com/nocturne/";
     changelog = "https://github.com/Jeffser/Nocturne/releases";
     license = lib.licenses.gpl3Plus;


### PR DESCRIPTION
## Things done

- this removes unused Python dependencies `favicon` & `pycairo` and keeps using the packaged `python3Packages.mpris-server` instead of a local definition
- i also added a small patch to skip the bundled `Navidrome` setup

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
