### PR TITLE
python3Packages.flash-attn-4: init at 4.0.0.beta15

### DIFF
--- a/pkgs/development/python-modules/flash-attn-4/default.nix
+++ b/pkgs/development/python-modules/flash-attn-4/default.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  apache-tvm-ffi,
+  cuda-bindings,
+  einops,
+  nvidia-cutlass-dsl,
+  quack-kernels,
+  torch,
+  torch-c-dlpack-ext,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "flash-attn-4";
+  version = "4.0.0.beta15";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Dao-AILab";
+    repo = "flash-attention";
+    tag = "fa4-v${finalAttrs.version}";
+    hash = "sha256-k6158mEJocKIRS4MQIM+Ih4VMHnXCKJGcykZFi91J2w=";
+  };
+
+  # FA4 is a separate distribution shipped under flash_attn/cute/ with its own pyproject.toml.
+  # The top-level setup.py builds the classic compiled flash-attn and excludes flash_attn.cute.
+  sourceRoot = "${finalAttrs.src.name}/flash_attn/cute";
+
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    apache-tvm-ffi
+    cuda-bindings
+    einops
+    nvidia-cutlass-dsl
+    quack-kernels
+    torch
+    torch-c-dlpack-ext
+  ];
+
+  pythonImportsCheck = [ "flash_attn.cute" ];
+
+  # No tests
+  doCheck = false;
+
+  meta = {
+    description = "CuTeDSL-based implementation of FlashAttention for Hopper and Blackwell GPUs";
+    homepage = "https://github.com/Dao-AILab/flash-attention/tree/main/flash_attn/cute";
+    changelog = "https://github.com/Dao-AILab/flash-attention/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+      prince213
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5705,6 +5705,8 @@ self: super: with self; {
 
   flash-attn = callPackage ../development/python-modules/flash-attn { };
 
+  flash-attn-4 = callPackage ../development/python-modules/flash-attn-4 { };
+
   flash-mla = callPackage ../development/python-modules/flash-mla { };
 
   flashinfer = callPackage ../development/python-modules/flashinfer { };


### PR DESCRIPTION
## Things done

Add [flash-attn-4](https://github.com/Dao-AILab/flash-attention/tree/main/flash_attn/cute), the Flash Attention based on NVIDIA's CuTeDSL.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
