### PR TITLE
linux: use correct strip program when stripping vmlinux

### DIFF
--- a/pkgs/os-specific/linux/kernel/build.nix
+++ b/pkgs/os-specific/linux/kernel/build.nix
@@ -510,7 +510,7 @@ lib.makeOverridable (
 
     preFixup = ''
       if [ -z "''${dontStrip-}" -a -e $out/vmlinux ]; then
-        strip -v -S -p $out/vmlinux
+        $STRIP -v -S -p $out/vmlinux
       fi
     '';
 


### PR DESCRIPTION
Otherwise may fail during cross complation with:

    [...]/strip: Unable to recognise the architecture of the input file: `/[...]/vmlinux`

---

Encountered while building a powerpc64-linux kernel on x86_64-linux via

```sh
nix-build . --argstr crossSystem powerpc64-linux -A linux
```

IIUC `strip` refers to the host toolchain by default which may or may not understand various binary formats, and `$STRIP` is set to the cross toolchain (in this case `powerpc64-unknown-linux-gnuabielfv1-strip`).

cc @OPNA2608 who seems to be interested in PowerPC, and added the original strip in 99bf69cd043d30c8a913827a013f689a95d68763 as part of https://github.com/NixOS/nixpkgs/pull/447752. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
