### PR TITLE
netboxPlugins: set structuredAttrs

### DIFF
--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-attachments/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-attachments/package.nix
@@ -12,6 +12,7 @@ buildPythonPackage (finalAttrs: {
   pname = "netbox-attachments";
   version = "11.2.1";
   pyproject = true;
+  __structuredAttrs = true;
 
   disabled = python.pythonVersion != netbox.python.pythonVersion;
 

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-bgp/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-bgp/package.nix
@@ -12,6 +12,7 @@ buildPythonPackage rec {
   pname = "netbox-bgp";
   version = "0.18.1";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "netbox-community";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-contextmenus/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-contextmenus/package.nix
@@ -11,6 +11,7 @@ buildPythonPackage rec {
   pname = "netbox-contextmenus";
   version = "1.4.14";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "PieterL75";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-contract/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-contract/package.nix
@@ -13,6 +13,7 @@ buildPythonPackage (finalAttrs: {
   pname = "netbox-contract";
   version = "2.4.5";
   pyproject = true;
+  __structuredAttrs = true;
 
   disabled = python.pythonVersion != netbox.python.pythonVersion;
 

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-dns/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-dns/package.nix
@@ -9,6 +9,7 @@ buildPythonPackage rec {
   pname = "netbox-plugin-dns";
   version = "1.5.8";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "peteeckel";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-documents/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-documents/package.nix
@@ -12,6 +12,7 @@ buildPythonPackage rec {
   pname = "netbox-documents";
   version = "0.8.2";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "jasonyates";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-floorplan-plugin/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-floorplan-plugin/package.nix
@@ -12,6 +12,7 @@ buildPythonPackage rec {
   pname = "netbox-floorplan-plugin";
   version = "0.9.1";
   pyproject = true;
+  __structuredAttrs = true;
 
   disabled = python.pythonVersion != netbox.python.pythonVersion;
 

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-interface-synchronization/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-interface-synchronization/package.nix
@@ -21,6 +21,7 @@ buildPythonPackage (finalAttrs: {
   pname = "netbox-interface-synchronization";
   version = "4.5.8";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "NetTech2001";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-napalm-plugin/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-napalm-plugin/package.nix
@@ -12,6 +12,7 @@ buildPythonPackage (finalAttrs: {
   pname = "netbox-napalm-plugin";
   version = "0.3.4";
   pyproject = true;
+  __structuredAttrs = true;
 
   disabled = python.pythonVersion != netbox.python.pythonVersion;
 

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-plugin-prometheus-sd/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-plugin-prometheus-sd/package.nix
@@ -17,6 +17,7 @@ buildPythonPackage (finalAttrs: {
   pname = "netbox-plugin-prometheus-sd";
   version = "1.3.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "FlxPeters";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-qrcode/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-qrcode/package.nix
@@ -21,6 +21,7 @@ buildPythonPackage (finalAttrs: {
   pname = "netbox-qrcode";
   version = "0.0.20";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "netbox-community";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-reorder-rack/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-reorder-rack/package.nix
@@ -11,6 +11,7 @@ buildPythonPackage rec {
   pname = "netbox-reorder-rack";
   version = "1.1.4";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "netbox-community";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-routing/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-routing/package.nix
@@ -13,6 +13,7 @@ buildPythonPackage rec {
   pname = "netbox-routing";
   version = "0.4.3";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "DanSheps";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-topology-views/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-topology-views/package.nix
@@ -12,6 +12,7 @@ buildPythonPackage rec {
   pname = "netbox-topology-views";
   version = "4.5.1";
   pyproject = true;
+  __structuredAttrs = true;
 
   disabled = python.pythonVersion != netbox.python.pythonVersion;
 


### PR DESCRIPTION
Maybe we should adjust the pr title to something like `various/netboxPlugins: set structuredAttrs`, but I haven't found anything like this in the readme's.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
