### PR TITLE
silo: init at 2026-06-18T00-00-00Z

### DIFF
--- a/pkgs/by-name/si/silo/package.nix
+++ b/pkgs/by-name/si/silo/package.nix
@@ -1,0 +1,87 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+let
+  # The web client verifies that the server version is a valid datetime string:
+  #
+  # Example:
+  #   versionToTimestamp "2026-04-17T00-00-00Z"
+  #   => "2026-04-17T00:00:00Z"
+  versionToTimestamp =
+    version:
+    let
+      splitTS = builtins.elemAt (builtins.split "(.*)(T.*)" version) 1;
+    in
+    builtins.concatStringsSep "" [
+      (builtins.elemAt splitTS 0)
+      (builtins.replaceStrings [ "-" ] [ ":" ] (builtins.elemAt splitTS 1))
+    ];
+
+  # CopyrightYear will be printed to the CLI UI.
+  # Example:
+  #   versionToYear "2026-04-17T00-00-00Z"
+  #   => "2026"
+  versionToYear = version: builtins.elemAt (lib.splitString "-" version) 0;
+in
+buildGoModule (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "silo";
+  version = "2026-06-18T00-00-00Z";
+
+  src = fetchFromGitHub {
+    owner = "pgsty";
+    repo = "minio";
+    tag = "RELEASE.${finalAttrs.version}";
+    hash = "sha256-TwuqWof8FozryQoZt1lybw7z8z8E3Ose4jbKZ0To2lk=";
+  };
+
+  vendorHash = "sha256-rewz3Sez/01iWGCEhMVmcVnIxxjgBzmeUyMqFi6s4mc=";
+
+  subPackages = [ "." ];
+
+  env.CGO_ENABLED = 0;
+
+  # nixpkgs go_1_26 pinned to 1.26.3; pgsty/minio's go.mod says go 1.26.4.
+  # Step down to 1.26.3 to use the available toolchain. If pgsty/minio
+  # genuinely needs 1.26.4 features, we can replace this with one of:
+  #   - Go toolchain auto-switch: prePatch GOTOOLCHAIN=go1.26.4+auto
+  #     (fails inside Nix sandbox since GOPROXY=off blocks toolchain download)
+  #   - Override go: buildGoModule.override { go = go_1_26.overrideAttrs ... }
+  #     (compile go 1.26.4 from source, ~5–10 min)
+  #   - Wait for nixpkgs to bump go_1_26 past 1.26.4
+  postPatch = ''
+    substituteInPlace go.mod \
+      --replace-fail "go 1.26.4" "go 1.26.3"
+  '';
+
+  tags = [ "kqueue" ];
+
+  ldflags =
+    let
+      t = "github.com/minio/minio/cmd";
+    in
+    [
+      "-s"
+      "-w"
+      "-X ${t}.Version=${versionToTimestamp finalAttrs.version}"
+      "-X ${t}.ReleaseTag=RELEASE.${finalAttrs.version}"
+      "-X ${t}.CommitID=${finalAttrs.src.rev}"
+      "-X ${t}.CopyrightYear=${versionToYear finalAttrs.version}"
+    ];
+
+  postInstall = ''
+    ln -s "$out/bin/minio" "$out/bin/silo"
+  '';
+
+  meta = {
+    description = "Community-maintained fork of MinIO packaged as silo";
+    homepage = "https://github.com/pgsty/minio";
+    changelog = "https://github.com/pgsty/minio/releases/tag/${finalAttrs.src.tag}";
+    maintainers = with lib.maintainers; [ randoneering ];
+    license = lib.licenses.agpl3Plus;
+    mainProgram = "silo";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Silo (github.com/pgsty/minio) is a community-maintained fork of MinIO by the Pigsty (https://pigsty.io) project. Changes from upstream MinIO are minimal. It restores the embedded management console version reference and updates docs/Go module paths. The binary is renamed from minio to silo.

It exists because MinIO Inc. moved features (WebUI, LDAP/OIDC, distributed erasure coding) into their proprietary AIStor product. Silo keeps the fully open-source (AGPLv3) MinIO alive with continued maintenance, binary releases, and security backports. This is essentially a drop-in replacement for anyone who needs the full-featured open-source MinIO.

Because I was not confident in my choice for the version, I reached out in discourse:

https://discourse.nixos.org/t/question-on-silo-pkg-minio-fork/77900

**Update 2026-07-23**

Go toolchain

`pgsty/minio` declares `go 1.26.4` in its `go.mod`, but nixpkgs currently pins `go_1_26` to `1.26.3`. To build with the available toolchain, the `postPatch` step rewrites the directive to `1.26.3`.

If the build fails or pgsty/minio actually requires a 1.26.4-only feature, three workarounds are available:

- **Toolchain auto-switch**: set `GOTOOLCHAIN=go1.26.4+auto` via `prePatch`. Go fetches the matching SDK on first build and caches it. Currently blocked: the Nix sandbox blocks the toolchain download because `buildGoModule` forces `GOPROXY=off` for reproducibility.
- **Build go 1.26.4 from source**: buildGoModule.override { go = go_1_26.overrideAttrs (_: { version = "1.26.4"; src = fetchurl { url = "..."; sha256 = "..."; }); }`. Adds 5–10 minutes per build for the Go toolchain compile.
- **Wait for nixpkgs**: drop the `postPatch` substitute once nixpkgs bumps `go_1_26` past `1.26.4` 

If what I added doesn't make sense, please let me now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
