### PR TITLE
[Backport release-26.05] root: fix Darwin build

### DIFF
--- a/pkgs/by-name/ro/root/package.nix
+++ b/pkgs/by-name/ro/root/package.nix
@@ -51,6 +51,7 @@
   patchRcPathPosix,
   onetbb,
   xrootd,
+  freetype,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -117,7 +118,10 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
     zstd
   ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk.privateFrameworksHook ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    apple-sdk.privateFrameworksHook
+    freetype
+  ]
   ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     libGLU
     libGL
@@ -137,11 +141,6 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail 'set(lcgpackages ' '#set(lcgpackages '
 
     patchShebangs cmake/unix/
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    # Eliminate impure reference to /System/Library/PrivateFrameworks
-    substituteInPlace core/macosx/CMakeLists.txt \
-      --replace-fail "-F/System/Library/PrivateFrameworks " ""
   ''
   +
     lib.optionalString


### PR DESCRIPTION
Backport of #525530.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
