### PR TITLE
tranquil-pds: init at 0.6.3, tranquil-pds-frontend: init at 0.6.3, nixos/tranquil-pds: init module; nixosTests.tranquil-pds: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19394,6 +19394,11 @@
     githubId = 79978224;
     name = "winston";
   };
+  nelind = {
+    name = "Nel";
+    github = "nelind3";
+    githubId = 57587152;
+  };
   nelsonjeppesen = {
     email = "nix@jeppesen.io";
     github = "NelsonJeppesen";

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -10,7 +10,7 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- Create the first release note entry in this section!
+- [tranquil](https://tangled.org/tranquil.farm/tranquil-pds) is an ATProto PDS (personal data server) implementation in Rust. A featureful, spec conscious and community driven alternative to the Bluesky reference implementation PDS. Available as [services.tranquil-pds](#opt-services.tranquil-pds.enable).
 
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1792,6 +1792,7 @@
   ./services/web-apps/suwayomi-server.nix
   ./services/web-apps/szurubooru.nix
   ./services/web-apps/tabbyapi.nix
+  ./services/web-apps/tranquil-pds.nix
   ./services/web-apps/trilium.nix
   ./services/web-apps/tt-rss.nix
   ./services/web-apps/tuliprox.nix

--- a/nixos/modules/services/web-apps/tranquil-pds.nix
+++ b/nixos/modules/services/web-apps/tranquil-pds.nix
@@ -1,0 +1,251 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.services.tranquil-pds;
+
+  inherit (lib) types mkPackageOption mkOption;
+
+  settingsFormat = pkgs.formats.toml { };
+in
+{
+  options.services.tranquil-pds = {
+    enable = lib.mkEnableOption "tranquil-pds AT Protocol personal data server";
+
+    package = mkPackageOption pkgs "tranquil-pds" { };
+
+    user = mkOption {
+      type = types.str;
+      default = "tranquil-pds";
+      description = "User under which tranquil-pds runs";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "tranquil-pds";
+      description = "Group under which tranquil-pds runs";
+    };
+
+    dataDir = mkOption {
+      type = types.str;
+      default = "/var/lib/tranquil-pds";
+      description = "Working directory for tranquil-pds. Also expected to be used for data (blobs)";
+    };
+
+    environmentFiles = mkOption {
+      type = types.listOf types.path;
+      default = [ ];
+      description = ''
+        File to load environment variables from. Loaded variables override
+        values set in {option}`environment`.
+
+        Use it to set values of `JWT_SECRET`, `DPOP_SECRET` and `MASTER_KEY`.
+
+        Generate these with:
+        ```
+        openssl rand -base64 48
+        ```
+      '';
+    };
+
+    database.createLocally = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Create the postgres database and user on the local host.
+      '';
+    };
+
+    settings = mkOption {
+      type = types.submodule {
+        freeformType = settingsFormat.type;
+
+        options = {
+          server = {
+            host = mkOption {
+              type = types.str;
+              default = "127.0.0.1";
+              description = "Host for tranquil-pds to listen on";
+            };
+
+            port = mkOption {
+              type = types.int;
+              default = 3000;
+              description = "Port for tranquil-pds to listen on";
+            };
+
+            hostname = mkOption {
+              type = types.str;
+              default = "";
+              example = "pds.example.com";
+              description = "The public-facing hostname of the PDS";
+            };
+
+            max_blob_size = mkOption {
+              type = types.int;
+              default = 10737418240; # 10 GiB
+              description = "Maximum allowed blob size in bytes.";
+            };
+          };
+
+          frontend = {
+            enabled =
+              lib.mkEnableOption "serving the frontend from the backend. Disable to serve the frontend manually"
+              // {
+                default = true;
+              };
+
+            dir = mkPackageOption pkgs "tranquil-pds-frontend" { };
+          };
+
+          storage = {
+            path = mkOption {
+              type = types.path;
+              default = "${cfg.dataDir}/blobs";
+              defaultText = "\${cfg.dataDir}/blobs";
+              description = "Directory for storing blobs";
+            };
+          };
+          tranquil_store = {
+            data_dir = mkOption {
+              type = types.path;
+              default = "${cfg.dataDir}/store";
+              defaultText = "\${cfg.dataDir}/store";
+              description = "Directory for tranquil-store files";
+            };
+          };
+        };
+      };
+
+      description = ''
+        Configuration options to set for the service. Secrets should be
+        specified using {option}`environmentFile`.
+
+        Refer to <https://tangled.org/tranquil.farm/tranquil-pds/blob/main/example.toml>
+        for available configuration options.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      (lib.mkIf cfg.database.createLocally {
+        services.postgresql = {
+          enable = true;
+          ensureDatabases = [ cfg.user ];
+          ensureUsers = [
+            {
+              name = cfg.user;
+              ensureDBOwnership = true;
+            }
+          ];
+        };
+
+        services.tranquil-pds.settings.database.url =
+          lib.mkDefault "postgresql:///${cfg.user}?host=/run/postgresql";
+
+        systemd.services.tranquil-pds = {
+          requires = [ "postgresql.service" ];
+          after = [ "postgresql.service" ];
+        };
+      })
+
+      {
+        users.users.${cfg.user} = {
+          isSystemUser = true;
+          inherit (cfg) group;
+          home = cfg.dataDir;
+        };
+
+        users.groups.${cfg.group} = { };
+
+        systemd.tmpfiles.settings."tranquil-pds" =
+          lib.genAttrs
+            [
+              cfg.dataDir
+              cfg.settings.storage.path
+              cfg.settings.tranquil_store.data_dir
+            ]
+            (_: {
+              d = {
+                mode = "0750";
+                inherit (cfg) user group;
+              };
+            });
+
+        environment.etc = {
+          "tranquil-pds/config.toml".source =
+            let
+              conf = settingsFormat.generate "tranquil-pds.toml" cfg.settings;
+            in
+            pkgs.runCommandLocal "validated-tranquil-config" { nativeBuildInputs = [ cfg.package ]; } ''
+              tranquil-server --config ${conf} validate --ignore-secrets
+              ln -s ${conf} $out
+            '';
+        };
+
+        systemd.services.tranquil-pds = {
+          description = "Tranquil PDS - ATProtocol Personal Data Server";
+          after = [ "network-online.target" ];
+          wants = [ "network-online.target" ];
+          wantedBy = [ "multi-user.target" ];
+
+          serviceConfig = {
+            User = cfg.user;
+            Group = cfg.group;
+            UMask = "0077";
+            ExecStart = lib.getExe cfg.package;
+            Restart = "on-failure";
+            RestartSec = 5;
+
+            WorkingDirectory = cfg.dataDir;
+            StateDirectory = "tranquil-pds";
+            ReadWritePaths = [
+              cfg.settings.storage.path
+            ];
+
+            EnvironmentFile = cfg.environmentFiles;
+
+            CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
+            ProtectProc = "invisible";
+            ProcSubset = "pid";
+            NoNewPrivileges = true;
+            ProtectSystem = "strict";
+            ProtectHome = true;
+            PrivateTmp = true;
+            PrivateDevices = true;
+            PrivateUsers = true;
+            ProtectHostname = true;
+            ProtectClock = true;
+            ProtectKernelTunables = true;
+            ProtectKernelModules = true;
+            ProtectKernelLogs = true;
+            ProtectControlGroups = true;
+            RestrictAddressFamilies = [
+              "AF_INET"
+              "AF_INET6"
+              "AF_UNIX"
+            ];
+            RestrictNamespaces = true;
+            LockPersonality = true;
+            MemoryDenyWriteExecute = true;
+            RestrictRealtime = true;
+            RestrictSUIDSGID = true;
+            RemoveIPC = true;
+            PrivateMounts = true;
+            SystemCallFilter = [
+              "@system-service"
+              "~@privileged @resources"
+            ];
+            SystemCallArchitectures = "native";
+          };
+        };
+      }
+    ]
+  );
+
+  meta.maintainers = with lib.maintainers; [ nelind ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1707,6 +1707,7 @@ in
   tracee = handleTestOn [ "x86_64-linux" ] ./tracee.nix { };
   traefik = runTestOn [ "aarch64-linux" "x86_64-linux" ] ./traefik.nix;
   trafficserver = runTest ./trafficserver.nix;
+  tranquil-pds = runTest ./tranquil-pds.nix;
   transfer-sh = runTest ./transfer-sh.nix;
   transmission_4 = runTest ./transmission.nix;
   trezord = runTest ./trezord.nix;

--- a/nixos/tests/tranquil-pds.nix
+++ b/nixos/tests/tranquil-pds.nix
@@ -1,0 +1,35 @@
+{ lib, ... }:
+{
+  name = "tranquil-pds";
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.tranquil-pds = {
+        enable = true;
+        database.createLocally = true;
+
+        settings = {
+          server = {
+            hostname = "pds";
+            port = 8080;
+          };
+
+          secrets = {
+            allow_insecure = true;
+            jwt_secret = "test-jwt-secret-must-be-32-chars-long";
+            dpop_secret = "test-dpop-secret-must-be-32-chars-long";
+            master_key = "test-master-key-must-be-32-chars-long";
+          };
+        };
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("tranquil-pds.service")
+    machine.wait_for_open_port(8080)
+    machine.succeed("curl --fail http://localhost:8080")
+  '';
+
+  meta.maintainers = with lib.maintainers; [ nelind ];
+}

--- a/pkgs/by-name/tr/tranquil-pds-frontend/package.nix
+++ b/pkgs/by-name/tr/tranquil-pds-frontend/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchgit,
+  nodejs,
+  pnpm,
+  pnpmConfigHook,
+  fetchPnpmDeps,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "tranquil-frontend";
+  version = "0.6.3";
+
+  src = fetchgit {
+    url = "https://tangled.org/tranquil.farm/tranquil-pds";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TORNOFPlbCt4QWNd+bmxkShTUvT/5ynOj+UBYITAhg8=";
+  };
+  sourceRoot = "${finalAttrs.src.name}/frontend";
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      sourceRoot
+      ;
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-qbmIAvE/3u/NB5x9bERCGQqwiDLkzjff3QchgR+ZDFs=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    pnpm
+    nodejs
+    pnpmConfigHook
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    pnpm build
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    cp -r ./dist $out
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "First party frontend for the Tranquil PDS implementation";
+    homepage = "https://tangled.org/tranquil.farm/tranquil-pds";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ nelind ];
+  };
+})

--- a/pkgs/by-name/tr/tranquil-pds/package.nix
+++ b/pkgs/by-name/tr/tranquil-pds/package.nix
@@ -5,6 +5,7 @@
   pkg-config,
   openssl,
   protobuf,
+  nixosTests,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -33,6 +34,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # the tranquil test suite has shown itself virtually impossible to complete on most hardware thus stopping reviews.
   # disable the check phase for now
   doCheck = false;
+
+  passthru.tests = { inherit (nixosTests) tranquil-pds; };
 
   meta = {
     description = "Tranquil ATProto Personal Data Server implementation written in Rust";

--- a/pkgs/by-name/tr/tranquil-pds/package.nix
+++ b/pkgs/by-name/tr/tranquil-pds/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  fetchgit,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  protobuf,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tranquil-pds";
+  version = "0.6.3";
+
+  src = fetchgit {
+    url = "https://tangled.org/tranquil.farm/tranquil-pds";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TORNOFPlbCt4QWNd+bmxkShTUvT/5ynOj+UBYITAhg8=";
+  };
+
+  cargoHash = "sha256-tQk9WQZmaG2XEx5gocPhYd8fZ2cikvduhln5h/w+WZA=";
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    protobuf
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  # the tranquil test suite has shown itself virtually impossible to complete on most hardware thus stopping reviews.
+  # disable the check phase for now
+  doCheck = false;
+
+  meta = {
+    description = "Tranquil ATProto Personal Data Server implementation written in Rust";
+    homepage = "https://tangled.org/tranquil.farm/tranquil-pds";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ nelind ];
+    mainProgram = "tranquil-server";
+  };
+})


### PR DESCRIPTION
add the [tranquil](https://tangled.org/tranquil.farm/tranquil-pds) PDS implementation and its first party frontend as a nixpkgs packages and a nixos module with myself as maintainer. these are largely based on the derivations and module we already have in the repo itself. tweaked slightly to (hopefully) fit the nixpkgs standard and format instead of local dev ease and my personal formatting.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
