### PR TITLE
python3Packages.markitdown: 0.1.4 -> 0.1.6, fix passthru.updateScript

### DIFF
--- a/pkgs/development/python-modules/markitdown/default.nix
+++ b/pkgs/development/python-modules/markitdown/default.nix
@@ -8,21 +8,20 @@
   hatchling,
 
   # dependencies
+  azure-ai-documentintelligence,
+  azure-identity,
   beautifulsoup4,
+  charset-normalizer,
   defusedxml,
-  ffmpeg-headless,
   lxml,
   magika,
   mammoth,
   markdownify,
-  numpy,
   olefile,
-  openai,
   openpyxl,
   pandas,
-  pathvalidate,
   pdfminer-six,
-  puremagic,
+  pdfplumber,
   pydub,
   python-pptx,
   requests,
@@ -42,14 +41,14 @@ let
 in
 buildPythonPackage (finalAttrs: {
   pname = "markitdown";
-  version = "0.1.4";
+  version = "0.1.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "markitdown";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-WKA2eY8wY3SM9xZ7Cek5eUcJbO5q6eMDx2aTKfQnFvE=";
+    hash = "sha256-pLL44w2jVj5X5/TmPqSveQe/9WLj0ddDUYPoSQlz+9E=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/packages/markitdown";
@@ -58,23 +57,24 @@ buildPythonPackage (finalAttrs: {
 
   pythonRelaxDeps = [
     "magika"
+    "mammoth"
+    "youtube-transcript-api"
   ];
   dependencies = [
+    azure-ai-documentintelligence
+    azure-identity
     beautifulsoup4
+    charset-normalizer
     defusedxml
-    ffmpeg-headless
     lxml
     magika
     mammoth
     markdownify
-    numpy
     olefile
-    openai
     openpyxl
     pandas
-    pathvalidate
     pdfminer-six
-    puremagic
+    pdfplumber
     pydub
     python-pptx
     requests
@@ -98,6 +98,11 @@ buildPythonPackage (finalAttrs: {
     "test_module_vectors"
     "test_cli_vectors"
     "test_module_misc"
+
+    # Require optional azure-ai-contentunderstanding, unavailable in nixpkgs.
+    # The fallback stubs hit `UserAgentPolicy() takes no arguments`.
+    "test_nonexistent_analyzer_raises_value_error"
+    "test_cu_registered_before_docintel"
   ];
 
   passthru.updateScript = gitUpdater { };

--- a/pkgs/development/python-modules/markitdown/default.nix
+++ b/pkgs/development/python-modules/markitdown/default.nix
@@ -105,7 +105,12 @@ buildPythonPackage (finalAttrs: {
     "test_cu_registered_before_docintel"
   ];
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = gitUpdater {
+    # Drop the "v" tag prefix before version comparison.
+    rev-prefix = "v";
+    # Skip PEP 440 pre-release tags.
+    ignoredVersions = "(a|b|rc)[0-9]+$";
+  };
 
   meta = {
     description = "Python tool for converting files and office documents to Markdown";


### PR DESCRIPTION
https://github.com/microsoft/markitdown/releases/tag/v0.1.6

Dependency changes from 0.1.4:
- Removed: `ffmpeg-headless`, `numpy`, `openai`, `pathvalidate`, `puremagic`
- Added core dep: `charset-normalizer`
- Added optional deps: `pdfplumber`, `azure-ai-documentintelligence`, `azure-identity`
- `azure-ai-contentunderstanding` is new upstream but not yet packaged in nixpkgs; omitted
- Added `mammoth` and `youtube-transcript-api` to `pythonRelaxDeps` (`~=1.11.0` and `~=1.0.0` constraints are tighter than nixpkgs carries)

`tests/test_cu_converter.py` (new in 0.1.6) adds two tests that need the unpackaged optional `azure-ai-contentunderstanding` SDK. Without it, `_cu_converter.py` falls back to stub classes and these tests fail with `TypeError: UserAgentPolicy() takes no arguments`, so `test_nonexistent_analyzer_raises_value_error` and `test_cu_registered_before_docintel` are added to `disabledTests`. Runtime is unaffected: the converter still raises `MissingDependencyException` when the extra is absent.

`fix passthru.updateScript`: `gitUpdater {}` never matched a version because upstream tags are `v`-prefixed (`v0.1.6`) and `generic-updater` drops tags that do not start with a digit, so the script always emitted `[]`. Added `rev-prefix = "v"` plus `ignoredVersions = "(a|b|rc)[0-9]+$"` to skip the PEP 440 pre-release tags (`v0.1.5b1`, `v0.1.0a1`, ...) that the odd-minor/patchlevel heuristics miss. Verified with `nix-shell maintainers/scripts/update.nix --argstr package python3Packages.markitdown --argstr skip-prompt true` (selects 0.1.6, skips pre-releases, resolves the correct hash).

Supersedes #523451 (0.1.5).

> **AI disclosure:** This update was prepared with Claude Code (LLM-based tool). Dependency changes were verified against the upstream `pyproject.toml` for v0.1.6, version constraints were cross-checked against nixpkgs package versions, the package was built (`nix-build -A python3Packages.markitdown`: 159 passed, 2 skipped), the updater was verified end-to-end via `nix-shell maintainers/scripts/update.nix`, and the expression was reviewed before submission.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
