### PR TITLE
azimuth: 1.0.3 -> 1.0.4

### DIFF
--- a/pkgs/by-name/az/azimuth/package.nix
+++ b/pkgs/by-name/az/azimuth/package.nix
@@ -3,43 +3,48 @@
   stdenv,
   fetchFromGitHub,
   libGL,
-  SDL,
+  SDL2,
   which,
+  pkg-config,
   installTool ? false,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "azimuth";
-  version = "1.0.3";
+  version = "1.0.4";
 
   src = fetchFromGitHub {
     owner = "mdsteele";
     repo = "azimuth";
-    rev = "v${finalAttrs.version}";
-    sha256 = "1znfvpmqiixd977jv748glk5zc4cmhw5813zp81waj07r9b0828r";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-N5Ahetw/zOXDrEiR1umQNF6i3yeawavoLceiU+xD//g=";
   };
 
-  nativeBuildInputs = [ which ];
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    which
+  ];
+
   buildInputs = [
     libGL
-    SDL
+    SDL2
   ];
 
   env.NIX_CFLAGS_COMPILE = toString [ "-Wno-error=maybe-uninitialized" ];
 
-  preConfigure = ''
-    substituteInPlace data/azimuth.desktop \
-      --replace Exec=azimuth "Exec=$out/bin/azimuth" \
-      --replace "Version=%AZ_VERSION_NUMBER" "Version=${finalAttrs.version}"
-  '';
-
   makeFlags = [
     "BUILDTYPE=release"
-    "INSTALLDIR=$(out)"
-  ]
-  ++ (if installTool then [ "INSTALLTOOL=true" ] else [ "INSTALLTOOL=false" ]);
+    "PREFIX=${placeholder "out"}"
+    "INSTALLTOOL=${if installTool then "true" else "false"}"
+  ];
 
   enableParallelBuilding = true;
+
+  doCheck = true;
+  checkTarget = "test";
 
   meta = {
     description = "Metroidvania game using only vectorial graphic";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
