### PR TITLE
luaPackages.vicious: 2.6.0 -> 2.7.1, build with luarocks

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -176,6 +176,7 @@ tree-sitter-norg-meta,,,,,,
 tree-sitter-orgmode,,,,,5.1,
 utf8,,,,,,
 tree-sitter-teal,,,,,,
+vicious,,,,,,
 vstruct,,,,,,
 vusted,,,,,,
 xml2lua,,,,,,teto

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -6357,6 +6357,36 @@ final: prev: {
     }
   ) { };
 
+  vicious = callPackage (
+    {
+      buildLuarocksPackage,
+      fetchurl,
+      fetchzip,
+      luaOlder,
+    }:
+    buildLuarocksPackage {
+      pname = "vicious";
+      version = "2.7.1-3";
+      knownRockspec =
+        (fetchurl {
+          url = "mirror://luarocks/vicious-2.7.1-4.rockspec";
+          sha256 = "1yvc9mbalsyrqysxkc1lf92ki5gzizn79y2azyavmgjwljif6lfi";
+        }).outPath;
+      src = fetchzip {
+        url = "https://github.com/vicious-widgets/vicious/archive/refs/tags/v2.7.1.zip";
+        sha256 = "0bfj3bc1gmbwwvpwkmqp658iwrwdifc78hzwwy1qpn7rbmarg2qv";
+      };
+
+      disabled = luaOlder "5.1";
+
+      meta = {
+        homepage = "https://vicious.rtfd.io";
+        license = lib.licenses.gpl2Plus;
+        description = "Modular widget library for the \"awesome\" window manager";
+      };
+    }
+  ) { };
+
   vstruct = callPackage (
     {
       buildLuarocksPackage,

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -1300,6 +1300,19 @@ in
     '';
   };
 
+  vicious = prev.vicious.overrideAttrs (old: {
+    meta = (old.meta or { }) // {
+      changelog = "https://github.com/vicious-widgets/vicious/blob/v${old.version}/CHANGELOG.rst";
+      maintainers = with lib.maintainers; [
+        makefu
+        mic92
+        mrcjkb
+        McSinyx
+      ];
+      platforms = lib.platforms.linux;
+    };
+  });
+
   vstruct = prev.vstruct.overrideAttrs (old: {
     meta = (old.meta or { }) // {
       broken = luaOlder "5.1" || luaAtLeast "5.4";

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -257,40 +257,4 @@ rec {
   };
 
   readline = callPackage ../development/lua-modules/readline { inherit (pkgs) readline; };
-
-  vicious = callPackage (
-    { fetchFromGitHub }:
-    stdenv.mkDerivation rec {
-      pname = "vicious";
-      version = "2.7.1";
-
-      src = fetchFromGitHub {
-        owner = "vicious-widgets";
-        repo = "vicious";
-        rev = "v${version}";
-        sha256 = "sha256-G4uXVV352IuD5/xDdJiLjWceUTEX18nv5nzVF9ga0i0=";
-      };
-
-      buildInputs = [ lua ];
-
-      installPhase = ''
-        mkdir -p $out/lib/lua/${lua.luaversion}/
-        cp -r . $out/lib/lua/${lua.luaversion}/vicious/
-        printf "package.path = '$out/lib/lua/${lua.luaversion}/?/init.lua;' ..  package.path\nreturn require((...) .. '.init')\n" > $out/lib/lua/${lua.luaversion}/vicious.lua
-      '';
-
-      meta = {
-        description = "Modular widget library for the awesome window manager";
-        homepage = "https://vicious.readthedocs.io";
-        changelog = "https://vicious.readthedocs.io/changelog.html";
-        license = lib.licenses.gpl2Plus;
-        maintainers = with lib.maintainers; [
-          makefu
-          mic92
-          McSinyx
-        ];
-        platforms = lib.platforms.linux;
-      };
-    }
-  ) { };
 }

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -262,13 +262,13 @@ rec {
     { fetchFromGitHub }:
     stdenv.mkDerivation rec {
       pname = "vicious";
-      version = "2.6.0";
+      version = "2.7.1";
 
       src = fetchFromGitHub {
         owner = "vicious-widgets";
         repo = "vicious";
         rev = "v${version}";
-        sha256 = "sha256-VlJ2hNou2+t7eSyHmFkC2xJ92OH/uJ/ewYHkFLQjUPQ=";
+        sha256 = "sha256-G4uXVV352IuD5/xDdJiLjWceUTEX18nv5nzVF9ga0i0=";
       };
 
       buildInputs = [ lua ];


### PR DESCRIPTION
Closes #525569.

I've published a rockspec for the `vicious` package via NURR, so that:

- We can maintain it using the generated Lua package set.
- It can be `require`d when used with `lua.withPackages (ps: [ps.vicious])` (#525569).

I've also added an override that:

- adds a changelog (because there was one before) - I've changed the URL so that it matches the version.
- Adds the existing maintainers + myself
- ~Symlinks `$out/share` to `$out/lib` so that awesomewm can find it.~


### Build result (before)

```
❯ : exa --tree result/lib/*
result/lib/lua
└── 5.2
    ├── vicious
    │   ├── CHANGELOG.rst
    │   ├── contrib
    │   │   ├── ac_linux.lua
    │   │   ├── ati_linux.lua
    │   │   ├── batpmu_linux.lua
    │   │   ├── batproc_linux.lua
    │   │   ├── btc_all.lua
    │   │   ├── buildbot_all.lua
    │   │   ├── cmus_all.lua -> ../widgets/cmus_all.lua
    │   │   ├── countfiles_all.lua
    │   │   ├── dio_linux.lua
    │   │   ├── init.lua
    │   │   ├── mpc_all.lua
    │   │   ├── net_linux.lua
    │   │   ├── netcfg.lua
    │   │   ├── nvinf_all.lua
    │   │   ├── nvsmi_all.lua
    │   │   ├── openweather_all.lua
    │   │   ├── ossvol_linux.lua
    │   │   ├── pop_all.lua
    │   │   ├── pulse_all.lua
    │   │   ├── rss_all.lua
    │   │   ├── sensors_linux.lua
    │   │   └── wpa_all.lua
    │   ├── CONTRIBUTING.rst
    │   ├── docs
    │   │   ├── Makefile
    │   │   ├── requirements.txt
    │   │   └── source
    │   │       ├── caching.rst
    │   │       ├── changelog.rst -> ../../CHANGELOG.rst
    │   │       ├── conf.py
    │   │       ├── contrib.rst
    │   │       ├── contributing.rst -> ../../CONTRIBUTING.rst
    │   │       ├── copying.rst
    │   │       ├── custom.rst
    │   │       ├── examples.rst
    │   │       ├── format.rst
    │   │       ├── index.rst
    │   │       ├── security.rst
    │   │       ├── usage-awesome.rst
    │   │       ├── usage-lua.rst
    │   │       └── widgets.rst
    │   ├── helpers.lua
    │   ├── init.lua
    │   ├── LICENSE
    │   ├── README.md
    │   ├── spawn.lua
    │   ├── templates
    │   │   ├── async.lua
    │   │   ├── README.md
    │   │   └── sync.lua
    │   ├── TODO
    │   ├── tools
    │   │   ├── headergen
    │   │   └── luacheckrc
    │   └── widgets
    │       ├── amdgpu_linux.lua
    │       ├── bat_freebsd.lua
    │       ├── bat_linux.lua
    │       ├── bat_openbsd.lua
    │       ├── cmus_all.lua
    │       ├── cpu_freebsd.lua
    │       ├── cpu_linux.lua
    │       ├── cpu_openbsd.lua
    │       ├── cpufreq_freebsd.lua
    │       ├── cpufreq_linux.lua
    │       ├── cpuinf_linux.lua
    │       ├── date_all.lua
    │       ├── dio_linux.lua
    │       ├── fanspeed_freebsd.lua
    │       ├── fs_all.lua
    │       ├── gmail_all.lua
    │       ├── hddtemp_linux.lua
    │       ├── hwmontemp_linux.lua
    │       ├── init.lua
    │       ├── mbox_all.lua
    │       ├── mboxc_all.lua
    │       ├── mdir_all.lua
    │       ├── mem_freebsd.lua
    │       ├── mem_linux.lua
    │       ├── mpd_all.lua
    │       ├── net_freebsd.lua
    │       ├── net_linux.lua
    │       ├── notmuch_all.lua
    │       ├── org_all.lua
    │       ├── os_bsd.lua
    │       ├── os_linux.lua
    │       ├── pkg_all.lua
    │       ├── raid_linux.lua
    │       ├── thermal_freebsd.lua
    │       ├── thermal_linux.lua
    │       ├── uptime_freebsd.lua
    │       ├── uptime_linux.lua
    │       ├── volume_freebsd.lua
    │       ├── volume_linux.lua
    │       ├── weather_all.lua
    │       ├── wifi_linux.lua
    │       └── wifiiw_linux.lua
    └── vicious.lua
```

### Build result (after)

```
❯ : exa --tree result/share/*
result/share/lua
└── 5.2
    └── vicious
        ├── contrib
        │   ├── ac_linux.lua
        │   ├── ati_linux.lua
        │   ├── batpmu_linux.lua
        │   ├── batproc_linux.lua
        │   ├── btc_all.lua
        │   ├── buildbot_all.lua
        │   ├── cmus_all.lua
        │   ├── countfiles_all.lua
        │   ├── dio_linux.lua
        │   ├── init.lua
        │   ├── mpc_all.lua
        │   ├── net_linux.lua
        │   ├── netcfg.lua
        │   ├── nvinf_all.lua
        │   ├── nvsmi_all.lua
        │   ├── openweather_all.lua
        │   ├── ossvol_linux.lua
        │   ├── pop_all.lua
        │   ├── pulse_all.lua
        │   ├── rss_all.lua
        │   ├── sensors_linux.lua
        │   └── wpa_all.lua
        ├── helpers.lua
        ├── init.lua
        ├── spawn.lua
        └── widgets
            ├── amdgpu_linux.lua
            ├── bat_freebsd.lua
            ├── bat_linux.lua
            ├── bat_openbsd.lua
            ├── cmus_all.lua
            ├── cpu_freebsd.lua
            ├── cpu_linux.lua
            ├── cpu_openbsd.lua
            ├── cpufreq_freebsd.lua
            ├── cpufreq_linux.lua
            ├── cpuinf_linux.lua
            ├── date_all.lua
            ├── dio_linux.lua
            ├── fanspeed_freebsd.lua
            ├── fs_all.lua
            ├── gmail_all.lua
            ├── hddtemp_linux.lua
            ├── hwmontemp_linux.lua
            ├── init.lua
            ├── mbox_all.lua
            ├── mboxc_all.lua
            ├── mdir_all.lua
            ├── mem_freebsd.lua
            ├── mem_linux.lua
            ├── mpd_all.lua
            ├── net_freebsd.lua
            ├── net_linux.lua
            ├── notmuch_all.lua
            ├── org_all.lua
            ├── os_bsd.lua
            ├── os_linux.lua
            ├── pkg_all.lua
            ├── raid_linux.lua
            ├── thermal_freebsd.lua
            ├── thermal_linux.lua
            ├── uptime_freebsd.lua
            ├── uptime_linux.lua
            ├── volume_freebsd.lua
            ├── volume_linux.lua
            ├── weather_all.lua
            ├── wifi_linux.lua
            └── wifiiw_linux.lua
```

The `$out/lib/<lua-version>/vicious.lua` in the "before" output seems redundant to me, since we have a ``$out/lib/<lua-version>/vicious/init.lua`.
But that might be something specific to awesomewm?

The luarocks build does not include directories that aren't needed by awesomewm, such as `templates/` or `tools/`.
The `doc/` directory is now included in the `$out/vicious-2.7.1-3-rocks/vicious/2.7.1-4/doc/` directory, where luarocks installs them to and expects to find them.

It's still not possible to just `require('vicious')` in a shell with `lua.withPackages (ps: [ps.vicious])` alone,
because it tries to `require('gears.timer')`, which [is an awesomewm module](https://awesomewm.org/doc/api/classes/gears.timer.html).
But I suppose if you have the awesomewm API on the Lua path, it works.

cc existing maintainers for testing with awesomewm: @makefu @Mic92 @McSinyx

If it doesn't work with awesomewm, we should either find a way to make it work or move it to another package set (something like `awesomwmPlugins`?).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
