### PR TITLE
libchamplain: remove libsoup 2.4 variant

### DIFF
--- a/pkgs/by-name/gp/gpx-viewer/package.nix
+++ b/pkgs/by-name/gp/gpx-viewer/package.nix
@@ -9,7 +9,7 @@
   vala,
   pkg-config,
   adwaita-icon-theme,
-  libchamplain,
+  libchamplain_libsoup3,
   gdl,
   wrapGAppsHook3,
 }:
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gdl
-    libchamplain
+    libchamplain_libsoup3
     adwaita-icon-theme
     libxml2
   ];

--- a/pkgs/by-name/li/libchamplain_libsoup3/package.nix
+++ b/pkgs/by-name/li/libchamplain_libsoup3/package.nix
@@ -15,10 +15,8 @@
   sqlite,
   gnome,
   clutter-gtk,
-  libsoup_2_4,
   libsoup_3,
   gobject-introspection, # , libmemphis
-  withLibsoup3 ? false,
 }:
 
 stdenv.mkDerivation rec {
@@ -51,7 +49,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     sqlite
-    (if withLibsoup3 then libsoup_3 else libsoup_2_4)
+    libsoup_3
   ];
 
   propagatedBuildInputs = [
@@ -64,7 +62,7 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     (lib.mesonBool "gtk_doc" (stdenv.buildPlatform == stdenv.hostPlatform))
     "-Dvapi=true"
-    (lib.mesonBool "libsoup3" withLibsoup3)
+    (lib.mesonBool "libsoup3" true)
   ];
 
   passthru = {
@@ -89,7 +87,7 @@ stdenv.mkDerivation rec {
        OpenCycleMap, OpenAerialMap, and Maps for free.
     '';
 
-    teams = lib.optionals withLibsoup3 [
+    teams = [
       lib.teams.gnome
       lib.teams.pantheon
     ];

--- a/pkgs/by-name/li/lifeograph/package.nix
+++ b/pkgs/by-name/li/lifeograph/package.nix
@@ -8,7 +8,7 @@
   wrapGAppsHook4,
   enchant,
   gtkmm4,
-  libchamplain,
+  libchamplain_libsoup3,
   libgcrypt,
   shared-mime-info,
   libshumate,
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     libgcrypt
     enchant
     gtkmm4
-    (libchamplain.override { withLibsoup3 = true; })
+    libchamplain_libsoup3
     libshumate
   ];
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1108,6 +1108,7 @@ mapAliases {
   libbpf_1 = throw "'libbpf_1' has been renamed to/replaced by 'libbpf'"; # Converted to throw 2025-10-27
   libbson = throw "'libbson' has been renamed to/replaced by 'mongoc'"; # Converted to throw 2025-10-27
   libcef = throw "'libcef' has been removed, as no packages depend on it"; # Added 2025-11-06
+  libchamplain = throw "'libchamplain' has been removed due to reliance on insecure libsoup 2.4. Consider using 'libchamplain_libsoup3' instead"; # Added 2026-05-29
   libdbiDrivers = warnAlias "'libdbiDrivers' has been renamed to 'libdbi-drivers'" libdbi-drivers; # Added 2026-02-08
   libdbiDriversBase = warnAlias "'libdbiDriversBase' has been renamed to 'libdbi-drivers-base'" libdbi-drivers-base; # Added 2026-02-08
   libdevil = throw "libdevil has been removed, as it was unmaintained in Nixpkgs and upstream since 2017"; # Added 2025-09-16

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6432,8 +6432,6 @@ with pkgs;
     else
       pkgs.libcanberra-gtk2;
 
-  libchamplain_libsoup3 = libchamplain.override { withLibsoup3 = true; };
-
   libchipcard = callPackage ../development/libraries/aqbanking/libchipcard.nix { };
 
   libdbi-drivers-base = libdbi-drivers.override {


### PR DESCRIPTION
`libchamplain` has referred to the version that links to libsoup 2.4 by default, and has thus been marked insecure for quite some time. All of the (few) dependents support building with the libsoup 3 version, so we drop the insecure version entirely ~~and make `libchamplain` refer to the libsoup 3 version~~.

reference for libsoup 2.4: #360897

I don't know if this needs a release note. I don't *think* so, but I can add one if it does. I've also gone for an immediate rename, but I can drop that for now if desirable.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
