### PR TITLE
gharial: init at 0.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10369,6 +10369,12 @@
     github = "Gurjaka";
     githubId = 143032436;
   };
+  gusahlg = {
+    name = "Gustav Ahlgren";
+    email = "gustav@ahlgren.nu";
+    github = "gusahlg";
+    githubId = 209215577;
+  };
   guserav = {
     github = "guserav";
     githubId = 28863828;

--- a/pkgs/by-name/gh/gharial/package.nix
+++ b/pkgs/by-name/gh/gharial/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  wayland,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "gharial";
+  version = "0.2.1";
+  __structuredAttrs = true;
+  src = fetchFromGitHub {
+    owner = "gusahlg";
+    repo = "gharial";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-o5r8nK95FE5lBMLZfqziEE7JGOAO0HQfxFcybMWee9s=";
+  };
+
+  cargoHash = "sha256-Fqhgdqs7xXmd6Bpg7kYLWLiu+Yn4JTbMtJo4iLLFcIs=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    wayland
+  ];
+
+  meta = {
+    description = "Minimal external window manager for the river Wayland compositor";
+    homepage = "https://github.com/gusahlg/gharial";
+    license =
+      with lib.licenses;
+      OR [
+        mit
+        asl20
+      ];
+    maintainers = with lib.maintainers; [ gusahlg ];
+    mainProgram = "gharial";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Adds `gharial`, a River-based Wayland window manager, as a new package.

Gharial provides a configurable window-management layer for the River compositor. This packages the upstream release and exposes the `gharial` and `gharialctl` binaries through nixpkgs.

Homepage: https://github.com/gusahlg/gharial

The upstream project is licensed as `MIT OR Apache-2.0`.

I did use ChatGPT for understanding the process of adding a package to nixpkgs. An important note is that I have checked all material directly generated by ai myself and confirmed it to be correct. I  have also manually reviewed and tested the package before submission. I have used this as my wm for a few days and have not found any major issues.

## Things done

* Built on platform:

  * [x] x86_64-linux
  * [ ] aarch64-linux
  * [ ] x86_64-darwin
  * [ ] aarch64-darwin
* Tested, as applicable:

  * [ ] [NixOS tests] in [nixos/tests].
  * [ ] [Package tests] at `passthru.tests`.
  * [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
* [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
* [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
* Nixpkgs Release Notes

  * [ ] Package update: when the change is major or breaking.
* NixOS Release Notes

  * [ ] Module addition: when adding a new NixOS module.
  * [ ] Module update: when the change is significant.
* [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
* [x] Follows the [automation/AI policy].
