### PR TITLE
adif-multitool: 0.1.20 -> 0.1.22

### DIFF
--- a/pkgs/by-name/ad/adif-multitool/package.nix
+++ b/pkgs/by-name/ad/adif-multitool/package.nix
@@ -5,15 +5,17 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "adif-multitool";
-  version = "0.1.20";
+  version = "0.1.22";
 
-  vendorHash = "sha256-U9BpTDHjUZicMjKeyxyM/eOxJeAY2DMQMHOEMiCeN/U=";
+  vendorHash = "sha256-Fin0DUvpNPqKXpbDVekvWZYghJIpMLY9IRr2wdbZczc=";
+
+  proxyVendor = true;
 
   src = fetchFromGitHub {
     owner = "flwyd";
     repo = "adif-multitool";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qeAH8UTyEZn8As3wTjluONpjeT/5l9zicN5+8uwnbLo=";
+    hash = "sha256-UYnm4S4DP0c2ZkPkPScUHXdKiAz6JY9Lzdu4mAO49Dc=";
   };
 
   meta = {


### PR DESCRIPTION
update to 0.1.22

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
