### PR TITLE
cope: unbreak

### DIFF
--- a/pkgs/by-name/co/cope/package.nix
+++ b/pkgs/by-name/co/cope/package.nix
@@ -14,6 +14,12 @@ perlPackages.buildPerlPackage {
     rev = "6d0322a8493361ad32e454b97998df715dbe7b97";
     hash = "sha256-VQveV7avM/4nbLroyujJaSoVAP3pXhwrzqzI3eMzxVo=";
   };
+
+  postPatch = ''
+    substituteInPlace lib/App/Cope.pm \
+      --replace-warn "feature->import( ':5.10' );" "require feature; feature->import( ':5.10' );"
+  '';
+
   nativeBuildInputs = [ makeWrapper ];
 
   buildInputs = with perlPackages; [
@@ -67,6 +73,5 @@ perlPackages.buildPerlPackage {
       gpl1Plus
     ];
     maintainers = with lib.maintainers; [ deftdawg ];
-    broken = true; # requires old Perl we don't ship anymore
   };
 }


### PR DESCRIPTION
fix build

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
