### PR TITLE
codexbar-cli: init at 0.31.0

### DIFF
--- a/pkgs/by-name/co/codexbar-cli/package.nix
+++ b/pkgs/by-name/co/codexbar-cli/package.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  stdenv,
+  stdenvNoCC,
+  fetchurl,
+  autoPatchelfHook,
+  makeWrapper,
+  versionCheckHook,
+  curl,
+  sqlite,
+}:
+
+let
+  platforms = {
+    x86_64-linux = "linux-x86_64";
+    aarch64-linux = "linux-aarch64";
+    x86_64-darwin = "macos-x86_64";
+    aarch64-darwin = "macos-arm64";
+  };
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "codexbar-cli";
+  version = "0.31.0";
+
+  src =
+    finalAttrs.passthru.sources.${stdenvNoCC.hostPlatform.system}
+      or (throw "codexbar-cli: unsupported platform ${stdenvNoCC.hostPlatform.system}");
+
+  # Tarball has no top-level directory.
+  sourceRoot = ".";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ]
+  ++ lib.optionals stdenvNoCC.hostPlatform.isLinux [ autoPatchelfHook ];
+
+  # Swift runtime is statically linked; these are the only dynamic deps.
+  buildInputs = lib.optionals stdenvNoCC.hostPlatform.isLinux [
+    curl
+    sqlite
+    (lib.getLib stdenv.cc.cc) # libstdc++.so.6, libgcc_s.so.1
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    # The binary locates VERSION relative to argv[0], so it must keep VERSION
+    # alongside it and be invoked by absolute path. makeWrapper's default exec
+    # sets argv[0] to the target's absolute path, satisfying both.
+    install -Dm755 CodexBarCLI $out/libexec/codexbar-cli/codexbar
+    install -Dm644 VERSION $out/libexec/codexbar-cli/VERSION
+
+    makeWrapper $out/libexec/codexbar-cli/codexbar $out/bin/codexbar
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru = {
+    sources = lib.mapAttrs (
+      system: suffix:
+      fetchurl {
+        url = "https://github.com/steipete/CodexBar/releases/download/v${finalAttrs.version}/CodexBarCLI-v${finalAttrs.version}-${suffix}.tar.gz";
+        hash =
+          {
+            x86_64-linux = "sha256-caaM9r6eE9tGsOv5dkR3XX9hzotOu65cH7lBUPDHTyY=";
+            aarch64-linux = "sha256-mVeN+84CD26FAD37fFJuoKWNiYQ99W8J7ZdmgldLceg=";
+            x86_64-darwin = "sha256-otzbCE8upcsgCzZ3rhC5ZmMRbtcl6AM3C/ZbBtNS0NQ=";
+            aarch64-darwin = "sha256-SveEqwP1k0tEHS4CPFkGqbip+ul+jfADZiFFMx6lMqA=";
+          }
+          .${system};
+      }
+    ) platforms;
+    updateScript = ./update.sh;
+  };
+
+  meta = {
+    description = "Show usage stats for OpenAI Codex and Claude Code from the command line";
+    homepage = "https://github.com/steipete/CodexBar";
+    changelog = "https://github.com/steipete/CodexBar/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "codexbar";
+    maintainers = with lib.maintainers; [ qweered ];
+    platforms = builtins.attrNames platforms;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/co/codexbar-cli/update.sh
+++ b/pkgs/by-name/co/codexbar-cli/update.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq common-updater-scripts
+
+set -euo pipefail
+
+# releases/latest skips the -beta prereleases that upstream also publishes.
+version=$(curl -fsSL https://api.github.com/repos/steipete/CodexBar/releases/latest \
+  | jq -r '.tag_name | ltrimstr("v")')
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../../../.."
+
+for system in \
+  x86_64-linux \
+  aarch64-linux \
+  x86_64-darwin \
+  aarch64-darwin
+do
+  update-source-version codexbar-cli "$version" \
+    --source-key="sources.$system" \
+    --ignore-same-version \
+    --ignore-same-hash
+done


### PR DESCRIPTION
Show usage stats for OpenAI Codex and Claude Code from the command line. Packages the upstream prebuilt CLI (Swift) via autoPatchelfHook. Needed for some dms-shell extensions

Assisted-by: claude-code with claude-opus-4-8[1m]-high

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
