### PR TITLE
ocamlPackages.odep: add (0.2.2)

### DIFF
--- a/pkgs/by-name/od/odep/package.nix
+++ b/pkgs/by-name/od/odep/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  ocamlPackages,
+}:
+buildDunePackage (finalAttrs: {
+  pname = "odep";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    tag = finalAttrs.version;
+    owner = "sim642";
+    repo = "odep";
+    hash = "sha256-1wpCiC6kC1dAFeez6ZZGKBKaDHBvh2tTXPQurmUHOyk=";
+  };
+
+  buildInputs = with ocamlPackages; [
+    bos
+    cmdliner
+    findlib
+    opam-state
+    parsexp
+    ppx_deriving
+    sexplib
+    ppx_sexp_conv
+    ppx_deriving_yojson
+  ];
+
+  meta = {
+    description = "Dependency graphs for OCaml modules, libraries and packages";
+    homepage = "https://github.com/sim642/odep";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.GirardR1006 ];
+  };
+})

--- a/pkgs/by-name/od/odep/package.nix
+++ b/pkgs/by-name/od/odep/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  fetchFromGitHub,
+  ocamlPackages,
+}:
+ocamlPackages.buildDunePackage (finalAttrs: {
+  pname = "odep";
+  version = "0.2.2";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    tag = finalAttrs.version;
+    owner = "sim642";
+    repo = "odep";
+    hash = "sha256-1wpCiC6kC1dAFeez6ZZGKBKaDHBvh2tTXPQurmUHOyk=";
+  };
+
+  buildInputs = with ocamlPackages; [
+    bos
+    cmdliner
+    findlib
+    opam-state
+    parsexp
+    ppx_deriving
+    sexplib
+    ppx_sexp_conv
+    ppx_deriving_yojson
+  ];
+
+  meta = {
+    description = "Dependency graphs for OCaml modules, libraries and packages";
+    homepage = "https://github.com/sim642/odep";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GirardR1006 ];
+  };
+})


### PR DESCRIPTION
Adding odep,  a dependency graphs generator for OCaml modules, libraries and packages 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
