### PR TITLE
fleet-{desktop,orbit}:  init at 1.55.0

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1067,6 +1067,7 @@
   ./services/monitoring/nezha.nix
   ./services/monitoring/ocsinventory-agent.nix
   ./services/monitoring/opentelemetry-collector.nix
+  ./services/monitoring/orbit.nix
   ./services/monitoring/osquery.nix
   ./services/monitoring/parsedmarc.nix
   ./services/monitoring/perses.nix

--- a/nixos/modules/services/monitoring/orbit.nix
+++ b/nixos/modules/services/monitoring/orbit.nix
@@ -1,0 +1,182 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.orbit;
+in
+{
+  options.services.orbit = {
+    enable = lib.mkEnableOption "Fleet Orbit agent" // {
+      description = "Enable the Fleet Orbit agent.";
+      example = lib.literalExpression ''
+        # Use an enrollment secret from a plaintext file managed outside the Nix store.
+        {
+          services.orbit = {
+            enable = true;
+            fleetUrl = "https://fleet.example.com";
+            enrollSecretPath = "/etc/fleet/enroll-secret";
+
+            desktop.enable = true;
+          };
+        }
+
+        # Use an enrollment secret from sops-nix.
+        { config, ... }:
+        {
+          sops.secrets.fleet-orbit-enroll-secret = { };
+
+          services.orbit = {
+            enable = true;
+            fleetUrl = "https://fleet.example.com";
+            enrollSecretPath = config.sops.secrets.fleet-orbit-enroll-secret.path;
+
+            desktop.enable = true;
+          };
+        }
+      '';
+    };
+
+    orbitPackage = lib.mkPackageOption pkgs "fleet-orbit" { };
+
+    osqueryPackage = lib.mkPackageOption pkgs "osquery" { };
+
+    desktop = {
+      enable = lib.mkEnableOption "Fleet Desktop tray application";
+
+      package = lib.mkPackageOption pkgs "fleet-desktop" { };
+
+      alternativeBrowserHost = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "fleet-browser.example.com";
+        description = ''
+          Alternative host to use for Fleet Desktop browser URLs. This can be
+          required when Fleet uses TLS client authentication.
+        '';
+      };
+    };
+
+    fleetUrl = lib.mkOption {
+      type = lib.types.str;
+      example = "https://fleet.example.com";
+      description = "The base URL of the Fleet server.";
+    };
+
+    enrollSecretPath = lib.mkOption {
+      type = lib.types.path;
+      example = "/run/secrets/fleet-enroll-secret";
+      description = ''
+        Path to a file containing the enroll secret for authenticating to the Fleet server.
+        This should point to a secret outside the Nix store, for example a sops-nix or agenix
+        secret path.
+      '';
+    };
+
+    fleetCertificate = lib.mkOption {
+      type = lib.types.path;
+      default = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+      defaultText = lib.literalExpression "\"\${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt\"";
+      description = "Path to the Fleet server certificate chain.";
+    };
+
+    debug = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable debug logging.";
+    };
+
+    devMode = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Run Orbit in development mode.";
+    };
+
+    enableScripts = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable Fleet script execution.";
+    };
+
+    endUserEmail = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "user@example.com";
+      description = "End-user email to pass to Orbit.";
+    };
+
+    fleetManagedHostIdentityCertificate = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Configure Orbit to use Fleet-managed host identity certificates.
+        This requires a Fleet Enterprise Edition subscription.
+      '';
+    };
+
+    hostIdentifier = lib.mkOption {
+      type = lib.types.nullOr (
+        lib.types.enum [
+          "uuid"
+          "instance"
+        ]
+      );
+      default = null;
+      example = "uuid";
+      description = "Host identifier mode to use when Orbit and osquery enroll to Fleet.";
+    };
+
+    insecure = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Disable TLS certificate verification.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.orbit = {
+      description = "Fleet Orbit agent";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+
+      environment = lib.filterAttrs (_: value: value != null) {
+        ORBIT_FLEET_URL = cfg.fleetUrl;
+        ORBIT_ENROLL_SECRET_PATH = "%d/enroll-secret";
+        ORBIT_FLEET_CERTIFICATE = cfg.fleetCertificate;
+        ORBIT_DEBUG = lib.boolToString cfg.debug;
+        ORBIT_DEV_MODE = lib.boolToString cfg.devMode;
+        ORBIT_ENABLE_SCRIPTS = lib.boolToString cfg.enableScripts;
+        ORBIT_END_USER_EMAIL = cfg.endUserEmail;
+        ORBIT_FLEET_MANAGED_HOST_IDENTITY_CERTIFICATE = lib.boolToString cfg.fleetManagedHostIdentityCertificate;
+        ORBIT_HOST_IDENTIFIER = cfg.hostIdentifier;
+        ORBIT_INSECURE = lib.boolToString cfg.insecure;
+        ORBIT_FLEET_DESKTOP_ALTERNATIVE_BROWSER_HOST = cfg.desktop.alternativeBrowserHost;
+
+        ORBIT_DISABLE_KEYSTORE = "true";
+        ORBIT_DISABLE_UPDATES = "true";
+        ORBIT_FLEET_DESKTOP = lib.boolToString cfg.desktop.enable;
+        ORBIT_LOG_FILE = "/var/log/orbit/orbit.log";
+        ORBIT_OSQUERY_DB = "/var/lib/orbit/osquery.db";
+        ORBIT_ROOT_DIR = "/var/lib/orbit";
+        NIX_ORBIT_OSQUERYD_PATH = lib.getExe' cfg.osqueryPackage "osqueryd";
+        NIX_ORBIT_OSQUERY_LOG_PATH = "/var/log/orbit/osquery";
+        NIX_ORBIT_DESKTOP_PATH = if cfg.desktop.enable then lib.getExe cfg.desktop.package else null;
+      };
+
+      serviceConfig = {
+        ExecStart = lib.getExe cfg.orbitPackage;
+        LoadCredential = [ "enroll-secret:${cfg.enrollSecretPath}" ];
+        StateDirectory = "orbit";
+        LogsDirectory = "orbit";
+        TimeoutStartSec = 0;
+        Restart = "always";
+        RestartSec = 60;
+        KillMode = "control-group";
+        KillSignal = "SIGTERM";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1296,6 +1296,7 @@ in
   openvswitch = runTest ./openvswitch.nix;
   optee = runTestOn [ "aarch64-linux" ] ./optee.nix;
   orangefs = runTest ./orangefs.nix;
+  orbit = runTestOn [ "x86_64-linux" ] ./orbit.nix;
   orthanc = runTest ./orthanc.nix;
   os-prober = handleTestOn [ "x86_64-linux" ] ./os-prober.nix { };
   osquery = handleTestOn [ "x86_64-linux" ] ./osquery.nix { };

--- a/nixos/tests/orbit.nix
+++ b/nixos/tests/orbit.nix
@@ -1,0 +1,47 @@
+{ ... }:
+
+{
+  name = "orbit";
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      environment.etc."fleet/enroll-secret".text = "test-secret";
+
+      services.orbit = {
+        enable = true;
+        orbitPackage = pkgs.writeShellApplication {
+          name = "orbit";
+          text = ''
+            test "$ORBIT_FLEET_URL" = "https://fleet.example.test"
+            test -r "$ORBIT_ENROLL_SECRET_PATH"
+            test "$(cat "$ORBIT_ENROLL_SECRET_PATH")" = "test-secret"
+            test -x "$NIX_ORBIT_OSQUERYD_PATH"
+            sleep infinity
+          '';
+        };
+        osqueryPackage = pkgs.writeShellApplication {
+          name = "osqueryd";
+          text = "echo osquery";
+        };
+        desktop = {
+          enable = true;
+          package = pkgs.writeShellApplication {
+            name = "fleet-desktop";
+            text = "echo fleet-desktop";
+          };
+          alternativeBrowserHost = "fleet-browser.example.test";
+        };
+        fleetUrl = "https://fleet.example.test";
+        enrollSecretPath = "/etc/fleet/enroll-secret";
+        debug = true;
+        enableScripts = true;
+        hostIdentifier = "uuid";
+      };
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("orbit.service")
+  '';
+}

--- a/pkgs/by-name/fl/fleet-desktop/package.nix
+++ b/pkgs/by-name/fl/fleet-desktop/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  buildGoModule,
+  fleet-orbit,
+  gtk3,
+  libayatana-appindicator,
+  nixosTests,
+  pkg-config,
+  versionCheckHook,
+}:
+
+buildGoModule {
+  pname = "fleet-desktop";
+  inherit (fleet-orbit) version src;
+  __structuredAttrs = true;
+
+  vendorHash = "sha256-fhACxmzJY0PEQmMbjQxlfQh5ZJ+7a4um0s8xFQq+57w=";
+
+  env.CGO_ENABLED = "1";
+
+  subPackages = [ "orbit/cmd/desktop" ];
+
+  goFlags = [ "-buildvcs=false" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=main.version=${fleet-orbit.version}"
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtk3
+    libayatana-appindicator
+  ];
+
+  postInstall = ''
+    mv "$out/bin/desktop" "$out/bin/fleet-desktop"
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.tests = {
+    inherit (nixosTests) orbit;
+  };
+
+  meta = {
+    description = "Fleet's desktop tray application";
+    homepage = "https://github.com/fleetdm/fleet";
+    changelog = "https://github.com/fleetdm/fleet/releases/tag/orbit-v${fleet-orbit.version}";
+    license = lib.licenses.mit;
+    mainProgram = "fleet-desktop";
+    maintainers = with lib.maintainers; [ adrielvelazquez ];
+    platforms = lib.platforms.linux;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+  };
+}

--- a/pkgs/by-name/fl/fleet-desktop/package.nix
+++ b/pkgs/by-name/fl/fleet-desktop/package.nix
@@ -54,7 +54,10 @@ buildGoModule {
     changelog = "https://github.com/fleetdm/fleet/releases/tag/orbit-v${fleet-orbit.version}";
     license = lib.licenses.mit;
     mainProgram = "fleet-desktop";
-    maintainers = with lib.maintainers; [ adrielvelazquez ];
+    maintainers = with lib.maintainers; [
+      adrielvelazquez
+      faukah
+    ];
     platforms = lib.platforms.linux;
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
   };

--- a/pkgs/by-name/fl/fleet-orbit/0001-orbit-nixos.patch
+++ b/pkgs/by-name/fl/fleet-orbit/0001-orbit-nixos.patch
@@ -1,0 +1,81 @@
+diff --git a/orbit/pkg/scripts/exec_nonwindows.go b/orbit/pkg/scripts/exec_nonwindows.go
+index cedbd73..b16d150 100644
+--- a/orbit/pkg/scripts/exec_nonwindows.go
++++ b/orbit/pkg/scripts/exec_nonwindows.go
+@@ -6,14 +6,49 @@ import (
+ 	"context"
+ 	"os"
+ 	"os/exec"
+ 	"path/filepath"
++	"strings"
+ 	"time"
+ 
+ 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+ 	"github.com/fleetdm/fleet/v4/server/fleet"
+ )
+ 
++// patchShebang replaces common shebang paths with NixOS-style paths.
++func patchShebang(contents []byte) []byte {
++	script := string(contents)
++
++	if !strings.HasPrefix(script, "#!") {
++		return contents
++	}
++
++	firstLineEnd := strings.Index(script, "\n")
++	if firstLineEnd == -1 {
++		firstLineEnd = len(script)
++	}
++
++	shebang := script[:firstLineEnd]
++	rest := script[firstLineEnd:]
++
++	replacements := map[string]string{
++		"#!/bin/bash":        "#!/run/current-system/sw/bin/bash",
++		"#!/bin/sh":          "#!/run/current-system/sw/bin/sh",
++		"#!/bin/zsh":         "#!/run/current-system/sw/bin/zsh",
++		"#!/usr/bin/python":  "#!/run/current-system/sw/bin/python",
++		"#!/usr/bin/python3": "#!/run/current-system/sw/bin/python3",
++	}
++
++	for old, new := range replacements {
++		if strings.HasPrefix(shebang, old) {
++			shebang = new + strings.TrimPrefix(shebang, old)
++			break
++		}
++	}
++
++	return []byte(shebang + rest)
++}
++
+ func ExecCmd(ctx context.Context, scriptPath string, env []string) (output []byte, exitCode int, err error) {
+ 	// initialize to -1 in case the process never starts
+ 	exitCode = -1
+ 
+ 	contents, err := os.ReadFile(scriptPath)
+@@ -21,17 +56,25 @@ func ExecCmd(ctx context.Context, scriptPath string, env []string) (output []byt
+ 	if err != nil {
+ 		return nil, -1, ctxerr.Wrapf(ctx, err, "opening script for validation %s", scriptPath)
+ 	}
+-	directExecute, err := fleet.ValidateShebang(string(contents))
++	patchedContents := patchShebang(contents)
++	if string(patchedContents) != string(contents) {
++		err = os.WriteFile(scriptPath, patchedContents, 0o600)
++		if err != nil {
++			return nil, -1, ctxerr.Wrapf(ctx, err, "writing patched script %s", scriptPath)
++		}
++	}
++
++	directExecute, err := fleet.ValidateShebang(string(patchedContents))
+ 	if err != nil {
+ 		return nil, -1, ctxerr.Wrapf(ctx, err, "validating script %s", scriptPath)
+ 	}
+ 
+-	cmd := exec.CommandContext(ctx, "/bin/sh", scriptPath)
++	cmd := exec.CommandContext(ctx, "/run/current-system/sw/bin/sh", scriptPath)
+ 
+ 	if directExecute {
+ 		err = os.Chmod(scriptPath, 0o700) // nolint:gosec // G302
+ 		if err != nil {
+ 			return nil, -1, ctxerr.Wrapf(ctx, err, "marking script as executable %s", scriptPath)
+ 		}

--- a/pkgs/by-name/fl/fleet-orbit/0002-osqueryd-path-override.patch
+++ b/pkgs/by-name/fl/fleet-orbit/0002-osqueryd-path-override.patch
@@ -1,0 +1,40 @@
+diff --git a/orbit/cmd/orbit/orbit.go b/orbit/cmd/orbit/orbit.go
+index ed6f10d..c4518fd 100644
+--- a/orbit/cmd/orbit/orbit.go
++++ b/orbit/cmd/orbit/orbit.go
+@@ -112,6 +112,16 @@ func main() {
+ 			Usage:   "Path to the Fleet server certificate chain",
+ 			EnvVars: []string{"ORBIT_FLEET_CERTIFICATE"},
+ 		},
++		&cli.StringFlag{
++			Name:    "osqueryd-path",
++			Usage:   "Override the path to the osqueryd binary",
++			EnvVars: []string{"NIX_ORBIT_OSQUERYD_PATH"},
++		},
++		&cli.StringFlag{
++			Name:    "desktop-path",
++			Usage:   "Override the path to the Fleet Desktop binary",
++			EnvVars: []string{"NIX_ORBIT_DESKTOP_PATH"},
++		},
+ 		&cli.StringFlag{
+ 			Name:    "fleet-desktop-alternative-browser-host",
+ 			Usage:   "Alternative host:port to use for Fleet Desktop in the browser (this may be required when using TLS client authentication in the Fleet server)",
+@@ -623,7 +633,17 @@ func orbitAction(c *cli.Context) error {
+ 	var updater *update.Updater
+ 	var updateRunner *update.Runner
+ 	var osqueryVersion string
+-	if !c.Bool("disable-updates") || c.Bool("dev-mode") {
++	if override := c.String("osqueryd-path"); override != "" {
++		log.Info().Msgf("Overriding osqueryd path: %s", override)
++		osquerydPath = override
++	}
++	if override := c.String("desktop-path"); override != "" {
++		log.Info().Msgf("Overriding Fleet Desktop path: %s", override)
++		desktopPath = override
++	}
++	if osquerydPath != "" && (!c.Bool("fleet-desktop") || desktopPath != "") {
++		log.Info().Msg("Using externally supplied component paths")
++	} else if !c.Bool("disable-updates") || c.Bool("dev-mode") {
+ 		updater, err := update.NewUpdater(opt)
+ 		if err != nil {
+ 			return fmt.Errorf("create updater: %w", err)

--- a/pkgs/by-name/fl/fleet-orbit/0003-osquery-log-path.patch
+++ b/pkgs/by-name/fl/fleet-orbit/0003-osquery-log-path.patch
@@ -1,0 +1,29 @@
+diff --git a/orbit/cmd/orbit/orbit.go b/orbit/cmd/orbit/orbit.go
+index ed6f10d..54af34b 100644
+--- a/orbit/cmd/orbit/orbit.go
++++ b/orbit/cmd/orbit/orbit.go
+@@ -242,6 +242,11 @@ func main() {
+ 			Usage:   "Sets a custom osquery database directory, it must be an absolute path",
+ 			EnvVars: []string{"ORBIT_OSQUERY_DB"},
+ 		},
++		&cli.StringFlag{
++			Name:    "osquery-log-path",
++			Usage:   "Path to osquery log file",
++			EnvVars: []string{"NIX_ORBIT_OSQUERY_LOG_PATH"},
++		},
+ 		&cli.BoolFlag{
+ 			Name:    "fleet-managed-host-identity-certificate",
+ 			Usage:   "Configures fleetd to use TPM-backed key to sign HTTP requests. This functionality is licensed under the Fleet EE License. Usage requires a current Fleet EE subscription.",
+@@ -862,7 +867,11 @@ func orbitAction(c *cli.Context) error {
+ 		optionsAfterFlagfile []osquery.Option
+ 	)
+ 	options = append(options, osquery.WithDataPath(c.String("root-dir"), ""))
+-	options = append(options, osquery.WithLogPath(filepath.Join(c.String("root-dir"), "osquery_log")))
++	osqueryLogPath := c.String("osquery-log-path")
++	if osqueryLogPath == "" {
++		osqueryLogPath = filepath.Join(c.String("root-dir"), "osquery_log")
++	}
++	options = append(options, osquery.WithLogPath(osqueryLogPath))
+ 	optionsAfterFlagfile = append(optionsAfterFlagfile, osquery.WithFlags(
+ 		[]string{"--database_path", osqueryDB},
+ 	))

--- a/pkgs/by-name/fl/fleet-orbit/0004-scripts-nixos.patch
+++ b/pkgs/by-name/fl/fleet-orbit/0004-scripts-nixos.patch
@@ -1,0 +1,33 @@
+diff --git a/server/fleet/scripts.go b/server/fleet/scripts.go
+index 4ae230e..930a520 100644
+--- a/server/fleet/scripts.go
++++ b/server/fleet/scripts.go
+@@ -387,8 +387,8 @@ const (
+ // anchored, so that it matches to the end of the line
+ var (
+ 	scriptHashbangValidation       = regexp.MustCompile(`^#!\s*(:?/usr)?/bin/(ba|z)?sh(?:\s*|\s+.*)$`)
+-	ErrUnsupportedInterpreter      = errors.New(`Interpreter not supported. Supported interpreters are "#!/bin/sh", "#!/bin/bash", "#!/bin/zsh", "#!/usr/bin/env python3", or an absolute path to "python" / "python3".`)
+-	ErrUnsupportedShellInterpreter = errors.New(`Interpreter not supported. Shell scripts must run in "#!/bin/sh", "#!/bin/bash", or "#!/bin/zsh."`)
++	ErrUnsupportedInterpreter      = errors.New(`Interpreter not supported. Supported interpreters are "#!/bin/sh", "#!/bin/bash", "#!/bin/zsh", "#!/run/current-system/sw/bin/sh", "#!/run/current-system/sw/bin/bash", "#!/run/current-system/sw/bin/zsh", "#!/usr/bin/env sh", "#!/usr/bin/env bash", "#!/usr/bin/env zsh", "#!/usr/bin/env python3", or an absolute path to "python" / "python3".`)
++	ErrUnsupportedShellInterpreter = errors.New(`Interpreter not supported. Shell scripts must run in "#!/bin/sh", "#!/bin/bash", "#!/bin/zsh", "#!/run/current-system/sw/bin/sh", "#!/run/current-system/sw/bin/bash", "#!/run/current-system/sw/bin/zsh", or their "/usr/bin/env" equivalents.`)
+ )
+ 
+ type ShebangKind int
+@@ -454,7 +454,7 @@ func shebangInfo(contents string) (kind shebangKind, directExecute bool, err err
+ 	// Support env-based shebangs like "#!/usr/bin/env python3"
+ 	if base == "env" {
+ 		// Require env to be in /bin or /usr/bin (common, predictable locations)
+-		if !strings.HasPrefix(interp, "/bin/") && !strings.HasPrefix(interp, "/usr/bin/") {
++		if !strings.HasPrefix(interp, "/bin/") && !strings.HasPrefix(interp, "/usr/bin/") && !strings.HasPrefix(interp, "/run/current-system/sw/bin/") {
+ 			return shebangNone, false, ErrUnsupportedInterpreter
+ 		}
+ 
+@@ -486,7 +486,7 @@ func shebangInfo(contents string) (kind shebangKind, directExecute bool, err err
+ 
+ 	switch {
+ 	case base == "sh" || base == "bash" || base == "zsh":
+-		if !strings.HasPrefix(interp, "/bin/") && !strings.HasPrefix(interp, "/usr/bin/") {
++		if !strings.HasPrefix(interp, "/bin/") && !strings.HasPrefix(interp, "/usr/bin/") && !strings.HasPrefix(interp, "/run/current-system/sw/bin/") {
+ 			return shebangNone, false, ErrUnsupportedInterpreter
+ 		}
+ 		return shebangShell, true, nil

--- a/pkgs/by-name/fl/fleet-orbit/package.nix
+++ b/pkgs/by-name/fl/fleet-orbit/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nixosTests,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "fleet-orbit";
+  version = "1.55.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "fleetdm";
+    repo = "fleet";
+    tag = "orbit-v${finalAttrs.version}";
+    hash = "sha256-gaS6A9Zfpb/VMQMAO5qI0lIaohD8jj4KWFRTU0OeqMo=";
+  };
+
+  vendorHash = "sha256-fhACxmzJY0PEQmMbjQxlfQh5ZJ+7a4um0s8xFQq+57w=";
+
+  env.CGO_ENABLED = "1";
+
+  subPackages = [ "orbit/cmd/orbit" ];
+
+  goFlags = [ "-buildvcs=false" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=${finalAttrs.version}"
+    "-X=github.com/fleetdm/fleet/v4/orbit/pkg/build.Commit=0000000000000000000000000000000000000000"
+    "-X=github.com/fleetdm/fleet/v4/orbit/pkg/build.Date=1970-01-01T00:00:00Z"
+  ];
+
+  patches = [
+    ./0001-orbit-nixos.patch
+    ./0002-osqueryd-path-override.patch
+    ./0003-osquery-log-path.patch
+    ./0004-scripts-nixos.patch
+  ];
+
+  doInstallCheck = true;
+  versionCheckProgramArg = "version";
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.tests = {
+    inherit (nixosTests) orbit;
+  };
+
+  meta = {
+    description = "Fleet's lightweight osquery manager";
+    homepage = "https://github.com/fleetdm/fleet";
+    changelog = "https://github.com/fleetdm/fleet/releases/tag/orbit-v${finalAttrs.version}";
+    license = with lib.licenses; [
+      mit
+      {
+        shortName = "fleet-ee";
+        fullName = "Fleet Enterprise Edition License";
+        url = "https://github.com/fleetdm/fleet/blob/orbit-v${finalAttrs.version}/ee/LICENSE";
+        free = false;
+      }
+    ];
+    mainProgram = "orbit";
+    maintainers = with lib.maintainers; [ adrielvelazquez ];
+    platforms = lib.platforms.linux;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+  };
+})

--- a/pkgs/by-name/fl/fleet-orbit/package.nix
+++ b/pkgs/by-name/fl/fleet-orbit/package.nix
@@ -63,7 +63,10 @@ buildGoModule (finalAttrs: {
       }
     ];
     mainProgram = "orbit";
-    maintainers = with lib.maintainers; [ adrielvelazquez ];
+    maintainers = with lib.maintainers; [
+      adrielvelazquez
+      faukah
+    ];
     platforms = lib.platforms.linux;
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
   };


### PR DESCRIPTION
Add Fleet Orbit and Fleet Desktop packages, plus a NixOS module for enrolling Orbit with a Fleet server. This was based on earlier attempts I made with a flake and using the .deb and future forks that built it from source

https://github.com/AdrielVelazquez/fleet-nixos
https://github.com/adamcik/fleet-nixos

Fleet Orbit is Fleet's lightweight osquery manager:
https://github.com/fleetdm/fleet/tree/main/orbit

Fleet Desktop is just a simple tray icon that links to the results:
https://fleetdm.com/docs/using-fleet/fleet-desktop

The Orbit package is built from source and patched for NixOS assumptions:
  - use nixpkgs-provided `osqueryd` and `fleet-desktop` paths instead of Orbit-managed downloaded components
  - place osquery logs under `/var/log/orbit`
  - support NixOS script interpreter paths under `/run/current-system/sw/bin`
  - keep Fleet script execution compatible with NixOS shebang validation

The new `services.orbit` module configures enrollment using a secret file path. Companies tend to hardcode this in the generated debian, but it's passed into the envs for this service. 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
