### PR TITLE
firefoxpwa: fix build failure with wrapper

### DIFF
--- a/pkgs/by-name/fi/firefoxpwa-unwrapped/package.nix
+++ b/pkgs/by-name/fi/firefoxpwa-unwrapped/package.nix
@@ -83,6 +83,11 @@ rustPlatform.buildRustPackage rec {
 
     wrapProgram $out/bin/firefoxpwa-connector \
       --prefix FFPWA_SYSDATA : "$out/share/firefoxpwa"
+
+    # Create empty `lib/firefoxpwa` directory so the Firefox wrapper won't fail
+    # trying to disable the update checks. It will try to write to
+    # `$out/lib/firefoxpwa/is-packaged-app`, which doesn't exist by default.
+    # mkdir $out/lib/firefoxpwa
   '';
 
   passthru = {


### PR DESCRIPTION
Closes #525683

Commit 1da3ca73732263dc0473f0d64ccdfa810eaa1fac introduced a better way to disable the automatic update checker by writing to `$out/${libDir}/is-packaged-app` this directory isn't present for `firefoxpwa` this PR simply creates this empty directory so the file creating won't fail.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
