### PR TITLE
atheme, libbmowgli: fast-forward to unstable commits

### DIFF
--- a/pkgs/by-name/at/atheme/package.nix
+++ b/pkgs/by-name/at/atheme/package.nix
@@ -1,26 +1,31 @@
 {
   lib,
   stdenv,
-  fetchgit,
+  fetchFromGitHub,
   libmowgli,
   pkg-config,
   git,
   gettext,
-  pcre,
+  pcre2,
   libidn,
   libxcrypt,
   cracklib,
   openssl,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "atheme";
-  version = "7.2.12";
+  version = "7.2.12-unstable-2026-05-12";
 
-  src = fetchgit {
-    url = "https://github.com/atheme/atheme.git";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-KAC1ZPNo4TqfVryKOYYef8cRWRgFmyEdvl1bgvpGNiM=";
+  src = fetchFromGitHub {
+    owner = "atheme";
+    repo = "atheme";
+    rev = "23071cdf2c7b20210799218b485f97f06311b41f";
+    hash = "sha256-e7pD4ZXQ3irrpJJSDRuJu2pVMjxVe8AUzzVL5yCb9PA=";
+    # for modules and pinned libmowgli
+    fetchSubmodules = true;
+    # configure checks for git tree
     leaveDotGit = true;
   };
 
@@ -29,9 +34,10 @@ stdenv.mkDerivation (finalAttrs: {
     git
     gettext
   ];
+
   buildInputs = [
     libmowgli
-    pcre
+    pcre2
     libidn
     libxcrypt
     cracklib
@@ -46,6 +52,14 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-contrib"
     "--enable-reproducible-builds"
   ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
 
   meta = {
     description = "Set of services for IRC networks";

--- a/pkgs/by-name/li/libmowgli/package.nix
+++ b/pkgs/by-name/li/libmowgli/package.nix
@@ -2,17 +2,22 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libmowgli";
-  version = "2.1.3";
+  version = "2.1.3-unstable-2024-04-01";
 
   src = fetchFromGitHub {
     owner = "atheme";
     repo = "libmowgli-2";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-jlw6ixMoIdIjmQ86N+KN+Gez218sw894POkcCYnT0s0=";
+    rev = "878f7e931b55d36e2e1b27807f7a620cbb0577d8";
+    hash = "sha256-Ik0GDsC0vEFNW/s10u+kNubqVh95ZqXb2I5W9iyU1z4=";
+  };
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
   };
 
   meta = {


### PR DESCRIPTION
Atheme/libmowgli are not doing release any more.

Part of #356387 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
