### PR TITLE
nixos/displayManager: replace ad-hoc type // { check } overrides

### DIFF
--- a/nixos/modules/services/display-managers/default.nix
+++ b/nixos/modules/services/display-managers/default.nix
@@ -101,16 +101,7 @@ in
       };
 
       defaultSession = lib.mkOption {
-        type = lib.types.nullOr lib.types.str // {
-          description = "session name";
-          check =
-            d:
-            lib.assertMsg (d != null -> (lib.types.str.check d && lib.elem d cfg.sessionData.sessionNames)) ''
-              Default graphical session, '${d}', not found.
-              Valid names for 'services.displayManager.defaultSession' are:
-                ${lib.concatStringsSep "\n  " cfg.sessionData.sessionNames}
-            '';
-        };
+        type = lib.types.nullOr (lib.types.str // { description = "session name"; });
         default = null;
         example = "gnome";
         description = ''
@@ -130,26 +121,12 @@ in
 
       sessionPackages = lib.mkOption {
         type = lib.types.listOf (
-          lib.types.package
+          lib.types.addCheck lib.types.package (
+            p: p ? providedSessions && p.providedSessions != [ ] && lib.all lib.isString p.providedSessions
+          )
           // {
             description = "package with provided sessions";
-            check =
-              p:
-              lib.assertMsg
-                (
-                  lib.types.package.check p
-                  && p ? providedSessions
-                  && p.providedSessions != [ ]
-                  && lib.all lib.isString p.providedSessions
-                )
-                ''
-                  Package, '${p.name}', did not specify any session names, as strings, in
-                  'passthru.providedSessions'. This is required when used as a session package.
-
-                  The session names can be looked up in:
-                    ${p}/share/xsessions
-                    ${p}/share/wayland-sessions
-                '';
+            descriptionClass = "composite";
           }
         );
         default = [ ];
@@ -209,6 +186,14 @@ in
         assertion = cfg.autoLogin.enable -> cfg.autoLogin.user != null;
         message = ''
           services.displayManager.autoLogin.enable requires services.displayManager.autoLogin.user to be set
+        '';
+      }
+      {
+        assertion = cfg.defaultSession == null || lib.elem cfg.defaultSession cfg.sessionData.sessionNames;
+        message = ''
+          Default graphical session, '${toString cfg.defaultSession}', not found.
+          Valid names for 'services.displayManager.defaultSession' are:
+            ${lib.concatStringsSep "\n    " cfg.sessionData.sessionNames}
         '';
       }
     ];


### PR DESCRIPTION
Replace ad-hoc `type // { check }` overrides, which are incompatible with the v2 merge mechanism (see #454964).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
