### PR TITLE
haskellPackages.haskell-language-server: fix or bump deps

### DIFF
--- a/pkgs/by-name/ko/koka/package.nix
+++ b/pkgs/by-name/ko/koka/package.nix
@@ -68,7 +68,7 @@ haskellPackages.mkDerivation {
     hashable
     isocline
     lens
-    lsp_2_8_0_0
+    lsp
     mtl
     network
     network-simple

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -297,6 +297,14 @@ with haskellLib;
     })
   ] super.cabal-add;
 
+  stylish-haskell = appendPatches [
+    (pkgs.fetchpatch {
+      name = "bump-optparse-applicative.patch";
+      url = "https://github.com/haskell/stylish-haskell/commit/d1bc9bb91a0f9b122f2d4348022ce0fa1566124f.patch";
+      hash = "sha256-kRP4mABb1rlrx4GBPTozOS9fPudSzb36JcTKA8VMhgw=";
+    })
+  ] super.stylish-haskell;
+
   ###########################################
   ### END HASKELL-LANGUAGE-SERVER SECTION ###
   ###########################################

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -198,25 +198,12 @@ with haskellLib;
     }
   );
 
-  # First to upgrade to lsp >= 2.8 while HLS hasn't yet had a compatible release
-  futhark = super.futhark.override {
-    lsp = self.lsp_2_8_0_0;
-    lsp-test =
-      overrideCabal
-        (old: {
-          testTargets = [
-            "tests"
-            "func-test"
-          ];
-        })
-        (
-          self.lsp-test_0_18_0_0.override {
-            lsp = self.lsp_2_8_0_0;
-            lsp-types = self.lsp-types_2_4_0_0;
-          }
-        );
-    lsp-types = self.lsp-types_2_4_0_0;
-  };
+  lsp-test = overrideCabal (old: {
+    testTargets = [
+      "tests"
+      "func-test"
+    ];
+  }) super.lsp-test;
 
   #######################################
   ### HASKELL-LANGUAGE-SERVER SECTION ###
@@ -280,7 +267,6 @@ with haskellLib;
     haskell-language-server
     hls-plugin-api
     ghcide
-    lsp-types
     ;
 
   # For -f-auto see cabal.project in haskell-language-server.

--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -81,7 +81,6 @@ with haskellLib;
   #
 
   ghc-exactprint = doDistribute self.ghc-exactprint_1_14_0_0;
-  hie-bios = doDistribute (dontCheck self.hie-bios_0_19_0); # Tests access homeless-shelter.
 
   #
   # Jailbreaks

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -32,9 +32,6 @@ default-package-overrides:
   - extensions == 0.1.0.2 # matches Cabal 3.12 (GHC 9.10)
   # 2026-01-30: Needs to match hasql from Stackage LTS 24
   - hasql-notifications < 0.2.5.0
-  # 2026-02-04: as requested by ghcide >= 2.13
-  - hie-bios < 0.18.0
-  - hiedb < 0.8.0
   # 2025-09-13: hnix 0.17.0 doesn't support hnix-store-core >= 0.8
   # https://github.com/haskell-nix/hnix/pull/1112
   # Note: When removing this, also remove hnix-store-core from maintainers/scripts/haskell/update-stackage.sh
@@ -49,10 +46,6 @@ default-package-overrides:
   # liquidhaskell(-boot) support one GHC at a time, so we choose the one matching the current GHC (9.10)
   - liquidhaskell == 0.9.10.*
   - liquidhaskell-boot == 0.9.10.*
-  # 2025-03-07: HLS and many other pkgs don't support lsp >= 2.8 (yet)
-  - lsp < 2.8
-  - lsp-test < 0.18
-  - lsp-types < 2.4
   # Needs to match microlens == 0.4.* in Stackage LTS 24
   - microlens-pro < 0.2.0.4
   # 2026-04-06: 4.0.10 merely adjusts to dependencies that are incompatible with our LTS

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -137,11 +137,14 @@ package-maintainers:
     - basic-sop
     - commutative-semigroups
     - generics-sop
+    - ghcide
     - ghcjs-base
     - ghcjs-dom
     - ghcjs-dom-javascript
     - ghcjs-dom-jsaddle
     - haskell-debugger
+    - hie-bios
+    - hiedb
     - jsaddle
     - jsaddle-clib
     - jsaddle-dom
@@ -152,6 +155,9 @@ package-maintainers:
     - large-records
     - lens-sop
     - linux-namespaces
+    - lsp
+    - lsp-test
+    - lsp-types
     - monoidal-containers
     - proto-lens-arbitrary
     - proto3-suite

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -191,8 +191,11 @@ dont-distribute-packages:
  - babylon
  - backblaze-b2-hs
  - backdropper
+ - baikai
  - baikai-claude
+ - baikai-effectful
  - baikai-openai
+ - baikai-trace-otel
  - balkon
  - ballast
  - bamboo
@@ -2671,6 +2674,7 @@ dont-distribute-packages:
  - pms-domain-service
  - pms-infra-agent-process
  - pms-infra-agent-serial
+ - pms-infra-agent-server
  - pms-infra-agent-socket
  - pms-infra-cmdrun
  - pms-infra-filesystem
@@ -3189,6 +3193,16 @@ dont-distribute-packages:
  - shibuya-kafka-adapter
  - shibuya-metrics
  - shibuya-pgmq-adapter
+ - shikumi
+ - shikumi-cache
+ - shikumi-cache-postgres
+ - shikumi-cache-redis
+ - shikumi-compile
+ - shikumi-eval
+ - shikumi-optimize
+ - shikumi-tools
+ - shikumi-trace
+ - shikumi-trace-otel
  - shine-varying
  - short-vec
  - short-vec-lens

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1141,13 +1141,6 @@ builtins.intersectAttrs super {
     ];
   }) super.lsp-test;
 
-  lsp_2_8_0_0 = doDistribute (
-    super.lsp_2_8_0_0.override {
-      lsp-types = self.lsp-types_2_4_0_0;
-    }
-  );
-  lsp-types_2_4_0_0 = doDistribute super.lsp-types_2_4_0_0;
-
   # the test suite attempts to run the binaries built in this package
   # through $PATH but they aren't in $PATH
   dhall-lsp-server = dontCheck super.dhall-lsp-server;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
