### PR TITLE
nixos/kanidm: allow changing server db_path

### DIFF
--- a/nixos/modules/services/security/kanidm.nix
+++ b/nixos/modules/services/security/kanidm.nix
@@ -63,6 +63,7 @@ let
   ]
   ++ optionals cfg.provision.enable provisionSecretFiles;
   enableServerBackup = cfg.server.enable && (cfg.server.settings.online_backup.versions != 0);
+  databaseDir = dirOf cfg.server.settings.db_path;
 
   # Merge bind mount paths and remove paths where a prefix is already mounted.
   # This makes sure that if e.g. the tls_chain is in the nix store and /nix/store is already in the mount
@@ -332,9 +333,8 @@ in
             type = types.nullOr types.str;
           };
           db_path = mkOption {
-            description = "Path to Kanidm database.";
+            description = "Path to Kanidm database. Must be in a directory dedicated to Kanidm.";
             default = "/var/lib/kanidm/kanidm.db";
-            readOnly = true;
             type = types.path;
           };
           tls_chain = mkOption {
@@ -933,13 +933,28 @@ in
 
     environment.systemPackages = mkIf cfg.client.enable [ cfg.package ];
 
-    systemd.tmpfiles.settings."10-kanidm" = mkIf enableServerBackup {
-      ${cfg.server.settings.online_backup.path}.d = {
-        mode = "0700";
-        user = "kanidm";
-        group = "kanidm";
-      };
-    };
+    systemd.tmpfiles.settings."10-kanidm" =
+      let
+        tmpFiles =
+          (
+            # StateDirectory is handled by systemd
+            lib.optionalAttrs (databaseDir != "/var/lib/kanidm") {
+              ${databaseDir}.d = {
+                mode = "0700";
+                user = "kanidm";
+                group = "kanidm";
+              };
+            }
+          )
+          // (lib.optionalAttrs enableServerBackup {
+            ${cfg.server.settings.online_backup.path}.d = {
+              mode = "0700";
+              user = "kanidm";
+              group = "kanidm";
+            };
+          });
+      in
+      mkIf (tmpFiles != { }) tmpFiles;
 
     systemd.services.kanidm = mkIf cfg.server.enable {
       description = "kanidm identity management daemon";
@@ -972,6 +987,8 @@ in
 
           BindPaths =
             [ ]
+            # Database directory, if not in StateDirectory
+            ++ optional (databaseDir != "/var/lib/kanidm") databaseDir
             # To store backups
             ++ optional enableServerBackup cfg.server.settings.online_backup.path
             ++ optional (


### PR DESCRIPTION
Adds the ability to change `services.kanidm.server.settings.db_path`.

- Removes `readOnly = true;`
- Creates and permissions the parent directory with tmpfiles
- Adds that directory to `BindPaths` (rw)

I suspect it was `readOnly = true;` as part of trying to get it working with `DynamicUser=yes`.

Shouldn't be a breaking change, would be good to backport to 26.05 (please do so I don't have to patch nixpkgs for six months)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy]. All bugs are organic

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
