### PR TITLE
[26.05] sm64baserom: don't build on hydra

### DIFF
--- a/pkgs/by-name/sm/sm64baserom/package.nix
+++ b/pkgs/by-name/sm/sm64baserom/package.nix
@@ -28,10 +28,17 @@ let
       }
       .${region};
   };
-  result = runCommand "baserom-${region}-safety-dir" { } ''
-    mkdir $out
-    ln -s ${file} $out/${file.name}
-  '';
+  result =
+    runCommand "baserom-${region}-safety-dir"
+      {
+        # Prevent Hydra from trying to build `file` because Hydra won't have
+        # the baserom file in its store.
+        meta.hydraPlatforms = [ ];
+      }
+      ''
+        mkdir $out
+        ln -s ${file} $out/${file.name}
+      '';
 in
 result
 // {


### PR DESCRIPTION
This avoids an unfixable [Hydra build failure](https://hydra.nixos.org/build/329892892) caused by the file required by `requireFile` (via `file`) not being present in Hydra's store.

A long-term fix for this and similar issues is already on `master` (https://github.com/NixOS/nixpkgs/pull/515536) but constitutes a breaking change, which is why we cannot backport it.

Hydra: https://hydra.nixos.org/build/329892892
ZHF: https://github.com/NixOS/nixpkgs/issues/516381

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
