### PR TITLE
obsidian: fix internal PDF viewer on Electron 40

### DIFF
--- a/pkgs/by-name/ob/obsidian/package.nix
+++ b/pkgs/by-name/ob/obsidian/package.nix
@@ -6,6 +6,7 @@
   electron_40, # see https://github.com/NixOS/nixpkgs/pull/521495
   makeDesktopItem,
   imagemagick,
+  asar,
   autoPatchelfHook,
   writeScript,
   _7zz,
@@ -87,10 +88,20 @@ let
       autoPatchelfHook
       makeWrapper
       imagemagick
+      asar
     ];
     installPhase = ''
       runHook preInstall
       mkdir -p $out/bin
+
+      # Mark Obsidian's app:// scheme `corsEnabled` to fix the internal PDF
+      # viewer; see https://github.com/NixOS/nixpkgs/pull/525772 for details.
+      # Remove once upstream registers the scheme with `corsEnabled`.
+      asar extract resources/app.asar app-src
+      substituteInPlace app-src/main.js \
+        --replace-fail "supportFetchAPI: true," "supportFetchAPI: true, corsEnabled: true,"
+      asar pack app-src resources/app.asar
+
       makeWrapper ${electron_40}/bin/electron $out/bin/obsidian \
         --add-flags $out/share/obsidian/app.asar \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-wayland-ime=true --wayland-text-input-version=3}}" \


### PR DESCRIPTION
Obsidian registers its app:// scheme without `corsEnabled`. 

Since Electron 40.9.3 (electron/electron#51152), cross-origin app:// fetches are rejected unless the scheme is CORS-enabled, breaking the internal PDF viewer. 

Fixes #523846

<img width="400" height="600" alt="image" src="https://github.com/user-attachments/assets/d42103c7-4653-4abc-be05-2e5943a17f7c" />

---

**Note:** 

Side quest - the issue mentioned the PDF viewer in the AppImage version works. Found out it does becase they're still on Electron 39.

```bash
dir=$(mktemp -d) && cd "$dir"
curl -fLO https://github.com/obsidianmd/obsidian-releases/releases/download/v1.12.7/Obsidian-1.12.7.AppImage
nix-shell -p squashfsTools --run 'unsquashfs -o 188392 -d extract Obsidian-1.12.7.AppImage'
grep -aoE "(Electron|Chrome)/[0-9.]+" extract/obsidian | sort -u
```

This will print:

```
Chrome/142.0.7444.265
Electron/39.8.3
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
