### PR TITLE
switch-to-configuration-ng: Fix timers resulting in old unit running

### DIFF
--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
@@ -2394,6 +2394,68 @@ won't take effect until you reboot the system.
     // because some may not be dependencies of the targets (i.e., they were manually started).
     // FIXME: detect units that are symlinks to other units.  We shouldn't start both at the same
     // time because we'll get a "Failed to add path to set" error from systemd.
+    //
+    // systemd timers cancelling stop commands:
+    // We must start the changed units that we stopped above with `restart` instead of `start`.
+    // This is because of systemd timers (and, more generally, anything that can pull a unit back
+    // up within the same systemd transaction, such as a `.target` being restarted while the unit
+    // is `WantedBy`/`RequiredBy` it), which can make our life miserable:
+    //     https://github.com/NixOS/nixpkgs/issues/49415
+    // If during the `stop` step above a timer (or dependency) restarts a unit, systemd cancels the
+    // stop and executes the restart. Because the `daemon-reload` that loads the new unit definition
+    // only happens *after* the stop step, such a cancelled stop leaves the unit running with the
+    // unit definition from *before* the configuration switch (e.g. the wrong binary or config).
+    // If we only `start`ed such a unit here, the `start` would be a no-op (the unit is already
+    // active) and the unit would keep running outdated.
+    // Thus, we must `restart` the units we stopped above (i.e. the units that are in both
+    // `units_to_stop` and `units_to_start`), which forces systemd to replace the running unit.
+    // We must do this only for the units we actually stopped, not for all `units_to_start`:
+    // if we `restart`ed all `.target`s, this would do too much, e.g. kill the network.
+    // A minor drawback is that units that fail the `restart` get a second chance with the
+    // subsequent `start`, which may be confusing when reading logs or designing timeouts.
+    // This mirrors the historical `switch-to-configuration.pl` fix for the same issue:
+    //     https://github.com/NixOS/nixpkgs/pull/307562
+    let units_to_restart_on_start = units_to_start
+        .keys()
+        .filter(|unit| units_to_stop.contains_key(*unit))
+        .cloned()
+        .collect::<Vec<String>>();
+    let units_to_restart_on_start_filtered =
+        filter_units(&units_to_filter, &units_to_stop)
+            .keys()
+            .filter(|unit| units_to_start.contains_key(*unit))
+            .cloned()
+            .collect::<Vec<String>>();
+    if !units_to_restart_on_start_filtered.is_empty() {
+        let mut units = units_to_restart_on_start_filtered
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<&str>>();
+        units.sort_by_key(|name| name.to_lowercase());
+        eprintln!(
+            "starting (via restart, see #49415) the following units: {}",
+            units.join(", ")
+        );
+    }
+    for unit in &units_to_restart_on_start {
+        match systemd.restart_unit(unit, "replace") {
+            Ok(job_path) => {
+                let mut jobs = submitted_jobs.borrow_mut();
+                jobs.insert(job_path, Job::Restart);
+            }
+            Err(err) => {
+                eprintln!("Failed to restart {unit}: {err}");
+                exit_code = 4;
+            }
+        }
+    }
+
+    block_on_jobs(&dbus_conn, &submitted_jobs);
+
+    // Ensure all active targets, as well as any changed units we stopped above, are started. The
+    // `restart`s above already replaced the units we stopped; the `start`s below additionally
+    // bring up the active targets and any genuinely new units. Units already started by the
+    // `restart` above are left untouched by `start`.
     let units_to_start_filtered = filter_units(&units_to_filter, &units_to_start);
     if !units_to_start_filtered.is_empty() {
         let mut units = units_to_start_filtered


### PR DESCRIPTION
* [ ] Draft PR because I LLM-translated this fully automatically from my Perl PR #307562 to gather some quick feedback on the idea before I put more time into it.
  * Especially from @jmbaur and @dasJ via https://github.com/NixOS/nixpkgs/pull/308801#issuecomment-2093558900 
  * I have also written comparatively little Rust so far, and have not read the code of `switch-to-configuration-ng` yet (haven't had the time to yet, just trying to make servers behave for now), so thorough review / change suggestions would be very appreciated. I have _nothing_ against anybody familiar with `switch-to-configuration-ng` saying "OK I'll take it from here" and take over, though I'll also be happy to put in more time and implement review feedback if preferred.

---

Fixes #49415.

This is the backport of the equivalent fix to `switch-to-configuration.pl` PR'd in https://github.com/NixOS/nixpkgs/pull/307562.

This is a fully LLM-automated translation of that older PR to the Rust `switch-to-configuration-ng`.

Assisted-by: Zoo Code + Claude Opus 4.8

---

I have verified that without this patch, the problem my PR in #307562 fixed in `switch-to-configuration.pl` is present in `switch-to-configuration-ng` of NixOS 25.11, and that this PR apparently fixes it.

I could repro the bug after 2 `switch-to-configuration`s without the patch, but with this patch could not repro it within 10 tries. So that's promising. The expected new output

```
starting (via restart, see #49415) the following units: nebula@servers.service
```

is printed when I change a config file (I use `nebula` for testing, and suffering from, this) via:

```nix
services.nebula.networks."mynet".settings.lighthouse.interval = 22;
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
