### PR TITLE
opentelemetry-collector: add preBuild check to catch stale sourceHash

### DIFF
--- a/pkgs/tools/misc/opentelemetry-collector/releases.nix
+++ b/pkgs/tools/misc/opentelemetry-collector/releases.nix
@@ -107,6 +107,18 @@ let
           "-w"
         ];
 
+        # Catch stale sourceHash: verify every direct dependency listed in
+        # the releases manifest appears at the expected version in the
+        # generated go.mod. If sourceHash is stale, the cached source will
+        # have old dep versions and this check will fail.
+        preBuild = ''
+          grep '^ *- gomod:' ${src}/distributions/${name}/manifest.yaml \
+            | sed 's/.*gomod: //' \
+            | while read -r expected; do
+                grep -q "$expected" go.mod || { echo "ERROR: ${name}: missing '$expected' in go.mod; sourceHash is likely stale. Set sourceHash = \"\" and rebuild."; exit 1; }
+              done
+        '';
+
         postInstall = ''
           # Fix binary name
           mv $out/bin/* $out/bin/$pname


### PR DESCRIPTION
## Summary

When the `opentelemetry-collector-builder` version is bumped, the `sourceHash` and `vendorHash` values in `releases.nix` must also be updated. If they aren't, nix's content-addressed store silently serves cached outputs from an older version, producing binaries that report the wrong version at runtime. This happened on the `nixos-unstable` branch where binaries reported `v0.124.0` despite the package declaring `v0.144.0`.

## Changes

Add a `preBuild` check in `mkDistribution` that verifies every direct dependency listed in the upstream releases `manifest.yaml` appears at the expected version in the generated `go.mod`. If `sourceHash` is stale, the cached source will have old dependency versions and the build fails with a clear error message:

```
ERROR: otelcol-contrib: missing 'go.opentelemetry.io/collector/extension/zpagesextension v0.151.0' in go.mod; sourceHash is likely stale. Set sourceHash = "" and rebuild.
```

## Testing

- `nix build .#opentelemetry-collector-contrib` succeeds on master (hashes are correct)
- `otelcol-contrib --version` reports `0.151.0`
- Reverting to a stale `sourceHash` triggers the check with a clear error
- Built and tested on `x86_64-linux`

## Disclosures

This fix and PR done at my behest by Claude Code - I'm way too much of a nixos noob to have figured out the root cause of the problem I encountered (the out of date deps mentioned in the unstable branch), much less find the place to fix it.  That said, I *did* insist on figuring out a way to keep it from happening again, which is what this PR is.