### PR TITLE
lib/systems cleanup, drop legacy U‐Boot image format, drop uImage support

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -23,6 +23,8 @@
   `lib.systems.{examples,platforms}.{sheevaplug,pogoplug4}` have been unified into `lib.systems.examples.armv5tel-multiplatform`.
   Note that there is no official support for ARMv5 and it is not possible to build even a simple NixOS configuration out of the box.
 
+- Support for the legacy U‐Boot image format has been removed from the Linux kernel builders, as it is deprecated upstream and no longer used by any platform in Nixpkgs.
+
 - `requireFile` now sets `meta.license = lib.licenses.unfree` by default. Users of `requireFile`-based derivations that preserve this default will need to explicitly allow their evaluation as described in [](#sec-allow-unfree).
 
 - `librest` providing 0.7 ABI was removed. `librest_1_0` providing 1.0 ABI was renamed to `librest` and `librest_1_0` was kept as an alias.

--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -19,6 +19,10 @@
 
 - `uhttpmock` providing 0.0 ABI was removed. `uhttpmock_1_0` providing 1.0 ABI was renamed to `uhttpmock` and `uhttpmock_1_0` was kept as an alias.
 
+- The ARMv5 Linux kernel build now uses a standard configuration and generates a standard compressed image instead of the deprecated legacy U‐Boot image format.
+  `lib.systems.{examples,platforms}.{sheevaplug,pogoplug4}` have been unified into `lib.systems.examples.armv5tel-multiplatform`.
+  Note that there is no official support for ARMv5 and it is not possible to build even a simple NixOS configuration out of the box.
+
 - `requireFile` now sets `meta.license = lib.licenses.unfree` by default. Users of `requireFile`-based derivations that preserve this default will need to explicitly allow their evaluation as described in [](#sec-allow-unfree).
 
 - `librest` providing 0.7 ABI was removed. `librest_1_0` providing 1.0 ABI was renamed to `librest` and `librest_1_0` was kept as an alias.

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -40,10 +40,9 @@ rec {
     rust.rustcTarget = "powerpc-unknown-linux-gnu";
   };
 
-  sheevaplug = {
+  armv5tel-multiplatform = {
     config = "armv5tel-unknown-linux-gnueabi";
-  }
-  // platforms.sheevaplug;
+  };
 
   raspberryPi = {
     config = "armv6l-unknown-linux-gnueabihf";
@@ -98,11 +97,6 @@ rec {
     useAndroidPrebuilt = false;
     useLLVM = true;
   };
-
-  pogoplug4 = {
-    config = "armv5tel-unknown-linux-gnueabi";
-  }
-  // platforms.pogoplug4;
 
   ben-nanonote = {
     config = "mipsel-unknown-linux-uclibc";

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -306,7 +306,7 @@ rec {
     linux-kernel = {
       name = "armv7l-hf-multiplatform";
       Major = "2.6"; # Using "2.6" enables 2.6 kernel syscalls in glibc.
-      baseConfig = "multi_v7_defconfig";
+      baseConfig = "defconfig";
       DTB = true;
       autoModules = true;
       preferBuiltin = true;

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -305,7 +305,6 @@ rec {
   armv7l-hf-multiplatform = {
     linux-kernel = {
       name = "armv7l-hf-multiplatform";
-      Major = "2.6"; # Using "2.6" enables 2.6 kernel syscalls in glibc.
       baseConfig = "defconfig";
       DTB = true;
       autoModules = true;

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -305,13 +305,6 @@ rec {
       autoModules = true;
       preferBuiltin = true;
       target = "zImage";
-      extraConfig = ''
-        # >=5.12 fails with:
-        # drivers/net/ethernet/micrel/ks8851_common.o: in function `ks8851_probe_common':
-        # ks8851_common.c:(.text+0x179c): undefined reference to `__this_module'
-        # See: https://lore.kernel.org/netdev/20210116164828.40545-1-marex@denx.de/T/
-        KS8851_MLL y
-      '';
     };
     gcc = {
       # Some table about fpu flags:

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -46,138 +46,15 @@ rec {
   ## ARM
   ##
 
-  pogoplug4 = {
+  armv5tel-multiplatform = {
     linux-kernel = {
-      name = "pogoplug4";
+      name = "armv5tel-multiplatform";
 
       baseConfig = "multi_v5_defconfig";
-      autoModules = false;
-      extraConfig = ''
-        # Ubi for the mtd
-        MTD_UBI y
-        UBIFS_FS y
-        UBIFS_FS_XATTR y
-        UBIFS_FS_ADVANCED_COMPR y
-        UBIFS_FS_LZO y
-        UBIFS_FS_ZLIB y
-        UBIFS_FS_DEBUG n
-      '';
-      makeFlags = [ "LOADADDR=0x8000" ];
-      target = "uImage";
-      # TODO reenable once manual-config's config actually builds a .dtb and this is checked to be working
-      #DTB = true;
-    };
-    gcc = {
-      arch = "armv5te";
-    };
-  };
-
-  sheevaplug = {
-    linux-kernel = {
-      name = "sheevaplug";
-
-      baseConfig = "multi_v5_defconfig";
-      autoModules = false;
-      extraConfig = ''
-        BLK_DEV_RAM y
-        BLK_DEV_INITRD y
-        BLK_DEV_CRYPTOLOOP m
-        BLK_DEV_DM m
-        DM_CRYPT m
-        MD y
-        BTRFS_FS m
-        XFS_FS m
-        JFS_FS m
-        EXT4_FS m
-        USB_STORAGE_CYPRESS_ATACB m
-
-        # mv cesa requires this sw fallback, for mv-sha1
-        CRYPTO_SHA1 y
-        # Fast crypto
-        CRYPTO_TWOFISH y
-        CRYPTO_TWOFISH_COMMON y
-        CRYPTO_BLOWFISH y
-        CRYPTO_BLOWFISH_COMMON y
-
-        IP_PNP y
-        IP_PNP_DHCP y
-        NFS_FS y
-        ROOT_NFS y
-        TUN m
-        NFS_V4 y
-        NFS_V4_1 y
-        NFS_FSCACHE y
-        NFSD m
-        NFSD_V2_ACL y
-        NFSD_V3 y
-        NFSD_V3_ACL y
-        NFSD_V4 y
-        NETFILTER y
-        IP_NF_IPTABLES y
-        IP_NF_FILTER y
-        IP_NF_MATCH_ADDRTYPE y
-        IP_NF_TARGET_LOG y
-        IP_NF_MANGLE y
-        IPV6 m
-        VLAN_8021Q m
-
-        CIFS y
-        CIFS_XATTR y
-        CIFS_POSIX y
-        CIFS_FSCACHE y
-        CIFS_ACL y
-
-        WATCHDOG y
-        WATCHDOG_CORE y
-        ORION_WATCHDOG m
-
-        ZRAM m
-        NETCONSOLE m
-
-        # Disable OABI to have seccomp_filter (required for systemd)
-        # https://github.com/raspberrypi/firmware/issues/651
-        OABI_COMPAT n
-
-        # Fail to build
-        DRM n
-        SCSI_ADVANSYS n
-        USB_ISP1362_HCD n
-        SND_SOC n
-        SND_ALI5451 n
-        FB_SAVAGE n
-        SCSI_NSP32 n
-        ATA_SFF n
-        SUNGEM n
-        IRDA n
-        ATM_HE n
-        SCSI_ACARD n
-        BLK_DEV_CMD640_ENHANCED n
-
-        FUSE_FS m
-
-        # systemd uses cgroups
-        CGROUPS y
-
-        # Latencytop
-        LATENCYTOP y
-
-        # Ubi for the mtd
-        MTD_UBI y
-        UBIFS_FS y
-        UBIFS_FS_XATTR y
-        UBIFS_FS_ADVANCED_COMPR y
-        UBIFS_FS_LZO y
-        UBIFS_FS_ZLIB y
-        UBIFS_FS_DEBUG n
-
-        # Kdb, for kernel troubles
-        KGDB y
-        KGDB_SERIAL_CONSOLE y
-        KGDB_KDB y
-      '';
-      makeFlags = [ "LOADADDR=0x0200000" ];
-      target = "uImage";
-      DTB = true; # Beyond 3.10
+      DTB = true;
+      autoModules = true;
+      preferBuiltin = true;
+      target = "zImage";
     };
     gcc = {
       arch = "armv5te";
@@ -407,7 +284,7 @@ rec {
       if version == null then
         pc
       else if lib.versionOlder version "6" then
-        sheevaplug
+        armv5tel-multiplatform
       else if lib.versionOlder version "7" then
         raspberrypi
       else

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -212,15 +212,6 @@ rec {
   };
 
   zero-gravitas = {
-    linux-kernel = {
-      name = "zero-gravitas";
-
-      baseConfig = "zero-gravitas_defconfig";
-      # Target verified by checking /boot on reMarkable 1 device
-      target = "zImage";
-      autoModules = false;
-      DTB = true;
-    };
     gcc = {
       fpu = "neon";
       cpu = "cortex-a9";
@@ -228,15 +219,6 @@ rec {
   };
 
   zero-sugar = {
-    linux-kernel = {
-      name = "zero-sugar";
-
-      baseConfig = "zero-sugar_defconfig";
-      DTB = true;
-      autoModules = false;
-      preferBuiltin = true;
-      target = "zImage";
-    };
     gcc = {
       cpu = "cortex-a7";
       fpu = "neon-vfpv4";
@@ -266,24 +248,6 @@ rec {
     gcc = {
       cpu = "cortex-a9";
       fpu = "neon";
-    };
-  };
-
-  guruplug = lib.recursiveUpdate sheevaplug {
-    # Define `CONFIG_MACH_GURUPLUG' (see
-    # <http://kerneltrap.org/mailarchive/git-commits-head/2010/5/19/33618>)
-    # and other GuruPlug-specific things.  Requires the `guruplug-defconfig'
-    # patch.
-    linux-kernel.baseConfig = "guruplug_defconfig";
-  };
-
-  beaglebone = lib.recursiveUpdate armv7l-hf-multiplatform {
-    linux-kernel = {
-      name = "beaglebone";
-      baseConfig = "bb.org_defconfig";
-      autoModules = false;
-      extraConfig = ""; # TBD kernel config
-      target = "zImage";
     };
   };
 
@@ -370,74 +334,6 @@ rec {
   };
 
   fuloong2f_n32 = {
-    linux-kernel = {
-      name = "fuloong2f_n32";
-      baseConfig = "lemote2f_defconfig";
-      autoModules = false;
-      extraConfig = ''
-        MIGRATION n
-        COMPACTION n
-
-        # nixos mounts some cgroup
-        CGROUPS y
-
-        BLK_DEV_RAM y
-        BLK_DEV_INITRD y
-        BLK_DEV_CRYPTOLOOP m
-        BLK_DEV_DM m
-        DM_CRYPT m
-        MD y
-        EXT4_FS m
-        USB_STORAGE_CYPRESS_ATACB m
-
-        IP_PNP y
-        IP_PNP_DHCP y
-        IP_PNP_BOOTP y
-        NFS_FS y
-        ROOT_NFS y
-        TUN m
-        NFS_V4 y
-        NFS_V4_1 y
-        NFS_FSCACHE y
-        NFSD m
-        NFSD_V2_ACL y
-        NFSD_V3 y
-        NFSD_V3_ACL y
-        NFSD_V4 y
-
-        # Fail to build
-        DRM n
-        SCSI_ADVANSYS n
-        USB_ISP1362_HCD n
-        SND_SOC n
-        SND_ALI5451 n
-        FB_SAVAGE n
-        SCSI_NSP32 n
-        ATA_SFF n
-        SUNGEM n
-        IRDA n
-        ATM_HE n
-        SCSI_ACARD n
-        BLK_DEV_CMD640_ENHANCED n
-
-        FUSE_FS m
-
-        # Needed for udev >= 150
-        SYSFS_DEPRECATED_V2 n
-
-        VGA_CONSOLE n
-        VT_HW_CONSOLE_BINDING y
-        SERIAL_8250_CONSOLE y
-        FRAMEBUFFER_CONSOLE y
-        EXT2_FS y
-        EXT3_FS y
-        MAGIC_SYSRQ y
-
-        # The kernel doesn't boot at all, with FTRACE
-        FTRACE n
-      '';
-      target = "vmlinux";
-    };
     gcc = {
       arch = "loongson2f";
       float = "hard";

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -192,11 +192,6 @@ rec {
       DTB = true;
       autoModules = true;
       preferBuiltin = true;
-      extraConfig = ''
-        # Disable OABI to have seccomp_filter (required for systemd)
-        # https://github.com/raspberrypi/firmware/issues/651
-        OABI_COMPAT n
-      '';
       target = "zImage";
     };
     gcc = {
@@ -311,19 +306,6 @@ rec {
       preferBuiltin = true;
       target = "zImage";
       extraConfig = ''
-        # Serial port for Raspberry Pi 3. Wasn't included in ARMv7 defconfig
-        # until 4.17.
-        SERIAL_8250_BCM2835AUX y
-        SERIAL_8250_EXTENDED y
-        SERIAL_8250_SHARE_IRQ y
-
-        # Hangs ODROID-XU4
-        ARM_BIG_LITTLE_CPUIDLE n
-
-        # Disable OABI to have seccomp_filter (required for systemd)
-        # https://github.com/raspberrypi/firmware/issues/651
-        OABI_COMPAT n
-
         # >=5.12 fails with:
         # drivers/net/ethernet/micrel/ks8851_common.o: in function `ks8851_probe_common':
         # ks8851_common.c:(.text+0x179c): undefined reference to `__this_module'
@@ -362,22 +344,6 @@ rec {
       autoModules = true;
       preferBuiltin = true;
       extraConfig = ''
-        # Raspberry Pi 3 stuff. Not needed for   s >= 4.10.
-        ARCH_BCM2835 y
-        BCM2835_MBOX y
-        BCM2835_WDT y
-        RASPBERRYPI_FIRMWARE y
-        RASPBERRYPI_POWER y
-        SERIAL_8250_BCM2835AUX y
-        SERIAL_8250_EXTENDED y
-        SERIAL_8250_SHARE_IRQ y
-
-        # Cavium ThunderX stuff.
-        PCI_HOST_THUNDER_ECAM y
-
-        # Nvidia Tegra stuff.
-        PCI_TEGRA y
-
         # The default (=y) forces us to have the XHCI firmware available in initrd,
         # which our initrd builder can't currently do easily.
         USB_XHCI_TEGRA m

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -226,31 +226,6 @@ rec {
     };
   };
 
-  utilite = {
-    linux-kernel = {
-      name = "utilite";
-      maseConfig = "multi_v7_defconfig";
-      autoModules = false;
-      extraConfig = ''
-        # Ubi for the mtd
-        MTD_UBI y
-        UBIFS_FS y
-        UBIFS_FS_XATTR y
-        UBIFS_FS_ADVANCED_COMPR y
-        UBIFS_FS_LZO y
-        UBIFS_FS_ZLIB y
-        UBIFS_FS_DEBUG n
-      '';
-      makeFlags = [ "LOADADDR=0x10800000" ];
-      target = "uImage";
-      DTB = true;
-    };
-    gcc = {
-      cpu = "cortex-a9";
-      fpu = "neon";
-    };
-  };
-
   # https://developer.android.com/ndk/guides/abis#v7a
   armv7a-android = {
     linux-kernel.name = "armeabi-v7a";
@@ -376,35 +351,6 @@ rec {
     gcc = {
       arch = "mips64r6";
       abi = "64";
-    };
-  };
-
-  # based on:
-  #   https://www.mail-archive.com/qemu-discuss@nongnu.org/msg05179.html
-  #   https://gmplib.org/~tege/qemu.html#mips64-debian
-  mips64el-qemu-linux-gnuabi64 = {
-    linux-kernel = {
-      name = "mips64el";
-      baseConfig = "64r2el_defconfig";
-      target = "vmlinuz";
-      autoModules = false;
-      DTB = true;
-      # for qemu 9p passthrough filesystem
-      extraConfig = ''
-        MIPS_MALTA y
-        PAGE_SIZE_4KB y
-        CPU_LITTLE_ENDIAN y
-        CPU_MIPS64_R2 y
-        64BIT y
-        CPU_MIPS64_R2 y
-
-        NET_9P y
-        NET_9P_VIRTIO y
-        9P_FS y
-        9P_FS_POSIX_ACL y
-        PCI y
-        VIRTIO_PCI y
-      '';
     };
   };
 

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -18,6 +18,8 @@
 
 - `boot.vesa` has been removed. It was deprecated in 2020 because Xorg now works better with kernel modesetting. If you still need the legacy VESA 800x600 fallback, set `boot.kernelParams = [ "vga=0x317" "nomodeset" ];` directly.
 
+- Support for the legacy U‐Boot image format has been removed from the initrd generators, as it is deprecated upstream and no longer used by any platform in Nixpkgs.
+
 - Python 2 has been removed from the top-level package set, as it is long past end-of-life. The `python2`, `python27`, `python2Full`, `python27Full`, `python2Packages`, and `python27Packages` attributes, along with the legacy `python`, `pythonFull`, and `pythonPackages` aliases, now throw an error directing you to `python3`. The `isPy2` and `isPy27` package flags have been removed accordingly. The only remaining Python 2 interpreter is vendored inside the `resholve` package for its `oil` dependency and is not exposed for general use.
 
 ## Other Notable Changes {#sec-release-26.11-notable-changes}

--- a/pkgs/build-support/kernel/initrd-compressor-meta.nix
+++ b/pkgs/build-support/kernel/initrd-compressor-meta.nix
@@ -1,18 +1,15 @@
 rec {
   cat = {
     executable = pkgs: "cat";
-    ubootName = "none";
     extension = ".cpio";
   };
   gzip = {
     executable = pkgs: "${pkgs.gzip}/bin/gzip";
     defaultArgs = [ "-9n" ];
-    ubootName = "gzip";
     extension = ".gz";
   };
   bzip2 = {
     executable = pkgs: "${pkgs.bzip2}/bin/bzip2";
-    ubootName = "bzip2";
     extension = ".bz2";
   };
   xz = {
@@ -29,24 +26,20 @@ rec {
       "--check=crc32"
       "--lzma1=dict=512KiB"
     ];
-    ubootName = "lzma";
     extension = ".lzma";
   };
   lz4 = {
     executable = pkgs: "${pkgs.lz4}/bin/lz4";
     defaultArgs = [ "-l" ];
-    ubootName = "lz4";
     extension = ".lz4";
   };
   lzop = {
     executable = pkgs: "${pkgs.lzop}/bin/lzop";
-    ubootName = "lzo";
     extension = ".lzo";
   };
   zstd = {
     executable = pkgs: "${pkgs.zstd}/bin/zstd";
     defaultArgs = [ "-10" ];
-    ubootName = "zstd";
     extension = ".zst";
   };
   pigz = gzip // {

--- a/pkgs/build-support/kernel/make-initrd-ng.nix
+++ b/pkgs/build-support/kernel/make-initrd-ng.nix
@@ -4,14 +4,13 @@ let
   # from it.
   compressors = import ./initrd-compressor-meta.nix;
   # Get the basename of the actual compression program from the whole
-  # compression command, for the purpose of guessing the u-boot
+  # compression command, for the purpose of guessing the
   # compression type and filename extension.
   compressorName = fullCommand: builtins.elemAt (builtins.match "([^ ]*/)?([^ ]+).*" fullCommand) 1;
 in
 {
   stdenvNoCC,
   cpio,
-  ubootTools,
   lib,
   pkgsBuildHost,
   makeInitrdNGTool,
@@ -57,22 +56,13 @@ in
   # symlinks to store paths.
   prepend ? [ ],
 
-  # Whether to wrap the initramfs in a u-boot image.
-  makeUInitrd ? stdenvNoCC.hostPlatform.linux-kernel.target == "uImage",
-
-  # If generating a u-boot image, the architecture to use. The default
-  # guess may not align with u-boot's nomenclature correctly, so it can
-  # be overridden.
-  # See https://gitlab.denx.de/u-boot/u-boot/-/blob/9bfb567e5f1bfe7de8eb41f8c6d00f49d2b9a426/common/image.c#L81-106 for a list.
-  uInitrdArch ? stdenvNoCC.hostPlatform.ubootArch,
-
-  # The name of the compression, as recognised by u-boot.
-  # See https://gitlab.denx.de/u-boot/u-boot/-/blob/9bfb567e5f1bfe7de8eb41f8c6d00f49d2b9a426/common/image.c#L195-204 for a list.
-  # If this isn't guessed, you may want to complete the metadata above and send a PR :)
-  uInitrdCompression ?
-    _compressorMeta.ubootName
-      or (throw "Unrecognised compressor ${_compressorName}, please specify uInitrdCompression"),
+  # Deprecated; remove in 27.05.
+  makeUInitrd ? null,
+  uInitrdArch ? null,
+  uInitrdCompression ? null,
 }:
+assert lib.assertMsg (makeUInitrd == null && uInitrdArch == null && uInitrdCompression == null)
+  "makeInitrdNg: U‐Boot legacy image support has been removed as it is deprecated upstream and ARMv5 kernels no longer default to uImage";
 stdenvNoCC.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
 
@@ -83,11 +73,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   inherit
     name
     extension
-    makeUInitrd
-    uInitrdArch
     prepend
     ;
-  ${if makeUInitrd then "uInitrdCompression" else null} = uInitrdCompression;
 
   compress = "${_compressorExecutable} ${lib.escapeShellArgs _compressorArgsReal}";
   contentsJSON = builtins.toJSON contents;
@@ -95,8 +82,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     makeInitrdNGTool
     cpio
-  ]
-  ++ lib.optional makeUInitrd ubootTools;
+  ];
 
   buildCommand = ''
     mkdir -p ./root/{run,tmp,var/empty}
@@ -109,13 +95,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     done
     (cd root && find . -print0 | sort -z | cpio --quiet -o -H newc -R +0:+0 --reproducible --null | eval -- $compress >> "$out/initrd")
 
-    if [ -n "$makeUInitrd" ]; then
-      mkimage -A "$uInitrdArch" -O linux -T ramdisk -C "$uInitrdCompression" -d "$out/initrd" $out/initrd.img
-      # Compatibility symlink
-      ln -sf "initrd.img" "$out/initrd"
-    else
-      ln -s "initrd" "$out/initrd$extension"
-    fi
+    ln -s "initrd" "$out/initrd$extension"
   '';
 
   passthru = {

--- a/pkgs/build-support/kernel/make-initrd.nix
+++ b/pkgs/build-support/kernel/make-initrd.nix
@@ -10,18 +10,16 @@
 # of algorithms.
 let
   # Some metadata on various compression programs, relevant to naming
-  # the initramfs file and, if applicable, generating a u-boot image
-  # from it.
+  # the initramfs file.
   compressors = import ./initrd-compressor-meta.nix;
   # Get the basename of the actual compression program from the whole
-  # compression command, for the purpose of guessing the u-boot
+  # compression command, for the purpose of guessing the
   # compression type and filename extension.
   compressorName = fullCommand: builtins.elemAt (builtins.match "([^ ]*/)?([^ ]+).*" fullCommand) 1;
 in
 {
   stdenvNoCC,
   cpio,
-  ubootTools,
   lib,
   pkgsBuildHost,
   # Name of the derivation (not of the resulting file!)
@@ -65,22 +63,13 @@ in
   # symlinks to store paths.
   prepend ? [ ],
 
-  # Whether to wrap the initramfs in a u-boot image.
-  makeUInitrd ? stdenvNoCC.hostPlatform.linux-kernel.target or "dummy" == "uImage",
-
-  # If generating a u-boot image, the architecture to use. The default
-  # guess may not align with u-boot's nomenclature correctly, so it can
-  # be overridden.
-  # See https://gitlab.denx.de/u-boot/u-boot/-/blob/9bfb567e5f1bfe7de8eb41f8c6d00f49d2b9a426/common/image.c#L81-106 for a list.
-  uInitrdArch ? stdenvNoCC.hostPlatform.linuxArch,
-
-  # The name of the compression, as recognised by u-boot.
-  # See https://gitlab.denx.de/u-boot/u-boot/-/blob/9bfb567e5f1bfe7de8eb41f8c6d00f49d2b9a426/common/image.c#L195-204 for a list.
-  # If this isn't guessed, you may want to complete the metadata above and send a PR :)
-  uInitrdCompression ?
-    _compressorMeta.ubootName
-      or (throw "Unrecognised compressor ${_compressorName}, please specify uInitrdCompression"),
+  # Deprecated; remove in 27.05.
+  makeUInitrd ? null,
+  uInitrdArch ? null,
+  uInitrdCompression ? null,
 }:
+assert lib.assertMsg (makeUInitrd == null && uInitrdArch == null && uInitrdCompression == null)
+  "makeInitrd: U‐Boot legacy image support has been removed as it is deprecated upstream and ARMv5 kernels no longer default to uImage";
 stdenvNoCC.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
 
@@ -91,18 +80,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   inherit
     name
     extension
-    makeUInitrd
-    uInitrdArch
     prepend
     ;
-  ${if makeUInitrd then "uInitrdCompression" else null} = uInitrdCompression;
 
   builder = ./make-initrd.sh;
 
   nativeBuildInputs = [
     cpio
-  ]
-  ++ lib.optional makeUInitrd ubootTools;
+  ];
 
   compress = "${_compressorExecutable} ${lib.escapeShellArgs _compressorArgsReal}";
 

--- a/pkgs/build-support/kernel/make-initrd.sh
+++ b/pkgs/build-support/kernel/make-initrd.sh
@@ -36,10 +36,4 @@ done
 (cd root && find * .[^.*] -exec touch -h -d '@1' '{}' +)
 (cd root && find * .[^.*] -print0 | sort -z | cpio --quiet -o -H newc -R +0:+0 --reproducible --null | eval -- $compress >> "$out/initrd")
 
-if [ -n "$makeUInitrd" ]; then
-  mkimage -A "$uInitrdArch" -O linux -T ramdisk -C "$uInitrdCompression" -d "$out/initrd" $out/initrd.img
-  # Compatibility symlink
-  ln -sf "initrd.img" "$out/initrd"
-else
-  ln -s "initrd" "$out/initrd$extension"
-fi
+ln -s "initrd" "$out/initrd$extension"

--- a/pkgs/os-specific/linux/kernel/build.nix
+++ b/pkgs/os-specific/linux/kernel/build.nix
@@ -19,7 +19,6 @@
   zlib,
   pahole,
   kmod,
-  ubootTools,
   fetchpatch,
   rustc-unwrapped,
   rust-bindgen-unwrapped,
@@ -115,31 +114,6 @@ lib.makeOverridable (
         extraMakeFlags
         ;
     };
-
-    # Folding in `ubootTools` in the default nativeBuildInputs is problematic, as
-    # it makes updating U-Boot cumbersome, since it will go above the current
-    # threshold of rebuilds
-    #
-    # To prevent these needless rounds of staging for U-Boot builds, we can
-    # limit the inclusion of ubootTools to target platforms where uImage *may*
-    # be produced.
-    #
-    # This command lists those (kernel-named) platforms:
-    #     .../linux $ grep -l uImage ./arch/*/Makefile | cut -d'/' -f3 | sort
-    #
-    # This is still a guesstimation, but since none of our cached platforms
-    # coincide in that list, this gives us "perfect" decoupling here.
-    linuxPlatformsUsingUImage = [
-      "arc"
-      "arm"
-      "csky"
-      "mips"
-      "powerpc"
-      "sh"
-      "sparc"
-      "xtensa"
-    ];
-    needsUbootTools = lib.elem stdenv.hostPlatform.linuxArch linuxPlatformsUsingUImage;
 
     config =
       let
@@ -267,7 +241,6 @@ lib.makeOverridable (
       kmod
       hexdump
     ]
-    ++ optional needsUbootTools ubootTools
     ++ optionals (lib.versionAtLeast version "5.2") [
       cpio
       pahole
@@ -536,12 +509,10 @@ lib.makeOverridable (
       kernelAtLeast = lib.versionAtLeast baseVersion;
     };
 
-    # Some image types need special install targets (e.g. uImage is installed with make uinstall on arm)
+    # Some image types need special install targets
     installTargets = [
       (stdenv.hostPlatform.linux-kernel.installTarget or (
-        if target == "uImage" && stdenv.hostPlatform.linuxArch == "arm" then
-          "uinstall"
-        else if
+        if
           (target == "zImage" || target == "Image.gz" || target == "vmlinuz.efi")
           && builtins.elem stdenv.hostPlatform.linuxArch [
             "arm"

--- a/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
+++ b/pkgs/stdenv/linux/make-bootstrap-tools-cross.nix
@@ -25,7 +25,7 @@ lib.mapAttrs (n: make) (
     # on how to request an upload.
     # Sort following the sorting in `./default.nix` `bootstrapFiles` argument.
 
-    armv5tel-unknown-linux-gnueabi = sheevaplug;
+    armv5tel-unknown-linux-gnueabi = armv5tel-multiplatform;
     armv6l-unknown-linux-gnueabihf = raspberryPi;
     armv7l-unknown-linux-gnueabihf = armv7l-hf-multiplatform;
     aarch64-unknown-linux-gnu = aarch64-multiplatform;

--- a/pkgs/test/cross/default.nix
+++ b/pkgs/test/cross/default.nix
@@ -189,7 +189,7 @@ let
     pkgs.pkgsLLVM.stdenv
     pkgs.pkgsStatic.bash
     pkgs.pkgsCross.arm-embedded.stdenv
-    pkgs.pkgsCross.sheevaplug.stdenv # for armv5tel
+    pkgs.pkgsCross.armv5tel-multiplatform.stdenv
     pkgs.pkgsCross.raspberryPi.stdenv # for armv6l
     pkgs.pkgsCross.armv7l-hf-multiplatform.stdenv
     pkgs.pkgsCross.m68k.stdenv

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -197,8 +197,8 @@ in
 
   crossIphone32 = mapTestOnCross systems.examples.iphone32 darwinCommon;
 
-  # Test some cross builds to the Sheevaplug
-  crossSheevaplugLinux = mapTestOnCross systems.examples.sheevaplug (
+  # Test some cross builds to ARMv5
+  armv5tel = mapTestOnCross systems.examples.armv5tel-multiplatform (
     linuxCommon
     // {
       ubootSheevaplug = nativePlatforms;
@@ -234,8 +234,6 @@ in
 
   # Linux on armv7l-hf
   armv7l-hf = mapTestOnCross systems.examples.armv7l-hf-multiplatform linuxCommon;
-
-  pogoplug4 = mapTestOnCross systems.examples.pogoplug4 linuxCommon;
 
   # Linux on aarch64
   aarch64 = mapTestOnCross systems.examples.aarch64-multiplatform linuxCommon;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

cherry picked from https://github.com/NixOS/nixpkgs/pull/419895

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] cross armv5, cross armv7
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
