### PR TITLE
s3fs: 1.95 -> 1.97

### DIFF
--- a/pkgs/by-name/s3/s3fs/package.nix
+++ b/pkgs/by-name/s3/s3fs/package.nix
@@ -7,25 +7,26 @@
   curl,
   openssl,
   libxml2,
-  fuse,
+  macfuse-stubs,
+  fuse3,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "s3fs-fuse";
-  version = "1.95";
+  version = "1.97";
 
   src = fetchFromGitHub {
     owner = "s3fs-fuse";
     repo = "s3fs-fuse";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-wHszw3S+fuZRwTvJy+FkxQTR2BAvr8H924Wd4/C5heE=";
+    hash = "sha256-iggSIrmxnhINdzJm60yTWkmDwUWJRNNVqwHGd2Lb7lw=";
   };
 
   buildInputs = [
     curl
     openssl
     libxml2
-    fuse
+    (if stdenv.hostPlatform.isDarwin then macfuse-stubs else fuse3)
   ];
   nativeBuildInputs = [
     autoreconfHook


### PR DESCRIPTION
update to 1.97

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
