### PR TITLE
sqlcheck: fix build on darwin

### DIFF
--- a/pkgs/by-name/sq/sqlcheck/package.nix
+++ b/pkgs/by-name/sq/sqlcheck/package.nix
@@ -37,6 +37,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
 
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-Wno-error=character-conversion";
+  __darwinAllowLocalNetworking = true;
+
   doCheck = true;
 
   meta = {
@@ -45,7 +48,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "sqlcheck";
     license = lib.licenses.asl20;
     platforms = with lib.platforms; unix ++ windows;
-    broken = stdenv.hostPlatform.isDarwin;
     maintainers = with lib.maintainers; [ h7x4 ];
   };
 })


### PR DESCRIPTION
Fix build by ignoring character-conversion warning.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
