### PR TITLE
notblood: init at 1.0.0

### DIFF
--- a/pkgs/by-name/no/notblood/package.nix
+++ b/pkgs/by-name/no/notblood/package.nix
@@ -8,8 +8,8 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  pname = "dethrace";
-  version = "0.9.0";
+  pname = "notblood";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "clipmove";
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   installPhase = ''
-    install -Dm755 dethrace $out/bin/dethrace
+    install -Dm755 notblood $out/bin/notblood
   '';
 
   meta = {

--- a/pkgs/by-name/no/notblood/package.nix
+++ b/pkgs/by-name/no/notblood/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  SDL2,
+  perl,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dethrace";
+  version = "0.9.0";
+
+  src = fetchFromGitHub {
+    owner = "clipmove";
+    repo = "NotBlood";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+e7019a60afc17898f55ad781d619e562173e7fc7=";
+    fetchSubmodules = true;
+  };
+
+  buildInputs = [ SDL2 ];
+  nativeBuildInputs = [
+    cmake
+    perl
+    libflac
+  ];
+
+  installPhase = ''
+    install -Dm755 dethrace $out/bin/dethrace
+  '';
+
+  meta = {
+    homepage = "https://github.com/clipmove/NotBlood";
+    description = "Gameplay Mod of NBlood";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ fluddsskark ];
+    mainProgram = "notblood";
+  };
+})


### PR DESCRIPTION
Add derivation for NotBlood game with necessary build inputs and metadata.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
