### PR TITLE
nixpeek: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29193,17 +29193,17 @@
     name = "Volker Diels-Grabsch";
     keys = [ { fingerprint = "A7E6 9C4F 69DC 5D6C FC84  EE34 A29F BD51 5F89 90AF"; } ];
   };
-  voidless = {
-    email = "julius.schmitt@yahoo.de";
-    github = "bratorange";
-    githubId = 45292658;
-    name = "Julius Schmitt";
-  };
   voidhartt = {
     email = "voidhartt@gmail.com";
     github = "voidhartt";
     githubId = 235449536;
     name = "voidhartt";
+  };
+  voidless = {
+    email = "julius.schmitt@yahoo.de";
+    github = "bratorange";
+    githubId = 45292658;
+    name = "Julius Schmitt";
   };
   voidnoi = {
     email = "voidnoi@proton.me";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29199,6 +29199,12 @@
     githubId = 45292658;
     name = "Julius Schmitt";
   };
+  voidhartt = {
+    email = "voidhartt@gmail.com";
+    github = "voidhartt";
+    githubId = 235449536;
+    name = "voidhartt";
+  };
   voidnoi = {
     email = "voidnoi@proton.me";
     github = "VoidNoi";

--- a/pkgs/by-name/ni/nixpeek/package.nix
+++ b/pkgs/by-name/ni/nixpeek/package.nix
@@ -3,7 +3,6 @@
   buildGoModule,
   fetchFromGitHub,
 }:
-
 buildGoModule {
   pname = "nixpeek";
   version = "0.1.0";
@@ -19,7 +18,7 @@ buildGoModule {
 
   __structuredAttrs = true;
 
-  subPackages = [ "cmd/nixpeek" ];
+  subPackages = ["cmd/nixpeek"];
 
   ldflags = [
     "-s"
@@ -32,6 +31,6 @@ buildGoModule {
     license = lib.licenses.mit;
     mainProgram = "nixpeek";
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ voidhartt ];
+    maintainers = with lib.maintainers; [voidhartt];
   };
 }

--- a/pkgs/by-name/ni/nixpeek/package.nix
+++ b/pkgs/by-name/ni/nixpeek/package.nix
@@ -18,7 +18,7 @@ buildGoModule {
 
   __structuredAttrs = true;
 
-  subPackages = ["cmd/nixpeek"];
+  subPackages = [ "cmd/nixpeek" ];
 
   ldflags = [
     "-s"
@@ -31,6 +31,6 @@ buildGoModule {
     license = lib.licenses.mit;
     mainProgram = "nixpeek";
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [voidhartt];
+    maintainers = with lib.maintainers; [ voidhartt ];
   };
 }

--- a/pkgs/by-name/ni/nixpeek/package.nix
+++ b/pkgs/by-name/ni/nixpeek/package.nix
@@ -1,9 +1,10 @@
-{ lib
-, buildGoModule
-, fetchFromGitHub
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
 }:
 
-buildGoModule rec {
+buildGoModule {
   pname = "nixpeek";
   version = "0.1.0";
 
@@ -15,6 +16,8 @@ buildGoModule rec {
   };
 
   vendorHash = "sha256-ecodI5ImNp1bkpNcUDKnKK/uUzJwOQ+u2lTz6eq7kM4=";
+
+  __structuredAttrs = true;
 
   subPackages = [ "cmd/nixpeek" ];
 

--- a/pkgs/by-name/ni/nixpeek/package.nix
+++ b/pkgs/by-name/ni/nixpeek/package.nix
@@ -1,0 +1,34 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "nixpeek";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "voidhartt";
+    repo = "NixPeek";
+    rev = "v0.1.0";
+    hash = "sha256-fNfxBlOtKj8mz0zR3h0dHZ0YQBq9czEjSk2Ge2j9zN8=";
+  };
+
+  vendorHash = "sha256-ecodI5ImNp1bkpNcUDKnKK/uUzJwOQ+u2lTz6eq7kM4=";
+
+  subPackages = [ "cmd/nixpeek" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = {
+    description = "Terminal UI for searching Nix packages with attrPath-first workflow";
+    homepage = "https://github.com/voidhartt/NixPeek";
+    license = lib.licenses.mit;
+    mainProgram = "nixpeek";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ voidhartt ];
+  };
+}


### PR DESCRIPTION
## Summary

Add `nixpeek`, a terminal UI for searching Nix packages with an attrPath-first workflow.

## What changed

- Added `pkgs/by-name/ni/nixpeek/package.nix`
- Added maintainer entry `voidhartt` in `maintainers/maintainer-list.nix`
- Package source points to upstream release tag `v0.1.0`

## Source and version

- Upstream repository: https://github.com/voidhartt/NixPeek
- Upstream release: `v0.1.0`
- Packaged version: `0.1.0`

## Testing

Validated package build with:

```bash
nix build --impure --expr 'let pkgs = import <nixpkgs> {}; in pkgs.callPackage ./pkgs/by-name/ni/nixpeek/package.nix {}' --no-link
```

And runtime smoke check:

```bash
result/bin/nixpeek --help
```
