### PR TITLE
nginx-config-formatter: enable and fix strictDeps

### DIFF
--- a/pkgs/by-name/ng/nginx-config-formatter/package.nix
+++ b/pkgs/by-name/ng/nginx-config-formatter/package.nix
@@ -12,8 +12,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "slomkowski";
     repo = "nginx-config-formatter";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-HB1knL/q1G2z6RyVCsOyIKpp4O6x68/93ccvox1FKGQ=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-HB1knL/q1G2z6RyVCsOyIKpp4O6x68/93ccvox1FKGQ=";
   };
 
   buildInputs = [ python3 ];

--- a/pkgs/by-name/ng/nginx-config-formatter/package.nix
+++ b/pkgs/by-name/ng/nginx-config-formatter/package.nix
@@ -18,6 +18,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ python3 ];
 
+  nativeCheckInputs = [ python3 ];
+
+  strictDeps = true;
+
   doCheck = true;
   checkPhase = ''
     python3 $src/test_nginxfmt.py

--- a/pkgs/by-name/ng/nginx-config-formatter/package.nix
+++ b/pkgs/by-name/ng/nginx-config-formatter/package.nix
@@ -32,6 +32,13 @@ stdenv.mkDerivation (finalAttrs: {
     install -m 0755 $src/nginxfmt.py $out/bin/nginxfmt
   '';
 
+  doInstallCheck = true;
+  # We can't do a version check because there is no version command
+  # but we do want to check that python3 is available
+  installCheckPhase = ''
+    $out/bin/nginxfmt --help
+  '';
+
   meta = {
     description = "Nginx config file formatter";
     maintainers = with lib.maintainers; [ Baughn ];


### PR DESCRIPTION
If `python3` is only in `buildInputs` but not `nativeCheckInputs`, the build fails (with `strictDeps`).
If `python3` is only in `nativeCheckInputs` but not `buildInputs`, the program builds but doesn't run.
    
Added a check to keep an eye on that.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
