### PR TITLE
sqlx-cli: 0.8.6 -> 0.9.0

### DIFF
--- a/pkgs/by-name/sq/sqlx-cli/package.nix
+++ b/pkgs/by-name/sq/sqlx-cli/package.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   rustPlatform,
-  fetchFromGitHub,
+  fetchCrate,
   installShellFiles,
   pkg-config,
   openssl,
@@ -14,16 +14,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sqlx-cli";
-  version = "0.8.6";
+  version = "0.9.0";
 
-  src = fetchFromGitHub {
-    owner = "launchbadge";
-    repo = "sqlx";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-Trnyrc17KWhX8QizKyBvXhTM7HHEqtywWgNqvQNMOAY=";
+  # Upstream stopped shipping a Cargo.lock starting with the v0.9.0 release
+  # https://github.com/transact-rs/sqlx/blob/v0.9.0/CHANGELOG.md#cargolock-removed-from-tracking
+  src = fetchCrate {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-XariusjsCgn0Qai0XWtr7EzSzDDTp1cCzjff1kJNO9Y=";
   };
 
-  cargoHash = "sha256-FxvzCe+dRfMUcPWA4lp4L6FJaSpMiXTqEyhzk+Dv1B8=";
+  cargoHash = "sha256-pHaMKuB9v3fjbgeVyLyRtfoQ9BkE6z+TjDfdBaVdbXM=";
 
   buildNoDefaultFeatures = true;
   buildFeatures = [
@@ -32,10 +32,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "sqlite"
     "mysql"
     "completions"
+    "sqlx-toml"
   ];
-
-  doCheck = false;
-  cargoBuildFlags = [ "--package sqlx-cli" ];
 
   nativeBuildInputs = [
     installShellFiles
@@ -66,7 +64,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "CLI for managing databases, migrations, and enabling offline mode with `sqlx::query!()` and friends";
-    homepage = "https://github.com/launchbadge/sqlx";
+    homepage = "https://github.com/transact-rs/sqlx";
+    changelog = "https://github.com/transact-rs/sqlx/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       greizgh


### PR DESCRIPTION
Changelog: https://github.com/transact-rs/sqlx/blob/v0.9.0/CHANGELOG.md

Diff: https://github.com/transact-rs/sqlx/compare/v0.8.6...v0.9.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
