### PR TITLE
nixos/opensnitch: Set connection timeout of 3s for faster tests

### DIFF
--- a/nixos/tests/opensnitch.nix
+++ b/nixos/tests/opensnitch.nix
@@ -75,10 +75,10 @@ in
     lib.concatLines (
       map (m: ''
         client_blocked_${m}.wait_for_unit("opensnitchd.service")
-        client_blocked_${m}.fail("curl http://server")
+        client_blocked_${m}.fail("curl --connect-timeout 3 http://server")
 
         client_allowed_${m}.wait_for_unit("opensnitchd.service")
-        client_allowed_${m}.succeed("curl http://server")
+        client_allowed_${m}.succeed("curl --connect-timeout 3 http://server")
       '') monitorMethods
     )
     + ''


### PR DESCRIPTION
The default connection timeout of curl appears to be much higher - running these tests without specifying a connection timeout took around 10 minutes. With the timeout applied, the tests run within a few seconds.

Note that I am not very familiar with these tests or NixOS tests in general, but this seemed like a sensible change to me.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
