### PR TITLE
maintainers: remove shreerammodi

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25380,13 +25380,6 @@
     githubId = 819413;
     name = "Benedict Aas";
   };
-  shreerammodi = {
-    name = "Shreeram Modi";
-    email = "shreerammodi10@gmail.com";
-    github = "shreerammodi";
-    githubId = 67710369;
-    keys = [ { fingerprint = "EA88 EA07 26E9 6CBF 6365  3966 163B 16EE 76ED 24CE"; } ];
-  };
   shunueda = {
     name = "Shun Ueda";
     github = "shunueda";

--- a/pkgs/by-name/in/inklecate/package.nix
+++ b/pkgs/by-name/in/inklecate/package.nix
@@ -39,6 +39,6 @@ buildDotnetModule rec {
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     badPlatforms = lib.platforms.aarch64;
-    maintainers = with lib.maintainers; [ shreerammodi ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
## Reasons

- Last commented in [January 2022](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Ashreerammodi)
- Hasn't created any PRs / Issues since [July 2021](https://github.com/NixOS/nixpkgs/issues?q=author%3Ashreerammodi)
- About 6 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Ashreerammodi%20-commenter%3Ashreerammodi%20-author%3Ashreerammodi%20-reviewed-by%3Ashreerammodi) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] inklecate