### PR TITLE
haskellPackages.{bitwise,psqueues,xz}: drop override

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1320,10 +1320,6 @@ with haskellLib;
     '';
   }) (addExtraLibrary self.QuickCheck super.Chart-tests);
 
-  # 2026-05-18: too strict bounds on QuickCheck < 2.16
-  # https://github.com/hasufell/lzma-static/issues/16
-  xz = doJailbreak super.xz;
-
   ghcup =
     lib.throwIf pkgs.config.allowAliases
       "ghcup cannot be used to install the haskell tool chain on NixOS because there is no compatible bindist. Please install ghc etc. via Nix. On non-NixOS systems you can use the ghcup shell installer"

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1515,10 +1515,6 @@ with haskellLib;
   optparse-applicative = doJailbreak super.optparse-applicative;
 
   # 2026-05-17: allow QuickCheck 2.16
-  # https://github.com/jaspervdj/psqueues/issues/67
-  psqueues = doJailbreak super.psqueues;
-
-  # 2026-05-17: allow QuickCheck 2.16
   # https://github.com/fizruk/http-api-data/issues/157
   http-api-data = doJailbreak super.http-api-data;
 

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1535,10 +1535,6 @@ with haskellLib;
   fgl = doJailbreak super.fgl;
 
   # 2026-05-17: allow QuickCheck 2.16
-  # Sent Claude an email on 2026-05-18.
-  bitwise = doJailbreak super.bitwise;
-
-  # 2026-05-17: allow QuickCheck 2.16
   # https://github.com/haskell-hvr/lzma/issues/45
   lzma = doJailbreak super.lzma;
 


### PR DESCRIPTION
Made obsolete by the latest hackage bump, these have new revisions published.

Not sure how many rebuilds these cause, so putting down as a PR first. Edit: Can be merged when the next set rebuild comes up.

## Things done

- Built on platform:
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
