### PR TITLE
haskellPackages.haskell-ci: 0.18.1 -> 0.19.20260331

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1335,10 +1335,6 @@ with haskellLib;
   # Therefore we jailbreak it.
   hakyll-contrib-hyphenation = doJailbreak super.hakyll-contrib-hyphenation;
 
-  # The test suite depends on an impure cabal-install installation in
-  # $HOME, which we don't have in our build sandbox.
-  cabal-install-parsers = dontCheck super.cabal-install-parsers;
-
   # Test suite requires database
   persistent-mysql = dontCheck super.persistent-mysql;
 
@@ -1839,29 +1835,47 @@ with haskellLib;
   # https://github.com/minimapletinytools/linear-tests/issues/1
   linear-tests = dontCheck super.linear-tests;
 
-  # 2023-04-09: haskell-ci needs Cabal-syntax 3.10
-  # 2024-03-21: pins specific version of ShellCheck
   # 2025-03-10: jailbreak, https://github.com/haskell-CI/haskell-ci/issues/771
-  haskell-ci = doJailbreak (
-    super.haskell-ci.overrideScope (
-      self: super: {
-        Cabal-syntax = self.Cabal-syntax_3_10_3_0;
-        ShellCheck = self.ShellCheck_0_9_0;
+  haskell-ci = lib.pipe super.haskell-ci [
+    (warnAfterVersion "0.18.1")
+    (overrideSrc {
+      # ATTN: also update cabal-install-parsers version below
+      version = "0.19.20260331-unstable-2026-04-15";
+      src = pkgs.fetchFromGitHub {
+        owner = "haskell-CI";
+        repo = "haskell-ci";
+        rev = "30692865b767dcab15086e63f2f4fd3d3d1fe8a5";
+        hash = "sha256-t1urzATbWwdRWkpCygg2kLZ3i8/0qG9ZOjDsNpnUBt0=";
+      };
+    })
+    (addBuildDepends [ self.tasty-hunit ])
+    # https://github.com/haskell-CI/haskell-ci/issues/819
+    doJailbreak
+    (
+      haskell-ci:
+      haskell-ci.override {
+        ShellCheck = self.ShellCheck_0_10_0;
+        cabal-install-parsers = lib.pipe self.cabal-install-parsers [
+          (warnAfterVersion "0.6.3")
+          (overrideSrc {
+            version = "0.6.4-unstable-2026-04-15";
+            inherit (self.haskell-ci) src;
+          })
+          (overrideCabal {
+            # Too strict bounds on tree-diff, tar
+            # https://github.com/haskell-CI/haskell-ci/issues/807
+            jailbreak = true;
+            postUnpack = ''
+              sourceRoot+="/cabal-install-parsers"
+            '';
+          })
+        ];
       }
     )
-  );
+  ];
 
-  # ShellCheck < 0.10.0 needs to be adjusted for changes in fgl >= 5.8
-  # https://github.com/koalaman/shellcheck/issues/2677
-  ShellCheck_0_9_0 = doJailbreak (
-    appendPatches [
-      (fetchpatch {
-        name = "shellcheck-fgl-5.8.1.1.patch";
-        url = "https://github.com/koalaman/shellcheck/commit/c05380d518056189412e12128a8906b8ca6f6717.patch";
-        sha256 = "0gbx46x1a2sh5mvgpqxlx9xkqcw4wblpbgqdkqccxdzf7vy50xhm";
-      })
-    ] super.ShellCheck_0_9_0
-  );
+  # Allow QuickCheck >= 2.16
+  ShellCheck_0_10_0 = doDistribute (doJailbreak super.ShellCheck_0_10_0);
 
   # Too strict bound on hspec (<2.11)
   utf8-light = doJailbreak super.utf8-light;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -124,7 +124,7 @@ extra-packages:
   - postgresql-binary < 0.14            # 2025-01-19: Needed for building postgrest
   - semaphore-compat == 1.0.*           # 2026-05-27: Match GHC 9.2 / Stackage Nightly
   - shake-cabal < 0.2.2.3               # 2023-07-01: last version to support Cabal 3.6.*
-  - ShellCheck == 0.9.0                 # 2024-03-21: pinned by haskell-ci
+  - ShellCheck == 0.10.0                # 2026-05-30: pinned by haskell-ci
   - simple-get-opt < 0.5                # 2025-05-01: for crux-0.7.2
   - stylish-haskell == 0.14.5.0         # 2025-04-14: needed for hls with ghc-lib 9.6
   - stylish-haskell == 0.14.6.0         # 2025-09-21: needed for hls with ghc-lib 9.8

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -130,6 +130,10 @@ builtins.intersectAttrs super {
   # Tests access homeless-shelter.
   hie-bios = dontCheck super.hie-bios;
 
+  # The test suite depends on an impure cabal-install installation in
+  # $HOME, which we don't have in our build sandbox.
+  cabal-install-parsers = dontCheck super.cabal-install-parsers;
+
   ###########################################
   ### END HASKELL-LANGUAGE-SERVER SECTION ###
   ###########################################


### PR DESCRIPTION
This plus a bunch of workarounds fixes the build of haskell-ci with Stackage Nightly.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
