### PR TITLE
lxqt.lxqt-{runner,panel}: migrate to pcre2

### DIFF
--- a/pkgs/desktops/lxqt/lxqt-panel/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-panel/default.nix
@@ -23,7 +23,7 @@
   lxqt-build-tools,
   lxqt-globalkeys,
   lxqt-menu-data,
-  pcre,
+  pcre2,
   qtbase,
   qtsvg,
   qttools,
@@ -71,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
     lm_sensors
     lxqt-globalkeys
     lxqt-menu-data
-    pcre
+    pcre2
     qtbase
     qtsvg
     qtwayland

--- a/pkgs/desktops/lxqt/lxqt-runner/default.nix
+++ b/pkgs/desktops/lxqt/lxqt-runner/default.nix
@@ -10,7 +10,7 @@
   lxqt-build-tools,
   lxqt-globalkeys,
   muparser,
-  pcre,
+  pcre2,
   pkg-config,
   qtbase,
   qtsvg,
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     libqtxdg
     lxqt-globalkeys
     muparser
-    pcre
+    pcre2
     qtbase
     qtsvg
     qtwayland


### PR DESCRIPTION
Part of #356387

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
