### PR TITLE
youtrack: 2026.1.12458 -> 2026.1.13570

### DIFF
--- a/pkgs/by-name/yo/youtrack/package.nix
+++ b/pkgs/by-name/yo/youtrack/package.nix
@@ -10,15 +10,15 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "youtrack";
-  version = "2026.1.12458";
+  version = "2026.1.13570";
 
   src = dockerTools.exportImage {
     diskSize = 8192;
     fromImage = dockerTools.pullImage {
       imageName = "jetbrains/youtrack";
       arch = "amd64";
-      imageDigest = "sha256:64b9c6c0e409e9cb7e62558bbb2ca0208a85d1c40331b41430e290404b300e40";
-      hash = "sha256-7rlilHogqwxPXZlhAHv5Kk2+i8rMyGP6eZR1DdbhRDM=";
+      imageDigest = "sha256:2ea82348ed037f91f847dd99f196e632769dbd44a00d5659ee7a50cf9774149a";
+      hash = "sha256-+GVDh4ptBQggtZDWI56pEvkPonL9QG9126amtwZS0T8=";
     };
   };
   unpackPhase = ''


### PR DESCRIPTION
Release Notes
- https://youtrack.jetbrains.com/releaseNotes?q=%23JT%20%23Resolved%20Released%20in%20build:%202026.1.12848&title=YouTrack+2026.1.12848+Release+Notes
- https://youtrack.jetbrains.com/releaseNotes?q=%23JT%20%23Resolved%20Released%20in%20build:%202026.1.13162&title=YouTrack+2026.1.13162+Release+Notes https://youtrack.jetbrains.com/releaseNotes?q=%23JT%20%23Resolved%20Released%20in%20build:%202026.1.13456&title=YouTrack+2026.1.13456+Release+Notes 
- https://youtrack.jetbrains.com/releaseNotes?q=%23JT%20%23Resolved%20Released%20in%20build:%202026.1.13570&title=YouTrack%202026.1.13570%20Release%20Notes

Fixes:
- CVE-2026-49368
- CVE-2026-49369
- CVE-2026-49370
- CVE-2026-49385
- CVE-2026-49386


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
