### PR TITLE
nzbget: 26.0 -> 26.1

### DIFF
--- a/pkgs/by-name/nz/nzbget/package.nix
+++ b/pkgs/by-name/nz/nzbget/package.nix
@@ -22,23 +22,29 @@ let
   par2TurboSrc = fetchFromGitHub {
     owner = "nzbgetcom";
     repo = "par2cmdline-turbo";
-    rev = "v1.3.0-20250808"; # from cmake/par2-turbo.cmake
-    hash = "sha256-ZP8AI5htmEcxQQtvgShcQ8qNoRL+jBR1BdKS6yyuB/E=";
+    rev = "v1.4.0-20260323"; # from cmake/par2-turbo.cmake
+    hash = "sha256-oeQY7GJkaEmxEqJALpjAPFpfq+YsNWv4VajotE25xCI=";
+  };
+  rapidyencSrc = fetchFromGitHub {
+    owner = "nzbgetcom";
+    repo = "rapidyenc";
+    rev = "v1.1.1-20260217"; # from cmake/rapidyenc.cmake
+    hash = "sha256-1K0LrB1AhacYS/54eCn+vQFAwP6IUVUrPCqFopojXDE=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "nzbget";
-  version = "26.0";
+  version = "26.1";
 
   src = fetchFromGitHub {
     owner = "nzbgetcom";
     repo = "nzbget";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-IyaTe0bBQKnIuG3wq29KMZjKSiKu3Atd3GsNg8PGhRI=";
+    hash = "sha256-sZwUixSoqs0l2KOx6WnvLTCUGsSAO4QCTKqnhD58r70=";
   };
 
   patches = [
-    # remove git usage for fetching modified+vendored par2cmdline-turbo
+    # remove git usage for fetching modified+vendored par2cmdline-turbo and rapidyenc
     ./remove-git-usage.patch
   ];
 
@@ -60,13 +66,13 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
   ];
 
-  preConfigure = ''
-    mkdir -p build/par2-turbo/src
-    cp -r ${par2TurboSrc} build/par2-turbo/src/par2-turbo
-    chmod -R u+w build/par2-turbo/src/par2-turbo
-  '';
-
   postPatch = ''
+    substituteInPlace cmake/par2-turbo.cmake \
+      --subst-var-by 'par2_turbo_src' '${par2TurboSrc}' \
+
+    substituteInPlace cmake/rapidyenc.cmake \
+      --subst-var-by 'rapidyenc_src' '${rapidyencSrc}'
+
     substituteInPlace daemon/util/Util.cpp \
       --replace-fail "std::string(\"uname \")" "std::string(\"${lib.getExe deterministic-uname} \")"
   '';

--- a/pkgs/by-name/nz/nzbget/remove-git-usage.patch
+++ b/pkgs/by-name/nz/nzbget/remove-git-usage.patch
@@ -1,42 +1,47 @@
-From 15dc4c64531845b64b574647fc7218170b100533 Mon Sep 17 00:00:00 2001
+From f0fc5eb48ff3a0e6f350bf1db6388a458a653cf7 Mon Sep 17 00:00:00 2001
 From: Morgan Helton <mhelton@gmail.com>
-Date: Tue, 25 Feb 2025 20:36:19 -0600
-Subject: [PATCH] feat: use pre-fetched par2-turbo
+Date: Sat, 30 May 2026 06:59:25 -0500
+Subject: [PATCH] chore: use placeholders for par2-turbo and rapidyenc
 
 ---
- cmake/par2-turbo.cmake | 19 +++++++------------
- 1 file changed, 7 insertions(+), 12 deletions(-)
+ cmake/par2-turbo.cmake | 6 +-----
+ cmake/rapidyenc.cmake  | 6 +-----
+ 2 files changed, 2 insertions(+), 10 deletions(-)
 
 diff --git a/cmake/par2-turbo.cmake b/cmake/par2-turbo.cmake
-index 0062b4d3..c0dd56ea 100644
+index 16a80ffa..992bfe79 100644
 --- a/cmake/par2-turbo.cmake
 +++ b/cmake/par2-turbo.cmake
-@@ -48,18 +48,13 @@ if(CMAKE_SYSROOT)
- 	)
- endif()
- 
--ExternalProject_add(
--	par2-turbo
--	PREFIX			par2-turbo
+@@ -56,11 +56,7 @@ endif()
+ ExternalProject_add(
+ 	par2-turbo
+ 	PREFIX			par2-turbo
 -	GIT_REPOSITORY	https://github.com/nzbgetcom/par2cmdline-turbo.git
--	GIT_TAG			v1.3.0-20250808
+-	GIT_TAG			v1.4.0-20260323
 -	TLS_VERIFY		TRUE
 -	GIT_SHALLOW		TRUE
 -	GIT_PROGRESS	TRUE
--	DOWNLOAD_EXTRACT_TIMESTAMP	TRUE
--	BUILD_BYPRODUCTS ${PAR2_LIBS}
--	CMAKE_ARGS		 ${CMAKE_ARGS}
--	INSTALL_COMMAND	""
-+ExternalProject_Add(
-+    	par2-turbo
-+    	PREFIX par2-turbo 
-+    	SOURCE_DIR ${CMAKE_BINARY_DIR}/par2-turbo/src/par2-turbo
-+    	BUILD_BYPRODUCTS ${PAR2_LIBS}
-+    	CMAKE_ARGS ${CMAKE_ARGS}
-+    	INSTALL_COMMAND ""
- )
- 
- set(LIBS ${LIBS} ${PAR2_LIBS})
++	URL @par2_turbo_src@
+ 	DOWNLOAD_EXTRACT_TIMESTAMP	TRUE
+ 	BUILD_BYPRODUCTS ${PAR2_LIBS}
+ 	CMAKE_ARGS		 ${CMAKE_ARGS}
+diff --git a/cmake/rapidyenc.cmake b/cmake/rapidyenc.cmake
+index 9242efe4..0e8d7527 100644
+--- a/cmake/rapidyenc.cmake
++++ b/cmake/rapidyenc.cmake
+@@ -51,11 +51,7 @@ endif()
+ ExternalProject_add(
+ 	rapidyenc
+ 	PREFIX			rapidyenc
+-	GIT_REPOSITORY	https://github.com/nzbgetcom/rapidyenc.git
+-	GIT_TAG			v1.1.1-20260217
+-	TLS_VERIFY		TRUE
+-	GIT_SHALLOW		TRUE
+-	GIT_PROGRESS	TRUE
++	URL @rapidyenc_src@
+ 	DOWNLOAD_EXTRACT_TIMESTAMP	TRUE
+ 	BUILD_BYPRODUCTS ${RAPIDYENC_LIBS}
+ 	CMAKE_ARGS		 ${CMAKE_ARGS}
 -- 
-2.50.1
+2.54.0
 


### PR DESCRIPTION
https://github.com/nzbgetcom/nzbget/compare/v26.0...v26.1
- remove git usage from CMake for new vendored dependency `rapidyenc`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
