### PR TITLE
various: fetchFromGitea -> fetchFromCodeberg

### DIFF
--- a/pkgs/by-name/aw/awww/package.nix
+++ b/pkgs/by-name/aw/awww/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   rustPlatform,
   pkg-config,
   lz4,
@@ -17,8 +17,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "awww";
   version = "0.12.1";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "LGFae";
     repo = "awww";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/cr/cropgui/package.nix
+++ b/pkgs/by-name/cr/cropgui/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   python3Packages,
-  fetchFromGitea,
+  fetchFromCodeberg,
   makeWrapper,
   libjpeg,
   exiftool,
@@ -11,8 +11,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pname = "cropgui";
   version = "0.9";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "jepler";
     repo = "cropgui";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/ga/gamepad-mirror/package.nix
+++ b/pkgs/by-name/ga/gamepad-mirror/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   appstream,
   cmake,
   desktop-file-utils,
@@ -27,8 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "gamepad-mirror";
   version = "0.3-unstable-2025-10-18";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "vendillah";
     repo = "GamepadMirror";
     rev = "aa86d55f21b4d206eab61d0bf7cd9ccafc8aa607";

--- a/pkgs/by-name/gi/git-pages/package.nix
+++ b/pkgs/by-name/gi/git-pages/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildGoModule,
-  fetchFromGitea,
+  fetchFromCodeberg,
   nix-update-script,
   versionCheckHook,
 }:
@@ -11,8 +11,7 @@ buildGoModule (finalAttrs: {
   version = "0.9.0";
   __structuredAttrs = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "git-pages";
     repo = "git-pages";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/hi/hittekaart/package.nix
+++ b/pkgs/by-name/hi/hittekaart/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   rustPlatform,
-  fetchFromGitea,
+  fetchFromCodeberg,
   python3,
   sqlite,
 }:
@@ -10,8 +10,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "hittekaart";
   version = "0.2.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "dunj3";
     repo = "hittekaart";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/nu/nu-lint/package.nix
+++ b/pkgs/by-name/nu/nu-lint/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   rustPlatform,
   nix-update-script,
   versionCheckHook,
@@ -10,8 +10,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nu-lint";
   version = "1.1.2";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "wvhulle";
     repo = "nu-lint";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/se/searchix/package.nix
+++ b/pkgs/by-name/se/searchix/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildGoModule,
-  fetchFromGitea,
+  fetchFromCodeberg,
   fetchFromGitHub,
   versionCheckHook,
   nix-update-script,
@@ -20,8 +20,7 @@ buildGoModule (finalAttrs: {
   pname = "searchix";
   version = "0.4.8";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "alinnow";
     repo = "searchix";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/to/tonearm/package.nix
+++ b/pkgs/by-name/to/tonearm/package.nix
@@ -2,7 +2,7 @@
   buildGo126Module,
   cairo,
   copyDesktopItems,
-  fetchFromGitea,
+  fetchFromCodeberg,
   gdk-pixbuf,
   glib,
   glib-networking,
@@ -41,8 +41,7 @@ in
 buildGo126Module (finalAttrs: {
   pname = "tonearm";
   version = "1.4.0";
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "dergs";
     repo = "Tonearm";
     tag = "v${finalAttrs.version}";

--- a/pkgs/development/python-modules/dramatiq-eager-broker/default.nix
+++ b/pkgs/development/python-modules/dramatiq-eager-broker/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitea,
+  fetchFromCodeberg,
   uv-build,
   dramatiq,
   pytestCheckHook,
@@ -13,8 +13,7 @@ buildPythonPackage rec {
 
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "yaal";
     repo = "dramatiq-eager-broker";
     tag = version;

--- a/pkgs/development/python-modules/rpatool/default.nix
+++ b/pkgs/development/python-modules/rpatool/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   buildPythonPackage,
   setuptools,
 }:
@@ -9,8 +9,7 @@ buildPythonPackage rec {
   pname = "rpatool";
   version = "1.0.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "shiz";
     repo = "rpatool";
     tag = "v${version}";


### PR DESCRIPTION
Simple change for replacing the gitea + domain with the now available fetcher (which does the exact same).

I've noticed other indirect uses of `fetchFromGitea` for codeberg on `pkgs/development/python-modules/maubot/plugins/generated.json` and `pkgs/by-name/he/helix/grammars.json`.

Leaving them untouched for now because it is not that important, and requires https://github.com/nix-community/nurl/issues/477.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core"
        functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in
      `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and
      other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
