### PR TITLE
Revert "Release 26.05"

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -1,4 +1,4 @@
-# Nixpkgs 26.05 ("Yarara", 2026.05/30) {#sec-nixpkgs-release-26.05}
+# Nixpkgs 26.05 ("Yarara", 2026.05/??) {#sec-nixpkgs-release-26.05}
 
 ## Highlights {#sec-nixpkgs-release-26.05-highlights}
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -1,4 +1,4 @@
-# Release 26.05 ("Yarara", 2026.05/30) {#sec-release-26.05}
+# Release 26.05 ("Yarara", 2026.05/??) {#sec-release-26.05}
 
 ## Highlights {#sec-release-26.05-highlights}
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#525937. We messed up the commit message. This is too embarrassing to leave it be. On a second thought, this commit message is even more embarrassing.