### PR TITLE
clementine, transmission_4, xournalpp: drop unused pcre dependency

### DIFF
--- a/pkgs/applications/networking/p2p/transmission/4.nix
+++ b/pkgs/applications/networking/p2p/transmission/4.nix
@@ -11,7 +11,6 @@
   inotify-tools,
   systemd,
   zlib,
-  pcre,
   rapidjson,
   small,
   libb64,
@@ -24,7 +23,6 @@
   miniupnpc,
   dht,
   libnatpmp,
-  libiconv,
   # Build options
   enableGTK3 ? false,
   gtkmm3,
@@ -54,7 +52,6 @@ let
       libpsl
       miniupnpc
       openssl
-      pcre
       zlib
     ]
     ++ optionals enableSystemd [ systemd ]
@@ -136,7 +133,6 @@ stdenv.mkDerivation (finalAttrs: {
     libutp
     miniupnpc
     openssl
-    pcre
     rapidjson
     small
     utf8cpp

--- a/pkgs/by-name/cl/clementine/package.nix
+++ b/pkgs/by-name/cl/clementine/package.nix
@@ -20,7 +20,6 @@
   libpulseaudio,
   gvfs,
   libcdio,
-  pcre,
   projectm_3,
   protobuf,
   pkg-config,
@@ -83,7 +82,6 @@ stdenv.mkDerivation (finalAttrs: {
     gvfs
     libsForQt5.liblastfm
     libpulseaudio
-    pcre
     projectm_3
     protobuf
     libsForQt5.qca-qt5

--- a/pkgs/by-name/xo/xournalpp/package.nix
+++ b/pkgs/by-name/xo/xournalpp/package.nix
@@ -11,7 +11,6 @@
 
   adwaita-icon-theme,
   alsa-lib,
-  binutils,
   glib,
   gsettings-desktop-schemas,
   gtk3,
@@ -20,7 +19,6 @@
   libsndfile,
   libxml2,
   libzip,
-  pcre,
   poppler,
   portaudio,
   qpdf,
@@ -59,7 +57,6 @@ stdenv.mkDerivation (finalAttrs: {
     libsndfile
     libxml2
     libzip
-    pcre
     poppler
     portaudio
     qpdf


### PR DESCRIPTION
Part of #356387 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
