### PR TITLE
texlive.withPackages: treat texsource containers as regular outputs

### DIFF
--- a/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-tex-env.nix
@@ -509,7 +509,7 @@ lib.fix (
 
         postactionScripts = builtins.catAttrs "postactionScript" pkgList.tlpkg;
 
-        # whethe to include doc, source containers
+        # whether to include doc, source containers
         withDocs = false;
         withSources = false;
 

--- a/pkgs/tools/typesetting/tex/texlive/build-texlive-package.nix
+++ b/pkgs/tools/typesetting/tex/texlive/build-texlive-package.nix
@@ -106,11 +106,8 @@ let
     lib.optional hasBinfiles "out"
     ++ lib.optional hasRunfiles "tex"
     ++ lib.optional hasDocfiles "texdoc"
-    ++
-      # omit building sources, since as far as we know, installing them is not common
-      # the sources will still be available under drv.texsource
-      # lib.optional hasSource "texsource" ++
-      lib.optional hasTlpkg "tlpkg"
+    ++ lib.optional hasSource "texsource"
+    ++ lib.optional hasTlpkg "tlpkg"
     ++ lib.optional hasManpages "man"
     ++ lib.optional hasInfo "info";
   outputDrvs = lib.getAttrs outputs containers;


### PR DESCRIPTION
Since Hydra no longer builds the `texlivePackages` subtree, `texsource` containers can now be treated as regular outputs in `buildTeXLivePackage`.  This also enables the `withSources` argument of `buildTeXEnv` to work as intended.

~~`buildTeXLivePackage` does not treat `texsource` containers as outputs, so `texsource` needs to be added explicitly to `otherOutputNames` in `buildTeXEnv` in order for the `withSources` argument to work as intended.~~

```shellsession
$ tree $(nix-build --no-build-output --quiet --no-out-link --expr '(import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/09046bfef2490927eb2baa2a396f3f0124c5ee26.tar.gz") {}).texliveMinimal.overrideAttrs { withSources = true; }')/share/texmf/source
/nix/store/g3ggd4dp2181ikcdac0y1rcic5as16zx-texlive-2025-r78234-final-env/share/texmf/source  [error opening dir]

0 directories, 0 files

$ tree $(nix-build --no-build-output --quiet --no-out-link --expr '(import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/895c726b94685f4dde71e1fe7403d0ea516ee45c.tar.gz") {}).texliveMinimal.overrideAttrs { withSources = true; }')/share/texmf/source
/nix/store/0bv0hbvxqmbw31aq1vxljnzzfxaka0ch-texlive-2025-r78234-final-env/share/texmf/source
├── generic
│   ├── hyphenex -> /nix/store/xr36mvsd275pnp7xw2p8fprm1vfb1hmr-hyphenex-57387-texsource/source/generic/hyphenex
│   └── hyph-utf8 -> /nix/store/d5ln38zmvvjcqs4bzd9ybcrrgld1fskh-hyph-utf8-74823-texsource/source/generic/hyph-utf8
├── latex
│   ├── amsfonts -> /nix/store/5zdwfmsnzyd9zi95xsgvcbzgzifnlwdz-amsfonts-3.04-texsource/source/latex/amsfonts
│   ├── ifplatform -> /nix/store/da0qs6hz0lvi8rr6imapdk4hrqz0h5bm-ifplatform-0.4a-texsource/source/latex/ifplatform
│   └── mflogo -> /nix/store/i8y1crjgc25lk6csvvs78d1ix097vriz-mflogo-2.0-texsource/source/latex/mflogo
└── luatex -> /nix/store/d5ln38zmvvjcqs4bzd9ybcrrgld1fskh-hyph-utf8-74823-texsource/source/luatex

9 directories, 0 files

```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test