### PR TITLE
nim-unwrapped-2_2: drop pcre

### DIFF
--- a/pkgs/by-name/ni/nim-2_2/package.nix
+++ b/pkgs/by-name/ni/nim-2_2/package.nix
@@ -7,7 +7,6 @@
   darwin,
   makeWrapper,
   openssl,
-  pcre,
   nim-unwrapped-2_2 ? buildPackages.nim-unwrapped-2_2,
 }:
 
@@ -93,7 +92,6 @@ let
         "--prefix LD_LIBRARY_PATH : ${
           lib.makeLibraryPath [
             openssl
-            pcre
           ]
         }"
         # These libraries may be referred to by the standard library.

--- a/pkgs/by-name/ni/nim-unwrapped-2_2/package.nix
+++ b/pkgs/by-name/ni/nim-unwrapped-2_2/package.nix
@@ -6,7 +6,6 @@
   fetchurl,
   boehmgc,
   openssl,
-  pcre,
   readline,
   sqlite,
   darwin,
@@ -24,7 +23,6 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     boehmgc
     openssl
-    pcre
     readline
     sqlite
   ];


### PR DESCRIPTION
pcre isn't needed for `nre2` anymore
* relevant: #356387


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
