### PR TITLE
x2gokdriveclient: migrate to pkgs/by-name

### DIFF
--- a/pkgs/by-name/x2/x2gokdriveclient/package.nix
+++ b/pkgs/by-name/x2/x2gokdriveclient/package.nix
@@ -3,11 +3,7 @@
   lib,
   fetchgit,
   qt5,
-  qtbase,
-  qtx11extras,
-  qttools,
   zlib,
-  gnumake,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -27,9 +23,9 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   buildInputs = [
-    qtbase
-    qtx11extras
-    qttools
+    qt5.qtbase
+    qt5.qtx11extras
+    qt5.qttools
     zlib
   ];
 
@@ -42,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "SHELL=/bin/bash" "SHELL=$SHELL" \
       --replace-fail "MAKEOVERRIDES" "NOMAKEOVERRIDES " \
       --replace-fail ".MAKEFLAGS" ".NOFLAGS " \
-      --replace-fail "qmake" "${qtbase.dev}/bin/qmake" \
+      --replace-fail "qmake" "${qt5.qtbase.dev}/bin/qmake" \
       --replace-fail "-o root -g root" ""
     substituteInPlace \
       VERSION.x2gokdriveclient \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10340,8 +10340,6 @@ with pkgs;
 
   wrapThunderbird = callPackage ../applications/networking/mailreaders/thunderbird/wrapper.nix { };
 
-  x2gokdriveclient = libsForQt5.callPackage ../applications/networking/remote/x2gokdriveclient { };
-
   x32edit = callPackage ../applications/audio/midas/x32edit.nix { };
 
   kodiPackages = recurseIntoAttrs (kodi.packages);


### PR DESCRIPTION
The package is already using `qt5.wrapQtAppsHook`, so why not use `qt5.qtbase` instead of `qtbase` so that it can be moved to pkgs/by-name?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
