### PR TITLE
nixos/gdm: use previous (25.11) UIDs for gdm-greeter-N users

### DIFF
--- a/nixos/modules/services/display-managers/gdm.nix
+++ b/nixos/modules/services/display-managers/gdm.nix
@@ -45,11 +45,11 @@ let
 
   setSessionScript = pkgs.callPackage ../x11/display-managers/account-service-util.nix { };
 
-  greeterUsers = lib.genAttrs' [ null 1 2 3 4 ] (
+  greeterUsers = lib.genAttrs' [ null 2 3 4 5 ] (
     i:
     let
-      # adding 1 to create `gdm-greeter{-2,-3,-4,-5}`
-      suffix = lib.optionalString (i != null) "-${toString (i + 1)}";
+      # creating `gdm-greeter{-2,-3,-4,-5}`
+      suffix = lib.optionalString (i != null) "-${toString i}";
     in
     lib.nameValuePair "gdm-greeter${suffix}" {
       isSystemUser = true;


### PR DESCRIPTION
the previous change led to users seeing
```
warning: not applying UID change of user ‘gdm-greeter-2’ (60580 -> 60579) in /etc/passwd
warning: not applying UID change of user ‘gdm-greeter-3’ (60581 -> 60580) in /etc/passwd
warning: not applying UID change of user ‘gdm-greeter-4’ (60582 -> 60581) in /etc/passwd
```

when rebuilding with an existing GDM setup, which I didn't encounter because I wasn't using `update-users-groups.pl`.

Closes #525919. Sorry for the super unfortunate timing of this only coming up on release day :sweat: 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
