### PR TITLE
python3Packages.remarshal: fix source, use finalAttrs

### DIFF
--- a/pkgs/development/python-modules/remarshal/default.nix
+++ b/pkgs/development/python-modules/remarshal/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "dbohdan";
+    owner = "remarshal-project";
     repo = "remarshal";
     tag = "v${version}";
     hash = "sha256-/K8x6ij23pk5O1+XJdFHaGbZ47nFMbXzp+4UMO5dGp4=";
@@ -53,7 +53,7 @@ buildPythonPackage rec {
     changelog = "https://github.com/remarshal-project/remarshal/releases/tag/${src.tag}";
     description = "Convert between TOML, YAML and JSON";
     license = lib.licenses.mit;
-    homepage = "https://github.com/dbohdan/remarshal";
+    homepage = "https://github.com/remarshal-project/remarshal";
     maintainers = [ ];
     mainProgram = "remarshal";
   };

--- a/pkgs/development/python-modules/remarshal/default.nix
+++ b/pkgs/development/python-modules/remarshal/default.nix
@@ -21,7 +21,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "remarshal";
   version = "1.3.0"; # test with `nix-build pkgs/pkgs-lib/format`
   pyproject = true;
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "remarshal-project";
     repo = "remarshal";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-/K8x6ij23pk5O1+XJdFHaGbZ47nFMbXzp+4UMO5dGp4=";
   };
 
@@ -50,11 +50,11 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
 
   meta = {
-    changelog = "https://github.com/remarshal-project/remarshal/releases/tag/${src.tag}";
+    changelog = "https://github.com/remarshal-project/remarshal/releases/tag/${finalAttrs.src.tag}";
     description = "Convert between TOML, YAML and JSON";
     license = lib.licenses.mit;
     homepage = "https://github.com/remarshal-project/remarshal";
     maintainers = [ ];
     mainProgram = "remarshal";
   };
-}
+})


### PR DESCRIPTION
Encountered because of `nixpkgs.config.fetchedSourceNameDefault = "versioned";` .

The new source was already referenced in the `meta.changelog` entry and is linked from `dbohdan`s GitHub page.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
