### PR TITLE
base24-schemes: init at 0-unstable-2025-11-08

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20393,6 +20393,12 @@
     email = "nyu@nyuku.ru";
     githubId = 97425873;
   };
+  nyxar77 = {
+    name = "nyxar77";
+    github = "nyxar77";
+    email = "dev@nyxar.space";
+    githubId = 153492661;
+  };
   nyxonios = {
     name = "nyxonios";
     github = "Nyxonios";

--- a/pkgs/by-name/ba/base24-schemes/package.nix
+++ b/pkgs/by-name/ba/base24-schemes/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  stdenv,
+  base16-schemes,
+}:
+stdenv.mkDerivation {
+  pname = "base24-schemes";
+  inherit (base16-schemes) version src;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/themes
+    install base24/*.yaml $out/share/themes/
+
+    runHook postInstall
+  '';
+
+  meta = base16-schemes.meta // {
+    description = "Base24 color schemes from Tinted Theming";
+    maintainers = with lib.maintainers; [ nyxar77 ];
+  };
+}


### PR DESCRIPTION
## Things done
Add `base24-schemes`, reusing the same upstream source as `base16-schemes`.

This package installs the Base24 YAML scheme files from the Tinted Theming schemes repository.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
