### PR TITLE
vapoursynth-editor: R19-mod-4 -> R19-mod-6.8

### DIFF
--- a/pkgs/by-name/va/vapoursynth-editor/package.nix
+++ b/pkgs/by-name/va/vapoursynth-editor/package.nix
@@ -6,19 +6,19 @@
   runCommand,
   python3,
   vapoursynth,
-  qt5,
+  qt6,
 }:
 
 let
   unwrapped = stdenv.mkDerivation rec {
     pname = "vapoursynth-editor";
-    version = "R19-mod-4";
+    version = "R19-mod-6.8";
 
     src = fetchFromGitHub {
       owner = "YomikoR";
       repo = "vapoursynth-editor";
-      rev = lib.toLower version;
-      hash = "sha256-+/9j9DJDGXbuTvE8ZXIu6wjcof39SyatS36Q6y9hLPg=";
+      tag = version;
+      hash = "sha256-eSdyhKRNsZeSRqkn5SzbB5YRuKehgCJD03PYiD5zQ/Y=";
     };
 
     postPatch = ''
@@ -27,15 +27,19 @@ let
     '';
 
     nativeBuildInputs = [
-      qt5.qmake
-      qt5.wrapQtAppsHook
+      qt6.qmake
+      qt6.wrapQtAppsHook
     ];
 
     buildInputs = [
-      qt5.qtbase
+      qt6.qtbase
       vapoursynth
-      qt5.qtwebsockets
+      qt6.qtwebsockets
+      qt6.qt5compat
     ];
+
+    # ../../common-src/helpers.h:4:10: fatal error: VapourSynth4.h: No such file or directory
+    env.NIX_CFLAGS_COMPILE = "-I${lib.getInclude vapoursynth}/include/vapoursynth";
 
     dontWrapQtApps = true;
 

--- a/pkgs/by-name/va/vapoursynth-editor/package.nix
+++ b/pkgs/by-name/va/vapoursynth-editor/package.nix
@@ -6,10 +6,7 @@
   runCommand,
   python3,
   vapoursynth,
-  qmake,
-  wrapQtAppsHook,
-  qtbase,
-  qtwebsockets,
+  qt5,
 }:
 
 let
@@ -30,14 +27,14 @@ let
     '';
 
     nativeBuildInputs = [
-      qmake
-      wrapQtAppsHook
+      qt5.qmake
+      qt5.wrapQtAppsHook
     ];
 
     buildInputs = [
-      qtbase
+      qt5.qtbase
       vapoursynth
-      qtwebsockets
+      qt5.qtwebsockets
     ];
 
     dontWrapQtApps = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5516,8 +5516,6 @@ with pkgs;
       ;
   };
 
-  vapoursynth-editor = libsForQt5.callPackage ../by-name/va/vapoursynth/editor.nix { };
-
   enchant = enchant_2;
 
   factorPackages-0_99 = callPackage ./factor-packages.nix {


### PR DESCRIPTION
The bump to R19-mod-6.10 has not yet been attempted yet, as it likely requires vapoursynth >=74.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
