### PR TITLE
prototools: init at 0.2.0

### DIFF
--- a/pkgs/by-name/pr/prototools/package.nix
+++ b/pkgs/by-name/pr/prototools/package.nix
@@ -1,0 +1,156 @@
+{
+  fetchFromGitHub,
+  installShellFiles,
+  lib,
+  nix-update-script,
+  protobuf,
+  python3Packages,
+  runCommand,
+  rustPlatform,
+  stdenv,
+  symlinkJoin,
+  versionCheckHook,
+}:
+
+let
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "ThalesGroup";
+    repo = "prototools";
+    tag = "prototext-v${version}";
+    hash = "sha256-svaczYXGQSMfKyEf30xRJl+UroXDFuJ9yL/AH5UBhU4=";
+  };
+
+  # Pre-compiled .pb fixture files required by prototext-core's build script.
+  # Shared between the Rust (prototext) and Python (prototext-codec) builds to
+  # avoid duplicating the protoc invocations and keep them in sync.
+  fixtures = runCommand "prototools-fixtures" { nativeBuildInputs = [ protobuf ]; } ''
+    mkdir -p $out
+    # Compile all well-known types into a single descriptor set with
+    # --include_imports so the embedded descriptor pool covers exactly the same
+    # types as the WKT scoring graph (wkt/SOURCES).  If wkt/SOURCES changes
+    # upstream, this list must be updated in sync.
+    protoc \
+      --descriptor_set_out=$out/descriptor.pb \
+      --proto_path=${protobuf}/include \
+      --include_imports \
+      google/protobuf/any.proto \
+      google/protobuf/api.proto \
+      google/protobuf/descriptor.proto \
+      google/protobuf/duration.proto \
+      google/protobuf/empty.proto \
+      google/protobuf/field_mask.proto \
+      google/protobuf/source_context.proto \
+      google/protobuf/struct.proto \
+      google/protobuf/timestamp.proto \
+      google/protobuf/type.proto \
+      google/protobuf/wrappers.proto
+    protoc \
+      --descriptor_set_out=$out/knife.pb \
+      --proto_path=${src}/prototext/fixtures/schemas \
+      knife.proto
+    protoc \
+      --descriptor_set_out=$out/enum_collision.pb \
+      --proto_path=${src}/prototext/fixtures/schemas \
+      enum_collision.proto
+    protoc \
+      --descriptor_set_out=$out/message_set.pb \
+      --proto_path=${src}/prototext/fixtures/schemas \
+      message_set.proto
+  '';
+
+  prototext = rustPlatform.buildRustPackage {
+    pname = "prototext";
+    inherit version src;
+
+    cargoRoot = ".";
+
+    cargoHash = "sha256-c4HxWaAaMygeUbJL9xlt80H486NTcVWHP3NeWDqXGVc=";
+
+    cargoBuildFlags = [
+      "-p"
+      "prototext"
+    ];
+    cargoTestFlags = [
+      "-p"
+      "prototext"
+    ];
+
+    # Disable the default features:
+    # - "protox" would embed a protoc binary and attempt network access.
+    # - The default wkt-db path would invoke reproto (not available here).
+    # Re-enable wkt-db via "prebuilt-wkt", which copies wkt/prebuilt/*.rkyv
+    # committed to the repository — no reproto needed.
+    buildNoDefaultFeatures = true;
+    buildFeatures = [
+      "wkt-db"
+      "prebuilt-wkt"
+    ];
+
+    nativeBuildInputs = [
+      installShellFiles
+    ];
+
+    patchPhase = ''
+      runHook prePatch
+      mkdir -p prototext/fixtures/prebuilt
+      cp ${fixtures}/descriptor.pb     prototext/fixtures/prebuilt/
+      cp ${fixtures}/knife.pb          prototext/fixtures/prebuilt/
+      cp ${fixtures}/enum_collision.pb prototext/fixtures/prebuilt/
+      cp ${fixtures}/message_set.pb    prototext/fixtures/prebuilt/
+      runHook postPatch
+    '';
+
+    postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      installShellCompletion --cmd prototext \
+        --bash <(PROTOTEXT_COMPLETE=bash $out/bin/prototext) \
+        --zsh  <(PROTOTEXT_COMPLETE=zsh  $out/bin/prototext) \
+        --fish <(PROTOTEXT_COMPLETE=fish $out/bin/prototext)
+      # prototext-gen-man calls create_dir_all internally; no mkdir needed.
+      # SOURCE_DATE_EPOCH and LC_ALL ensure reproducible man page output.
+      SOURCE_DATE_EPOCH=0 LC_ALL=C $out/bin/prototext-gen-man $out/share/man/man1
+    '';
+
+    nativeInstallCheckInputs = [ versionCheckHook ];
+    doInstallCheck = true;
+
+    passthru = {
+      updateScript = nix-update-script { };
+      inherit src version fixtures;
+    };
+
+    meta = {
+      description = "Lossless protobuf <-> enhanced textproto converter";
+      longDescription = ''
+        Command-line tool for converting protobuf binary wire format to and
+        from an enhanced textproto representation, with lossless round-trip.
+        Supports automatic schema inference for Well-Known Types without a
+        .proto file.
+      '';
+      homepage = "https://github.com/ThalesGroup/prototools";
+      changelog = "https://github.com/ThalesGroup/prototools/releases/tag/prototext-v${version}";
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [ douzebis ];
+      mainProgram = "prototext";
+      platforms = lib.platforms.unix;
+    };
+  };
+
+in
+symlinkJoin {
+  name = "prototools-${version}";
+  strictDeps = true;
+  __structuredAttrs = true;
+  paths = [
+    prototext
+    python3Packages.protoscan
+  ];
+  passthru = {
+    inherit src version fixtures;
+  };
+  meta = prototext.meta // {
+    description = "Protocol Buffer utilities: prototext and protoscan CLIs";
+    mainProgram = "prototext";
+  };
+}

--- a/pkgs/development/python-modules/fdp-scan/default.nix
+++ b/pkgs/development/python-modules/fdp-scan/default.nix
@@ -1,0 +1,73 @@
+{
+  buildPythonPackage,
+  cargo,
+  hatchling,
+  lib,
+  protobuf,
+  prototools,
+  python,
+  pytestCheckHook,
+  rustPlatform,
+  rustc,
+  stdenv,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "fdp-scan";
+  inherit (prototools) version;
+  pyproject = true;
+  __structuredAttrs = true;
+
+  inherit (prototools) src;
+  sourceRoot = "${prototools.src.name}/fdp-scan-pyo3";
+
+  # Cargo.lock lives at the workspace root (one level above sourceRoot).
+  # cargoRoot = ".." tells cargoSetupHook to look there for Cargo.lock.
+  # fetchCargoVendor gets no sourceRoot/cargoRoot so it also scans from
+  # the workspace root.
+  cargoRoot = "..";
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-c4HxWaAaMygeUbJL9xlt80H486NTcVWHP3NeWDqXGVc=";
+  };
+
+  build-system = [ hatchling ];
+
+  nativeBuildInputs = [
+    cargo
+    rustc
+    rustPlatform.cargoSetupHook
+    python # needed at build time for PYO3_PYTHON (Rust build scripts)
+  ];
+
+  buildInputs = [ python ]; # needed for linking against libpython
+
+  env.PYO3_PYTHON = python.interpreter;
+
+  # Compile the Rust cdylib and drop it into the fdp_scan_lib/ package
+  # directory alongside the committed __init__.py and .pyi stub.
+  # Hatchling (via build-system) then assembles the wheel from that directory,
+  # generating .dist-info automatically — no manual installPhase needed.
+  preBuild = ''
+    CARGO_TARGET_DIR="$PWD/target" \
+      cargo build --release --lib -p fdp_scan_lib --offline --frozen
+    cp target/release/libfdp_scan_lib${stdenv.hostPlatform.extensions.sharedLibrary} \
+       fdp_scan_lib/fdp_scan_lib.so
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    protobuf
+  ];
+
+  enabledTestPaths = [ "tests/" ];
+
+  pythonImportsCheck = [ "fdp_scan_lib" ];
+
+  meta = {
+    description = "Rust extension for scanning binaries for embedded protobuf FileDescriptorProto blobs";
+    homepage = "https://github.com/ThalesGroup/prototools";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ douzebis ];
+  };
+})

--- a/pkgs/development/python-modules/protoscan/default.nix
+++ b/pkgs/development/python-modules/protoscan/default.nix
@@ -1,0 +1,68 @@
+{
+  buildPythonPackage,
+  lib,
+  prototools,
+  stdenv,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  click,
+  fdp-scan,
+  protobuf,
+
+  # nativeBuildInputs
+  installShellFiles,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage {
+  pname = "protoscan";
+  inherit (prototools) version;
+  pyproject = true;
+  __structuredAttrs = true;
+
+  inherit (prototools) src;
+
+  sourceRoot = "${prototools.src.name}/protoscan";
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    click
+    fdp-scan
+    protobuf
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  enabledTestPaths = [ "src/protoscan/tests/" ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd protoscan \
+      --bash <(_PROTOSCAN_COMPLETE=bash_source $out/bin/protoscan) \
+      --zsh  <(_PROTOSCAN_COMPLETE=zsh_source  $out/bin/protoscan) \
+      --fish <(_PROTOSCAN_COMPLETE=fish_source $out/bin/protoscan)
+    # protoscan-gen-man calls mkdir(parents=True) internally; no mkdir needed.
+    # SOURCE_DATE_EPOCH and LC_ALL ensure reproducible man page output.
+    SOURCE_DATE_EPOCH=0 LC_ALL=C $out/bin/protoscan-gen-man $out/share/man/man1
+  '';
+
+  pythonImportsCheck = [ "protoscan" ];
+
+  meta = {
+    description = "Scan binary files for embedded protobuf FileDescriptorProto blobs";
+    homepage = "https://github.com/ThalesGroup/prototools";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ douzebis ];
+    mainProgram = "protoscan";
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/development/python-modules/prototext-codec/default.nix
+++ b/pkgs/development/python-modules/prototext-codec/default.nix
@@ -1,0 +1,79 @@
+{
+  buildPythonPackage,
+  cargo,
+  hatchling,
+  lib,
+  prototools,
+  python,
+  pytestCheckHook,
+  pythonProtobuf, # Python protobuf library (google.protobuf) for tests
+  rustPlatform,
+  rustc,
+  stdenv,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "prototext-codec";
+  inherit (prototools) version;
+  pyproject = true;
+  __structuredAttrs = true;
+
+  inherit (prototools) src;
+  sourceRoot = "${prototools.src.name}/prototext-pyo3";
+
+  # Cargo.lock lives at the workspace root (one level above sourceRoot).
+  # cargoRoot = ".." tells cargoSetupHook to look there for Cargo.lock.
+  # fetchCargoVendor gets no sourceRoot/cargoRoot so it also scans from
+  # the workspace root.
+  cargoRoot = "..";
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-c4HxWaAaMygeUbJL9xlt80H486NTcVWHP3NeWDqXGVc=";
+  };
+
+  build-system = [ hatchling ];
+
+  nativeBuildInputs = [
+    cargo
+    rustc
+    rustPlatform.cargoSetupHook
+    python # needed at build time for PYO3_PYTHON (Rust build scripts)
+  ];
+
+  buildInputs = [ python ]; # needed for linking against libpython
+
+  env.PYO3_PYTHON = python.interpreter;
+
+  # prototext-core's build.rs checks DESCRIPTOR_PB (and siblings) first;
+  # when set, it copies the .pb files directly from those store paths into
+  # OUT_DIR, bypassing the fixtures/prebuilt/ fallback (which is read-only
+  # in the Nix sandbox).  prototools.fixtures is a separate derivation that
+  # runs protoc once and caches the results in the Nix store.
+  env.DESCRIPTOR_PB = "${prototools.fixtures}/descriptor.pb";
+  env.KNIFE_PB = "${prototools.fixtures}/knife.pb";
+  env.ENUM_COLLISION_PB = "${prototools.fixtures}/enum_collision.pb";
+  env.MESSAGE_SET_PB = "${prototools.fixtures}/message_set.pb";
+
+  preBuild = ''
+    CARGO_TARGET_DIR="$PWD/target" \
+      cargo build --release --lib -p prototext_codec_lib --offline --frozen
+    cp target/release/libprototext_codec_lib${stdenv.hostPlatform.extensions.sharedLibrary} \
+       prototext_codec_lib/prototext_codec_lib.so
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pythonProtobuf
+  ];
+
+  enabledTestPaths = [ "tests/" ];
+
+  pythonImportsCheck = [ "prototext_codec_lib" ];
+
+  meta = {
+    description = "Lossless protobuf decoder Python extension (PyO3)";
+    homepage = "https://github.com/ThalesGroup/prototools";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ douzebis ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5533,6 +5533,10 @@ self: super: with self; {
 
   favicon = callPackage ../development/python-modules/favicon { };
 
+  fdp-scan = callPackage ../development/python-modules/fdp-scan {
+    inherit (pkgs) prototools;
+  };
+
   fe25519 = callPackage ../development/python-modules/fe25519 { };
 
   feather-format = callPackage ../development/python-modules/feather-format { };
@@ -13158,6 +13162,15 @@ self: super: with self; {
   proton-vpn-local-agent = callPackage ../development/python-modules/proton-vpn-local-agent { };
 
   protonup-ng = callPackage ../development/python-modules/protonup-ng { };
+
+  protoscan = callPackage ../development/python-modules/protoscan {
+    inherit (pkgs) prototools;
+  };
+
+  prototext-codec = callPackage ../development/python-modules/prototext-codec {
+    inherit (pkgs) prototools;
+    pythonProtobuf = self.protobuf;
+  };
 
   prov = callPackage ../development/python-modules/prov { };
 


### PR DESCRIPTION
Prototools: a collection of reverse-engineering utilities for the protobuf ecosystem.

This is **PR 1 of 2**. It adds `prototools`, a collection of Protocol Buffer
utilities open-sourced by ThalesGroup
(https://github.com/ThalesGroup/prototools).

PR 1 (this PR) packages `prototext`: a Rust utility for decoding protobuf
messages, with automatic type inference support. Supports lossless
decode/encode round-trip, even with non-canonical or malformed protobufs.
It also packages `prototext-codec`, the PyO3 Python binding for the
`prototext-core` Rust library.

PR 2 (follow-up) adds `reproto`: a Python utility for decompiling protobuf
descriptors back into .proto source code.

---

### What this adds

**`pkgs.prototools`** — a `symlinkJoin` of:

- **`prototext`** — a Rust CLI that converts protobuf binary wire format to
  and from a schema-aware textproto representation, with lossless round-trip.
  Supports auto-inference of the schema, given a database of descriptors.

- **`protoscan`** — a Python CLI that scans arbitrary binary files for
  embedded `FileDescriptorProto` blobs.

Also adds:

- **`python3Packages.prototext-codec`** — a PyO3 Rust extension exposing
  the `prototext-core` lossless protobuf decoder to Python.

---

### Notes

**`workspace-hack` crate**: the Cargo workspace uses
[`cargo-hakari`](https://docs.rs/cargo-hakari) to manage a `workspace-hack`
crate that deduplicates dependency feature unification across all crates,
ensuring they all depend on exactly the same set of inputs and speeding up
from-scratch builds. This crate appears in the vendored dependency tree but
has no effect on the built artefacts. Happy to take a different approach if
reviewers have a preference.

**PyO3 build approach**: the `fdp-scan` extension is built with a manual
`cargo build --release --lib` rather than maturin, consistent with the
project's existing `default.nix` (which also drives `cargo build` directly).

**`.pyi` type stubs**: `fdp_scan_lib.pyi` and `prototext_codec_lib.pyi` are
Python type stubs (generated from the Rust sources via `pyo3-stub-gen`)
committed to the source repository and copied into `site-packages` alongside
the `.so`.

**`prototext-codec` build approach**: like `fdp-scan`, built with a manual
`cargo build --release --lib` rather than maturin. The `patchPhase`
pre-compiles three `.pb` fixture files needed by `prototext-pyo3/build.rs`
(which links against `prototext-core`). Uses `pkgs.protobuf` (system
`protoc`) in `nativeBuildInputs` and `python3Packages.protobuf` in
`nativeCheckInputs` (for the Python `protobuf` module used by tests).

---

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files (`./result/bin/prototext`, `./result/bin/protoscan`)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

