### PR TITLE
firefox/wrapper: quote is-packaged-app path

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -413,7 +413,7 @@ let
           done
 
           # Disable update checks
-          touch $out/${libDir}/is-packaged-app
+          touch "$out/${libDir}/is-packaged-app"
 
           cd "$out"
 


### PR DESCRIPTION
The unquoted $out/${libDir}/is-packaged-app path word-splits on applicationNames containing spaces (e.g. "Firefox Developer Edition"), breaking the Darwin build for firefox-devedition and similar variants.

Regression from 1da3ca73732263dc0473f0d64ccdfa810eaa1fac.

```
nix build .#firefox-devedition
this derivation will be built:
  /nix/store/bbvd4lm0n7sxvj2rdh4niifiwwczp674-firefox-devedition-152.0b1.drv
building '/nix/store/bbvd4lm0n7sxvj2rdh4niifiwwczp674-firefox-devedition-152.0b1.drv'...
firefox-devedition> structuredAttrs is enabled
firefox-devedition> touch: cannot touch 'Developer': Permission denied
firefox-devedition> touch: cannot touch 'Edition.app/Contents/Resources/is-packaged-app': No such file or directory
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
