### PR TITLE
geobug: init at 0.9.1

### DIFF
--- a/pkgs/by-name/ge/geobug/package.nix
+++ b/pkgs/by-name/ge/geobug/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  python3Packages,
+  fetchFromCodeberg,
+  gobject-introspection,
+  wrapGAppsHook4,
+  geoclue2,
+  libadwaita,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "geobug";
+  version = "0.9.1";
+  pyproject = true;
+
+  src = fetchFromCodeberg {
+    owner = "tpikonen";
+    repo = "geobug";
+    tag = finalAttrs.version;
+    hash = "sha256-u9+tCKE5zhX6PGl1IsYcqCT0Q1p/eP+V68N6ggAgDoQ=";
+  };
+
+  nativeBuildInputs = [
+    gobject-introspection
+    wrapGAppsHook4
+  ];
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies =
+    (with python3Packages; [
+      gpxpy
+      pygobject3
+    ])
+    ++ [
+      geoclue2
+      libadwaita
+    ];
+
+  pythonImportsCheck = [
+    "geobug"
+  ];
+
+  strictDeps = true;
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Adaptive GeoClue client";
+    longDescription = ''
+      Geobug is an adaptive client for GeoClue, the geolocation D-bus server from freedesktop.org. It can display your location information (coordinates, speed etc.) and save a track of your movements to a GPX-file.
+    '';
+    homepage = "https://codeberg.org/tpikonen/geobug";
+    changelog = "https://codeberg.org/tpikonen/geobug/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      Luflosi
+    ];
+    mainProgram = "geobug";
+  };
+})


### PR DESCRIPTION
https://codeberg.org/tpikonen/geobug
I use this application to record GPX tracks on my PinePhone.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test