### PR TITLE
python3Packages.triton: hardcode CC for runtime JIT compilation

### DIFF
--- a/pkgs/development/python-modules/triton/default.nix
+++ b/pkgs/development/python-modules/triton/default.nix
@@ -104,6 +104,16 @@ buildPythonPackage (finalAttrs: {
         --replace-fail "include(GoogleTest)" "find_package(GTest REQUIRED)"
     ''
 
+    # Hardcode the CC path so Triton's runtime JIT compilation doesn't break
+    # in environments without a compiler in PATH.
+    + ''
+      substituteInPlace python/triton/runtime/build.py \
+        --replace-fail 'cc = os.environ.get("CC")' \
+          'cc = os.environ.get("CC", "${
+            lib.getExe' (if cudaSupport then cudaPackages.backendStdenv.cc else stdenv.cc) "cc"
+          }")'
+    ''
+
     # triton will try dlopening libcublas.so at runtime
     + lib.optionalString cudaSupport ''
       substituteInPlace third_party/nvidia/include/cublas_instance.h \


### PR DESCRIPTION
Triton JIT-compiles `cuda_utils.c` at runtime using whatever `cc`/`gcc` is on PATH. When no properly wrapped compiler is available the fallback `gcc` cannot locate glibc's `crti.o`, `-lc`, or `-lgcc_s`, and JIT compilation fails.

This patch hardcodes the Nix cc-wrapper path in `build.py`'s CC lookup [here](https://github.com/triton-lang/triton/blob/v3.6.0/python/triton/runtime/build.py#L26). 

**Reproducer:**
```python
from triton.backends.nvidia.driver import CudaUtils
utils = CudaUtils()
```

gives
```
$ python repro_triton.py
/nix/store/<hash>-cc-wrapper/bin/ld: cannot find crti.o: No such file or directory
/nix/store/<hash>-cc-wrapper/bin/ld: cannot find -lgcc_s: No such file or directory
/nix/store/<hash>-cc-wrapper/bin/ld: cannot find -lc: No such file or directory
/nix/store/<hash>-cc-wrapper/bin/ld: cannot find -lgcc_s: No such file or directory
/nix/store/<hash>-cc-wrapper/bin/ld: cannot find crtn.o: No such file or directory
collect2: error: ld returned 1 exit status
Traceback (most recent call last):
  File "repro_triton.py", line 4, in <module>
    utils = CudaUtils()
  File "/nix/store/<hash>-python3.13-triton-3.7.0/lib/python3.13/site-packages/triton/backends/nvidia/driver.py", line 70, in __init__
    mod = compile_module_from_src(
        src=Path(os.path.join(dirname, "driver.c")).read_text(),
    ...<3 lines>...
        libraries=libraries,
    )
  File "/nix/store/<hash>-python3.13-triton-3.7.0/lib/python3.13/site-packages/triton/runtime/build.py", line 101, in compile_module_from_src
    so = _build(name, src_path, tmpdir, library_dirs or [], include_dirs or [], libraries or [], ccflags or [])
  File "/nix/store/<hash>-python3.13-triton-3.7.0/lib/python3.13/site-packages/triton/runtime/build.py", line 56, in _build
    subprocess.check_call(cc_cmd, stdout=subprocess.DEVNULL)
  File "/nix/store/<hash>-python3.13/lib/python3.13/subprocess.py", line 419, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/nix/store/<hash>-gcc/bin/gcc', '/tmp/tmptx61pdd9/cuda_utils.c', '-O3', '-shared', '-fPIC', '-Wno-psabi', '-o', '/tmp/tmptx61pdd9/cuda_utils.cpython-313-x86_64-linux-gnu.so', '-l:libcuda.so.1', '-L/nix/store/<hash>-python3.13-triton-3.7.0/lib/python3.13/site-packages/triton/backends/nvidia/lib', '-L/nix/store/<hash>-cuda13.2-cuda_cudart-13.2.51/lib/stubs', '-I/nix/store/<hash>-cuda13.2-cuda_cudart-13.2.51/include', '-I/nix/store/<hash>-python3.13-triton-3.7.0/lib/python3.13/site-packages/triton/backends/nvidia/include', '-I/tmp/tmptx61pdd9', '-I/nix/store/<hash>-python3.13/include/python3.13', '-Wl,-rpath,/run/opengl-driver/lib']' returned non-zero exit status 1.
```

Assisted-by: Claude Code (claude-opus-4-6)

## Things done

## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].