### PR TITLE
treewide: follow some GitHub redirects for `fetchFromGitHub`

### DIFF
--- a/pkgs/applications/office/beancount/beancount-ing-diba.nix
+++ b/pkgs/applications/office/beancount/beancount-ing-diba.nix
@@ -12,7 +12,7 @@ python3.pkgs.buildPythonApplication rec {
 
   src = fetchFromGitHub {
     owner = "siddhantgoel";
-    repo = "beancount-ing-diba";
+    repo = "beancount-ing";
     rev = "v${version}";
     sha256 = "sha256-zjwajl+0ix4wnW0bf4MAuO9Lr9F8sBv87TIL5Ghmlxg=";
   };
@@ -29,7 +29,7 @@ python3.pkgs.buildPythonApplication rec {
   ];
 
   meta = {
-    homepage = "https://github.com/siddhantgoel/beancount-ing-diba";
+    homepage = "https://github.com/siddhantgoel/beancount-ing";
     description = "Beancount Importers for ING-DiBa (Germany) CSV Exports";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ matthiasbeyer ];

--- a/pkgs/by-name/_4/_4d-minesweeper/package.nix
+++ b/pkgs/by-name/_4/_4d-minesweeper/package.nix
@@ -27,8 +27,8 @@ stdenv.mkDerivation {
   version = "2.0";
 
   src = fetchFromGitHub {
-    owner = "gapophustu";
-    repo = "4D-Minesweeper";
+    owner = "Alzager";
+    repo = "4D-Minesweeper-Archived";
     rev = "db176d8aa5981a597bbae6a1a74aeebf0f376df4";
     hash = "sha256-A5QKqCo9TTdzmK13WRSAfkrkeUqHc4yQCzy4ZZ9uX2M=";
   };
@@ -80,7 +80,7 @@ stdenv.mkDerivation {
   dontStrip = true;
 
   meta = {
-    homepage = "https://github.com/gapophustu/4D-Minesweeper";
+    homepage = "https://github.com/Alzager/4D-Minesweeper-Archived";
     description = "4D Minesweeper game written in Godot";
     license = lib.licenses.mpl20;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/aa/aaa/package.nix
+++ b/pkgs/by-name/aa/aaa/package.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "1.1.1";
 
   src = fetchFromGitHub {
-    owner = "DomesticMoth";
+    owner = "asciimoth";
     repo = "aaa";
     tag = "v${finalAttrs.version}";
     sha256 = "sha256-gIOlPjZOcmVLi9oOn4gBv6F+3Eq6t5b/3fKzoFqxclw=";
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Terminal viewer for 3a format";
-    homepage = "https://github.com/DomesticMoth/aaa";
+    homepage = "https://github.com/asciimoth/aaa";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ asciimoth ];
     mainProgram = "aaa";

--- a/pkgs/by-name/ac/aces-container/package.nix
+++ b/pkgs/by-name/ac/aces-container/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.0.2";
 
   src = fetchFromGitHub {
-    owner = "ampas";
+    owner = "aces-aswf";
     repo = "aces_container";
     tag = "v${finalAttrs.version}";
     hash = "sha256-luMqXqlJ6UzoawEDmbK38lm3GHosaZm/mFJntBF54Y4=";
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Reference Implementation of SMPTE ST2065-4";
-    homepage = "https://github.com/ampas/aces_container";
+    homepage = "https://github.com/aces-aswf/aces_container";
     license = lib.licenses.ampas;
     maintainers = with lib.maintainers; [ paperdigits ];
     mainProgram = "aces-container";

--- a/pkgs/by-name/ae/aeron-cpp/package.nix
+++ b/pkgs/by-name/ae/aeron-cpp/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation {
   inherit version;
 
   src = fetchFromGitHub {
-    owner = "real-logic";
+    owner = "aeron-io";
     repo = "aeron";
     tag = version;
     hash = "sha256-sROEZVOfScrlqMLbfrPtw3LQCQ5TfMcrLiP6j/Z9rSM=";

--- a/pkgs/by-name/ai/airwave/package.nix
+++ b/pkgs/by-name/ai/airwave/package.nix
@@ -19,7 +19,7 @@ multiStdenv.mkDerivation (finalAttrs: {
   version = "1.3.3";
 
   src = fetchFromGitHub {
-    owner = "phantom-code";
+    owner = "psycha0s";
     repo = "airwave";
     tag = finalAttrs.version;
     hash = "sha256-mvT0b0auKiu1T8cbR9RoBT94hKSnXDamqkIQPnUqVq0=";
@@ -55,7 +55,7 @@ multiStdenv.mkDerivation (finalAttrs: {
   # shrinking.
   dontPatchELF = true;
 
-  # Cf. https://github.com/phantom-code/airwave/issues/57
+  # Cf. https://github.com/psycha0s/airwave/issues/57
   hardeningDisable = [ "format" ];
 
   cmakeFlags = [ "-DVSTSDK_PATH=${vst2-sdk}" ];
@@ -78,7 +78,7 @@ multiStdenv.mkDerivation (finalAttrs: {
       protocol to correctly embed the plugin editor into the host
       window.
     '';
-    homepage = "https://github.com/phantom-code/airwave";
+    homepage = "https://github.com/psycha0s/airwave";
     license = lib.licenses.mit;
     platforms = [ "x86_64-linux" ];
     maintainers = with lib.maintainers; [ michalrus ];

--- a/pkgs/by-name/am/amass/package.nix
+++ b/pkgs/by-name/am/amass/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
   buildInputs = [ libpostalWithData ];
 
   src = fetchFromGitHub {
-    owner = "OWASP";
+    owner = "owasp-amass";
     repo = "Amass";
     tag = "v${finalAttrs.version}";
     hash = "sha256-d4zy64W5cIseOVAaekN5Q4I5WuLz+M/cP7FXQ3CQ+mk=";
@@ -21,7 +21,7 @@ buildGoModule (finalAttrs: {
 
   vendorHash = "sha256-3MpE61ixMps4IRIZkqjzG225zk4fsERkssoNoItUXbQ=";
 
-  # https://github.com/OWASP/Amass/issues/640
+  # https://github.com/owasp-amass/amass/issues/640
   doCheck = false;
 
   meta = {
@@ -35,7 +35,7 @@ buildGoModule (finalAttrs: {
       target networks.
     '';
     homepage = "https://owasp.org/www-project-amass/";
-    changelog = "https://github.com/OWASP/Amass/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/owasp-amass/amass/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       kalbasit

--- a/pkgs/by-name/an/anchor/package.nix
+++ b/pkgs/by-name/an/anchor/package.nix
@@ -9,7 +9,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "1.0.2";
 
   src = fetchFromGitHub {
-    owner = "solana-foundation";
+    owner = "otter-sec";
     repo = "anchor";
     tag = "v${finalAttrs.version}";
     hash = "sha256-J8q+oNT6x36LlTO/szlkxIcT5oFJ3y8b3YyqwBjDYX8=";
@@ -32,8 +32,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Solana Sealevel Framework";
-    homepage = "https://github.com/solana-foundation/anchor";
-    changelog = "https://github.com/solana-foundation/anchor/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    homepage = "https://github.com/otter-sec/anchor";
+    changelog = "https://github.com/otter-sec/anchor/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       Denommus

--- a/pkgs/by-name/an/anup/package.nix
+++ b/pkgs/by-name/an/anup/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage rec {
   version = "0.4.0";
 
   src = fetchFromGitHub {
-    owner = "Acizza";
+    owner = "jonathanlmc";
     repo = "anup";
     tag = version;
     hash = "sha256-4pXF4p4K8+YihVB9NdgT6bOidmQEgWXUbcbvgXJ0IDA=";
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   meta = {
-    homepage = "https://github.com/Acizza/anup";
+    homepage = "https://github.com/jonathanlmc/anup";
     description = "Anime tracker for AniList featuring a TUI";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ natto1784 ];

--- a/pkgs/by-name/ap/apftool-rs/package.nix
+++ b/pkgs/by-name/ap/apftool-rs/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "suyulin";
-    repo = "apftool-rs";
+    repo = "afptool-rs";
     tag = "v${finalAttrs.version}";
     hash = "sha256-bcXZIY0CDyWE3vh04IU3kXRxi/uUm5TD8ifA0jq47rc=";
   };
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "About Tools for Rockchip image unpack tool";
     mainProgram = "apftool-rs";
-    homepage = "https://github.com/suyulin/apftool-rs";
+    homepage = "https://github.com/suyulin/afptool-rs";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ colemickens ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/ap/appindicator-sharp/package.nix
+++ b/pkgs/by-name/ap/appindicator-sharp/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
   version = "0-unstable-2016-01-18";
 
   src = fetchFromGitHub {
-    owner = "stsundermann";
+    owner = "sundermann";
     repo = "appindicator-sharp";
     rev = "5a79cde93da6d68a4b1373f1ce5796c3c5fe1b37";
     sha256 = "sha256:1i0vqbp05l29f5v9ygp7flm4s05pcnn5ivl578mxmhb51s7ncw6l";
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Bindings for appindicator using gobject-introspection";
-    homepage = "https://github.com/stsundermann/appindicator-sharp";
+    homepage = "https://github.com/sundermann/appindicator-sharp";
     license = lib.licenses.lgpl3Only;
     maintainers = with lib.maintainers; [ kevincox ];
   };

--- a/pkgs/by-name/ap/apriltag/package.nix
+++ b/pkgs/by-name/ap/apriltag/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "AprilRobotics";
-    repo = "AprilTags";
+    repo = "apriltag";
     tag = "v${finalAttrs.version}";
     hash = "sha256-pBUjRKfP884+bNgV5B4b8TiuhyZ9p/jIluxs+idv/28=";
   };

--- a/pkgs/by-name/ar/art/package.nix
+++ b/pkgs/by-name/ar/art/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.26.6";
 
   src = fetchFromGitHub {
-    owner = "artpixls";
+    owner = "artraweditor";
     repo = "ART";
     tag = finalAttrs.version;
     hash = "sha256-m5KQUY7loLKH7X2cDw5n7biH1GJTVONTbguILdjNWrI=";

--- a/pkgs/by-name/as/assh/package.nix
+++ b/pkgs/by-name/as/assh/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
   version = "2.17.2";
 
   src = fetchFromGitHub {
-    repo = "advanced-ssh-config";
+    repo = "assh";
     owner = "moul";
     tag = "v${finalAttrs.version}";
     hash = "sha256-/w4RluA7py6d75S04czNsgHpmR5rmAUZx8OnZfu9oNg=";

--- a/pkgs/by-name/as/async-profiler/package.nix
+++ b/pkgs/by-name/as/async-profiler/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "4.3";
 
   src = fetchFromGitHub {
-    owner = "jvm-profiling-tools";
+    owner = "async-profiler";
     repo = "async-profiler";
     tag = "v${finalAttrs.version}";
     hash = "sha256-wysOjirCfxm0SmwDW7GS+S73lAT8/0g4avu7T5+qy2Q=";
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Low overhead sampling profiler for Java that does not suffer from Safepoint bias problem";
-    homepage = "https://github.com/jvm-profiling-tools/async-profiler";
+    homepage = "https://github.com/async-profiler/async-profiler";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ mschuwalow ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/au/audiness/package.nix
+++ b/pkgs/by-name/au/audiness/package.nix
@@ -10,7 +10,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "audiusGmbH";
+    owner = "audius";
     repo = "audiness";
     tag = finalAttrs.version;
     hash = "sha256-zru37eNQyY9AcbALge1qlINuxzVKq3RTNypm5Pyhkz8=";

--- a/pkgs/by-name/au/ausweisapp/package.nix
+++ b/pkgs/by-name/au/ausweisapp/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "Governikus";
-    repo = "AusweisApp2";
+    repo = "AusweisApp";
     rev = finalAttrs.version;
     hash = "sha256-pr41KbejZCOvfXH2uHO5MA/VklSNU38EL6AgznvGqeY=";
   };
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Official authentication app for German ID card and residence permit";
-    downloadPage = "https://github.com/Governikus/AusweisApp2/releases";
+    downloadPage = "https://github.com/Governikus/AusweisApp/releases";
     homepage = "https://www.ausweisapp.bund.de/open-source-software";
     license = lib.licenses.eupl12;
     mainProgram = "AusweisApp";

--- a/pkgs/by-name/av/avizo/package.nix
+++ b/pkgs/by-name/av/avizo/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation {
   version = "1.3-unstable-2024-11-03";
 
   src = fetchFromGitHub {
-    owner = "misterdanb";
+    owner = "heyjuvi";
     repo = "avizo";
     rev = "5efaa22968b2cc1a3c15a304cac3f22ec2727b17";
     sha256 = "sha256-KYQPHVxjvqKt4d7BabplnrXP30FuBQ6jQ1NxzR5U7qI=";
@@ -56,7 +56,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Neat notification daemon for Wayland";
-    homepage = "https://github.com/misterdanb/avizo";
+    homepage = "https://github.com/heyjuvi/avizo";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;
     maintainers = [

--- a/pkgs/by-name/aw/aws-rotate-key/package.nix
+++ b/pkgs/by-name/aw/aws-rotate-key/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   version = "1.2.0";
 
   src = fetchFromGitHub {
-    owner = "Fullscreen";
+    owner = "stefansundin";
     repo = "aws-rotate-key";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-fYpgHHOw0k/8WLGhq+uVOvoF4Wff6wzTXuN8r4D+TmU=";
@@ -31,7 +31,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Easily rotate your AWS key";
-    homepage = "https://github.com/Fullscreen/aws-rotate-key";
+    homepage = "https://github.com/stefansundin/aws-rotate-key";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.mbode ];
     mainProgram = "aws-rotate-key";

--- a/pkgs/by-name/ba/bash-my-aws/package.nix
+++ b/pkgs/by-name/ba/bash-my-aws/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
   version = "0-unstable-2025-01-22";
 
   src = fetchFromGitHub {
-    owner = "bash-my-aws";
+    owner = "mbailey";
     repo = "bash-my-aws";
     rev = "d338b43cc215719c1853ec500c946db6b9caaa11";
     sha256 = "sha256-PR52T6XCrakQsBOJXf0PaYpYE5oMcIz5UDA4I9B7C38=";

--- a/pkgs/by-name/ba/batticonplus/package.nix
+++ b/pkgs/by-name/ba/batticonplus/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.0.1";
 
   src = fetchFromGitHub {
-    owner = "artist4xlibre";
+    owner = "artist4artixlinux";
     repo = "batticonplus";
     tag = "v${finalAttrs.version}";
     hash = "sha256-H9ZoiQ5zWMIoWWol2a6f9Z8g4o9DIHYdF+/nEsBfuzc=";
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Lightweight battery status icon for the system tray and notifier (based on cbatticon)";
     mainProgram = "batticonplus";
-    homepage = "https://github.com/artist4xlibre/batticonplus";
+    homepage = "https://github.com/artist4artixlinux/batticonplus";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ yechielw ];

--- a/pkgs/by-name/bi/bibata-cursors-translucent/package.nix
+++ b/pkgs/by-name/bi/bibata-cursors-translucent/package.nix
@@ -9,7 +9,7 @@ stdenvNoCC.mkDerivation rec {
   version = "1.1.2";
 
   src = fetchFromGitHub {
-    owner = "Silicasandwhich";
+    owner = "silica-dev";
     repo = "Bibata_Cursor_Translucent";
     rev = "v${version}";
     sha256 = "sha256-RroynJfdFpu+Wl9iw9NrAc9wNZsSxWI+heJXUTwEe7s=";
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation rec {
 
   meta = {
     description = "Translucent Varient of the Material Based Cursor";
-    homepage = "https://github.com/Silicasandwhich/Bibata_Cursor_Translucent";
+    homepage = "https://github.com/silica-dev/Bibata_Cursor_Translucent";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;
     maintainers = [ ];

--- a/pkgs/by-name/bi/biscuit-cli/package.nix
+++ b/pkgs/by-name/bi/biscuit-cli/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.6.0";
 
   src = fetchFromGitHub {
-    owner = "biscuit-auth";
+    owner = "eclipse-biscuit";
     repo = "biscuit-cli";
     tag = finalAttrs.version;
     sha256 = "sha256-s4Y4MhM79Z+4VxB03+56OqRQJaSHj2VQEJcL6CsT+2k=";

--- a/pkgs/by-name/bp/bpftop/package.nix
+++ b/pkgs/by-name/bp/bpftop/package.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage.override { stdenv = clangStdenv; } (finalAttrs: {
   version = "0.9.0";
 
   src = fetchFromGitHub {
-    owner = "Netflix";
+    owner = "jfernandez";
     repo = "bpftop";
     tag = "v${finalAttrs.version}";
     hash = "sha256-QukcBq80tASPSHRg1yRouYiZqvca+ipp6RGzXqP2CwA=";
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage.override { stdenv = clangStdenv; } (finalAttrs: {
 
   meta = {
     description = "Dynamic real-time view of running eBPF programs";
-    homepage = "https://github.com/Netflix/bpftop";
+    homepage = "https://github.com/jfernandez/bpftop";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       _0x4A6F

--- a/pkgs/by-name/bt/btor2tools/package.nix
+++ b/pkgs/by-name/bt/btor2tools/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation {
   version = "0-unstable-2025-09-18";
 
   src = fetchFromGitHub {
-    owner = "boolector";
+    owner = "hwmcc";
     repo = "btor2tools";
     rev = "d33c73ff1d173f1bfac8ba6b1c6d68ba62c55f8e";
     sha256 = "sha256-RVjZ5HM2yQ3eAICFuzwvNeQDXzWzzSiCCslIWMJi6U8=";
@@ -54,7 +54,7 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Generic parser and tool package for the BTOR2 format";
-    homepage = "https://github.com/Boolector/btor2tools";
+    homepage = "https://github.com/hwmcc/btor2tools";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ thoughtpolice ];

--- a/pkgs/by-name/bu/buildah-unwrapped/package.nix
+++ b/pkgs/by-name/bu/buildah-unwrapped/package.nix
@@ -21,7 +21,7 @@ buildGoModule (finalAttrs: {
   version = "1.44.0";
 
   src = fetchFromGitHub {
-    owner = "containers";
+    owner = "podman-container-tools";
     repo = "buildah";
     tag = "v${finalAttrs.version}";
     hash = "sha256-/Rv5la54ikmP4qVT19tg0sv0kM+xpQO6w9XU1PpGFk4=";
@@ -80,7 +80,7 @@ buildGoModule (finalAttrs: {
     description = "Tool which facilitates building OCI images";
     mainProgram = "buildah";
     homepage = "https://buildah.io/";
-    changelog = "https://github.com/containers/buildah/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/podman-container-tools/buildah/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     teams = [ lib.teams.podman ];
   };

--- a/pkgs/by-name/bw/bws/package.nix
+++ b/pkgs/by-name/bw/bws/package.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "bitwarden";
-    repo = "sdk";
+    repo = "sdk-sm";
     tag = "bws-v${finalAttrs.version}";
     hash = "sha256-cdiTdgNvUDN0/KzMDEiHo+GIYkUaWEZTAnWahBrMZ4I=";
   };

--- a/pkgs/by-name/c2/c2fmzq/package.nix
+++ b/pkgs/by-name/c2/c2fmzq/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "c2FmZQ";
-    repo = "c2FmZQ";
+    repo = "photos";
     rev = "v${finalAttrs.version}";
     hash = "sha256-qIJnrMqsaa7GcsJpyWHhi6nea72XCQy5BaGWBtQKzFo=";
   };
@@ -34,7 +34,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Securely encrypt, store, and share files, including but not limited to pictures and videos";
-    homepage = "https://github.com/c2FmZQ/c2FmZQ";
+    homepage = "https://github.com/c2FmZQ/photos";
     license = lib.licenses.gpl3Only;
     mainProgram = "c2FmZQ-server";
     maintainers = with lib.maintainers; [ hmenke ];

--- a/pkgs/by-name/ca/cagent/package.nix
+++ b/pkgs/by-name/ca/cagent/package.nix
@@ -12,7 +12,7 @@ buildGoModule (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "docker";
-    repo = "cagent";
+    repo = "docker-agent";
     tag = "v${finalAttrs.version}";
     hash = "sha256-jcJxzdtU0Zzov7EKvJCxgbrfwMcI4k7OgHVrb5S4fs8=";
   };
@@ -44,9 +44,9 @@ buildGoModule (finalAttrs: {
       orchestrates AI agents with specialized capabilities and tools,
       and the interactions between agents.
     '';
-    homepage = "https://github.com/docker/cagent";
-    changelog = "https://github.com/docker/cagent/releases/tag/v${finalAttrs.version}";
-    downloadPage = "https://github.com/docker/cagent/releases";
+    homepage = "https://github.com/docker/docker-agent";
+    changelog = "https://github.com/docker/docker-agent/releases/tag/v${finalAttrs.version}";
+    downloadPage = "https://github.com/docker/docker-agent/releases";
     license = lib.licenses.asl20;
     mainProgram = "cagent";
     maintainers = with lib.maintainers; [ MH0386 ];

--- a/pkgs/by-name/ca/cano/package.nix
+++ b/pkgs/by-name/ca/cano/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.2.0-alpha";
 
   src = fetchFromGitHub {
-    owner = "CobbCoding1";
+    owner = "Cano-Projects";
     repo = "Cano";
     tag = "v${finalAttrs.version}";
     hash = "sha256-OaWj0AKw3+sEhcAbIjgOLfxwCKRG6O1k+zSp0GnnFn8=";
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Text Editor Written In C Using ncurses";
-    homepage = "https://github.com/CobbCoding1/Cano";
+    homepage = "https://github.com/Cano-Projects/Cano";
     license = lib.licenses.asl20;
     mainProgram = "Cano";
     maintainers = with lib.maintainers; [ sigmanificient ];

--- a/pkgs/by-name/ca/cargo-limit/package.nix
+++ b/pkgs/by-name/ca/cargo-limit/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.0.10";
 
   src = fetchFromGitHub {
-    owner = "alopatindev";
+    owner = "cargo-limit";
     repo = "cargo-limit";
     tag = finalAttrs.version;
     sha256 = "sha256-joWDB9fhCsYVZFZdr+Gfm4JaRlm5kj+CHp34Sx5iQYk=";
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Cargo subcommand \"limit\": reduces the noise of compiler messages";
-    homepage = "https://github.com/alopatindev/cargo-limit";
+    homepage = "https://github.com/cargo-limit/cargo-limit";
     license = with lib.licenses; [
       asl20 # or
       mit

--- a/pkgs/by-name/ca/cargo-rr/package.nix
+++ b/pkgs/by-name/ca/cargo-rr/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.3.0";
 
   src = fetchFromGitHub {
-    owner = "danielzfranklin";
+    owner = "dzfranklin";
     repo = "cargo-rr";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-t8pRqeOdaRVG0titQhxezT2aDjljSs//MnRTTsJ73Yo=";
@@ -33,7 +33,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Cargo subcommand \"rr\": a light wrapper around rr, the time-travelling debugger";
     mainProgram = "cargo-rr";
-    homepage = "https://github.com/danielzfranklin/cargo-rr";
+    homepage = "https://github.com/dzfranklin/cargo-rr";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [
       otavio

--- a/pkgs/by-name/ca/cassandra-cpp-driver/package.nix
+++ b/pkgs/by-name/ca/cassandra-cpp-driver/package.nix
@@ -15,8 +15,8 @@ stdenv.mkDerivation (finalAttrs: {
   version = "2.17.1";
 
   src = fetchFromGitHub {
-    owner = "datastax";
-    repo = "cpp-driver";
+    owner = "apache";
+    repo = "cassandra-cpp-driver";
     tag = finalAttrs.version;
     sha256 = "sha256-GuvmKHJknudyn7ahrn/8+kKUA4NW5UjCfkYoX3aTE+Q=";
   };

--- a/pkgs/by-name/cd/cdxgen/package.nix
+++ b/pkgs/by-name/cd/cdxgen/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "11.10.0";
 
   src = fetchFromGitHub {
-    owner = "CycloneDX";
+    owner = "cdxgen";
     repo = "cdxgen";
     tag = "v${finalAttrs.version}";
     hash = "sha256-RmgR6OfNrZUYFyn36zTHERIHlzszaFqTX8b4Rf2TF/U=";
@@ -65,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Creates CycloneDX Software Bill-of-Materials (SBOM) for your projects from source and container images";
     mainProgram = "cdxgen";
-    homepage = "https://github.com/CycloneDX/cdxgen";
+    homepage = "https://github.com/cdxgen/cdxgen";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       quincepie

--- a/pkgs/by-name/cf/cfm/package.nix
+++ b/pkgs/by-name/cf/cfm/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "0.6.6";
 
   src = fetchFromGitHub {
-    owner = "willeccles";
+    owner = "sophec";
     repo = "cfm";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-uXL0RO9P+NYSZ0xCv91KzjHOJJI500YUT8IJkFS86pE=";
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    homepage = "https://github.com/willeccles/cfm";
+    homepage = "https://github.com/sophec/cfm";
     description = "Simple and fast TUI file manager with no dependencies";
     license = lib.licenses.mpl20;
     maintainers = [ ];

--- a/pkgs/by-name/ch/chars/package.nix
+++ b/pkgs/by-name/ch/chars/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.7.0";
 
   src = fetchFromGitHub {
-    owner = "antifuchs";
+    owner = "boinkor-net";
     repo = "chars";
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-mBtwdPzIc6RgEFTyReStFlhS4UhhRWjBTKT6gD3tzpQ=";
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Commandline tool to display information about unicode characters";
     mainProgram = "chars";
-    homepage = "https://github.com/antifuchs/chars";
+    homepage = "https://github.com/boinkor-net/chars";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ bbigras ];
   };


### PR DESCRIPTION
This PR updates some `fetchFromGitHub` calls and corresponding `github.com/<owner>/<repo>` links in the same location to point directly to canonical repositories instead of redirecting URLs.

This doesn't update all `fetchFromGitHub` redirects since that would produce a diff too large for maintainers to review.

**Motivation:**
This avoids silent failures if upstream redirects ever change or disappear, and improves reliability and reproducibility of fetches.

**How:**
Changes were generated using [this script](https://git.kybe.xyz/2kybe3/nixpkgs-github-redirect).

**How to verify:**
You can verify that all modified package sources still build using the following script with a `changed.txt` file containing the changed package list.

This is the same approach I used to confirm that everything still compiles.

<details>
  <summary>Verify script</summary>

```bash
#!/usr/bin/env bash

out="result.txt"
: > "$out"

while read -r pkg; do
    echo "=== $pkg ==="

    output=$(nix build "./nixpkgs#$pkg.src" -L -v --rebuild --no-link --print-out-paths)
    status=$?

    if [ $status -eq 0 ]; then
        echo "$pkg: success | $output" | tee -a "$out"
    else
        echo "$pkg: failed" | tee -a "$out"
    fi
done < ./changed.txt
```
</details>

<details>
  <summary>Changed Packages</summary>

```
aeron-cpp
apftool-rs
airwave
aaa
amass
_4d-minesweeper
aces-container
anchor
anup
async-profiler
art
appindicator-sharp
apriltag
assh
aws-rotate-key
audiness
ausweisapp
avizo
bazel-gazelle
batticonplus
bash-my-aws
bibata-cursors-translucent
biff
beancount-ing-diba
biscuit-cli
btor2tools
bpftop
cagent
bws
buildah-unwrapped
cargo-limit
cdxgen
c2fmzq
cassandra-cpp-driver
cano
cargo-rr
cfm
chars
chiri
```
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
