### PR TITLE
mariannefont: init at 0-unstable-2021-12-05

### DIFF
--- a/pkgs/by-name/ma/mariannefont/package.nix
+++ b/pkgs/by-name/ma/mariannefont/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  installFonts,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "mariannefont";
+  version = "0-unstable-2021-12-05";
+
+  src = fetchFromGitHub {
+    owner = "JohannCOSTE";
+    repo = "marianne_ttf_tcpdf";
+    rev = "ee4d5025cd37b03562a0f2fb333b081fe7196dc5";
+    hash = "sha256-outIIWJtUWZW527i9ciP0AT5LGaQDO6IK9Kn6R8w6ZU=";
+  };
+
+  nativeBuildInputs = [ installFonts ];
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  meta = {
+    homepage = "https://www.info.gouv.fr/marque-de-letat/la-typographie";
+    description = "Font to be used in official French State
+    communication";
+    # Seems the official website forbid the use of the font for non-State
+    # communication, but the official decree
+    # https://www.legifrance.gouv.fr/circulaire/id/44935 is not that clear
+    # on that matter
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ GirardR1006 ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Add the Marianne font, to be used for communication from French state actors.

 
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
