### PR TITLE
nimmm: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/by-name/ni/nimmm/lock.json
+++ b/pkgs/by-name/ni/nimmm/lock.json
@@ -35,6 +35,18 @@
       "sha256": "06b9ylqbjcxgm9mjfzljbi8gr9sbajykcqpcxgyqymynqyhxmqjn",
       "srcDir": "src",
       "url": "https://github.com/shoyu777/wcwidth-nim/archive/86f8db1a883f6a64e590a56aed81e788389b7196.tar.gz"
+    },
+    {
+      "method": "fetchzip",
+      "packages": [
+        "tinyre"
+      ],
+      "path": "/nix/store/w556rbsnv2fxb229av2iq180ri9x0d9j-source",
+      "ref": "1.6.0",
+      "rev": "77469f58916369bc3863194cabb05238577fb257",
+      "sha256": "18wjz5yqzr1dz6286p2w02fk2xjr54l477g90bz4pskjcqrqnjbv",
+      "srcDir": "",
+      "url": "https://github.com/khchen/tinyre/archive/77469f58916369bc3863194cabb05238577fb257.tar.gz"
     }
   ]
 }

--- a/pkgs/by-name/ni/nimmm/package.nix
+++ b/pkgs/by-name/ni/nimmm/package.nix
@@ -8,20 +8,19 @@
 
 buildNimPackage (finalAttrs: {
   pname = "nimmm";
-  version = "0.4.0";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "joachimschmidt557";
     repo = "nimmm";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-yq91rQlX6bfYHHw72+8m53PCD7hViLe56jAwPTeBBcg=";
+    hash = "sha256-NK2OH5eAlcityUdz9p95Y7iNOX39ed0Krdns1+2NKLU=";
   };
 
   lockFile = ./lock.json;
 
   buildInputs = [
     termbox
-    pcre
   ];
 
   meta = {


### PR DESCRIPTION
Updates nimmm to 0.5.0 following my upstream release: https://github.com/joachimschmidt557/nimmm/releases/tag/v0.5.0

This removes the dependency on `pcre`, addressing #356387

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
