### PR TITLE
prometheus-qbittorrent-exporter: 1.13.0 -> 2.0.1

### DIFF
--- a/pkgs/by-name/pr/prometheus-qbittorrent-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-qbittorrent-exporter/package.nix
@@ -6,22 +6,24 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "prometheus-qbittorrent-exporter";
-  version = "1.13.0";
+  version = "2.0.1";
 
   src = fetchFromGitHub {
     owner = "martabal";
     repo = "qbittorrent-exporter";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ivHTGj2+6c23KW5aT5a8NFzUxV13u0y9UnHttZYTkuA=";
+    hash = "sha256-bVfYDIT3FMCFs/p+fFwm+xKiqbffPJ26Z2KFmBlqMjg=";
   };
-  sourceRoot = "${finalAttrs.src.name}/src";
 
-  vendorHash = "sha256-FHKt2QpvianVVbAJUcaou/+Ok69a8NbkM7ymVgxUi0I=";
+  vendorHash = "sha256-vw4uwQt/PI8yl81NC3wAdgCiPacg/Pmv2MNlnR9Y/v0=";
 
   ldflags = [
     "-s"
     "-X 'qbit-exp/app.version=v${finalAttrs.version}'"
   ];
+
+  # Tests create a local http server
+  __darwinAllowLocalNetworking = true;
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update prometheus-qbittorrent-exporter to 2.0.1.

qBittorrent 5.2.0 introduced a change to the authentication flow according to [prometheus-qbittorrent-exporter's release note](https://github.com/martabal/qbittorrent-exporter/releases/tag/v2.0.0), so it's necessary to update prometheus-qbittorrent-exporter.

I think this should be backported because `nixos-26.05` has qBittorrent 5.2.1.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (it works on my NixOS machine)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
