### PR TITLE
sherpa: fix Darwin build with CMAKE_INSTALL_NAME_DIR

### DIFF
--- a/pkgs/by-name/sh/sherpa/package.nix
+++ b/pkgs/by-name/sh/sherpa/package.nix
@@ -6,7 +6,7 @@
   gfortran,
   libzip,
   lhapdf,
-  patchelf,
+  testers,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -27,8 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     gfortran
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ patchelf ];
+  ];
 
   buildInputs = [
     libzip
@@ -38,15 +37,12 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     # Needed to initialize a valid SHERPA_LIBRARY_PATH
     "-DCMAKE_INSTALL_LIBDIR=lib"
+    (lib.cmakeFeature "CMAKE_INSTALL_NAME_DIR" "${placeholder "out"}/lib/SHERPA-MC")
   ];
 
-  preFixup =
-    lib.optionalString stdenv.hostPlatform.isDarwin ''
-      install_name_tool -add_rpath "$out"/lib/SHERPA-MC "$out"/bin/Sherpa
-    ''
-    + lib.optionalString stdenv.hostPlatform.isLinux ''
-      patchelf --add-rpath "$out"/lib/SHERPA-MC "$out"/bin/Sherpa
-    '';
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+  };
 
   meta = {
     description = "Monte Carlo event generator for the Simulation of High-Energy Reactions of PArticles";
@@ -54,7 +50,5 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://gitlab.com/sherpa-team/sherpa";
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ veprbl ];
-    # never built on aarch64-darwin since first introduction in nixpkgs
-    broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64;
   };
 })


### PR DESCRIPTION
Replace post-build install_name_tool/patchelf rpath hacks with CMAKE_INSTALL_NAME_DIR at configure time.
Remove the aarch64-darwin broken marker.
Add testers.testVersion.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
