### PR TITLE
{teams-for-linux,winboat}: factor out electron pin

### DIFF
--- a/pkgs/by-name/te/teams-for-linux/package.nix
+++ b/pkgs/by-name/te/teams-for-linux/package.nix
@@ -13,6 +13,9 @@
   which,
 }:
 
+let
+  electron = electron_41;
+in
 buildNpmPackage rec {
   pname = "teams-for-linux";
   version = "2.11.1";
@@ -46,7 +49,7 @@ buildNpmPackage rec {
     runHook preBuild
 
     electron_dist="$(mktemp -d)"
-    cp -r ${electron_41.dist}/. "$electron_dist"
+    cp -r ${electron.dist}/. "$electron_dist"
     chmod -R u+w "$electron_dist"
 
     npm exec electron-builder -- \
@@ -54,7 +57,7 @@ buildNpmPackage rec {
         -c.npmRebuild=true \
         -c.asarUnpack="**/*.node" \
         -c.electronDist="$electron_dist" \
-        -c.electronVersion=${electron_41.version} \
+        -c.electronVersion=${electron.version} \
         -c.mac.identity=null
 
     runHook postBuild
@@ -76,7 +79,7 @@ buildNpmPackage rec {
     popd
 
     # Linux needs 'aplay' for notification sounds
-    makeWrapper '${lib.getExe electron_41}' "$out/bin/teams-for-linux" \
+    makeWrapper '${lib.getExe electron}' "$out/bin/teams-for-linux" \
       --prefix PATH : ${
         lib.makeBinPath [
           alsa-utils

--- a/pkgs/by-name/wi/winboat/package.nix
+++ b/pkgs/by-name/wi/winboat/package.nix
@@ -16,6 +16,9 @@
   nix-update-script,
 }:
 
+let
+  electron = electron_40;
+in
 buildNpmPackage (finalAttrs: {
   pname = "winboat";
   version = "0.9.0";
@@ -59,8 +62,8 @@ buildNpmPackage (finalAttrs: {
     node scripts/build.ts
     npm exec electron-builder --linux -- \
       --dir \
-      -c.electronDist=${electron_40.dist} \
-      -c.electronVersion=${electron_40.version}
+      -c.electronDist=${electron.dist} \
+      -c.electronVersion=${electron.version}
   '';
 
   installPhase = ''
@@ -81,7 +84,7 @@ buildNpmPackage (finalAttrs: {
     ln -sf $out/share/winboat/resources/data $out/share/winboat/data
     ln -sf $out/share/winboat/resources/guest_server $out/share/winboat/guest_server
 
-    makeWrapper ${electron_40}/bin/electron $out/bin/winboat \
+    makeWrapper ${electron}/bin/electron $out/bin/winboat \
       --add-flag "$out/share/winboat/resources/app.asar" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --suffix PATH : ${


### PR DESCRIPTION
This reduces the burden of bumping the electron version.
These are the last two packages where a pinned electron is being used multiple times without an alias.

This should cause 0 rebuilds

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
