### PR TITLE
antigravity-cli: fix command sandbox on Linux

### DIFF
--- a/pkgs/by-name/an/antigravity-cli/package.nix
+++ b/pkgs/by-name/an/antigravity-cli/package.nix
@@ -3,6 +3,7 @@
   stdenvNoCC,
   fetchurl,
   autoPatchelfHook,
+  makeBinaryWrapper,
   versionCheckHook,
 }:
 let
@@ -38,7 +39,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   sourceRoot = ".";
 
-  nativeBuildInputs = lib.optionals stdenvNoCC.hostPlatform.isElf [ autoPatchelfHook ];
+  nativeBuildInputs = lib.optionals stdenvNoCC.isLinux [
+    autoPatchelfHook
+    makeBinaryWrapper
+  ];
 
   dontConfigure = true;
   dontBuild = true;
@@ -49,6 +53,16 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     install -Dm755 antigravity $out/bin/agy
 
     runHook postInstall
+  '';
+
+  # agy runs agent commands inside its own nsjail, which bind-mounts only the
+  # host's /lib, /lib64 and every directory on $PATH. On NixOS the binary's
+  # glibc interpreter lives in /nix/store (on none of those), so the jail cannot
+  # exec it and command execution fails; agy then falls back to running
+  # unsandboxed on the host. Putting /nix/store on $PATH makes nsjail bind-mount
+  # the store into the jail so the interpreter and every tool/library resolve.
+  postFixup = lib.optionalString stdenvNoCC.isLinux ''
+    wrapProgram $out/bin/agy --suffix PATH : /nix/store
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];


### PR DESCRIPTION
agy runs agent commands inside an nsjail that bind-mounts only the host's /lib, /lib64 and the directories on $PATH. On NixOS agy's glibc interpreter lives in /nix/store, which is on none of those, so the jail cannot exec it and command execution fails; agy then falls back to running unsandboxed on the host.

Wrap agy to put /nix/store on $PATH, which makes nsjail bind-mount the store into the jail so the interpreter and every tool/library resolve and sandboxed execution works. nsjail is Linux-only, so the wrapper is gated on stdenv.isLinux.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
