### PR TITLE
mplayer: enable strictDeps and structuredAttrs, add versionCheckHook

### DIFF
--- a/pkgs/applications/video/mplayer/default.nix
+++ b/pkgs/applications/video/mplayer/default.nix
@@ -66,6 +66,7 @@
   libjpeg,
   useUnfreeCodecs ? false,
   buildPackages,
+  versionCheckHook,
 }:
 
 assert xineramaSupport -> x11Support;
@@ -117,7 +118,7 @@ let
 
 in
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "mplayer";
   version = "1.5-unstable-2024-12-21";
 
@@ -128,6 +129,7 @@ stdenv.mkDerivation {
   };
 
   prePatch = ''
+    echo "${finalAttrs.version}" > VERSION
     sed -i /^_install_strip/d configure
 
     rm -rf ffmpeg
@@ -283,6 +285,10 @@ stdenv.mkDerivation {
     fi
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--help";
+  doInstallCheck = true;
+
   __structuredAttrs = true;
 
   meta = {
@@ -299,4 +305,4 @@ stdenv.mkDerivation {
       "aarch64-linux"
     ];
   };
-}
+})

--- a/pkgs/applications/video/mplayer/default.nix
+++ b/pkgs/applications/video/mplayer/default.nix
@@ -178,93 +178,42 @@ stdenv.mkDerivation {
 
   configurePlatforms = [ ];
   configureFlags = [
-    "--enable-freetype"
-    (if fontconfigSupport then "--enable-fontconfig" else "--disable-fontconfig")
-  ]
-  ++ (
-    if x11Support then
-      [
-        "--enable-x11"
-        "--enable-gl"
-      ]
-    else
-      [
-        "--disable-x11"
-        "--disable-gl"
-      ]
-  )
-  ++ [
-    (if xineramaSupport then "--enable-xinerama" else "--disable-xinerama")
-    (if xvSupport then "--enable-xv" else "--disable-xv")
-    (if alsaSupport then "--enable-alsa" else "--disable-alsa")
-    (if screenSaverSupport then "--enable-xss" else "--disable-xss")
-    (if vdpauSupport then "--enable-vdpau" else "--disable-vdpau")
-    (if cddaSupport then "--enable-cdparanoia" else "--disable-cdparanoia")
-    (if dvdnavSupport then "--enable-dvdnav" else "--disable-dvdnav")
-    (if bluraySupport then "--enable-bluray" else "--disable-bluray")
-    (if amrSupport then "--enable-libopencore_amrnb" else "--disable-libopencore_amrnb")
-    (if cacaSupport then "--enable-caca" else "--disable-caca")
-  ]
-  ++ (
-    if lameSupport then
-      [
-        "--enable-mp3lame"
-        "--disable-mp3lame-lavc"
-      ]
-    else
-      [
-        "--disable-mp3lame"
-        "--enable-mp3lame-lavc"
-      ]
-  )
-  ++ [
-    (if speexSupport then "--enable-speex" else "--disable-speex")
-    (if theoraSupport then "--enable-theora" else "--disable-theora")
-  ]
-  ++ (
-    if x264Support then
-      [
-        "--enable-x264"
-        "--disable-x264-lavc"
-      ]
-    else
-      [
-        "--disable-x264"
-        "--enable-x264-lavc"
-      ]
-  )
-  ++ [
-    (if jackaudioSupport then "" else "--disable-jack")
-    (if pulseSupport then "--enable-pulse" else "--disable-pulse")
-  ]
-  ++ (
-    if v4lSupport then
-      [
-        "--enable-v4l2"
-        "--enable-tv-v4l2"
-        "--enable-radio"
-        "--enable-radio-v4l2"
-        "--enable-radio-capture"
-      ]
-    else
-      [
-        "--disable-v4l2"
-        "--disable-tv-v4l2"
-        "--disable-radio"
-        "--disable-radio-v4l2"
-        "--disable-radio-capture"
-      ]
-  )
-  ++ [
-    "--disable-xanim"
-    "--disable-xvid"
-    "--disable-xvid-lavc"
-    "--disable-ossaudio"
-    "--disable-ffmpeg_a"
+    (lib.enableFeature true "freetype")
+    (lib.enableFeature fontconfigSupport "fontconfig")
+    (lib.enableFeature x11Support "x11")
+    (lib.enableFeature x11Support "gl")
+    (lib.enableFeature xineramaSupport "xinerama")
+    (lib.enableFeature xvSupport "xv")
+    (lib.enableFeature alsaSupport "alsa")
+    (lib.enableFeature screenSaverSupport "xss")
+    (lib.enableFeature vdpauSupport "vdpau")
+    (lib.enableFeature cddaSupport "cdparanoia")
+    (lib.enableFeature dvdnavSupport "dvdnav")
+    (lib.enableFeature bluraySupport "bluray")
+    (lib.enableFeature amrSupport "libopencore_amrnb")
+    (lib.enableFeature cacaSupport "caca")
+    (lib.enableFeature lameSupport "mp3lame")
+    (lib.enableFeature (!lameSupport) "mp3lame-lavc")
+    (lib.enableFeature speexSupport "speex")
+    (lib.enableFeature theoraSupport "theora")
+    (lib.enableFeature x264Support "x264")
+    (lib.enableFeature (!x264Support) "x264-lavc")
+    (lib.enableFeature pulseSupport "pulse")
+    (lib.enableFeature v4lSupport "v4l2")
+    (lib.enableFeature v4lSupport "tv-v4l2")
+    (lib.enableFeature v4lSupport "radio")
+    (lib.enableFeature v4lSupport "radio-v4l2")
+    (lib.enableFeature v4lSupport "radio-capture")
+    (lib.enableFeature false "xanim")
+    (lib.enableFeature false "xvid")
+    (lib.enableFeature false "xvid-lavc")
+    (lib.enableFeature false "ossaudio")
+    (lib.enableFeature false "ffmpeg_a")
     "--yasm=${buildPackages.yasm}/bin/yasm"
     # Note, the `target` vs `host` confusion is intentional.
     "--target=${stdenv.hostPlatform.config}"
   ]
+  ++ lib.optional (!jackaudioSupport) "--disable-jack"
   ++ lib.optional (useUnfreeCodecs && codecs != null && !crossBuild) "--codecsdir=${codecs}"
   ++ lib.optional (stdenv.hostPlatform.isx86 && !crossBuild) "--enable-runtime-cpudetection"
   ++ lib.optional fribidiSupport "--enable-fribidi"

--- a/pkgs/applications/video/mplayer/default.nix
+++ b/pkgs/applications/video/mplayer/default.nix
@@ -180,7 +180,20 @@ stdenv.mkDerivation {
   configureFlags = [
     "--enable-freetype"
     (if fontconfigSupport then "--enable-fontconfig" else "--disable-fontconfig")
-    (if x11Support then "--enable-x11 --enable-gl" else "--disable-x11 --disable-gl")
+  ]
+  ++ (
+    if x11Support then
+      [
+        "--enable-x11"
+        "--enable-gl"
+      ]
+    else
+      [
+        "--disable-x11"
+        "--disable-gl"
+      ]
+  )
+  ++ [
     (if xineramaSupport then "--enable-xinerama" else "--disable-xinerama")
     (if xvSupport then "--enable-xv" else "--disable-xv")
     (if alsaSupport then "--enable-alsa" else "--disable-alsa")
@@ -191,25 +204,61 @@ stdenv.mkDerivation {
     (if bluraySupport then "--enable-bluray" else "--disable-bluray")
     (if amrSupport then "--enable-libopencore_amrnb" else "--disable-libopencore_amrnb")
     (if cacaSupport then "--enable-caca" else "--disable-caca")
-    (
-      if lameSupport then
-        "--enable-mp3lame --disable-mp3lame-lavc"
-      else
-        "--disable-mp3lame --enable-mp3lame-lavc"
-    )
+  ]
+  ++ (
+    if lameSupport then
+      [
+        "--enable-mp3lame"
+        "--disable-mp3lame-lavc"
+      ]
+    else
+      [
+        "--disable-mp3lame"
+        "--enable-mp3lame-lavc"
+      ]
+  )
+  ++ [
     (if speexSupport then "--enable-speex" else "--disable-speex")
     (if theoraSupport then "--enable-theora" else "--disable-theora")
-    (if x264Support then "--enable-x264 --disable-x264-lavc" else "--disable-x264 --enable-x264-lavc")
+  ]
+  ++ (
+    if x264Support then
+      [
+        "--enable-x264"
+        "--disable-x264-lavc"
+      ]
+    else
+      [
+        "--disable-x264"
+        "--enable-x264-lavc"
+      ]
+  )
+  ++ [
     (if jackaudioSupport then "" else "--disable-jack")
     (if pulseSupport then "--enable-pulse" else "--disable-pulse")
-    (
-      if v4lSupport then
-        "--enable-v4l2 --enable-tv-v4l2 --enable-radio --enable-radio-v4l2 --enable-radio-capture"
-      else
-        "--disable-v4l2 --disable-tv-v4l2 --disable-radio --disable-radio-v4l2 --disable-radio-capture"
-    )
+  ]
+  ++ (
+    if v4lSupport then
+      [
+        "--enable-v4l2"
+        "--enable-tv-v4l2"
+        "--enable-radio"
+        "--enable-radio-v4l2"
+        "--enable-radio-capture"
+      ]
+    else
+      [
+        "--disable-v4l2"
+        "--disable-tv-v4l2"
+        "--disable-radio"
+        "--disable-radio-v4l2"
+        "--disable-radio-capture"
+      ]
+  )
+  ++ [
     "--disable-xanim"
-    "--disable-xvid --disable-xvid-lavc"
+    "--disable-xvid"
+    "--disable-xvid-lavc"
     "--disable-ossaudio"
     "--disable-ffmpeg_a"
     "--yasm=${buildPackages.yasm}/bin/yasm"

--- a/pkgs/applications/video/mplayer/default.nix
+++ b/pkgs/applications/video/mplayer/default.nix
@@ -137,6 +137,9 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     pkg-config
     yasm
+  ]
+  ++ lib.optionals cacaSupport [
+    libcaca # caca-config
   ];
   buildInputs = [
     freetype
@@ -175,6 +178,8 @@ stdenv.mkDerivation {
   ++ lib.optional libjpegSupport libjpeg
   ++ lib.optional bs2bSupport libbs2b
   ++ lib.optional v4lSupport libv4l;
+
+  strictDeps = true;
 
   configurePlatforms = [ ];
   configureFlags = [
@@ -277,6 +282,8 @@ stdenv.mkDerivation {
       echo "NoDisplay=True" >> $out/share/applications/mplayer.desktop
     fi
   '';
+
+  __structuredAttrs = true;
 
   meta = {
     description = "Movie player that supports many video formats";


### PR DESCRIPTION
Entries in `configureFlags` should be single flags, not multiple space separated flags per string.

During the configure phase `caca-config` is run so we need `libcaca` in `nativeBuildInputs` as well.

The version is taken from a VERSION file by version.sh , if it exists.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
