### PR TITLE
cargo-pgrx: expose generic helper as separate file & use versionCheckHook

### DIFF
--- a/pkgs/development/tools/rust/cargo-pgrx/default.nix
+++ b/pkgs/development/tools/rust/cargo-pgrx/default.nix
@@ -1,70 +1,18 @@
 {
-  fetchCrate,
   lib,
-  openssl,
-  pkg-config,
-  rustPlatform,
+  callPackage,
 }:
 
-let
-  generic =
-    {
-      version,
-      hash,
-      cargoHash,
-    }:
-    rustPlatform.buildRustPackage {
-      pname = "cargo-pgrx";
-
-      inherit version;
-
-      src = fetchCrate {
-        inherit version hash;
-        pname = "cargo-pgrx";
-      };
-
-      inherit cargoHash;
-
-      nativeBuildInputs = [
-        pkg-config
-      ];
-
-      buildInputs = [
-        openssl
-      ];
-
-      preCheck = ''
-        export PGRX_HOME=$(mktemp -d)
-      '';
-
-      checkFlags = [
-        # requires pgrx to be properly initialized with cargo pgrx init
-        "--skip=object_utils::tests::parses_managed_postmasters"
-        # test name in versions < 0.18
-        "--skip=command::schema::tests::test_parse_managed_postmasters"
-      ];
-
-      meta = {
-        description = "Build Postgres Extensions with Rust";
-        homepage = "https://github.com/pgcentralfoundation/pgrx";
-        changelog = "https://github.com/pgcentralfoundation/pgrx/releases/tag/v${version}";
-        license = lib.licenses.mit;
-        maintainers = with lib.maintainers; [
-          happysalada
-          matthiasbeyer
-        ];
-        mainProgram = "cargo-pgrx";
-      };
+lib.mapAttrs (_: callPackage ./generic.nix { }) (
+  (import ./pinned.nix)
+  // {
+    # Default version for direct usage.
+    # Not to be used with buildPgrxExtension, where it should be pinned.
+    # When you make an extension use the latest version, *copy* this to a separate pinned attribute.
+    cargo-pgrx = {
+      version = "0.18.0";
+      hash = "sha256-sBezVDNnyqFQwvFm/CkhlY1zm7Ii2NQPeTfoUQu55e0=";
+      cargoHash = "sha256-/miOlhZ87fnKT1f+XVaWK4xAzHje8OGVlYl4iU0Sf34=";
     };
-in
-{
-  # Default version for direct usage.
-  # Not to be used with buildPgrxExtension, where it should be pinned.
-  # When you make an extension use the latest version, *copy* this to a separate pinned attribute.
-  cargo-pgrx = generic {
-    version = "0.18.0";
-    hash = "sha256-sBezVDNnyqFQwvFm/CkhlY1zm7Ii2NQPeTfoUQu55e0=";
-    cargoHash = "sha256-/miOlhZ87fnKT1f+XVaWK4xAzHje8OGVlYl4iU0Sf34=";
-  };
-}
-// lib.mapAttrs (_: generic) (import ./pinned.nix)
+  }
+)

--- a/pkgs/development/tools/rust/cargo-pgrx/generic.nix
+++ b/pkgs/development/tools/rust/cargo-pgrx/generic.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  rustPlatform,
+  fetchCrate,
+  pkg-config,
+  openssl,
+}:
+
+lib.extendMkDerivation {
+  constructDrv = rustPlatform.buildRustPackage;
+  excludeDrvArgNames = [
+    "version"
+    "cargoHash"
+  ];
+  extendDrvArgs =
+    finalAttrs:
+    {
+      version,
+      hash,
+      cargoHash,
+    }:
+    {
+      pname = "cargo-pgrx";
+
+      inherit version;
+
+      src = fetchCrate {
+        inherit (finalAttrs)
+          pname
+          version
+          ;
+        inherit hash;
+      };
+
+      inherit cargoHash;
+
+      nativeBuildInputs = [
+        pkg-config
+      ];
+
+      buildInputs = [
+        openssl
+      ];
+
+      preCheck = ''
+        export PGRX_HOME=$(mktemp -d)
+      '';
+
+      checkFlags = [
+        # requires pgrx to be properly initialized with cargo pgrx init
+        "--skip=object_utils::tests::parses_managed_postmasters"
+        # test name in versions < 0.18
+        "--skip=command::schema::tests::test_parse_managed_postmasters"
+      ];
+
+      meta = {
+        description = "Build Postgres Extensions with Rust";
+        homepage = "https://github.com/pgcentralfoundation/pgrx";
+        changelog = "https://github.com/pgcentralfoundation/pgrx/releases/tag/v${finalAttrs.version}";
+        license = lib.licenses.mit;
+        maintainers = with lib.maintainers; [
+          happysalada
+          matthiasbeyer
+        ];
+        mainProgram = "cargo-pgrx";
+      };
+    };
+}

--- a/pkgs/development/tools/rust/cargo-pgrx/generic.nix
+++ b/pkgs/development/tools/rust/cargo-pgrx/generic.nix
@@ -4,6 +4,7 @@
   fetchCrate,
   pkg-config,
   openssl,
+  versionCheckHook,
 }:
 
 lib.extendMkDerivation {
@@ -52,6 +53,9 @@ lib.extendMkDerivation {
         # test name in versions < 0.18
         "--skip=command::schema::tests::test_parse_managed_postmasters"
       ];
+
+      nativeInstallCheckInputs = [ versionCheckHook ];
+      doInstallCheck = true;
 
       meta = {
         description = "Build Postgres Extensions with Rust";


### PR DESCRIPTION
This makes it easier for downstream users to reuse the generic helper
to pin their own versions of cargo-pgrx.

Also use `versionCheckHook`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
