### PR TITLE
python3: splice properly wrapPython along with all other python-package.nix

### DIFF
--- a/pkgs/by-name/ya/yaml-merge/package.nix
+++ b/pkgs/by-name/ya/yaml-merge/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitHub,
   python3Packages,
-  pkgsHostTarget,
 }:
 
 stdenv.mkDerivation {
@@ -19,9 +18,7 @@ stdenv.mkDerivation {
 
   pythonPath = with python3Packages; [ pyyaml ];
   nativeBuildInputs = [
-    # Not `python3Packages.wrapPython` to workaround `python3Packages.wrapPython.__spliced.buildHost` having the wrong `pythonHost`
-    # See https://github.com/NixOS/nixpkgs/issues/434307
-    pkgsHostTarget.python3Packages.wrapPython
+    python3Packages.wrapPython
   ];
 
   installPhase = ''

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -481,10 +481,6 @@ in
     } ./wheel-unpack-hook.sh
   ) { };
 
-  wrapPython = callPackage ../wrap-python.nix {
-    inherit (pkgs.buildPackages) makeWrapper;
-  };
-
   sphinxHook = callPackage (
     { makePythonHook, installShellFiles }:
     makePythonHook {

--- a/pkgs/development/interpreters/python/wrap-python.nix
+++ b/pkgs/development/interpreters/python/wrap-python.nix
@@ -11,7 +11,10 @@ makePythonHook {
   substitutions.sitePackages = python.sitePackages;
   substitutions.executable = python.interpreter;
   substitutions.python = python.pythonOnBuildForHost;
-  substitutions.pythonHost = python;
+  # TODO(@doronbehar) This should have been python.pythonOnHostForHost - the
+  # same way it works in ../lua-5/wrap-lua.nix, but from some reason it
+  # doesn't work.
+  substitutions.pythonHost = python.pythonOnTargetForTarget;
   substitutions.magicalSedExpression =
     let
       # Looks weird? Of course, it's between single quoted shell strings.

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -35,7 +35,6 @@
   rpcsvc-proto,
   bash,
   python3Packages,
-  pkgsHostTarget,
   nixosTests,
   libiconv,
   testers,
@@ -119,10 +118,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     python3Packages.python
-    # Not `python3Packages.wrapPython` to workaround
-    # `python3Packages.wrapPython.__spliced.buildHost` having the wrong
-    # `pythonHost`. See https://github.com/NixOS/nixpkgs/issues/434307
-    pkgsHostTarget.python3Packages.wrapPython
+    python3Packages.wrapPython
     wafHook
     pkg-config
     bison

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -25,6 +25,8 @@ self: super: with self; {
     );
   };
 
+  wrapPython = callPackage ../development/interpreters/python/wrap-python.nix { };
+
   setuptools = callPackage ../development/python-modules/setuptools { };
 
   # by_regex ensures inherit statements are sorted after the (first) attribute name that is inherited.


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test