### PR TITLE
zabbix: pcre -> pcre2

### DIFF
--- a/pkgs/servers/monitoring/zabbix/agent.nix
+++ b/pkgs/servers/monitoring/zabbix/agent.nix
@@ -5,7 +5,6 @@
   pkg-config,
   libiconv,
   openssl,
-  pcre,
   pcre2,
 }:
 
@@ -26,14 +25,14 @@ import ./versions.nix (
     buildInputs = [
       libiconv
       openssl
-      (if (lib.versions.major version >= "7" && lib.versions.minor version >= "4") then pcre2 else pcre)
+      pcre2
     ];
 
     configureFlags = [
       "--enable-agent"
       "--enable-ipv6"
       "--with-iconv"
-      "--with-libpcre"
+      "--with-libpcre2"
       "--with-openssl=${openssl.dev}"
     ];
     makeFlags = [

--- a/pkgs/servers/monitoring/zabbix/agent2.nix
+++ b/pkgs/servers/monitoring/zabbix/agent2.nix
@@ -6,7 +6,6 @@
   pkg-config,
   libiconv,
   openssl,
-  pcre,
   pcre2,
   zlib,
 }:
@@ -37,7 +36,7 @@ import ./versions.nix (
     buildInputs = [
       libiconv
       openssl
-      (if (lib.versions.major version >= "7" && lib.versions.minor version >= "4") then pcre2 else pcre)
+      pcre2
       zlib
     ];
 
@@ -57,7 +56,7 @@ import ./versions.nix (
         --enable-agent2 \
         --enable-ipv6 \
         --with-iconv \
-        --with-libpcre \
+        --with-libpcre2 \
         --with-openssl=${openssl.dev}
     '';
 

--- a/pkgs/servers/monitoring/zabbix/proxy.nix
+++ b/pkgs/servers/monitoring/zabbix/proxy.nix
@@ -7,7 +7,6 @@
   libevent,
   libiconv,
   openssl,
-  pcre,
   pcre2,
   zlib,
   buildPackages,
@@ -64,7 +63,7 @@ import ./versions.nix (
       libevent
       libiconv
       openssl
-      (if (lib.versions.major version >= "7" && lib.versions.minor version >= "4") then pcre2 else pcre)
+      pcre2
       zlib
     ]
     ++ optional odbcSupport unixodbc
@@ -80,7 +79,7 @@ import ./versions.nix (
       "--with-iconv"
       "--with-libcurl"
       "--with-libevent"
-      "--with-libpcre"
+      "--with-libpcre2"
       "--with-openssl=${openssl.dev}"
       "--with-zlib=${zlib}"
     ]

--- a/pkgs/servers/monitoring/zabbix/server.nix
+++ b/pkgs/servers/monitoring/zabbix/server.nix
@@ -9,7 +9,6 @@
   libiconv,
   libxml2,
   openssl,
-  pcre,
   pcre2,
   zlib,
   jabberSupport ? true,
@@ -61,7 +60,7 @@ import ./versions.nix (
       libiconv
       libxml2
       openssl
-      (if lib.versionAtLeast version "7.4" then pcre2 else pcre)
+      pcre2
       zlib
     ]
     ++ optional odbcSupport unixodbc
@@ -79,7 +78,7 @@ import ./versions.nix (
       "--with-iconv"
       "--with-libcurl"
       "--with-libevent"
-      "--with-libpcre"
+      "--with-libpcre2"
       "--with-libxml2"
       "--with-openssl=${openssl.dev}"
       "--with-zlib=${zlib}"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

motivation is ping from #356387

i read docs and `pcre2` _is_ supported on older `zabbix` LTS releases now :+1:

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
