### PR TITLE
nixos/dovecot: place globals first in rendered config

### DIFF
--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -7,7 +7,6 @@
 
 let
   inherit (lib)
-    all
     attrsToList
     concatMapStringsSep
     concatStringsSep
@@ -19,7 +18,6 @@ let
     isBool
     isDerivation
     isInt
-    isList
     isPath
     isString
     listToAttrs
@@ -98,53 +96,67 @@ let
     i: n: v:
     "${i}${toString n} = ${v}";
 
-  formatKeyValue =
-    indent: n: v:
-    if (v == null) then
-      ""
-    else if isInt v then
-      toOption indent n (toString v)
+  isPrimitive = v: !isAttrs v || isDerivation v;
+
+  formatPrimitive =
+    v:
+    if isInt v then
+      toString v
     else if isBool v then
-      toOption indent n (yesOrNo v)
+      yesOrNo v
     else if isString v then
-      toOption indent n v
-    else if isList v then
-      if all isString v then
-        toOption indent n (concatStringsSep " " v)
-      else
-        map (formatKeyValue indent n) v
+      v
     else if isPath v || isDerivation v then
       # paths -> copy to store
       # derivations -> just use output path instead of looping over the attrs
-      toOption indent n "${v}"
-    else if isAttrs v && v ? _section then
-      let
-        sectionType = v._section.type;
-        sectionName = v._section.name;
-        sectionTitle = concatStringsSep " " (
-          filter (s: s != null) [
-            sectionType
-            sectionName
-          ]
-        );
-      in
-      concatStringsSep "\n" (
-        [
-          "${indent}${sectionTitle} {"
-        ]
-        ++ (mapAttrsToList (formatKeyValue "${indent}  ") (removeAttrs v [ "_section" ]))
-        ++ [ "${indent}}" ]
-      )
-    else if isAttrs v then
-      concatStringsSep "\n" (
-        [
-          "${indent}${n} {"
-        ]
-        ++ (mapAttrsToList (formatKeyValue "${indent}  ") v)
-        ++ [ "${indent}}" ]
-      )
+      "${v}"
     else
-      throw (traceSeq v "services.dovecot2.settings: unexpected type");
+      throw (traceSeq v "services.dovecot2.settings: unexpected primitive type");
+
+  formatSection =
+    indent: n: v:
+    let
+      sectionTitle =
+        if v ? _section then
+          concatStringsSep " " (
+            filter (s: s != null) [
+              v._section.type
+              v._section.name
+            ]
+          )
+        else
+          n;
+      inner = removeAttrs v [ "_section" ];
+    in
+    concatStringsSep "\n" (
+      [ "${indent}${sectionTitle} {" ]
+      ++ flatten (mapAttrsToList (primitiveLinesFor "${indent}  ") inner)
+      ++ flatten (mapAttrsToList (sectionLinesFor "${indent}  ") inner)
+      ++ [ "${indent}}" ]
+    );
+
+  # emit lines for a k=v pair only when the value is a primitive
+  primitiveLinesFor =
+    indent: n: v:
+    let
+      primitives = filter isPrimitive (flatten [ v ]);
+      hasOnlySections = primitives == [ ] && v != [ ];
+    in
+    # Only emit an empty list if the original entry was also an empty list.
+    # This is so that values like k = [{ ... }] will not produce an output
+    # here, but k = [] will, even though they result in the same
+    # primitives = [].
+    optional (!hasOnlySections && v != null) (
+      toOption indent n (concatMapStringsSep " " formatPrimitive primitives)
+    );
+
+  # emit lines for a k=v pair only when the value is *not* a primitive
+  sectionLinesFor =
+    indent: n: v:
+    let
+      sections = filter (e: !isPrimitive e) (flatten [ v ]);
+    in
+    map (e: formatSection indent n e) sections;
 
   doveConf =
     let
@@ -156,10 +168,13 @@ let
       ];
     in
     concatStringsSep "\n" (
-      optional (configVersion != null) (formatKeyValue "" "dovecot_config_version" configVersion)
-      ++ optional (storageVersion != null) (formatKeyValue "" "dovecot_storage_version" storageVersion)
+      optionals (configVersion != null) (primitiveLinesFor "" "dovecot_config_version" configVersion)
+      ++ optionals (storageVersion != null) (
+        primitiveLinesFor "" "dovecot_storage_version" storageVersion
+      )
       ++ optionals (cfg.includeFiles != [ ]) (map (f: "!include ${f}") cfg.includeFiles)
-      ++ flatten (mapAttrsToList (formatKeyValue "") remainingSettings)
+      ++ flatten (mapAttrsToList (primitiveLinesFor "") remainingSettings)
+      ++ flatten (mapAttrsToList (sectionLinesFor "") remainingSettings)
     );
 
   isPre24 = versionOlder cfg.package.version "2.4";


### PR DESCRIPTION
Fixes #525365

this PR just changes the ordering so that all non-list and non-attrs values are put first

I'm not sure if this fixes every edge case imaginable with the dovecot config format, but the problem mentioned in the issue should at least be fixed

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
