### PR TITLE
vscode-with-extensions: use the editor's iconName for the desktop icon

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -188,6 +188,7 @@ stdenv.mkDerivation (
     passthru = {
       inherit
         executableName
+        iconName
         longName
         tests
         updateScript

--- a/pkgs/applications/editors/vscode/with-extensions.nix
+++ b/pkgs/applications/editors/vscode/with-extensions.nix
@@ -52,6 +52,11 @@
 
 let
   inherit (vscode) executableName longName;
+  # The wrapped editor may override `iconName` (e.g. code-cursor, windsurf,
+  # kiro and antigravity-ide all set it to a name without the `vs` prefix). Read
+  # the real value from the package, falling back to the generic.nix default for
+  # editors built before `iconName` was exposed via passthru.
+  iconName = vscode.iconName or "vs${executableName}";
   wrappedPkgVersion = lib.getVersion vscode;
   wrappedPkgName = lib.removeSuffix "-${wrappedPkgVersion}" vscode.name;
 
@@ -100,7 +105,12 @@ runCommand "${wrappedPkgName}-with-extensions-${wrappedPkgVersion}"
         mkdir -p "$out/share/applications"
         mkdir -p "$out/share/pixmaps"
 
-        ln -sT "${vscode}/share/pixmaps/vs${executableName}.png" "$out/share/pixmaps/vs${executableName}.png"
+        ln -sT "${vscode}/share/pixmaps/${iconName}.png" "$out/share/pixmaps/${iconName}.png"
+        # Carry over the themed icons too; the .desktop entry's `Icon=` is
+        # resolved against the icon theme before falling back to pixmaps.
+        if [ -d "${vscode}/share/icons" ]; then
+          ln -sT "${vscode}/share/icons" "$out/share/icons"
+        fi
         ln -sT "${vscode}/share/applications/${executableName}.desktop" "$out/share/applications/${executableName}.desktop"
         ln -sT "${vscode}/share/applications/${executableName}-url-handler.desktop" "$out/share/applications/${executableName}-url-handler.desktop"
         makeWrapper "${vscode}/bin/${executableName}" "$out/bin/${executableName}" ${extensionsFlag}


### PR DESCRIPTION
`vscode-with-extensions` hardcoded the wrapped editor's icon basename to `vs${executableName}`, the default value of `iconName` in the generic builder. Editors that override `iconName` to something without the `vs` prefix (code-cursor, windsurf, kiro, antigravity-ide) therefore ended up with a dangling `vs<name>.png` pixmap symlink and no real icon, so their desktop entry's `Icon=` resolved to nothing and launchers/docks showed a blank icon.

Expose `iconName` via passthru and have the wrapper link the real pixmap (with a `vs${executableName}` fallback for editors built before this passthru existed). Also carry over the themed `share/icons` tree, which the wrapper previously dropped entirely.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
