### PR TITLE
testlib: 0.9.41 -> 0.9.41-unstable-2026-02-06

### DIFF
--- a/pkgs/by-name/te/testlib/package.nix
+++ b/pkgs/by-name/te/testlib/package.nix
@@ -7,27 +7,29 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "testlib";
-  version = "0.9.41";
+  version = "0.9.41-unstable-2026-02-06";
 
   src = fetchFromGitHub {
     owner = "MikeMirzayanov";
     repo = "testlib";
-    tag = finalAttrs.version;
-    hash = "sha256-AttzDYLDlpfL3Zvds6yBR/m6W/3UZKR+1LVylqOTQcw=";
+    rev = "1e4e8a24c79c6bad3becbdb5a332ffc352b7d5dd";
+    hash = "sha256-+gTiv/3glv5KfT6Hitcuh7uReSvI2j0ii1Ufr1vGfms=";
   };
 
   installPhase = ''
     runHook preInstall
-    install -Dt $out/include/testlib testlib.h
+    install -Dm644 testlib.h $out/include/testlib.h
     runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch=master" ];
+  };
 
   meta = {
     description = "C++ library to develop competitive programming problems";
     homepage = "https://github.com/MikeMirzayanov/testlib";
-    changelog = "https://github.com/MikeMirzayanov/testlib/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/MikeMirzayanov/testlib/compare/0.9.41...${finalAttrs.src.rev}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ bot-wxt1221 ];
     platforms = lib.platforms.all;


### PR DESCRIPTION
Upstream has not tagged or released 0.9.45 yet, but `master` `testlib.h`
already defines `VERSION "0.9.45"`.

This updates `testlib` from the 0.9.41 release to the current upstream
`master` snapshot at `1e4e8a24c79c6bad3becbdb5a332ffc352b7d5dd`.

The package version is set to `0.9.41-unstable-2026-02-06`, following the
Nixpkgs rule for unreleased snapshots: use the latest released upstream
version preceding the fetched commit, then append `-unstable-YYYY-MM-DD`.

Changes:
- update the source revision and hash
- update `passthru.updateScript` to track `master`
- change `meta.changelog` to a compare URL
- install only `$out/include/testlib.h`
- drop `$out/include/testlib/testlib.h`

The header install path change lets consumers include `"testlib.h"`,
matching upstream (a.k.a. mike) 's recommended usage.

Verification:
- `nix-build -A testlib`
- verified `result/include/testlib.h` exists
- verified `result/include/testlib/testlib.h` does not exist
- verified the installed header contains `#define VERSION "0.9.45"`
- verified `maintainers/scripts/update.nix` runs for `testlib`

AI disclosure: PR summary and commit message has been rewritten using AI tools. I am fully aware of the changes I made and have checked all the text and resulting code.

cc @Bot-wxt1221 

https://github.com/MikeMirzayanov/testlib/compare/0.9.41...1e4e8a24c79c6bad3becbdb5a332ffc352b7d5dd

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
