### PR TITLE
clash-verge-rev: add aarch64-darwin support

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10433,6 +10433,12 @@
     github = "h3cth0r";
     githubId = 43997408;
   };
+  hadal84 = {
+    name = "Çınar Emir";
+    email = "hadal84@proton.me";
+    github = "hadal84";
+    githubId = 143954694;
+  };
   h7x4 = {
     name = "h7x4";
     email = "h7x4@nani.wtf";

--- a/pkgs/by-name/cl/clash-verge-rev/package.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/package.nix
@@ -54,8 +54,9 @@ let
     mainProgram = "clash-verge";
     maintainers = with lib.maintainers; [
       hhr2020
+      hadal84
     ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 in
 stdenv.mkDerivation {
@@ -73,19 +74,29 @@ stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/{bin,share,lib/Clash\ Verge/resources}
-    cp -r ${unwrapped}/share/* $out/share
-    cp -r ${unwrapped}/bin/clash-verge $out/bin/clash-verge
-    # This can't be symbol linked. It will find mihomo in its runtime path
+    mkdir -p $out/bin
     cp ${service}/bin/clash-verge-service $out/bin/clash-verge-service
     ln -s ${mihomo}/bin/mihomo $out/bin/verge-mihomo
+
+    '' + lib.optionalString stdenv.isLinux ''
+
+    mkdir -p $out/{share,lib/Clash\ Verge/resources}
+    cp -r ${unwrapped}/share/* $out/share
+    cp -r ${unwrapped}/bin/clash-verge $out/bin/clash-verge
     # people who want to use alpha build show override mihomo themselves. The alpha core entry was removed in clash-verge.
     ln -s ${v2ray-geoip}/share/v2ray/geoip.dat $out/lib/Clash\ Verge/resources/geoip.dat
     ln -s ${v2ray-domain-list-community}/share/v2ray/geosite.dat $out/lib/Clash\ Verge/resources/geosite.dat
     ln -s ${dbip-country-lite.mmdb} $out/lib/Clash\ Verge/resources/Country.mmdb
 
+    '' + lib.optionalString stdenv.isDarwin ''
+
+    mkdir -p $out/Applications
+    cp -r ${unwrapped}/Applications/* $out/Applications/
+
+    '' + ''
     runHook postInstall
-  '';
+    '';
+
   # For testing convenience
   passthru = { inherit unwrapped service; };
 }

--- a/pkgs/by-name/cl/clash-verge-rev/service.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/service.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   meta,
   procps,
+  stdenv,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -43,5 +44,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "test"
     "client"
   ];
+
+  doCheck = !stdenv.isDarwin;
   inherit meta;
 })

--- a/pkgs/by-name/cl/clash-verge-rev/unwrapped.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/unwrapped.nix
@@ -24,6 +24,9 @@
   libsoup_3,
   openssl,
   webkitgtk_4_1,
+
+  lib,
+  stdenv,
 }:
 rustPlatform.buildRustPackage {
   inherit version src meta;
@@ -58,7 +61,7 @@ rustPlatform.buildRustPackage {
     substituteInPlace src-tauri/src/utils/dirs.rs \
       --replace-fail 'once("/tmp")' 'once(&std::env::var("XDG_RUNTIME_DIR").unwrap_or_else(|_| std::env::var("UID").map(|uid| format!("/run/user/{}", uid)).unwrap_or_else(|_| "/tmp".to_string())))' \
       --replace-fail 'join("verge")' 'join("clash-verge-rev")'
-
+'' + lib.optionalString stdenv.isLinux ''
     substituteInPlace $cargoDepsCopy/*/libappindicator-sys-*/src/lib.rs \
       --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
 
@@ -66,7 +69,7 @@ rustPlatform.buildRustPackage {
       --replace-fail '"gsettings"' '"${glib.bin}/bin/gsettings"' \
       --replace-fail '"kreadconfig6"' '"${kdePackages.kconfig}/bin/kreadconfig6"' \
       --replace-fail '"kwriteconfig6"' '"${kdePackages.kconfig}/bin/kwriteconfig6"'
-
+'' + ''
     # this file tries to override the linker used when compiling for certain platforms
     rm .cargo/config.toml
 
@@ -91,15 +94,16 @@ rustPlatform.buildRustPackage {
   ];
 
   buildInputs = [
+    openssl
+  ] ++ lib.optionals stdenv.isLinux [
     libayatana-appindicator
     libsoup_3
-    openssl
     webkitgtk_4_1
   ];
 
   # make sure the .desktop file name does not contain whitespace,
   # so that the service can register it as an auto-start item
-  postInstall = ''
+  postInstall = lib.optionalString stdenv.isLinux ''
     mv $out/share/applications/Clash\ Verge.desktop $out/share/applications/clash-verge.desktop
   '';
 }


### PR DESCRIPTION
Added Darwin build dependencies and modified post build hooks for Clash Verge Rev to enable compilation on macOS.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ x ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ x ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ x ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ x ] Follows the [automation/AI policy].