### PR TITLE
sslscan: migrate to by-name, modernize

### DIFF
--- a/pkgs/by-name/ss/sslscan/package.nix
+++ b/pkgs/by-name/ss/sslscan/package.nix
@@ -16,7 +16,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-qrd0NJS7M3nKFpAOpd8raGLrMj6PixTqiuus25lv+PA=";
   };
 
-  buildInputs = [ openssl ];
+  buildInputs = [
+    (openssl.override { withZlib = true; })
+  ];
 
   makeFlags = [
     "PREFIX=$(out)"

--- a/pkgs/tools/security/sslscan/default.nix
+++ b/pkgs/tools/security/sslscan/default.nix
@@ -5,14 +5,14 @@
   openssl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "sslscan";
   version = "2.2.2";
 
   src = fetchFromGitHub {
     owner = "rbsec";
     repo = "sslscan";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-qrd0NJS7M3nKFpAOpd8raGLrMj6PixTqiuus25lv+PA=";
   };
 
@@ -27,10 +27,10 @@ stdenv.mkDerivation rec {
     description = "Tests SSL/TLS services and discover supported cipher suites";
     mainProgram = "sslscan";
     homepage = "https://github.com/rbsec/sslscan";
-    changelog = "https://github.com/rbsec/sslscan/blob/${version}/Changelog";
+    changelog = "https://github.com/rbsec/sslscan/blob/${finalAttrs.version}/Changelog";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       fpletz
     ];
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2904,10 +2904,6 @@ with pkgs;
 
   strip-nondeterminism = perlPackages.strip-nondeterminism;
 
-  sslscan = callPackage ../tools/security/sslscan {
-    openssl = openssl.override { withZlib = true; };
-  };
-
   staticjinja = with python3.pkgs; toPythonApplication staticjinja;
 
   stoken = callPackage ../tools/security/stoken (config.stoken or { });


### PR DESCRIPTION
This PR migrates sslscan to pkgs/by-name/ss/sslscan/package.nix, updates it to the modern finalAttrs derivation style, and moves the openssl.override { withZlib = true; } logic into the package itself. The old entry in all-packages.nix is removed since the by‑name layout now handles it automatically.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
