### PR TITLE
redisearch: int at 8.8.0

### DIFF
--- a/pkgs/by-name/ev/eve/package.nix
+++ b/pkgs/by-name/ev/eve/package.nix
@@ -1,0 +1,34 @@
+{
+  cmake,
+  fetchFromGitHub,
+  lib,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "eve";
+  version = "2023.02.15";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "jfalcou";
+    repo = "eve";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-k7dDtLR9PoJp9SR0z4j6uNwm8JOJQiHXbr09kXtRJ7g=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  meta = {
+    changelog = "https://github.com/jfalcou/eve/releases/tag/${finalAttrs.src.tag}";
+    description = "Expressive Vector Engine";
+    homepage = "https://jfalcou.github.io/eve";
+    license = lib.licenses.boost;
+    maintainers = with lib.maintainers; [ hythera ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/re/redisearch/devendor-vectorsimilarity.patch
+++ b/pkgs/by-name/re/redisearch/devendor-vectorsimilarity.patch
@@ -1,0 +1,29 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -307,7 +307,6 @@
+     ${root}/src/redisearch_rs/headers
+     ${root}/deps/libuv/include
+     ${root}/deps
+-    ${root}/deps/VectorSimilarity/src
+     ${root}/deps/rmalloc
+     ${root}/src/ttl_table
+     ${BOOST_DIR}
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -47,8 +47,6 @@
+     target_compile_options(uv_a PRIVATE $<$<COMPILE_LANGUAGE:C>:-Wno-error=incompatible-pointer-types-discards-qualifiers>)
+ endif()
+ 
+-option(VECSIM_BUILD_TESTS "Build vecsim tests" OFF)
+-add_subdirectory(${root}/deps/VectorSimilarity ${CMAKE_CURRENT_BINARY_DIR}/VectorSimilarity)
+ 
+ # Workaround: fmt 11.2.0 is missing <cstdlib> include, which is needed for clang 21+ on macOS
+ # This was fixed in fmt 12.0.0, but that requires patching several levels upstream.
+@@ -147,7 +145,6 @@
+     ttl_table
+     ${HIREDIS_LIBS})
+ 
+-add_dependencies(redisearch_c VectorSimilarity)
+ add_dependencies(redisearch_c generate_command_info)
+ 
+ #----------------------------------------------------------------------------------------------

--- a/pkgs/by-name/re/redisearch/external-libs.patch
+++ b/pkgs/by-name/re/redisearch/external-libs.patch
@@ -1,0 +1,50 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index be6f2cb91..064f67879 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -289,9 +289,6 @@ if (NOT DEFINED BOOST_DIR)
+ endif()
+ 
+ include(${root}/build/boost/boost.cmake)
+-if (NOT IS_DIRECTORY ${BOOST_DIR})
+-    message(FATAL_ERROR "BOOST_DIR is not defined or does not point to a valid directory ${BOOST_DIR}")
+-endif()
+ 
+ message(STATUS "BOOST_DIR: ${BOOST_DIR}")
+ set(BOOST_ROOT ${BOOST_DIR})
+@@ -310,7 +307,6 @@ include_directories(
+     ${root}/deps/VectorSimilarity/src
+     ${root}/deps/rmalloc
+     ${root}/src/ttl_table
+-    ${BOOST_DIR}
+     ${root})
+ 
+ #----------------------------------------------------------------------------------------------
+diff --git a/build/boost/boost.cmake b/build/boost/boost.cmake
+index 1bee3ecef..85cc40f52 100644
+--- a/build/boost/boost.cmake
++++ b/build/boost/boost.cmake
+@@ -13,22 +13,5 @@ else()
+     message(STATUS "BOOST_DIR '${BOOST_DIR}' is not a valid boost directory path")
+     set(BOOST_ENABLE_CMAKE ON)
+ 
+-    message(STATUS "fetching boost")
+-
+-    include(FetchContent)
+-    # we want to see the progress of the download, so we set FETCHCONTENT_QUIET to false
+-    Set(FETCHCONTENT_QUIET FALSE)
+-    FetchContent_Declare(
+-            Boost
+-            URL https://github.com/boostorg/boost/releases/download/boost-1.88.0/boost-1.88.0-b2-nodocs.tar.gz
+-            USES_TERMINAL_DOWNLOAD TRUE
+-            DOWNLOAD_NO_EXTRACT FALSE
+-            DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+-    )
+-    FetchContent_MakeAvailable(Boost)
+-
+-    message(STATUS "boost fetched")
+-    message(STATUS "boost source dir: ${boost_SOURCE_DIR}")
+-    message(STATUS "boost binary dir: ${boost_BINARY_DIR}")
+-    set(BOOST_DIR ${boost_SOURCE_DIR})
++    find_package(Boost REQUIRED)
+ endif()

--- a/pkgs/by-name/re/redisearch/package.nix
+++ b/pkgs/by-name/re/redisearch/package.nix
@@ -1,0 +1,101 @@
+{
+  boost,
+  cargo,
+  cctools,
+  cmake,
+  fetchFromGitHub,
+  lib,
+  libxcrypt,
+  nix-update-script,
+  openssl,
+  redis,
+  rustPlatform,
+  stdenv,
+  vectorsimilarity,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "redisearch";
+  version = "8.8.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "RediSearch";
+    repo = "RediSearch";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-Wc7KHCoK2LUXvH8kQkGhABfsZd+hw/Nq9aLDKD9gNjQ=";
+    leaveDotGit = true;
+    postFetch = ''
+      # Fetcher fails to remove the `.git/modules` directory due it
+      # not being empty after all submodules have been initialized.
+      rm -rf $out/.git
+
+      # Remove unused submodules for legal compliance.
+      rm -rf $out/deps/{googletest,VectorSimilarity}
+    '';
+  };
+
+  cargoRoot = "src/redisearch_rs";
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) cargoRoot src;
+    hash = "sha256-YnlIOHRRBSan6uPVR9oYs9epRSLWKDXsKl0GmMWsc2s=";
+  };
+
+  patches = [
+    ./external-libs.patch
+    ./devendor-vectorsimilarity.patch
+  ];
+
+  makeFlags = [
+    "IGNORE_MISSING_DEPS=1"
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  postPatch = ''
+    # RediSearch needs a `.git` file to find the git root.
+    touch .git
+
+    patchShebangs build.sh
+  '';
+
+  nativeBuildInputs = [
+    cargo
+    cmake
+    rustPlatform.bindgenHook
+    rustPlatform.cargoSetupHook
+  ]
+  # Required for creating the combined library on darwin.
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ cctools.libtool ];
+
+  buildInputs = [
+    boost
+    libxcrypt
+    openssl
+    vectorsimilarity
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    cp bin/*/*/*.so $out/lib
+
+    runHook postInstall
+  '';
+
+  # Try to keep redis modules in sync with the version of redis.
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=${redis.version}" ];
+  };
+
+  meta = {
+    description = "Query and indexing engine for Redis";
+    license = lib.licenses.agpl3Only;
+    platforms = lib.platforms.all;
+    teams = [ lib.teams.redis ];
+  };
+})

--- a/pkgs/by-name/sc/scalablevectorsearch/external-libs.patch
+++ b/pkgs/by-name/sc/scalablevectorsearch/external-libs.patch
@@ -1,0 +1,94 @@
+diff --git a/cmake/eve.cmake b/cmake/eve.cmake
+index ae24bdd..39e88c6 100644
+--- a/cmake/eve.cmake
++++ b/cmake/eve.cmake
+@@ -12,13 +12,7 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-Include(FetchContent)
+-FetchContent_Declare(
+-    eve
+-    GIT_REPOSITORY https://github.com/jfalcou/eve
+-    GIT_TAG v2023.02.15
+-)
+ 
++find_package(eve REQUIRED)
+ set(EVE_BUILD_TEST OFF)
+-FetchContent_MakeAvailable(eve)
+ target_link_libraries(${SVS_LIB} INTERFACE eve::eve)
+diff --git a/cmake/fmt.cmake b/cmake/fmt.cmake
+index c6b6ba1..62688b4 100644
+--- a/cmake/fmt.cmake
++++ b/cmake/fmt.cmake
+@@ -13,10 +13,5 @@
+ 
+ set(CMAKE_POSITION_INDEPENDENT_CODE YES)
+ set(FMT_INSTALL YES)
+-FetchContent_Declare(
+-    fmt
+-    GIT_REPOSITORY https://github.com/fmtlib/fmt
+-    GIT_TAG 12.1.0
+-)
+-FetchContent_MakeAvailable(fmt)
++find_package(fmt REQUIRED)
+ target_link_libraries(${SVS_LIB} INTERFACE fmt::fmt)
+diff --git a/cmake/robin-map.cmake b/cmake/robin-map.cmake
+index 974f118..9fd880b 100644
+--- a/cmake/robin-map.cmake
++++ b/cmake/robin-map.cmake
+@@ -12,14 +12,7 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-Include(FetchContent)
+-FetchContent_Declare(
+-    RobinMap
+-    GIT_REPOSITORY https://github.com/Tessil/robin-map
+-    GIT_TAG v1.4.0
+-)
+-
++find_package(tsl-robin-map REQUIRED)
+ set(TSL_ROBIN_MAP_ENABLE_INSTALL ON CACHE BOOL "Enable robin-map install logic" FORCE)
+ 
+-FetchContent_MakeAvailable(RobinMap)
+ target_link_libraries(${SVS_LIB} INTERFACE tsl::robin_map)
+diff --git a/cmake/spdlog.cmake b/cmake/spdlog.cmake
+index 263fcc8..030fd5b 100644
+--- a/cmake/spdlog.cmake
++++ b/cmake/spdlog.cmake
+@@ -29,12 +29,7 @@ set(CMAKE_CXX_STANDARD ${SVS_CXX_STANDARD})
+ set(SPDLOG_INSTALL YES CACHE BOOL "" FORCE)
+ set(SPDLOG_FMT_EXTERNAL YES CACHE BOOL "" FORCE)
+ 
+-FetchContent_Declare(
+-    spdlog
+-    GIT_REPOSITORY https://github.com/gabime/spdlog
+-    GIT_TAG v1.15.3
+-)
+-FetchContent_MakeAvailable(spdlog)
++find_package(spdlog REQUIRED)
+ target_link_libraries(${SVS_LIB} INTERFACE spdlog::spdlog)
+ 
+ set(CMAKE_CXX_STANDARD ${PRESET_CMAKE_CXX_STANDARD})
+diff --git a/cmake/toml.cmake b/cmake/toml.cmake
+index 626e221..aa42f21 100644
+--- a/cmake/toml.cmake
++++ b/cmake/toml.cmake
+@@ -21,15 +21,8 @@ include(FetchContent)
+ # This hopefully allows us to modify our CMake infrastructure after an
+ # initial configuration without the patch being applied again and failing.
+ set(TOML_PATCH "${CMAKE_CURRENT_LIST_DIR}/patches/tomlplusplus_v330.patch")
+-FetchContent_Declare(
+-    tomlplusplus
+-    GIT_REPOSITORY https://github.com/marzer/tomlplusplus.git
+-    GIT_TAG        v3.3.0
+-    PATCH_COMMAND
+-    ${CMAKE_CURRENT_LIST_DIR}/patches/apply_patch_toml.sh ${TOML_PATCH}
+-)
+ 
++find_package(tomlplusplus REQUIRED)
+ # Set the override variable to enable toml++ installation.
+ set(TOMLPLUSPLUS_INSTALL ON)
+-FetchContent_MakeAvailable(tomlplusplus)
+ target_link_libraries(${SVS_LIB} INTERFACE tomlplusplus::tomlplusplus)

--- a/pkgs/by-name/sc/scalablevectorsearch/package.nix
+++ b/pkgs/by-name/sc/scalablevectorsearch/package.nix
@@ -1,0 +1,57 @@
+{
+  cmake,
+  eve,
+  fetchFromGitHub,
+  fmt,
+  lib,
+  robin-map,
+  spdlog,
+  stdenv,
+  tomlplusplus,
+}:
+
+let
+  # ScalableVectorSearch requires a custom patched version of toml++.
+  # https://github.com/intel/ScalableVectorSearch/blob/main/cmake/patches/tomlplusplus_v330.patch
+  tomlplusplus' = (
+    tomlplusplus.overrideAttrs (final: prev: { patches = prev.patches ++ [ ./tomlplusplus.patch ]; })
+  );
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "scalablevectorsearch";
+  version = "0.4.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "intel";
+    repo = "ScalableVectorSearch";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JoNUKOrFMDVz69/4WkEprL+EfTxcCF6sfwRk6Kf5x1E=";
+  };
+
+  patches = [ ./external-libs.patch ];
+
+  nativeBuildInputs = [ cmake ];
+
+  propagatedBuildInputs = [
+    eve
+    fmt
+    robin-map
+    spdlog
+    tomlplusplus'
+  ];
+
+  meta = {
+    changelog = "https://github.com/intel/ScalableVectorSearch/blob/${finalAttrs.src.tag}/NEWS.md";
+    description = "Intel's Scalable Vector Search library";
+    homepage = "https://github.com/intel/ScalableVectorSearch";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      hythera
+      miniharinn
+    ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/sc/scalablevectorsearch/tomlplusplus.patch
+++ b/pkgs/by-name/sc/scalablevectorsearch/tomlplusplus.patch
@@ -1,0 +1,37 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1179d37..59cf878 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -31,7 +31,8 @@ target_include_directories(
+ target_compile_features(tomlplusplus_tomlplusplus INTERFACE cxx_std_17)
+
+ # ---- Install rules and examples ----
+-if(PROJECT_IS_TOP_LEVEL)
++option(TOMLPLUSPLUS_INSTALL "Enable cmake installation" OFF)
++if(TOMLPLUSPLUS_INSTALL OR PROJECT_IS_TOP_LEVEL)
+   include(cmake/install-rules.cmake)
+   option(BUILD_EXAMPLES "Build examples tree." OFF)
+   if(BUILD_EXAMPLES)
+diff --git a/include/toml++/impl/make_node.h b/include/toml++/impl/make_node.h
+index 4b754b7..5ebc665 100644
+--- a/include/toml++/impl/make_node.hpp
++++ b/include/toml++/impl/make_node.hpp
+@@ -134,6 +134,18 @@ TOML_IMPL_NAMESPACE_START
+ 		return node_ptr{ make_node_impl(static_cast<T&&>(val), flags) };
+ 	}
+
++	TOML_NODISCARD
++	inline node_ptr make_node(node_ptr&& val, value_flags flags = preserve_source_value_flags)
++	{
++        return std::move(val);
++	}
++
++	TOML_NODISCARD
++	inline node_ptr make_node(const node_ptr& val, value_flags flags = preserve_source_value_flags)
++	{
++        return make_node(*val);
++	}
++
+ 	template <typename... T>
+ 	struct emplaced_type_of_
+ 	{

--- a/pkgs/by-name/ve/vectorsimilarity/external-libs.patch
+++ b/pkgs/by-name/ve/vectorsimilarity/external-libs.patch
@@ -1,0 +1,42 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3661cf7a..67fe6dc8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -62,22 +62,13 @@ if(VECSIM_BUILD_TESTS)
+ 	set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} ${LLVM_LD_FLAGS}")
+ 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} ${LLVM_LD_FLAGS}")
+ 
+-	FetchContent_Declare(
+-		googletest
+-		URL https://github.com/google/googletest/archive/refs/tags/v1.16.0.zip
+-	)
+-
+ 	# For Windows: Prevent overriding the parent project's compiler/linker settings
+ 	set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+-	FetchContent_MakeAvailable(googletest)
++  find_package(GTest REQUIRED)
+ 
+ 	option(BENCHMARK_ENABLE_GTEST_TESTS "" OFF)
+ 	option(BENCHMARK_ENABLE_TESTING "" OFF)
+-	FetchContent_Declare(
+-		google_benchmark
+-		URL https://github.com/google/benchmark/archive/refs/tags/v1.8.0.zip
+-	)
+-	FetchContent_MakeAvailable(google_benchmark)
++  find_package(benchmark REQUIRED)
+ 
+ 	add_subdirectory(tests/unit unit_tests)
+ 	add_subdirectory(tests/module module_tests)
+diff --git a/cmake/cpu_features.cmake b/cmake/cpu_features.cmake
+index 07f09776..06d20142 100644
+--- a/cmake/cpu_features.cmake
++++ b/cmake/cpu_features.cmake
+@@ -3,7 +3,6 @@ option(BUILD_TESTING "" OFF)
+ option(CMAKE_POSITION_INDEPENDENT_CODE "" ON)
+ FetchContent_Declare(
+ 	cpu_features
+-	GIT_REPOSITORY  https://github.com/google/cpu_features.git
+-	GIT_TAG         v0.10.1
++  URL @cpu_features_src@
+ )
+ FetchContent_MakeAvailable(cpu_features)

--- a/pkgs/by-name/ve/vectorsimilarity/install.patch
+++ b/pkgs/by-name/ve/vectorsimilarity/install.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3661cf7a..9695c765 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -90,8 +90,8 @@ endif()
+ add_subdirectory(src/VecSim)
+ 
+ # Needed for build as ExternalProject (like RediSearch does)
+-install(TARGETS VectorSimilarity DESTINATION ${CMAKE_INSTALL_PREFIX})
+-install(TARGETS VectorSimilaritySpaces DESTINATION ${CMAKE_INSTALL_PREFIX})
++install(TARGETS VectorSimilarity LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
++install(DIRECTORY src/VecSim DESTINATION ${CMAKE_INSTALL_PREFIX}/include FILES_MATCHING PATTERN "*.h")
+ 
+ # Print compiler flags (similar to RediSearch)
+ get_directory_property(COMPILE_DEFS COMPILE_DEFINITIONS)

--- a/pkgs/by-name/ve/vectorsimilarity/package.nix
+++ b/pkgs/by-name/ve/vectorsimilarity/package.nix
@@ -1,0 +1,50 @@
+{
+  cmake,
+  cpu_features,
+  fetchFromGitHub,
+  lib,
+  replaceVars,
+  scalablevectorsearch,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vectorsimilarity";
+  version = "8.6.0-unstable-2026-05-04";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "RedisAI";
+    repo = "VectorSimilarity";
+    rev = "8c5791f3977701e178c64193ef865b9ca513decf";
+    hash = "sha256-y+dDWy4x5nuwRt5x6fq9mKeVoP2sXzM8tiH+d6BMHp0=";
+  };
+
+  patches = [
+    ./install.patch
+    ./svs-find-package.patch
+    (replaceVars ./external-libs.patch {
+      cpu_features_src = cpu_features.src;
+    })
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "VECSIM_BUILD_TESTS" false)
+    (lib.cmakeFeature "VECSIM_LIBTYPE" "SHARED")
+    (lib.cmakeBool "SVS_SHARED_LIB" false)
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ scalablevectorsearch ];
+
+  meta = {
+    description = "Redis vector similarity search library";
+    homepage = "https://github.com/RedisAI/VectorSimilarity";
+    license = lib.licenses.agpl3Only;
+    platforms = lib.platforms.all;
+    teams = [ lib.teams.redis ];
+  };
+})

--- a/pkgs/by-name/ve/vectorsimilarity/svs-find-package.patch
+++ b/pkgs/by-name/ve/vectorsimilarity/svs-find-package.patch
@@ -1,0 +1,18 @@
+--- a/cmake/svs.cmake
++++ b/cmake/svs.cmake
+@@ -104,14 +104,7 @@
+         set(SVS_LVQ_HEADER "svs/extensions/vamana/lvq.h")
+         set(SVS_LEANVEC_HEADER "svs/extensions/vamana/leanvec.h")
+     else()
+-        # This file is included from both CMakeLists.txt and python_bindings/CMakeLists.txt
+-        # Set `root` relative to this file, regardless of where it is included from.
+-        get_filename_component(root ${CMAKE_CURRENT_LIST_DIR}/.. ABSOLUTE)
+-        set(SVS_EXPERIMENTAL_CHECK_BOUNDS OFF CACHE BOOL "Disable SVS bounds checking" FORCE)
+-        add_subdirectory(
+-            ${root}/deps/ScalableVectorSearch
+-            deps/ScalableVectorSearch
+-        )
++        find_package(svs REQUIRED)
+         set(SVS_LVQ_HEADER "svs/quantization/lvq/impl/lvq_impl.h")
+         set(SVS_LEANVEC_HEADER "svs/leanvec/impl/leanvec_impl.h")
+     endif()


### PR DESCRIPTION
Related to #525226

This PR brings [RediSearch](https://github.com/redisearch/redisearch) to nixpkgs. While we could devendor all dependencies like VectorSimilarity etc. I decided against it for now since it would make things a lot more complicated. The cmake setup is already a bit complex and annoying to work with as a lot of dependencies are fetched. But if someone is interested in devendoring, I have no objections in the future. This would also complete the Redis Stack and would allow us to provide a fill redis to users.

To test the module, add `loadmodule /nix/store/.../lib/redisearch.so` to your `redis.conf`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
