### PR TITLE
spice-up: drop unused libsoup 2.4 dependency, modernize

### DIFF
--- a/pkgs/by-name/sp/spice-up/package.nix
+++ b/pkgs/by-name/sp/spice-up/package.nix
@@ -15,19 +15,18 @@
   libevdev,
   libgee,
   libgudev,
-  libsoup_2_4,
   pantheon,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "spice-up";
   version = "1.9.1";
 
   src = fetchFromGitHub {
     owner = "Philip-Scott";
     repo = "Spice-up";
-    rev = version;
-    sha256 = "sha256-FI6YMbqZfaU19k8pS2eoNCnX8O8F99SHHOxMwHC5fTc=";
+    tag = finalAttrs.version;
+    hash = "sha256-FI6YMbqZfaU19k8pS2eoNCnX8O8F99SHHOxMwHC5fTc=";
   };
 
   nativeBuildInputs = [
@@ -46,11 +45,16 @@ stdenv.mkDerivation rec {
     libevdev
     libgee
     libgudev
-    libsoup_2_4
     pantheon.granite
   ];
 
+  # Drop dependency on libsoup 2.4, which is insecure. It's no longer actually
+  # used upstream, so this is harmless.
+  # https://github.com/Philip-Scott/Spice-up/issues/328
   postPatch = ''
+    substituteInPlace meson.build --replace-fail "soup_dep = dependency('libsoup-2.4')" ""
+    substituteInPlace src/meson.build --replace-fail "soup_dep," ""
+
     chmod +x meson/post_install.py
     patchShebangs meson/post_install.py
   '';
@@ -72,4 +76,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3Plus;
     mainProgram = "com.github.philip_scott.spice-up";
   };
-}
+})


### PR DESCRIPTION
Upstream no longer actually uses libsoup 2.4, as reported in https://github.com/Philip-Scott/Spice-up/issues/328. Since this is the case, and libsoup 2.4 is likely to be removed soon due to having had known vulnerabilities for years (#360897), we drop the dependency to keep this package working.

Tested by making a really basic presentation and trying to export it as PDF. Seems to work fine. 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
