### PR TITLE
gtk-server: 2.4.6 -> 2.4.7, use GTK4, modernize

### DIFF
--- a/pkgs/by-name/gt/gtk-server/package.nix
+++ b/pkgs/by-name/gt/gtk-server/package.nix
@@ -32,8 +32,6 @@ stdenv.mkDerivation (finalAttrs: {
     gtk3
   ];
 
-  configureOptions = [ "--with-gtk3" ];
-
   meta = {
     homepage = "http://www.gtk-server.org/";
     description = "Gtk-server for interpreted GUI programming";

--- a/pkgs/by-name/gt/gtk-server/package.nix
+++ b/pkgs/by-name/gt/gtk-server/package.nix
@@ -3,10 +3,10 @@
   stdenv,
   fetchurl,
   glib,
-  gtk3,
+  gtk4,
   libffcall,
   pkg-config,
-  wrapGAppsHook3,
+  wrapGAppsHook4,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -24,12 +24,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     pkg-config
-    wrapGAppsHook3
+    wrapGAppsHook4
   ];
   buildInputs = [
     libffcall
     glib
-    gtk3
+    gtk4
   ];
 
   meta = {

--- a/pkgs/by-name/gt/gtk-server/package.nix
+++ b/pkgs/by-name/gt/gtk-server/package.nix
@@ -11,11 +11,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gtk-server";
-  version = "2.4.6";
+  version = "2.4.7";
 
   src = fetchurl {
     url = "https://www.gtk-server.org/stable/gtk-server-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-sFL3y068oXDKgkEUcNnGVsNSPBdI1NzpsqdYJfmOQoA=";
+    hash = "sha256-YRvnE4fH5jWITSiMUbtlaOJFKAW0/Alzo1YVDlm8CO8=";
   };
 
   preConfigure = ''
@@ -35,6 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     homepage = "http://www.gtk-server.org/";
     description = "Gtk-server for interpreted GUI programming";
+    changelog = "http://www.gtk-server.org/notes.txt";
     license = lib.licenses.gpl2Plus;
     maintainers = [ ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/gt/gtk-server/package.nix
+++ b/pkgs/by-name/gt/gtk-server/package.nix
@@ -39,5 +39,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Plus;
     maintainers = [ ];
     platforms = lib.platforms.linux;
+    mainProgram = "gtk-server";
   };
 })

--- a/pkgs/by-name/gt/gtk-server/package.nix
+++ b/pkgs/by-name/gt/gtk-server/package.nix
@@ -33,9 +33,9 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
-    homepage = "http://www.gtk-server.org/";
+    homepage = "https://www.gtk-server.org/";
     description = "Gtk-server for interpreted GUI programming";
-    changelog = "http://www.gtk-server.org/notes.txt";
+    changelog = "https://www.gtk-server.org/notes.txt";
     license = lib.licenses.gpl2Plus;
     maintainers = [ ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
Note, I'm not familiar with the package and only stumbled upon it because of the `configureOptions`.
I did verify that `gtk-server -help` runs and I wanted to add it as a version check, but it seems to require a display.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
