### PR TITLE
cheese-paper: init at 1.0.0-unstable-2026-08-16

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2111,6 +2111,12 @@
     githubId = 4923335;
     name = "Alexey Orlenko";
   };
+  aquifolly = {
+    email = "oliviafloof@disroot.org";
+    github = "aquifolly";
+    githubId = 35699052;
+    name = "holly";
+  };
   ar1a = {
     email = "aria@ar1as.space";
     github = "ar1a";

--- a/pkgs/by-name/ch/cheese-paper/package.nix
+++ b/pkgs/by-name/ch/cheese-paper/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  rustPlatform,
+  pkg-config,
+  libgit2,
+  libxkbcommon,
+  openssl,
+  vulkan-loader,
+  zlib,
+  stdenv,
+  wayland,
+  nix-update-script,
+  fetchFromCodeberg,
+  dbus,
+  makeWrapper,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cheese-paper";
+  version = "1.0.0-unstable-2026-07-05";
+
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "ByteOfBrie";
+    repo = "cheese-paper";
+    rev = "c4554acd410604f56419fef66c1144859891c128";
+    hash = "sha256-rooocVpNqA3kvGgfwK9PVZupUiZLU0QyRIoN2zlc0zM=";
+    fetchLFS = true;
+  };
+  cargoHash = "sha256-LZCX40dq+NlD6EEaKD1JtKloUqudjO9IssAXOpmSWD8=";
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libgit2
+    libxkbcommon
+    openssl
+    vulkan-loader
+    zlib
+  ]
+  ++ lib.optionals stdenv.isLinux [
+    wayland
+  ];
+
+  # disable update checking
+  buildNoDefaultFeatures = true;
+
+  postFixup = ''
+    wrapProgram $out/bin/cheese-paper \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          wayland
+          vulkan-loader
+          libxkbcommon
+          dbus
+        ]
+      }
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Organized writing tool with simple file format";
+    homepage = "https://codeberg.org/ByteOfBrie/cheese-paper";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ aquifolly ];
+    mainProgram = "cheese-paper";
+  };
+})


### PR DESCRIPTION
https://codeberg.org/ByteOfBrie/cheese-paper
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
