### PR TITLE
vimPlugins.fff-nvim: 0.8.0 -> 0.8.4

### DIFF
--- a/pkgs/applications/editors/vim/plugins/non-generated/fff-nvim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/fff-nvim/default.nix
@@ -13,18 +13,18 @@
   writableTmpDirAsHomeHook,
 }:
 let
-  version = "0.8.0";
+  version = "0.8.4";
   src = fetchFromGitHub {
     owner = "dmtrKovalenko";
     repo = "fff.nvim";
     tag = "v${version}";
-    hash = "sha256-JbV2dTQhTyZgDZYvFoR1mz9CeM2IPv59Qmp2iiJC8a0=";
+    hash = "sha256-w88NovzYVTiUVZmgvvmRvRq1didlbxMJYtKj1A3VB/Y=";
   };
   fff-nvim-lib = rustPlatform.buildRustPackage {
     pname = "fff-nvim-lib";
     inherit version src;
 
-    cargoHash = "sha256-L/Ens/wzw/jKaa1T3A2pLIBKs09saPEk/0bRhgRezPQ=";
+    cargoHash = "sha256-2LGrohseOYdroUFY3cHy57HzgfS34CBuIbN1AFuYTUg=";
 
     cargoBuildFlags = [
       "-p"
@@ -65,9 +65,12 @@ let
       openssl
     ];
 
-    # This test requires curl and GitHub access
     checkFlags = [
+      # This test requires curl and GitHub access
       "--skip=update_check::tests::test_update_check_end_to_end"
+
+      # This test depends on catching a race window and is not deterministic
+      "--skip=drop_during_post_scan_does_not_crash"
     ];
 
     env = {


### PR DESCRIPTION
https://github.com/dmtrKovalenko/fff/compare/v0.8.0...v0.8.4

Skipped the `drop_during_post_scan_does_not_crash` test recently added upstream, which failed locally when building:
```
nix build .#vimPlugins.fff-nvim --impure
error: Cannot build '/nix/store/rc9qv0wbyyzy100jwc6qkagnpj7bjfxa-fff-nvim-lib-0.8.4.drv'.
       Reason: builder failed with exit code 101.
       Output paths:
         /nix/store/2s0kj741qi8cmhbl82z27pbnydyvjr9l-fff-nvim-lib-0.8.4
...
       > thread 'drop_during_post_scan_does_not_crash' (8742) panicked at crates/fff-core/tests/fuzz_file_operations.rs:854:5:
       > Test didn't catch post_scan_indexing_active=true in any round. The test is not exercising the race. (0/10)
...
       > error: test failed, to rerun pass `-p fff-search --test fuzz_file_operations`
error: Cannot build '/nix/store/p5z6lagm8b5hh6ccvgm1rqqqmri019bi-vimplugin-fff.nvim-0.8.4.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/5rbn18aycz6chkpqs24xgbx19iw77gbm-vimplugin-fff.nvim-0.8.4
❌ git+file:///home/bridgesense/Documents/Tools/nixpkgs?shallow=1#vimPlugins.fff-nvim
error: Build failed due to failed dependency
```
This test depends on catching a race window and is not deterministic:
https://github.com/dmtrKovalenko/fff/blob/5e53b6e8cf83913d51a63b54f606b07d6e4de4bc/crates/fff-core/tests/fuzz_file_operations.rs#L779

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
