### PR TITLE
mihomo: add missing permissions for TUN

### DIFF
--- a/nixos/modules/services/networking/mihomo.nix
+++ b/nixos/modules/services/networking/mihomo.nix
@@ -67,6 +67,25 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    security.polkit = lib.mkIf (cfg.tunMode && config.services.resolved.enable) {
+      enable = lib.mkDefault true;
+      extraConfig = ''
+        // systemd-resolved access for Mihomo TUN DNS setup
+        polkit.addRule(function(action, subject) {
+          var actions = [
+            "org.freedesktop.resolve1.revert",
+            "org.freedesktop.resolve1.set-default-route",
+            "org.freedesktop.resolve1.set-dns-servers",
+            "org.freedesktop.resolve1.set-domains",
+          ];
+
+          if (actions.indexOf(action.id) >= 0 && subject.user == "mihomo") {
+            return polkit.Result.YES;
+          }
+        });
+      '';
+    };
+
     ### systemd service
     systemd.services."mihomo" = {
       description = "Mihomo daemon, A rule-based proxy in Go.";
@@ -118,7 +137,7 @@ in
       // lib.optionalAttrs cfg.tunMode {
         PrivateDevices = false;
         PrivateUsers = false;
-        RestrictAddressFamilies = "AF_INET AF_INET6 AF_NETLINK";
+        RestrictAddressFamilies = "AF_UNIX AF_INET AF_INET6 AF_NETLINK";
       };
     };
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Mihomo uses sing-tun under the hood. With TUN mode enabled on system with systemd-resolved, it invokes `resolvectl` to configure DNS hijacking. Currently these calls will fail because they fail to authenticate with polkit.

This PR adds necessary permission for this calls to apply successfully.

Upstream code has no error handling for this, there won't be any error message or log, but the effect can be easily observed via `resolvectl status`. The TUN device should have DNS server configured (`198.18.0.2` by default) and set itself as default route.

Ref: https://github.com/SagerNet/sing-tun/blob/eb58efc8915db6b27256690a4b777eacb4834eb7/tun_linux.go#L1092-L1105

Disclosure: the diagnose is assisted by codex.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
