### PR TITLE
bintools-wrapper: add bare ld symlink for pseudo-cross builds

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -267,6 +267,19 @@ stdenvNoCC.mkDerivation {
       wrap ${targetPrefix}ld ${./ld-wrapper.sh} ''${ld:-$ldPath/${targetPrefix}ld}${exeSuffix}
     fi
 
+    ${optionalString (targetPrefix != "" && targetPlatform.config == stdenvNoCC.hostPlatform.config) ''
+      # Pseudo-cross: targetPlatform.config == hostPlatform.config but gcc.arch differs
+      # (e.g. x86_64-unknown-linux-gnu with meteorlake vs generic). GCC's collect2
+      # identifies build==target by config string alone and calls bare `ld`, not the
+      # prefixed one. Symlink bare `ld` -> `${targetPrefix}ld` so collect2 finds it.
+      if [ -e "$out/bin/${targetPrefix}ld${exeSuffix}" ]; then
+        ln -sf "${targetPrefix}ld${exeSuffix}" "$out/bin/ld${exeSuffix}"
+      fi
+      if [ -e "$out/bin/${targetPrefix}ld.bfd${exeSuffix}" ]; then
+        ln -sf "${targetPrefix}ld.bfd${exeSuffix}" "$out/bin/ld.bfd${exeSuffix}"
+      fi
+    ''}
+
     for variant in $ldPath/${targetPrefix}ld.*${exeSuffix}; do
       basename=$(basename "${if exeSuffix != "" then "\${variant%${exeSuffix}}" else "$variant"}")
       wrap $basename ${./ld-wrapper.sh} $variant


### PR DESCRIPTION
## Summary

When `hostPlatform` and `buildPlatform` share the same config string (e.g. `x86_64-unknown-linux-gnu`) but differ in `gcc.arch` (e.g. `meteorlake` vs generic), nixpkgs treats the build as cross and creates a *prefixed* `bintools-wrapper` — but GCC's `collect2` identifies build==target by config string alone and calls bare `ld`, not the prefixed one. The bare `ld` doesn't exist in the wrapper, so any package that goes through `stdenvNoLibc` (musl, glibc, libgcc) fails with:

```
collect2: fatal error: cannot find 'ld'
compilation terminated.
```

This fix adds a `ld` → `${targetPrefix}ld` symlink (and likewise for `ld.bfd`) when `targetPrefix` is non-empty but the target config string matches the host — exactly the pseudo-cross condition.

The condition in full:

```nix
${optionalString (targetPrefix != "" && targetPlatform.config == stdenvNoCC.hostPlatform.config) ''
  if [ -e "$out/bin/${targetPrefix}ld${exeSuffix}" ]; then
    ln -sf "${targetPrefix}ld${exeSuffix}" "$out/bin/ld${exeSuffix}"
  fi
  if [ -e "$out/bin/${targetPrefix}ld.bfd${exeSuffix}" ]; then
    ln -sf "${targetPrefix}ld.bfd${exeSuffix}" "$out/bin/ld.bfd${exeSuffix}"
  fi
''}
```

- `targetPrefix != ""` — true only for cross/pseudo-cross wrappers; native builds have an empty prefix so no symlink is added there.
- `targetPlatform.config == stdenvNoCC.hostPlatform.config` — true only for pseudo-cross (same ISA, different microarch attrs); genuine cross has mismatched config strings so collect2 won't call bare `ld` there anyway.

## Motivation / context

Tested on an Intel Meteor Lake machine (`gcc.arch = "meteorlake"`) where the upstream config produces a pseudo-cross stdenv. `pkgs.musl` (built against `stdenvNoLibc`) previously failed at the `collect2: cannot find 'ld'` stage; with this patch it builds cleanly.

Reproduced and verified locally with `nix build --override-input nixpkgs path:/patched-nixpkgs`.

## Things done

- [x] I've read [`CONTRIBUTING.md`](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [x] Written a meaningful commit message
- [x] Tests added / existing tests still pass (build of `pkgs.musl` on affected hardware passes)

## Built on platform(s)

- [x] `x86_64-linux` (Meteor Lake, pseudo-cross stdenv with `gcc.arch = "meteorlake"`)

## Automation/AI policy

- [x] This contribution was assisted by an LLM. The `Assisted-by:` trailer is present in the commit: `Assisted-by: Claude claude-sonnet-4-6 (Anthropic)`.