### PR TITLE
cdecl: 18.5 -> 18.7.2

### DIFF
--- a/pkgs/by-name/cd/cdecl/package.nix
+++ b/pkgs/by-name/cd/cdecl/package.nix
@@ -11,17 +11,20 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cdecl";
-  version = "18.5";
+  version = "18.7.2";
 
   src = fetchFromGitHub {
     owner = "paul-j-lucas";
     repo = "cdecl";
     tag = "cdecl-${finalAttrs.version}";
-    hash = "sha256-cC098+W8cbcumBv+3ZFwGYXmens4u0aQSx5Lvw6maYM=";
+    hash = "sha256-j6NEKnc/2j4Btlo1fzTWoO0DdqRNV9iksRQCADaW3w8=";
   };
 
   strictDeps = true;
-  preConfigure = "./bootstrap";
+  preConfigure = ''
+    mkdir .git
+    ./bootstrap
+  '';
 
   nativeBuildInputs = [
     autoconf
@@ -40,6 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
       ++ lib.optionals stdenv.cc.isClang [
         "-Wno-error=int-conversion"
         "-Wno-error=incompatible-function-pointer-types"
+        "-Wno-implicit-function-declaration"
       ]
     );
     NIX_LDFLAGS = "-lreadline";


### PR DESCRIPTION
Update to 18.7.2

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
