### PR TITLE
bintools-wrapper: add bare ld symlink for pseudo-cross builds

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -267,6 +267,19 @@ stdenvNoCC.mkDerivation {
       wrap ${targetPrefix}ld ${./ld-wrapper.sh} ''${ld:-$ldPath/${targetPrefix}ld}${exeSuffix}
     fi
 
+    ${optionalString (targetPrefix != "" && targetPlatform.config == stdenvNoCC.hostPlatform.config) ''
+      # Pseudo-cross: targetPlatform.config == hostPlatform.config but gcc.arch differs
+      # (e.g. x86_64-unknown-linux-gnu with meteorlake vs generic). GCC's collect2
+      # identifies build==target by config string alone and calls bare `ld`, not the
+      # prefixed one. Symlink bare `ld` -> `${targetPrefix}ld` so collect2 finds it.
+      if [ -e "$out/bin/${targetPrefix}ld${exeSuffix}" ]; then
+        ln -sf "${targetPrefix}ld${exeSuffix}" "$out/bin/ld${exeSuffix}"
+      fi
+      if [ -e "$out/bin/${targetPrefix}ld.bfd${exeSuffix}" ]; then
+        ln -sf "${targetPrefix}ld.bfd${exeSuffix}" "$out/bin/ld.bfd${exeSuffix}"
+      fi
+    ''}
+
     for variant in $ldPath/${targetPrefix}ld.*${exeSuffix}; do
       basename=$(basename "${if exeSuffix != "" then "\${variant%${exeSuffix}}" else "$variant"}")
       wrap $basename ${./ld-wrapper.sh} $variant


### PR DESCRIPTION
When `hostPlatform` and `buildPlatform` share the same config string but differ in `gcc.arch` (pseudo-cross), nixpkgs builds a prefixed `bintools-wrapper`. GCC's `collect2` identifies build==target by config string alone and calls bare `ld` — which doesn't exist in the wrapper, causing `collect2: fatal error: cannot find 'ld'`.

Adds bare `ld` -> `${targetPrefix}ld` symlink when `targetPrefix` is non-empty but config strings match.

**Before** (unpatched, pseudo-cross host with `gcc.arch = "meteorlake"`):
collect2: fatal error: cannot find 'ld'
compilation terminated.

**After** (`pkgs.musl` builds cleanly with `--override-input nixpkgs path:/patched-nixpkgs`):
/nix/store/ac8ilqn4nm8l03syh043ffwrh48v1z8i-musl-x86_64-unknown-linux-gnu-1.2.5

Assisted-by: Claude claude-sonnet-4-6 (Anthropic)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test