### PR TITLE
goldendict-ng: 26.3.0 -> 26.5.6

### DIFF
--- a/pkgs/by-name/go/goldendict-ng/package.nix
+++ b/pkgs/by-name/go/goldendict-ng/package.nix
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "goldendict-ng";
-  version = "26.3.0";
+  version = "26.5.6";
 
   src = fetchFromGitHub {
     owner = "xiaoyifang";
     repo = "goldendict-ng";
-    tag = "v${finalAttrs.version}-Release.fce2b872";
-    hash = "sha256-DLo3dVoeib/lIp6jKeMyeREN6pHufa3HhyNIxtu3Q94=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Y/I03WqEkgg1O8AP6lAcf6H6Uys4SL6zAqx+zxMuNEM=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
Update to 26.5.6

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
