### PR TITLE
boa: 0.20 -> 0.21.1, adopt package

### DIFF
--- a/pkgs/by-name/bo/boa/package.nix
+++ b/pkgs/by-name/bo/boa/package.nix
@@ -48,6 +48,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       mit # or
       unlicense
     ];
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ iamanaws ];
   };
 })

--- a/pkgs/by-name/bo/boa/package.nix
+++ b/pkgs/by-name/bo/boa/package.nix
@@ -10,17 +10,20 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "boa";
-  version = "0.20";
+  version = "0.21.1";
 
   src = fetchFromGitHub {
     owner = "boa-dev";
     repo = "boa";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-foCIzzFoEpcE6i0QrSbiob3YHIOeTpjwpAMtcPGL8Vg=";
+    hash = "sha256-APzbYaQ9DF7jpr7tRvF/RWpD3TTm/4pApFf4WNcQ9XU=";
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-PphgRSVCj724eYAC04Orpz/klYuAhphiQ3v5TRChs+w=";
+  cargoHash = "sha256-DcSTYNpoLWIy35dHUc52ASpmkzdCwDmDlY9fFKOfJpw=";
+
+  # cargo-auditable fails on `dep:either`.
+  auditable = false;
 
   cargoBuildFlags = [
     "--package"
@@ -41,13 +44,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Embeddable and experimental Javascript engine written in Rust";
-    mainProgram = "boa";
     homepage = "https://github.com/boa-dev/boa";
-    changelog = "https://github.com/boa-dev/boa/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/boa-dev/boa/releases/tag/${finalAttrs.src.tag}";
     license = with lib.licenses; [
       mit # or
       unlicense
     ];
+    mainProgram = "boa";
     maintainers = with lib.maintainers; [ iamanaws ];
   };
 })


### PR DESCRIPTION
Changelog
https://github.com/boa-dev/boa/releases/tag/v0.21
https://github.com/boa-dev/boa/releases/tag/v0.21.1
https://github.com/boa-dev/boa/compare/v0.20...v0.21.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
