### PR TITLE
csol: init at 1.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9939,6 +9939,12 @@
     githubId = 104317939;
     name = "gilice";
   };
+  gimura = {
+    email = "gimura0001@gmail.com";
+    github = "gimura2022";
+    githubId = 109300813;
+    name = "gimura";
+  };
   gin66 = {
     email = "jochen@kiemes.de";
     github = "gin66";

--- a/pkgs/by-name/cs/csol/package.nix
+++ b/pkgs/by-name/cs/csol/package.nix
@@ -1,0 +1,52 @@
+{
+  stdenv,
+  lib,
+  cmake,
+  ncurses,
+  fetchFromGitHub,
+  makeWrapper,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "csol";
+  version = "1.6.0";
+
+  src = fetchFromGitHub {
+    owner = "nielssp";
+    repo = "csol";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-EWQL63xE6Z7npXH5ht5KYtQaPrDwuPe2ZhmHrvYIAu8=";
+  };
+
+  __structuredAttrs = true;
+
+  strictDeps = true;
+
+  patches = [ ./replace-etc-path.patch ];
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+  ];
+  buildInputs = [ ncurses ];
+
+  postFixup = ''
+    wrapProgram $out/bin/csol \
+      --add-flags "-c $out/etc/xdg/csol/csolrc"
+  '';
+
+  cmakeFlags = [
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+  ];
+
+  hardeningDisable = [ "format" ];
+
+  meta = {
+    description = "A small collection of solitaire/patience games (Klondike, FreeCell, Spider, Yukon, etc.) to play in the terminal";
+    license = lib.licenses.mit;
+    homepage = "https://nielssp.dk/csol";
+    changelog = "https://github.com/nielssp/csol/releases/tag/v${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ gimura ];
+    mainProgram = "csol";
+  };
+})

--- a/pkgs/by-name/cs/csol/replace-etc-path.patch
+++ b/pkgs/by-name/cs/csol/replace-etc-path.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6c17703..70896f7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -21,7 +21,7 @@ add_executable(csol ${SRC_LIST} csolrc)
+ target_link_libraries(csol ${CURSES_LIBRARIES})
+ 
+ install(TARGETS csol DESTINATION bin COMPONENT binaries)
+-install(FILES "${CMAKE_BINARY_DIR}/csolrc" DESTINATION /etc/xdg/csol COMPONENT config)
+-install(DIRECTORY "${CMAKE_BINARY_DIR}/themes" DESTINATION /etc/xdg/csol COMPONENT config)
+-install(DIRECTORY "${CMAKE_BINARY_DIR}/games" DESTINATION /etc/xdg/csol COMPONENT config)
++install(FILES "${CMAKE_BINARY_DIR}/csolrc" DESTINATION etc/xdg/csol COMPONENT config)
++install(DIRECTORY "${CMAKE_BINARY_DIR}/themes" DESTINATION etc/xdg/csol COMPONENT config)
++install(DIRECTORY "${CMAKE_BINARY_DIR}/games" DESTINATION etc/xdg/csol COMPONENT config)
+ install(FILES "${PROJECT_SOURCE_DIR}/doc/csol.6" DESTINATION ${CMAKE_INSTALL_PREFIX}/share/man/man6)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Description of changes
Add one new package:
- `csol` - small collection of solitaire/patience games from https://github.com/nielssp/csol/tree/master

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
