### PR TITLE
 python313Packages.pygobject: add option to build without cairo;  networkd-dispatcher: use pygobject3 without cairo 

### DIFF
--- a/pkgs/by-name/ne/networkd-dispatcher/package.nix
+++ b/pkgs/by-name/ne/networkd-dispatcher/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     (python3.withPackages (ps: [
       ps.dbus-python
-      ps.pygobject3
+      (ps.pygobject3.override { withCairo = false; })
     ]))
   ];
 

--- a/pkgs/development/python-modules/pygobject/3.nix
+++ b/pkgs/development/python-modules/pygobject/3.nix
@@ -13,6 +13,8 @@
   ninja,
   gnome,
   python,
+
+  withCairo ? true,
 }:
 
 buildPythonPackage rec {
@@ -41,14 +43,18 @@ buildPythonPackage rec {
   ];
 
   buildInputs = [
-    cairo
     glib
+  ]
+  ++ lib.optionals withCairo [
+    cairo
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ ncurses ];
 
   propagatedBuildInputs = [
-    pycairo
     gobject-introspection # e.g. try building: python3Packages.urwid python3Packages.pydbus
+  ]
+  ++ lib.optionals withCairo [
+    pycairo
   ];
 
   # Fixes https://github.com/NixOS/nixpkgs/issues/378447
@@ -61,7 +67,9 @@ buildPythonPackage rec {
     # This is only used for figuring out what version of Python is in
     # use, and related stuff like figuring out what the install prefix
     # should be, but it does need to be able to execute Python code.
-    "-Dpython=${python.pythonOnBuildForHost.interpreter}"
+    (lib.mesonOption "python" python.pythonOnBuildForHost.interpreter)
+
+    (lib.mesonEnable "pycairo" withCairo)
   ];
 
   passthru = {


### PR DESCRIPTION
This avoids a bunch of graphical dependencies on headless servers that use networkd-dispatcher.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
