### PR TITLE
rqlite: 9.4.5 -> 10.2.0, adopt package

### DIFF
--- a/pkgs/by-name/rq/rqlite/package.nix
+++ b/pkgs/by-name/rq/rqlite/package.nix
@@ -2,43 +2,52 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  stdenv,
 }:
 
-buildGoModule (finalAttrs: {
-  pname = "rqlite";
-  version = "9.4.5";
+buildGoModule (
+  finalAttrs:
+  let
+    cmdPackage = "github.com/rqlite/rqlite/v${lib.versions.major finalAttrs.version}/cmd";
+  in
+  {
+    pname = "rqlite";
+    version = "10.2.0";
 
-  src = fetchFromGitHub {
-    owner = "rqlite";
-    repo = "rqlite";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-jvqmRmURAvo0bNrwgft95oHupRf8FJaB3XRgnU43wRo=";
-  };
+    src = fetchFromGitHub {
+      owner = "rqlite";
+      repo = "rqlite";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-XpdI3OFkMHlnUQ6LXo/NDagRwaRkQMq2UmFg4MOKNJ4=";
+    };
 
-  vendorHash = "sha256-PPmX/KbNO/LEwGlw8bziek4uDd5sgDo3+wNlBJm/qA4=";
+    vendorHash = "sha256-7f9A9BnENKF7kRftB/ii1EQeHMsYp9ZSb5T474ngs6E=";
 
-  subPackages = [
-    "cmd/rqlite"
-    "cmd/rqlited"
-    "cmd/rqbench"
-  ];
+    subPackages = [
+      "cmd/rqlite"
+      "cmd/rqlited"
+      "cmd/rqbench"
+    ];
 
-  # Leaving other flags from https://github.com/rqlite/rqlite/blob/master/package.sh
-  # since automatically retrieving those is nontrivial and inessential
-  ldflags = [
-    "-s"
-    "-w"
-    "-X github.com/rqlite/rqlite/cmd.Version=${finalAttrs.version}"
-  ];
+    # Mirror the upstream release build metadata
+    ldflags = [
+      "-s"
+      "-X ${cmdPackage}.CompilerCommand=${stdenv.cc.targetPrefix}cc"
+      "-X ${cmdPackage}.Version=${finalAttrs.version}"
+      "-X ${cmdPackage}.Branch=${finalAttrs.src.tag}"
+      "-X ${cmdPackage}.Commit=${finalAttrs.src.tag}"
+      "-X ${cmdPackage}.Buildtime=1970-01-01T00:00:00Z"
+    ];
 
-  # Tests are in a different subPackage which fails trying to access the network
-  doCheck = false;
+    doCheck = true;
 
-  meta = {
-    description = "Lightweight, distributed relational database built on SQLite";
-    homepage = "https://github.com/rqlite/rqlite";
-    changelog = "https://github.com/rqlite/rqlite/blob/${finalAttrs.src.tag}/CHANGELOG.md";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ iamanaws ];
-  };
-})
+    meta = {
+      description = "Lightweight, fault-tolerant, distributed relational database built on SQLite";
+      homepage = "https://github.com/rqlite/rqlite";
+      changelog = "https://github.com/rqlite/rqlite/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+      license = lib.licenses.mit;
+      mainProgram = "rqlite";
+      maintainers = with lib.maintainers; [ iamanaws ];
+    };
+  }
+)

--- a/pkgs/by-name/rq/rqlite/package.nix
+++ b/pkgs/by-name/rq/rqlite/package.nix
@@ -39,6 +39,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/rqlite/rqlite";
     changelog = "https://github.com/rqlite/rqlite/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ iamanaws ];
   };
 })


### PR DESCRIPTION
Supersedes https://github.com/NixOS/nixpkgs/pull/514292

https://github.com/rqlite/rqlite
https://github.com/rqlite/rqlite/blob/v10.2.0/CHANGELOG.md

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
