### PR TITLE
nixseparatedebuginfod2: 2.0.0 -> 2.0.1

### DIFF
--- a/pkgs/by-name/ni/nixseparatedebuginfod2/package.nix
+++ b/pkgs/by-name/ni/nixseparatedebuginfod2/package.nix
@@ -17,16 +17,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nixseparatedebuginfod2";
-  version = "2.0.0";
+  version = "2.0.1";
 
   src = fetchFromGitHub {
     owner = "symphorien";
     repo = "nixseparatedebuginfod2";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-D327Pz3oHOHgfekXnDRQ0l+GrIcFUK1zcIqzR2Y3zqU=";
+    hash = "sha256-PG/TqfXTuricAcwCB+2dKlVgHXxhCVVRJaVJ5v0xd4o=";
   };
 
-  cargoHash = "sha256-iAhm54jb+5Nv/XG6GYpoEgPjYmBTHvEnnmynFF8D8n4=";
+  cargoHash = "sha256-XDkW1tCSvmiTU0GN3L0oL0uhgWYQSlxRIV0xcwSlgkY=";
 
   buildInputs = [
     libarchive
@@ -56,12 +56,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   passthru.tests = { inherit (nixosTests) nixseparatedebuginfod2; };
 
-  # flaky tests
-  checkFlags = [ "--skip=substituter::http" ];
-
   meta = {
     description = "Downloads and provides debug symbols and source code for nix derivations to gdb and other debuginfod-capable debuggers as needed";
     homepage = "https://github.com/symphorien/nixseparatedebuginfod2";
+    changelog = "https://https://github.com/symphorien/nixseparatedebuginfod2/blob/v${finalAttrs.version}/CHANGELOG.md/";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       symphorien


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
