### PR TITLE
wml: migrate to pcre2

### DIFF
--- a/pkgs/by-name/wm/wml/package.nix
+++ b/pkgs/by-name/wm/wml/package.nix
@@ -5,7 +5,7 @@
   lynx,
   makeBinaryWrapper,
   ncurses,
-  pcre,
+  pcre2,
   perl,
   perlPackages,
   stdenv,
@@ -31,13 +31,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "wml";
-  version = "2.32.0-unstable-2025-12-23";
+  version = "2.32.0-unstable-2026-05-08";
 
   src = fetchFromGitHub {
     owner = "thewml";
     repo = "website-meta-language";
-    rev = "de200ecef0b2a64553799b1d83dfa65580d0bc16";
-    hash = "sha256-okeDaCX4Pp5qVFfHmaz+keagX6vgzFTtGoiim/pW6IA=";
+    rev = "673e78b37887f4d40c422759d634913c52e7334d";
+    hash = "sha256-rAxVha2Y16tEF+rLqebbAgBVPNrxYhNhvXnQ6/Oq1bg=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src";
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = perlDeps ++ [
     ncurses
-    pcre
+    pcre2
     perl
   ];
 


### PR DESCRIPTION
Upstream Link: https://github.com/thewml/website-meta-language/commit/673e78b37887f4d40c422759d634913c52e7334d

Tracking Link: https://github.com/NixOS/nixpkgs/issues/356387


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
