### PR TITLE
zsh-artisan: init at 0-unstable-2025-12-08

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8719,6 +8719,13 @@
     githubId = 345808;
     name = "Jakub Okoński";
   };
+  FatBoyXPC = {
+    name = "FatBoyXPC";
+    email = "fatboyxpc@gmail.com";
+    github = "FatBoyXPC";
+    githubId = 744962;
+    keys = [ { fingerprint = "0E08 1B81 CBCA 1CF7 9568  A13F C4ED 3CA2 3211 8969"; } ];
+  };
   faukah = {
     github = "faukah";
     name = "faukah";

--- a/pkgs/by-name/zs/zsh-artisan/package.nix
+++ b/pkgs/by-name/zs/zsh-artisan/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "zsh-artisan";
+  version = "0-unstable-2025-12-08";
+
+  src = fetchFromGitHub {
+    owner = "jessarcher";
+    repo = "zsh-artisan";
+    rev = "4063d53fd310f715c7a8fb7d4e133812ef0b3128";
+    hash = "sha256-O0Tn9zQWR0i7UWJ9VtOvxjqpqz9Sj7aKogdHZSOATC0=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+  installPhase = ''
+    runHook preInstall
+
+    install -D artisan.plugin.zsh --target-directory=$out/share/zsh-artisan
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Laravel artisan plugin for zsh";
+    longDescription = ''
+      Laravel artisan plugin for zsh to help you to run artisan from anywhere in the project tree,
+      with auto-completion, and it can automatically open files created by artisan!
+    '';
+    homepage = "https://github.com/jessarcher/zsh-artisan";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.FatBoyXPC ];
+  };
+}


### PR DESCRIPTION
Adding the zsh-artisan zsh plugin to nixpkgs. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
