### PR TITLE
libr3: migrate to pcre2 and modernize

### DIFF
--- a/pkgs/by-name/li/libr3/package.nix
+++ b/pkgs/by-name/li/libr3/package.nix
@@ -2,21 +2,25 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  pcre,
+  pcre2,
   pkg-config,
   check,
   autoreconfHook,
+  testers,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  pname = "r3";
-  version = "1.3.4";
+  pname = "libr3";
+  version = "2.0.0-unstable-2025-11-24";
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "c9s";
     repo = "r3";
-    rev = finalAttrs.version;
-    sha256 = "09cixbms817p6nb77wz3rxp0znnac8ybycvsrrzgwlbfn58a3zwl";
+    rev = "b07a1d4dfe02766f104307ec8f00bb74c549bdd4";
+    hash = "sha256-qsnkzciPuBoz2ZJWQUEjieBIY5ix2coFTJaGtDBH6uo=";
   };
 
   nativeBuildInputs = [
@@ -24,15 +28,19 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
 
-  buildInputs = [ check ];
-  propagatedBuildInputs = [ pcre ];
+  buildInputs = [
+    check
+    pcre2
+  ];
 
-  strictDeps = true;
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
 
   meta = {
     description = "High-performance path dispatching library";
     homepage = "https://github.com/c9s/r3";
     license = [ lib.licenses.mit ];
+    pkgConfigModules = [
+      "r3"
+    ];
   };
-
 })


### PR DESCRIPTION
Link: https://github.com/NixOS/nixpkgs/issues/356387


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
