### PR TITLE
togl, libtogl: init at 0.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25853,6 +25853,12 @@
     github = "sjmonson";
     githubId = 17662218;
   };
+  smorin = {
+    name = "Steve Morin";
+    email = "steve.morin@gmail.com";
+    github = "smorin";
+    githubId = 124719;
+  };
   smrehman = {
     name = "Syed Moiz Ur Rehman";
     email = "smrehman@proton.me";

--- a/pkgs/by-name/li/libtogl/package.nix
+++ b/pkgs/by-name/li/libtogl/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "libtogl";
+  version = "0.5.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "smorin";
+    repo = "toggle";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JUs98p2FDWG4/0mh8LnX0UhPOKIuaBFBixqdnhjxGyM=";
+  };
+
+  cargoHash = "sha256-LO8dAvm9OegESxobknPBF5FrSCcQ29qNymPATWJ14z4=";
+
+  # Build only the FFI crate (produces the static + shared C library).
+  cargoBuildFlags = [
+    "-p"
+    "togl-ffi"
+  ];
+
+  # The crate's C smoke test shells out to a C compiler and a nested cargo
+  # build, which is impractical in the sandbox; the FFI surface is covered by
+  # the crate's Rust unit tests upstream.
+  doCheck = false;
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  # cargoInstallHook installs the built `libtogl.{a,so/dylib}` into $out/lib.
+  # Keep the shared library in $out (runtime); move the static library to $dev
+  # alongside the header and pkg-config file (development closure).
+  postInstall = ''
+    install -Dm444 "$out/lib/libtogl.a" -t "$dev/lib"
+    rm "$out/lib/libtogl.a"
+
+    # Install the committed header and pkg-config template from the fetched
+    # source, not the build dir — independent of whether build.rs regenerated
+    # the header during compilation.
+    install -Dm444 ${finalAttrs.src}/crates/togl-ffi/include/togl.h -t "$dev/include"
+
+    mkdir -p "$dev/lib/pkgconfig"
+    substitute ${finalAttrs.src}/crates/togl-ffi/togl.pc.in "$dev/lib/pkgconfig/togl.pc" \
+      --subst-var-by prefix "$dev" \
+      --subst-var-by version "${finalAttrs.version}"
+    # The header lives in $dev; the shared library lives in $out — point libdir there.
+    substituteInPlace "$dev/lib/pkgconfig/togl.pc" \
+      --replace-fail 'exec_prefix=''${prefix}' "exec_prefix=$out"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "ABI-stable C library (libtogl) for toggling code comments across languages";
+    homepage = "https://github.com/smorin/toggle";
+    changelog = "https://github.com/smorin/toggle/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ smorin ];
+    pkgConfigModules = [ "togl" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/to/togl/package.nix
+++ b/pkgs/by-name/to/togl/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "togl";
+  version = "0.5.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "smorin";
+    repo = "toggle";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JUs98p2FDWG4/0mh8LnX0UhPOKIuaBFBixqdnhjxGyM=";
+  };
+
+  cargoHash = "sha256-LO8dAvm9OegESxobknPBF5FrSCcQ29qNymPATWJ14z4=";
+
+  # Virtual workspace: build and test only the CLI crate (binaries `toggle`, `togl`).
+  cargoBuildFlags = [
+    "-p"
+    "togl-cli"
+  ];
+  cargoTestFlags = [
+    "-p"
+    "togl-cli"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI tool for toggling code comments across multiple languages";
+    homepage = "https://github.com/smorin/toggle";
+    changelog = "https://github.com/smorin/toggle/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ smorin ];
+    mainProgram = "togl";
+  };
+})


### PR DESCRIPTION
## Description of changes

Adds two new packages:

- **`togl`** — a CLI for toggling code comments (commenting/uncommenting line ranges and named marker sections) across many languages. Installs the `toggle` and `togl` binaries (same behaviour under either name).
- **`libtogl`** — the project's ABI-stable C library exposing the same engine over a C FFI, with a multi-output layout (`out` = shared library; `dev` = static library + `togl.h` header + `pkg-config` file).

Upstream: https://github.com/smorin/toggle (v0.5.0). License: MIT. Both packages are maintained by `smorin` (already in the maintainer list).

The two packages share the same source and `cargoHash` (single virtual Cargo workspace); `togl` builds `-p togl-cli` and `libtogl` builds `-p togl-ffi`.

## Things done

- Built on platform(s)
  - [x] aarch64-darwin
  - [ ] x86_64-darwin
  - [ ] aarch64-linux
  - [ ] x86_64-linux
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (yes)
- [x] Ran `nixpkgs-review` — merges cleanly on current `master`; impacted packages are exactly `togl` and `libtogl`; all outputs (`togl`, `libtogl`, `libtogl.dev`) build
- [x] Tested execution of all binary files: `togl --version` → `togl 0.5.0`; subcommands present in `--help`
- [x] `libtogl` verified: shared lib in `$out/lib`, static lib + `togl.h` + `togl.pc` (`Version: 0.5.0`) in `$dev`
- [x] Formatted with `nixfmt-rfc-style`
- [x] Meta set (`description`, `homepage`, `changelog`, `license`, `maintainers`, `mainProgram` / `pkgConfigModules`, `platforms`)
- [x] Fits the guidelines in [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md) and the [Nixpkgs manual](https://nixos.org/manual/nixpkgs/unstable/).

---
Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
