### PR TITLE
woodpecker-pipeline-transform: 0.3.0 -> 1.0.0

### DIFF
--- a/pkgs/by-name/wo/woodpecker-pipeline-transform/package.nix
+++ b/pkgs/by-name/wo/woodpecker-pipeline-transform/package.nix
@@ -5,16 +5,16 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "woodpecker-pipeline-transform";
-  version = "0.3.0";
+  version = "1.0.0";
 
   src = fetchFromCodeberg {
     owner = "lafriks";
     repo = "woodpecker-pipeline-transform";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-5bdNtVjk7TBoS0Z026th674ZXCRRc3DbtVOLl+acKhQ=";
+    hash = "sha256-UXQ+b3SI+MO0T993hslQaRVMdHdPt9RnjyhfmLtooAU=";
   };
 
-  vendorHash = "sha256-4JRSrkxH8/NlSwUk6KagC5+mx+UXSLvo1thSRciAewc=";
+  vendorHash = "sha256-NE4KUbYA19YJPQW9quSYgm0exj3lToj9Zkiv05TgyOI=";
 
   meta = {
     description = "Utility to convert different pipelines to Woodpecker CI pipelines";


### PR DESCRIPTION
we finally got a https://codeberg.org/lafriks/woodpecker-pipeline-transform/releases/tag/v1.0.0
we should use it!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
