### PR TITLE
nixfmt: 1.2.0 → 1.3.1

### DIFF
--- a/pkgs/by-name/ni/nixfmt/generated-package.nix
+++ b/pkgs/by-name/ni/nixfmt/generated-package.nix
@@ -24,10 +24,10 @@
 }:
 mkDerivation {
   pname = "nixfmt";
-  version = "1.2.0";
+  version = "1.3.1";
   src = fetchzip {
-    url = "https://github.com/nixos/nixfmt/archive/v1.2.0.tar.gz";
-    sha256 = "1qvj1sddh7bgggqnj7cnhvfh4iz1pwzc9a9awc1g7y349yvpwad3";
+    url = "https://github.com/nixos/nixfmt/archive/v1.3.1.tar.gz";
+    sha256 = "1c0iz6hrzafld8vkldcmall7fvby6xgzzqgap8c3bxwhaxhq86hm";
   };
   isLibrary = true;
   isExecutable = true;
@@ -58,6 +58,6 @@ mkDerivation {
   jailbreak = true;
   homepage = "https://github.com/NixOS/nixfmt";
   description = "Official formatter for Nix code";
-  license = lib.licenses.mpl20;
+  license = lib.meta.getLicenseFromSpdxId "MPL-2.0";
   mainProgram = "nixfmt";
 }

--- a/pkgs/by-name/ni/nixfmt/package.nix
+++ b/pkgs/by-name/ni/nixfmt/package.nix
@@ -2,27 +2,31 @@
   haskell,
   haskellPackages,
   lib,
-  runCommand,
-  nixfmt,
+  stdenv,
+  versionCheckHook,
 }:
 let
   inherit (haskell.lib.compose) overrideCabal justStaticExecutables;
 
-  overrides = {
+  cabalOverrides = {
     passthru.updateScript = ./update.sh;
-
     teams = [ lib.teams.formatter ];
-
-    # These tests can be run with the following command.
-    #
-    # $ nix-build -A nixfmt.tests
-    passthru.tests = runCommand "nixfmt-tests" { nativeBuildInputs = [ nixfmt ]; } ''
-      nixfmt --version > $out
-    '';
   };
+
+  # haskellPackages.mkDerivation and haskell.lib.compose.overrideCabal
+  # do not allow access to `doInstallCheck` or `nativeInstallCheckInputs`,
+  # so we override directly with `.overrideAttrs`.
+  lateOverrides = finalAttrs: prevAttrs: {
+    doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+    nativeInstallCheckInputs = prevAttrs.nativeInstallCheckInputs or [ ] ++ [
+      versionCheckHook
+    ];
+  };
+
   raw-pkg = haskellPackages.callPackage ./generated-package.nix { };
 in
 lib.pipe raw-pkg [
-  (overrideCabal overrides)
+  (overrideCabal cabalOverrides)
   justStaticExecutables
+  (drv: drv.overrideAttrs lateOverrides)
 ]

--- a/pkgs/by-name/ni/nixfmt/package.nix
+++ b/pkgs/by-name/ni/nixfmt/package.nix
@@ -8,9 +8,10 @@
 let
   inherit (haskell.lib.compose) overrideCabal justStaticExecutables;
 
-  cabalOverrides = {
+  cabalOverrides = drv: {
     passthru.updateScript = ./update.sh;
     teams = [ lib.teams.formatter ];
+    changelog = "https://github.com/NixOS/nixfmt/releases/tag/v${drv.version}";
   };
 
   # haskellPackages.mkDerivation and haskell.lib.compose.overrideCabal


### PR DESCRIPTION
- **nixfmt: 1.2.0 → 1.3.1**
- **nixfmt: add versionCheckHook**
- **nixfmt: add `meta.changelog`**

Changelog: https://github.com/NixOS/nixfmt/releases/tag/v1.3.0

Closes #526656

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
    - `nix-build -A nixfmt -A treefmt.tests -A nixfmt-tree.tests`
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
  - See comments below.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
