### PR TITLE
python3Packages.kernels: 0.11.7 -> 0.15.1

### DIFF
--- a/pkgs/development/python-modules/kernels-data/default.nix
+++ b/pkgs/development/python-modules/kernels-data/default.nix
@@ -2,9 +2,10 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  kernels,
 
   # build-system
-  setuptools,
+  rustPlatform,
 
   # dependencies
   huggingface-hub,
@@ -14,30 +15,29 @@
   tomlkit,
 }:
 buildPythonPackage (finalAttrs: {
-  pname = "kernels";
-  version = "0.15.1";
+  pname = "kernels-data";
+  inherit (kernels) src version;
   pyproject = true;
   __structuredAttrs = true;
 
-  src = fetchFromGitHub {
-    owner = "huggingface";
-    repo = "kernels";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-NyFVWaJat5uwT8edzyIQuPfleVP+hg45an+rux6bIfo=";
+  # sourceRoot = "${finalAttrs.src.name}/kernels-data/bindings/python";
+  buildAndTestSubdir = "kernels-data/bindings/python";
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      # sourceRoot
+      ;
+    hash = "sha256-zcgxnQfEPEqBMoNe6yqFhGyfVhrgaao56Rwcm9J3Fi8=";
   };
 
-  sourceRoot = "${finalAttrs.src.name}/kernels";
-
   build-system = [
-    setuptools
+    rustPlatform.maturinBuildHook
   ];
 
   dependencies = [
-    huggingface-hub
-    kernels-data
-    packaging
-    pyyaml
-    tomlkit
   ];
 
   # Tests require pervasive internet access

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8390,6 +8390,8 @@ self: super: with self; {
 
   kernels = callPackage ../development/python-modules/kernels { };
 
+  kernels-data = callPackage ../development/python-modules/kernels-data { };
+
   kestra = callPackage ../development/python-modules/kestra { };
 
   keyboard = callPackage ../development/python-modules/keyboard { };


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/huggingface/kernels/compare/v0.11.7...v0.15.1
Changelog: https://github.com/huggingface/kernels/releases/tag/v0.15.1

cc @osbm

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test