### PR TITLE
balatro-mod-manager: 0.4.0 -> 0.4.1

### DIFF
--- a/pkgs/by-name/ba/balatro-mod-manager/package.nix
+++ b/pkgs/by-name/ba/balatro-mod-manager/package.nix
@@ -15,13 +15,13 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "balatro-mod-manager";
-  version = "0.4.0";
+  version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "skyline69";
     repo = "balatro-mod-manager";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ISEgmyGA96r+OolKc/8qiKee43ruNonmWdqfM4pr3p8=";
+    hash = "sha256-cazd6Cns87cjwBORQIsAD5rBes7eTGCAz7bytZO+TsQ=";
   };
 
   nodeModules = stdenv.mkDerivation {
@@ -52,13 +52,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
     outputHashAlgo = "sha256";
     outputHash =
       {
-        x86_64-linux = "sha256-97O4DrnjZO2mhSrCQz9xbcRCSaxMNNa4NaLNPlmecJg=";
-        aarch64-linux = "sha256-0H14Be8jhBwOBG2Ui8gYrnAcTtatLVsBxFVfTyzmutw=";
+        x86_64-linux = "sha256-SQCF05uuJg16Il7SvCXlzkm64wJyPfNzVqfgDj7YldI=";
+        aarch64-linux = "sha256-YobKPWe+0StlyJkYEeUmNzYAinGwR042HWpdwWOCt6Q=";
       }
       .${stdenv.hostPlatform.system} or (throw "Unsupported system ${stdenv.hostPlatform.system}");
   };
 
-  cargoHash = "sha256-TPZf4jtv/3mIpe6ASzPkIusQC/iPFpYN51XiiH6pkZc=";
+  cargoHash = "sha256-m27OdD+hpj1fGiTbe9VmdY+2EFBZKJ3o/4WMdpCpRSw=";
 
   dontUseCargoParallelTests = true;
   checkFlags = [


### PR DESCRIPTION
https://github.com/skyline69/balatro-mod-manager/releases/tag/v0.4.1
Diff: https://github.com/skyline69/balatro-mod-manager/compare/v0.4.0...v0.4.1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
