### PR TITLE
fuse-archive: 1.10 -> 1.22

### DIFF
--- a/pkgs/by-name/fu/fuse-archive/package.nix
+++ b/pkgs/by-name/fu/fuse-archive/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fuse,
+  fuse3,
   libarchive,
   pkg-config,
   boost,
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fuse-archive";
-  version = "1.10";
+  version = "1.22";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "fuse-archive";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Fta/IYKWsB4ZuPOWtGO6p6l03eoRXaO0lIGaCU3SRag=";
+    hash = "sha256-uE+22ONNnPqAi8zBV0v3qu3um2gNoX4/jNUA7E+UQOE=";
   };
 
   postPatch = ''
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [
-    fuse
+    fuse3
     libarchive
     boost
   ];
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
   makeFlags = [ "prefix=${placeholder "out"}" ];
 
   meta = {
-    inherit (fuse.meta) platforms;
+    inherit (fuse3.meta) platforms;
     description = "Serve an archive or a compressed file as a read-only FUSE file system";
     homepage = "https://github.com/google/fuse-archive";
     changelog = "https://github.com/google/fuse-archive/releases/tag/v${finalAttrs.version}";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

Updates fuse -> fuse3:

```
$ fuse-archive -V
fuse-archive 1.22
libarchive 3.8.7 zlib/1.3.2 liblzma/5.8.3 bz2lib/1.0.8 libzstd/1.5.7 openssl/3.6.2 libb2/bundled libacl/2.3.2 libattr/2.3.2
FUSE library version 3.17.4
using FUSE kernel interface version 7.40
fusermount3 version: 3.17.4

$ ldd $(which fuse-archive)|grep fuse
	libfuse3.so.4 => /nix/store/x2lk8cgjawkn0rm3prndx3v9cppzgpij-fuse-3.17.4/lib/libfuse3.so.4 (0x000075bf4f200000)
```

Refs #526161

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

