### PR TITLE
losange: init at 0.10.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26970,6 +26970,12 @@
     githubId = 6064962;
     name = "TakWolf";
   };
+  talal = {
+    email = "noreply@talal.ch";
+    github = "talal";
+    githubId = 3526562;
+    name = "Muhammad Talal Anwar";
+  };
   talhaHavadar = {
     email = "havadartalha@gmail.com";
     github = "talhaHavadar";

--- a/pkgs/by-name/lo/losange/package.nix
+++ b/pkgs/by-name/lo/losange/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+
+  # buildInputs
+  mpv,
+  libadwaita,
+  libepoxy,
+  openssl,
+
+  # nativeBuildInputs
+  makeBinaryWrapper,
+  pkg-config,
+  wrapGAppsHook4,
+  glib,
+
+  # Wrapper
+  nodejs,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "losange";
+  version = "0.10.1";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "tymmesyde";
+    repo = "losange";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-mr54/vnaopLwG9lhFiZJGgxWH/VaGitROVEeV7GSyHM=";
+  };
+
+  cargoHash = "sha256-LJ8EpxEIN8wojSmQ+WVshYRxGFAC9sUk5tnh3I2J408=";
+
+  buildInputs = [
+    mpv
+    libadwaita
+    libepoxy
+    openssl
+  ];
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    pkg-config
+    wrapGAppsHook4
+    glib
+  ];
+
+  postInstall = ''
+    install -Dm444 data/xyz.timtimtim.Losange.gschema.xml -t $out/share/gsettings-schemas/$name/glib-2.0/schemas/
+    glib-compile-schemas $out/share/gsettings-schemas/$name/glib-2.0/schemas/
+
+    install -Dm444 data/icons/xyz.timtimtim.Losange.svg -t $out/share/icons/hicolor/scalable/apps/
+    install -Dm444 data/xyz.timtimtim.Losange.desktop -t $out/share/applications/
+    install -Dm444 data/xyz.timtimtim.Losange.metainfo.xml -t $out/share/metainfo/
+
+    # The application fails if '-o' is passed without an argument (e.g. when opened using a launcher)
+    # therefore we match upstream's shell wrapper to handle empty URL cases.
+    substituteInPlace $out/share/applications/xyz.timtimtim.Losange.desktop \
+      --replace-fail "Exec=sh -c \"/usr/bin/losange -o '%u'\"" "Exec=sh -c \"losange -o '%u'\""
+  '';
+
+  # Node.js is required to run `server.js`
+  # Losange will automatically download the required version of `server.js` at runtime.
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix PATH : "${lib.makeBinPath [ nodejs ]}"
+    )
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "losange";
+    description = "Simple Stremio client for GNOME";
+    homepage = "https://github.com/tymmesyde/Losange";
+    changelog = "https://github.com/tymmesyde/Losange/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ talal ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds [Losange](https://github.com/tymmesyde/Losange), a simple [Stremio](https://stremio.com/) client for GNOME made with [Relm4](https://github.com/Relm4/Relm4).

[stremio-linux-shell](https://github.com/Stremio/stremio-linux-shell) already exists in nixpkgs but that client uses CEF (upstream switched from CEF to webkit but new version not released yet).

Losange doesn't use CEF or webkit it is built using Relm4 and uses [stremio-core](https://github.com/Stremio/stremio-core) + libmpv under the hood.

I based this derivation on [@fxzzi's derivation](https://gitlab.com/fazzi/azzipkgs/-/blob/d915e25e038e34cf60614e1110aafd179b1c8b3a/pkgs/losange/package.nix).

@fxzzi @thunze let me know if you want to be added to maintainers list.

P.S. could the PR reviewer/merger kindly also add the relevant backport label to this PR? `26.05` just got released and it would be nice to also have this packge in the stable `26.05` channel.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
