### PR TITLE
ladybird: add ability to use alternative gui toolkits

### DIFF
--- a/nixos/modules/programs/ladybird.nix
+++ b/nixos/modules/programs/ladybird.nix
@@ -9,12 +9,30 @@ let
   cfg = config.programs.ladybird;
 in
 {
-  options = {
-    programs.ladybird.enable = lib.mkEnableOption "the Ladybird web browser";
+  options.programs.ladybird = {
+    enable = lib.mkEnableOption "the Ladybird web browser";
+    package = lib.mkPackageOption pkgs "ladybird" { };
+    gui = lib.mkOption {
+      type = lib.types.str;
+      default = null;
+      description = ''
+        Which gui framework to use, one of "Qt", "Gtk", "Appkit" (Darwin only)
+      '';
+      example = "Gtk";
+    };
   };
 
-  config = lib.mkIf cfg.enable {
-    environment.systemPackages = [ pkgs.ladybird ];
-    fonts.fontDir.enable = true;
-  };
+  config =
+    let
+      package = cfg.package.override (
+        lib.optionalAttrs (cfg.gui != null) {
+          withGui = cfg.gui;
+        }
+      );
+    in
+    lib.mkIf cfg.enable {
+      environment.systemPackages = [ cfg.package ];
+      fonts.fontDir.enable = true;
+    };
+
 }

--- a/pkgs/by-name/la/ladybird/package.nix
+++ b/pkgs/by-name/la/ladybird/package.nix
@@ -42,6 +42,11 @@
   sdl3,
   icu78,
   simdjson,
+  gtk4,
+  libadwaita,
+  bison,
+  libxkbcommon,
+  withGui ? if stdenv.hostPlatform.isDarwin then "AppKit" else "Qt", # or "Gtk"
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -103,8 +108,10 @@ stdenv.mkDerivation (finalAttrs: {
     python3
     rustPlatform.cargoSetupHook
     rustc
-    qt6Packages.wrapQtAppsHook
     libtommath
+  ]
+  ++ lib.optionals (withGui == "Qt") [
+    qt6Packages.wrapQtAppsHook
   ];
 
   buildInputs = [
@@ -121,8 +128,6 @@ stdenv.mkDerivation (finalAttrs: {
     libxcrypt
     mimalloc
     openssl
-    qt6Packages.qtbase
-    qt6Packages.qtmultimedia
     sdl3
     simdutf
     (skia.overrideAttrs (prev: {
@@ -147,7 +152,17 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     libpulseaudio.dev
+  ]
+  ++ lib.optionals (withGui == "Qt") [
     qt6Packages.qtwayland
+    qt6Packages.qtbase
+    qt6Packages.qtmultimedia
+  ]
+  ++ lib.optionals (withGui == "Gtk" && stdenv.hostPlatform.isLinux) [
+    gtk4
+    libadwaita
+    bison
+    libxkbcommon
   ];
 
   cmakeFlags = [
@@ -162,9 +177,13 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     "-DCMAKE_INSTALL_LIBEXECDIR=libexec"
+  ]
+  ++ lib.optionals (withGui == "Gtk") [
+    "-DLADYBIRD_GUI_FRAMEWORK=Gtk"
+  ]
+  ++ lib.optionals (withGui == "Qt" && stdenv.hostPlatform.isDarwin) [
+    "-DLADYBIRD_GUI_FRAMEWORK=Qt"
   ];
-
-  # FIXME: Add an option to -DENABLE_QT=ON on macOS to use Qt rather than Cocoa for the GUI
 
   # ld: [...]/OESVertexArrayObject.cpp.o: undefined reference to symbol 'glIsVertexArrayOES'
   # ld: [...]/libGL.so.1: error adding symbols: DSO missing from command line
@@ -205,7 +224,7 @@ stdenv.mkDerivation (finalAttrs: {
     ];
 
   meta = {
-    description = "Browser using the SerenityOS LibWeb engine with a Qt or Cocoa GUI";
+    description = "Browser using the SerenityOS LibWeb engine with a Qt, GTK, or Appkit GUI";
     homepage = "https://ladybird.org";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds an overridable attribute for [ladybird](ladybird.org) to change the UI toolkit used. Ladybird recently [added](https://github.com/LadybirdBrowser/ladybird/pull/8691) support for a GTK frontend, and also supports Qt and Cocoa. Qt is the default on all platforms except for macOS.

This also adds an two options to the ladybird package: `gtk-ui` and `qt-ui-on-mac`. However, I can't figure out how to test the module (first time doing module contribution), so those may or may not work at the moment. If someone would be willing guide me in testing the module, that would be much appreciated.

There are also currently assertions to make sure `gtk-ui` is only set on linux systems and `qt-ui-on-mac` is only set on darwin systems. The former can be removed if/when [this pr](https://github.com/LadybirdBrowser/ladybird/pull/9720) gets merged upstream.

I intend to try to run the NixOS tests, but my computer isn't all that beefy so I need to find a large block of time to do it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
