### PR TITLE
ario: remove unused libsoup_2_4 dependency

### DIFF
--- a/pkgs/by-name/ar/ario/package.nix
+++ b/pkgs/by-name/ar/ario/package.nix
@@ -11,7 +11,6 @@
   gettext,
   gtk3,
   libmpdclient,
-  libsoup_2_4,
   libxml2,
   taglib,
   wrapGAppsHook3,
@@ -40,7 +39,6 @@ stdenv.mkDerivation rec {
     dbus-glib
     gtk3
     libmpdclient
-    libsoup_2_4
     libxml2
     taglib
   ];


### PR DESCRIPTION
This seems to no longer be used upstream. I'm having a hard time pinpointing exactly when this occurred via SourceForge, but the source archive from `ario.src` doesn't mention libsoup at all, the package builds and runs, and Debian seems to have removed the dependency at some point as well (it's no longer present [in Salsa](https://salsa.debian.org/debian/ario/-/blob/5c1c1050baace1a5c6c8be80027765f72062b114/debian/control), whereas it [used to be](https://salsa.debian.org/debian/ario/-/blob/d27546c62c9df746f0a6d500048e13fa921600b1/debian/control)).

Found while trying to eliminate libsoup 2.4 (#360897).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
