### PR TITLE
redumper: 709 → 720, enable on Darwin

### DIFF
--- a/pkgs/by-name/re/redumper/darwin-fixes.patch
+++ b/pkgs/by-name/re/redumper/darwin-fixes.patch
@@ -1,0 +1,38 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2abda97..e5d9760 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -218,33 +218,6 @@ target_link_libraries(redumper ${libs})
+ 
+ install(TARGETS redumper DESTINATION "bin")
+ 
+-# bundle LLVM libc++ for C++20 support (system libc++ is too old, static linking not allowed on macOS)
+-if(REDUMPER_TARGET_MACOS)
+-    set_target_properties(redumper PROPERTIES INSTALL_RPATH "@executable_path/../lib")
+-    
+-    install(FILES
+-        "${LLVM_LIB_PATH}/c++/libc++.1.0.dylib"
+-        "${LLVM_LIB_PATH}/c++/libc++.1.dylib"
+-        "${LLVM_LIB_PATH}/c++/libc++abi.1.0.dylib"
+-        "${LLVM_LIB_PATH}/c++/libc++abi.1.dylib"
+-        "${LLVM_LIB_PATH}/libunwind.1.0.dylib"
+-        "${LLVM_LIB_PATH}/libunwind.1.dylib"
+-        DESTINATION "lib"
+-    )
+-    
+-    # fix install names after files are copied & re-sign binaries after modification (install_name_tool invalidates signatures)
+-    install(CODE "
+-        execute_process(COMMAND install_name_tool -change ${LLVM_LIB_PATH}/c++/libc++.1.dylib @rpath/libc++.1.dylib \${CMAKE_INSTALL_PREFIX}/bin/redumper)
+-        execute_process(COMMAND install_name_tool -id @rpath/libc++.1.dylib \${CMAKE_INSTALL_PREFIX}/lib/libc++.1.0.dylib)
+-        execute_process(COMMAND install_name_tool -id @rpath/libc++abi.1.dylib \${CMAKE_INSTALL_PREFIX}/lib/libc++abi.1.0.dylib)
+-        execute_process(COMMAND install_name_tool -id @rpath/libunwind.1.dylib \${CMAKE_INSTALL_PREFIX}/lib/libunwind.1.0.dylib)
+-        execute_process(COMMAND codesign --force --sign - \${CMAKE_INSTALL_PREFIX}/bin/redumper)
+-        execute_process(COMMAND codesign --force --sign - \${CMAKE_INSTALL_PREFIX}/lib/libc++.1.0.dylib)
+-        execute_process(COMMAND codesign --force --sign - \${CMAKE_INSTALL_PREFIX}/lib/libc++abi.1.0.dylib)
+-        execute_process(COMMAND codesign --force --sign - \${CMAKE_INSTALL_PREFIX}/lib/libunwind.1.0.dylib)
+-    ")
+-endif()
+-
+ # Windows 7 requires administrative access in order to access the disc drive
+ if(MSVC AND CMAKE_SYSTEM_VERSION VERSION_EQUAL "6.1")
+     set_target_properties(redumper PROPERTIES LINK_FLAGS "/MANIFESTUAC:\"level='requireAdministrator' uiAccess='false'\"")

--- a/pkgs/by-name/re/redumper/package.nix
+++ b/pkgs/by-name/re/redumper/package.nix
@@ -18,6 +18,8 @@ llvmPackages.libcxxStdenv.mkDerivation (finalAttrs: {
     hash = "sha256-3J+/v8Rhu5yT+MgAxcNBiHLAPAcNWc/YJXxFMgOZnPs=";
   };
 
+  __structuredAttrs = true;
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/re/redumper/package.nix
+++ b/pkgs/by-name/re/redumper/package.nix
@@ -6,6 +6,7 @@
   ninja,
   llvmPackages,
   gtest,
+  versionCheckHook,
   nix-update-script,
 }:
 
@@ -43,6 +44,10 @@ llvmPackages.libcxxStdenv.mkDerivation (finalAttrs: {
   ];
 
   doCheck = true;
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru.updateScript = nix-update-script {
     extraArgs = [

--- a/pkgs/by-name/re/redumper/package.nix
+++ b/pkgs/by-name/re/redumper/package.nix
@@ -39,8 +39,8 @@ llvmPackages.libcxxStdenv.mkDerivation (finalAttrs: {
 
   # https://github.com/superg/redumper/blob/main/.github/workflows/cmake.yml
   cmakeFlags = [
-    "-DREDUMPER_VERSION_BUILD=${finalAttrs.src.tag}"
-    "-DFETCHCONTENT_SOURCE_DIR_GOOGLETEST=${gtest.src}"
+    (lib.cmakeFeature "REDUMPER_VERSION_BUILD" "${finalAttrs.src.tag}")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_GOOGLETEST" "${gtest.src}")
   ];
 
   doCheck = true;

--- a/pkgs/by-name/re/redumper/package.nix
+++ b/pkgs/by-name/re/redumper/package.nix
@@ -18,6 +18,8 @@ llvmPackages.libcxxStdenv.mkDerivation (finalAttrs: {
     hash = "sha256-3J+/v8Rhu5yT+MgAxcNBiHLAPAcNWc/YJXxFMgOZnPs=";
   };
 
+  strictDeps = true;
+
   nativeBuildInputs = [
     cmake
     ninja

--- a/pkgs/by-name/re/redumper/package.nix
+++ b/pkgs/by-name/re/redumper/package.nix
@@ -39,7 +39,7 @@ llvmPackages.libcxxStdenv.mkDerivation (finalAttrs: {
 
   # https://github.com/superg/redumper/blob/main/.github/workflows/cmake.yml
   cmakeFlags = [
-    "-DREDUMPER_VERSION_BUILD=${finalAttrs.version}"
+    "-DREDUMPER_VERSION_BUILD=${finalAttrs.src.tag}"
     "-DFETCHCONTENT_SOURCE_DIR_GOOGLETEST=${gtest.src}"
   ];
 

--- a/pkgs/by-name/re/redumper/package.nix
+++ b/pkgs/by-name/re/redumper/package.nix
@@ -2,25 +2,27 @@
   lib,
   fetchFromGitHub,
   cmake,
+  ctestCheckHook,
   ninja,
   llvmPackages,
+  gtest,
   nix-update-script,
 }:
 
 # redumper is using C++ modules, this requires latest C++20 compiler and build tools
 llvmPackages.libcxxStdenv.mkDerivation (finalAttrs: {
   pname = "redumper";
-  version = "709";
+  version = "720";
 
   src = fetchFromGitHub {
     owner = "superg";
     repo = "redumper";
     tag = "b${finalAttrs.version}";
-    hash = "sha256-3J+/v8Rhu5yT+MgAxcNBiHLAPAcNWc/YJXxFMgOZnPs=";
+    hash = "sha256-Gl+BJV9yWFGHk5HZudre+YUaaqCYcQpT50oeDcc39ds=";
   };
 
   patches = [
-    ./darwin-fixes.patch
+    ./remove-static-linking.patch
   ];
 
   __structuredAttrs = true;
@@ -29,6 +31,7 @@ llvmPackages.libcxxStdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
+    ctestCheckHook
     ninja
     llvmPackages.clang-tools
   ];
@@ -36,7 +39,10 @@ llvmPackages.libcxxStdenv.mkDerivation (finalAttrs: {
   # https://github.com/superg/redumper/blob/main/.github/workflows/cmake.yml
   cmakeFlags = [
     "-DREDUMPER_VERSION_BUILD=${finalAttrs.version}"
+    "-DFETCHCONTENT_SOURCE_DIR_GOOGLETEST=${gtest.src}"
   ];
+
+  doCheck = true;
 
   passthru.updateScript = nix-update-script {
     extraArgs = [

--- a/pkgs/by-name/re/redumper/package.nix
+++ b/pkgs/by-name/re/redumper/package.nix
@@ -18,6 +18,10 @@ llvmPackages.libcxxStdenv.mkDerivation (finalAttrs: {
     hash = "sha256-3J+/v8Rhu5yT+MgAxcNBiHLAPAcNWc/YJXxFMgOZnPs=";
   };
 
+  patches = [
+    ./darwin-fixes.patch
+  ];
+
   __structuredAttrs = true;
 
   strictDeps = true;
@@ -28,13 +32,9 @@ llvmPackages.libcxxStdenv.mkDerivation (finalAttrs: {
     llvmPackages.clang-tools
   ];
 
-  env.NIX_CFLAGS_COMPILE = "-isystem ${llvmPackages.libcxx.dev}/include/c++/v1";
-
   # https://github.com/superg/redumper/blob/main/.github/workflows/cmake.yml
   cmakeFlags = [
-    "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"
     "-DREDUMPER_VERSION_BUILD=${finalAttrs.version}"
-    "-DREDUMPER_CLANG_LINK_OPTIONS=" # overrides the '-static' default
   ];
 
   meta = {
@@ -42,7 +42,7 @@ llvmPackages.libcxxStdenv.mkDerivation (finalAttrs: {
     description = "Low level CD dumper utility";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ hughobrien ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
     mainProgram = "redumper";
   };
 })

--- a/pkgs/by-name/re/redumper/package.nix
+++ b/pkgs/by-name/re/redumper/package.nix
@@ -4,6 +4,7 @@
   cmake,
   ninja,
   llvmPackages,
+  nix-update-script,
 }:
 
 # redumper is using C++ modules, this requires latest C++20 compiler and build tools
@@ -36,6 +37,13 @@ llvmPackages.libcxxStdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     "-DREDUMPER_VERSION_BUILD=${finalAttrs.version}"
   ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "b(.*)"
+    ];
+  };
 
   meta = {
     homepage = "https://github.com/superg/redumper";

--- a/pkgs/by-name/re/redumper/remove-static-linking.patch
+++ b/pkgs/by-name/re/redumper/remove-static-linking.patch
@@ -1,9 +1,15 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 2abda97..e5d9760 100644
+index 2f5d66a..e437573 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -218,33 +218,6 @@ target_link_libraries(redumper ${libs})
+@@ -221,39 +221,8 @@ endif()
  
+ target_link_libraries(redumper ${libs})
+ 
+-if(REDUMPER_TARGET_LINUX)
+-    target_link_options(redumper PRIVATE "-static")
+-endif()
+-
  install(TARGETS redumper DESTINATION "bin")
  
 -# bundle LLVM libc++ for C++20 support (system libc++ is too old, static linking not allowed on macOS)


### PR DESCRIPTION
Changelog: https://github.com/superg/redumper/releases/tag/b720
Diff: https://github.com/superg/redumper/compare/b709...b720

[redumper switched to gtest][1], so configure checkPhase to run the test suite. Also enable support for Darwin.

Static builds and cross-compilation are currently broken (though this was already the case before the update).

[1]: https://github.com/superg/redumper/commit/d6ec7f18c6c9c52c371b810bfcb908912be11c79

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
