### PR TITLE
[Backport release-26.05] various: fetchFromGitea -> fetchFromCodeberg

### DIFF
--- a/pkgs/by-name/aw/awww/package.nix
+++ b/pkgs/by-name/aw/awww/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   rustPlatform,
   pkg-config,
   lz4,
@@ -17,8 +17,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "awww";
   version = "0.12.1";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "LGFae";
     repo = "awww";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/cr/cropgui/package.nix
+++ b/pkgs/by-name/cr/cropgui/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   python3Packages,
-  fetchFromGitea,
+  fetchFromCodeberg,
   makeWrapper,
   libjpeg,
   exiftool,
@@ -11,8 +11,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pname = "cropgui";
   version = "0.9";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "jepler";
     repo = "cropgui";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/ga/gamepad-mirror/package.nix
+++ b/pkgs/by-name/ga/gamepad-mirror/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   appstream,
   cmake,
   desktop-file-utils,
@@ -27,8 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "gamepad-mirror";
   version = "0.3-unstable-2025-10-18";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "vendillah";
     repo = "GamepadMirror";
     rev = "aa86d55f21b4d206eab61d0bf7cd9ccafc8aa607";

--- a/pkgs/by-name/gi/git-pages/package.nix
+++ b/pkgs/by-name/gi/git-pages/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildGoModule,
-  fetchFromGitea,
+  fetchFromCodeberg,
   nix-update-script,
   versionCheckHook,
 }:
@@ -11,8 +11,7 @@ buildGoModule (finalAttrs: {
   version = "0.9.0";
   __structuredAttrs = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "git-pages";
     repo = "git-pages";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/hi/hittekaart/package.nix
+++ b/pkgs/by-name/hi/hittekaart/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   rustPlatform,
-  fetchFromGitea,
+  fetchFromCodeberg,
   python3,
   sqlite,
 }:
@@ -10,8 +10,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "hittekaart";
   version = "0.2.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "dunj3";
     repo = "hittekaart";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/nu/nu-lint/package.nix
+++ b/pkgs/by-name/nu/nu-lint/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   rustPlatform,
   nix-update-script,
   versionCheckHook,
@@ -10,8 +10,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nu-lint";
   version = "1.1.2";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "wvhulle";
     repo = "nu-lint";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/se/searchix/package.nix
+++ b/pkgs/by-name/se/searchix/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildGoModule,
-  fetchFromGitea,
+  fetchFromCodeberg,
   fetchFromGitHub,
   versionCheckHook,
   nix-update-script,
@@ -20,8 +20,7 @@ buildGoModule (finalAttrs: {
   pname = "searchix";
   version = "0.4.7";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "alinnow";
     repo = "searchix";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/to/tonearm/package.nix
+++ b/pkgs/by-name/to/tonearm/package.nix
@@ -2,7 +2,7 @@
   buildGo126Module,
   cairo,
   copyDesktopItems,
-  fetchFromGitea,
+  fetchFromCodeberg,
   gdk-pixbuf,
   glib,
   glib-networking,
@@ -41,8 +41,7 @@ in
 buildGo126Module (finalAttrs: {
   pname = "tonearm";
   version = "1.4.0";
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "dergs";
     repo = "Tonearm";
     tag = "v${finalAttrs.version}";

--- a/pkgs/development/python-modules/dramatiq-eager-broker/default.nix
+++ b/pkgs/development/python-modules/dramatiq-eager-broker/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitea,
+  fetchFromCodeberg,
   uv-build,
   dramatiq,
   pytestCheckHook,
@@ -13,8 +13,7 @@ buildPythonPackage rec {
 
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "yaal";
     repo = "dramatiq-eager-broker";
     tag = version;

--- a/pkgs/development/python-modules/rpatool/default.nix
+++ b/pkgs/development/python-modules/rpatool/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   buildPythonPackage,
   setuptools,
 }:
@@ -9,8 +9,7 @@ buildPythonPackage rec {
   pname = "rpatool";
   version = "1.0.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "shiz";
     repo = "rpatool";
     tag = "v${version}";


### PR DESCRIPTION
Manual backport of #525942

Stacked on top of https://github.com/NixOS/nixpkgs/pull/526211

**Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).**

Even as a non-committer, if you find that it is not acceptable, leave a comment.

> [!TIP]
> If you maintain all packages touched by this pull request, and they are all located under `pkgs/by-name/*`, you can comment **`@NixOS/nixpkgs-merge-bot merge`** to automatically merge this PR using the [`nixpkgs-merge-bot`](https://github.com/NixOS/nixpkgs/blob/master/ci/README.md#nixpkgs-merge-bot).
