### PR TITLE
podman-desktop: patch for deadlock on darwin

### DIFF
--- a/pkgs/by-name/po/podman-desktop/disable-tray-darwin.patch
+++ b/pkgs/by-name/po/podman-desktop/disable-tray-darwin.patch
@@ -1,0 +1,60 @@
+diff --git a/packages/main/src/index.ts b/packages/main/src/index.ts
+index b427156..8aa5f2a 100644
+--- a/packages/main/src/index.ts
++++ b/packages/main/src/index.ts
+@@ -80,7 +80,7 @@ app.once('before-quit', event => {
+     });
+ });
+ 
+-let tray: Tray;
++let tray: Tray | undefined;
+ 
+ // Handle the open-url event (macOS/Linux). For Windows, it needs to be handle in the second-instance event
+ app.on('will-finish-launching', () => {
+@@ -95,8 +95,13 @@ app.whenReady().then(
+   async () => {
+     // Setup the default tray icon + menu items
+     animatedTray = new AnimatedTray();
+-    tray = new Tray(animatedTray.getDefaultImage());
+-    animatedTray.setTray(tray);
++    // On macOS, creating the menu-bar status item can deadlock the main thread
++    // against WindowServer (NSSceneStatusItem _requestScene). The application is
++    // fully usable from the Dock, so skip creating the tray entirely on macOS.
++    if (!isMac()) {
++      tray = new Tray(animatedTray.getDefaultImage());
++      animatedTray.setTray(tray);
++    }
+     const trayMenu = new TrayMenu(tray, animatedTray);
+ 
+     const _onDidCreatedConfigurationRegistry = new Emitter<ConfigurationRegistry>();
+diff --git a/packages/main/src/tray-menu.ts b/packages/main/src/tray-menu.ts
+index bd558a4..e7765ab 100644
+--- a/packages/main/src/tray-menu.ts
++++ b/packages/main/src/tray-menu.ts
+@@ -55,7 +55,7 @@ export class TrayMenu {
+   private menuContainerProviderConnectionItems = new Map<string, ProviderContainerConnectionInfoMenuItem>();
+ 
+   constructor(
+-    private readonly tray: Tray,
++    private readonly tray: Tray | undefined,
+     private readonly animatedTray: AnimatedTray,
+   ) {
+     ipcMain.on(
+@@ -140,7 +140,7 @@ export class TrayMenu {
+     });
+ 
+     if (isWindows()) {
+-      tray.on('click', this.showMainWindow.bind(this));
++      tray?.on('click', this.showMainWindow.bind(this));
+     }
+ 
+     // create menu first time
+@@ -277,7 +277,7 @@ export class TrayMenu {
+     generatedMenuTemplate.push(...this.endMenuTemplate);
+ 
+     const contextMenu = Menu.buildFromTemplate(generatedMenuTemplate);
+-    this.tray.setContextMenu(contextMenu);
++    this.tray?.setContextMenu(contextMenu);
+ 
+     // update animated tray status
+     this.updateGlobalStatus();

--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -51,11 +51,9 @@ stdenv.mkDerivation (finalAttrs: {
 
         new_node_major="$(get_major_version '.engines.node')"
         new_electron_major="$(get_major_version '.devDependencies.electron')"
-        new_pnpm_major="$(get_major_version '.packageManager')"
 
         sed -i -E "s/nodejs_[0-9]+/nodejs_$new_node_major/g" "$PKG_FILE"
         sed -i -E "s/electron_[0-9]+/electron_$new_electron_major/g" "$PKG_FILE"
-        sed -i -E "s/pnpm_[0-9]+/pnpm_$new_pnpm_major/g" "$PKG_FILE"
       '';
     }))
     (nix-update-script {

--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -3,13 +3,11 @@
   stdenv,
   fetchFromGitHub,
   makeBinaryWrapper,
-  copyDesktopItems,
   electron_41,
   nodejs_24,
   pnpm_10_29_2,
   fetchPnpmDeps,
   pnpmConfigHook,
-  makeDesktopItem,
   darwin,
   nix-update-script,
   _experimental-update-script-combinators,
@@ -99,9 +97,6 @@ stdenv.mkDerivation (finalAttrs: {
     pnpm
     pnpmConfigHook
   ]
-  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
-    copyDesktopItems
-  ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     darwin.autoSignDarwinBinariesHook
   ];
@@ -150,6 +145,13 @@ stdenv.mkDerivation (finalAttrs: {
 
         install -Dm644 buildResources/icon.svg "$out/share/icons/hicolor/scalable/apps/podman-desktop.svg"
 
+        # Derive the .desktop entry from upstream to keep it aligned and avoid regressions.
+        install -Dm644 .flatpak.desktop "$out/share/applications/podman-desktop.desktop"
+        substituteInPlace "$out/share/applications/podman-desktop.desktop" \
+          --replace-fail 'Exec=run.sh %U' 'Exec=podman-desktop %U' \
+          --replace-fail 'Icon=io.podman_desktop.PodmanDesktop' 'Icon=podman-desktop'
+        sed -i '/^X-Flatpak=/d' "$out/share/applications/podman-desktop.desktop"
+
         makeWrapper '${electron}/bin/electron' "$out/bin/podman-desktop" \
           --add-flags "$out/share/lib/podman-desktop/resources/app.asar" \
           --set XDG_SESSION_TYPE 'x11' \
@@ -161,20 +163,6 @@ stdenv.mkDerivation (finalAttrs: {
         runHook postInstall
       ''
     );
-
-  # see: https://github.com/podman-desktop/podman-desktop/blob/main/.flatpak.desktop
-  desktopItems = [
-    (makeDesktopItem {
-      name = "podman-desktop";
-      exec = "podman-desktop %U";
-      icon = "podman-desktop";
-      desktopName = appName;
-      genericName = "Desktop client for podman";
-      comment = finalAttrs.meta.description;
-      categories = [ "Utility" ];
-      startupWMClass = appName;
-    })
-  ];
 
   meta = {
     description = "Graphical tool for developing on containers and Kubernetes";

--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -82,6 +82,12 @@ stdenv.mkDerivation (finalAttrs: {
     # podman should be installed with nix; disable auto-installation
     ./extension-no-download-podman.patch
     ./system-defaults-dir.patch
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # Creating the macOS menu-bar status item can deadlock the main thread
+    # against WindowServer (NSSceneStatusItem _requestScene), leaving the app
+    # permanently unresponsive.
+    ./disable-tray-darwin.patch
   ];
 
   env = {


### PR DESCRIPTION
Supersedes the original single commit from [this PR](https://github.com/NixOS/nixpkgs/pull/508532), split into atomic commits per `CONTRIBUTING.md` and updated for `podman-desktop` `1.27.2` (the tree moved from `1.26.2` while the old PR was in draft).

Commits:

1. `podman-desktop: fix tray crashing on darwin` - On recent macOS the menu-bar status item deadlocks the Electron main thread against WindowServer (`NSSceneStatusItem _requestScene` -> `FBSScene activateWithCompletion:` -> `dispatch_async_and_wait`, parked in `kevent_id`), leaving the app unresponsive. Adds `disable-tray-darwin.patch`, applied only on Darwin, skipping tray creation on macOS.
2. `podman-desktop: disable pnpm auto-bump in update script` - `pnpm` is pinned to a minor (`pnpm_10_29_2`). The updater extracted only the major version and rewrote it to `pnpm_10`, which does not exist in nixpkgs and breaks the build. Removes the `pnpm` rewrite from the updater.
3. `podman-desktop: derive .desktop entry from upstream .flatpak.desktop` - Generates the entry from upstream's `.flatpak.desktop` at install time, rewriting only the launcher command and icon name and dropping `X-Flatpak`. Keeps `Categories` and `Keywords` aligned with upstream; the `--replace-fail` patterns fail the build if upstream renames those lines.

## Deviations from the original PR

- Dropped the `installPhase` concatenation to `lib.optionalString` change. It was stylistic and equivalent, per @booxter's review.
- Dropped the version check. @booxter suggested `versionCheckHook` plus `writableTmpDirAsHomeHook` to run the check at build time. I implemented that, but it cannot pass for this package: `podman-desktop` is a GUI Electron app with no `--version` or `--help` flag that prints a version and exits. Every invocation boots the app and acquires the single-instance lock, so the check only produced `An instance of Podman Desktop is already running` and failed the build on Darwin. The main process has no headless version path, so the check was removed rather than forced.
- `.desktop` keywords and categories are now parsed from upstream's `.flatpak.desktop` instead of a hardcoded subset, which is @booxter's suggested approach to stay aligned and avoid regressions. This drops the previously hand-set `GenericName` and `Comment`, since upstream's file does not define them.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test