### PR TITLE
[26.05] polkit-stdin-agent: init at 0.3.0

### DIFF
--- a/pkgs/by-name/po/polkit-stdin-agent/package.nix
+++ b/pkgs/by-name/po/polkit-stdin-agent/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitea,
+  nix-update-script,
+  nixosTests,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "polkit-stdin-agent";
+  version = "0.3.0";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "r-vdp";
+    repo = "polkit-stdin-agent";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Nl/+IBbUEsxSKSWLXwUB3mV4iAG0z9mv+Bl6CSeFzR4=";
+  };
+
+  cargoHash = "sha256-Eb/7ejVmtG5FNSh66gZO3337KCPNi+xtYVC5qyFKJzg=";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Non-interactive polkit authentication agent that answers PAM prompts from a file descriptor";
+    longDescription = ''
+      Registers a per-process polkit authentication agent for a wrapped
+      command and answers the PAM conversation from a file descriptor
+      instead of /dev/tty, giving run0 / systemd-run the same
+      "password on stdin" ergonomics as `sudo --stdin`.
+
+      Used by `nixos-rebuild --elevate=run0 --ask-elevate-password` to
+      authenticate on a target host over SSH without allocating a TTY.
+    '';
+    homepage = "https://codeberg.org/r-vdp/polkit-stdin-agent";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ rvdp ];
+    platforms = lib.platforms.linux;
+    mainProgram = "polkit-stdin-agent";
+  };
+})


### PR DESCRIPTION
A non-interactive polkit authentication agent that answers PAM prompts from a file descriptor. Provides the missing `sudo --stdin` equivalent for run0/systemd-run, which authorise via polkit and otherwise require a controlling terminal for pkttyagent.

Used by the upcoming `nixos-rebuild --elevate=run0 --ask-elevate-password`.

Reason for backport:
Useful for VM tests of run0systemd-run/pkexec independent of `nixos-rebuild`. Also useful for tools such as run0-sudo-shim to emulate `sudo --stdin` with run0. That shim may be used with nixpkgs 26.05, handling that is significantly easier if `polkit-stdin-agent` is universally available.

(cherry picked from commit 4d4952ae28c707aeb66c7def830fd1dd60669510)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
