### PR TITLE
gnuradioPackages.fosphor: fix build with boost 1.89

### DIFF
--- a/pkgs/development/gnuradio-modules/fosphor/default.nix
+++ b/pkgs/development/gnuradio-modules/fosphor/default.nix
@@ -37,6 +37,12 @@ mkDerivation {
   };
   disabled = gnuradioOlder "3.9" || gnuradioAtLeast "3.11";
 
+  # Boost 1.89 removed the boost_system stub library.
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail 'COMPONENTS system chrono thread' 'COMPONENTS chrono thread'
+  '';
+
   nativeBuildInputs = [
     cmake
     pkg-config


### PR DESCRIPTION
## Things done

Fixed the following build error:

```
-- Could NOT find Boost: missing: system (found /nix/store/7p0nrcgqa1qfgznany6indj0xlcrs375-boost-1.89.0-dev/lib/cmake/Boost-1.89.0/BoostConfig.cmake (found suitable version "1.89.0", minimum required is "1.65"))
CMake Error at CMakeLists.txt:97 (message):
  Boost required to compile gr-fosphor
```

Tested
<img width="981" height="1055" alt="gr-fosphor" src="https://github.com/user-attachments/assets/2b86f404-ff75-4849-83d3-6f3b258eafb5" />

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
