### PR TITLE
tetro-tui: init at 3.5.2

### DIFF
--- a/pkgs/by-name/te/tetro-tui/package.nix
+++ b/pkgs/by-name/te/tetro-tui/package.nix
@@ -1,0 +1,23 @@
+{ lib, rustPlatform, fetchFromGitHub }:
+
+rustPlatform.buildRustPackage rec {
+  pname = "tetro-tui";
+  version = "3.5.2";
+
+  src = fetchFromGitHub {
+    owner = "Strophox";
+    repo = "tetro-tui";
+    rev = "v${version}";
+    hash = "sha256-9UHP3mo7sEjVPtBdLgbJpW3RlyXA8zAbY20CgBVdptg=";
+  };
+
+  cargoHash = "sha256-fBbHwCnlUuas+g1dFIRmOZM+hD32tp/++k1KNEFzphY=";
+
+  meta = with lib; {
+    description = "Tetro TUI is a terminal-based but modern tetromino-stacking game that is customizable and cross-platform.";
+    homepage = "https://github.com/Strophox/tetro-tui";
+    license = licenses.mit;
+    mainProgram = "tetro-tui";
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/by-name/te/tetro-tui/package.nix
+++ b/pkgs/by-name/te/tetro-tui/package.nix
@@ -1,6 +1,8 @@
 { lib, rustPlatform, fetchFromGitHub }:
 
 rustPlatform.buildRustPackage rec {
+  __structuredAttrs = true;
+
   pname = "tetro-tui";
   version = "3.5.2";
 

--- a/pkgs/by-name/te/tetro-tui/package.nix
+++ b/pkgs/by-name/te/tetro-tui/package.nix
@@ -1,4 +1,8 @@
-{ lib, rustPlatform, fetchFromGitHub }:
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
 
 rustPlatform.buildRustPackage rec {
   __structuredAttrs = true;


### PR DESCRIPTION
<!--
^ Adds tetro-tui 3.5.2, a modern terminal-based tetromino-stacking game written in Rust. ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
