### PR TITLE
libcupsfilters: custom test page

### DIFF
--- a/pkgs/by-name/li/libcupsfilters/package.nix
+++ b/pkgs/by-name/li/libcupsfilters/package.nix
@@ -5,6 +5,7 @@
   dejavu_fonts,
   fetchFromGitHub,
   fetchpatch,
+  fetchurl,
   fontconfig,
   ghostscript,
   lcms2,
@@ -21,6 +22,12 @@
   stdenv,
 }:
 
+let
+  testpage = fetchurl {
+    url = "https://codeberg.org/raboof/cups-testpage/releases/download/v0.1/default-testpage.pdf";
+    hash = "sha256-gtR/r/tORsXLw4PlFhxm29+//YNAKTT0c4z3GsgtzNw=";
+  };
+in
 stdenv.mkDerivation {
   pname = "libcupsfilters";
   version = "2.1.1";
@@ -99,6 +106,10 @@ stdenv.mkDerivation {
     "CUPS_DATADIR=$(out)/share/cups"
     "CUPS_SERVERROOT=$(out)/etc/cups"
   ];
+
+  preBuild = ''
+    cp ${testpage} data/default-testpage.pdf
+  '';
 
   meta = {
     homepage = "https://github.com/OpenPrinting/libcupsfilters";


### PR DESCRIPTION
The upstream CUPS test page is terrible: it includes images that are way lower-quality than today's consumer printers, both in terms of resolution and colour depth.

Upstream [doesn't seem interested](https://github.com/OpenPrinting/libcupsfilters/pull/100) in improving this. The next best thing is to at least have a slightly-better test page in Nix, and take the opportunity to throw in a Nix logo or two.

I spoke to someone who is familiar with print and they mentioned solid rgbcmyk blocks are more useful than the 'color wheel'.

I could imagine further improvements (maybe adding a 'rainbow gradient', text in various point sizes, 'hyperbolic wedges'), but this seems like a good first step.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
