### PR TITLE
dateutils: fix build errors

### DIFF
--- a/pkgs/by-name/da/dateutils/package.nix
+++ b/pkgs/by-name/da/dateutils/package.nix
@@ -2,8 +2,11 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   autoreconfHook,
   tzdata,
+  bison,
+  flex,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -12,20 +15,33 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://bitbucket.org/hroptatyr/dateutils/downloads/dateutils-${finalAttrs.version}.tar.xz";
-    sha256 = "sha256-uP6gsJcUu63yArmzQ0zOa1nCgueGkmjQwIuFiA/btEY=";
+    hash = "sha256-uP6gsJcUu63yArmzQ0zOa1nCgueGkmjQwIuFiA/btEY=";
   };
+
+  patches = [
+    # TODO: Remove when updating to the next release.
+    (fetchpatch {
+      url = "https://github.com/hroptatyr/dateutils/commit/b30902c2f46288b570c7fa8de06e17cc7dfd6a37.patch";
+      hash = "sha256-38LBUv4FLpK3TTIXXvIGr0qE0CSqF2IqCbZY5RGyi6Q=";
+    })
+  ];
 
   # https://github.com/hroptatyr/dateutils/issues/148
   postPatch = "rm test/dzone.008.ctst";
 
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [
+    autoreconfHook
+    flex
+    bison
+  ];
   buildInputs = [ tzdata ]; # needed for datezone
+
   enableParallelBuilding = true;
 
   doCheck = true;
 
   meta = {
-    description = "Bunch of tools that revolve around fiddling with dates and times in the command line";
+    description = "Command-line utilities for date and time calculations and conversions";
     homepage = "http://www.fresse.org/dateutils/";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

* Fix `yyparse` function declaration using `substituteInPlace`
* Add `flex` and `bison` to `nativeBuildInputs`
* Replace `src.sha256` with `src.hash`
* Update `meta.description`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
