### PR TITLE
openlist: remove fuse; 4.2.1 -> 4.2.2

### DIFF
--- a/pkgs/by-name/op/openlist/frontend.nix
+++ b/pkgs/by-name/op/openlist/frontend.nix
@@ -6,24 +6,24 @@
   fetchzip,
 
   nodejs,
-  openlistPnpm ? pnpm_10,
+  openlistPnpm ? pnpm_11,
   pnpmConfigHook,
-  pnpm_10,
+  pnpm_11,
 }:
 buildNpmPackage (finalAttrs: {
   pname = "openlist-frontend";
-  version = "4.2.1";
+  version = "4.2.2";
 
   src = fetchFromGitHub {
     owner = "OpenListTeam";
     repo = "OpenList-Frontend";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-4WSL6j0dANUNlHFkMBb8j/KyNHWDQmLnC1y2FFJiBEI=";
+    hash = "sha256-RLuAGjiYELy+roip2TtvUXGOw6Vk+GkczT1LSI0Vx+8=";
   };
 
   i18n = fetchzip {
     url = "https://github.com/OpenListTeam/OpenList-Frontend/releases/download/v${finalAttrs.version}/i18n.tar.gz";
-    hash = "sha256-VzHNZh0ZA2FncAkyozHeBilN4KKsPqbpMESx4QCppW0=";
+    hash = "sha256-ZO/ozyRNqh2W4/acQmGHoEMpjpf2jph7Gn/kOlwVSFs=";
     stripRoot = false;
   };
 
@@ -40,8 +40,8 @@ buildNpmPackage (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = openlistPnpm;
-    fetcherVersion = 3;
-    hash = "sha256-rTDk1p568AKim+ZD00uq1q4XNNMeUFL1rGDBWx2C6DQ=";
+    fetcherVersion = 4;
+    hash = "sha256-ujsCuQexnKPNwoJzaWmhu3+4xMkZ0jR04m2exG674dI=";
   };
 
   npmConfigHook = pnpmConfigHook;
@@ -49,6 +49,13 @@ buildNpmPackage (finalAttrs: {
   # [plugin vite:legacy-generate-polyfill-chunk]
   # Error: getaddrinfo ENOTFOUND localhost
   __darwinAllowLocalNetworking = true;
+
+  preBuild = ''
+    rm -rf node_modules/mpegts.js
+    cp -R ${finalAttrs.passthru.mpegts-js}/lib/node_modules/mpegts.js node_modules/mpegts.js
+    chmod -R u+w node_modules/mpegts.js
+    test -f node_modules/mpegts.js/dist/mpegts.js
+  '';
 
   installPhase = ''
     runHook preInstall
@@ -58,6 +65,25 @@ buildNpmPackage (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru = {
+    # OpenList depends on a forked mpegts.js git package whose source does not include the generated dist/
+    mpegts-js = buildNpmPackage {
+      pname = "mpegts-js-openlist";
+      version = "1.8.1-unstable-2026-05-16";
+
+      src = fetchFromGitHub {
+        owner = "OpenListTeam";
+        repo = "mpegts.js";
+        rev = "1e51e0f6f918cf08e05dfae9c7bfcf658d6b4ac2";
+        hash = "sha256-z+S3iSYqrMuxFRGa5JZIfGMyi7IErpnluwZUVLxqz2o=";
+      };
+
+      npmDepsHash = "sha256-UDI0iPK/ouVgpzscGrQXNnVUseLWYmR0W9THpBm4WqA=";
+
+      meta.license = lib.licenses.asl20;
+    };
+  };
 
   meta = {
     description = "Frontend of OpenList";

--- a/pkgs/by-name/op/openlist/package.nix
+++ b/pkgs/by-name/op/openlist/package.nix
@@ -8,7 +8,6 @@
   installShellFiles,
   libredirect,
   versionCheckHook,
-  fuse,
 }:
 
 buildGoModule (finalAttrs: {
@@ -42,9 +41,12 @@ buildGoModule (finalAttrs: {
   ]
   ++ lib.optional stdenv.hostPlatform.isDarwin libredirect.hook;
 
-  buildInputs = [ fuse ];
-
   tags = [ "jsoniter" ];
+
+  subPackages = [
+    "."
+    "pkg/gowebdav/cmd/gowebdav"
+  ];
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/op/openlist/package.nix
+++ b/pkgs/by-name/op/openlist/package.nix
@@ -12,13 +12,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "openlist";
-  version = "4.2.1";
+  version = "4.2.2";
 
   src = fetchFromGitHub {
     owner = "OpenListTeam";
     repo = "OpenList";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-9MDcAQh06W6mOhYpFR49bxvTTrIoJnKY9P3WRVWsujI=";
+    hash = "sha256-MxoF+hpzn/44knjVeaINo4/1T4ia7HG8mm+tbvJEsfQ=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -34,7 +34,7 @@ buildGoModule (finalAttrs: {
   frontend = callPackage ./frontend.nix { };
 
   proxyVendor = true;
-  vendorHash = "sha256-Ho9zVKdzpGKZ/ftJmidUkMBsN4qfvLa96Fg3ayTfYac=";
+  vendorHash = "sha256-ScPfry0PtSlABdyG+7egMAndG7D3iz1+ceAAhLQPtkM=";
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/by-name/op/openlist/update.nix
+++ b/pkgs/by-name/op/openlist/update.nix
@@ -18,13 +18,30 @@ writeShellApplication {
   ];
 
   text = ''
-    # get old info
     oldVersion=$(nix-instantiate --eval --strict -A "openlist.version" | jq -e -r)
 
     get_latest_release() {
         local repo=$1
         curl --fail ''${GITHUB_TOKEN:+ -H "Authorization: bearer $GITHUB_TOKEN"} \
              -s "https://api.github.com/repos/OpenListTeam/$repo/releases/latest" | jq -r ".tag_name"
+    }
+
+    get_github_commit_date() {
+        local repo=$1
+        local rev=$2
+
+        curl --fail ''${GITHUB_TOKEN:+ -H "Authorization: bearer $GITHUB_TOKEN"} \
+             -s "https://api.github.com/repos/OpenListTeam/$repo/commits/$rev" \
+          | jq -e -r '.commit.committer.date[0:10]'
+    }
+
+    get_github_package_version_at_rev() {
+        local repo=$1
+        local rev=$2
+
+        curl --fail ''${GITHUB_TOKEN:+ -H "Authorization: bearer $GITHUB_TOKEN"} \
+             -s "https://raw.githubusercontent.com/OpenListTeam/$repo/$rev/package.json" \
+          | jq -e -r '.version'
     }
 
     version=$(get_latest_release "OpenList")
@@ -41,6 +58,18 @@ writeShellApplication {
     update-source-version openlist.frontend "$frontendVersion" \
       --source-key=i18n --ignore-same-version \
       --file=pkgs/by-name/op/openlist/frontend.nix
+
+    frontendLockFile="$(nix-build --no-out-link -A openlist.frontend.src)/pnpm-lock.yaml"
+    mpegtsRev=$(sed -nE 's/.*github:OpenListTeam\/mpegts\.js#([0-9a-f]{40}).*/\1/p' "$frontendLockFile"| head -n1)
+    mpegtsBaseVersion=$(get_github_package_version_at_rev "mpegts.js" "$mpegtsRev")
+    mpegtsDate=$(get_github_commit_date "mpegts.js" "$mpegtsRev")
+
+    update-source-version openlist.frontend.mpegts-js "$mpegtsBaseVersion-unstable-$mpegtsDate" \
+      --rev="$mpegtsRev" \
+      --file=pkgs/by-name/op/openlist/frontend.nix
+    nix-update openlist.frontend.mpegts-js \
+      --version=skip \
+      --override-filename=pkgs/by-name/op/openlist/frontend.nix
 
     nix-update openlist --version="$version"
   '';


### PR DESCRIPTION
- remove fuse #526161
https://github.com/OpenListTeam/OpenList/blob/main/internal/fuse/fs.go#L10-L23
This is just a placeholder, so it's safe to just remove fuse from buidInputs.
```
func (fs *Fs) Init() {
	//TODO implement me
	panic("implement me")
}

func (fs *Fs) Destroy() {
	//TODO implement me
	panic("implement me")
}

func (fs *Fs) Statfs(path string, stat *fuse.Statfs_t) int {
	//TODO implement me
	panic("implement me")
}
```

- 4.2.1 -> 4.2.2
pnpm_11: https://github.com/OpenListTeam/OpenList-Frontend/blob/0a10a259ef70e023fab4faf938fc873755fbbe94/package.json#L10
mpegts.js: https://github.com/OpenListTeam/OpenList-Frontend/blob/0a10a259ef70e023fab4faf938fc873755fbbe94/package.json#L100
OpenList depends on a forked `mpegts.js` [git package](https://github.com/OpenListTeam/mpegts.js) whose source does not include the generated `dist/` so we have to build it first.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
