### PR TITLE
Allow .override to compose with .overrideScope

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -189,6 +189,8 @@ rec {
               # NOTE: part of the above documentation had to be duplicated in `mkDerivation`'s `overrideAttrs`.
               #       design/tech debt issue: https://github.com/NixOS/nixpkgs/issues/273815
               fdrv: makeOverridable (mirrorArgs (args: (f args).overrideAttrs fdrv)) origArgs;
+            ${if result ? overrideScope then "overrideScope" else null} =
+              fscope: makeOverridable (mirrorArgs (args: (f args).overrideScope fscope)) origArgs;
           }
         else if isFunction result then
           # Transform the result into a functor while propagating its arguments

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -319,6 +319,58 @@ runTests {
       expected = functionArgs f;
     };
 
+  # Test that makeOverridable composes with overrideScope (like it does with overrideAttrs)
+  testMakeOverridableOverrideScopeComposition =
+    let
+      mkScope =
+        { prefix ? "pkg" }:
+        lib.makeScope lib.callPackageWith (self: {
+          foo = self.callPackage ({ }: "${prefix}-foo") { };
+          bar = self.callPackage ({ foo }: "${foo}+bar") { };
+        });
+      scope0 = makeOverridable mkScope { };
+    in
+    {
+      expr = {
+        # Both override mechanisms are present initially
+        has-override = scope0 ? override;
+        has-overrideScope = scope0 ? overrideScope;
+
+        # overrideScope preserves override
+        overrideScope-then-override-exists =
+          (scope0.overrideScope (_final: _prev: { })) ? override;
+
+        # override preserves overrideScope
+        override-then-overrideScope-exists =
+          (scope0.override { prefix = "custom"; }) ? overrideScope;
+
+        # overrideScope result is correct
+        overrideScope-result =
+          (scope0.overrideScope (_final: prev: { foo = prev.foo + "+overlay"; })).bar;
+
+        # override then overrideScope composes (override is NOT reverted)
+        override-then-overrideScope =
+          ((scope0.override { prefix = "custom"; }).overrideScope
+            (_final: prev: { foo = prev.foo + "+overlay"; })
+          ).bar;
+
+        # overrideScope then override composes (overrideScope is NOT reverted)
+        overrideScope-then-override =
+          ((scope0.overrideScope (_final: prev: { foo = prev.foo + "+overlay"; })).override
+            { prefix = "custom"; }
+          ).bar;
+      };
+      expected = {
+        has-override = true;
+        has-overrideScope = true;
+        overrideScope-then-override-exists = true;
+        override-then-overrideScope-exists = true;
+        overrideScope-result = "pkg-foo+overlay+bar";
+        override-then-overrideScope = "custom-foo+overlay+bar";
+        overrideScope-then-override = "custom-foo+overlay+bar";
+      };
+    };
+
   # TRIVIAL
 
   testId = {


### PR DESCRIPTION
This just copies the approach for composing with `.overrideAttrs`. This allows using `.overrideScope` on `llvmPackages` in an overlay without it breaking when `pkgs/build-support/build-mozilla-mach/default.nix` tries to `.override` the result.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
