### PR TITLE
ifuse: 1.1.4+date=2022-04-04 -> 1.2.1

### DIFF
--- a/pkgs/by-name/if/ifuse/package.nix
+++ b/pkgs/by-name/if/ifuse/package.nix
@@ -4,20 +4,24 @@
   fetchFromGitHub,
   autoreconfHook,
   pkg-config,
-  fuse,
+  fuse3,
   usbmuxd,
   libimobiledevice,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "ifuse";
-  version = "1.1.4+date=2022-04-04";
+  version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "libimobiledevice";
     repo = "ifuse";
-    rev = "6f5b8e410f9615b3369ca5eb5367745e13d83b92";
-    hash = "sha256-KbuJLS2BWua9DnhLv2KtsQObin0PQwXQwEdgi3lSAPk=";
+    tag = finalAttrs.version;
+    hash = "sha256-STMELfxbWf2W6NKKqBxgbQLZpYXv9N0cDLgHho5PRYM=";
+  };
+
+  env = {
+    VER = finalAttrs.version;
   };
 
   nativeBuildInputs = [
@@ -26,7 +30,7 @@ stdenv.mkDerivation {
   ];
 
   buildInputs = [
-    fuse
+    fuse3
     usbmuxd
     libimobiledevice
   ];
@@ -45,4 +49,4 @@ stdenv.mkDerivation {
     maintainers = [ ];
     mainProgram = "ifuse";
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/libimobiledevice/ifuse/compare/6f5b8e410f9615b3369ca5eb5367745e13d83b92...6f5b8e410f9615b3369ca5eb5367745e13d83b92

https://github.com/NixOS/nixpkgs/issues/526161

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
