### PR TITLE
netwatch: init at 0.25.4

### DIFF
--- a/pkgs/by-name/ne/netwatch/package.nix
+++ b/pkgs/by-name/ne/netwatch/package.nix
@@ -1,0 +1,44 @@
+{
+  fetchFromGitHub,
+  lib,
+  libpcap,
+  nix-update-script,
+  pkg-config,
+  rustPlatform,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "netwatch-tui";
+  version = "0.25.4";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "matthart1983";
+    repo = "netwatch";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rbQ9lTQJgy93Z2WojaTkU5z1fkJX4mUjsx2Or7FNrJc=";
+  };
+
+  cargoHash = "sha256-D06ywfwurtfI8NAfGS88YOoSVi4KfjEBgUA8EfLKamQ=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ libpcap ];
+
+  doInstallCheck = true;
+  nativeCheckInputs = [ versionCheckHook ];
+
+  __darwinAllowLocalNetworking = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Real-time network diagnostics in your terminal.";
+    homepage = "https://github.com/matthart1983/netwatch";
+    changelog = "https://github.com/matthart1983/netwatch/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    mainProgram = "netwatch";
+    maintainers = with lib.maintainers; [ tomasrivera ];
+  };
+})


### PR DESCRIPTION
Adds netwatch a [Real-time network diagnostics in your terminal](https://github.com/matthart1983/netwatch)

Most of the derivation was taken from the repo's [package.nix](https://github.com/matthart1983/netwatch/blob/main/package.nix)

### AI/Automation
As said in the commit message, I was assissted by ChatGPT 5.5. HIs only input was replacing the `cargoLock.lockfile = ./Cargo.lock` by a `cargoHash`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
