### PR TITLE
python3Packages.{shiboken6{,-generator},pyside6}: enable strictDeps, structuredAttrs, fix cross

### DIFF
--- a/pkgs/development/python-modules/pyside6/default.nix
+++ b/pkgs/development/python-modules/pyside6/default.nix
@@ -14,42 +14,44 @@
   pkgsBuildBuild,
 }:
 let
-  packages = with python.pkgs.qt6; [
-    # required
-    python.pkgs.ninja
-    python.pkgs.packaging
-    python.pkgs.setuptools
-    qtbase
+  packages =
+    with python.pkgs.qt6;
+    [
+      # required
+      python.pkgs.ninja
+      python.pkgs.packaging
+      python.pkgs.setuptools
+      qtbase
 
-    # optional
-    qt3d
-    qtcharts
-    qtconnectivity
-    qtdatavis3d
-    qtdeclarative
-    qthttpserver
-    qtmultimedia
-    qtnetworkauth
-    qtquick3d
-    qtremoteobjects
-    qtscxml
-    qtsensors
-    qtspeech
-    qtsvg
-    qtwebchannel
-    qtwebsockets
-    qtpositioning
-    qtlocation
-    qtshadertools
-    qtserialport
-    qtserialbus
-    qtgraphs
-    qttools
-  ]
-  # qtwebview is broken in cross
-  ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
-    qtwebview
-  ];
+      # optional
+      qt3d
+      qtcharts
+      qtconnectivity
+      qtdatavis3d
+      qtdeclarative
+      qthttpserver
+      qtmultimedia
+      qtnetworkauth
+      qtquick3d
+      qtremoteobjects
+      qtscxml
+      qtsensors
+      qtspeech
+      qtsvg
+      qtwebchannel
+      qtwebsockets
+      qtpositioning
+      qtlocation
+      qtshadertools
+      qtserialport
+      qtserialbus
+      qtgraphs
+      qttools
+    ]
+    # qtwebview is broken in cross
+    ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+      qtwebview
+    ];
   qt_linked = symlinkJoin {
     name = "qt_linked";
     paths = packages;

--- a/pkgs/development/python-modules/pyside6/default.nix
+++ b/pkgs/development/python-modules/pyside6/default.nix
@@ -10,6 +10,8 @@
   shiboken6,
   llvmPackages,
   symlinkJoin,
+  buildPackages,
+  pkgsBuildBuild,
 }:
 let
   packages = with python.pkgs.qt6; [
@@ -36,7 +38,6 @@ let
     qtsvg
     qtwebchannel
     qtwebsockets
-    qtwebview
     qtpositioning
     qtlocation
     qtshadertools
@@ -44,6 +45,10 @@ let
     qtserialbus
     qtgraphs
     qttools
+  ]
+  # qtwebview is broken in cross
+  ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    qtwebview
   ];
   qt_linked = symlinkJoin {
     name = "qt_linked";
@@ -90,6 +95,8 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     ninja
     python
+  ]
+  ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
     pythonImportsCheckHook
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ moveBuildTree ];
@@ -98,7 +105,11 @@ stdenv.mkDerivation (finalAttrs: {
     if stdenv.hostPlatform.isLinux then
       # qtwebengine fails under darwin
       # see https://github.com/NixOS/nixpkgs/pull/312987
-      packages ++ [ python.pkgs.qt6.qtwebengine ]
+      packages
+      # qtwebengine is broken in cross
+      ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+        python.pkgs.qt6.qtwebengine
+      ]
     else
       python.pkgs.qt6.darwinVersionInputs
       ++ [
@@ -109,9 +120,18 @@ stdenv.mkDerivation (finalAttrs: {
 
   propagatedBuildInputs = [ shiboken6 ];
 
+  strictDeps = true;
+
   cmakeFlags = [
     "-DBUILD_TESTS=OFF"
     "-Dis_pyside6_superproject_build=1"
+    # Needed for cross, similarly to the way the indivudual Qt6 modules are built
+    "-DQt6QmlTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QmlTools"
+    "-DQt6QuickTools_DIR=${pkgsBuildBuild.qt6.qtdeclarative}/lib/cmake/Qt6QuickTools"
+    "-DQt6Quick3DTools_DIR=${pkgsBuildBuild.qt6.qtquick3d}/lib/cmake/Qt6Quick3DTools"
+    "-DQt6RemoteObjectsTools_DIR=${pkgsBuildBuild.qt6.qtremoteobjects}/lib/cmake/Qt6RemoteObjectsTools"
+    "-DQt6ScxmlTools_DIR=${pkgsBuildBuild.qt6.qtscxml}/lib/cmake/Qt6ScxmlTools"
+    "-DQt6ShaderToolsTools_DIR=${pkgsBuildBuild.qt6.qtshadertools}/lib/cmake/Qt6ShaderToolsTools"
   ];
 
   dontWrapQtApps = true;
@@ -119,7 +139,7 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     cd ../../..
     chmod +w .
-    ${python.pythonOnBuildForHost.interpreter} setup.py egg_info --build-type=pyside6
+    python3 setup.py egg_info --build-type=pyside6 --qtpaths=${lib.getExe' buildPackages.python3.pkgs.qt6.qtbase "qtpaths"}
     cp -r PySide6.egg-info $out/${python.sitePackages}/
 
     mkdir -p "$devtools"
@@ -127,6 +147,8 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   pythonImportsCheck = [ "PySide6" ];
+
+  __structuredAttrs = true;
 
   meta = {
     description = "Python bindings for Qt";

--- a/pkgs/development/python-modules/shiboken6-generator/default.nix
+++ b/pkgs/development/python-modules/shiboken6-generator/default.nix
@@ -4,7 +4,9 @@
   llvmPackages,
   python,
   cmake,
+  ninja,
   stdenv,
+  buildPackages,
 }:
 
 let
@@ -28,8 +30,8 @@ stdenv'.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    python.pkgs.ninja
-    (python.withPackages (ps: [
+    ninja
+    (buildPackages.python3.withPackages (ps: [
       ps.packaging
       ps.setuptools
     ]))
@@ -41,6 +43,8 @@ stdenv'.mkDerivation (finalAttrs: {
     python.pkgs.qt6.qtbase
   ];
 
+  strictDeps = true;
+
   cmakeFlags = [
     "-Dis_pyside6_superproject_build=1"
   ];
@@ -50,9 +54,11 @@ stdenv'.mkDerivation (finalAttrs: {
   postInstall = ''
     cd ../../..
     chmod +w .
-    python3 setup.py egg_info --build-type=shiboken6-generator
+    python3 setup.py egg_info --build-type=shiboken6-generator --qtpaths=${lib.getExe' buildPackages.python3.pkgs.qt6.qtbase "qtpaths"}
     cp -r shiboken6_generator.egg-info $out/${python.sitePackages}/
   '';
+
+  __structuredAttrs = true;
 
   meta = {
     description = "Generator for the pyside6 Qt bindings - tools";

--- a/pkgs/development/python-modules/shiboken6/default.nix
+++ b/pkgs/development/python-modules/shiboken6/default.nix
@@ -5,11 +5,17 @@
   shiboken6-generator,
   numpy,
   cmake,
+  ninja,
   stdenv,
+  buildPackages,
 }:
 
 let
   stdenv' = if stdenv.cc.isClang then stdenv else llvmPackages.stdenv;
+  pythonWithPackages = python.pythonOnBuildForHost.withPackages (ps: [
+    ps.packaging
+    ps.setuptools
+  ]);
 in
 stdenv'.mkDerivation (finalAttrs: {
   pname = "shiboken6";
@@ -20,11 +26,8 @@ stdenv'.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    python.pkgs.ninja
-    (python.pythonOnBuildForHost.withPackages (ps: [
-      ps.packaging
-      ps.setuptools
-    ]))
+    ninja
+    pythonWithPackages
   ];
 
   propagatedNativeBuildInputs = [
@@ -36,10 +39,14 @@ stdenv'.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin python.pkgs.qt6.darwinVersionInputs;
 
+  strictDeps = true;
+
   cmakeFlags = [
     "-DBUILD_TESTS=OFF"
     "-DNUMPY_INCLUDE_DIR=${numpy.coreIncludeDir}"
     "-Dis_pyside6_superproject_build=1"
+    # Upstream variable explicitly provided to help with cross-compilation
+    "-DQFP_PYTHON_HOST_PATH=${pythonWithPackages.interpreter}"
   ];
 
   # We intentionally use single quotes around `${BASH}` since it expands from a CMake
@@ -57,11 +64,13 @@ stdenv'.mkDerivation (finalAttrs: {
   postInstall = ''
     cd ../../..
     chmod +w .
-    python3 setup.py egg_info --build-type=shiboken6
+    python3 setup.py egg_info --build-type=shiboken6 --qtpaths=${lib.getExe' buildPackages.python3.pkgs.qt6.qtbase "qtpaths"}
     cp -r shiboken6.egg-info $out/${python.sitePackages}/
   '';
 
   dontWrapQtApps = true;
+
+  __structuredAttrs = true;
 
   meta = {
     description = "Generator for the pyside6 Qt bindings - Python library";


### PR DESCRIPTION
I think additional changes for darwin (moving `python.pkgs.qt6.darwinVersionInputs`) may be necessary, but I can't test it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
