### PR TITLE
tango-icon-theme: enable strictDeps and structuredAttrs, use SRI hash

### DIFF
--- a/pkgs/by-name/ta/tango-icon-theme/package.nix
+++ b/pkgs/by-name/ta/tango-icon-theme/package.nix
@@ -23,21 +23,27 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [ ./rsvg-convert.patch ];
 
-  nativeBuildInputs = [
+  depsBuildBuild = [
     pkg-config
+  ];
+
+  nativeBuildInputs = [
     intltool
     gtk3
-  ];
-  buildInputs = [
-    iconnamingutils
-    imagemagick
     librsvg
+    imagemagick
+    iconnamingutils
+    gnome-icon-theme
+    hicolor-icon-theme
   ];
+
   propagatedBuildInputs = [
     gnome-icon-theme
     hicolor-icon-theme
   ];
   # still missing parent icon themes: cristalsvg
+
+  strictDeps = true;
 
   dontDropIconThemeCache = true;
 
@@ -46,6 +52,8 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     gtk-update-icon-cache $out/share/icons/Tango
   '';
+
+  __structuredAttrs = true;
 
   meta = {
     description = "Basic set of icons";

--- a/pkgs/by-name/ta/tango-icon-theme/package.nix
+++ b/pkgs/by-name/ta/tango-icon-theme/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://tango.freedesktop.org/releases/tango-icon-theme-${finalAttrs.version}.tar.gz";
-    sha256 = "13n8cpml71w6zfm2jz5fa7r1z18qlzk4gv07r6n1in2p5l1xi63f";
+    hash = "sha256-bpjYAy1X2BisyQfsR+anGIUf8lGufCmq+4aHQ+tlyI4=";
   };
 
   patches = [ ./rsvg-convert.patch ];


### PR DESCRIPTION
No diff in output.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
