### PR TITLE
evernote2md: init at 0.22.2

### DIFF
--- a/pkgs/by-name/ev/evernote2md/package.nix
+++ b/pkgs/by-name/ev/evernote2md/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "evernote2md";
+  version = "0.22.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "wormi4ok";
+    repo = "evernote2md";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-y8Nc+rqjtVR7z9kPZZ/bZUPlmPwePCW8UmGwxxKm2J0=";
+  };
+
+  vendorHash = "sha256-AbfnxH5Xy+3ZYd74qig9ado9Nn/bqPrDEW9IfsYr+Sk=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  meta = {
+    description = "Convert Evernote .enex files to Markdown";
+    homepage = "https://github.com/wormi4ok/evernote2md";
+    changelog = "https://github.com/wormi4ok/evernote2md/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tbutter ];
+    mainProgram = "evernote2md";
+  };
+})


### PR DESCRIPTION
Package evernote2md

A tool to convert evernote enex files to md files

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
