### PR TITLE
home-assistant: construct package set with overrideScope

### DIFF
--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -30,7 +30,6 @@ let
     mapAttrsToList
     mergeAttrsList
     mkEnableOption
-    mkDefault
     mkIf
     mkMerge
     mkOption

--- a/pkgs/development/python-modules/aioesphomeapi/default.nix
+++ b/pkgs/development/python-modules/aioesphomeapi/default.nix
@@ -26,14 +26,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "aioesphomeapi";
-  version = "44.23.0"; # must track the major version that home-assistant pins
+  version = "44.24.1"; # must track the major version that home-assistant pins
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "esphome";
     repo = "aioesphomeapi";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-mKk4NO44mVTV5Fe8oDhQYcNp8V1OLsPt4xk+kztXwrM=";
+    hash = "sha256-D2MJISyHz4s0Rk6wGMrYVJHfvA/Xbw2UEp2KqTqS2nA=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/aioesphomeapi/default.nix
+++ b/pkgs/development/python-modules/aioesphomeapi/default.nix
@@ -26,14 +26,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "aioesphomeapi";
-  version = "45.0.2";
+  version = "44.23.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "esphome";
     repo = "aioesphomeapi";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ajucVk5yF0akOIfBX28sjOndpmHQumJBUp5jnq//B+M=";
+    hash = "sha256-mKk4NO44mVTV5Fe8oDhQYcNp8V1OLsPt4xk+kztXwrM=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/aioesphomeapi/default.nix
+++ b/pkgs/development/python-modules/aioesphomeapi/default.nix
@@ -26,7 +26,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "aioesphomeapi";
-  version = "44.23.0";
+  version = "44.23.0"; # must track the major version that home-assistant pins
   pyproject = true;
 
   src = fetchFromGitHub {

--- a/pkgs/servers/home-assistant/build-custom-component/default.nix
+++ b/pkgs/servers/home-assistant/build-custom-component/default.nix
@@ -6,14 +6,15 @@
 }:
 
 let
+  inherit (home-assistant) python3Packages;
+
   manifestRequirementsCheckHook = import ./manifest-requirements-check-hook.nix {
-    inherit lib makeSetupHook;
-    inherit (home-assistant) python;
+    inherit lib makeSetupHook python3Packages;
   };
 in
 
 lib.extendMkDerivation {
-  constructDrv = home-assistant.python.pkgs.buildPythonPackage;
+  constructDrv = python3Packages.buildPythonPackage;
   excludeDrvArgNames = [
     "meta"
     "nativeBuildInputs"
@@ -52,7 +53,7 @@ lib.extendMkDerivation {
       '';
 
       nativeBuildInputs =
-        with home-assistant.python.pkgs;
+        with home-assistant.python3Packages;
         [
           manifestRequirementsCheckHook
           packaging

--- a/pkgs/servers/home-assistant/build-custom-component/manifest-requirements-check-hook.nix
+++ b/pkgs/servers/home-assistant/build-custom-component/manifest-requirements-check-hook.nix
@@ -1,13 +1,13 @@
 {
   lib,
-  python,
+  python3Packages,
   makeSetupHook,
 }:
 
 makeSetupHook {
   name = "manifest-check-hook";
   substitutions = {
-    pythonCheckInterpreter = python.interpreter;
+    pythonCheckInterpreter = python3Packages.python.interpreter;
     checkManifest = ./check_manifest.py;
   };
   meta.license = lib.licenses.mit;

--- a/pkgs/servers/home-assistant/custom-components/README.md
+++ b/pkgs/servers/home-assistant/custom-components/README.md
@@ -12,7 +12,7 @@ function arguments. Pass them into `dependencies` for them to
 be available to Home Assistant.
 
 Out-of-tree components need to use Python packages from
-`home-assistant.python.pkgs` as to not introduce conflicting package
+`home-assistant.python3Pacakges` as to not introduce conflicting package
 versions into the Python environment.
 
 

--- a/pkgs/servers/home-assistant/custom-components/frigate/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/frigate/package.nix
@@ -48,8 +48,8 @@ buildHomeAssistantComponent rec {
     pytest-timeout
     pytestCheckHook
   ]
-  ++ (homeassistant.getPackages "mqtt" homeassistant.python.pkgs)
-  ++ (homeassistant.getPackages "stream" homeassistant.python.pkgs);
+  ++ (homeassistant.getPackages "mqtt" homeassistant.python3Packages)
+  ++ (homeassistant.getPackages "stream" homeassistant.python3Packages);
 
   disabledTests = [
     # https://github.com/blakeblackshear/frigate-hass-integration/issues/922

--- a/pkgs/servers/home-assistant/custom-components/moonraker/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/moonraker/package.nix
@@ -32,7 +32,7 @@ buildHomeAssistantComponent rec {
     pytest-cov-stub
     pytestCheckHook
   ]
-  ++ home-assistant.getPackages "camera" home-assistant.python.pkgs;
+  ++ home-assistant.getPackages "camera" home-assistant.python3Packages;
 
   disabledTests = [
     # tests try to open sockets

--- a/pkgs/servers/home-assistant/custom-components/powercalc/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/powercalc/package.nix
@@ -43,7 +43,7 @@ buildHomeAssistantComponent rec {
     aioresponses
     pytest-freezegun
   ]
-  ++ home-assistant.getPackages "camera" home-assistant.python.pkgs;
+  ++ home-assistant.getPackages "camera" home-assistant.python3Packages;
 
   preCheck = ''
     patchShebangs --build tests/setup.sh

--- a/pkgs/servers/home-assistant/custom-components/yandex-station/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/yandex-station/package.nix
@@ -36,7 +36,7 @@ buildHomeAssistantComponent rec {
     home-assistant
     pytestCheckHook
   ]
-  ++ (home-assistant.getPackages "stream" home-assistant.python.pkgs);
+  ++ (home-assistant.getPackages "stream" home-assistant.python3Packages);
 
   meta = {
     changelog = "https://github.com/AlexxIT/YandexStation/releases/tag/${src.tag}";

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -5,7 +5,7 @@
   fetchFromGitHub,
   fetchPypi,
   fetchpatch,
-  python314,
+  python314Packages,
   replaceVars,
   ffmpeg-headless,
   inetutils,
@@ -246,10 +246,9 @@ let
     })
   ];
 
-  python = python314.override {
-    self = python;
-    packageOverrides = lib.composeManyExtensions (defaultOverrides ++ [ packageOverrides ]);
-  };
+  python3Packages = python314Packages.overrideScope (
+    final: prev: lib.composeManyExtensions (defaultOverrides ++ [ packageOverrides ]) final prev
+  );
 
   componentPackages = import ./component-packages.nix;
 
@@ -259,16 +258,18 @@ let
 
   getPackages = component: componentPackages.components.${component};
 
-  componentBuildInputs = lib.concatMap (component: getPackages component python.pkgs) extraComponents;
+  componentBuildInputs = lib.concatMap (
+    component: getPackages component python3Packages
+  ) extraComponents;
 
   # Ensure that we are using a consistent package set
-  extraBuildInputs = extraPackages python.pkgs;
+  extraBuildInputs = extraPackages python3Packages;
 
   # Don't forget to run update-component-packages.py after updating
   hassVersion = "2026.5.4";
 
 in
-python.pkgs.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "homeassistant";
   version =
     assert (componentPackages.version == hassVersion);
@@ -276,7 +277,7 @@ python.pkgs.buildPythonApplication rec {
   pyproject = true;
 
   # check REQUIRED_PYTHON_VER in homeassistant/const.py
-  disabled = python.pythonOlder "3.14";
+  disabled = python3Packages.pythonOlder "3.14";
 
   # don't try and fail to strip 6600+ python files, it takes minutes!
   dontStrip = true;
@@ -295,7 +296,7 @@ python.pkgs.buildPythonApplication rec {
     hash = "sha256-o5S6rnOTqzPLZpMBxgmp9IpmLlEHLvHTH68ql2EkVbI=";
   };
 
-  build-system = with python.pkgs; [
+  build-system = with python3Packages; [
     setuptools
   ];
 
@@ -347,7 +348,7 @@ python.pkgs.buildPythonApplication rec {
     "uv"
   ];
 
-  dependencies = with python.pkgs; [
+  dependencies = with python3Packages; [
     # Mirror what gets installed for Home Assistant Container, which means
     # installing what is in requirements.txt. The PEP517 specification gets
     # embedded in wheel metadata but only represents a subset.
@@ -421,7 +422,7 @@ python.pkgs.buildPythonApplication rec {
   # upstream only tests on Linux, so do we.
   doCheck = stdenv.hostPlatform.isLinux;
 
-  requirementsTest = with python.pkgs; [
+  requirementsTest = with python3Packages; [
     # test infrastructure (selectively from requirement_test.txt)
     freezegun
     pytest-asyncio
@@ -440,7 +441,7 @@ python.pkgs.buildPythonApplication rec {
   nativeCheckInputs =
     requirementsTest
     ++ [ versionCheckHook ]
-    ++ (with python.pkgs; [
+    ++ (with python3Packages; [
       # Used in tests/non_packaged_scripts/test_alexa_locales.py
       beautifulsoup4
       # Used in tests/scripts/test_check_config.py
@@ -448,7 +449,7 @@ python.pkgs.buildPythonApplication rec {
       # Used in tests/helpers/test_httpx_client.py
       h2
     ])
-    ++ lib.concatMap (component: getPackages component python.pkgs) [
+    ++ lib.concatMap (component: getPackages component python3Packages) [
       # some components are needed even if tests in tests/components are disabled
       "frontend"
       "hue"
@@ -506,12 +507,12 @@ python.pkgs.buildPythonApplication rec {
       availableComponents
       extraComponents
       getPackages
-      python
+      python3Packages
       supportedComponentsWithTests
       ;
-    pythonPath = python.pkgs.makePythonPath (componentBuildInputs ++ extraBuildInputs);
-    frontend = python.pkgs.home-assistant-frontend;
-    intents = python.pkgs.home-assistant-intents;
+    pythonPath = python3Packages.makePythonPath (componentBuildInputs ++ extraBuildInputs);
+    frontend = python3Packages.home-assistant-frontend;
+    intents = python3Packages.home-assistant-intents;
     tests = {
       nixos = nixosTests.home-assistant;
       components = callPackage ./tests.nix { };

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   version = "2026.5.4";
   pyproject = true;
 
-  disabled = python.version != home-assistant.python.version;
+  disabled = python.version != home-assistant.python3Packages.python.version;
 
   src = fetchFromGitHub {
     owner = "KapJI";

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -5,11 +5,11 @@
 }:
 
 let
-  getComponentDeps = component: home-assistant.getPackages component home-assistant.python.pkgs;
+  getComponentDeps = component: home-assistant.getPackages component home-assistant.python3Packages;
   inherit (lib) concatMap;
 
   # some components' tests have additional dependencies
-  extraCheckInputs = with home-assistant.python.pkgs; {
+  extraCheckInputs = with home-assistant.python3Packages; {
     alexa = concatMap getComponentDeps [
       "cloud"
       "frontend"
@@ -185,7 +185,7 @@ lib.listToAttrs (
 
         nativeCheckInputs =
           old.requirementsTest
-          ++ home-assistant.getPackages component home-assistant.python.pkgs
+          ++ home-assistant.getPackages component home-assistant.python3Packages
           ++ extraCheckInputs.${component} or [ ];
 
         disabledTests = extraDisabledTests.${component} or [ ];

--- a/pkgs/servers/home-assistant/update-component-packages.py
+++ b/pkgs/servers/home-assistant/update-component-packages.py
@@ -34,7 +34,7 @@ from rich.console import Console
 from rich.table import Table
 
 COMPONENT_PREFIX = "homeassistant.components"
-PKG_SET = "home-assistant.python.pkgs"
+PKG_SET = "home-assistant.python3Packages"
 
 # If some requirements are matched by multiple or no Python packages, the
 # following can be used to choose the correct one

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7727,7 +7727,7 @@ with pkgs;
     lib.makeExtensible (
       self:
       lib.packagesFromDirectoryRecursive {
-        inherit (home-assistant.python.pkgs) callPackage;
+        inherit (home-assistant.python3Packages) callPackage;
         directory = ../servers/home-assistant/custom-components;
       }
     )


### PR DESCRIPTION
No direct access to the unspliced `python.pkgs` any more, which should improve cross compat.

Reverts aioesphomeapi to the last major version to fix compat issues reported against the Voice PE hardware.

All rebuilds in this PR should result from the aioesphomeapi revert. For native builds the package set changes make no difference.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
