### PR TITLE
matcha: 0.37.0 -> 0.40.1

### DIFF
--- a/pkgs/by-name/ma/matcha/package.nix
+++ b/pkgs/by-name/ma/matcha/package.nix
@@ -14,16 +14,16 @@ buildGoModule (finalAttrs: {
   __structuredAttrs = true;
 
   pname = "matcha";
-  version = "0.37.0";
+  version = "0.40.1";
 
   src = fetchFromGitHub {
     owner = "floatpane";
     repo = "matcha";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-bvy7og6om+Mqn4J0GrtIx8VQQXUiy8Y7Kueyfj5FWWQ=";
+    hash = "sha256-4GbuiFFHQ14O+S2TtWiP1UWg3h6J9Cys6A8k5+0Ww/I=";
   };
 
-  vendorHash = "sha256-SH7zP5+3R82mMx9vHY8QbPUkLr29pwbIbiV55UUQu+M=";
+  vendorHash = "sha256-TFc7e7gNtFNiCJHARngWSBKGqGhH7PiX48VkU9kD9Bs=";
   proxyVendor = true;
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [


### PR DESCRIPTION
## Description

Automated version bump for `matcha` email client.

- Old: 0.37.0
- New: 0.40.1
- Upstream release: https://github.com/floatpane/matcha/releases/tag/v0.40.1

## Things done

- Built on `x86_64-linux` via GitHub Actions
- Hashes regenerated from upstream tarball
- No package metadata changes beyond version + hashes

cc maintainer for review.