### PR TITLE
ONLYOFFICE DesktopEditors: updates

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -29,6 +29,12 @@
   "module-hardware-facter-usage": [
     "index.html#module-hardware-facter-usage"
   ],
+  "module-programs-onlyoffice": [
+    "index.html#module-programs-onlyoffice"
+  ],
+  "module-programs-onlyoffice-quickstart": [
+    "index.html#module-programs-onlyoffice-quickstart"
+  ],
   "module-security-tpm2": [
     "index.html#module-security-tpm2"
   ],

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -33,6 +33,7 @@
 - [compsize](https://github.com/kilobyte/compsize), setcap wrapper for `compsize` package, a cli utility to to inspect compression type/ratio on BTRFS filesystems. Available as [programs.compsize](#opt-programs.compsize.enable)
 
 - [tranquil](https://tangled.org/tranquil.farm/tranquil-pds) is an ATProto PDS (personal data server) implementation in Rust. A featureful, spec conscious and community driven alternative to the Bluesky reference implementation PDS. Available as [services.tranquil-pds](#opt-services.tranquil-pds.enable).
+- [onlyoffice](https://www.onlyoffice.com) is an open-source office suite which is provided as a web application and also as a desktop application known as ONLYOFFICE DesktopEditors. The [programs.onlyoffice](#opt-programs.onlyoffice.enable) NixOS module installs ONLYOFFICE DesktopEditors such that fonts installed using [fonts.packages](#opt-fonts.packages) are available within the office suite.
 
 - [Cardwire](https://github.com/OpenGamingCollective/cardwire), a GPU manager for Linux that uses eBPF+LSM hooks to control GPUs. Available as [services.cardwired](#opt-services.cardwired.enable).
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -301,6 +301,7 @@
   ./programs/oblogout.nix
   ./programs/obs-studio.nix
   ./programs/oddjobd.nix
+  ./programs/onlyoffice.nix
   ./programs/opengamepadui.nix
   ./programs/openvpn3.nix
   ./programs/partition-manager.nix

--- a/nixos/modules/programs/onlyoffice.md
+++ b/nixos/modules/programs/onlyoffice.md
@@ -1,0 +1,16 @@
+# ONLYOFFICE DesktopEditors {#module-programs-onlyoffice}
+
+[ONLYOFFICE](https://www.onlyoffice.com) is an open-source office suite which is provided as a web application and also as a desktop application known as ONLYOFFICE DesktopEditors. This module is for ONLYOFFICE DesktopEditors.
+
+## Quickstart {#module-programs-onlyoffice-quickstart}
+
+This module installs ONLYOFFICE DesktopEditors such that fonts installed via the `fonts.packages` NixOS module are made available to ONLYOFFICE.
+
+Here's an example of a configuration:
+
+```nix
+{ config, ... }:
+{
+  programs.onlyoffice.enable = true;
+}
+```

--- a/nixos/modules/programs/onlyoffice.nix
+++ b/nixos/modules/programs/onlyoffice.nix
@@ -1,0 +1,40 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.onlyoffice;
+in
+{
+  options.programs.onlyoffice = {
+    enable = lib.mkEnableOption "ONLYOFFICE Desktop Editors, an open-source office suite";
+
+    package = lib.mkPackageOption pkgs "onlyoffice-desktopeditors" { };
+
+    extraFontPackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ ];
+      example = lib.literalExpression "[ pkgs.nanum pkgs.liberation_ttf ]";
+      description = "Additional fonts to include with onlyoffice. Defaults to fonts.packages.";
+    };
+  };
+
+  config =
+    let
+      package = cfg.package.override {
+        extraFontPackages =
+          if cfg.extraFontPackages == [ ] then config.fonts.packages else cfg.extraFontPackages;
+      };
+    in
+    lib.mkIf cfg.enable {
+      environment.systemPackages = [ package ];
+    };
+
+  meta = {
+    maintainers = [ lib.maintainers.emmanuelrosa ];
+    doc = ./onlyoffice.md;
+  };
+}

--- a/pkgs/by-name/on/onlyoffice-desktopeditors/package.nix
+++ b/pkgs/by-name/on/onlyoffice-desktopeditors/package.nix
@@ -28,6 +28,7 @@
   libdrm,
   makeWrapper,
   libgbm,
+  libGL,
   noto-fonts-cjk-sans,
   nspr,
   nss,
@@ -78,11 +79,11 @@ let
 
   derivation = stdenv.mkDerivation rec {
     pname = "onlyoffice-desktopeditors";
-    version = "9.1.0";
+    version = "9.4.0";
     minor = null;
     src = fetchurl {
       url = "https://github.com/ONLYOFFICE/DesktopEditors/releases/download/v${version}/onlyoffice-desktopeditors_amd64.deb";
-      hash = "sha256-D36E7hYCTJ9Lw9XnB8nxMGMJDJRhM+K+bviuM9uuzhk=";
+      hash = "sha256-QnFDToG+QrFVn9mJ0kv21BNILyeNxqXjKCAqT8Ghhkk=";
     };
 
     nativeBuildInputs = [
@@ -180,6 +181,7 @@ buildFHSEnv {
     curl
     derivation
     noto-fonts-cjk-sans
+    libGL
   ];
 
   runScript = "/bin/onlyoffice-desktopeditors";

--- a/pkgs/by-name/on/onlyoffice-desktopeditors/package.nix
+++ b/pkgs/by-name/on/onlyoffice-desktopeditors/package.nix
@@ -3,6 +3,9 @@
   lib,
   fetchurl,
   buildFHSEnv,
+  symlinkJoin,
+  runCommand,
+  extraFontPackages ? [ ],
   # Alphabetic ordering below
   alsa-lib,
   at-spi2-atk,
@@ -65,9 +68,26 @@ let
   #
   # into `~/.local/share/fonts/`, otherwise the default template fonts, and
   # things like bullet points, will not look as expected.
+  #
+  # To make fonts packaged with Nix available to OnlyOffice, add the packages using the `extraFontPackages' attribute:
+  # (onlyoffice-desktopeditors.override { extraFontPackages = [ pkgs.font-bh-ttf ]; })
 
   # TODO: Find out which of these fonts we'd be allowed to distribute along
   #       with this package, or how to make this easier for users otherwise.
+
+  onlyoffice-fonts = symlinkJoin {
+    name = "onlyoffice-fonts";
+    paths = [ noto-fonts-cjk-sans ] ++ extraFontPackages;
+  };
+
+  fontsDir = runCommand "onlyoffice-fonts-dir" { } ''
+    font_regexp='.*\.\(ttf\|ttc\|otf\)?'
+    mkdir -p $out
+
+    find ${onlyoffice-fonts} -type l -iregex "$font_regexp" -print0 | while IFS= read -r -d "" file; do
+      cp -L --update=none "$file" $out/
+    done
+  '';
 
   runtimeLibs = lib.makeLibraryPath [
     curl
@@ -173,14 +193,12 @@ in
 
 # In order to download plugins, OnlyOffice uses /usr/bin/curl so we have to wrap it.
 # Curl still needs to be in runtimeLibs because the library is used directly in other parts of the code.
-# Fonts are also discovered by looking in /usr/share/fonts, so adding fonts to targetPkgs will include them
 buildFHSEnv {
   inherit (derivation) pname version;
 
   targetPkgs = pkgs': [
     curl
     derivation
-    noto-fonts-cjk-sans
     libGL
   ];
 
@@ -192,6 +210,11 @@ buildFHSEnv {
     cp -r ${derivation}/share/applications $out/share
     substituteInPlace $out/share/applications/onlyoffice-desktopeditors.desktop \
         --replace-fail "/usr/bin/onlyoffice-desktopeditors" "$out/bin/onlyoffice-desktopeditors"
+  '';
+
+  extraBuildCommands = ''
+    mkdir -p $out/usr/share/
+    ln -s ${fontsDir} $out/usr/share/fonts
   '';
 
   passthru.updateScript = ./update.sh;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR updates onlyoffice-desktopeditors and adds a NixOS module to make system-wide fonts available to onlyoffice-desktopeditors.

- Updates onlyoffice-desktopeditors from 9.1.0 to 9.4.0. See  changelog https://github.com/ONLYOFFICE/DesktopEditors/blob/master/CHANGELOG.md#940
- Adds `programs.onlyoffice` NixOS module. This is different from the `services.onlyoffice` module, which is for the web-based build.

This PR replaces https://github.com/NixOS/nixpkgs/pull/498961

## About fonts

For a number of years, system-wide fonts, such as those installed via `fonts.packages` have been unavailable to users who run ONLYOFFICE on NixOS due to the way ONLYOFFICE loads fonts. You can read about the details here: https://github.com/ONLYOFFICE/DocumentServer/issues/1859

The NixOS module included in this PR installs ONLYOFFICE in such a way that system-wide fonts are now usable within ONLYOFFICE. It does this by utilizing a new attribute added to the `onlyoffice-desktopeditors` package, which in turn makes the fonts available in the bwrap container.

One downside to the implementatioin is that because ONLYOFFICE doesn't load font files which are symlinks, the fonts are dereferenced by the derivation. With large font packages, such as `google-fonts` this can take some time and use up more disk space. Disk space can be reclaimed with `nix store optimise`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
