### PR TITLE
update nixos/hardware.fw-fanctrl + package fw-fanctrl

### DIFF
--- a/nixos/modules/hardware/fw-fanctrl.nix
+++ b/nixos/modules/hardware/fw-fanctrl.nix
@@ -55,7 +55,7 @@ in
     };
 
     keepDefaultStrategies = mkOption {
-      type = lib.types.bool;
+      type = types.bool;
       default = true;
       description = ''
         Keep the default strategies of the fw-fanctrl package.

--- a/nixos/modules/hardware/fw-fanctrl.nix
+++ b/nixos/modules/hardware/fw-fanctrl.nix
@@ -9,6 +9,20 @@ let
 
   settingsFormat = pkgs.formats.json { };
   cfg = config.hardware.fw-fanctrl;
+
+  userConfig = settingsFormat.generate "user.json" cfg.settings;
+  finalConfig =
+    if cfg.keepDefaultStrategies then
+      pkgs.runCommand "config.json" { } ''
+        ${lib.getExe pkgs.jq} -s '.[0] * .[1]' ${cfg.package}/share/fw-fanctrl/config.json ${userConfig} >$out
+      ''
+    else
+      userConfig;
+  fw-fanctrl =
+    if cfg.frameworkToolPackage == pkgs.framework-tool then
+      cfg.package
+    else
+      cfg.package.override { inherit (cfg) frameworkToolPackage; };
 in
 {
   imports = [
@@ -48,6 +62,7 @@ in
         Set this to false if you only want to see your own strategies defined with `hardware.fw-fanctrl.config.strategies`
       '';
     };
+
     settings = mkOption {
       default = { };
       description = ''
@@ -120,59 +135,43 @@ in
     };
   };
 
-  config =
-    let
-      defaultConfig =
-        if cfg.keepDefaultStrategies then
-          builtins.fromJSON (builtins.readFile "${cfg.package}/share/fw-fanctrl/config.json")
-        else
-          { };
-      finalConfig = lib.attrsets.recursiveUpdate defaultConfig cfg.config;
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      fw-fanctrl
+      cfg.frameworkToolPackage
+    ];
 
-      fw-fanctrl =
-        if cfg.frameworkToolPackage == pkgs.framework-tool then
-          cfg.package
-        else
-          cfg.package.override { inherit (cfg) frameworkToolPackage; };
-      configFile = settingsFormat.generate "custom.json" finalConfig;
-    in
-    lib.mkIf cfg.enable {
-      environment.systemPackages = [
-        fw-fanctrl
-        cfg.frameworkToolPackage
-      ];
-
-      systemd.services = {
-        fw-fanctrl = {
-          description = "Framework Fan Controller";
-          after = [ "multi-user.target" ];
-          serviceConfig = {
-            Type = "simple";
-            Restart = "always";
-            ExecStart = "${lib.getExe fw-fanctrl} --output-format JSON run --config ${configFile} --silent ${lib.optionalString cfg.disableBatteryTempCheck "--no-battery-sensors"}";
-            ExecStopPost = "${lib.getExe cfg.frameworkToolPackage} --autofanctrl";
-          };
-          wantedBy = [ "multi-user.target" ];
+    systemd.services = {
+      fw-fanctrl = {
+        description = "Framework Fan Controller";
+        after = [ "multi-user.target" ];
+        serviceConfig = {
+          Type = "simple";
+          Restart = "always";
+          ExecStart = "${lib.getExe fw-fanctrl} --output-format JSON run --config ${finalConfig} --silent ${lib.optionalString cfg.disableBatteryTempCheck "--no-battery-sensors"}";
+          ExecStopPost = "${lib.getExe cfg.frameworkToolPackage} --autofanctrl";
         };
+        wantedBy = [ "multi-user.target" ];
+      };
 
-        fw-fanctrl-suspend = {
-          description = "Framework Fan Controller sleep hook";
-          before = [ "sleep.target" ];
-          unitConfig = {
-            StopWhenUnneeded = "yes";
-          };
-          requires = [ "fw-fanctrl.service" ];
-          after = [ "fw-fanctrl.service" ];
-          serviceConfig = {
-            Type = "oneshot";
-            RemainAfterExit = "yes";
-            ExecStart = "${lib.getExe fw-fanctrl} pause";
-            ExecStop = "${lib.getExe fw-fanctrl} resume";
-          };
-          wantedBy = [ "sleep.target" ];
+      fw-fanctrl-suspend = {
+        description = "Framework Fan Controller sleep hook";
+        before = [ "sleep.target" ];
+        unitConfig = {
+          StopWhenUnneeded = "yes";
         };
+        requires = [ "fw-fanctrl.service" ];
+        after = [ "fw-fanctrl.service" ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = "yes";
+          ExecStart = "${lib.getExe fw-fanctrl} pause";
+          ExecStop = "${lib.getExe fw-fanctrl} resume";
+        };
+        wantedBy = [ "sleep.target" ];
       };
     };
+  };
 
   meta = {
     maintainers = [ lib.maintainers.Svenum ];

--- a/nixos/modules/hardware/fw-fanctrl.nix
+++ b/nixos/modules/hardware/fw-fanctrl.nix
@@ -24,6 +24,15 @@ in
       '';
     };
 
+    keepDefaultStrategies = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Keep the default strategies of the fw-fanctrl package.
+        Set this to false if you only want to see your own strategies defined with `hardware.fw-fanctrl.config.strategies`
+      '';
+    };
+
     config = lib.mkOption {
       default = { };
       description = ''
@@ -97,7 +106,11 @@ in
 
   config =
     let
-      defaultConfig = builtins.fromJSON (builtins.readFile "${cfg.package}/share/fw-fanctrl/config.json");
+      defaultConfig =
+        if cfg.keepDefaultStrategies then
+          builtins.fromJSON (builtins.readFile "${cfg.package}/share/fw-fanctrl/config.json")
+        else
+          { };
       finalConfig = lib.attrsets.recursiveUpdate defaultConfig cfg.config;
       configFile = configFormat.generate "custom.json" finalConfig;
     in

--- a/nixos/modules/hardware/fw-fanctrl.nix
+++ b/nixos/modules/hardware/fw-fanctrl.nix
@@ -5,6 +5,8 @@
   ...
 }:
 let
+  inherit (lib) types mkOption;
+
   configFormat = pkgs.formats.json { };
   cfg = config.hardware.fw-fanctrl;
 in
@@ -22,15 +24,16 @@ in
 
     package = lib.mkPackageOption pkgs "fw-fanctrl" { };
     frameworkToolPackage = lib.mkPackageOption pkgs "framework-tool" { };
-    disableBatteryTempCheck = lib.mkOption {
-      type = lib.types.bool;
+
+    disableBatteryTempCheck = mkOption {
+      type = types.bool;
       default = false;
       description = ''
         Disable checking battery temperature sensor
       '';
     };
 
-    keepDefaultStrategies = lib.mkOption {
+    keepDefaultStrategies = mkOption {
       type = lib.types.bool;
       default = true;
       description = ''
@@ -39,64 +42,63 @@ in
       '';
     };
 
-    config = lib.mkOption {
+    config = mkOption {
       default = { };
       description = ''
         Additional config entries for the fw-fanctrl service (documentation: <https://github.com/TamtamHero/fw-fanctrl/blob/main/doc/configuration.md>)
       '';
-      type = lib.types.submodule {
-        freeformType = lib.types.attrsOf configFormat.type;
+      type = types.submodule {
+        freeformType = types.attrsOf configFormat.type;
         options = {
-          defaultStrategy = lib.mkOption {
-            type = lib.types.str;
+          defaultStrategy = mkOption {
+            type = types.str;
             default = "lazy";
             description = "Default strategy to use";
           };
 
-          strategyOnDischarging = lib.mkOption {
-            type = lib.types.str;
+          strategyOnDischarging = mkOption {
+            type = types.str;
             default = "";
             description = "Default strategy on discharging";
           };
 
-          strategies = lib.mkOption {
+          strategies = mkOption {
             default = { };
             description = ''
               Additional strategies which can be used by fw-fanctrl
             '';
-            type = lib.types.attrsOf (
-              lib.types.submodule {
+            type = types.attrsOf (
+              types.submodule {
                 options = {
-                  fanSpeedUpdateFrequency = lib.mkOption {
-                    type = lib.types.ints.unsigned;
+                  fanSpeedUpdateFrequency = mkOption {
+                    type = types.ints.unsigned;
                     default = 5;
                     description = "How often the fan speed should be updated in seconds";
                   };
 
-                  movingAverageInterval = lib.mkOption {
-                    type = lib.types.ints.unsigned;
+                  movingAverageInterval = mkOption {
+                    type = types.ints.unsigned;
                     default = 25;
                     description = "Interval (seconds) of the last temperatures to use to calculate the average temperature";
                   };
 
-                  speedCurve = lib.mkOption {
+                  speedCurve = mkOption {
                     default = [ ];
                     description = "How should the speed curve look like";
-                    type = lib.types.listOf (
-                      lib.types.submodule {
+                    type = types.listOf (
+                      types.submodule {
                         options = {
-                          temp = lib.mkOption {
-                            type = lib.types.either lib.types.float lib.types.int;
+                          temp = mkOption {
+                            type = types.either types.float types.int;
                             default = 0;
                             description = "Temperature in °C at which the fan speed should be changed";
                           };
 
-                          speed = lib.mkOption {
-                            type = lib.types.ints.between 0 100;
+                          speed = mkOption {
+                            type = types.ints.between 0 100;
                             default = 0;
                             description = "Percent how fast the fan should run at";
                           };
-
                         };
                       }
                     );

--- a/nixos/modules/hardware/fw-fanctrl.nix
+++ b/nixos/modules/hardware/fw-fanctrl.nix
@@ -7,16 +7,23 @@
 let
   inherit (lib) types mkOption;
 
-  configFormat = pkgs.formats.json { };
+  settingsFormat = pkgs.formats.json { };
   cfg = config.hardware.fw-fanctrl;
 in
 {
   imports = [
-    (lib.mkRemovedOptionModule [
-      "hardware"
-      "fw-fanctrl"
-      "ectoolPackage"
-    ] "This option was removed. Use `hardware.fw-fanctrl.frameworkToolPackage` instead.")
+    (lib.mkRemovedOptionModule
+      [
+        "hardware"
+        "fw-fanctrl"
+        "ectoolPackage"
+      ]
+      "This option was removed due to depency changes. Use `hardware.fw-fanctrl.frameworkToolPackage` instead."
+    )
+    (lib.mkRenamedOptionModule
+      [ "hardware" "fw-fanctrl" "config" ]
+      [ "hardware" "fw-fanctrl" "settings" ]
+    )
   ];
 
   options.hardware.fw-fanctrl = {
@@ -41,14 +48,13 @@ in
         Set this to false if you only want to see your own strategies defined with `hardware.fw-fanctrl.config.strategies`
       '';
     };
-
-    config = mkOption {
+    settings = mkOption {
       default = { };
       description = ''
         Additional config entries for the fw-fanctrl service (documentation: <https://github.com/TamtamHero/fw-fanctrl/blob/main/doc/configuration.md>)
       '';
       type = types.submodule {
-        freeformType = types.attrsOf configFormat.type;
+        freeformType = types.attrsOf settingsFormat.type;
         options = {
           defaultStrategy = mkOption {
             type = types.str;
@@ -69,6 +75,7 @@ in
             '';
             type = types.attrsOf (
               types.submodule {
+                freeformType = types.attrsOf settingsFormat.type;
                 options = {
                   fanSpeedUpdateFrequency = mkOption {
                     type = types.ints.unsigned;
@@ -87,6 +94,7 @@ in
                     description = "How should the speed curve look like";
                     type = types.listOf (
                       types.submodule {
+                        freeformType = types.attrsOf settingsFormat.type;
                         options = {
                           temp = mkOption {
                             type = types.either types.float types.int;
@@ -120,13 +128,13 @@ in
         else
           { };
       finalConfig = lib.attrsets.recursiveUpdate defaultConfig cfg.config;
-      configFile = configFormat.generate "custom.json" finalConfig;
 
       fw-fanctrl =
         if cfg.frameworkToolPackage == pkgs.framework-tool then
           cfg.package
         else
           cfg.package.override { inherit (cfg) frameworkToolPackage; };
+      configFile = settingsFormat.generate "custom.json" finalConfig;
     in
     lib.mkIf cfg.enable {
       environment.systemPackages = [

--- a/nixos/modules/hardware/fw-fanctrl.nix
+++ b/nixos/modules/hardware/fw-fanctrl.nix
@@ -9,13 +9,19 @@ let
   cfg = config.hardware.fw-fanctrl;
 in
 {
+  imports = [
+    (lib.mkRemovedOptionModule [
+      "hardware"
+      "fw-fanctrl"
+      "ectoolPackage"
+    ] "This option was removed. Use `hardware.fw-fanctrl.frameworkToolPackage` instead.")
+  ];
+
   options.hardware.fw-fanctrl = {
     enable = lib.mkEnableOption "the fw-fanctrl systemd service and install the needed packages";
 
     package = lib.mkPackageOption pkgs "fw-fanctrl" { };
-
-    ectoolPackage = lib.mkPackageOption pkgs "fw-ectool" { };
-
+    frameworkToolPackage = lib.mkPackageOption pkgs "framework-tool" { };
     disableBatteryTempCheck = lib.mkOption {
       type = lib.types.bool;
       default = false;
@@ -113,28 +119,49 @@ in
           { };
       finalConfig = lib.attrsets.recursiveUpdate defaultConfig cfg.config;
       configFile = configFormat.generate "custom.json" finalConfig;
+
+      fw-fanctrl =
+        if cfg.frameworkToolPackage == pkgs.framework-tool then
+          cfg.package
+        else
+          cfg.package.override { inherit (cfg) frameworkToolPackage; };
     in
     lib.mkIf cfg.enable {
       environment.systemPackages = [
-        cfg.package
-        cfg.ectoolPackage
+        fw-fanctrl
+        cfg.frameworkToolPackage
       ];
 
-      systemd.services.fw-fanctrl = {
-        description = "Framework Fan Controller";
-        after = [ "multi-user.target" ];
-        serviceConfig = {
-          Type = "simple";
-          Restart = "always";
-          ExecStart = "${lib.getExe cfg.package} --output-format JSON run --config ${configFile} --silent ${lib.optionalString cfg.disableBatteryTempCheck "--no-battery-sensors"}";
-          ExecStopPost = "${lib.getExe cfg.ectoolPackage} autofanctrl";
+      systemd.services = {
+        fw-fanctrl = {
+          description = "Framework Fan Controller";
+          after = [ "multi-user.target" ];
+          serviceConfig = {
+            Type = "simple";
+            Restart = "always";
+            ExecStart = "${lib.getExe fw-fanctrl} --output-format JSON run --config ${configFile} --silent ${lib.optionalString cfg.disableBatteryTempCheck "--no-battery-sensors"}";
+            ExecStopPost = "${lib.getExe cfg.frameworkToolPackage} --autofanctrl";
+          };
+          wantedBy = [ "multi-user.target" ];
         };
-        wantedBy = [ "multi-user.target" ];
-      };
 
-      # Create suspend config
-      environment.etc."systemd/system-sleep/fw-fanctrl-suspend.sh".source =
-        "${cfg.package}/share/fw-fanctrl/fw-fanctrl-suspend";
+        fw-fanctrl-suspend = {
+          description = "Framework Fan Controller sleep hook";
+          before = [ "sleep.target" ];
+          unitConfig = {
+            StopWhenUnneeded = "yes";
+          };
+          requires = [ "fw-fanctrl.service" ];
+          after = [ "fw-fanctrl.service" ];
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = "yes";
+            ExecStart = "${lib.getExe fw-fanctrl} pause";
+            ExecStop = "${lib.getExe fw-fanctrl} resume";
+          };
+          wantedBy = [ "sleep.target" ];
+        };
+      };
     };
 
   meta = {

--- a/nixos/modules/hardware/fw-fanctrl.nix
+++ b/nixos/modules/hardware/fw-fanctrl.nix
@@ -86,7 +86,7 @@ in
                       lib.types.submodule {
                         options = {
                           temp = lib.mkOption {
-                            type = lib.types.int;
+                            type = lib.types.either lib.types.float lib.types.int;
                             default = 0;
                             description = "Temperature in °C at which the fan speed should be changed";
                           };

--- a/pkgs/by-name/fw/fw-fanctrl/package.nix
+++ b/pkgs/by-name/fw/fw-fanctrl/package.nix
@@ -1,35 +1,31 @@
 {
   lib,
   python3Packages,
-  fw-ectool,
+  framework-tool,
   fetchFromGitHub,
 }:
 
 python3Packages.buildPythonPackage rec {
   pname = "fw-fanctrl";
-  version = "1.0.4";
+  version = "1.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "TamtamHero";
     repo = "fw-fanctrl";
     tag = "v${version}";
-    hash = "sha256-lwuBbyJnWUAXkKemhsdx73fAzO2QX2n81az074hGkzI=";
+    hash = "sha256-UFjKzCQ5QBw6t7LZ3d2Nk1G8WcsuuLkZkEkx0Sf6ndw=";
   };
 
   build-system = [ python3Packages.setuptools ];
 
   dependencies = [ python3Packages.jsonschema ];
 
-  makeWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ fw-ectool ]}" ];
+  makeWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ framework-tool ]}" ];
 
   postInstall = ''
     mkdir -p $out/share/fw-fanctrl
     install -m 644 $src/src/fw_fanctrl/_resources/config.json $out/share/fw-fanctrl/config.json
-    install -m 755 $src/services/system-sleep/fw-fanctrl-suspend $out/share/fw-fanctrl/fw-fanctrl-suspend
-    patchShebangs --build $out/share/fw-fanctrl/fw-fanctrl-suspend
-    substituteInPlace $out/share/fw-fanctrl/fw-fanctrl-suspend \
-      --replace-fail '"%PYTHON_SCRIPT_INSTALLATION_PATH%"' $out/bin/fw-fanctrl
   '';
 
   meta = {

--- a/pkgs/by-name/fw/fw-fanctrl/package.nix
+++ b/pkgs/by-name/fw/fw-fanctrl/package.nix
@@ -2,6 +2,7 @@
   lib,
   python3Packages,
   framework-tool,
+  frameworkToolPackage ? framework-tool,
   fetchFromGitHub,
 }:
 
@@ -21,7 +22,7 @@ python3Packages.buildPythonPackage rec {
 
   dependencies = [ python3Packages.jsonschema ];
 
-  makeWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ framework-tool ]}" ];
+  makeWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ frameworkToolPackage ]}" ];
 
   postInstall = ''
     mkdir -p $out/share/fw-fanctrl


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR introduces the `keepDefaultStrategies` option. If `true` all strategies inside the fw-fanctrl package will be used in addition to custom ones, if `false` only the custom strategies defined in `hardware.fw-fanctrl.config.strategies` will be used.

I decided to set `default` to `true` as this solution does not break any existing configurations.

fixes https://github.com/TamtamHero/fw-fanctrl/issues/181

In addition I update the `fw-fanctrl` package and update the module regarding to this update.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
