### PR TITLE
nixos/hysteria: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3647,6 +3647,12 @@
     githubId = 5700358;
     name = "Thomas Blank";
   };
+  blaobla = {
+    email = "trilobitahalo@gmail.com";
+    github = "blaobla";
+    githubId = 35721724;
+    name = "Yang Kong";
+  };
   bleetube = {
     email = "git@blee.tube";
     matrix = "@blee:satstack.cloud";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1233,6 +1233,7 @@
   ./services/networking/htpdate.nix
   ./services/networking/https-dns-proxy.nix
   ./services/networking/hylafax/default.nix
+  ./services/networking/hysteria.nix
   ./services/networking/i2p.nix
   ./services/networking/i2pd.nix
   ./services/networking/icecream/daemon.nix

--- a/nixos/modules/services/networking/hysteria.nix
+++ b/nixos/modules/services/networking/hysteria.nix
@@ -1,0 +1,83 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+
+let
+  cfg = config.services.hysteria;
+in
+{
+  meta.maintainers = with lib.maintainers; [ blaobla ];
+
+  options.services.hysteria = {
+    enable = lib.mkEnableOption "Hysteria proxy service";
+
+    package = lib.mkPackageOption pkgs "hysteria" { };
+
+    configFile = lib.mkOption {
+      type = lib.types.path;
+      default = "./configs/hysteria.yaml";
+      description = "Path to your Hysteria YAML configuration file.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 443;
+      description = "Allow cliets to connect your hysteria server port";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Firewall rules for Hysteria.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [ 443 ];
+      allowedUDPPorts = [ cfg.port ];
+    };
+
+    users.users.hysteria = {
+      isSystemUser = true;
+      group = "hysteria";
+      home = "/var/lib/hysteria";
+      createHome = true;
+    };
+    users.groups.hysteria = { };
+
+    systemd.services.hysteria = {
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+
+      serviceConfig = {
+        User = "hysteria";
+        Group = "hysteria";
+        WorkingDirectory = "/var/lib/hysteria";
+        StateDirectory = "hysteria";
+        StateDirectoryMode = "0700";
+
+        ExecStart = [
+          "${lib.getExe cfg.package} server -c ${cfg.configFile}"
+        ];
+
+        Restart = "on-failure";
+        RestartSec = "5s";
+
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
+        CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
+        LimitNOFILE = 65536;
+      };
+    };
+
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ✅] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


## Description

Add a new NixOS module for [Hysteria](https://github.com/apernet/hysteria), a powerful, lightning-fast proxy protocol.

## Features

- Systemd service management with proper hardening
- Dedicated system user/group for security
- Optional firewall port opening
- Support for custom configuration file
- TCP port 443 for ACME certificate verification
- UDP port for Hysteria service (configurable)

## Configuration example

### hysteria.nix
```nix
services.hysteria = {
  enable = true;
  configFile = "./hysteria/config.yaml";
  port = 8443;
  openFirewall = true;
};
```
### ./hysteria/config.yaml
```yaml
# listen: :8443 

acme:
  domains:
    - your.domain.net 
  email: your@email.com 
  type: tls  # add this to apply acme by 443 port 

auth:
  type: password
  password: Se7RAuFZ8Lzg 

masquerade: 
  type: proxy
  proxy:
    url: https://news.ycombinator.com/ 
    rewriteHost: true