### PR TITLE
kdePackages.kdenlive: add missing qtimageformats dependency

### DIFF
--- a/pkgs/kde/gear/kdenlive/default.nix
+++ b/pkgs/kde/gear/kdenlive/default.nix
@@ -16,6 +16,7 @@
   kio-extras,
   opentimelineio,
   frei0r,
+  qtimageformats,
 }:
 mkKdeDerivation {
   pname = "kdenlive";
@@ -40,6 +41,7 @@ mkKdeDerivation {
     qtsvg
     qtmultimedia
     qtnetworkauth
+    qtimageformats # UI uses webp images
 
     kddockwidgets
     qqc2-desktop-style


### PR DESCRIPTION
~kirigami dependency required - https://github.com/ngi-nix/forge/pull/551#issuecomment-4583532938~

qtimageformats required because of this error (I am running xfce)

```
qt.multimedia.symbolsresolver: Couldn't load pipewire-0.3 library
qt.multimedia.symbolsresolver: Couldn't resolve pipewire-0.3 symbols
::::: SHOWING WELCOME!!!!!!
:::::::::: CREATING SPLASH SCREEN SPLASH
qrc:/qt/qml/org/kde/kdenlive/Splash.qml:174:13: QML Image: Error decoding: qrc:/pics/splash-background.webp: Unsupported image format
```

<img width="322" height="303" alt="Screenshot_2026-05-31_18-37-31" src="https://github.com/user-attachments/assets/58c19bea-f9af-4469-a612-153fcb59b067" />

With this PR, it shows the splash screen image.

<img width="322" height="303" alt="Screenshot_2026-05-31_18-37-52" src="https://github.com/user-attachments/assets/ee9f1cd1-1804-44c0-b9ed-a4140a415dc2" />


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core"
        functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in
      `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and
      other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
