### PR TITLE
blendfarm: switch to pcre2

### DIFF
--- a/pkgs/by-name/bl/blendfarm/package.nix
+++ b/pkgs/by-name/bl/blendfarm/package.nix
@@ -5,7 +5,7 @@
   buildDotnetModule,
   dotnetCorePackages,
   xz,
-  pcre,
+  pcre2,
   autoPatchelfHook,
   bintools,
   fixDarwinDylibNames,
@@ -86,7 +86,7 @@ buildDotnetModule rec {
 
   runtimeDeps = [
     xz
-    pcre
+    pcre2
     libgdiplus
     glib
     libxrandr
@@ -116,7 +116,7 @@ buildDotnetModule rec {
 
   # add libraries not found by autopatchelf
   libPath = lib.makeLibraryPath [
-    pcre
+    pcre2
     xz
   ];
   makeWrapperArgs = [ "--prefix LD_LIBRARY_PATH : ${libPath}" ];


### PR DESCRIPTION
See #356387

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
