### PR TITLE
fahclient: 8.5.3 -> 8.5.6

### DIFF
--- a/pkgs/by-name/fa/fahclient/package.nix
+++ b/pkgs/by-name/fa/fahclient/package.nix
@@ -6,7 +6,7 @@
   openssl,
   re2,
   libevent,
-  git,
+  gitMinimal,
   versionCheckHook,
   zlib,
   expat,
@@ -16,30 +16,32 @@
 }:
 let
   pname = "fah-client";
-  version = "8.5.3";
+  version = "8.5.6";
 
   cbangSrc = fetchFromGitHub {
     owner = "cauldrondevelopmentllc";
     repo = "cbang";
     tag = "bastet-v${version}";
-    hash = "sha256-RU13qT9UQ1uNsRNBaEGSWTgNmE3f72veabl2OmKK6Z0=";
+    hash = "sha256-oh3q/gmAKx8BHoaw6Dxkd0GoxYyJ6is8uCKcivQVv2g=";
   };
 
   fah-client = stdenv.mkDerivation {
     inherit pname version;
+    __structuredAttrs = true;
+    strictDeps = true;
 
     src = fetchFromGitHub {
       owner = "FoldingAtHome";
       repo = "fah-client-bastet";
       tag = "v${version}";
-      hash = "sha256-PBguylWnYU5iTzrjWA1B5Iwb57JpoWGPSpjgNJP3aoI=";
+      hash = "sha256-B5h2eXSCvYG5juNkBRBh+KUsm26O9JTI1S7yKkHgZ7c=";
     };
 
     nativeBuildInputs = [
-      scons
-      re2
+      gitMinimal
       libevent
-      git
+      re2
+      scons
     ];
 
     buildInputs = [ openssl ];


### PR DESCRIPTION
## Things done

Fixes #526223.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
