### PR TITLE
python3Packages.pims: fix tests

### DIFF
--- a/pkgs/development/python-modules/pims/default.nix
+++ b/pkgs/development/python-modules/pims/default.nix
@@ -7,30 +7,54 @@
   pytestCheckHook,
   scikit-image,
   slicerator,
+  packaging,
+  tifffile,
+  jinja2,
+  jpype1,
+  matplotlib,
+  moviepy,
+  setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pims";
   version = "0.7";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "soft-matter";
     repo = "pims";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-3SBZk11w6eTZFmETMRJaYncxY38CYne1KzoF5oRgzuY=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
     slicerator
     imageio
     numpy
+    packaging
+    tifffile # imported within try-excet block so optional but setup.py requires it.
   ];
+
+  optional-dependencies = {
+    # CI says its extras
+    extras = [
+      jinja2
+      jpype1
+      matplotlib
+      moviepy
+      scikit-image
+    ];
+  };
 
   nativeCheckInputs = [
     pytestCheckHook
-    scikit-image
-  ];
+  ]
+  ++ finalAttrs.passthru.optional-dependencies.extras;
 
   pythonImportsCheck = [ "pims" ];
 
@@ -46,13 +70,16 @@ buildPythonPackage rec {
   disabledTestPaths = [
     # AssertionError: Tuples differ: (377, 505, 4) != (384, 512, 4)
     "pims/tests/test_display.py"
+
+    # tests require internet connection
+    "pims/tests/test_bioformats.py"
   ];
 
   meta = {
     description = "Module to load video and sequential images in various formats";
     homepage = "https://github.com/soft-matter/pims";
-    changelog = "https://github.com/soft-matter/pims/releases/tag/v${version}";
+    changelog = "https://github.com/soft-matter/pims/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd3;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
