### PR TITLE
haskellPackages.warp: skip tests on darwin due to sandbox

### DIFF
--- a/pkgs/development/haskell-modules/configuration-darwin.nix
+++ b/pkgs/development/haskell-modules/configuration-darwin.nix
@@ -294,6 +294,12 @@ self: super:
 
     warp = overrideCabal (drv: {
       __darwinAllowLocalNetworking = true;
+      # These fail in darwin sandbox with:
+      #   Network.SendFile.MacOS.sendloopHeader: permission denied (Operation not permitted)
+      testFlags = drv.testFlags or [ ] ++ [
+        "--skip=/Response/range requests/"
+        "--skip=/Response/partial files/"
+      ];
     }) super.warp;
 
     ghcjs-dom-hello = overrideCabal (drv: {


### PR DESCRIPTION
Warp has been failing to build in the darwin sandbox for a long time, because of some failing tests, even with local networking enabled. This does not surface when using it from the cache, because hydra builds without sandbox. But for development / nixpkgs-review, this is heavily annoying. Disabling these two tests makes the build pass on the community builder for me.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] aarch64-darwin
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
