### PR TITLE
music-assistant: migrate python package set to overrideScope

### DIFF
--- a/pkgs/by-name/mu/music-assistant/package.nix
+++ b/pkgs/by-name/mu/music-assistant/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  python3,
+  python3Packages,
   fetchFromGitHub,
   ffmpeg_7-headless,
   nixosTests,
@@ -10,34 +10,33 @@
 }:
 
 let
-  python = python3.override {
-    self = python;
-    packageOverrides = self: super: {
-      music-assistant-frontend = self.callPackage ./frontend.nix { };
+  pythonPackages = python3Packages.overrideScope (
+    prev: final: {
+      music-assistant-frontend = prev.callPackage ./frontend.nix { };
 
-      music-assistant-models = super.music-assistant-models.overridePythonAttrs (oldAttrs: {
+      music-assistant-models = final.music-assistant-models.overridePythonAttrs (oldAttrs: {
         version = "1.1.115";
 
         src = oldAttrs.src.override {
           hash = "sha256-oEXL0B8JNH4PcltpES375ov7QGs+gtYKlMGr1B7BlKY=";
         };
       });
-    };
-  };
+    }
+  );
 
   providerPackages = (import ./providers.nix).providers;
   providerNames = lib.attrNames providerPackages;
   providerDependencies = lib.concatMap (
-    provider: (providerPackages.${provider} python.pkgs)
+    provider: (providerPackages.${provider} pythonPackages)
   ) providers;
 
-  pythonPath = python.pkgs.makePythonPath providerDependencies;
+  pythonPath = pythonPackages.makePythonPath providerDependencies;
 in
 
 assert
   (lib.elem "ariacast" providers) -> throw "music-assistant: ariacast has not been packaged, yet.";
 
-python.pkgs.buildPythonApplication rec {
+pythonPackages.buildPythonApplication rec {
   pname = "music-assistant";
   version = "2.8.7";
   pyproject = true;
@@ -99,7 +98,7 @@ python.pkgs.buildPythonApplication rec {
     fi
   '';
 
-  build-system = with python.pkgs; [
+  build-system = with pythonPackages; [
     setuptools
   ];
 
@@ -118,7 +117,7 @@ python.pkgs.buildPythonApplication rec {
   ];
 
   dependencies =
-    with python.pkgs;
+    with pythonPackages;
     [
       # Only packages required in pyproject.toml
       aiodns
@@ -162,7 +161,7 @@ python.pkgs.buildPythonApplication rec {
     ++ gql.optional-dependencies.all
     ++ pyjwt.optional-dependencies.crypto;
 
-  optional-dependencies = with python.pkgs; {
+  optional-dependencies = with pythonPackages; {
     # Required subset of optional-dependencies in pyproject.toml
     test = [
       pytest-aiohttp
@@ -172,7 +171,7 @@ python.pkgs.buildPythonApplication rec {
   };
 
   nativeCheckInputs =
-    with python.pkgs;
+    with pythonPackages;
     [
       pytestCheckHook
     ]
@@ -206,7 +205,7 @@ python.pkgs.buildPythonApplication rec {
 
   passthru = {
     inherit
-      python
+      pythonPackages
       pythonPath
       providerPackages
       providerNames


### PR DESCRIPTION
Makes cross problems much more unlikely, since we most definitely stop relying on the unspliced python3.pkgs.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
