### PR TITLE
aprs-symbols: init at 2024-unstable

### DIFF
--- a/pkgs/by-name/ap/aprs-symbols/package.nix
+++ b/pkgs/by-name/ap/aprs-symbols/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "aprs-symbols";
+  version = "2024-unstable";
+
+  src = fetchFromGitHub {
+    owner = "hessu";
+    repo = "aprs-symbols";
+    rev = "f2286a9cd43eb6ba4501250b4c39fff111e3796c";
+    sha256 = "sha256-ORjnFC8l0l+qL2xmZZwJBfpe4vgoExMpIKuGO+B5mwY=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  installPhase = ''
+    mkdir -p $out/share/aprs-symbols
+    cp README.md COPYRIGHT.md $out/share/aprs-symbols/
+    cp -r png $out/share/aprs-symbols/
+  '';
+
+  meta = {
+    description = "The aprs.fi high-resolution symbol set";
+    longDescription = ''
+      This is a new APRS symbol graphics set, which can be used by any APRS applications.
+      It targets modern high-resolution displays, including Retina and 4K displays.
+    '';
+    homepage = "https://github.com/hessu/aprs-symbols";
+    license = lib.licenses.free;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ mafo ];
+  };
+}


### PR DESCRIPTION
Init aprs-symbols at 2024-unstable
## Things done

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
