### PR TITLE
python3Packages.tmdbsimple: 2.9.2-unstable-2025-01-07 -> 2.9.6

### DIFF
--- a/pkgs/development/python-modules/tmdbsimple/default.nix
+++ b/pkgs/development/python-modules/tmdbsimple/default.nix
@@ -4,19 +4,18 @@
   fetchFromGitHub,
   setuptools,
   requests,
-  unstableGitUpdater,
 }:
 
-buildPythonPackage {
+buildPythonPackage (finalAttrs: {
   pname = "tmdbsimple";
-  version = "2.9.2-unstable-2025-01-07";
+  version = "2.9.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "celiao";
     repo = "tmdbsimple";
-    rev = "0b3359f7bab3ade391b2e5de964ed115b00984a6";
-    hash = "sha256-usyL2lHSJwvPnWncI3K+yTmeU5DN1AkRzHC5nFh3vxs=";
+    tag = finalAttrs.version;
+    hash = "sha256-ooyfwRCvH980gym8ujpLxbmR7FYfi59gGXqT8K40pNw=";
   };
 
   build-system = [ setuptools ];
@@ -28,12 +27,10 @@ buildPythonPackage {
   # The tests require an internet connection and an API key
   doCheck = false;
 
-  passthru.updateScript = unstableGitUpdater { };
-
   meta = {
     description = "Wrapper for The Movie Database API v3";
     homepage = "https://github.com/celiao/tmdbsimple";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ theobori ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Now we shoulde use the project git tags instead of its git commits hash because it's active again.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
