### PR TITLE
moodle: update documentRoot path to /public

### DIFF
--- a/nixos/modules/services/web-apps/moodle.nix
+++ b/nixos/modules/services/web-apps/moodle.nix
@@ -326,9 +326,9 @@ in
       virtualHosts.${cfg.virtualHost.hostName} = mkMerge [
         cfg.virtualHost
         {
-          documentRoot = mkForce "${cfg.package}/share/moodle";
+          documentRoot = mkForce "${cfg.package}/share/moodle/public";
           extraConfig = ''
-            <Directory "${cfg.package}/share/moodle">
+            <Directory "${cfg.package}/share/moodle/public">
               <FilesMatch "\.php$">
                 <If "-f %{REQUEST_FILENAME}">
                   SetHandler "proxy:unix:${fpm.socket}|fcgi://localhost/"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

In 5.1 Moodle changed the document root path to be in `/public`.
https://docs.moodle.org/502/en/Upgrading

```
Warning:

The directory structure of Moodle files and the security model have changed in 5.1.

1. A new "public" folder has been introduced to contain all web accessible files. Configuration and other sensitive files are now stored outside this folder for better security.

2. You will need to reconfigure your web server to accommodate the security change as part of the upgrade process. See the section below [Code directories restructure](https://docs.moodle.org/502/en/Upgrading#Code_directories_restructure).
```
 
I get a similar message, when running the current Moodle options.

```
The Moodle root directory must not be publicly accessible. Please reconfigure your web server to use the `/public` directory instead.
```

This PR updates the documentRoot and extraConfig paths from `share/moodle` to `share/moodle/public`.

I used Claude to set the testing Nix VM up in a flake.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
