### PR TITLE
notion-electron: init at 2.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18559,6 +18559,13 @@
     matrix = "@motiejus:jakstys.lt";
     name = "Motiejus Jakštys";
   };
+  Mowerick = {
+    email = "oliverhagenauer@gmail.com";
+    github = "Mowerick";
+    githubId = 102822250;
+    keys = [ { fingerprint = "6472 901A F0E7 F983 4893  042F 5F76 361C 2EF9 C95F"; } ];
+    name = "Oliver Hagenauer";
+  };
   mpcsh = {
     email = "m@mpc.sh";
     github = "mpcsh";

--- a/pkgs/by-name/no/notion-electron/package.nix
+++ b/pkgs/by-name/no/notion-electron/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildNpmPackage,
+  makeWrapper,
+  desktop-file-utils,
+  electron,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "notion-electron";
+  version = "2.1.0";
+
+  src = fetchFromGitHub {
+    owner = "anechunaev";
+    repo = "notion-electron";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pFPGkE2XwlBEbitl0OatfQAht1TmcErnVMZCFYjwZ8I=";
+  };
+
+  npmDepsHash = "sha256-EMY7Y95bp12+jLn5Wv6x134utA0LFqldP/d8zHrs/RI=";
+
+  __structuredAttrs = true;
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+    desktop-file-utils
+  ];
+
+  npmFlags = [ "--ignore-scripts" ];
+
+  dontNpmBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/notion-electron
+    mkdir -p $out/bin
+    mkdir -p $out/share/icons/hicolor/256x256/apps
+    mkdir -p $out/share/applications
+
+    cp -r . $out/lib/notion-electron/
+
+    cp notion-electron.desktop $out/share/applications/
+    cp notion-electron.png $out/share/icons/hicolor/256x256/apps/
+
+    desktop-file-edit \
+      --set-key="Exec" --set-value="notion-electron %U" \
+      $out/share/applications/notion-electron.desktop
+
+    makeWrapper ${electron}/bin/electron $out/bin/notion-electron \
+              --add-flags "$out/lib/notion-electron"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Enhanced Notion Desktop client for Linux";
+    homepage = "https://github.com/anechunaev/notion-electron";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Mowerick ];
+    platforms = lib.platforms.linux;
+    mainProgram = "notion-electron";
+  };
+})


### PR DESCRIPTION
This PR introduces `notion-electron` to Nixpkgs and adds my user (`Mowerick`) to the maintainers list.

`notion-electron` is an enhanced, unofficial Notion Desktop client for Linux built with Electron. 
Homepage: https://github.com/anechunaev/notion-electron

The package was built using `buildNpmPackage` and wraps the Electron binary.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test