### PR TITLE
valkey-ldap: init at 1.1.0

### DIFF
--- a/pkgs/by-name/va/valkey-ldap/package.nix
+++ b/pkgs/by-name/va/valkey-ldap/package.nix
@@ -1,0 +1,42 @@
+{
+  fetchFromGitHub,
+  lib,
+  openssl,
+  pkg-config,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "valkey-ldap";
+  version = "1.1.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "valkey-io";
+    repo = "valkey-ldap";
+    tag = finalAttrs.version;
+    hash = "sha256-+D3Mvm4ZRgv3830tpHTt/Hxga2CuAC+5ZaosF1HSpno=";
+  };
+
+  cargoHash = "sha256-HfiMr1un2dKFAdjBTNKRS1fB9Z/iMcJmMkqDyCbDswk=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    openssl
+    rustPlatform.bindgenHook
+  ];
+
+  # Requires custom memory allocator
+  doCheck = false;
+
+  meta = {
+    changelog = "https://github.com/valkey-io/valkey-ldap/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    description = "Module which brings LDAP authentication fo Valkey";
+    homepage = "https://github.com/valkey-io/valkey-ldap";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.all;
+    teams = [ lib.teams.redis ];
+  };
+})


### PR DESCRIPTION
Related #526326
Related #526411

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
