### PR TITLE
requireFile: use stdenvNoCC

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -892,7 +892,7 @@ rec {
   # Docs in doc/build-helpers/fetchers.chapter.md
   # See https://nixos.org/manual/nixpkgs/unstable/#requirefile
   requireFile = lib.extendMkDerivation {
-    constructDrv = stdenv.mkDerivation;
+    constructDrv = stdenvNoCC.mkDerivation;
 
     excludeDrvArgNames = [
       "hash"

--- a/pkgs/build-support/trivial-builders/test/default.nix
+++ b/pkgs/build-support/trivial-builders/test/default.nix
@@ -25,6 +25,7 @@ recurseIntoAttrs {
   symlinkJoin = recurseIntoAttrs (callPackage ./symlink-join.nix { });
   overriding = callPackage ../test-overriding.nix { };
   inherit references;
+  requireFile = callPackage ./requireFile.nix { };
   writeCBin = callPackage ./writeCBin.nix { };
   writeClosure-union = callPackage ./writeClosure-union.nix {
     inherit (references) samples;

--- a/pkgs/build-support/trivial-builders/test/requireFile.nix
+++ b/pkgs/build-support/trivial-builders/test/requireFile.nix
@@ -1,0 +1,22 @@
+{
+  pkgsStatic,
+  lib,
+  requireFile,
+  emptyFile,
+}:
+let
+  name = "this-is-a-test";
+  requireFileTest =
+    requireFile:
+    requireFile {
+      inherit name;
+      url = "this-is-a-test";
+      hash = lib.fakeHash;
+    };
+  requireFile-native = requireFileTest requireFile;
+  requireFile-static = requireFileTest pkgsStatic.requireFile;
+in
+assert lib.assertMsg (
+  requireFile-native.name == name && requireFile-static.name == name
+) "requireFile derivation name must be the same across different package sets";
+emptyFile


### PR DESCRIPTION
When not using stdenvNoCC with a package-set setup for cross-compilation, the host platform's target triplet is added as a suffix to the derivation name, invalidating the requireFile FOD. Using stdenvNoCC prevents that due to some logic in `make-derivation.nix`, which more closely matches the behavior before switching to `extendMkDerivation`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
