### PR TITLE
valkey-json: init at 1.0.2-unstable-2026-06-09

### DIFF
--- a/pkgs/by-name/va/valkey-json/external-libs.patch
+++ b/pkgs/by-name/va/valkey-json/external-libs.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3c0afed..8617a12 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -201,20 +198,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CFLAGS} ${ADDITIONAL_FLAGS}")
+ message("CMAKE_C_FLAGS: ${CMAKE_C_FLAGS}")
+ message("CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
+ 
+-# Fetch RapidJSON
+-FetchContent_Declare(
+-    rapidjson
+-    GIT_REPOSITORY https://github.com/Tencent/rapidjson.git
+-    GIT_TAG ebd87cb468fb4cb060b37e579718c4a4125416c1
+-)
+-
+-# Disable RapidJSON tests and examples
+-set(RAPIDJSON_BUILD_TESTS OFF CACHE BOOL "Build rapidjson tests" FORCE)
+-set(RAPIDJSON_BUILD_EXAMPLES OFF CACHE BOOL "Build rapidjson examples" FORCE)
+-set(RAPIDJSON_BUILD_DOC OFF CACHE BOOL "Build rapidjson documentation" FORCE)
+-
+-# Make Rapidjson available
+-FetchContent_MakeAvailable(rapidjson)
++find_package(RapidJSON REQUIRED)
+ 
+ add_subdirectory(src)
+ 

--- a/pkgs/by-name/va/valkey-json/package.nix
+++ b/pkgs/by-name/va/valkey-json/package.nix
@@ -1,0 +1,55 @@
+{
+  cmake,
+  fetchFromGitHub,
+  lib,
+  rapidjson,
+  stdenv,
+  valkey,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "valkey-json";
+  version = "1.0.2-unstable-2026-06-09";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "valkey-io";
+    repo = "valkey-json";
+    rev = "8ff1f53b7db9a5d69c716b6b4a6bdb4fefc63a9e";
+    hash = "sha256-mOn/Y121sC8vTnPTxYnM4DAW9INvgrHeOvXY3gyPrUQ=";
+  };
+
+  patches = [
+    ./external-libs.patch
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "VALKEY_SERVER_PATH" "${valkey}/bin/valkey-server")
+    (lib.cmakeFeature "VALKEY_MODULE_H_PATH" "${valkey.src}/src/valkeymodule.h")
+    (lib.cmakeBool "ENABLE_UNIT_TESTS" false)
+    (lib.cmakeBool "ENABLE_INTEGRATION_TESTS" false)
+  ];
+
+  hardeningDisable = [ "format" ];
+
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-Wno-error=implicit-const-int-float-conversion";
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ rapidjson ];
+
+  installPhase = ''
+    mkdir -p $out/lib
+    cp src/libjson.* $out/lib
+  '';
+
+  meta = {
+    changelog = "https://github.com/valkey-io/valkey-json/blob/${finalAttrs.version}/00-RELEASENOTES";
+    description = "Module which provides native JSON support for Valkey";
+    homepage = "https://github.com/valkey-io/valkey-json";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.all;
+    teams = [ lib.teams.redis ];
+  };
+})


### PR DESCRIPTION
Related #526326
Related #526395

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
