### PR TITLE
writers.writeNu: check using nushell's nu-check built-in

### DIFF
--- a/pkgs/build-support/writers/scripts.nix
+++ b/pkgs/build-support/writers/scripts.nix
@@ -848,6 +848,11 @@ rec {
 
     Can be called with or without extra arguments.
 
+    The contents of the script are checked using the `nu-check` built-in.
+    Unfortunately, when `nu-check` detects a problem, it reports it in a
+    somewhat confusing manner and without informing the user of its location
+    within the code (https://github.com/nushell/nushell/issues/16127).
+
     # Examples
     :::{.example}
     ## `pkgs.writers.writeNu` without arguments
@@ -877,12 +882,21 @@ rec {
   */
   writeNu =
     name: argsOrScript:
+    let
+      interpreter = "${lib.getExe pkgs.nushell} --no-config-file";
+      # The only tool that can serve this purpose seems to be the Nushell
+      # built-in `nu-check`. Since that is a built-in, a Nushell script that
+      # invokes it is created here and used as the check. `writeNu` is not
+      # used in the creation of this wrapper, because that would be infinitely
+      # recursive.
+      check = makeScriptWriter {
+        inherit interpreter;
+      } "nu-check-wrapper" "def main [path] { nu-check --debug $path }";
+    in
     if lib.isAttrs argsOrScript && !lib.isDerivation argsOrScript then
-      makeScriptWriter (
-        argsOrScript // { interpreter = "${lib.getExe pkgs.nushell} --no-config-file"; }
-      ) name
+      makeScriptWriter ({ inherit check; } // argsOrScript // { inherit interpreter; }) name
     else
-      makeScriptWriter { interpreter = "${lib.getExe pkgs.nushell} --no-config-file"; } name argsOrScript;
+      makeScriptWriter { inherit interpreter check; } name argsOrScript;
 
   /**
     Like writeScriptBin but the first line is a shebang to nu


### PR DESCRIPTION
```
nix-repl> :b writers.writeNu "foo" "valid"

This derivation produced the following outputs:
  out -> /nix/store/wh41vxn07lv5gq53dm8cfxdbq8pfflnq-foo

nix-repl> :b writers.writeNu "foo" "'invalid"
error: Cannot build '/nix/store/4d0zvqamqvk31f023w7wlgra13xq49av-foo.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/j444vna69a9w1l1pgk597ffqap4vc1i1-foo
       Last 10 log lines:
       > Error: nu::shell::error
       >
       >   × Failed to parse content
       >    ╭─[/nix/store/q28bzm5ljnq5y9km89505y96pgqlyg0h-nu-check-wrapper:2:19]
       >  1 │ #! /nix/store/h6y0fybw66qx4d784nh515m4s8160ian-nushell-0.113.0/bin/nu --no-config-file
       >  2 │ def main [path] { nu-check --debug $path }
       >    ·                   ────┬───
       >    ·                       ╰── Found : Unexpected end of code.
       >    ╰────
       >
       For full logs, run:
         nix log /nix/store/4d0zvqamqvk31f023w7wlgra13xq49av-foo.drv
error: Cannot build '/nix/store/f627gmqzjnsdy6rdgr0f0y1wqbp45gll-foo.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/42lrfkc7797jq86dp5ilq2sjmb3gpnbn-foo
error: Build failed due to failed dependency
[4 built (2 failed)]
nix-repl>
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
