### PR TITLE
libkrunfw: fix build failure when cross compiling to aarch64-linux

### DIFF
--- a/pkgs/by-name/li/libkrunfw/package.nix
+++ b/pkgs/by-name/li/libkrunfw/package.nix
@@ -10,6 +10,7 @@
   perl,
   elfutils,
   python3,
+  buildPackages,
   variant ? null,
 }:
 
@@ -56,6 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   makeFlags = [
     "PREFIX=${placeholder "out"}"
+    "STRIP=${stdenv.cc.targetPrefix}strip"
   ]
   ++ lib.optionals (variant == "sev") [
     "SEV=1"
@@ -64,9 +66,14 @@ stdenv.mkDerivation (finalAttrs: {
     "TDX=1"
   ];
 
+  depsBuildBuild = [
+    elfutils
+    buildPackages.stdenv.cc
+  ];
+
   # Fixes https://github.com/containers/libkrunfw/issues/55
   env = lib.optionalAttrs stdenv.targetPlatform.isAarch64 {
-    NIX_CFLAGS_COMPILE = "-march=armv8-a+crypto";
+    NIX_CFLAGS_COMPILE_FOR_TARGET = "-march=armv8-a+crypto";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Closes: #526360

## Things done

`gcc` was not found, so I added `buildPackages.stdenv.cc`, it also failed without bintools as well.
After that there was a strip error, so I make strip using the target edition.
Also the cflags were not passed correctly, so I changed the env var
lastly, i needed to pass HOSTLDFLAGS to make the linker happy

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
