### PR TITLE
srsran: adjust repo, set structuredAttrs, change description, add maintainer, fix cmake variable for lte rates parameter

### DIFF
--- a/pkgs/by-name/sr/srsran/package.nix
+++ b/pkgs/by-name/sr/srsran/package.nix
@@ -24,11 +24,12 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "srsran";
   version = "25_10";
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "srsran";
-    repo = "srsran";
-    rev = "release_${builtins.replaceStrings [ "." ] [ "_" ] finalAttrs.version}";
+    repo = "srsRAN_4G";
+    tag = "release_${builtins.replaceStrings [ "." ] [ "_" ] finalAttrs.version}";
     sha256 = "sha256-DwQ4u17m8D5RqX3OIYSyeE5+51sLah1qchRcwlX5i0A=";
   };
 
@@ -68,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     "-DENABLE_WERROR=OFF"
-    (lib.cmakeBool "ENABLE_LTE_RATES" enableLteRates)
+    (lib.cmakeBool "USE_LTE_RATES" enableLteRates)
     (lib.cmakeBool "ENABLE_AVX" enableAvx)
     (lib.cmakeBool "ENABLE_AVX2" enableAvx2)
     (lib.cmakeBool "ENABLE_FMA" enableFma)
@@ -81,9 +82,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://www.srslte.com/";
-    description = "Open-source 4G and 5G software radio suite";
+    changelog = "https://github.com/srsran/srsRAN_4G/releases/tag/${finalAttrs.src.tag}";
+    description = "Open-source 4G software radio suite, including complete LTE UE, eNodeB and EPC applications";
     license = lib.licenses.agpl3Plus;
-    platforms = with lib.platforms; linux;
-    maintainers = with lib.maintainers; [ hexagonal-sun ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      hexagonal-sun
+      felbinger
+    ];
   };
 })


### PR DESCRIPTION
5G parts of srsran have been moved to OCUDU. The repository in which srsran is located has been changed, I adjusted the descriptions according to https://www.srsran.com/4g
Also I'd like to support maintaining this package, so I added myself as maintainer.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
