### PR TITLE
bmfdec: init at 0-unstable-2023-04-16

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19735,6 +19735,12 @@
     github = "nigelgbanks";
     githubId = 487373;
   };
+  nikableh = {
+    email = "nika@nikableh.moe";
+    github = "nikableh";
+    githubId = 61655860;
+    name = "Nika Krasnova";
+  };
   nikitavoloboev = {
     email = "nikita.voloboev@gmail.com";
     github = "nikivdev";

--- a/pkgs/by-name/bm/bmfdec/package.nix
+++ b/pkgs/by-name/bm/bmfdec/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bmfdec";
+  version = "0-unstable-2023-04-16";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "pali";
+    repo = "bmfdec";
+    rev = "c7b72f6ece126a8f686d66402009a14cb032a769";
+    hash = "sha256-6qQS6SpLiRzCt02RyGYZUDjt/CNp8DoCH/RG89GX/dE=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 -t $out/bin bmfdec bmfparse bmf2mof
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Decompile binary MOF file (BMF) from WMI buffer";
+    homepage = "https://github.com/pali/bmfdec";
+    license = lib.licenses.gpl2Only;
+    maintainers = [ lib.maintainers.nikableh ];
+  };
+})


### PR DESCRIPTION
Program for decompiling binary MOF files (BMF) from WMI buffer. Used in development of kernel WMI drivers.

I've also tested the cross-compilation:
```
nix-build -A bmfdec --arg crossSystem '{ config = "aarch64-unknown-linux-gnu"; }'
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
