### PR TITLE
python3Packages.pipx: 1.8.0 -> 1.14.0, fix, clean

### DIFF
--- a/pkgs/development/python-modules/pipx/default.nix
+++ b/pkgs/development/python-modules/pipx/default.nix
@@ -6,23 +6,33 @@
   hatchling,
   hatch-vcs,
   installShellFiles,
+  colorama,
   packaging,
   platformdirs,
-  pytestCheckHook,
+  tomli,
   userpath,
+  uv,
   git,
+  writableTmpDirAsHomeHook,
+  pytestCheckHook,
+  pypiserver,
+  pytest-cov-stub,
+  pytest-mock,
+  pytest-subprocess,
+  pytest-xdist,
+  watchdog,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pipx";
-  version = "1.8.0";
+  version = "1.14.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pypa";
     repo = "pipx";
-    tag = version;
-    hash = "sha256-TEF5zBAB0tvfY0dsZOnu2r9P+pheMr/OOI6CCY8PItg=";
+    tag = finalAttrs.version;
+    hash = "sha256-4qSCyaYHam9y04qTgEUvbo/XiY9WNqX2fKZJOAVE2EM=";
   };
 
   build-system = [
@@ -32,10 +42,19 @@ buildPythonPackage rec {
 
   dependencies = [
     argcomplete
+    colorama
     packaging
     platformdirs
+    tomli
     userpath
-  ];
+  ]
+  ++ finalAttrs.passthru.optional-dependencies.uv;
+
+  optional-dependencies = {
+    uv = [
+      uv
+    ];
+  };
 
   nativeBuildInputs = [
     installShellFiles
@@ -45,26 +64,21 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     git
+    writableTmpDirAsHomeHook
+    pypiserver
+    pytest-cov-stub
+    pytest-mock
+    pytest-subprocess
+    pytest-xdist
+    watchdog
   ];
-
-  preCheck = ''
-    export HOME=$(mktemp -d)
-  '';
 
   pytestFlags = [
     # start local pypi server and use in tests
     "--net-pypiserver"
   ];
 
-  disabledTestPaths = [
-    "tests/test_install_all_packages.py"
-  ];
-
   disabledTests = [
-    # disable tests which are difficult to emulate due to shell manipulations
-    "path_warning"
-    "script_from_internet"
-    "ensure_null_pythonpath"
     # disable tests, which require internet connection
     "install"
     "inject"
@@ -93,6 +107,7 @@ buildPythonPackage rec {
     "test_skip_maintenance"
     "test_unpin"
     "test_unpin_warning"
+    "test_shared_libs_excludes_setuptools"
   ];
 
   postInstall = ''
@@ -102,12 +117,16 @@ buildPythonPackage rec {
       --fish <(register-python-argcomplete pipx --shell fish)
   '';
 
+  pythonImportsCheck = [ "pipx" ];
+
+  __structuredAttrs = true;
+
   meta = {
     description = "Install and run Python applications in isolated environments";
     mainProgram = "pipx";
     homepage = "https://github.com/pypa/pipx";
-    changelog = "https://github.com/pypa/pipx/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/pypa/pipx/blob/main/docs/changelog.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ yshym ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/pypa/pipx/compare/1.8.0...1.14.0

Changelog: https://github.com/pypa/pipx/blob/main/docs/changelog.md

fix packages currently failing with:
```python
    def test_parse_specifier_for_metadata(package_spec_in, package_or_url_correct, valid_spec, monkeypatch, root):
        monkeypatch.chdir(root)
        if valid_spec:
            package_or_url = parse_specifier_for_metadata(package_spec_in)
>           assert package_or_url == package_or_url_correct
E           AssertionError: assert 'my-project[c...myproject.git' == 'my-project[c...myproject.git'
E             
E             - my-project[cli]@ git+ssh://git@bitbucket.org/my-company/myproject.git
E             + my-project[cli] @ git+ssh://git@bitbucket.org/my-company/myproject.git
E             ?                +
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
