### PR TITLE
python3Packages.quack-kernels: init at 0.5.0

### DIFF
--- a/pkgs/development/python-modules/quack-kernels/default.nix
+++ b/pkgs/development/python-modules/quack-kernels/default.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  apache-tvm-ffi,
+  einops,
+  nvidia-cutlass-dsl,
+  torch,
+  torch-c-dlpack-ext,
+
+  # optional-dependencies
+  # nvidia-matmul-heuristics,
+  jax,
+  # jax-tvm-ffi,
+  pandas,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "quack-kernels";
+  version = "0.5.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Dao-AILab";
+    repo = "quack";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Y56jJUTn/HopOe0yNxxxwMf+abXSdzTa8+YoiHd/rFE=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    apache-tvm-ffi
+    einops
+    nvidia-cutlass-dsl
+    torch
+    torch-c-dlpack-ext
+  ];
+
+  optional-dependencies = {
+    heuristics = [
+      # nvidia-matmul-heuristics
+    ];
+    jax = [
+      jax
+      # jax-tvm-ffi
+    ];
+    bench = [
+      pandas
+    ];
+  };
+
+  pythonImportsCheck = [ "quack" ];
+
+  # Fatal Python error: Aborted
+  doCheck = false;
+
+  meta = {
+    description = "Quirky Assortment of CuTe Kernels";
+    homepage = "https://github.com/Dao-AILab/quack";
+    changelog = "https://github.com/Dao-AILab/quack/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+      prince213
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16680,6 +16680,8 @@ self: super: with self; {
 
   qtpy = callPackage ../development/python-modules/qtpy { };
 
+  quack-kernels = callPackage ../development/python-modules/quack-kernels { };
+
   quadprog = callPackage ../development/python-modules/quadprog { };
 
   qualysclient = callPackage ../development/python-modules/qualysclient { };


### PR DESCRIPTION
## Things done

Add [quack-kernels](https://github.com/Dao-AILab/quack), a Quirky Assortment of CuTe Kernels.

Adapted from https://github.com/NixOS/nixpkgs/pull/525141

cc @Prince213

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
