### PR TITLE
epifaster: init at 1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16239,6 +16239,12 @@
     githubId = 30468956;
     name = "Lukas Heiligenbrunner";
   };
+  lukas-sgx = {
+    email = "lukas.soigneux@epitech.eu";
+    github = "lukas-sgx";
+    githubId = 68616614;
+    name = "Lukas Soigneux";
+  };
   lukaslihotzki = {
     email = "lukas@lihotzki.de";
     github = "lukaslihotzki";

--- a/pkgs/by-name/ep/epifaster/package.nix
+++ b/pkgs/by-name/ep/epifaster/package.nix
@@ -1,0 +1,39 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "epifaster";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "EpiSDK";
+    repo = "EpiFaster";
+    rev = "v${version}";
+    hash = "sha256-klTqsW6pzrlxoRhh/4DoVtMYEOkt62Hu+o4SKobJAV4=";
+  };
+
+  cargoHash = "sha256-LoSEGRgS/AuGk2KCEZKqDskPm083Jj59OtBShvBWxtQ=";
+
+  postPatch = ''
+    substituteInPlace src/main.rs \
+      --replace '".local/lib/epiclang/plugins"' '"${placeholder "out"}/lib/epiclang/plugins"'
+  '';
+
+  postInstall = ''
+    if ls $src/plugins/*.so 2>/dev/null; then
+      mkdir -p $out/lib/epifaster/plugins
+      cp $src/plugins/*.so $out/lib/epifaster/plugins/
+    fi
+  '';
+
+  meta = {
+    description = "Rewrite and optimization of Epiclang, ~57% faster";
+    homepage = "https://github.com/EpiSDK/EpiFaster";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ lukas-sgx ];
+    mainProgram = "epiclang";
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/ep/epifaster/package.nix
+++ b/pkgs/by-name/ep/epifaster/package.nix
@@ -1,9 +1,11 @@
-{ lib
-, rustPlatform
-, fetchFromGitHub
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
 }:
 
 rustPlatform.buildRustPackage rec {
+  __structuredAttrs = true;
   pname = "epifaster";
   version = "1.0";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
epifaster: init at 1.0

High-performance coding style checker,rewritten in Rust for ~90% faster execution. Homepage: https://github.com/EpiSDK/EpiFaster

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
