### PR TITLE
_86box{,-with-roms}: 5.3 -> 6.0

### DIFF
--- a/pkgs/by-name/_8/_86box/package.nix
+++ b/pkgs/by-name/_8/_86box/package.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   kdePackages,
   pkg-config,
@@ -21,6 +20,7 @@
   discord-gamesdk,
   libpcap,
   libslirp,
+  libserialport,
   wayland,
   wayland-scanner,
   libsndfile,
@@ -41,24 +41,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "86box";
-  version = "5.3";
+  version = "6.0";
 
   src = fetchFromGitHub {
     owner = "86Box";
     repo = "86Box";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-n68Ghhsv15TzpOMH4dBTNxa6AYwqN5s2C5pyO9VVaco=";
+    hash = "sha256-Qm7y/7LpBopti0K+jrC9TgORfFGjFYP/4rYPr7802gw=";
   };
 
   patches = [
     ./darwin.patch
-    # Fix build: Only make the fallthrough define available in C code
-    # https://github.com/86Box/86Box/issues/6607
-    (fetchpatch {
-      name = "fix-fallthrough-define-c-only.patch";
-      url = "https://github.com/86Box/86Box/commit/0092ce15de3efac108b961882f870a8c05e8c38f.patch";
-      hash = "sha256-DqjOtnyk6Zv9XHCLeuxD1wcLfvjGwGFvUWS0alXcchs=";
-    })
   ];
 
   postPatch = ''
@@ -87,6 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
     jack2
     libpcap
     libslirp
+    libserialport
     qt5.qtbase
     qt5.qttools
     libsndfile
@@ -105,6 +99,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags =
     lib.optional stdenv.hostPlatform.isDarwin "-DCMAKE_MACOSX_BUNDLE=OFF"
+    # On Darwin, 86Box ignores pkg-config for libserialport and links
+    # $LIBSERIALPORT_ROOT/lib/libserialport.dylib directly, so point it at the store path.
+    ++ lib.optional stdenv.hostPlatform.isDarwin "-DLIBSERIALPORT_ROOT=${libserialport}"
     ++ lib.optional enableNewDynarec "-DNEW_DYNAREC=ON"
     ++ lib.optional enableVncRenderer "-DVNC=ON"
     ++ lib.optional (!enableDynarec) "-DDYNAREC=OFF"
@@ -114,9 +111,9 @@ stdenv.mkDerivation (finalAttrs: {
     lib.optionalString stdenv.hostPlatform.isLinux ''
       install -Dm644 -t $out/share/applications $src/src/unix/assets/net.86box.86Box.desktop
 
-      for size in 48 64 72 96 128 192 256 512; do
-        install -Dm644 -t $out/share/icons/hicolor/"$size"x"$size"/apps \
-          $src/src/unix/assets/"$size"x"$size"/net.86box.86Box.png
+      for icon in $src/src/unix/assets/*x*/net.86box.86Box.png; do
+        size=$(basename "$(dirname "$icon")")
+        install -Dm644 -t $out/share/icons/hicolor/"$size"/apps "$icon"
       done;
     ''
     + lib.optionalString unfreeEnableRoms ''
@@ -129,7 +126,7 @@ stdenv.mkDerivation (finalAttrs: {
       owner = "86Box";
       repo = "roms";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-7/xhhT29ijGNVlW7oJXdyJuhUwVs0b4dIUjc3lVtNEY=";
+      hash = "sha256-AjFxyxW6Op4w637k5AXPtibqablVoPK03Axh2h2JWdI=";
     };
     updateScript = ./update.sh;
   };


### PR DESCRIPTION
Version bump, and added a missing dep discovered during Cmake boostrap: `libserialport` for serial port passthrough.

Fixed also `postInstall` for the new icon sizes on Linux.

Release: https://86box.net/2026/05/31/86box-v6-0.html

Changelog: https://github.com/86Box/86Box/compare/v5.3...v6.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
