### PR TITLE
_1password-gui: update.sh - Linux version check and macOS beta handling improvements

### DIFF
--- a/pkgs/by-name/_1/_1password-gui/update.sh
+++ b/pkgs/by-name/_1/_1password-gui/update.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p jq curl
+#!nix-shell -i bash -p jq curl gawk
 #shellcheck shell=bash
 set -euo pipefail
 
-# For Linux version checks we rely on Repology API to check 1Password managed Arch User Repository.
-REPOLOGY_PROJECT_URI="https://repology.org/api/v1/project/1password"
+# For Linux version checks we query upstream's APT repository.
+#
+# Repository only offers amd64 packages for the desktop app.
+# We assume updates are always for both architectures.
+OP_APT_REPO_DIST_BASE="https://downloads.1password.com/linux/debian/amd64/dists"
+OP_APT_REPO_COMPONENT_INDEX="main/binary-amd64/Packages"
 
 # For Darwin version checks we query the same endpoint 1Password 8 for Mac queries.
 # This is the base URI. For stable channel an additional path of "N", for beta channel, "Y" is required.
@@ -33,25 +37,43 @@ read_local_versions() {
 
 read_remote_versions() {
   local channel="$1"
+  local apt_index="${OP_APT_REPO_DIST_BASE}/${channel}/${OP_APT_REPO_COMPONENT_INDEX}"
+  local apt_awk_prog=$'
+    /^Package: 1password$/ { pkg_is_1password_gui=1 }
+    /^Version/ && pkg_is_1password_gui { print $2; exit }
+  '
   local chan_os ver
 
   if [[ ${channel} == "stable" ]]; then
-    remote_versions["stable/linux"]=$(
-      "${CURL[@]}" "${REPOLOGY_PROJECT_URI}" \
-        | "${JQ[@]}" '.[] | select(.repo == "aur" and .srcname == "1password" and .status == "newest") | .version'
-    )
+    chan_os="${channel}/linux"
+    ver=$("${CURL[@]}" "${apt_index}" | awk "${apt_awk_prog}")
+    if [[ -n ${ver} ]]; then
+      remote_versions["${chan_os}"]="${ver}"
+    else
+      echo "No remote version for ${chan_os}" >&2
+    fi
 
-    remote_versions["stable/darwin"]=$(
+    chan_os="${channel}/darwin"
+    ver=$(
       "${CURL[@]}" "${APP_UPDATES_URI_BASE}/N" \
         | "${JQ[@]}" 'select(.available == "1") | .version'
     )
+    if [[ -n ${ver} ]]; then
+      remote_versions["${chan_os}"]="${ver}"
+    else
+      echo "No remote version for ${chan_os}" >&2
+    fi
   else
-    remote_versions["beta/linux"]=$(
-      # AUR version string uses underscores instead of dashes for betas.
-      # We fix that with a `sub` in jq query.
-      "${CURL[@]}" "${REPOLOGY_PROJECT_URI}" \
-        | "${JQ[@]}" '.[] | select(.repo == "aur" and .srcname == "1password-beta") | .version | sub("_"; "-")'
+    chan_os="${channel}/linux"
+    ver=$(
+      # Deb package version string uses tilde instead of dashes for betas.
+      "${CURL[@]}" "${apt_index}" | awk "${apt_awk_prog}" | sed 's/~/-/'
     )
+    if [[ -n ${ver} ]]; then
+      remote_versions["${chan_os}"]="${ver}"
+    else
+      echo "No remote version for ${chan_os}" >&2
+    fi
 
     # Handle macOS Beta app-update feed quirk.
     # If there is a newer release in the stable channel, queries for beta

--- a/pkgs/by-name/_1/_1password-gui/update.sh
+++ b/pkgs/by-name/_1/_1password-gui/update.sh
@@ -17,11 +17,7 @@ CURL=(
   "-H" "user-agent: nixpkgs#_1password-gui update.sh" # repology requires a descriptive user-agent
 )
 
-JQ=(
-  "jq"
-  "--raw-output"
-  "--exit-status" # exit non-zero if no output is produced
-)
+JQ=("jq" "--raw-output")
 
 
 read_local_versions() {
@@ -37,7 +33,7 @@ read_local_versions() {
 
 read_remote_versions() {
   local channel="$1"
-  local darwin_beta_maybe
+  local chan_os ver
 
   if [[ ${channel} == "stable" ]]; then
     remote_versions["stable/linux"]=$(
@@ -60,13 +56,15 @@ read_remote_versions() {
     # Handle macOS Beta app-update feed quirk.
     # If there is a newer release in the stable channel, queries for beta
     # channel will return the stable channel version; masking the current beta.
-    darwin_beta_maybe=$(
+    chan_os="${channel}/darwin"
+    ver=$(
       "${CURL[@]}" "${APP_UPDATES_URI_BASE}/Y" \
-        | "${JQ[@]}" 'select(.available == "1") | .version'
+        | "${JQ[@]}" 'select(.available == "1" and (.version | endswith(".BETA"))) | .version'
     )
-    # Only consider versions that end with '.BETA'
-    if [[ ${darwin_beta_maybe} =~ \.BETA$ ]]; then
-      remote_versions["beta/darwin"]=${darwin_beta_maybe}
+    if [[ -n ${ver} ]]; then
+      remote_versions["${chan_os}"]="${ver}"
+    else
+      echo "No remote version for ${chan_os}" >&2
     fi
   fi
 }


### PR DESCRIPTION
It looks like the upstream is no longer updating their own [AUR repository](https://aur.archlinux.org/packages/1password). Claiming it's owned by the upstream based on the fact that it's linked from https://support.1password.com/install-linux/#arch-linux and signed using their PGP key.

So switch to scraping their APT repo to get update signals. We still download the tarballs and check them against their detached PGP signatures.

One more commit simplifies the macOS Beta quirk handling in the script, relying more on the jq filters, rather than shell constructs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
