### PR TITLE
nixos/fwupd: allow fwupd-refresh user to refresh metadata via polkit

### DIFF
--- a/nixos/modules/services/hardware/fwupd.nix
+++ b/nixos/modules/services/hardware/fwupd.nix
@@ -202,8 +202,8 @@ in
     systemd = {
       packages = [ cfg.package ];
 
-      # fwupd-refresh expects a user that we do not create, so just run with DynamicUser
-      # instead and ensure we take ownership of /var/lib/fwupd
+      # The upstream unit runs as User=fwupd-refresh; ensure it can take
+      # ownership of /var/lib/fwupd.
       services.fwupd-refresh.serviceConfig = {
         StateDirectory = "fwupd";
         # Better for debugging, upstream sets stderr to null for some reason..
@@ -219,7 +219,21 @@ in
     };
     users.groups.fwupd-refresh = { };
 
-    security.polkit.enable = true;
+    security.polkit = {
+      enable = true;
+      # fwupd-refresh.service has no seat, so polkit denies these actions.
+      # Upstream's TrustedUids needs a static uid which we only allocate at
+      # activation time, so grant access via a rule on the user name instead.
+      extraConfig = ''
+        polkit.addRule(function(action, subject) {
+          if ((action.id == "org.freedesktop.fwupd.get-remotes" ||
+               action.id == "org.freedesktop.fwupd.refresh-remote") &&
+              subject.user == "fwupd-refresh") {
+            return polkit.Result.YES;
+          }
+        });
+      '';
+    };
   };
 
   meta = {


### PR DESCRIPTION
fwupd 2.x gates the `GetRemotes` and `UpdateMetadata` D-Bus methods behind the `org.freedesktop.fwupd.get-remotes` and `org.freedesktop.fwupd.refresh-remote` polkit actions, which default to `auth_admin` for callers without an active seat.
`fwupd-refresh.service` runs as the `fwupd-refresh` system user, so polkit denies the request and the refresh fails with:

```
fwupdmgr[…]: Failed to obtain auth
systemd[1]: fwupd-refresh.service: Main process exited, code=exited, status=1/FAILURE
```

Upstream's intended bypass is `TrustedUids` in `fwupd.conf`, but on NixOS the `fwupd-refresh` uid is allocated at activation time and is not known during evaluation. Add a polkit rule keyed on the user name instead.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
