### PR TITLE
pnpmConfigHook: fix pnpmWorkspaces with multiple entries under __structuredAttrs

### DIFF
--- a/pkgs/build-support/node/fetch-pnpm-deps/pnpm-config-hook.sh
+++ b/pkgs/build-support/node/fetch-pnpm-deps/pnpm-config-hook.sh
@@ -80,9 +80,15 @@ pnpmConfigHook() {
     fi
 
     echo "Installing dependencies"
-    if [[ -n "$pnpmWorkspaces" ]]; then
+    if [ -z "${__structuredAttrs:-}" ]; then
+        # Without __structuredAttrs, pnpmWorkspaces is a space-separated string.
         local IFS=" "
         for ws in $pnpmWorkspaces; do
+            pnpmInstallFlags+=("--filter=$ws")
+        done
+    else
+        # With __structuredAttrs, pnpmWorkspaces is a bash array.
+        for ws in "${pnpmWorkspaces[@]}"; do
             pnpmInstallFlags+=("--filter=$ws")
         done
     fi

--- a/pkgs/test/pnpm/default.nix
+++ b/pkgs/test/pnpm/default.nix
@@ -1,7 +1,8 @@
-{ callPackage }:
+{ callPackage, lib }:
 {
   pnpm-empty-lockfile = callPackage ./pnpm-empty-lockfile { };
   pnpm-fixup-state-db = callPackage ./pnpm-fixup-state-db { };
+  pnpm-workspaces = lib.recurseIntoAttrs (callPackage ./pnpm-workspaces { });
   pnpm_11_v3 = callPackage ./pnpm_11_v3 { };
   pnpm_11_v4 = callPackage ./pnpm_11_v4 { };
 }

--- a/pkgs/test/pnpm/pnpm-workspaces/default.nix
+++ b/pkgs/test/pnpm/pnpm-workspaces/default.nix
@@ -1,0 +1,56 @@
+{
+  stdenv,
+  fetchPnpmDeps,
+  pnpm,
+  pnpmConfigHook,
+}:
+let
+  mkTest =
+    { structuredAttrs }:
+    stdenv.mkDerivation (finalAttrs: {
+      name = "pnpm-workspaces-${if structuredAttrs then "structured" else "legacy"}";
+
+      src = ./src;
+
+      pnpmDeps = fetchPnpmDeps {
+        pname = "pnpm-workspaces";
+        inherit (finalAttrs) src pnpmWorkspaces;
+        inherit pnpm;
+        fetcherVersion = 4;
+        hash = "sha256-dIp6CNh1Kn4aqJWku1G/FUdn/u+epzhqlqwnAkB2uW0=";
+      };
+
+      pnpmWorkspaces = [
+        "@pnpm-workspaces-test/a"
+        "@pnpm-workspaces-test/b"
+      ];
+
+      __structuredAttrs = structuredAttrs;
+
+      nativeBuildInputs = [
+        pnpm
+        pnpmConfigHook
+      ];
+
+      buildPhase = ''
+        runHook preBuild
+
+        for package in a b; do
+          if [ -e "packages/$package/node_modules/@pnpm-workspaces-test/$package-dep" ]; then
+            echo "$package was installed (its dependency $package-dep is linked)"
+          else
+            echo "ERROR: $package was not installed"
+            exit 1
+          fi
+        done
+
+        touch $out
+
+        runHook postBuild
+      '';
+    });
+in
+{
+  legacy = mkTest { structuredAttrs = false; };
+  structured = mkTest { structuredAttrs = true; };
+}

--- a/pkgs/test/pnpm/pnpm-workspaces/src/package.json
+++ b/pkgs/test/pnpm/pnpm-workspaces/src/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "pnpm-workspaces-test",
+  "version": "0.0.0",
+  "private": true
+}

--- a/pkgs/test/pnpm/pnpm-workspaces/src/packages/a-dep/package.json
+++ b/pkgs/test/pnpm/pnpm-workspaces/src/packages/a-dep/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@pnpm-workspaces-test/a-dep",
+  "version": "0.0.0"
+}

--- a/pkgs/test/pnpm/pnpm-workspaces/src/packages/a/package.json
+++ b/pkgs/test/pnpm/pnpm-workspaces/src/packages/a/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@pnpm-workspaces-test/a",
+  "version": "0.0.0",
+  "dependencies": {
+    "@pnpm-workspaces-test/a-dep": "workspace:*"
+  }
+}

--- a/pkgs/test/pnpm/pnpm-workspaces/src/packages/b-dep/package.json
+++ b/pkgs/test/pnpm/pnpm-workspaces/src/packages/b-dep/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@pnpm-workspaces-test/b-dep",
+  "version": "0.0.0"
+}

--- a/pkgs/test/pnpm/pnpm-workspaces/src/packages/b/package.json
+++ b/pkgs/test/pnpm/pnpm-workspaces/src/packages/b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@pnpm-workspaces-test/b",
+  "version": "0.0.0",
+  "dependencies": {
+    "@pnpm-workspaces-test/b-dep": "workspace:*"
+  }
+}

--- a/pkgs/test/pnpm/pnpm-workspaces/src/pnpm-lock.yaml
+++ b/pkgs/test/pnpm/pnpm-workspaces/src/pnpm-lock.yaml
@@ -1,0 +1,25 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  packages/a:
+    dependencies:
+      '@pnpm-workspaces-test/a-dep':
+        specifier: workspace:*
+        version: link:../a-dep
+
+  packages/a-dep: {}
+
+  packages/b:
+    dependencies:
+      '@pnpm-workspaces-test/b-dep':
+        specifier: workspace:*
+        version: link:../b-dep
+
+  packages/b-dep: {}

--- a/pkgs/test/pnpm/pnpm-workspaces/src/pnpm-workspace.yaml
+++ b/pkgs/test/pnpm/pnpm-workspaces/src/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'


### PR DESCRIPTION
Under __structuredAttrs, pnpmWorkspaces packages other than the first were not installed, because Nix exports pnpmWorkspaces as a bash array but the hook iterated it with `for ws in $pnpmWorkspaces`, which reads only the first element and so emits only the first --filter.

The nixpkgs-vet ratchet (NPV-166) now requires __structuredAttrs on new packages, so multi-workspace pnpm packages are likely to hit this more often going forward.

Assisted-by: Claude Code (Claude Opus 4.8)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
