### PR TITLE
wf-touch, hyprlandPlugins.hyprgrass: fix build failures

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprgrass.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprgrass.nix
@@ -12,27 +12,35 @@
 
 mkHyprlandPlugin {
   pluginName = "hyprgrass";
-  version = "0.8.2-unstable-2025-10-08";
+  version = "0.8.2-unstable-2026-05-18";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "horriblename";
     repo = "hyprgrass";
-    rev = "fdfa60d464a18ae20b7a7bc63c0d2336f37c164b";
-    hash = "sha256-2Y2D2wuNqSldprawq8BSca90gSYSR5ZKL5ZW2YAV2F8=";
+    rev = "c9968ba79b3537eff127d6ab6df767d76f17544a";
+    hash = "sha256-rVLdIs67in1fhaatayWrLu+kCOJ0cveKze/BRjYtxRw=";
   };
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     cmake
-    doctest
     meson
     ninja
   ];
 
-  buildInputs = [ wf-touch ];
+  buildInputs = [
+    doctest
+    wf-touch
+  ];
 
   dontUseCmakeConfigure = true;
 
   doCheck = true;
+
+  enableParallelBuilding = true;
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/wf/wf-touch/package.nix
+++ b/pkgs/by-name/wf/wf-touch/package.nix
@@ -14,14 +14,18 @@
 
 stdenv.mkDerivation {
   pname = "wf-touch";
-  version = "0-unstable-2021-03-19";
+  version = "0-unstable-2025-02-11";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "WayfireWM";
     repo = "wf-touch";
-    rev = "8974eb0f6a65464b63dd03b842795cb441fb6403";
-    hash = "sha256-MjsYeKWL16vMKETtKM5xWXszlYUOEk3ghwYI85Lv4SE=";
+    rev = "093d8943df03cc8a2667990a065513c1bf2b57e0";
+    hash = "sha256-gEBwXTd42UePgxI8rYmdLBF6cVagmtVANYzeleq0c7s=";
   };
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     meson
@@ -30,11 +34,16 @@ stdenv.mkDerivation {
     ninja
   ];
 
-  buildInputs = [ doctest ];
-
   propagatedBuildInputs = [ glm ];
 
   mesonBuildType = "release";
+
+  postPatch = ''
+    # doctest is header-only, fix the meson build to not try to link against a library
+    substituteInPlace meson.build \
+      --replace-fail "doctest = dependency('doctest', required: get_option('tests'))" \
+      "doctest = declare_dependency(include_directories: include_directories('${doctest}/include'))"
+  '';
 
   # Patch wf-touch to generate pkgconfig
   patches = fetchpatch {

--- a/pkgs/by-name/wf/wf-touch/package.nix
+++ b/pkgs/by-name/wf/wf-touch/package.nix
@@ -14,15 +14,15 @@
 
 stdenv.mkDerivation {
   pname = "wf-touch";
-  version = "0-unstable-2025-02-11";
+  version = "0-unstable-2021-03-19";
 
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "WayfireWM";
     repo = "wf-touch";
-    rev = "093d8943df03cc8a2667990a065513c1bf2b57e0";
-    hash = "sha256-gEBwXTd42UePgxI8rYmdLBF6cVagmtVANYzeleq0c7s=";
+    rev = "8974eb0f6a65464b63dd03b842795cb441fb6403";
+    hash = "sha256-MjsYeKWL16vMKETtKM5xWXszlYUOEk3ghwYI85Lv4SE=";
   };
 
   strictDeps = true;
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
   mesonBuildType = "release";
 
   postPatch = ''
-    # doctest is header-only, fix the meson build to not try to link against a library
+    # doctest is header-only, fix the meson build to not try to link against the library
     substituteInPlace meson.build \
       --replace-fail "doctest = dependency('doctest', required: get_option('tests'))" \
       "doctest = declare_dependency(include_directories: include_directories('${doctest}/include'))"


### PR DESCRIPTION
Fixes 2 build failures with `wf-touch` and `hyprlandPlugins.hyprgrass` by patching `doctest` consumption and updating the package to build with `hyprland` 0.55 respectively

not entirely sure about the approach for `wf-touch` so if anyone has insight I'd appreciate it!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
