### PR TITLE
vcmi: fix build

### DIFF
--- a/pkgs/by-name/vc/vcmi/package.nix
+++ b/pkgs/by-name/vc/vcmi/package.nix
@@ -5,6 +5,7 @@
   SDL2_ttf,
   boost,
   cmake,
+  gettext,
   fetchFromGitHub,
   ffmpeg,
   fuzzylite,
@@ -30,16 +31,27 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "vcmi";
   version = "1.7.4";
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   src = fetchFromGitHub {
     owner = "vcmi";
     repo = "vcmi";
     tag = finalAttrs.version;
     fetchSubmodules = true;
-    hash = "sha256-uzdnRKF0xb2B2r6kTzk6OEDGBdOwcu9eGYsvv4ALCF0=";
+    # Disable git background maintenance for the whole prefetch, including submodule clones.
+    # Upstream nix-prefetch-git only disables it on the outer repo (NixOS/nixpkgs#524215), so
+    # submodule clones can still race with their own maintenance and break `.git` cleanup.
+    preFetch = ''
+      export GIT_CONFIG_GLOBAL="$TMPDIR/gitconfig"
+      printf '[maintenance]\n\tauto = false\n' > "$GIT_CONFIG_GLOBAL"
+    '';
+    hash = "sha256-iV1twkoOJyUsUkq17mdTYk1YvfmUtLHdtR3H77BoNJk=";
   };
 
   nativeBuildInputs = [
     cmake
+    gettext # msgfmt
     ninja
     pkg-config
     python3
@@ -98,13 +110,13 @@ stdenv.mkDerivation (finalAttrs: {
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgram = "${placeholder "out"}/bin/vcmiclient";
-  versionCheckProgramArg = "--version";
   versionCheckKeepEnvironment = [
     "XDG_CACHE_HOME"
     "XDG_CONFIG_HOME"
     "XDG_DATA_HOME"
   ];
   preVersionCheck = ''
+    cd $(mktemp -d)
     export \
       XDG_CACHE_HOME="$TMPDIR" \
       XDG_CONFIG_HOME="$TMPDIR" \


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
