### PR TITLE
ratatouille-lv2: init at 0.9.11

### DIFF
--- a/pkgs/by-name/ra/ratatouille-lv2/package.nix
+++ b/pkgs/by-name/ra/ratatouille-lv2/package.nix
@@ -1,0 +1,65 @@
+{
+  cairo,
+  fetchFromGitHub,
+  lib,
+  libx11,
+  libjack2,
+  libsndfile,
+  lv2,
+  pkg-config,
+  stdenv,
+  xorgproto,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ratatouille-lv2";
+  version = "0.9.11";
+
+  src = fetchFromGitHub {
+    owner = "brummer10";
+    repo = "Ratatouille.lv2";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-mig3yUGSNz1xuyz6ljKqJUjNqmEcsbXSH1vTxTGdOFk=";
+    fetchSubmodules = true;
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    libx11
+    xorgproto
+    cairo
+    lv2
+    libsndfile
+    libjack2
+  ];
+
+  makeFlags = [
+    "PREFIX=$(out)"
+    "INSTALL_DIR=$(out)/lib/lv2"
+    "EXE_INSTALL_DIR=$(out)/bin"
+    "CLAP_INSTAL_DIR=$(out)/lib/clap"
+    "VST2_INSTAL_DIR=$(out)/lib/vst"
+    "user=root"
+    "STRIP=:"
+  ];
+
+  postPatch = ''
+    substituteInPlace Ratatouille/makefile \
+      --replace-fail "-flto=auto" ""
+  '';
+
+  meta = {
+    homepage = "https://github.com/brummer10/Ratatouille.lv2";
+    description = "Neural Amp Modeler LV2 plugin";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ eymeric ];
+    platforms = lib.platforms.linux;
+    mainProgram = "Ratatouille";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes : #371836

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
