### PR TITLE
installFonts: provide a default installPhase

### DIFF
--- a/pkgs/build-support/setup-hooks/install-fonts.sh
+++ b/pkgs/build-support/setup-hooks/install-fonts.sh
@@ -22,6 +22,14 @@
 #
 preInstallHooks+=(installFonts)
 
+# Default installPhase so font packages needn't hand-write one just to skip
+# stdenv's `make install` (font sources often ship a Makefile with no install
+# target). Must be a variable, not a function: stdenv defines installPhase()
+# after setup hooks load. The -z guard lets a package's own installPhase win.
+if [ -z "${installPhase:-}" ]; then
+  installPhase=$'runHook preInstall\nrunHook postInstall'
+fi
+
 installFont() {
   if (($# != 2)); then
     nixErrorLog "expected 2 arguments!"

--- a/pkgs/by-name/at/atkinson-hyperlegible-mono/package.nix
+++ b/pkgs/by-name/at/atkinson-hyperlegible-mono/package.nix
@@ -25,12 +25,6 @@ stdenvNoCC.mkDerivation {
 
   dontBuild = true;
 
-  # default installPhase invokes python, but we still want the font hook to run
-  installPhase = ''
-    runHook preInstall
-    runHook postInstall
-  '';
-
   meta = {
     description = "New (2024) monospace sibling family to Atkinson Hyperlegible Next";
     homepage = "https://www.brailleinstitute.org/freefont/";

--- a/pkgs/by-name/at/atkinson-hyperlegible-next/package.nix
+++ b/pkgs/by-name/at/atkinson-hyperlegible-next/package.nix
@@ -25,12 +25,6 @@ stdenvNoCC.mkDerivation {
 
   nativeBuildInputs = [ installFonts ];
 
-  # default installPhase invokes python, but we still want the font hook to run
-  installPhase = ''
-    runHook preInstall
-    runHook postInstall
-  '';
-
   meta = {
     description = "New (2024) second version of the Atkinson Hyperlegible fonts";
     homepage = "https://www.brailleinstitute.org/freefont/";

--- a/pkgs/by-name/be/beon/package.nix
+++ b/pkgs/by-name/be/beon/package.nix
@@ -31,11 +31,6 @@ stdenvNoCC.mkDerivation {
     installFonts
   ];
 
-  installPhase = ''
-    runHook preInstall
-    runHook postInstall
-  '';
-
   preInstall = "rm -r docs/proof";
   postInstall = ''
     mkfontdir $out/share/fonts

--- a/pkgs/by-name/eb/eb-garamond/package.nix
+++ b/pkgs/by-name/eb/eb-garamond/package.nix
@@ -39,13 +39,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postBuild
   '';
 
-  # installFonts adds a hook to `postInstall` that installs fonts
-  # into the correct directories
-  installPhase = ''
-    runHook preInstall
-    runHook postInstall
-  '';
-
   meta = {
     homepage = "http://www.georgduffner.at/ebgaramond/";
     description = "Digitization of the Garamond shown on the Egenolff-Berner specimen";

--- a/pkgs/by-name/gu/gubbi-font/package.nix
+++ b/pkgs/by-name/gu/gubbi-font/package.nix
@@ -26,11 +26,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   preBuild = "patchShebangs generate.pe";
 
-  installPhase = ''
-    runHook preInstall
-    runHook postInstall
-  '';
-
   meta = {
     inherit (finalAttrs.src.meta) homepage;
     description = "Kannada font";

--- a/pkgs/by-name/lk/lklug-sinhala/package.nix
+++ b/pkgs/by-name/lk/lklug-sinhala/package.nix
@@ -16,11 +16,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ installFonts ];
 
-  installPhase = ''
-    runHook preInstall
-    runHook postInstall
-  '';
-
   meta = {
     description = "Unicode Sinhala font by Lanka Linux User Group";
     homepage = "http://www.lug.lk/fonts/lklug";

--- a/pkgs/by-name/lo/lora/package.nix
+++ b/pkgs/by-name/lo/lora/package.nix
@@ -29,13 +29,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ installFonts ];
 
-  # installFonts adds a hook to `postInstall` that installs fonts
-  # into the correct directories
-  installPhase = ''
-    runHook preInstall
-    runHook postInstall
-  '';
-
   meta = {
     description = "Lora Font: well-balanced contemporary serif with roots in calligraphy";
     homepage = "https://github.com/cyrealtype/lora";

--- a/pkgs/by-name/os/oswald/package.nix
+++ b/pkgs/by-name/os/oswald/package.nix
@@ -25,11 +25,6 @@ stdenvNoCC.mkDerivation {
 
   preInstall = "rm -r legacy/";
 
-  installPhase = ''
-    runHook preInstall
-    runHook postInstall
-  '';
-
   meta = {
     description = "Reworking of the classic gothic typeface style";
     longDescription = ''

--- a/pkgs/by-name/wq/wqy_zenhei/package.nix
+++ b/pkgs/by-name/wq/wqy_zenhei/package.nix
@@ -18,11 +18,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   dontBuild = true;
 
-  installPhase = ''
-    runHook preInstall
-    runHook postInstall
-  '';
-
   meta = {
     description = "Chinese Unicode font with full CJK coverage";
     homepage = "http://wenq.org";

--- a/pkgs/by-name/xi/xits-math/package.nix
+++ b/pkgs/by-name/xi/xits-math/package.nix
@@ -29,13 +29,6 @@ stdenv.mkDerivation (finalAttrs: {
     rm *.otf
   '';
 
-  # installFonts adds a hook to `postInstall` that installs fonts
-  # into the correct directories
-  installPhase = ''
-    runHook preInstall
-    runHook postInstall
-  '';
-
   meta = {
     homepage = "https://github.com/alif-type/xits";
     description = "OpenType implementation of STIX fonts with math support";


### PR DESCRIPTION
Font sources frequently ship a Makefile with no `install` target, so the stdenv default installPhase (`make install`) fails. Every such package had to hand-write an empty installPhase doing nothing but `runHook preInstall` / `runHook postInstall` to suppress it.

Provide that as the default in the hook instead. It is set as the installPhase *variable* rather than a function because stdenv defines the installPhase() function after setup hooks are sourced; the `-z` guard keeps a package's own installPhase attribute taking precedence.

I checked outputs of all touched packages

Assisted-by: claude-code with claude-opus-4-8[1m]-high

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
