### PR TITLE
font-v: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/font-v/default.nix
+++ b/pkgs/development/python-modules/font-v/default.nix
@@ -6,12 +6,13 @@
   gitMinimal,
   gitpython,
   pytestCheckHook,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "font-v";
   version = "2.1.0";
-  format = "setuptools";
+  pyproject = true;
 
   # PyPI source tarballs omit tests, fetch from Github instead
   src = fetchFromGitHub {
@@ -21,7 +22,9 @@ buildPythonPackage rec {
     hash = "sha256-ceASyYcNul5aWPAPGajCQrqsQ3bN1sE+nMbCbj7f35w=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     fonttools
     gitpython
   ];
@@ -30,6 +33,7 @@ buildPythonPackage rec {
     gitMinimal
     pytestCheckHook
   ];
+
   preCheck = ''
     # Many tests assume they are running from a git checkout, although they
     # don't care which one. Create a dummy git repo to satisfy the tests:
@@ -38,6 +42,7 @@ buildPythonPackage rec {
     git config user.name Test
     git commit --allow-empty --message 'Dummy commit for tests'
   '';
+
   disabledTests = [
     # These tests assume they are actually running from a font-v git checkout,
     # so just skip them:

--- a/pkgs/development/python-modules/font-v/default.nix
+++ b/pkgs/development/python-modules/font-v/default.nix
@@ -9,7 +9,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "font-v";
   version = "2.1.0";
   pyproject = true;
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "source-foundry";
     repo = "font-v";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-ceASyYcNul5aWPAPGajCQrqsQ3bN1sE+nMbCbj7f35w=";
   };
 
@@ -56,4 +56,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ danc86 ];
   };
-}
+})

--- a/pkgs/development/python-modules/font-v/default.nix
+++ b/pkgs/development/python-modules/font-v/default.nix
@@ -51,6 +51,7 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "Python utility for manipulating font version headers";
+    changelog = "https://github.com/source-foundry/font-v/blob/v${finalAttrs.version}/CHANGELOG.md";
     mainProgram = "font-v";
     homepage = "https://github.com/source-foundry/font-v";
     license = lib.licenses.mit;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- part of: https://github.com/NixOS/nixpkgs/issues/515974

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
