### PR TITLE
avm: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29174,6 +29174,14 @@
     githubId = 1771332;
     name = "László Vaskó";
   };
+  VlaDexa = {
+    name = "Vladislav Grechannik";
+    email = "nixpkgs@vladexa.xyz";
+    keys = [ { fingerprint = "1E21 85DA D156 B08C 2740  D301 D58B FE42 A558 7A72"; } ];
+    github = "VlaDexa";
+    githubId = 52157081;
+    matrix = "@vladexa:vladexa.xyz";
+  };
   vlinkz = {
     email = "vmfuentes64@gmail.com";
     github = "vlinkz";

--- a/pkgs/by-name/av/avm/package.nix
+++ b/pkgs/by-name/av/avm/package.nix
@@ -1,0 +1,61 @@
+{
+  cmake,
+  enableVmaf ? true,
+  fetchFromGitHub,
+  gitUpdater,
+  lib,
+  libvmaf,
+  perl,
+  pkg-config,
+  python3,
+  stdenv,
+  versionCheckHook,
+  yasm,
+  ...
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "avm";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "AOMediaCodec";
+    repo = "avm";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dmMQfOP71DdjHZw6DpbiiOB5a9khIu6QnZ0F5WsMuM8=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    cmake
+    perl
+    pkg-config
+    python3
+    yasm
+  ];
+
+  propagatedBuildInputs = lib.optional enableVmaf libvmaf;
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_INSTALL_BINDIR" "bin")
+    (lib.cmakeFeature "CMAKE_INSTALL_INCLUDEDIR" "include")
+    (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
+  ]
+  ++ (lib.optional enableVmaf (lib.cmakeFeature "CONFIG_TUNE_VMAF" "1"));
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+  };
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    homepage = "https://github.com/AOMediaCodec/avm";
+    description = "AVM (AOM Video Model) is the reference software for AV2 codec from Alliance for Open Media";
+    changelog = "https://github.com/AOMediaCodec/avm/blob/${finalAttrs.src.tag}/CHANGELOG";
+    license = lib.licenses.bsd3Clear;
+    maintainers = with lib.maintainers; [ VlaDexa ];
+    mainProgram = "avmenc";
+  };
+})


### PR DESCRIPTION
Adds software for newly released AV2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
