### PR TITLE
various: update source to resolve redirection

### DIFF
--- a/pkgs/by-name/ct/ctrtool/package.nix
+++ b/pkgs/by-name/ct/ctrtool/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.3.0";
 
   src = fetchFromGitHub {
-    owner = "jakcron";
+    owner = "3DSGuy";
     repo = "Project_CTR";
     rev = "ctrtool-v${finalAttrs.version}";
     sha256 = "GvEzv97DqCsaDWVqDpajQRWYe+WM8xCYmGE0D3UcSrM=";
@@ -37,6 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     license = lib.licenses.mit;
     description = "Tool to extract data from a 3ds rom";
+    homepage = "https://github.com/3DSGuy/Project_CTR";
     platforms = with lib.platforms; linux ++ darwin;
     maintainers = with lib.maintainers; [ marius851000 ];
     mainProgram = "ctrtool";

--- a/pkgs/by-name/nb/nbxplorer/package.nix
+++ b/pkgs/by-name/nb/nbxplorer/package.nix
@@ -10,7 +10,7 @@ buildDotnetModule rec {
   version = "2.6.0";
 
   src = fetchFromGitHub {
-    owner = "dgarage";
+    owner = "btcpayserver";
     repo = "NBXplorer";
     tag = "v${version}";
     hash = "sha256-X1+UdsKVOC3QpES22p0MG1Rz1oresilBM+b/4I1nCyI=";
@@ -29,6 +29,7 @@ buildDotnetModule rec {
 
   meta = {
     description = "Minimalist UTXO tracker for HD Cryptocurrency Wallets";
+    homepage = "https://github.com/btcpayserver/NBXplorer";
     maintainers = with lib.maintainers; [
       kcalvinalvin
       erikarvstedt

--- a/pkgs/by-name/ph/physlock/package.nix
+++ b/pkgs/by-name/ph/physlock/package.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "13";
   pname = "physlock";
   src = fetchFromGitHub {
-    owner = "muennich";
+    owner = "xyb3rt";
     repo = "physlock";
     rev = "v${finalAttrs.version}";
     sha256 = "1mz4xxjip5ldiw9jgfq9zvqb6w10bcjfx6939w1appqg8f521a7s";
@@ -33,6 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Secure suspend/hibernate-friendly alternative to `vlock -an`";
+    homepage = "https://github.com/xyb3rt/physlock";
     mainProgram = "physlock";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/sy/syntex/package.nix
+++ b/pkgs/by-name/sy/syntex/package.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation {
   version = "0.0pre20160915";
   src = fetchFromGitHub {
     owner = "mxgmn";
-    repo = "SynTex";
+    repo = "TextureSynthesis";
     rev = "f499a7c8112be4a63eb44843ba72957c2c9a04db";
     sha256 = "13fz6frlxsdz8qq94fsvim27cd5klmdsax5109yxm9175vgvpa0a";
   };
@@ -31,6 +31,7 @@ stdenv.mkDerivation {
   buildInputs = [ mono ];
   meta = {
     description = "Texture synthesis from examples";
+    homepage = "https://github.com/mxgmn/TextureSynthesis";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/python-modules/asn1ate/default.nix
+++ b/pkgs/development/python-modules/asn1ate/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     sha256 = "1p8hv4gsyqsdr0gafcq497n52pybiqmc22di8ai4nsj60fv0km45";
     rev = "v${version}";
-    owner = "kimgr";
+    owner = "schneider-electric";
     repo = "asn1ate";
   };
 
@@ -21,6 +21,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Python library for translating ASN.1 into other forms";
+    homepage = "https://github.com/schneider-electric/asn1ate";
     mainProgram = "asn1ate";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;


### PR DESCRIPTION
Follow-up to #512901, updating the URLs from this PR (and extracting addition of updated homepage) for packages with a redirect on the source URL.

This should not create any rebuild

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
