### PR TITLE
ccusage: init at 20.0.6

### DIFF
--- a/pkgs/by-name/cc/ccusage/package.nix
+++ b/pkgs/by-name/cc/ccusage/package.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  fetchurl,
+  pkg-config,
+  apple-sdk_15,
+  libiconv,
+  versionCheckHook,
+  nix-update-script,
+  runCommand,
+  jq,
+}:
+
+let
+  # ccusage embeds the LiteLLM model-pricing table at build time. Its build
+  # script otherwise downloads this file from the network, which fails in the
+  # sandbox. Upstream pins the data via a flake input and points
+  # CCUSAGE_PRICING_JSON_PATH at it; mirror that exact revision here so the
+  # build is offline and reproducible (see package.nix + flake.lock in the
+  # upstream repo at tag v20.0.6). Bump this revision together with the package
+  # version; nix-update only refreshes the src and cargo hashes.
+  litellmPricing = fetchurl {
+    url = "https://raw.githubusercontent.com/BerriAI/litellm/f27df8d516802ce4c1b32973992154fe83b851cf/model_prices_and_context_window.json";
+    hash = "sha256-zJa6H2EwP9s+hMVs78Y+hwo4UX1dHRtvX5J3MdGh5aI=";
+  };
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ccusage";
+  version = "20.0.6";
+
+  src = fetchFromGitHub {
+    owner = "ryoppippi";
+    repo = "ccusage";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-uf/FlPprxx4jh74YwjmYMtoIHpTkKrWTLetbNoYiFv4=";
+  };
+
+  # The Cargo workspace lives in rust/, not at the repo root.
+  cargoRoot = "rust";
+  buildAndTestSubdir = "rust";
+
+  cargoHash = "sha256-izA2Gs5nPmt0zn6/e1xM80vyyQHYKGEUDpUFRpyFiB8=";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    apple-sdk_15
+    libiconv
+  ];
+
+  env.CCUSAGE_PRICING_JSON_PATH = "${litellmPricing}";
+
+  # Build only the ccusage binary out of the multi-crate workspace.
+  cargoBuildFlags = [
+    "-p"
+    "ccusage"
+    "--bin"
+    "ccusage"
+  ];
+
+  # Upstream disables the test suite in its own Nix build; parts of it rely on
+  # network access and live pricing data. versionCheckHook still exercises the
+  # built binary below.
+  doCheck = false;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+
+    tests = {
+      # With no agent data on disk, ccusage must still emit a valid, empty JSON
+      # report. --offline keeps it from reaching the network, exercising the
+      # pricing table baked in at build time. This guards the data discovery,
+      # JSON serialization, and offline-pricing paths without needing fixtures.
+      smoke =
+        runCommand "ccusage-smoke-test"
+          {
+            nativeBuildInputs = [
+              finalAttrs.finalPackage
+              jq
+            ];
+          }
+          ''
+            export HOME="$(mktemp -d)"
+            ccusage daily --json --offline > report.json
+            jq -e '.daily == [] and .totals.totalTokens == 0' report.json
+            touch "$out"
+          '';
+    };
+  };
+
+  meta = {
+    description = "Analyze coding agent CLI token usage and costs from local data";
+    homepage = "https://github.com/ryoppippi/ccusage";
+    changelog = "https://github.com/ryoppippi/ccusage/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ thrix ];
+    mainProgram = "ccusage";
+  };
+})


### PR DESCRIPTION
Analyze coding agent CLI token usage and costs from local data.

Packaged from the upstream Rust workspace, which became the primary implementation in v20.0.0 (earlier Node/pnpm packaging attempts were abandoned). The crate's build script normally downloads the LiteLLM pricing table; `CCUSAGE_PRICING_JSON_PATH` is pointed at a pinned copy fetched separately so the build stays offline and reproducible in the sandbox.

Assisted-by: Claude Code


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
