### PR TITLE
sysprof: fix dependency cycle

### DIFF
--- a/pkgs/development/tools/profiling/sysprof/default.nix
+++ b/pkgs/development/tools/profiling/sysprof/default.nix
@@ -70,6 +70,15 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dinstall-static=false"
   ];
 
+  # need to only wrap the binaries in $out, otherwise $out<->$lib end up with a dependency cycle
+  dontWrapGApps = true;
+
+  postFixup = ''
+    for program in $out/bin/*; do
+      wrapProgram "$program" "''${gappsWrapperArgs[@]}"
+    done
+  '';
+
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "sysprof";


### PR DESCRIPTION
It seems that `sysprof-50.0-lib/libexec/*` is getting wrapped since https://github.com/NixOS/nixpkgs/pull/511330
This isn't the case on current master, so we're not getting this dependency cycle there:
```
error: cycle detected in build of '/nix/store/nz7y0f1gh19yjby67jzzzi2bkd1jq6fg-sysprof-50.0.drv' in the references of output 'lib' from output 'out'
```

Adding `__structuredAttrs = true;` alone doesn't fix it, sadly. I'm sure there's a better way to skip outputs, but I didn't have time to go down this rabbit hole.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
