### PR TITLE
linuxKernel.packages.linux_7_0.tsme-test: 7.0.10-unstable-2022-12-07 -> 7.0.10-unstable-2026-02-09

### DIFF
--- a/pkgs/os-specific/linux/tsme-test/default.nix
+++ b/pkgs/os-specific/linux/tsme-test/default.nix
@@ -8,14 +8,25 @@
 
 stdenv.mkDerivation {
   pname = "tsme-test";
-  version = "${kernel.version}-unstable-2022-12-07";
+  version = "${kernel.version}-unstable-2026-02-09";
 
   src = fetchFromGitHub {
     owner = "AMDESE";
     repo = "mem-encryption-tests";
-    rev = "7abb072ffc50ceb0b4145ae84105ce6c91bd1ff4";
-    hash = "sha256-v0KAGlo6ci0Ij1NAiMUK0vWDHBiFnpQG4Er6ArIKncQ=";
+    rev = "361bf41092aec06d7f6e7be239a62bc5a5ff2c66";
+    hash = "sha256-aDv4gXcAXOBnJ256Ph06q0qBa9bSXvTbAG+AClFJUTI=";
   };
+
+  patches = [
+    # tsme-test.c calls kzalloc()/kzalloc_node()/kfree() without including
+    # <linux/slab.h>. It only compiled on newer kernels because slab.h is
+    # reachable transitively via <linux/mm.h> (mm.h -> huge_mm.h -> fs.h ->
+    # slab.h); the fs.h -> slab.h link was added in v5.18 and is absent from
+    # v5.17 and earlier, so the module fails to build on 5.10/5.15. Add the
+    # include explicitly.
+    # https://github.com/torvalds/linux/commit/8b9f3ac5b01db85c6cf74c2c3a71280cc3045c9c
+    ./include-slab.patch
+  ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 

--- a/pkgs/os-specific/linux/tsme-test/include-slab.patch
+++ b/pkgs/os-specific/linux/tsme-test/include-slab.patch
@@ -1,0 +1,10 @@
+--- a/tsme-test.c
++++ b/tsme-test.c
+@@ -13,6 +13,7 @@
+ #include <linux/smp.h>
+ #include <linux/mm.h>
+ #include <linux/io.h>
++#include <linux/slab.h>
+ #include <linux/kobject.h>
+ #include <linux/sysfs.h>
+


### PR DESCRIPTION
[![](https://hydra-banner.harinn.dev/build/329739798)](https://hydra.nixos.org/build/329739798)

This PR fixes `linuxKernel.packages.linux_7_0.tsme-test` which has been broken since it was initially added in #509589. This new February 2026 commit AMDESE/mem-encryption-tests@361bf41092aec06d7f6e7be239a62bc5a5ff2c66 is the only one that has been made to the project since 2022.

The build failure occurred because [the call to `__flush_tlb_all`](https://github.com/AMDESE/mem-encryption-tests/blob/7abb072ffc50ceb0b4145ae84105ce6c91bd1ff4/tsme-test.c#L47) got broken by the restriction in torvalds/linux@6276c67f2bc4aeaf350a7cf889c33c38b3330ea9. The update fixes it because the newer commit removed the call to `__flush_tlb_all`.

This PR also adds a patch to prevent regression when building against older versions of Linux. The package now includes calls [to `kzalloc_node`](https://github.com/AMDESE/mem-encryption-tests/blob/361bf41092aec06d7f6e7be239a62bc5a5ff2c66/tsme-test.c#L172) [and `kzalloc`](https://github.com/AMDESE/mem-encryption-tests/blob/361bf41092aec06d7f6e7be239a62bc5a5ff2c66/tsme-test.c#L220) [and `kfree`](https://github.com/AMDESE/mem-encryption-tests/blob/361bf41092aec06d7f6e7be239a62bc5a5ff2c66/tsme-test.c#L267-L270), which is fine in Linux 5.18 and newer because torvalds/linux@8b9f3ac5b01db85c6cf74c2c3a71280cc3045c9c happened to add `#include <linux/slab.h>` to `include/linux/fs.h` which is [included by `include/linux/huge_mm.h`](https://github.com/torvalds/linux/blob/v6.1/include/linux/huge_mm.h#L8) which is [included by `include/linux/huge_mm.h`](https://github.com/torvalds/linux/blob/v6.1/include/linux/mm.h#L737) which is [included by this package](https://github.com/AMDESE/mem-encryption-tests/blob/361bf41092aec06d7f6e7be239a62bc5a5ff2c66/tsme-test.c#L14), but for earlier Linux versions, an explicit `#include` is necessary.

The `aarch64-linux` build failures all predate this PR.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
