### PR TITLE
gsoap: 2.8.108 -> 2.8.142

### DIFF
--- a/pkgs/by-name/gs/gsoap/package.nix
+++ b/pkgs/by-name/gs/gsoap/package.nix
@@ -13,17 +13,16 @@
 }:
 
 let
-  majorVersion = "2.8";
   isCross = stdenv.hostPlatform != stdenv.buildPlatform;
 
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gsoap";
-  version = "${majorVersion}.108";
+  version = "2.8.142";
 
   src = fetchurl {
-    url = "mirror://sourceforge/project/gsoap2/gsoap-${majorVersion}/gsoap_${finalAttrs.version}.zip";
-    sha256 = "0x58bwlclk7frv03kg8bp0pm7zl784samvbzskrnr7dl5v866nvl";
+    url = "mirror://sourceforge/gsoap2/gsoap_${finalAttrs.version}.zip";
+    hash = "sha256-bXGWvWWR7Cl3R0xoHjUbSjPrXC1kyeLmcnsATzMLN1I=";
   };
 
   buildInputs = [
@@ -40,11 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   # Parallel building doesn't work as of 2.8.49
   enableParallelBuilding = false;
 
-  # Future versions of automake require subdir-objects if the source is structured this way
-  # As of 2.8.49 (maybe earlier) this is needed to silence warnings
   prePatch = ''
-    substituteInPlace configure.ac \
-      --replace 'AM_INIT_AUTOMAKE([foreign])' 'AM_INIT_AUTOMAKE([foreign subdir-objects])'
     ${lib.optionalString isCross ''
       substituteInPlace gsoap/wsdl/Makefile.am \
         --replace-fail 'SOAP=$(top_builddir)/gsoap/src/soapcpp2$(EXEEXT)' 'SOAP=${lib.getExe' buildPackages.gsoap "soapcpp2"}'


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
