### PR TITLE
vimPlugins.difftastic-nvim: init at 0.0.9

### DIFF
--- a/pkgs/applications/editors/vim/plugins/non-generated/difftastic-nvim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/difftastic-nvim/default.nix
@@ -1,0 +1,63 @@
+{
+  vimPlugins,
+  lib,
+  vimUtils,
+  rustPlatform,
+  stdenv,
+  nix-update-script,
+  fetchFromGitHub,
+}:
+let
+  version = "0.0.9";
+  src = fetchFromGitHub {
+    owner = "clabby";
+    repo = "difftastic.nvim";
+    rev = "6041ef0244b3fecf3b7f07de9af8cfbf8dbc4945";
+    hash = "sha256-23NGKhytF3OsLJgdrC51IH/sIGoqe/yBfmPsZKHOMSk=";
+  };
+
+  difftastic-nvim-lib = rustPlatform.buildRustPackage {
+    pname = "difftastic-nvim-lib";
+    inherit version src;
+    cargoHash = "sha256-VSlFlLa4knQ7bH8yFHSKTTtt1cQ76dstlCdWBAtkf1I=";
+    postInstall = ''
+      ln -s $out/lib/libdifftastic_nvim${stdenv.hostPlatform.extensions.sharedLibrary} $out/lib/difftastic_nvim.so
+    '';
+    env.RUSTFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-C link-arg=-undefined -C link-arg=dynamic_lookup";
+  };
+in
+vimUtils.buildVimPlugin {
+  pname = "difftastic-nvim";
+  inherit version src;
+  dependencies = [
+    vimPlugins.nui-nvim
+  ];
+
+  postPatch = ''
+    substituteInPlace lua/difftastic-nvim/binary.lua \
+      --replace-fail \
+      'release_dir = plugin_root .. "/target/release"' \
+      "release_dir = '${difftastic-nvim-lib}/lib'"
+  '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      attrPath = "vimPlugins.difftastic-nvim.difftastic-nvim-lib";
+    };
+
+    # needed for the update script
+    inherit difftastic-nvim-lib;
+
+  };
+
+  meta = {
+    description = "Neovim plugin that displays difftastic's structural diffs in a side-by-side view with syntax highlighting";
+    homepage = "https://github.com/clabby/difftastic.nvim/";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+
+    maintainers = with lib.maintainers; [
+      auscyber
+    ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
