### PR TITLE
stripe-cli: 1.37.2 -> 1.41.2

### DIFF
--- a/pkgs/by-name/st/stripe-cli/package.nix
+++ b/pkgs/by-name/st/stripe-cli/package.nix
@@ -12,7 +12,7 @@
 
 buildGoModule (finalAttrs: {
   pname = "stripe-cli";
-  version = "1.37.2";
+  version = "1.41.2";
 
   # required for tests
   __darwinAllowLocalNetworking = true;
@@ -21,9 +21,9 @@ buildGoModule (finalAttrs: {
     owner = "stripe";
     repo = "stripe-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Hsp90qmwy8D6SpDrgElB0Om6lumtkFjp2e///GEwkuE=";
+    hash = "sha256-2SjfaJTHj++o1hTs1UdzlPHrOq51HQmPLbQQ6yvl9ik=";
   };
-  vendorHash = "sha256-EDdRgApJ7gv/4ma/IfaHi+jjpTPegsUfqHbvoFMn048=";
+  vendorHash = "sha256-nyzBNR4D50vNbyzVwoRsiGqsu7ehv20PKTvMG/QM6f4=";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -64,10 +64,14 @@ buildGoModule (finalAttrs: {
         # network access
         "TestConflictWithPluginCommand"
         "TestLogin"
+        "TestRefreshPluginManifestSucceedsIfNoAPIKey"
 
         # not providing git or the various editors it wants to call
         "TestGetOpenEditorCommand"
         "TestGetDefaultGitEditor"
+
+        # broken for aarch64
+        "TestGetReleaseForVersion"
       ];
     in
     [ "-skip=^${lib.concatStringsSep "$|^" skippedTests}$" ];


### PR DESCRIPTION

## Things done
Update stripe-cli from 1.37.2 to 1.41.2. There were new tests that require internet so I simply added it to the list. Additionally, one of the tests for just getting a release version doesn't work on aarch64 so I just skipped it for now.

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
