### PR TITLE
nixos/oo7-service: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -50,6 +50,8 @@
 
 - [stash-clipboard](https://github.com/NotAShelf/stash), a Wayland clipboard "manager" with fast persistent history and multi-media support. Available as [services.stash-clipboard](#opt-services.stash-clipboard.enable).
 
+- [OO7](https://github.com/linux-credentials/oo7) is a desktop-agnostic Secret Service provider. Available as [services.oo7](#opt-services.oo7.enable)
+
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -593,6 +593,7 @@
   ./services/desktops/linyaps.nix
   ./services/desktops/malcontent.nix
   ./services/desktops/neard.nix
+  ./services/desktops/oo7.nix
   ./services/desktops/pipewire/pipewire.nix
   ./services/desktops/pipewire/wireplumber.nix
   ./services/desktops/playerctld.nix

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -678,6 +678,14 @@ let
           '';
         };
 
+        oo7 = {
+          enable = lib.mkEnableOption ''
+            automatically unlock the user's default Session Keyring using pam_oo7.
+            If the user's login password does not match their keyring password,
+            oo7 will prompt separately after login.
+          '';
+        };
+
         enableUMask = lib.mkOption {
           default = config.security.pam.enableUMask;
           defaultText = lib.literalExpression "config.security.pam.enableUMask";
@@ -1198,6 +1206,7 @@ let
                       || cfg.pamMount
                       || cfg.kwallet.enable
                       || cfg.enableGnomeKeyring
+                      || cfg.oo7.enable
                       || config.services.intune.enable
                       || cfg.googleAuthenticator.enable
                       || cfg.gnupg.enable
@@ -1260,6 +1269,12 @@ let
                       enable = cfg.enableGnomeKeyring;
                       control = "optional";
                       modulePath = "${pkgs.gnome-keyring}/lib/security/pam_gnome_keyring.so";
+                    }
+                    {
+                      name = "oo7";
+                      enable = cfg.oo7.enable;
+                      control = "optional";
+                      modulePath = "${pkgs.oo7-pam}/lib/security/pam_oo7.so";
                     }
                     {
                       name = "intune";
@@ -1477,6 +1492,12 @@ let
                   use_authtok = true;
                 };
               }
+              {
+                name = "oo7";
+                enable = cfg.oo7.enable;
+                control = "optional";
+                modulePath = "${pkgs.oo7-pam}/lib/security/pam_oo7.so";
+              }
             ];
 
             session = utils.pam.autoOrderRules [
@@ -1691,6 +1712,15 @@ let
                 enable = cfg.enableGnomeKeyring;
                 control = "optional";
                 modulePath = "${pkgs.gnome-keyring}/lib/security/pam_gnome_keyring.so";
+                settings = {
+                  auto_start = true;
+                };
+              }
+              {
+                name = "oo7";
+                enable = cfg.oo7.enable;
+                control = "optional";
+                modulePath = "${pkgs.oo7-pam}/lib/security/pam_oo7.so";
                 settings = {
                   auto_start = true;
                 };

--- a/nixos/modules/services/desktops/oo7.nix
+++ b/nixos/modules/services/desktops/oo7.nix
@@ -1,0 +1,41 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.services.oo7;
+in
+{
+  options.services.oo7 = {
+    enable = lib.mkEnableOption ''
+      oo7, a service providing the Secret Service D-Bus API.
+    '';
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.dbus.packages = [ pkgs.oo7-server ];
+
+    systemd.packages = [ pkgs.oo7-server ];
+
+    systemd.user.services.oo7-daemon.wantedBy = [ "default.target" ];
+
+    xdg.portal.extraPortals = [ pkgs.oo7-portal ];
+
+    security.pam.services.login.oo7.enable = true;
+
+    security.wrappers.oo7-daemon = {
+      owner = "root";
+      group = "root";
+      capabilities = "cap_ipc_lock=ep";
+      source = "${pkgs.oo7-server}/libexec/oo7-daemon";
+    };
+  };
+
+  meta = {
+    inherit (pkgs.oo7.meta)
+      maintainers
+      ;
+  };
+}

--- a/pkgs/by-name/oo/oo7-pam/package.nix
+++ b/pkgs/by-name/oo/oo7-pam/package.nix
@@ -1,0 +1,46 @@
+{
+  cargo,
+  meson,
+  ninja,
+  oo7,
+  pkg-config,
+  rustPlatform,
+  rustc,
+  stdenv,
+  systemdLibs,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "oo7-pam";
+  inherit (oo7) version src cargoDeps;
+
+  sourceRoot = "${finalAttrs.src.name}/pam";
+  cargoRoot = "../";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+  separateDebugInfo = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+    rustPlatform.cargoSetupHook
+    rustc
+    cargo
+  ];
+
+  buildInputs = [
+    systemdLibs
+  ];
+
+  meta = {
+    inherit (oo7.meta)
+      homepage
+      changelog
+      license
+      maintainers
+      platforms
+      ;
+    description = "${oo7.meta.description} (PAM modules)";
+  };
+})

--- a/pkgs/by-name/oo/oo7-server/package.nix
+++ b/pkgs/by-name/oo/oo7-server/package.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   cargo,
   meson,
   ninja,
@@ -8,6 +9,7 @@
   rustc,
   stdenv,
   systemdLibs,
+  useWrappedDaemon ? true,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "oo7-server";
@@ -28,6 +30,11 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     systemdLibs
   ];
+
+  postFixup = lib.optionalString useWrappedDaemon ''
+    substituteInPlace "$out/share/systemd/user/oo7-daemon.service" \
+      --replace-fail "$out/libexec/oo7-daemon" "/run/wrappers/bin/oo7-daemon"
+  '';
 
   meta = {
     inherit (oo7.meta)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
