### PR TITLE
ocamlPackages: remove legacy uses of dune_3

### DIFF
--- a/pkgs/development/ocaml-modules/chrome-trace/default.nix
+++ b/pkgs/development/ocaml-modules/chrome-trace/default.nix
@@ -1,21 +1,18 @@
 {
   lib,
   buildDunePackage,
-  dune_3,
+  dune,
 }:
 
 buildDunePackage {
   pname = "chrome-trace";
-  inherit (dune_3) src version;
-
-  minimalOCamlVersion = "4.08";
-  duneVersion = "3";
+  inherit (dune) src version;
 
   dontAddPrefix = true;
 
   meta = {
     description = "Chrome trace event generation library";
-    inherit (dune_3.meta) homepage;
+    inherit (dune.meta) homepage;
     license = lib.licenses.mit;
   };
 }

--- a/pkgs/development/ocaml-modules/dune-action-plugin/default.nix
+++ b/pkgs/development/ocaml-modules/dune-action-plugin/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildDunePackage,
-  dune_3,
+  dune,
   dune-glob,
   dune-private-libs,
   dune-rpc,
@@ -9,9 +9,7 @@
 
 buildDunePackage {
   pname = "dune-action-plugin";
-  inherit (dune_3) src version;
-
-  duneVersion = "3";
+  inherit (dune) src version;
 
   dontAddPrefix = true;
 
@@ -22,7 +20,7 @@ buildDunePackage {
   ];
 
   meta = {
-    inherit (dune_3.meta) homepage;
+    inherit (dune.meta) homepage;
     description = "API for writing dynamic Dune actions";
     maintainers = [ ];
     license = lib.licenses.mit;

--- a/pkgs/development/ocaml-modules/dune-configurator/default.nix
+++ b/pkgs/development/ocaml-modules/dune-configurator/default.nix
@@ -1,16 +1,14 @@
 {
   lib,
   buildDunePackage,
-  dune_3,
+  dune,
   csexp,
 }:
 
 buildDunePackage {
   pname = "dune-configurator";
 
-  inherit (dune_3) src version patches;
-
-  minimalOCamlVersion = "4.05";
+  inherit (dune) src version;
 
   dontAddPrefix = true;
 

--- a/pkgs/development/ocaml-modules/dune-glob/default.nix
+++ b/pkgs/development/ocaml-modules/dune-glob/default.nix
@@ -1,16 +1,14 @@
 {
   lib,
   buildDunePackage,
-  dune_3,
+  dune,
   dune-private-libs,
   re,
 }:
 
 buildDunePackage {
   pname = "dune-glob";
-  inherit (dune_3) src version;
-
-  duneVersion = "3";
+  inherit (dune) src version;
 
   dontAddPrefix = true;
 
@@ -20,7 +18,7 @@ buildDunePackage {
   ];
 
   meta = {
-    inherit (dune_3.meta) homepage;
+    inherit (dune.meta) homepage;
     description = "Glob string matching language supported by dune";
     maintainers = [ ];
     license = lib.licenses.mit;

--- a/pkgs/development/ocaml-modules/dune-private-libs/default.nix
+++ b/pkgs/development/ocaml-modules/dune-private-libs/default.nix
@@ -1,18 +1,14 @@
 {
   lib,
   buildDunePackage,
-  dune_3,
+  dune,
   stdune,
 }:
 
 buildDunePackage {
   pname = "dune-private-libs";
 
-  duneVersion = "3";
-
-  inherit (dune_3) src version;
-
-  minimalOCamlVersion = "4.08";
+  inherit (dune) src version;
 
   dontAddPrefix = true;
 

--- a/pkgs/development/ocaml-modules/dune-rpc/default.nix
+++ b/pkgs/development/ocaml-modules/dune-rpc/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildDunePackage,
-  dune_3,
+  dune,
   csexp,
   stdune,
   ocamlc-loc,
@@ -13,9 +13,7 @@
 
 buildDunePackage {
   pname = "dune-rpc";
-  inherit (dune_3) src version;
-
-  duneVersion = "3";
+  inherit (dune) src version;
 
   dontAddPrefix = true;
 
@@ -31,7 +29,7 @@ buildDunePackage {
 
   meta = {
     description = "Library to connect and control a running dune instance";
-    inherit (dune_3.meta) homepage;
+    inherit (dune.meta) homepage;
     maintainers = [ ];
     license = lib.licenses.mit;
   };

--- a/pkgs/development/ocaml-modules/dune-site/default.nix
+++ b/pkgs/development/ocaml-modules/dune-site/default.nix
@@ -1,15 +1,13 @@
 {
   lib,
   buildDunePackage,
-  dune_3,
+  dune,
   dune-private-libs,
 }:
 
 buildDunePackage {
   pname = "dune-site";
-  inherit (dune_3) src version;
-
-  duneVersion = "3";
+  inherit (dune) src version;
 
   dontAddPrefix = true;
 
@@ -17,7 +15,7 @@ buildDunePackage {
 
   meta = {
     description = "Library for embedding location information inside executable and libraries";
-    inherit (dune_3.meta) homepage;
+    inherit (dune.meta) homepage;
     maintainers = [ ];
     license = lib.licenses.mit;
   };

--- a/pkgs/development/ocaml-modules/dyn/default.nix
+++ b/pkgs/development/ocaml-modules/dyn/default.nix
@@ -1,14 +1,13 @@
 {
   buildDunePackage,
-  dune_3,
+  dune,
   ordering,
   pp,
 }:
 
 buildDunePackage {
   pname = "dyn";
-  inherit (dune_3) version src;
-  duneVersion = "3";
+  inherit (dune) version src;
 
   dontAddPrefix = true;
 
@@ -17,7 +16,7 @@ buildDunePackage {
     pp
   ];
 
-  meta = dune_3.meta // {
+  meta = dune.meta // {
     description = "Dynamic type";
   };
 }

--- a/pkgs/development/ocaml-modules/fs-io/default.nix
+++ b/pkgs/development/ocaml-modules/fs-io/default.nix
@@ -1,12 +1,12 @@
-{ buildDunePackage, dune_3 }:
+{ buildDunePackage, dune }:
 
 buildDunePackage {
   pname = "fs-io";
-  inherit (dune_3) version src;
+  inherit (dune) version src;
 
   dontAddPrefix = true;
 
-  meta = dune_3.meta // {
+  meta = dune.meta // {
     description = "Dune's file system IO library";
   };
 }

--- a/pkgs/development/ocaml-modules/top-closure/default.nix
+++ b/pkgs/development/ocaml-modules/top-closure/default.nix
@@ -1,12 +1,12 @@
-{ buildDunePackage, dune_3 }:
+{ buildDunePackage, dune }:
 
 buildDunePackage {
   pname = "top-closure";
-  inherit (dune_3) version src;
+  inherit (dune) version src;
 
   dontAddPrefix = true;
 
-  meta = dune_3.meta // {
+  meta = dune.meta // {
     description = "Dune's topological closure library";
   };
 }


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
