### PR TITLE
noiz2sa: init at 0.52

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22992,6 +22992,12 @@
     githubId = 25647735;
     name = "Victor Freire";
   };
+  rattboi = {
+    email = "rattboi@gmail.com";
+    github = "rattboi";
+    githubId = 166042;
+    name = "Bradon Kanyid";
+  };
   ravenjoad = {
     email = "raven@hallsby.com";
     github = "ravenjoad";

--- a/pkgs/by-name/no/noiz2sa/package.nix
+++ b/pkgs/by-name/no/noiz2sa/package.nix
@@ -1,0 +1,106 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  fetchpatch,
+  unzip,
+  pkg-config,
+  SDL,
+  SDL_mixer,
+  bulletml,
+  makeWrapper,
+}:
+
+let
+  debianVersion = "0.51a-13";
+  debianPatch =
+    patchname: extraArgs:
+    fetchpatch (
+      {
+        name = "${patchname}.patch";
+        url = "https://sources.debian.org/data/main/n/noiz2sa/${debianVersion}/debian/patches/${patchname}.patch";
+      }
+      // extraArgs
+    );
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "noiz2sa";
+  version = "0.52";
+
+  src = fetchurl {
+    url = "https://abagames.sakura.ne.jp/windows/noiz2sa${
+      lib.replaceStrings [ "." ] [ "_" ] finalAttrs.version
+    }.zip";
+    hash = "sha256-lZdZFAqAs8xxiUahGLaCX9UhjzGGE4pRp4GcX7k43/w=";
+  };
+
+  patches = [
+    (debianPatch "build" {
+      excludes = [
+        "src/bulletml/*"
+        "src/Makefile"
+      ];
+      hash = "sha256-EfKX0npjAE2gzdpdth2V0Qamj1BcxyB40IsxNq6KxaQ=";
+    })
+    (debianPatch "deg-out-of-range" {
+      hash = "sha256-4imehhIHC2E9XFzepxdyPE8Ga5DIAb94PmReRNOeEz4=";
+    })
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    unzip
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    SDL
+    SDL_mixer
+    bulletml
+  ];
+
+  sourceRoot = "noiz2sa";
+
+  buildPhase = ''
+    runHook preBuild
+
+    pushd src
+
+    $CC -c $(pkg-config --cflags sdl SDL_mixer) -O3 *.c
+    $CXX -c $(pkg-config --cflags sdl SDL_mixer) -O3 *.cc \
+      -I${bulletml}/include
+    $CC -o noiz2sa *.o \
+      $(pkg-config --libs sdl SDL_mixer) \
+      -L${bulletml}/lib -lbulletml -lstdc++ -lm
+
+    popd
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/games/noiz2sa
+    install -m755 src/noiz2sa $out/share/games/noiz2sa/noiz2sa-unwrapped
+    cp -r boss middle zako images sounds $out/share/games/noiz2sa/
+
+    makeWrapper $out/share/games/noiz2sa/noiz2sa-unwrapped $out/bin/noiz2sa \
+      --chdir "$out/share/games/noiz2sa"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Abstract shoot-em-up game";
+    homepage = "http://www.asahi-net.or.jp/~cs8k-cyu/windows/noiz2sa_e.html";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ rattboi ];
+    platforms = lib.platforms.linux;
+    mainProgram = "noiz2sa";
+  };
+})


### PR DESCRIPTION
## Description

Adds `noiz2sa`, an abstract shoot-em-up originally by ABA Games (2003), using the SDL2 port by IoriBranford. The original game used 640x480x8bpp rendering which is poorly supported on modern hardware; this port runs in desktop resolution with 32-bit color via SDL2/OpenGL.

## Checklist

- [x] package built on my machine
- [x] `meta.description` is set
- [x] `meta.license` is set
- [x] `meta.maintainers` is set
- [x] `meta.platforms` is set
- [x] `meta.mainProgram` is set
- [ ] NixOS module (not applicable)

## Testing

Built and ran on NixOS (x86_64-linux):

    nix-build -A noiz2sa

Game launches, audio works, controls work, high scores persist to `~/.local/share/noiz2sa/`.

## Notes

- Binary assets (sounds, images) are committed directly to the source repo to avoid Git LFS, which nixpkgs fetchers don't support
- OGG music files were re-encoded with libvorbis floor type 1 for compatibility with stb_vorbis (the backend used by SDL2_mixer ≥ 2.6)
- Links against the existing nixpkgs `bulletml` package, same as `rrootage`, `titanion`, and other ABA Games ports