### PR TITLE
nsis: unbreak on darwin

### DIFF
--- a/pkgs/by-name/ns/nsis/package.nix
+++ b/pkgs/by-name/ns/nsis/package.nix
@@ -4,6 +4,8 @@
   symlinkJoin,
   fetchurl,
   fetchzip,
+  makeWrapper,
+  runCommand,
   scons,
   zlib,
   libiconv,
@@ -29,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
     chmod -R u+w $out/share/nsis
   '';
 
-  nativeBuildInputs = [ scons ];
+  nativeBuildInputs = [ scons ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ makeWrapper ];
   buildInputs = [ zlib ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
 
   env = {
@@ -67,6 +69,36 @@ stdenv.mkDerivation (finalAttrs: {
   prefixKey = "PREFIX=";
   installTargets = [ "install-compiler" ];
 
+  # NSIS can crash when compiling Unicode installers under non-UTF-8 locales on macOS
+  # see https://sourceforge.net/p/nsis/bugs/1165/ for more info
+  # code adapted from the makensis formulae in Homebrew
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    wrapProgram $out/bin/makensis \
+      --run '
+        case "''${LC_ALL:-}" in
+          *UTF-8*|*utf8*) ;;
+          "")
+            case "''${LC_CTYPE:-} ''${LANG:-}" in
+              *UTF-8*|*utf8*) ;;
+              *) export LC_ALL=en_US.UTF-8 ;;
+            esac
+            ;;
+          *) export LC_ALL=en_US.UTF-8 ;;
+        esac
+      '
+  '';
+
+  passthru.tests = {
+    compile-bigtest =
+      runCommand "nsis-compile-bigtest" { nativeBuildInputs = [ finalAttrs.finalPackage ]; }
+        ''
+          pushd ${finalAttrs.srcWinDistributable}/Examples >/dev/null
+          makensis bigtest.nsi "-XOutfile /dev/null"
+          popd >/dev/null
+          touch $out
+        '';
+  };
+
   meta = {
     description = "Free scriptable win32 installer/uninstaller system that doesn't suck and isn't huge";
     homepage = "https://nsis.sourceforge.io/";
@@ -74,6 +106,5 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ pombeirp ];
     mainProgram = "makensis";
-    broken = stdenv.hostPlatform.isDarwin;
   };
 })


### PR DESCRIPTION
this pr removes the broken marker for Darwin, and wraps makensis on Darwin to force a UTF-8 locale when the caller's locale is non-UTF-8

it follows the downstream workaround used by Homebrew for the NSIS locale bug: https://sourceforge.net/p/nsis/bugs/1165/ 

i also added a bigtest passthru test since nsis already had it built in so i thought why not

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
