### PR TITLE
caido: 0.56.0 -> 0.56.2

### DIFF
--- a/pkgs/by-name/ca/caido-cli/package.nix
+++ b/pkgs/by-name/ca/caido-cli/package.nix
@@ -9,25 +9,25 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "caido-cli";
-  version = "0.56.0";
+  version = "0.56.2";
 
   src = fetchurl (
     {
       x86_64-linux = {
         url = "https://caido.download/releases/v${finalAttrs.version}/caido-cli-v${finalAttrs.version}-linux-x86_64.tar.gz";
-        hash = "sha256-G8E/GtVYzTM5JIkNnQm3PxzfZya3hVJlzUxN3s4CEdM=";
+        hash = "sha256-SUkysiFdH4ilA6MKYMiSqC80NkYZ9YVO/7CT0hQY++Q=";
       };
       aarch64-linux = {
         url = "https://caido.download/releases/v${finalAttrs.version}/caido-cli-v${finalAttrs.version}-linux-aarch64.tar.gz";
-        hash = "sha256-X+jDesBDXOWSQBTPA1kCaGBRvoaDGCR0TkNWNqYtNok=";
+        hash = "sha256-rYRzo3iYjWAvRGm1+wBLGkr3eUoAGbi71+AX0qmoIXs=";
       };
       x86_64-darwin = {
         url = "https://caido.download/releases/v${finalAttrs.version}/caido-cli-v${finalAttrs.version}-mac-x86_64.zip";
-        hash = "sha256-6Rnybe9kH65C4PHg7j9Rwz2TMjH1XPGnI1mu0/g0up8=";
+        hash = "sha256-mMWivNwgAmMYitERwnP/lAzgzua/2UDDDffSbgZXlr4=";
       };
       aarch64-darwin = {
         url = "https://caido.download/releases/v${finalAttrs.version}/caido-cli-v${finalAttrs.version}-mac-aarch64.zip";
-        hash = "sha256-07huWaIC1wO7RxC2F8VhgqKvtXcrNxbWDKFhuZhv/E8=";
+        hash = "sha256-19eEV79yk6PCHdl7oTw4Gqt10B7rYnZCJxBebDssFZc=";
       };
     }
     .${stdenv.hostPlatform.system}

--- a/pkgs/by-name/ca/caido-desktop/package.nix
+++ b/pkgs/by-name/ca/caido-desktop/package.nix
@@ -9,24 +9,24 @@
 
 let
   pname = "caido-desktop";
-  version = "0.56.0";
+  version = "0.56.2";
 
   sources = {
     x86_64-linux = {
       url = "https://caido.download/releases/v${version}/caido-desktop-v${version}-linux-x86_64.AppImage";
-      hash = "sha256-UA4MPEEnFiiR0ueYoE3H1Z5f7J56NYNahTbWyAImmfQ=";
+      hash = "sha256-GW8prdvR9+WNO7bdz9ok27Aqra9+jgpZyBnYIM+G5Ys=";
     };
     aarch64-linux = {
       url = "https://caido.download/releases/v${version}/caido-desktop-v${version}-linux-aarch64.AppImage";
-      hash = "sha256-HTegv6UlWe0gID5sGLlUTFc0z6giF7BCIwbCHb/rLjc=";
+      hash = "sha256-mN5wf9RUllfbR/CfLTE6Ywzoj8wKmEG1clVCKRqPUtU=";
     };
     x86_64-darwin = {
       url = "https://caido.download/releases/v${version}/caido-desktop-v${version}-mac-x86_64.dmg";
-      hash = "sha256-ZnN8DK3OuzZ0rKE+1czFhn2rH8QHJvlgvjc9k3DrV/Q=";
+      hash = "sha256-4B3DQJL8M6otnLpFjr4haZA4EWHpgVADQW4DcwsDhIM=";
     };
     aarch64-darwin = {
       url = "https://caido.download/releases/v${version}/caido-desktop-v${version}-mac-aarch64.dmg";
-      hash = "sha256-XbcmecB4DKPp0WlqBBnc2TvorXEMsDSR5oW/VeUBcVs=";
+      hash = "sha256-kZdfcZueMmgEHpNTIPANsN7X4lnVOfZXbKHxComaalM=";
     };
   };
 


### PR DESCRIPTION
**v0.56.1**
Changelog: This release fixes an issue preventing users from accessing IPv6 URLs directly.

**v0.56.2 Latest**
Changelog: This release fixes an issue where the "version available" notification would continue to appear after the app had already been updated.

<div align="center">
  <img width="240" height="363" alt="image" src="https://github.com/user-attachments/assets/13ee26ad-bbbf-4971-b9a8-07963c8dfe59" />
</div>

---

This PR includes both caido-cli and caido-desktop (as separate commits). Both applications are related, so it makes sense to push them together.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
