### PR TITLE
yaak: add gsettings-desktop-schemas and dconf

### DIFF
--- a/pkgs/by-name/ya/yaak/package.nix
+++ b/pkgs/by-name/ya/yaak/package.nix
@@ -18,6 +18,8 @@
   librsvg,
   gdk-pixbuf,
   adwaita-icon-theme,
+  gsettings-desktop-schemas,
+  dconf,
   protobuf,
   perl,
   makeWrapper,
@@ -77,6 +79,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     webkitgtk_4_1
+    gsettings-desktop-schemas
+    dconf
   ];
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
@@ -137,6 +141,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
     + ''
       popd
     '';
+
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    wrapProgram $out/bin/yaak-app \
+      --inherit-argv0 \
+      --set-default WEBKIT_DISABLE_DMABUF_RENDERER 1 \
+      --set-default WEBKIT_DISABLE_COMPOSITING_MODE 1
+  '';
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Yaak misbehaves on NixOS : The ui of yaak is not usable a lot of elements don't appear.

GLib-GIO-ERROR: Settings schema '...' is not installed


## Things done

Add gsettings-desktop-schemas and dconf to provide the required GSettings backend and schemas.
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [*] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [*] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [*] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [*] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
