### PR TITLE
hyphen: Add more languages and variants

### DIFF
--- a/pkgs/development/libraries/hyphen/dictionaries.nix
+++ b/pkgs/development/libraries/hyphen/dictionaries.nix
@@ -5,22 +5,19 @@
   stdenv,
   lib,
   fetchgit,
-  fetchurl,
   symlinkJoin,
 }:
 
 let
-  libreofficeRepository = "https://anongit.freedesktop.org/git/libreoffice/dictionaries.git";
-  libreofficeCommit = "9e27d044d98e65f89af8c86df722a77be827bdc8";
-  libreofficeSubdir = "de";
-
   # this does not assume any structure for dictFilePath and readmeFilePath
   mkDictFromLibreofficeGitCustom =
     {
       subdir,
       shortName,
+      dictFileName,
       shortDescription,
       dictFilePath,
+      filenameAliases ? "",
       readmeFilePath ? "",
     }:
     stdenv.mkDerivation rec {
@@ -28,8 +25,8 @@ let
       pname = "hyphen-dict-${shortName}-libreoffice";
       src = fetchgit {
         url = "https://anongit.freedesktop.org/git/libreoffice/dictionaries.git";
-        rev = "a2bf59878dd76685803ec260e15d875746ad6e25";
-        hash = "sha256-3CvjgNjsrm4obATK6LmtYob8i2ngTbwP6FB4HlJMPCE=";
+        rev = "e4ad1862342d7e1365978499ca951ae4788c9dc0";
+        hash = "sha256-sv3KnmrewE1dRxeO+TqfOjfHjoJpzJ6p8MdBDiT3Ips=";
       };
       meta = {
         description = "Hyphen dictionary for ${shortDescription} from LibreOffice";
@@ -44,6 +41,10 @@ let
         cd $src/${subdir}
         install -dm755 "$out/share/hyphen"
         install -m644 "${dictFilePath}" "$out/share/hyphen"
+        # Aliases can be found in dictionaries.xcu.
+        for lang in ${filenameAliases}; do
+          ln -s "$out/share/hyphen/hyph_${dictFileName}.dic" "$out/share/hyphen/hyph_$lang.dic"
+        done
         # docs
         if [ -n "${readmeFilePath}" ]; then
           install -dm755 "$out/share/doc/"
@@ -60,6 +61,7 @@ let
       shortName,
       shortDescription,
       dictFileName,
+      filenameAliases ? "",
       readmeFileName ? "",
     }:
     mkDictFromLibreofficeGitCustom {
@@ -67,6 +69,8 @@ let
       inherit shortName;
       inherit shortDescription;
       dictFilePath = "hyph_${dictFileName}.dic";
+      dictFileName = dictFileName;
+      filenameAliases = filenameAliases;
       readmeFilePath = if (readmeFileName != "") then "README_${readmeFileName}.txt" else "";
     };
 
@@ -80,13 +84,26 @@ let
 
     # AFRIKAANS
 
+    af_NA = af-za;
     af_ZA = af-za;
     af-za = mkDictFromLibreofficeGit {
       subdir = "af_ZA";
       shortName = "af-za";
       shortDescription = "Afrikaans";
       dictFileName = "af_ZA";
+      filenameAliases = "af_NA";
       readmeFileName = "af_ZA";
+    };
+
+    # ASSAMESE
+
+    as_IN = as-in;
+    as-in = mkDictFromLibreofficeGit {
+      subdir = "as_IN";
+      shortName = "as-in";
+      shortDescription = "Assamese";
+      dictFileName = "as_IN";
+      readmeFileName = "as_IN";
     };
 
     # BELARUSSIAN
@@ -113,11 +130,17 @@ let
 
     # CATALAN
 
+    ca_ES_valencia = ca-es;
+    ca_AD = ca-es;
+    ca_FR = ca-es;
+    ca_IT = ca-es;
     ca_ES = ca-es;
     ca-es = mkDictFromLibreofficeGitCustom {
       subdir = "ca";
       shortName = "ca-es";
       shortDescription = "Catalan";
+      dictFileName = "ca";
+      filenameAliases = "ca_ES_valencia ca_AD ca_FR ca_IT";
       dictFilePath = "dictionaries/hyph_ca.dic";
       readmeFilePath = "README_hyph_ca.txt";
     };
@@ -140,6 +163,7 @@ let
       subdir = "da_DK";
       shortName = "da-dk";
       shortDescription = "Danish";
+      dictFileName = "da_DK";
       dictFilePath = "hyph_da_DK.dic";
       readmeFilePath = "HYPH_da_DK_README.txt";
     };
@@ -187,11 +211,26 @@ let
     # ENGLISH
 
     en_GB = en-gb;
+    en_ZA = en-gb;
+    en_NA = en-gb;
+    en_ZW = en-gb;
+    en_AU = en-gb;
+    en_CA = en-gb;
+    en_IE = en-gb;
+    en_IN = en-gb;
+    en_BZ = en-gb;
+    en_BS = en-gb;
+    en_GH = en-gb;
+    en_JM = en-gb;
+    en_MW = en-gb;
+    en_NZ = en-gb;
+    en_TT = en-gb;
     en-gb = mkDictFromLibreofficeGit {
       subdir = "en";
       shortName = "en-gb";
       shortDescription = "English (Great Britain)";
       dictFileName = "en_GB";
+      filenameAliases = "en_ZA en_NA en_ZW en_AU en_CA en_IE en_IN en_BZ en_BS en_GH en_JM en_MW en_NZ en_TT";
       readmeFileName = "hyph_en_GB";
     };
 
@@ -223,18 +262,42 @@ let
       subdir = "eo";
       shortName = "eo";
       shortDescription = "Esperanto";
+      dictFileName = "eo";
       dictFilePath = "hyph_eo.dic";
       readmeFilePath = "desc_eo.txt";
     };
 
     # SPANISH
 
+    es_AR = es-es;
+    es_BO = es-es;
+    es_CL = es-es;
+    es_CO = es-es;
+    es_CR = es-es;
+    es_CU = es-es;
+    es_DO = es-es;
+    es_EC = es-es;
+    es_GQ = es-es;
+    es_GT = es-es;
+    es_HN = es-es;
+    es_MX = es-es;
+    es_NI = es-es;
+    es_PA = es-es;
+    es_PE = es-es;
+    es_PH = es-es;
+    es_PR = es-es;
+    es_PY = es-es;
+    es_SV = es-es;
+    es_US = es-es;
+    es_UY = es-es;
+    es_VE = es-es;
     es_ES = es-es;
     es-es = mkDictFromLibreofficeGit {
       subdir = "es";
       shortName = "es-es";
-      shortDescription = "Spanish (Spain)";
+      shortDescription = "Spanish";
       dictFileName = "es";
+      filenameAliases = "es_AR es_BO es_CL es_CO es_CR es_CU es_DO es_EC es_GQ es_GT es_HN es_MX es_NI es_PA es_PE es_PH es_PR es_PY es_SV es_US es_UY es_VE";
       readmeFileName = "hyph_es";
     };
 
@@ -251,13 +314,30 @@ let
 
     # FRENCH
 
+    fr_BE = fr-fr;
+    fr_CA = fr-fr;
+    fr_CH = fr-fr;
+    fr_LU = fr-fr;
+    fr_MC = fr-fr;
     fr_FR = fr-fr;
     fr-fr = mkDictFromLibreofficeGit {
       subdir = "fr_FR";
       shortName = "fr-fr";
       shortDescription = "French";
       dictFileName = "fr";
+      filenameAliases = "fr_BE fr_CA fr_CH fr_LU fr_MC";
       readmeFileName = "hyph_fr";
+    };
+
+    # GALICIAN
+
+    gl_ES = gl-es;
+    gl-es = mkDictFromLibreofficeGit {
+      subdir = "gl";
+      shortName = "gl-es";
+      shortDescription = "Galician";
+      dictFileName = "gl";
+      readmeFileName = "hyph-gl";
     };
 
     # CROATIAN
@@ -289,19 +369,34 @@ let
       subdir = "id";
       shortName = "id-id";
       shortDescription = "Indonesian";
+      dictFileName = "id_ID";
       dictFilePath = "hyph_id_ID.dic";
       readmeFilePath = "README-dict.adoc";
     };
 
     # ITALIAN
 
+    it-CH = it-it;
     it_IT = it-it;
     it-it = mkDictFromLibreofficeGit {
       subdir = "it_IT";
       shortName = "it-it";
       shortDescription = "Italian";
       dictFileName = "it_IT";
+      filenameAliases = "it_CH";
       readmeFileName = "hyph_it_IT";
+    };
+
+    # KANNADA
+
+    kn_IN = kn-in;
+    kn-in = mkDictFromLibreofficeGitCustom {
+      subdir = "kn_IN";
+      shortName = "kn-in";
+      shortDescription = "Kannada";
+      dictFileName = "kn_IN";
+      dictFilePath = "hyph_kn_IN.dic";
+      readmeFilePath = "README-kn_IN.txt";
     };
 
     # LITHUANIAN
@@ -311,6 +406,7 @@ let
       subdir = "lt_LT";
       shortName = "lt-lt";
       shortDescription = "Lithuanian";
+      dictFileName = "lt";
       dictFilePath = "hyph_lt.dic";
       readmeFilePath = "README_hyph";
     };
@@ -339,12 +435,14 @@ let
 
     # DUTCH
 
+    nl_BE = nl-nl;
     nl_NL = nl-nl;
     nl-nl = mkDictFromLibreofficeGit {
       subdir = "nl_NL";
       shortName = "nl-nl";
       shortDescription = "Dutch";
       dictFileName = "nl_NL";
+      filenameAliases = "nl_BE";
       readmeFileName = "NL";
     };
 
@@ -366,6 +464,26 @@ let
       shortDescription = "Norwegian (Nynorsk)";
       dictFileName = "nn_NO";
       readmeFileName = "hyph_NO";
+    };
+
+    # ORIYA
+
+    or_IN = or-in;
+    or-in = mkDictFromLibreofficeGit {
+      subdir = "or_IN";
+      shortName = "or-in";
+      shortDescription = "Oriya";
+      dictFileName = "or_IN";
+    };
+
+    # PANJABI
+
+    pa_IN = pa-in;
+    pa-in = mkDictFromLibreofficeGit {
+      subdir = "pa_IN";
+      shortName = "pa-in";
+      shortDescription = "Panjabi";
+      dictFileName = "pa_IN";
     };
 
     # POLISH
@@ -421,6 +539,16 @@ let
       readmeFileName = "ru_RU";
     };
 
+    # SANSKRIT
+
+    sa_IN = sa-in;
+    sa-in = mkDictFromLibreofficeGit {
+      subdir = "sa_IN";
+      shortName = "sa-in";
+      shortDescription = "Sanskrit (India)";
+      dictFileName = "sa_IN";
+    };
+
     # SLOVAK
 
     sk_SK = sk-sk;
@@ -461,6 +589,7 @@ let
       subdir = "sr";
       shortName = "sr-sr";
       shortDescription = "Serbian (Cyrillic)";
+      dictFileName = "sr";
       dictFilePath = "hyph_sr.dic";
       readmeFilePath = "README.txt";
     };
@@ -470,12 +599,14 @@ let
       subdir = "sr";
       shortName = "sr-sr-latn";
       shortDescription = "Serbian (Latin)";
+      dictFileName = "sr-Latn";
       dictFilePath = "hyph_sr-Latn.dic";
       readmeFilePath = "README.txt";
     };
 
     # SWEDISH
 
+    sv_FI = sv-se;
     sv_SE = sv-se;
     sv-se = mkDictFromLibreofficeGit {
       subdir = "sv_SE";
@@ -525,6 +656,7 @@ let
       subdir = "zu_ZA";
       shortName = "zu-za";
       shortDescription = "Zulu";
+      dictFileName = "zu_ZA";
       dictFilePath = "hyph_zu_ZA.dic";
       # no readme file provided, leave empty
     };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Previously, hyphenation data for certain languages and variants of languages specified in `dictionaries.xcu` were disregarded (for instance, even though the hyphenation data for `en_GB` is also used by upstream for `en_CA`, `en_CA` was excluded from the package). This results in significant deviations from upstream implementation.

I went through every `dictionaries.xcu` file I could find and looked for patterns resembling the following snippet:
```xml
<node oor:name="HyphDic_en-GB" oor:op="fuse">
    <prop oor:name="Locations" oor:type="oor:string-list">
        <value>%origin%/hyph_en_GB.dic</value>
    </prop>
    <prop oor:name="Format" oor:type="xs:string">
        <value>DICT_HYPH</value>
    </prop>
    <prop oor:name="Locales" oor:type="oor:string-list">
        <value>en-GB en-ZA en-NA en-ZW en-AU en-CA en-IE en-IN en-BZ en-BS en-GH en-JM en-MW en-NZ en-TT</value>
    </prop>
</node>
```
For each pattern I found, I created an entry and a symlink to the appropriate dictionary. Do note that this is my first time working with the Nix language (and nixpkgs). It is very possible that I have made some mistakes. Let me know if that is the case.

Oh and, I think I updated the package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
