### PR TITLE
coulomb: fix wrapper injection and missing GUI icons

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -157,6 +157,11 @@
     githubId = 105598867;
     matrix = "@0xmrtt:envs.net";
   };
+  _0xSA7 = {
+    name = "Saleh Diaa Ahmed";
+    github = "0xSA7";
+    githubId = 153073356;
+  };
   _1000101 = {
     email = "b1000101@pm.me";
     github = "1000101";

--- a/pkgs/by-name/co/coulomb/package.nix
+++ b/pkgs/by-name/co/coulomb/package.nix
@@ -16,6 +16,8 @@
   gdk-pixbuf,
   atk,
   cairo,
+  adwaita-icon-theme,
+  librsvg,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -51,6 +53,8 @@ stdenv.mkDerivation (finalAttrs: {
     gdk-pixbuf
     atk
     cairo
+    adwaita-icon-theme
+    librsvg
   ];
 
   mitmCache = gradle.fetchDeps {
@@ -75,13 +79,14 @@ stdenv.mkDerivation (finalAttrs: {
     cp -r app/build/resources/main/icons/vector/* $out/share/icons/
     cp app/build/resources/main/icons/vector/light/coulomb.svg $out/share/icons/hicolor/scalable/apps/io.github.hamza_algohary.Coulomb.svg
 
-    makeWrapper ${jdk21_headless}/bin/java $out/bin/coulomb \
-      --add-flags "-Djava.library.path=${lib.makeLibraryPath finalAttrs.buildInputs}" \
-      --add-flags "-jar $out/share/coulomb/app-all.jar" \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath finalAttrs.buildInputs}" \
-      ''${gappsWrapperArgs[@]}
-
     runHook postInstall
+  '';
+  postFixup = ''
+    makeWrapper ${jdk21_headless}/bin/java $out/bin/coulomb \
+    --add-flags "-Djava.library.path=${lib.makeLibraryPath finalAttrs.buildInputs}" \
+    --add-flags "-jar $out/share/coulomb/app-all.jar" \
+    --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath finalAttrs.buildInputs}" \
+    ''${gappsWrapperArgs[@]}
   '';
 
   passthru.updateScript = nix-update-script { };
@@ -90,7 +95,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Simple and beautiful circuit simulator app";
     homepage = "https://github.com/hamza-algohary/Coulomb";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ thtrf ];
+    maintainers = with lib.maintainers; [
+      thtrf
+      _0xSA7
+    ];
     platforms = lib.platforms.linux;
     mainProgram = "coulomb";
   };


### PR DESCRIPTION
coulomb couldn't display gtk icons like`system-restart-symbolic`and was throwing `Gdk-CRITICAL` errors ([debugging logs](https://gist.github.com/0xSA7/17a7c9a5f4228c74636ea95b157d15fc))

the cause was lifecycle issue introduced in https://github.com/NixOS/nixpkgs/pull/406870#discussion_r2090931170  the package was generating its wrapper during the `installPhase` using `makeWrapper`. However, `wrapGAppsHook4` produce the args of the warpper later during the `fixupPhase`. that's why the wrapper missed the entries needed by gtk to discover icon themes

additionally, even with the icon paths available, the application failed to load svg icons. Since the app uses GTK, the underlying `gdk-pixbuf` requires `librsvg` to properly render vector graphics, and it was missing from the build inputs also so [this upstream issue exists](https://github.com/hamza-algohary/Coulomb/issues/12) as a fix:
- Reordered the wrapper generation from `installPhase` to the `postFixup` phase to ensure GUI environment variables are correctly injected to gtk.
- Added `adwaita-icon-theme` and `librsvg` to `buildInputs` to provide the base icons and enable svg rendering support.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
