### PR TITLE
rshim-user-space: 2.6.6 -> 2.7.3

### DIFF
--- a/pkgs/by-name/rs/rshim-user-space/fix-console-handling.patch
+++ b/pkgs/by-name/rs/rshim-user-space/fix-console-handling.patch
@@ -1,0 +1,218 @@
+From 28f4fb2781058fdc271986e91e0996fcce3aaaef Mon Sep 17 00:00:00 2001
+From: Markus Theil <markus.theil@secunet.com>
+Date: Thu, 19 Feb 2026 15:15:51 +0100
+Subject: [PATCH] linux: fix console handling
+
+Since using glibc 2.42 struct termio was no longer exposed
+from glibc.
+
+An earlier fix was to provide the definition of struct termio
+if not given in glibc. But it mixed up the ioctls for struct
+termios with an internal struct termio.
+
+This commit fixes this by providing definitions from kernel
+headers instead of glibc and translating between all relevant
+ioctl sets necessary to use screen, minicom or stty with different
+glibc versions.
+
+Signed-off-by: Markus Theil <markus.theil@secunet.com>
+---
+ src/rshim.c      |  4 ++
+ src/rshim.h      |  7 +++-
+ src/rshim_fuse.c | 98 +++++++++++++++++++++++++++++++++++++-----------
+ 3 files changed, 86 insertions(+), 23 deletions(-)
+
+diff --git a/src/rshim.c b/src/rshim.c
+index 78018f5d..d3004508 100644
+--- a/src/rshim.c
++++ b/src/rshim.c
+@@ -191,7 +191,11 @@ const char *magic_to_str(uint64_t magic)
+ 
+ /* Terminal characteristics for newly created consoles. */
+ #define INIT_C_CC "\003\034\177\025\004\0\1\0\021\023\032\0\022\017\027\026\0"
++#ifdef __linux__
++static struct termios2 init_console_termios = {
++#else
+ static struct termios init_console_termios = {
++#endif
+   .c_iflag = INLCR | ICRNL,
+   .c_oflag = OPOST | ONLCR,
+   .c_cflag = B115200 | HUPCL | CLOCAL | CREAD | CS8,
+diff --git a/src/rshim.h b/src/rshim.h
+index 412e709d..e58b9181 100644
+--- a/src/rshim.h
++++ b/src/rshim.h
+@@ -16,7 +16,9 @@
+ #include <fcntl.h>
+ #ifdef __linux__
+ #include <linux/virtio_ids.h>
++#include <asm/termios.h>
+ #else
++#include <termios.h>
+ #define	VIRTIO_ID_NET 1
+ #define	VIRTIO_ID_CONSOLE 3
+ #endif
+@@ -26,7 +28,6 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <sys/mount.h>
+-#include <termios.h>
+ #include <unistd.h>
+ #ifdef HAVE_CONFIG_H
+ #include <config.h>
+@@ -408,7 +409,11 @@ struct rshim_backend {
+   pthread_cond_t ctrl_wait_cond;
+ 
+   /* Current termios settings for the console. */
++#ifdef __linux__
++  struct termios2 cons_termios;
++#else
+   struct termios cons_termios;
++#endif
+ 
+   /* Pending boot & fifo request for the worker. */
+   uint8_t *boot_work_buf;
+diff --git a/src/rshim_fuse.c b/src/rshim_fuse.c
+index ac423657..ebd214a6 100644
+--- a/src/rshim_fuse.c
++++ b/src/rshim_fuse.c
+@@ -26,27 +26,9 @@
+ #include <fuse/cuse_lowlevel.h>
+ #include <fuse/fuse_opt.h>
+ #endif
++#include <asm/termios.h>
+ #include <features.h>
+ #include <unistd.h>
+-/*
+- * glibc 2.42+ no longer pulls in struct termio; provide a minimal definition so
+- * we can keep using the legacy layout expected by existing userspace tools.
+- */
+-#if !__GLIBC_PREREQ(2, 42)   // if glibc is before 2.42
+-#include <termio.h>
+-#else
+-#ifndef NCC
+-#define NCC 8
+-#endif
+-struct termio {
+-  unsigned short c_iflag;
+-  unsigned short c_oflag;
+-  unsigned short c_cflag;
+-  unsigned short c_lflag;
+-  unsigned char c_line;
+-  unsigned char c_cc[NCC];
+-};
+-#endif
+ #elif defined(__FreeBSD__)
+ #include <termios.h>
+ #include <sys/stat.h>
+@@ -398,6 +380,13 @@ static void rshim_fuse_console_ioctl(fuse_req_t req, int cmd, void *arg,
+                                      size_t in_bufsz, size_t out_bufsz)
+ {
+   rshim_backend_t *bd = fuse_req_userdata(req);
++  /* dummy data, needed for stty to work */
++  static const struct winsize ws = {
++        .ws_row = 24,
++        .ws_col = 80,
++        .ws_xpixel = 0,
++        .ws_ypixel = 0,
++  };
+ 
+   if (!bd) {
+     fuse_reply_err(req, ENODEV);
+@@ -407,21 +396,71 @@ static void rshim_fuse_console_ioctl(fuse_req_t req, int cmd, void *arg,
+   pthread_mutex_lock(&bd->mutex);
+ 
+   switch (cmd) {
+-  case TCGETS:
++  /* ------ */
++  /* TERMIO */
++  /* -------*/
++  case TCGETA:
+     if (!out_bufsz) {
+       struct iovec iov = { arg, sizeof(struct termio) };
+ 
+       fuse_reply_ioctl_retry(req, NULL, 0, &iov, 1);
+     } else {
+-      fuse_reply_ioctl(req, 0, &bd->cons_termios, sizeof(struct termio));
++      struct termio cons_termio = {
++        .c_iflag = bd->cons_termios.c_iflag & 0xffff,
++        .c_oflag = bd->cons_termios.c_oflag & 0xffff,
++        .c_cflag = bd->cons_termios.c_cflag & 0xffff,
++        .c_lflag = bd->cons_termios.c_lflag & 0xffff,
++        .c_line = bd->cons_termios.c_line,
++      };
++
++      memcpy(&cons_termio.c_cc, &bd->cons_termios.c_cc, sizeof(cons_termio.c_cc));
++      fuse_reply_ioctl(req, 0, &bd->cons_termios, sizeof(bd->cons_termios));
++    }
++    break;
++
++  case TCSETA:
++  case TCSETAW:
++  case TCSETAF:
++    if (!in_bufsz) {
++      struct iovec iov = { arg, sizeof(struct termio)};
++
++      fuse_reply_ioctl_retry(req, &iov, 1, NULL, 0);
++    } else {
++      struct termio cons_termio = { 0 };
++
++      memcpy(&cons_termio, in_buf, sizeof(struct termio));
++      bd->cons_termios.c_iflag = cons_termio.c_iflag;
++      bd->cons_termios.c_oflag = cons_termio.c_oflag;
++      bd->cons_termios.c_cflag = cons_termio.c_cflag;
++      bd->cons_termios.c_lflag = cons_termio.c_lflag;
++      memset(&bd->cons_termios.c_cc, 0, sizeof(bd->cons_termios.c_cc));
++      memcpy(&bd->cons_termios.c_cc, &cons_termio.c_cc, sizeof(cons_termio.c_cc));
++      fuse_reply_ioctl(req, 0, NULL, 0);
++    }
++    break;
++
++  /* ---------------- */
++  /* TERMIOS/TERMIOS2 */
++  /* ---------------- */
++  case TCGETS:
++  case TCGETS2:
++    if (!out_bufsz) {
++      struct iovec iov = { arg, sizeof(bd->cons_termios) };
++
++      fuse_reply_ioctl_retry(req, NULL, 0, &iov, 1);
++    } else {
++      fuse_reply_ioctl(req, 0, &bd->cons_termios, sizeof(bd->cons_termios));
+     }
+     break;
+ 
+   case TCSETS:
++  case TCSETS2:
+   case TCSETSW:
++  case TCSETSW2:
+   case TCSETSF:
++  case TCSETSF2:
+     if (!in_bufsz) {
+-      struct iovec iov = {arg, sizeof(bd->cons_termios)};
++      struct iovec iov = { arg, sizeof(bd->cons_termios)};
+ 
+       fuse_reply_ioctl_retry(req, &iov, 1, NULL, 0);
+     } else {
+@@ -430,6 +469,21 @@ static void rshim_fuse_console_ioctl(fuse_req_t req, int cmd, void *arg,
+     }
+     break;
+ 
++  /* ---------- */
++  /* BSD IOCTLs */
++  /* ---------- */
++  case TIOCGWINSZ:
++    if (out_bufsz == 0) {
++        struct iovec iov = { arg, sizeof(struct winsize) };
++        fuse_reply_ioctl_retry(req, NULL, 0, &iov, 1);
++    } else {
++        fuse_reply_ioctl(req, 0, &ws, sizeof(ws));
++    }
++    break;
++
++  /* ------- */
++  /* Default */
++  /* ------- */
+   default:
+     fuse_reply_err(req, ENOSYS);
+     break;

--- a/pkgs/by-name/rs/rshim-user-space/fix-fuse-3-support.patch
+++ b/pkgs/by-name/rs/rshim-user-space/fix-fuse-3-support.patch
@@ -1,0 +1,28 @@
+From 8f739318029105415da01bf8723d2f89d3188860 Mon Sep 17 00:00:00 2001
+From: Markus Theil <theil.markus@gmail.com>
+Date: Mon, 1 Jun 2026 10:45:47 +0200
+Subject: [PATCH] configure: fix fuse cflags override for fuse 3
+
+Signed-off-by: Markus Theil <theil.markus@gmail.com>
+---
+ configure.ac | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 72fa487..6a934d7 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -85,7 +85,12 @@ AS_IF([test "x$build_fuse" = "xyes"], [
+   if test $backend = freebsd; then
+     AC_CHECK_LIB(cuse, cuse_dev_create)
+   else
+-    PKG_CHECK_MODULES(fuse, fuse, [], PKG_CHECK_MODULES(fuse, fuse3, [use_fuse3=yes], [AC_MSG_ERROR([Can't find fuse])]))
++    PKG_CHECK_EXISTS([fuse], [
++      PKG_CHECK_MODULES(fuse, fuse)
++    ], [PKG_CHECK_EXISTS([fuse3], [
++      PKG_CHECK_MODULES(fuse, fuse3)
++      use_fuse3=yes
++    ], [AC_MSG_ERROR([Can't find fuse])])])
+   fi
+   if test "x$use_fuse3" = "xyes"; then
+     AC_SUBST(CPPFLAGS, "$CPPFLAGS -DFUSE_USE_VERSION=30")

--- a/pkgs/by-name/rs/rshim-user-space/package.nix
+++ b/pkgs/by-name/rs/rshim-user-space/package.nix
@@ -4,8 +4,7 @@
   bashNonInteractive,
   coreutils,
   fetchFromGitHub,
-  fetchpatch2,
-  fuse,
+  fuse3,
   gawk,
   gnugrep,
   gnused,
@@ -13,6 +12,7 @@
   libusb1,
   makeBinaryWrapper,
   pciutils,
+  perl,
   pkg-config,
   procps,
   pv,
@@ -25,13 +25,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rshim-user-space";
-  version = "2.6.6";
+  version = "2.7.3";
 
   src = fetchFromGitHub {
     owner = "Mellanox";
     repo = "rshim-user-space";
     rev = "rshim-${finalAttrs.version}";
-    hash = "sha256-OdrJnOm0QegQ2ex1hFSWPfwYuBnXpGeMJ2YfvNyIwTU=";
+    hash = "sha256-2Hu5ysjh38dBaGeZirke+qMb6jw+6sTh8qd4LPei5ms=";
   };
 
   nativeBuildInputs = [
@@ -42,14 +42,27 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals withBfbInstall [ makeBinaryWrapper ];
 
   buildInputs = [
-    fuse
+    fuse3
     libusb1
     pciutils
     systemd
   ];
 
+  patches = [
+    # https://github.com/Mellanox/rshim-user-space/pull/391
+    # Avoid nested PKG_CHECK_MODULES which leaks help text into ./configure
+    # as bare shell, producing "fuse_CFLAGS: command not found" noise.
+    ./fix-fuse-3-support.patch
+    # https://github.com/Mellanox/rshim-user-space/pull/363
+    # Fix console handling under glibc >= 2.42 where struct termio was removed.
+    ./fix-console-handling.patch
+  ];
+
   prePatch = ''
     patchShebangs scripts/bfb-install
+    patchShebangs scripts/bf-reg
+    substituteInPlace scripts/bfb-install \
+      --replace-fail 'bf-reg' "${placeholder "out"}/bin/bf-reg"
   '';
 
   strictDeps = true;
@@ -62,6 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
   ''
   + lib.optionalString withBfbInstall ''
     cp -a scripts/bfb-install "$out"/bin/
+    cp -a scripts/bf-reg "$out"/bin/
   '';
 
   postFixup = lib.optionalString withBfbInstall ''
@@ -74,6 +88,7 @@ stdenv.mkDerivation (finalAttrs: {
           gnugrep
           gnused
           pciutils
+          perl
           procps
           pv
           systemd


### PR DESCRIPTION
This also performs some maintenance:
- fix warning, that bf-reg cannot be found in bfb-install
- migrate to fuse 3
- fix console handling, which is still not upstream


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
