### PR TITLE
nixos/getty: add `enable` option

### DIFF
--- a/nixos/modules/config/console.nix
+++ b/nixos/modules/config/console.nix
@@ -162,6 +162,8 @@ in
     (lib.mkIf cfg.enable (
       lib.mkMerge [
         {
+          services.getty.enable = true;
+
           environment.systemPackages = [ pkgs.kbd ];
 
           # Let systemd-vconsole-setup.service do the work of setting up the

--- a/nixos/modules/services/ttys/getty.nix
+++ b/nixos/modules/services/ttys/getty.nix
@@ -10,6 +10,7 @@ let
     literalExpression
     maintainers
     mkDefault
+    mkEnableOption
     mkIf
     mkOption
     mkRemovedOptionModule
@@ -66,6 +67,8 @@ in
   options = {
 
     services.getty = {
+
+      enable = mkEnableOption "getty";
 
       autologinUser = mkOption {
         type = types.nullOr types.str;
@@ -143,7 +146,7 @@ in
 
   ###### implementation
 
-  config = mkIf config.console.enable {
+  config = mkIf cfg.enable {
     # Note: this is set here rather than up there so that changing
     # nixos.label would not rebuild manual pages
     services.getty.greetingLine = mkDefault ''<<< Welcome to ${config.system.nixos.distroName} ${config.system.nixos.label} (\m) - \l >>>'';

--- a/nixos/modules/services/ttys/getty.nix
+++ b/nixos/modules/services/ttys/getty.nix
@@ -4,10 +4,20 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
+  inherit (lib)
+    escapeShellArgs
+    literalExpression
+    maintainers
+    mkDefault
+    mkIf
+    mkOption
+    mkRemovedOptionModule
+    mkRenamedOptionModule
+    optionals
+    types
+    ;
+
   cfg = config.services.getty;
 
   baseArgs = [

--- a/nixos/modules/services/ttys/kmscon.nix
+++ b/nixos/modules/services/ttys/kmscon.nix
@@ -148,6 +148,8 @@ in
       }
     ];
 
+    services.getty.enable = true;
+
     services.kmscon.config = lib.mkIf cfg.useXkbConfig (
       lib.mapAttrs (_: lib.mkDefault) (
         lib.filterAttrs (_: v: v != "") {
@@ -189,14 +191,9 @@ in
 
       restartIfChanged = false;
       # logind spawns autovt@ttyN.service on VT switch; point it at kmscon
+      # getty module also uses autovt@tty1 to pull tty1 in
       aliases = [ "autovt@.service" ];
     };
-
-    # tty1 is special: logind does not spawn autovt@tty1, it expects a static
-    # pull-in via getty.target. With getty@ suppressed, we must replace it.
-    systemd.targets.getty.wants = lib.mkIf (!config.services.displayManager.enable) [
-      "kmsconvt@tty1.service"
-    ];
 
     systemd.suppressedSystemUnits = [ "getty@.service" ];
 


### PR DESCRIPTION
Currently `services.getty` only depends on `console.enable`. But kmscon also depends on some getty configuration (e.g. /etc/issue, getty.target, ...). Add a `services.getty.enable` option and let the modules enable getty themselves.

tl;dr I'm trying to make this config work:
```nix
{
  console.enable = false;
  services.kmscon.enable = true;
}
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
