### PR TITLE
python3Packages.flashinfer-python: 0.6.4 -> 0.6.17

### DIFF
--- a/pkgs/development/python-modules/flashinfer-python/default.nix
+++ b/pkgs/development/python-modules/flashinfer-python/default.nix
@@ -145,6 +145,7 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
     '';
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
+      GaetanLepage
       breakds
       daniel-fahey
     ];

--- a/pkgs/development/python-modules/flashinfer-python/default.nix
+++ b/pkgs/development/python-modules/flashinfer-python/default.nix
@@ -1,60 +1,73 @@
-# NOTE: At runtime, FlashInfer will fall back to PyTorch’s JIT compilation if a
-# requested kernel wasn’t pre-compiled in AOT mode, and JIT compilation always
-# requires the CUDA toolkit (via nvcc) to be available.
+# NOTE: Since 0.6.x, upstream no longer pre-compiles kernels here (the AOT half now lives in the
+# separate `flashinfer-jit-cache` distribution). Every kernel is therefore compiled at runtime via
+# PyTorch's JIT, which requires the CUDA toolkit (via nvcc) to be available.
 #
-# This means that if you plan to use flashinfer, you will need to set the
-# environment variable `CUDA_HOME` to `cudatoolkit`.
+# This means that if you plan to use flashinfer, you will need to set the environment variable
+# `CUDA_HOME` to `cudatoolkit`.
 {
   lib,
-  config,
   buildPythonPackage,
   fetchFromGitHub,
 
   # build-system
   apache-tvm-ffi,
+  packaging,
   setuptools,
 
   # nativeBuildInputs
-  cmake,
   ninja,
   cudaPackages,
 
   # dependencies
   click,
+  cuda-bindings,
+  cuda-core,
+  cuda-tile,
   einops,
+  nccl4py,
   numpy,
+  nvidia-cudnn-frontend,
+  nvidia-cutlass-dsl,
   nvidia-ml-py,
   requests,
   tabulate,
   torch,
   tqdm,
+
+  # tests
+  mpi4py,
+  numba,
+  nvidia-cutlass,
+  pytestCheckHook,
+  responses,
+
+  cudaSupport ? torch.cudaSupport,
 }:
 
-buildPythonPackage (finalAttrs: {
+buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
   pname = "flashinfer-python";
-  version = "0.6.4";
+  version = "0.6.17";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "flashinfer-ai";
     repo = "flashinfer";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-Hq3oTeEJHRvXwThI8vc06E3Ot/FnPP0sZUfze3ISa2o=";
+    hash = "sha256-7l+NuSphSl90osaWIKWTNk3xiBYvz4QH0/0dcZCgLnc=";
   };
 
   build-system = [
     apache-tvm-ffi
+    packaging
     setuptools
   ];
 
   nativeBuildInputs = [
-    cmake
     ninja
     (lib.getBin cudaPackages.cuda_nvcc)
   ];
-
-  dontUseCmakeConfigure = true;
 
   buildInputs = with cudaPackages; [
     cccl
@@ -63,45 +76,65 @@ buildPythonPackage (finalAttrs: {
     libcurand
   ];
 
-  # FlashInfer offers two installation modes:
-  #
-  # JIT mode: CUDA kernels are compiled at runtime using PyTorch’s JIT, with
-  # compiled kernels cached for future use. JIT mode allows fast installation,
-  # as no CUDA kernels are pre-compiled, making it ideal for development and
-  # testing. JIT version is also available as a sdist in PyPI.
-  #
-  # AOT mode: Core CUDA kernels are pre-compiled and included in the library,
-  # reducing runtime compilation overhead. If a required kernel is not
-  # pre-compiled, it will be compiled at runtime using JIT. AOT mode is
-  # recommended for production environments.
-  #
-  # Here we use opt for the AOT version.
-  preConfigure = ''
-    export FLASHINFER_ENABLE_AOT=1
-    export TORCH_NVCC_FLAGS="--maxrregcount=64"
-    export MAX_JOBS="$NIX_BUILD_CORES"
-  '';
-
-  env.FLASHINFER_CUDA_ARCH_LIST = lib.concatStringsSep ";" torch.cudaCapabilities;
+  env = {
+    FLASHINFER_CUDA_ARCH_LIST = lib.concatStringsSep " " torch.cudaCapabilities;
+  };
 
   pythonRemoveDeps = [
-    "nvidia-cudnn-frontend"
-    "nvidia-cutlass-dsl"
+    # `cuda-python` is a meta-package pulling in the sub-packages of github:NVIDIA/cuda-python.
+    # Only the ones flashinfer actually imports are substituted below.
+    "cuda-python"
   ];
   dependencies = [
+    apache-tvm-ffi
     click
+    cuda-bindings
+    cuda-core
+    cuda-tile
     einops
+    nccl4py
+    ninja
     numpy
+    nvidia-cudnn-frontend
+    nvidia-cutlass-dsl
     nvidia-ml-py
+    packaging
     requests
     tabulate
     torch
     tqdm
   ];
 
+  preCheck = ''
+    export FLASHINFER_WORKSPACE_BASE=$(mktemp -d)
+  '';
+  nativeCheckInputs = [
+    # nvshmem4py
+    mpi4py
+    numba
+    nvidia-cutlass # pycute
+    pytestCheckHook
+    responses
+  ];
+
+  disabledTestPaths = [
+    # Require unpackaged nvshmem4py
+    "tests/comm/test_nvshmem.py"
+    "tests/comm/test_nvshmem_allreduce.py"
+  ];
+
+  # Tests require access to a GPU
+  doCheck = false;
+  passthru.gpuCheck = finalAttrs.finalPackage.overrideAttrs {
+    requiredSystemFeatures = [ "cuda" ];
+    doInstallCheck = true;
+  };
+
   meta = {
-    broken = !torch.cudaSupport || !config.cudaSupport;
+    broken = !cudaSupport;
     homepage = "https://flashinfer.ai/";
+    downloadPage = "https://github.com/flashinfer-ai/flashinfer";
+    changelog = "https://github.com/flashinfer-ai/flashinfer/releases/tag/${finalAttrs.src.tag}";
     description = "Library and kernel generator for Large Language Models";
     longDescription = ''
       FlashInfer is a library and kernel generator for Large Language Models

--- a/pkgs/development/python-modules/flashinfer-python/default.nix
+++ b/pkgs/development/python-modules/flashinfer-python/default.nix
@@ -144,6 +144,7 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
       scenarios.
     '';
     license = lib.licenses.asl20;
+    teams = [ lib.teams.cuda ];
     maintainers = with lib.maintainers; [
       GaetanLepage
       breakds


### PR DESCRIPTION
- **python3Packages.flashinfer-python: 0.6.4 -> 0.6.17** ([Diff](https://github.com/flashinfer-ai/flashinfer/compare/v0.6.4...v0.6.17), [Changelog](https://github.com/flashinfer-ai/flashinfer/releases/tag/v0.6.17))
- **python3Packages.flashinfer: add GaetanLepage to maintainers**
- **python3Packages.flashinfer: add cuda to teams**

cc @breakds @daniel-fahey
cc @NixOS/cuda-maintainers

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
