### PR TITLE
nixos/{systemd/initrd,etc-overlay}: Make /sysroot/* depend on initrd-root-fs.target

### DIFF
--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -748,6 +748,8 @@ in
           };
           requiredBy = [ "initrd-fs.target" ];
           before = [ "initrd-fs.target" ];
+          requires = [ "initrd-root-fs.target" ];
+          after = [ "initrd-root-fs.target" ];
         }
       ];
 

--- a/nixos/modules/system/etc/etc-activation.nix
+++ b/nixos/modules/system/etc/etc-activation.nix
@@ -107,12 +107,14 @@
             before = [ "initrd-fs.target" ];
             requires = [
               config.boot.initrd.systemd.services.initrd-find-etc.name
+              "initrd-root-fs.target"
             ]
             ++ lib.optionals config.system.etc.overlay.mutable [
               config.boot.initrd.systemd.services."rw-etc".name
             ];
             after = [
               config.boot.initrd.systemd.services.initrd-find-etc.name
+              "initrd-root-fs.target"
             ]
             ++ lib.optionals config.system.etc.overlay.mutable [
               config.boot.initrd.systemd.services."rw-etc".name


### PR DESCRIPTION
The selfish reason for making this is that I want lustration in Systemd initrd to work without me having to manually add dependencies for `sysroot-etc.mount` and `sysroot-run.mount`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
