### PR TITLE
haskellPackages.dataframe: unpin from 0.3.3.6

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1773,6 +1773,13 @@ with haskellLib;
   # https://github.com/obsidiansystems/database-id/issues/1
   database-id-class = doJailbreak super.database-id-class;
 
+  # Too strict version bounds (<0.4) on network-run
+  # https://github.com/abhinav/pinch/pull/72
+  pinch = lib.pipe super.pinch [
+    (warnAfterVersion "0.5.2.0")
+    doJailbreak
+  ];
+
   # TODO: when (likely in 25.x) Stackage bumps random to 1.3, review
   dataframe-persistent = lib.pipe super.dataframe-persistent [
     doJailbreak # 2026-01-23: too strict bounds on dataframe >= 0.4

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -27,9 +27,6 @@
 default-package-overrides:
   - chs-cabal == 0.1.1.2 # matches Cabal 3.12 (GHC 9.10)
   - clash-lib-hedgehog < 1.9 # needs to match clash-lib from Stackage
-  # 2026-01-23: dataframe >= 0.3.3.7 uses random-1.3, which breaks dependency coherence on 25.11, whose default version is random-1.2
-  # TODO: when (likely in 25.x) Stackage bumps random to 1.3, review
-  - dataframe == 0.3.3.6
   # 2025-12-26: Needs to match egison-pattern-src from Stackage LTS
   - egison-pattern-src-th-mode < 0.2.2
   - extensions == 0.1.0.2 # matches Cabal 3.12 (GHC 9.10)

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -451,6 +451,7 @@ dont-distribute-packages:
  - clash
  - clash-protocols
  - clash-protocols-base
+ - clash-vexriscv
  - classify-frog
  - classy-effects
  - classy-effects-th
@@ -668,7 +669,6 @@ dont-distribute-packages:
  - datafix
  - dataflow
  - dataframe
- - dataframe-hasktorch
  - dataframe-lazy
  - dataframe-parquet
  - dataframe-parquet-th
@@ -1296,6 +1296,7 @@ dont-distribute-packages:
  - halma-gui
  - halma-telegram-bot
  - hamusic
+ - hanalyze
  - hans-pcap
  - happlets-lib-gtk
  - HAppS-Data
@@ -1687,6 +1688,7 @@ dont-distribute-packages:
  - hsqml-demo-morris
  - hsqml-morris
  - hsreadability
+ - hsrs
  - hssourceinfo
  - hssqlppp-th
  - hstar
@@ -1963,6 +1965,7 @@ dont-distribute-packages:
  - kif-parser
  - kind-integer
  - kind-rational
+ - kiroku-otel
  - kit
  - kmeans-par
  - kmeans-vector


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`dataframe` has gone several updates and is now on version 2.0. The previous dependency issue that kept it on 0.3.3.6, the `random >= 1.3` constraint, has been removed. 

`pinch` was jailbroken in order to get `dataframe` to build. The violating constraint has already been fixed upstream. 

Many `dataframe`-adjacent packages have not been bumped in `nixpkgs` yet, so the ecosystem may not be fully complete. Is it worth it to keep an extra version on 0.3.3.6? 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux (wsl)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
