### PR TITLE
netatalk: enable Spotlight search

### DIFF
--- a/pkgs/by-name/ne/netatalk/package.nix
+++ b/pkgs/by-name/ne/netatalk/package.nix
@@ -26,6 +26,15 @@
   iniparser,
   pandoc,
   sqlite,
+  talloc,
+  xapian,
+  flex,
+  bison,
+  dconf,
+  localsearch,
+  tinysparql,
+  xapianSupport ? false,
+  localsearchSupport ? false,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -42,6 +51,10 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
     file
+  ]
+  ++ lib.optionals localsearchSupport [
+    flex
+    bison
   ];
 
   buildInputs = [
@@ -64,6 +77,16 @@ stdenv.mkDerivation (finalAttrs: {
     iniparser
     pandoc
     sqlite
+    talloc
+  ]
+  ++ lib.optionals xapianSupport [
+    xapian
+    file
+  ]
+  ++ lib.optionals localsearchSupport [
+    tinysparql
+    dconf
+    localsearch
   ];
 
   mesonFlags = [
@@ -77,7 +100,25 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dwith-cracklib=true"
     "-Dwith-cracklib-path=${cracklib.out}"
     "-Dwith-statedir-creation=false"
+    "-Dwith-spotlight-backends=${
+      lib.concatStringsSep "," (
+        [ "cnid" ] ++ lib.optional xapianSupport "xapian" ++ lib.optional localsearchSupport "localsearch"
+      )
+    }"
   ];
+
+  # TODO: drop once upstream makes this path configurable.
+  postPatch = lib.optionalString localsearchSupport ''
+    substituteInPlace meson.build \
+      --replace-fail "install_emptydir('/etc/dconf/db')" "install_emptydir('etc/dconf/db')"
+    substituteInPlace config/dconf/meson.build \
+      --replace-fail "install_dir: '/etc/dconf/profile'" "install_dir: 'etc/dconf/profile'"
+  '';
+
+  # netatalk probes for the LocalSearch schema at configure time.
+  preConfigure = lib.optionalString localsearchSupport ''
+    export XDG_DATA_DIRS="''${XDG_DATA_DIRS:+$XDG_DATA_DIRS:}${localsearch}/share/gsettings-schemas/localsearch-${localsearch.version}"
+  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
netatalk 4.5.0 can now build with Spotlight support, but was not
enabled because the cnid default lightweight backend requires `talloc`.

Add `talloc` so the cnid Spotlight backend is built out of the box.

Also add opt-in flags for the heavier backends, both default off:

  - xapianSupport
  - localsearchSupport

Upstream PR addressing the TODO comment: https://github.com/Netatalk/netatalk/pull/3058

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
