### PR TITLE
zerostack: init at 1.4.2

### DIFF
--- a/pkgs/by-name/ze/zerostack/package.nix
+++ b/pkgs/by-name/ze/zerostack/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "zerostack";
+  version = "1.4.2";
+
+  src = fetchFromGitHub {
+    owner = "gi-dellav";
+    repo = "zerostack";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hwUZCy+rB/jtGpo96vm3yDAKoNB481pG3vkp4O/yYsI=";
+  };
+
+  cargoHash = "sha256-QK/zk1Z1ZJ/pTAH4dzrsAkIPUyT5+SaAkmVZVkVZ3KU=";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    # Required by the aws-lc-sys build script (rustls TLS backend pulled in
+    # transitively via reqwest/rig). pkg-config is used by the *-sys crates
+    # to probe for system libraries.
+    cmake
+    pkg-config
+  ];
+
+  # cmake here is only invoked from a crate build script, not to configure
+  # this project, so the cmake setup-hook's configurePhase must be disabled.
+  dontUseCmakeConfigure = true;
+
+  # Upstream's .cargo/config.toml pins the mold linker via
+  # -fuse-ld=mold, which isn't present in the nixpkgs build sandbox.
+  # It's only a local dev-speed optimization, so drop the override and
+  # use the default toolchain.
+  postPatch = ''
+    rm .cargo/config.toml
+  '';
+
+  passthru.updateScript = nix-update-script {
+    # Upstream also publishes -rcN prerelease tags (e.g. v1.4.0-rc2); only
+    # track stable vX.Y.Z releases.
+    extraArgs = [
+      "--version-regex"
+      "^v([0-9.]+)$"
+    ];
+  };
+
+  meta = {
+    description = "Minimalistic coding agent optimized for memory footprint and performance";
+    homepage = "https://github.com/gi-dellav/zerostack";
+    changelog = "https://github.com/gi-dellav/zerostack/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ magnetophon ];
+    mainProgram = "zerostack";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Minimalistic coding agent written in Rust, optimized for memory footprint and performance

https://github.com/gi-dellav/zerostack

This package and PR description were drafted with AI assistance (Claude); I reviewed, built, and tested everything myself.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
