### PR TITLE
incus: fix lxc environment quoting

### DIFF
--- a/pkgs/by-name/in/incus/package.nix
+++ b/pkgs/by-name/in/incus/package.nix
@@ -2,7 +2,13 @@ import ./generic.nix {
   hash = "sha256-g0YnvPMwk7WpYCl5VbRtHKVYoLlrk6QYhRaRRqulVQM=";
   version = "7.1.0";
   vendorHash = "sha256-VqvDrjdBTblqEOY/HtoKXGRAdoTJpSWxkmgJNNPw6eQ=";
-  patches = [ ];
+  patches = fetchpatch2: [
+    (fetchpatch2 {
+      name = "lxc-fix-environment-quoting.patch";
+      url = "https://github.com/lxc/incus/commit/a1276cdb57297245496ac8c1db76b90d1fcebd3b.patch?full_index=1";
+      hash = "sha256-NqEMYcDYx18KbqShKxmaK1o08c8/X4O87zXclQ36Ors=";
+    })
+  ];
   nixUpdateExtraArgs = [
     "--override-filename=pkgs/by-name/in/incus/package.nix"
   ];


### PR DESCRIPTION
https://github.com/lxc/incus/pull/3432/changes/a1276cdb57297245496ac8c1db76b90d1fcebd3b 
https://discuss.linuxcontainers.org/t/new-incus-install-fails-to-start-container/26742/12


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
