### PR TITLE
nixos/pam_mount: migrate to fuse3

### DIFF
--- a/nixos/modules/security/pam_mount.nix
+++ b/nixos/modules/security/pam_mount.nix
@@ -179,10 +179,10 @@ in
           }" />
           <!-- specify the binaries to be called -->
           <!-- the comma in front of the options is necessary for empty options -->
-          <fusemount>${pkgs.fuse}/bin/mount.fuse %(VOLUME) %(MNTPT) -o ,${
+          <fusemount>${pkgs.fuse3}/bin/mount.fuse3 %(VOLUME) %(MNTPT) -o ,${
             lib.concatStringsSep "," (cfg.fuseMountOptions ++ [ "%(OPTIONS)" ])
           }'</fusemount>
-          <fuseumount>${pkgs.fuse}/bin/fusermount -u %(MNTPT)</fuseumount>
+          <fuseumount>${pkgs.fuse3}/bin/fusermount3 -u %(MNTPT)</fuseumount>
           <!-- the comma in front of the options is necessary for empty options -->
           <cryptmount>${pkgs.pam_mount}/bin/mount.crypt -o ,${
             lib.concatStringsSep "," (cfg.cryptMountOptions ++ [ "%(OPTIONS)" ])


### PR DESCRIPTION
Part of #526161

Works out of the box with fuse3.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
