### PR TITLE
etlegacy-unwrapped: 2.83.2 -> 2.84.0

### DIFF
--- a/pkgs/by-name/et/etlegacy-unwrapped/package.nix
+++ b/pkgs/by-name/et/etlegacy-unwrapped/package.nix
@@ -21,25 +21,35 @@
   zlib,
 }:
 let
-  version = "2.83.2";
+  version = "2.84.0";
   fakeGit = writeScriptBin "git" ''
     if [ "$1" = "describe" ]; then
       echo "${version}"
     fi
   '';
+  binarySuffix =
+    if stdenv.hostPlatform.isx86_64 then
+      "x86_64"
+    else if stdenv.hostPlatform.isAarch64 then
+      "aarch64"
+    else if stdenv.hostPlatform.isi686 then
+      "386"
+    else
+      throw "Unsupported architecture: ${stdenv.hostPlatform.system}";
 in
 stdenv.mkDerivation {
   pname = "etlegacy-unwrapped";
   inherit version;
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   src = fetchFromGitHub {
     owner = "etlegacy";
     repo = "etlegacy";
     tag = "v${version}";
-    hash = "sha256-hZwLYaYV0j3YwFi8KRr4DZV73L2yIwFJ3XqCyq6L7hE=";
+    hash = "sha256-E1eR0OIfXn2QkSGYNu1JFXDIVrkz+pxM7IU0GVkvAFQ=";
   };
-
-  strictDeps = true;
 
   nativeBuildInputs = [
     cmake
@@ -69,6 +79,9 @@ stdenv.mkDerivation {
     (lib.cmakeFeature "CMAKE_BUILD_TYPE" "Release")
     (lib.cmakeBool "BUILD_SERVER" true)
     (lib.cmakeBool "BUILD_CLIENT" true)
+    (lib.cmakeBool "BUNDLED_WOLFSSL" false)
+    (lib.cmakeBool "BUNDLED_OPENSSL" false)
+    (lib.cmakeBool "BUNDLED_CURL" false)
     (lib.cmakeBool "BUNDLED_ZLIB" false)
     (lib.cmakeBool "BUNDLED_CJSON" false)
     (lib.cmakeBool "BUNDLED_JPEG" false)
@@ -86,8 +99,11 @@ stdenv.mkDerivation {
     (lib.cmakeBool "INSTALL_OMNIBOT" false)
     (lib.cmakeBool "INSTALL_GEOIP" false)
     (lib.cmakeBool "INSTALL_WOLFADMIN" false)
+    (lib.cmakeBool "FEATURE_FREETYPE" true)
+    (lib.cmakeBool "FEATURE_GETTEXT" true)
     (lib.cmakeBool "FEATURE_AUTOUPDATE" false)
     (lib.cmakeBool "FEATURE_RENDERER2" false)
+    (lib.cmakeBool "RENDERER_DYNAMIC" true)
     (lib.cmakeFeature "INSTALL_DEFAULT_BASEDIR" "${placeholder "out"}/lib/etlegacy")
     (lib.cmakeFeature "INSTALL_DEFAULT_BINDIR" "${placeholder "out"}/bin")
   ];
@@ -104,5 +120,7 @@ stdenv.mkDerivation {
     maintainers = with lib.maintainers; [
       ashleyghooper
     ];
+    mainProgram = "etl." + binarySuffix;
+    platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/et/etlegacy-unwrapped/package.nix
+++ b/pkgs/by-name/et/etlegacy-unwrapped/package.nix
@@ -19,6 +19,7 @@
   SDL2,
   sqlite,
   zlib,
+  versionCheckHook,
 }:
 let
   version = "2.84.0";
@@ -107,6 +108,9 @@ stdenv.mkDerivation {
     (lib.cmakeFeature "INSTALL_DEFAULT_BASEDIR" "${placeholder "out"}/lib/etlegacy")
     (lib.cmakeFeature "INSTALL_DEFAULT_BINDIR" "${placeholder "out"}/bin")
   ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "ET: Legacy is an open source project based on the code of Wolfenstein: Enemy Territory which was released in 2010 under the terms of the GPLv3 license";

--- a/pkgs/by-name/et/etlegacy/package.nix
+++ b/pkgs/by-name/et/etlegacy/package.nix
@@ -7,9 +7,20 @@
   makeBinaryWrapper,
 }:
 
+let
+  binarySuffix =
+    if stdenv.hostPlatform.isx86_64 then
+      "x86_64"
+    else if stdenv.hostPlatform.isAarch64 then
+      "aarch64"
+    else if stdenv.hostPlatform.isi686 then
+      "386"
+    else
+      throw "Unsupported architecture: ${stdenv.hostPlatform.system}";
+in
 symlinkJoin {
   pname = "etlegacy";
-  version = "2.83.2";
+  version = "2.84.0";
 
   paths = [
     etlegacy-assets
@@ -39,7 +50,7 @@ symlinkJoin {
       for the popular online FPS game Wolfenstein: Enemy Territory - whose
       gameplay is still considered unmatched by many, despite its great age.
     '';
-    mainProgram = "etl." + (if stdenv.hostPlatform.isi686 then "i386" else "x86_64");
+    mainProgram = "etl." + binarySuffix;
     maintainers = with lib.maintainers; [
       ashleyghooper
     ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
