### PR TITLE
watchar: init at 3.0.1; nixos/watcharr: init module; nixosTests.watcharr: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1779,6 +1779,7 @@
   ./services/web-apps/umami.nix
   ./services/web-apps/vikunja.nix
   ./services/web-apps/wakapi.nix
+  ./services/web-apps/watcharr.nix
   ./services/web-apps/weblate.nix
   ./services/web-apps/whitebophir.nix
   ./services/web-apps/whoami.nix

--- a/nixos/modules/services/web-apps/watcharr.nix
+++ b/nixos/modules/services/web-apps/watcharr.nix
@@ -1,0 +1,118 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.watcharr;
+  settingsFormat = pkgs.formats.json { };
+  stateDir = "/var/lib/watcharr";
+in
+{
+  options.services.watcharr = {
+    enable = lib.mkEnableOption "Watcharr";
+
+    package = lib.mkPackageOption pkgs "watcharr" { };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether to open the listen port (3080) in the firewall.";
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/run/secrets/watcharr.env";
+      description = "Path to a systemd `EnvironmentFile` with secrets (e.g. `WATCHARR_JWT_SECRET`, `WATCHARR_TMDB_KEY`).";
+    };
+
+    settings = lib.mkOption {
+      type = settingsFormat.type;
+      default = { };
+      example = {
+        DEFAULT_COUNTRY = "JP";
+        SIGNUP_ENABLED = false;
+        JELLYFIN_HOST = "https://jellyfin.example.com";
+      };
+      description = ''
+        Free-form configuration written to `watcharr.json` in the state dir on each start.
+        Watcharr's admin UI also writes there; values set here are re-applied on every restart.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.watcharr = {
+      description = "Watcharr, self-hosted watched list for movies, TV, anime, and games";
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      environment.WATCHARR_DATA = stateDir;
+
+      serviceConfig = {
+        DynamicUser = true;
+        StateDirectory = "watcharr";
+        StateDirectoryMode = "0700";
+        ExecStartPre = lib.mkIf (cfg.settings != { }) (
+          "${pkgs.coreutils}/bin/install -m 0640 "
+          + "${settingsFormat.generate "watcharr.json" cfg.settings} "
+          + "${stateDir}/watcharr.json"
+        );
+        ExecStart = lib.getExe cfg.package;
+        EnvironmentFile = cfg.environmentFile;
+        Restart = "on-failure";
+
+        AmbientCapabilities = "";
+        CapabilityBoundingSet = "";
+        DeviceAllow = "";
+        LockPersonality = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@pkey"
+          "@system-service"
+          "~@privileged"
+          "~@chown:EPERM"
+          "~@keyring"
+          "~@memlock"
+          "~@resources"
+          "~@setuid"
+          "~@timer"
+        ];
+        UMask = "0077";
+      };
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [ 3080 ];
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ miniharinn ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1749,6 +1749,7 @@ in
   warzone2100 = runTest ./warzone2100.nix;
   wasabibackend = runTest ./wasabibackend.nix;
   wastebin = runTest ./wastebin.nix;
+  watcharr = runTest ./watcharr.nix;
   watchdogd = runTest ./watchdogd.nix;
   webhook = runTest ./webhook.nix;
   weblate = runTest ./web-apps/weblate.nix;

--- a/nixos/tests/watcharr.nix
+++ b/nixos/tests/watcharr.nix
@@ -1,0 +1,21 @@
+{ lib, ... }:
+{
+  name = "watcharr";
+  meta.maintainers = with lib.maintainers; [ miniharinn ];
+
+  nodes.machine = {
+    services.watcharr.enable = true;
+  };
+
+  testScript = ''
+    machine.wait_for_unit("watcharr.service")
+    machine.wait_for_open_port(3080)
+    machine.wait_for_open_port(3000)
+
+    machine.succeed("curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:3080/api/features | grep -q 401")
+    machine.succeed("curl --fail --silent --show-error http://127.0.0.1:3080/ | grep -q '<title>Watcharr</title>'")
+
+    machine.succeed("test -f /var/lib/watcharr/watcharr.db")
+    machine.succeed("test -f /var/lib/watcharr/watcharr.log")
+  '';
+}

--- a/pkgs/by-name/wa/watcharr/package.nix
+++ b/pkgs/by-name/wa/watcharr/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  buildGoModule,
+  buildNpmPackage,
+  fetchFromGitHub,
+  makeWrapper,
+  nix-update-script,
+  nodejs,
+  nixosTests,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "watcharr";
+  version = "3.0.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "sbondCo";
+    repo = "Watcharr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-C0KQQuT6+KtbsgqvGp+dhqEAlUDq/ZsdIr089h+cXHM=";
+  };
+
+  modRoot = "server";
+  vendorHash = "sha256-3JcOVWlnGnpvfcIvilMZPLBFLEmpwNbyJv41mQEnugs=";
+
+  subPackages = [ "." ];
+
+  # go-sqlite3 cgo build flag
+  env.CGO_CFLAGS = "-D_LARGEFILE64_SOURCE";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    mv $out/bin/Watcharr $out/bin/watcharr
+    wrapProgram $out/bin/watcharr \
+      --prefix PATH : ${lib.makeBinPath [ nodejs ]} \
+      --chdir ${finalAttrs.passthru.frontend}
+  '';
+
+  passthru = {
+    frontend = buildNpmPackage {
+      pname = "watcharr-frontend";
+      inherit (finalAttrs) src version;
+
+      npmDepsHash = "sha256-TKPgoHheA/9h/4VdRYeVw4zb5ZOBOATpUwM6jh26Tzo=";
+
+      installPhase = ''
+        runHook preInstall
+
+        npm prune --omit=dev
+
+        mkdir -p $out/ui
+        cp -r build/. node_modules package.json $out/ui/
+
+        runHook postInstall
+      '';
+    };
+
+    tests = {
+      inherit (nixosTests) watcharr;
+    };
+
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Self-hosted watched list for movies, TV shows, anime, and games";
+    homepage = "https://watcharr.app";
+    changelog = "https://github.com/sbondCo/Watcharr/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ miniharinn ];
+    mainProgram = "watcharr";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Init full suite of `watcharr` including: package, module, and nixosTest

Upstream Git: https://github.com/sbondCo/Watcharr
Homepage: https://watcharr.app/

It is a watch list tracker, a webapp that lets you track your watched TV/movies/series/etc. in one place. Hoping to have this in Nixpkgs as a native NixOS module, since the only way now is to use OCI containers.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
