### PR TITLE
cups-kyodialog: 9.4 -> 10.1

### DIFF
--- a/pkgs/by-name/cu/cups-kyodialog/package.nix
+++ b/pkgs/by-name/cu/cups-kyodialog/package.nix
@@ -23,13 +23,12 @@
 
 assert region == "Global" || region == "EU";
 
-let
-  kyodialog_version = "9.4";
-  date = "20240521";
-in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "cups-kyodialog";
-  version = "${kyodialog_version}-${date}";
+  version = "${finalAttrs.kyodialog_version}-${finalAttrs.date}";
+
+  kyodialog_version = "10.1";
+  date = "20240521";
 
   dontStrip = true;
 
@@ -39,10 +38,10 @@ stdenv.mkDerivation rec {
     # 2. Search for printer model, e.g. "TASKalfa 6053ci"
     # 3. Locate e.g. "Linux Print Driver (9.3)" in the list
     urls = [
-      "https://www.kyoceradocumentsolutions.us/content/download-center-americas/us/drivers/drivers/KyoceraLinuxPackages_${date}_tar_gz.download.gz"
-      "https://web.archive.org/web/20260107200228/https://www.kyoceradocumentsolutions.us/content/download-center-americas/us/drivers/drivers/KyoceraLinuxPackages_${date}_tar_gz.download.gz"
+      "https://www.kyoceradocumentsolutions.us/content/dam/download-center-americas-cf/us/drivers/drivers/KyoceraLinuxPackages_${finalAttrs.date}_tar_gz.download.gz"
+      "https://web.archive.org/web/20260815085244/https://www.kyoceradocumentsolutions.us/content/dam/download-center-americas-cf/us/drivers/drivers/KyoceraLinuxPackages_20240521_tar_gz.download.gz"
     ];
-    hash = "sha256-H9n4KpaLGNk5du4+BAmMjRyLmXaHap8HdNZlX/Kia4E=";
+    hash = "sha256-jJNTNcZiIcIkXZBEp+M012eaDbdAaa9YFUJ5msfWDy0=";
     extension = "tar.gz";
     stripRoot = false;
     postFetch = ''
@@ -64,7 +63,7 @@ stdenv.mkDerivation rec {
           or (throw "unsupported system: ${stdenv.hostPlatform.system}");
     in
     ''
-      ar p "$src/Debian/${region}/kyodialog_${platform}/kyodialog_${kyodialog_version}-0_${platform}.deb" data.tar.gz | tar -xz
+      ar p "$src/Debian/${region}/kyodialog_${platform}/kyodialog_${finalAttrs.kyodialog_version}-0_${platform}.deb" data.tar.gz | tar -xz
     '';
 
   nativeBuildInputs = [
@@ -86,7 +85,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     # allow cups to find the ppd files
     mkdir -p $out/share/cups/model
-    mv ./usr/share/kyocera${kyodialog_version}/ppd${kyodialog_version} $out/share/cups/model/Kyocera
+    mv ./usr/share/kyocera${finalAttrs.kyodialog_version}/ppd${finalAttrs.kyodialog_version} $out/share/cups/model/Kyocera
 
     # remove absolute path prefixes to filters in ppd
     find $out -name "*.ppd" -exec sed -E -i "s:/usr/lib/cups/filter/::g" {} \;
@@ -98,18 +97,18 @@ stdenv.mkDerivation rec {
     wrapPythonProgramsIn $out/lib/cups/filter "$propagatedBuildInputs"
 
 
-    install -Dm444 usr/share/doc/kyodialog/copyright $out/share/doc/${pname}/copyright
+    install -Dm444 usr/share/doc/kyodialog/copyright $out/share/doc/${finalAttrs.pname}/copyright
   ''
   + lib.optionalString withQtGui ''
     install -D usr/bin/kyoPPDWrite_H $out/bin/kyoPPDWrite_H
-    install -D usr/bin/kyodialog${kyodialog_version} $out/bin/kyodialog
+    install -D usr/bin/kyodialog${finalAttrs.kyodialog_version} $out/bin/kyodialog
 
-    install -Dm444 usr/share/kyocera${kyodialog_version}/appicon_H.png $out/share/${pname}/icons/appicon_H.png
+    install -Dm444 usr/share/kyocera${finalAttrs.kyodialog_version}/appicon_H.png $out/share/${finalAttrs.pname}/icons/appicon_H.png
 
-    install -Dm444 usr/share/applications/kyodialog${kyodialog_version}.desktop $out/share/applications/kyodialog.desktop
+    install -Dm444 usr/share/applications/kyodialog${finalAttrs.kyodialog_version}.desktop $out/share/applications/kyodialog.desktop
     substituteInPlace $out/share/applications/kyodialog.desktop \
-      --replace Exec=\"/usr/bin/kyodialog${kyodialog_version}\" Exec=\"$out/bin/kyodialog\" \
-      --replace Icon=/usr/share/kyocera/appicon_H.png Icon=$out/share/${pname}/icons/appicon_H.png
+      --replace Exec=\"/usr/bin/kyodialog${finalAttrs.kyodialog_version}\" Exec=\"$out/bin/kyodialog\" \
+      --replace Icon=/usr/share/kyocera/appicon_H.png Icon=$out/share/${finalAttrs.pname}/icons/appicon_H.png
   '';
 
   meta = {
@@ -123,4 +122,4 @@ stdenv.mkDerivation rec {
       "x86_64-linux"
     ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The old url `https://www.kyoceradocumentsolutions.us/content/download-center-americas/us/drivers/drivers/KyoceraLinuxPackages_20240521_tar_gz.download.gz`started returning the new version, so uncached builds are now failing.

I have an ECOSYS P2040dn which works the same way with the ppd files included in the new release, but I cannot test further than that.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
