### PR TITLE
urdfdom-headers: 2.0.1 -> 3.0.0, urdfdom: 5.0.4 -> 6.0.0

### DIFF
--- a/pkgs/by-name/ur/urdfdom-headers/package.nix
+++ b/pkgs/by-name/ur/urdfdom-headers/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "urdfdom-headers";
-  version = "2.0.1";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "ros";
     repo = "urdfdom_headers";
     tag = finalAttrs.version;
-    hash = "sha256-tBNoG5gH3haZETUlI4Pn1mg14T/sMil9n/iSzjJC+Rg=";
+    hash = "sha256-9bKUuHKSzYiKNDbZwMkB9rbeDC1CUv4X8wDBKkuJkp8=";
   };
 
   patches = [

--- a/pkgs/by-name/ur/urdfdom/package.nix
+++ b/pkgs/by-name/ur/urdfdom/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "urdfdom";
-  version = "5.0.4";
+  version = "6.0.0";
 
   src = fetchFromGitHub {
     owner = "ros";
     repo = "urdfdom";
     tag = finalAttrs.version;
-    hash = "sha256-52Iv9ltYaGr6Ys3FreBSHOfJnVEp7kwjBpi8Cm6aC/g=";
+    hash = "sha256-7ExQaz1/QshWwX8C3F2ZY4/Ty8U3/dXnBfwjGYB0SRg=";
   };
 
   patches = [


### PR DESCRIPTION
fix for sdformat-urdf (not in nixpkgs) :
```cpp
       > [ 75%] Building CXX object CMakeFiles/sdformat_urdf_plugin.dir/src/sdformat_urdf_plugin.cpp.o
       > In file included from /build/sdformat_urdf-release-release-rolling-sdformat_urdf-2.1.0-2/src/sdformat_urdf_plugin.cpp:17:
       > /nix/store/mzw7zxv2xq45mxmay7c479p1zmh7gc94-ros-rolling-urdf-parser-plugin-2.14.0-r1/include/urdf_parser_plugin/urdf_parser_plugin/parser.h:34:2: warning: #warning This header is obsolete, please include urdf_parser_plugin/parser.hpp instead [-Wcpp]
       >    34 | #warning \
       >       |  ^~~~~~~
       > In file included from /nix/store/mzw7zxv2xq45mxmay7c479p1zmh7gc94-ros-rolling-urdf-parser-plugin-2.14.0-r1/include/urdf_parser_plugin/urdf_parser_plugin/parser.h:38:
       > /nix/store/mzw7zxv2xq45mxmay7c479p1zmh7gc94-ros-rolling-urdf-parser-plugin-2.14.0-r1/include/urdf_parser_plugin/urdf_parser_plugin/parser.hpp:54:17: error: 'ModelInterfaceSharedPtr' in namespace 'urdf' does not name a type
       >    54 |   virtual urdf::ModelInterfaceSharedPtr parse(const std::string & data) = 0;
       >       |                 ^~~~~~~~~~~~~~~~~~~~~~~
       > /build/sdformat_urdf-release-release-rolling-sdformat_urdf-2.1.0-2/src/sdformat_urdf_plugin.cpp:33:3: error: 'urdf::ModelInterfaceSharedPtr sdformat_urdf::SDFormatURDFParser::parse(const std::string&)' marked 'override', but does not override
       >    33 |   parse(const std::string & data) override
       >       |   ^~~~~
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
