### PR TITLE
mp3fs: use fuse3

### DIFF
--- a/pkgs/by-name/mp/mp3fs/package.nix
+++ b/pkgs/by-name/mp/mp3fs/package.nix
@@ -15,20 +15,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mp3fs";
-  version = "1.1.1";
+  version = "1.1.1-unstable-2023-01-29";
 
   src = fetchFromGitHub {
     owner = "khenriks";
     repo = "mp3fs";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-dF+DfkNKvYOucS6KjYR1MMGxayM+1HVS8mbmaavmgKM=";
+    rev = "cd2ca80eb3912ff8385e6d537df10d9a768a3a96";
+    hash = "sha256-lueF8fEV+0LQOxf2MhK9dPWkfsTF4nP3PijqjJvDPzo=";
   };
-
-  postPatch = ''
-    substituteInPlace src/mp3fs.cc \
-      --replace-fail "#include <fuse_darwin.h>" "" \
-      --replace-fail "osxfuse_version()" "fuse_version()"
-  '';
 
   nativeBuildInputs = [
     autoreconfHook

--- a/pkgs/by-name/mp/mp3fs/package.nix
+++ b/pkgs/by-name/mp/mp3fs/package.nix
@@ -2,8 +2,9 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   flac,
-  fuse,
+  fuse3,
   lame,
   libid3tag,
   libvorbis,
@@ -24,6 +25,15 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-lueF8fEV+0LQOxf2MhK9dPWkfsTF4nP3PijqjJvDPzo=";
   };
 
+  patches = [
+    (fetchpatch2 {
+      name = "Enable fuse3 support.patch";
+      # https://github.com/khenriks/mp3fs/pull/81
+      url = "https://github.com/khenriks/mp3fs/commit/6e1326de4a19b236eef88b89599755adf394526f.patch?full_index=1";
+      hash = "sha256-V2HZy0jiXAHGAjre+QtCdGev7maWJ8hW3F2e/87CEKA=";
+    })
+  ];
+
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
@@ -32,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     flac
-    fuse
+    fuse3
     lame
     libid3tag
     libvorbis


### PR DESCRIPTION
fuse (2.x) is being deprecated, so replace it with fuse3 (3.x).
See https://github.com/NixOS/nixpkgs/issues/526161.

https://github.com/khenriks/mp3fs/pull/81 is a PR (not yet merged) to implement fuse3 support.
To apply cleanly, I need to update the package.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test