### PR TITLE
home-assistant-custom-components.llm_intents: init at 1.8.1

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/llm_intents/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/llm_intents/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  sympy,
+  pytest-asyncio,
+  pytest-cov-stub,
+  pytest-freezer,
+  pytest-homeassistant-custom-component,
+  pytestCheckHook,
+}:
+
+buildHomeAssistantComponent (finalAttrs: {
+  owner = "skye-harris";
+  domain = "llm_intents";
+  version = "1.8.1";
+
+  src = fetchFromGitHub {
+    inherit (finalAttrs) owner;
+    repo = "llm_intents";
+    tag = finalAttrs.version;
+    hash = "sha256-KIC9rDu2AKSLlW0lNXR05AyhreAnFAhNuNRlqdZwy5w=";
+  };
+
+  dependencies = [
+    sympy
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-cov-stub
+    pytest-freezer
+    pytest-homeassistant-custom-component
+    pytestCheckHook
+  ];
+
+  meta = {
+    changelog = "https://github.com/skye-harris/llm_intents/releases/tag/${finalAttrs.src.tag}";
+    description = "Exposes internet search tools for use by LLM-backed Assist in Home Assistant";
+    homepage = "https://github.com/skye-harris/llm_intents";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jpds ];
+  };
+})


### PR DESCRIPTION
* https://github.com/skye-harris/llm_intents

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] Live system
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
