### PR TITLE
polari: 49.0 -> 50.0

### DIFF
--- a/pkgs/by-name/po/polari/package.nix
+++ b/pkgs/by-name/po/polari/package.nix
@@ -32,11 +32,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "polari";
-  version = "49.0";
+  version = "50.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/polari/${lib.versions.major finalAttrs.version}/polari-${finalAttrs.version}.tar.xz";
-    hash = "sha256-UmJv3jkJkhrFhsxMwQ8w8SOq9hVaF374hhyg5V1t6FA=";
+    hash = "sha256-pSiWuSZHJf19WtCOYp10r6ZKNOT2PnP2ELl87TblZ9s=";
   };
 
   patches = [

--- a/pkgs/by-name/po/polari/package.nix
+++ b/pkgs/by-name/po/polari/package.nix
@@ -17,12 +17,11 @@
   gtk4,
   tinysparql,
   libadwaita,
-  gtk3,
   glib,
   glib-networking,
   libsecret,
   libsoup_3,
-  webkitgtk_4_1,
+  webkitgtk_6_0,
   gobject-introspection,
   gnome,
   wrapGAppsHook4,
@@ -32,11 +31,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "polari";
-  version = "49.0";
+  version = "50.0";
 
   src = fetchurl {
     url = "mirror://gnome/sources/polari/${lib.versions.major finalAttrs.version}/polari-${finalAttrs.version}.tar.xz";
-    hash = "sha256-UmJv3jkJkhrFhsxMwQ8w8SOq9hVaF374hhyg5V1t6FA=";
+    hash = "sha256-pSiWuSZHJf19WtCOYp10r6ZKNOT2PnP2ELl87TblZ9s=";
   };
 
   patches = [
@@ -88,7 +87,6 @@ stdenv.mkDerivation (finalAttrs: {
     gtk4
     tinysparql
     libadwaita
-    gtk3 # for thumbnailer
     glib
     glib-networking
     gsettings-desktop-schemas
@@ -98,7 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
     gdk-pixbuf
     libsecret
     libsoup_3
-    webkitgtk_4_1 # for thumbnailer
+    webkitgtk_6_0 # for thumbnailer
   ];
 
   postFixup = ''


### PR DESCRIPTION
changelog: https://gitlab.gnome.org/GNOME/polari/-/blob/50.0/NEWS
diff: https://gitlab.gnome.org/GNOME/polari/-/compare/49.0...50.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
