### PR TITLE
eigen_5: add withDoc option, fix #526648

### DIFF
--- a/pkgs/by-name/ei/eigen_5/package.nix
+++ b/pkgs/by-name/ei/eigen_5/package.nix
@@ -10,6 +10,8 @@
   doxygen,
   cmake,
   graphviz,
+
+  withDoc ? true, # upstream disable for cross, even if it seems to build fine
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -34,16 +36,22 @@ stdenv.mkDerivation (finalAttrs: {
 
   outputs = [
     "out"
-    "doc"
-  ];
+  ]
+  ++ lib.optional withDoc "doc";
 
   nativeBuildInputs = [
-    doxygen
     cmake
+  ]
+  ++ lib.optionals withDoc [
+    doxygen
     graphviz
   ];
 
-  postInstall = ''
+  cmakeFlags = [
+    (lib.cmakeBool "EIGEN_BUILD_DOC" withDoc)
+  ];
+
+  postInstall = lib.optionalString withDoc ''
     cmake --build . -t install-doc
   '';
 

--- a/pkgs/by-name/ei/eigen_5/package.nix
+++ b/pkgs/by-name/ei/eigen_5/package.nix
@@ -52,6 +52,9 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postInstall = lib.optionalString withDoc ''
+    # Fontconfig error: No writable cache directories
+    export XDG_CACHE_HOME="$(mktemp -d)"
+
     cmake --build . -t install-doc
   '';
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
