### PR TITLE
gdbgui: modernize and migrate to pyproject

### DIFF
--- a/pkgs/development/tools/misc/gdbgui/default.nix
+++ b/pkgs/development/tools/misc/gdbgui/default.nix
@@ -5,7 +5,7 @@
   gdb,
 }:
 
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "gdbgui";
 
   version = "0.15.3.0";
@@ -22,12 +22,12 @@ python3Packages.buildPythonApplication rec {
   ];
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-/HyFE0JnoN03CDyCQCo/Y9RyH4YOMoeB7khReIb8t7Y=";
   };
 
   postPatch = ''
-    echo ${version} > gdbgui/VERSION.txt
+    echo ${finalAttrs.version} > gdbgui/VERSION.txt
     # relax version requirements
     sed -i 's/==.*$//' requirements.txt
   '';
@@ -51,4 +51,4 @@ python3Packages.buildPythonApplication rec {
       dump_stack
     ];
   };
-}
+})

--- a/pkgs/development/tools/misc/gdbgui/default.nix
+++ b/pkgs/development/tools/misc/gdbgui/default.nix
@@ -9,11 +9,13 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pname = "gdbgui";
 
   version = "0.15.3.0";
-  format = "setuptools";
+  pyproject = true;
+
+  build-system = with python3Packages; [ setuptools ];
 
   buildInputs = [ gdb ];
 
-  propagatedBuildInputs = with python3Packages; [
+  dependencies = with python3Packages; [
     eventlet
     flask-compress
     flask-socketio

--- a/pkgs/development/tools/misc/gdbgui/default.nix
+++ b/pkgs/development/tools/misc/gdbgui/default.nix
@@ -10,6 +10,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
   version = "0.15.3.0";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
     inherit (finalAttrs) pname version;
     hash = "sha256-/HyFE0JnoN03CDyCQCo/Y9RyH4YOMoeB7khReIb8t7Y=";

--- a/pkgs/development/tools/misc/gdbgui/default.nix
+++ b/pkgs/development/tools/misc/gdbgui/default.nix
@@ -7,9 +7,19 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "gdbgui";
-
   version = "0.15.3.0";
   pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-/HyFE0JnoN03CDyCQCo/Y9RyH4YOMoeB7khReIb8t7Y=";
+  };
+
+  postPatch = ''
+    echo ${finalAttrs.version} > gdbgui/VERSION.txt
+    # relax version requirements
+    sed -i 's/==.*$//' requirements.txt
+  '';
 
   build-system = with python3Packages; [ setuptools ];
 
@@ -22,17 +32,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     pygdbmi
     pygments
   ];
-
-  src = fetchPypi {
-    inherit (finalAttrs) pname version;
-    hash = "sha256-/HyFE0JnoN03CDyCQCo/Y9RyH4YOMoeB7khReIb8t7Y=";
-  };
-
-  postPatch = ''
-    echo ${finalAttrs.version} > gdbgui/VERSION.txt
-    # relax version requirements
-    sed -i 's/==.*$//' requirements.txt
-  '';
 
   postInstall = ''
     wrapProgram $out/bin/gdbgui \


### PR DESCRIPTION
- Migrates to `pyproject`: https://github.com/NixOS/nixpkgs/issues/515974
- Switches from `rec` to `finalAttrs` and from `propagatedBuildInputs` to `dependencies` because I was editing the file anyways


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
