### PR TITLE
nixosTests.gocryptfs: init

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -673,6 +673,7 @@ in
   gobgpd = runTest ./gobgpd.nix;
   gocd-agent = runTest ./gocd-agent.nix;
   gocd-server = runTest ./gocd-server.nix;
+  gocryptfs = runTest ./gocryptfs.nix;
   gokapi = runTest ./gokapi.nix;
   gollum = runTest ./gollum.nix;
   gonic = runTest ./gonic.nix;

--- a/nixos/tests/gocryptfs.nix
+++ b/nixos/tests/gocryptfs.nix
@@ -1,0 +1,57 @@
+{
+  name = "gocryptfs";
+  meta = {
+    maintainers = [ ];
+  };
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+
+      environment.systemPackages = [
+        pkgs.gocryptfs
+        pkgs.openssl
+      ];
+
+      specialisation.fstab-test.configuration = {
+        fileSystems."/plain" = {
+          device = "/encrypted";
+          fsType = "fuse.gocryptfs";
+          options = [
+            "nofail"
+            "allow_other"
+            "passfile=/tmp/password.txt"
+          ];
+        };
+      };
+    };
+
+  testScript = ''
+
+    # Generate a password
+    machine.execute("openssl rand -base64 32 > /tmp/password.txt")
+
+    # Initialize an encrypted vault
+    machine.execute("mkdir -p /encrypted /plain")
+    machine.execute("gocryptfs -init /encrypted  -passfile /password.txt -quiet")
+
+    # Open and mount vault
+    machine.execute("gocryptfs /encrypted /plain  -passfile /tmp/password.txt -quiet")
+
+    machine.execute("echo test > /plain/data.txt")
+    machine.execute("echo test > /tmp/data.txt")
+
+    # Unmount
+    machine.execute("fusermount -u /plain")
+
+    # Switch to the specialisation
+    machine.succeed("/run/current-system/specialisation/fstab-test/bin/switch-to-configuration test")
+
+    # Wait for mount
+    machine.wait_for_unit("local-fs.target")
+
+    # Check data
+    machine.succeed("diff /plain/data.txt /tmp/data.txt")
+
+  '';
+}


### PR DESCRIPTION
Add a nixos vm test for gocryptfs, and more specifically tests the fstab gocryptfs mount

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
