### PR TITLE
astro-language-server: 2.16.7 -> 2.16.10

### DIFF
--- a/pkgs/by-name/as/astro-language-server/package.nix
+++ b/pkgs/by-name/as/astro-language-server/package.nix
@@ -2,32 +2,42 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  pnpm_10,
+  pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
   nodejs,
   nix-update-script,
+  fetchpatch2,
 }:
+let
+  pnpm = pnpm_11;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "astro-language-server";
-  version = "2.16.7";
+  version = "2.16.10";
 
   src = fetchFromGitHub {
     owner = "withastro";
     repo = "astro";
     tag = "@astrojs/language-server@${finalAttrs.version}";
-    hash = "sha256-0UkbHGOvMJxY4RXVLx9T8oh2cnuwziEuwUfFrls4Wc0=";
+    hash = "sha256-ZzLLGfbY6Rtjzqw+MMCHthvalo3B8lf/qxFJNJ/2LdQ=";
   };
+
+  patches = [
+    # remove on next release
+    (fetchpatch2 {
+      name = "fix-supply-chain-verification-fail.patch";
+      url = "https://github.com/withastro/astro/commit/272ca6173b40cfa37299c27b513f495f386d4009.patch?full_index=1";
+      includes = [ "pnpm-workspace.yaml" ];
+      hash = "sha256-jPYFiyBlIoqpbIcT/hPa+VlF1IX+QCP8CVFQGarzlEs=";
+    })
+  ];
 
   # https://pnpm.io/filtering#--filter-package_name-1
   pnpmWorkspaces = [
     "@astrojs/language-server..."
     "@astrojs/ts-plugin"
   ];
-  prePnpmInstall = ''
-    pnpm config set dedupe-peer-dependents false
-    pnpm approve-builds @emmetio/css-parser
-  '';
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs)
@@ -35,17 +45,17 @@ stdenv.mkDerivation (finalAttrs: {
       version
       src
       pnpmWorkspaces
-      prePnpmInstall
+      patches
       ;
-    pnpm = pnpm_10;
+    inherit pnpm;
     fetcherVersion = 3;
-    hash = "sha256-1kdXt0Wc/ON//hwBYozRSMAyKQqEfSMfOI7XJyd9MBc=";
+    hash = "sha256-qXYFfTIZ3aEbIC//Ai29EQHpjYunTKxWszfTw4nvUfE=";
   };
 
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
-    pnpm_10
+    pnpm
   ];
 
   buildInputs = [ nodejs ];


### PR DESCRIPTION
Release notes: https://github.com/withastro/astro/releases/tag/%40astrojs%2Flanguage-server%402.16.10
Upgrades pnpm from v10 to v11 to match upstream.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
