### PR TITLE
icewm: 3.8.2 -> 4.0.0

### DIFF
--- a/pkgs/by-name/ic/icewm/package.nix
+++ b/pkgs/by-name/ic/icewm/package.nix
@@ -33,6 +33,7 @@
   libsndfile,
   libtiff,
   libxcb,
+  libxcursor,
   mkfontdir,
   pcre2,
   perl,
@@ -41,13 +42,13 @@
 
 gccStdenv.mkDerivation (finalAttrs: {
   pname = "icewm";
-  version = "3.8.2";
+  version = "4.0.0";
 
   src = fetchFromGitHub {
     owner = "ice-wm";
     repo = "icewm";
     tag = finalAttrs.version;
-    hash = "sha256-CbIQICov0h3lBDT54dEODkINNXou6CUEhRQAPZwfYK0=";
+    hash = "sha256-4+nW8JJ3CDEPOZZ4p0EZM86h+rAifTuGDZxoFMUI7K0=";
   };
 
   strictDeps = true;
@@ -90,6 +91,7 @@ gccStdenv.mkDerivation (finalAttrs: {
     libsndfile
     libtiff
     libxcb
+    libxcursor
     mkfontdir
     pcre2
   ];
@@ -109,6 +111,7 @@ gccStdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://ice-wm.org/";
+    changelog = "https://github.com/ice-wm/icewm/releases/tag/${finalAttrs.src.tag}";
     description = "Simple, lightweight X window manager";
     longDescription = ''
       IceWM is a window manager for the X Window System. The goal of IceWM is


### PR DESCRIPTION
Diff: https://github.com/ice-wm/icewm/compare/3.8.2...4.0.0

Changelog: https://github.com/ice-wm/icewm/releases/tag/4.0.0
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
