### PR TITLE
intel-vaapi-driver: 2.4.1-unstable-2024-10-29 -> 2.4.5

### DIFF
--- a/pkgs/by-name/in/intel-vaapi-driver/package.nix
+++ b/pkgs/by-name/in/intel-vaapi-driver/package.nix
@@ -20,15 +20,15 @@
   nix-update-script,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "intel-vaapi-driver";
-  version = "2.4.1-unstable-2024-10-29";
+  version = "2.4.5";
 
   src = fetchFromGitHub {
-    owner = "intel";
+    owner = "irql-notlessorequal";
     repo = "intel-vaapi-driver";
-    rev = "fd727a4e9cb8b2878a1e93d4dddc8dd1c1a4e0ea";
-    hash = "sha256-OMFdRjzpUKdxB9eK/1OLYLaOC3NHnzZVxmh6yKrbYoE=";
+    tag = finalAttrs.version;
+    hash = "sha256-exQBA42jCmwybE7WIfF83cjmzBdtluDzUtOdqt49HSg=";
   };
 
   # Set the correct install path:
@@ -67,10 +67,11 @@ stdenv.mkDerivation {
 
   enableParallelBuilding = true;
 
-  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
-    homepage = "https://01.org/linuxmedia";
+    homepage = "https://github.com/irql-notlessorequal/intel-vaapi-driver";
+    changelog = "https://github.com/irql-notlessorequal/intel-vaapi-driver/blob/${finalAttrs.src.tag}/NEWS";
     license = lib.licenses.mit;
     description = "VA-API user mode driver for Intel GEN Graphics family";
     longDescription = ''
@@ -89,4 +90,4 @@ stdenv.mkDerivation {
     ];
     maintainers = with lib.maintainers; [ SuperSandro2000 ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/irql-notlessorequal/intel-vaapi-driver/compare/fd727a4e9cb8b2878a1e93d4dddc8dd1c1a4e0ea...2.4.5

Changelog: https://github.com/irql-notlessorequal/intel-vaapi-driver/blob/2.4.5/NEWS


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
