### PR TITLE
tor: 0.4.9.8 -> 0.4.9.9

### DIFF
--- a/pkgs/by-name/to/tor/package.nix
+++ b/pkgs/by-name/to/tor/package.nix
@@ -46,11 +46,11 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tor";
-  version = "0.4.9.8";
+  version = "0.4.9.9";
 
   src = fetchurl {
     url = "https://dist.torproject.org/tor-${finalAttrs.version}.tar.gz";
-    hash = "sha256-rB85Ti3Sqwh30n2Sj9DZ6GZi/jymr9/7n9m28PltBd4=";
+    hash = "sha256-vXW6f9aPYHx4Bvz3AVajAKqSbprWml5WqOZBT1In6DM=";
   };
 
   outputs = [


### PR DESCRIPTION
Release notes: https://gitlab.torproject.org/tpo/core/tor/-/raw/tor-0.4.9.9/ReleaseNotes
Diff: https://gitlab.torproject.org/tpo/core/tor/-/compare/tor-0.4.9.8...tor-0.4.9.9
TROVE: https://gitlab.torproject.org/tpo/core/team/-/wikis/NetworkTeam/TROVE

This release fixes nine medium severity and one low severity security issues.

Fixes: TROVE-2026-013, TROVE-2026-014, TROVE-2026-015, TROVE-2026-016, TROVE-2026-017, TROVE-2026-018, TROVE-2026-019, TROVE-2026-020, TROVE-2026-021, TROVE-2026-022

Tested:
- Running a relay with the NixOS module
- Usage as a SOCKS5 proxy with curl
- Usage as a standalone instance with Tor Browser
- Running a full mini-network in the NixOS test

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
