### PR TITLE
[staging-25.11] avahi: Handle 5 security findings + 1 NixOS mitigation

### DIFF
--- a/nixos/modules/services/networking/avahi-daemon.nix
+++ b/nixos/modules/services/networking/avahi-daemon.nix
@@ -279,6 +279,10 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    warnings = [
+      (lib.mkIf cfg.wideArea "Enabling `services.avahi.wideArea` exposes this system to `CVE-2024-52615`.")
+    ];
+
     users.users.avahi = {
       description = "avahi-daemon privilege separation user";
       home = "/var/empty";

--- a/pkgs/development/libraries/avahi/default.nix
+++ b/pkgs/development/libraries/avahi/default.nix
@@ -150,6 +150,34 @@ stdenv.mkDerivation rec {
         hash = "sha256-rW6jmKg9oH44rRZow0zE4z6lfTlD8wpFUC8DaI/gruA=";
       })
     */
+    # https://github.com/avahi/avahi/pull/806 merged 2025-12-17
+    (fetchpatch {
+      name = "CVE-2025-68276.patch"; # AKA GHSA-mhf3-865v-g5rc
+      url = "https://github.com/avahi/avahi/commit/0c013e2e819be3bda74cecf48b5f64956cf8a760.patch";
+      hash = "sha256-kNOwl2DC2FR7CFvPQBBEYaSUSbFnR/ETH9JNGMwzzLE=";
+    })
+    (fetchpatch {
+      name = "CVE-2025-68468.patch"; # AKA GHSA-cp79-r4x9-vf52
+      url = "https://github.com/avahi/avahi/commit/f66be13d7f31a3ef806d226bf8b67240179d309a.patch";
+      hash = "sha256-HkbKSN2LYqPfVnij1/n6ToN4vKugex3ZPxjHz6pN8eA=";
+    })
+    (fetchpatch {
+      name = "CVE-2025-68471.patch"; # AKA GHSA-56rf-42xr-qmmg
+      url = "https://github.com/avahi/avahi/commit/9c6eb53bf2e290aed84b1f207e3ce35c54cc0aa1.patch";
+      hash = "sha256-V0OiC0UkZXhUnOUcrPZ+Xvph7MJMQ9DEXgVafoshSi4=";
+    })
+    (fetchpatch {
+      name = "CVE-2026-24401.patch"; # AKA GHSA-h4vp-5m8j-f6w3
+      url = "https://github.com/avahi/avahi/commit/78eab31128479f06e30beb8c1cbf99dd921e2524.patch";
+      hash = "sha256-Iq7ghHS8gTJ5OeD6Bemis+wPJzKXb2P44qbtTaAaWZI=";
+    })
+    # https://github.com/avahi/avahi/pull/891 merged 2026-04-01
+    (fetchpatch {
+      name = "CVE-2026-34933.patch"; # AKA GHSA-w65r-6gxh-vhvc
+      url = "https://github.com/avahi/avahi/compare/0ccadca425af151ebb67f276e5cc88e50266a8e6%5E%5E...0ccadca425af151ebb67f276e5cc88e50266a8e6.patch";
+      hash = "sha256-yi40iuQmTAW+nLsOIJhh7kg4vG/lqT/PCaSEBPfF2mw=";
+    })
+
   ];
 
   depsBuildBuild = [

--- a/pkgs/development/libraries/avahi/default.nix
+++ b/pkgs/development/libraries/avahi/default.nix
@@ -140,6 +140,16 @@ stdenv.mkDerivation rec {
       url = "https://github.com/avahi/avahi/commit/366e3798bdbd6b7bf24e59379f4a9a51af575ce9.patch";
       hash = "sha256-9AdhtzrimmcpMmeyiFcjmDfG5nqr/S8cxWTaM1mzCWA=";
     })
+    # https://github.com/avahi/avahi/pull/662 merged 2025-06-19
+    # NOTE: CVE-2024-52615 is mitigated by the default NixOS configuration.
+    # NOTE: CVE-2025-59529 is introduced by 4e2e1ea0908d7e6ad7f38ae04fdcdf2411f8b942.
+    /*
+      (fetchpatch {
+        name = "CVE-2024-52615.patch"; # AKA GHSA-x6vp-f33h-h32g
+        url = "https://github.com/avahi/avahi/commit/4e2e1ea0908d7e6ad7f38ae04fdcdf2411f8b942.patch";
+        hash = "sha256-rW6jmKg9oH44rRZow0zE4z6lfTlD8wpFUC8DaI/gruA=";
+      })
+    */
   ];
 
   depsBuildBuild = [

--- a/pkgs/development/libraries/avahi/default.nix
+++ b/pkgs/development/libraries/avahi/default.nix
@@ -253,5 +253,10 @@ stdenv.mkDerivation rec {
       DNS") and DNS-SD (for "DNS-Based Service Discovery")
       protocols.
     '';
+
+    knownVulnerabilities = [
+      # NOTE: CVE-2024-52615 mitigated by the default NixOS configuration.
+      # "CVE-2024-52615: Avahi Wide-Area DNS Uses Constant Source Port"
+    ];
   };
 }


### PR DESCRIPTION
Manual backport of #508012 to `staging-25.11`.

### Scope reduced from the master PR:
Dropped the `services.avahi.wideArea` default flip and the related description tweak, since changing a default is a backwards-incompatible behavior change unsuitable for a stable release branch (per `CONTRIBUTING.md`). The release-notes entry from `48f7a8d22332` was also skipped (it targeted `rl-2605.section.md`).

The runtime warning (`f715bbf5a4de`) is kept: on 25.11 the vulnerable default remains, so users need a nudge to opt out (`services.avahi.wideArea = false` or upstream's `enable-wide-area=no`). Per `GHSA-x6vp-f33h-h32g`, the impact is limited to systems actively using wide-area DNS.

The package file path differs (`pkgs/development/libraries/avahi/default.nix` on 25.11 vs `pkgs/by-name/av/avahi/package.nix` on master after `117015d37322`); git's rename detection handled this automatically during cherry-pick.

### Question for maintainers:
Is the scope reduction the right call, or would you prefer something different? Specifically:

1. The `wideArea` default flip is a behavior change — keeping the master defaults on 25.11 felt wrong for a stable release. Happy to include it if you disagree.
2. The runtime warning is kept so users in the vulnerable default get a nudge; let me know if you'd rather drop it to keep the backport silent.
3. No release-notes entry was added. If you'd like one in `rl-2511.section.md` as a late addendum, I can add it.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [x] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.
