### PR TITLE
nixos/systemd/initrd: reject /dev/root in fileSystems by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -13,7 +13,6 @@
   - If you use LUKS disk encryption, ensure that `fileSystems."/".device` is set to `"/dev/mapper/<name>"`, where `<name>` matches the name in your `boot.initrd.luks.devices.<name>` definition, to avoid systemd timing out while prompting for a passphrase. If you have a more complex setup, e.g. with LVM on top of LUKS, you may need to add `"x-systemd.device-timeout=infinity"` to `fileSystems."/".options` instead. If you need to disable the timeout before you can boot into the system, pass `systemd.default_device_timeout_sec=infinity` on the kernel command line.
   - The `cryptsetup-askpass` program is not available; use `systemctl default` instead, which will prompt for passphrases as necessary. If you pipe password responses into SSH over stdin, use `ssh -o RequestTTY=force` to ensure `systemctl default` gets a TTY to prompt on.
   - Many kernel parameters have been replaced with native systemd versions; see [](#sec-boot-problems).
-  - `/dev/root` is not available with the systemd stage 1. In the old scripted stage 1, `/dev/root` was a symlink created by the init script from the `root=` kernel command line. With systemd stage 1, this symlink is not provided. If your configuration uses `/dev/root` in `fileSystems`, replace it with a stable device path such as `/dev/disk/by-label/...`, `/dev/disk/by-uuid/...`, or the appropriate `/dev/mapper/...` path.
 
 - The system.nix file has been added as an alternative entry point to configuration.nix (and flake.nix) that allows configuring NixOS without using `nix-channel`.
   This file must evaluate to a NixOS system derivation or an attribute set of such derivations, in which case the attribute to build has to be selected with the `--attr` option of `nixos-rebuild` or `nixos-install`.
@@ -173,6 +172,8 @@
 ## Backward Incompatibilities {#sec-release-26.05-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
+
+- `/dev/root` is not available with systemd stage 1. In the old scripted stage 1, `/dev/root` was a symlink created by the init script from the `root=` kernel command line. With systemd stage 1, this symlink is not provided. If your configuration uses `/dev/root` in `fileSystems`, replace it with a stable device path such as `/dev/disk/by-label/...`, `/dev/disk/by-uuid/...`, or the appropriate `/dev/mapper/...` path, or set `boot.initrd.systemd.allowFileSystemsDevRoot = true` if you know that `/dev/root` is being configured elsewhere.
 
 - [](#opt-services.openssh.settings.AcceptEnv) is now explicitly defined as an option that takes a list of strings, to facilitate option merging. Setting it to a string value is no longer supported.
 

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -309,6 +309,20 @@ in
       '';
     };
 
+    allowFileSystemsDevRoot = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether to allow {option}`fileSystems.*.device` to be set to
+        `/dev/root` when systemd stage 1 is enabled.
+
+        The scripted stage 1 init script creates `/dev/root` from the `root=`
+        kernel command line, but systemd stage 1, which became the default from
+        26.05, does not provide that symlink. Set this to true if you know that
+        `/dev/root` is being configured elsewhere.
+      '';
+    };
+
     emergencyAccess = mkOption {
       type =
         with types;
@@ -477,6 +491,25 @@ in
           assertion =
             cfg.root == "fstab" -> any (fs: fs.mountPoint == "/") (builtins.attrValues config.fileSystems);
           message = "The ‘fileSystems’ option does not specify your root file system.";
+        }
+        {
+          assertion =
+            cfg.allowFileSystemsDevRoot
+            || !any (fs: fs.device == "/dev/root") (builtins.attrValues config.fileSystems);
+          message =
+            let
+              devRootFileSystems = filter (fs: fs.device == "/dev/root") (builtins.attrValues config.fileSystems);
+            in
+            ''
+              systemd stage 1 does not provide the `/dev/root` compatibility symlink used by scripted stage 1.
+
+              The following fileSystems entries set device = "/dev/root":
+              ${concatStringsSep "\n" (map (fs: "- ${fs.mountPoint}") devRootFileSystems)}
+
+              Replace `/dev/root` with a stable device path such as `/dev/disk/by-label/...`, `/dev/disk/by-uuid/...`,
+              or the appropriate `/dev/mapper/...` path, or set `boot.initrd.systemd.allowFileSystemsDevRoot = true` if
+              you know that `/dev/root` is being configured elsewhere.
+            '';
         }
       ]
       ++


### PR DESCRIPTION
Implements an assertion to prevent #526285 footgun during upgrade to 26.05

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
