### PR TITLE
nixos/avahi-daemon: disable the full mDNS NSS module by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -40,6 +40,8 @@
 
 - `security.polkit.enablePkexecWrapper` has been introduced, making the `pkexec` setuid wrapper opt-in.
 
+- When Avahi's mDNS resolver is enabled (`services.avahi.nssmdns4` or `services.avahi.nssmdns6`), only the minimal mDNS resolver is enabled by default to avoid adding a 5 second delay to every failed reverse hostname lookup (e.g., delaying ping by 5 seconds). The "full" mDNS resolver now remains disabled unless `services.avahi.nssmdnsFull` is also enabled. Users who have customized [`/etc/mdns.allow`](https://github.com/avahi/nss-mdns/tree/master#etcmdnsallow) to allow mDNS domains not ending `.local` must enable `services.avahi.nssmdnsFull` to continue to resolve such domains.
+
 - `systemd.user.extraConfig` has been removed in favor of the structured [](#opt-systemd.user.settings.Manager) option. Use `systemd.user.settings.Manager` to set any `systemd-user.conf(5)` option directly. For example, replace `systemd.user.extraConfig = "DefaultTimeoutStartSec=60";` with `systemd.user.settings.Manager.DefaultTimeoutStartSec = 60;`.
 
 - `services.timesyncd.extraConfig` has been removed in favor of the structured [](#opt-services.timesyncd.settings.Time) option. Use `services.timesyncd.settings.Time` to set any `timesyncd.conf(5)` option directly. For example, replace `services.timesyncd.extraConfig = "PollIntervalMaxSec=180";` with `services.timesyncd.settings.Time.PollIntervalMaxSec = 180;`.

--- a/nixos/modules/services/networking/avahi-daemon.nix
+++ b/nixos/modules/services/networking/avahi-daemon.nix
@@ -262,6 +262,28 @@ in
       '';
     };
 
+    nssmdnsFull = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to enable the full mDNS NSS (Name Service Switch) plug-in.
+
+        By default, only the minimal module is enabled. The minimal module
+        will only resolve `.local` domains and only perform reverse hostname
+        lookups for `169.254.0.0/16`. The full module will use mDNS to resolve any
+        domain allowed by [`/etc/mdns.allow`][1] and will perform reverse hostname
+        lookups for any IP address.
+
+        [1]: https://github.com/avahi/nss-mdns/tree/master#etcmdnsallow
+
+        ::: {.note}
+        Enabling this option will introduce a 5 second delay to failed reverse
+        hostname lookups. For example, this will often add a 5 second delay to
+        ping.
+        :::
+      '';
+    };
+
     cacheEntriesMax = lib.mkOption {
       type = lib.types.nullOr lib.types.int;
       default = null;
@@ -285,6 +307,15 @@ in
   config = lib.mkIf cfg.enable {
     warnings = [
       (lib.mkIf cfg.wideArea "Enabling `services.avahi.wideArea` exposes this system to `CVE-2024-52615`.")
+    ];
+
+    assertions = [
+      {
+        assertion = cfg.nssmdnsFull -> (cfg.nssmdns4 || cfg.nssmdns6);
+        message = ''
+          `services.avahi.nssmdnsFull` requires one or both of `services.avahi.nssmdns4` and/or `services.avahi.nssmdns6` to be enabled.
+        '';
+      }
     ];
 
     users.users.avahi = {
@@ -312,7 +343,7 @@ in
       lib.optionals (cfg.nssmdns4 || cfg.nssmdns6) (
         lib.mkMerge [
           (lib.mkBefore [ "${mdns}_minimal [NOTFOUND=return]" ]) # before resolve
-          (lib.mkAfter [ "${mdns}" ]) # after dns
+          (lib.mkAfter (lib.optional cfg.nssmdnsFull "${mdns}")) # after dns
         ]
       );
 


### PR DESCRIPTION
Previously, enabling nssmdns would enable the full mdns module by default, as well as the minimal one. Unfortunately, the full one introduces a 5 second delay whenever it fails to perform a reverse hostname lookup (`gethostbyaddr`).

This patch disables the full mdns NSS module unless the new disabled-by-default `nssmdns_full` option is enabled.

This shouldn't negatively affect the vast majority of users. The only affected users are those who either:

1. Rely on Avahi to resolve IP addresses into hostnames on their local network. E.g., they need `host 192.168.1.20` to return the machine's hostname.
2. Are using mDNS hostnames that don't end in `.local`.

The minimal module is sufficient for, e.g., users who just want to resolve hostnames for local printers and network shares.

fixes #291108

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test