### PR TITLE
virglrenderer: set vulkan-dload to false; fixes venus

### DIFF
--- a/pkgs/by-name/vi/virglrenderer/package.nix
+++ b/pkgs/by-name/vi/virglrenderer/package.nix
@@ -68,6 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
   mesonFlags = [
     (lib.mesonBool "video" vaapiSupport)
     (lib.mesonBool "venus" vulkanSupport)
+    (lib.mesonBool "vulkan-dload" false)
     (lib.mesonOption "drm-renderers" (
       lib.optionalString nativeContextSupport (
         lib.concatStringsSep "," (


### PR DESCRIPTION
Fixes: https://github.com/NixOS/nixpkgs/issues/526801

NOTE: I don't know if this is the "right" fix, or if we want to support dynamic loading of Vulkan on NixOS?

But it fixes it, at least.

NOTE: This seems to link in the loader:
```
cole@zeph:/nix/store/rmhr3pmq4gv9p1nsr3mjpq1cvs9vw7w9-virglrenderer-1.3.0/libexec/ > ldd virgl_render_server
        linux-vdso.so.1 (0x0000736060624000)
        libgbm.so.1 => /nix/store/vqdj7h2d94f494in371j7jwz8akymryi-mesa-libgbm-26.0.3/lib/libgbm.so.1 (0x00007360604a3000)
        libvulkan.so.1 => /nix/store/d6vnmfmcz5b299180issiaad4m96wh8k-vulkan-loader-1.4.341.0/lib/libvulkan.so.1 (0x0000736060412000)
        libc.so.6 => /nix/store/57iz36553175g3178pvxjij8z5rcsd4n-glibc-2.42-61/lib/libc.so.6 (0x0000736060207000)
        libdrm.so.2 => /nix/store/8fbsxg75a01nm3ivxg8kl3zxd7wx34p2-libdrm-2.4.133/lib/libdrm.so.2 (0x00007360601ee000)
        libm.so.6 => /nix/store/57iz36553175g3178pvxjij8z5rcsd4n-glibc-2.42-61/lib/libm.so.6 (0x00007360600f4000)
        libgcc_s.so.1 => /nix/store/chqq8mpmpyfi9kgsngya71akv5xicn03-gcc-15.2.0-lib/lib/libgcc_s.so.1 (0x00007360600c7000)
        libdl.so.2 => /nix/store/57iz36553175g3178pvxjij8z5rcsd4n-glibc-2.42-61/lib/libdl.so.2 (0x00007360600c2000)
        /nix/store/57iz36553175g3178pvxjij8z5rcsd4n-glibc-2.42-61/lib/ld-linux-x86-64.so.2 => /nix/store/57iz36553175g3178pvxjij8z5rcsd4n-glibc-2.42-61/lib64/ld-linux-x86-64.so.2 (0x0000736060626000)
```

Specifically: `libvulkan.so.1 => /nix/store/d6vnmfmcz5b299180issiaad4m96wh8k-vulkan-loader-1.4.341.0/lib/libvulkan.so.1 (0x0000736060412000)`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
