### PR TITLE
logsonic: init at 1.4.0

### DIFF
--- a/pkgs/by-name/lo/logsonic/frontend.nix
+++ b/pkgs/by-name/lo/logsonic/frontend.nix
@@ -1,0 +1,27 @@
+{
+  buildNpmPackage,
+  src,
+  version,
+}:
+
+buildNpmPackage {
+  pname = "logsonic-frontend";
+  inherit version src;
+
+  npmDepsHash = "sha256-mZlv6mREFajOcTuUhVZqYEiDKAhB8gdXMU+LgjH4ILQ=";
+
+  __structuredAttrs = true;
+
+  strictDeps = true;
+
+  sourceRoot = "source/frontend";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r dist $out/
+
+    runHook postInstall
+  '';
+}

--- a/pkgs/by-name/lo/logsonic/package.nix
+++ b/pkgs/by-name/lo/logsonic/package.nix
@@ -1,0 +1,56 @@
+{
+  buildGoModule,
+  callPackage,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "logsonic";
+  version = "1.4.0";
+
+  __structuredAttrs = true;
+
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "logsonic";
+    repo = "logsonic";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2BFmXxEVPdojH2p0dwijFk4vLFBEp8QWvB/WssBHFlk=";
+  };
+
+  frontend = callPackage ./frontend.nix {
+    inherit (finalAttrs) version src;
+  };
+
+  modRoot = "backend";
+
+  vendorHash = "sha256-E5lJcYBHeAWr4V+zyDQSn4N7tpNcvtQyRwft+n+42yY=";
+
+  preBuild = ''
+    mkdir -p pkg/static
+    cp -r ${finalAttrs.frontend}/dist pkg/static/
+  '';
+
+  passthru = {
+    inherit (finalAttrs) frontend;
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--subpackage"
+        "frontend"
+      ];
+    };
+  };
+
+  meta = {
+    description = "Desktop-first log analytics application";
+    homepage = "https://github.com/logsonic/logsonic";
+    changelog = "https://github.com/logsonic/logsonic/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "logsonic";
+    maintainers = with lib.maintainers; [ mschuwalow ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds logsonic at version 1.4.0. The included update script was tested and successfully automatically updates from 1.1.1 to 1.4.0.

Repo: https://github.com/logsonic/logsonic

> LogSonic is a Desktop-First Log Analytics application which runs on Windows, Mac and Linux. It runs fully offline with no external dependencies. It installs as a single self-contained binary that serves a feature-rich User interface in your local browser. The log ingestion wizard supports importing local log files (single or many at once) and automatically recognises well-known log patterns to tokenise the contents. The log search experience is blazing fast, delightful and intuitive.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
