### PR TITLE
krb5: 1.22.1 -> 1.22.2

### DIFF
--- a/pkgs/by-name/kr/krb5/CVE-2026-40355-and-CVE-2026-40356.patch
+++ b/pkgs/by-name/kr/krb5/CVE-2026-40355-and-CVE-2026-40356.patch
@@ -1,0 +1,61 @@
+From acea6182e46fff3d1d64a3172cdff307b07ca441 Mon Sep 17 00:00:00 2001
+From: Greg Hudson <ghudson@mit.edu>
+Date: Wed, 8 Apr 2026 17:57:59 -0400
+Subject: [PATCH] Fix two NegoEx parsing vulnerabilities
+
+In parse_nego_message(), check the result of the second call to
+vector_base() before dereferencing it.  In parse_message(), check for
+a short header_len to prevent an integer underflow when calculating
+the remaining message length.
+
+Reported by Cem Onat Karagun.
+
+CVE-2026-40355:
+
+In MIT krb5 release 1.18 and later, if an application calls
+gss_accept_sec_context() on a system with a NegoEx mechanism
+registered in /etc/gss/mech, an unauthenticated remote attacker can
+trigger a null pointer dereference, causing the process to terminate.
+
+CVE-2026-40356:
+
+In MIT krb5 release 1.18 and later, if an application calls
+gss_accept_sec_context() on a system with a NegoEx mechanism
+registered in /etc/gss/mech, an unauthenticated remote attacker can
+trigger a read overrun of up to 52 bytes, possibly causing the process
+to terminate.  Exfiltration of the bytes read does not appear
+possible.
+
+(cherry picked from commit 2e75f0d9362fb979f5fc92829431a590a130929f)
+
+ticket: 9205
+version_fixed: 1.22.3
+---
+ lib/gssapi/spnego/negoex_util.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/lib/gssapi/spnego/negoex_util.c b/src/lib/gssapi/spnego/negoex_util.c
+index edc5462e844..a65238e5730 100644
+--- a/lib/gssapi/spnego/negoex_util.c
++++ b/lib/gssapi/spnego/negoex_util.c
+@@ -253,6 +253,10 @@ parse_nego_message(OM_uint32 *minor, struct k5input *in,
+     offset = k5_input_get_uint32_le(in);
+     count = k5_input_get_uint16_le(in);
+     p = vector_base(offset, count, EXTENSION_LENGTH, msg_base, msg_len);
++    if (p == NULL) {
++        *minor = ERR_NEGOEX_INVALID_MESSAGE_SIZE;
++        return GSS_S_DEFECTIVE_TOKEN;
++    }
+     for (i = 0; i < count; i++) {
+         extension_type = load_32_le(p + i * EXTENSION_LENGTH);
+         if (extension_type & EXTENSION_FLAG_CRITICAL) {
+@@ -391,7 +395,8 @@ parse_message(OM_uint32 *minor, spnego_gss_ctx_id_t ctx, struct k5input *in,
+     msg_len = k5_input_get_uint32_le(in);
+     conv_id = k5_input_get_bytes(in, GUID_LENGTH);
+ 
+-    if (in->status || msg_len > token_remaining || header_len > msg_len) {
++    if (in->status || msg_len > token_remaining ||
++        header_len < (size_t)(in->ptr - msg_base) || header_len > msg_len) {
+         *minor = ERR_NEGOEX_INVALID_MESSAGE_SIZE;
+         return GSS_S_DEFECTIVE_TOKEN;
+     }

--- a/pkgs/by-name/kr/krb5/package.nix
+++ b/pkgs/by-name/kr/krb5/package.nix
@@ -34,13 +34,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "krb5";
-  version = "1.22.1";
+  version = "1.22.2";
 
   __structuredAttrs = true;
 
   src = fetchurl {
     url = "https://kerberos.org/dist/krb5/${lib.versions.majorMinor finalAttrs.version}/krb5-${finalAttrs.version}.tar.gz";
-    hash = "sha256-GogyuMrZI+u/E5T2fi789B46SfRgKFpm41reyPoAU68=";
+    hash = "sha256-MkP/vI6k1Kwi3cfdKh3FTFeHTEBki2D/lwCXY1VOrxM=";
   };
 
   patches = lib.optionals stdenv.hostPlatform.isFreeBSD [
@@ -170,6 +170,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   meta = {
+    changelog = "https://web.mit.edu/Kerberos/krb5-${lib.versions.majorMinor finalAttrs.version}/";
     description = "MIT Kerberos 5";
     homepage = "http://web.mit.edu/kerberos/";
     license = lib.licenses.mit;

--- a/pkgs/by-name/kr/krb5/package.nix
+++ b/pkgs/by-name/kr/krb5/package.nix
@@ -43,7 +43,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-MkP/vI6k1Kwi3cfdKh3FTFeHTEBki2D/lwCXY1VOrxM=";
   };
 
-  patches = lib.optionals stdenv.hostPlatform.isFreeBSD [
+  patches = [
+    # https://github.com/krb5/krb5/pull/1506
+    ./CVE-2026-40355-and-CVE-2026-40356.patch
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isFreeBSD [
     (fetchpatch {
       name = "fix-missing-ENODATA.patch";
       url = "https://cgit.freebsd.org/ports/plain/security/krb5-122/files/patch-lib_krad_packet.c?id=0501f716c4aff7880fde56e42d641ef504593b7d";


### PR DESCRIPTION
Changelog: https://web.mit.edu/Kerberos/krb5-1.22/
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
