### PR TITLE
pixelfed: 0.12.6 -> 0.12.7; fix build

### DIFF
--- a/nixos/tests/web-apps/pixelfed/default.nix
+++ b/nixos/tests/web-apps/pixelfed/default.nix
@@ -4,6 +4,7 @@
 let
   supportedSystems = [
     "x86_64-linux"
+    "aarch64-linux"
     "i686-linux"
   ];
 in

--- a/nixos/tests/web-apps/pixelfed/standard.nix
+++ b/nixos/tests/web-apps/pixelfed/standard.nix
@@ -4,7 +4,7 @@
 
   nodes = {
     server =
-      { pkgs, ... }:
+      { pkgs, lib, ... }:
       {
         services.pixelfed = {
           enable = true;
@@ -19,16 +19,25 @@
           );
           settings."FORCE_HTTPS_URLS" = false;
         };
+
+        # to prevent getting killed by oom
+        virtualisation.memorySize = 2048;
+        virtualisation.emptyDiskImages = [ 4096 ];
+        swapDevices = [ { device = "/dev/vdb"; } ];
+
+        # allows running nixos test on qemu without kvm, eg. github actions on aarch64-linux
+        systemd.settings.Manager.DefaultDeviceTimeoutSec = lib.mkForce 1800;
+        boot.initrd.kernelModules = [ "virtio_console" ];
       };
   };
 
   testScript = ''
     # Wait for Pixelfed PHP pool
-    server.wait_for_unit("phpfpm-pixelfed.service")
+    server.wait_for_unit("phpfpm-pixelfed.service", timeout=1800)
     # Wait for NGINX
-    server.wait_for_unit("nginx.service")
+    server.wait_for_unit("nginx.service", timeout=1800)
     # Wait for HTTP port
-    server.wait_for_open_port(80)
+    server.wait_for_open_port(80, timeout=1800)
     # Access the homepage.
     server.succeed("curl -H 'Host: pixelfed.local' http://localhost")
     # Create an account

--- a/pkgs/by-name/pi/pixelfed/package.nix
+++ b/pkgs/by-name/pi/pixelfed/package.nix
@@ -7,19 +7,21 @@
   dataDir ? "/var/lib/pixelfed",
   runtimeDir ? "/run/pixelfed",
 }:
-
-php.buildComposerProject2 (finalAttrs: {
+let
+  php' = php.withExtensions ({ enabled, all }: enabled ++ (with all; [ ffi ]));
+in
+php'.buildComposerProject2 (finalAttrs: {
   pname = "pixelfed";
-  version = "0.12.6";
+  version = "0.12.7";
 
   src = fetchFromGitHub {
     owner = "pixelfed";
     repo = "pixelfed";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-FxJWoFNyIGQ6o9g2Q0/jaBMyeH8UnbTgha2goHAurvY=";
+    hash = "sha256-Ay1WJWEPwzeTtScaj+g72lsoWODeHWtjnQT5aa6epbU=";
   };
 
-  vendorHash = "sha256-4x+vvkQUhqxBwm+9Lx7n6Ww6qvfLwqd8IXXCuCSAijE=";
+  vendorHash = "sha256-RNJzvWrKfxr2uBFtc05N1pUfBmvy01JiJHMWgtJ01pA=";
 
   postInstall = ''
     chmod -R u+w $out/share


### PR DESCRIPTION
Autoupdates were [broken](https://nixpkgs-update-logs.nix-community.org/pixelfed/2026-05-30.log) because a dependency requires ffi extension.

Note for the NGI team members reviewing, pixelfed is funded via NGI0 Entrust and Review grants https://github.com/ngi-nix/projects/issues/52.

- closes https://github.com/ngi-nix/projects/issues/1018

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core"
        functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in
      `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and
      other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
