### PR TITLE
libburn: 1.5.6 -> 1.5.8

### DIFF
--- a/pkgs/by-name/li/libburn/package.nix
+++ b/pkgs/by-name/li/libburn/package.nix
@@ -2,31 +2,21 @@
   lib,
   stdenv,
   fetchFromGitea,
-  fetchpatch,
   autoreconfHook,
   pkg-config,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libburn";
-  version = "1.5.6";
+  version = "1.5.8";
 
   src = fetchFromGitea {
     domain = "dev.lovelyhq.com";
     owner = "libburnia";
     repo = "libburn";
     rev = "release-${finalAttrs.version}";
-    hash = "sha256-Xo45X4374FXvlrJ4Q0PahYvuWXO0k3N0ke0mbURYt54=";
+    hash = "sha256-W/9dUUQGB1V76G9YshNjJcrptAuVVcsXiM5ZQ9Q50Xs=";
   };
-
-  patches = [
-    # Fix the build against C23 compilers (like gcc-15):
-    (fetchpatch {
-      name = "c23.patch";
-      url = "https://dev.lovelyhq.com/libburnia/libburn/commit/d537f9dd35282df834a311ead5f113af67d223b3.patch";
-      hash = "sha256-aouU/6AchLhzMzvkVvUnFHWfebYTrkEJ6P3fF5pvE9M=";
-    })
-  ];
 
   nativeBuildInputs = [
     autoreconfHook

--- a/pkgs/by-name/li/libisoburn/package.nix
+++ b/pkgs/by-name/li/libisoburn/package.nix
@@ -17,14 +17,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libisoburn";
-  version = "1.5.6";
+  version = "1.5.8.pl02";
 
   src = fetchFromGitea {
     domain = "dev.lovelyhq.com";
     owner = "libburnia";
     repo = "libisoburn";
     rev = "release-${finalAttrs.version}";
-    hash = "sha256-16qNVlWFVXfvbte5EgP/u193wK2GV/r22hVX0SZWr+0=";
+    hash = "sha256-wYX2foI0YXrhVENz8QqfS9IdXwbsHP7rqYOWzlo8FdM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libisofs/package.nix
+++ b/pkgs/by-name/li/libisofs/package.nix
@@ -11,14 +11,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libisofs";
-  version = "1.5.8";
+  version = "1.5.8.pl02";
 
   src = fetchFromGitea {
     domain = "dev.lovelyhq.com";
     owner = "libburnia";
     repo = "libisofs";
     rev = "release-${finalAttrs.version}";
-    hash = "sha256-tOkJfS/utUPn38rn0u5zAo1N4IIkvpejg89Oxw6Xqv4=";
+    hash = "sha256-uyE+7H5zWcBgtOsoFtiLFroeqA0Kj7tg7s+1IzXNKBo=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Changelog: https://dev.lovelyhq.com/libburnia/libburn/src/tag/release-1.5.8/ChangeLog


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
