### PR TITLE
python3Packages.aiohttp: 3.13.5 -> 3.14.0

### DIFF
--- a/pkgs/development/python-modules/aiohttp/default.nix
+++ b/pkgs/development/python-modules/aiohttp/default.nix
@@ -41,6 +41,7 @@
   pytest-codspeed,
   pytest-cov-stub,
   pytest-mock,
+  pytest-timeout,
   pytest-xdist,
   pytestCheckHook,
   re-assert,
@@ -48,7 +49,7 @@
   zlib-ng,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "aiohttp";
   version = "3.14.0";
   pyproject = true;
@@ -56,7 +57,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "aio-libs";
     repo = "aiohttp";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-RRXdDDkQlL7erfYgs4+gSy6GMlVUG7PrDLTQBYJJ1To=";
   };
 
@@ -99,7 +100,7 @@ buildPythonPackage rec {
     propcache
     yarl
   ]
-  ++ optional-dependencies.speedups;
+  ++ finalAttrs.passthru.optional-dependencies.speedups;
 
   optional-dependencies.speedups = [
     aiodns
@@ -119,6 +120,7 @@ buildPythonPackage rec {
     pytest-codspeed
     pytest-cov-stub
     pytest-mock
+    pytest-timeout
     pytest-xdist
     pytestCheckHook
     re-assert
@@ -167,10 +169,10 @@ buildPythonPackage rec {
   '';
 
   meta = {
-    changelog = "https://docs.aiohttp.org/en/${src.tag}/changes.html";
+    changelog = "https://docs.aiohttp.org/en/${finalAttrs.src.tag}/changes.html";
     description = "Asynchronous HTTP Client/Server for Python and asyncio";
     license = lib.licenses.asl20;
     homepage = "https://github.com/aio-libs/aiohttp";
     maintainers = with lib.maintainers; [ dotlambda ];
   };
-}
+})

--- a/pkgs/development/python-modules/aiohttp/default.nix
+++ b/pkgs/development/python-modules/aiohttp/default.nix
@@ -50,14 +50,14 @@
 
 buildPythonPackage rec {
   pname = "aiohttp";
-  version = "3.13.5";
+  version = "3.14.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "aio-libs";
     repo = "aiohttp";
     tag = "v${version}";
-    hash = "sha256-bAP1/a2COHbe+39KY3GHXSo1Iq9x9xX8O2mLhmFlMlE=";
+    hash = "sha256-RRXdDDkQlL7erfYgs4+gSy6GMlVUG7PrDLTQBYJJ1To=";
   };
 
   postPatch = ''
@@ -68,6 +68,10 @@ buildPythonPackage rec {
     # don't install Cython using pip
     substituteInPlace Makefile \
       --replace-fail "cythonize: .install-cython" "cythonize:"
+
+    # don't depend on coverage for tests
+    substituteInPlace setup.cfg \
+      --replace-fail "ignore:Couldn't import C tracer:coverage.exceptions.CoverageWarning" ""
   '';
 
   build-system = [


### PR DESCRIPTION
Diff: https://github.com/aio-libs/aiohttp/compare/v3.13.5...v3.14.0

Changelog: https://docs.aiohttp.org/en/v3.14.0/changes.html

fixes CVE-2026-47265, CVE-2026-50269

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
