### PR TITLE
nixos/cgit: serve assets below `...nginx.location`

### DIFF
--- a/nixos/modules/services/networking/cgit.nix
+++ b/nixos/modules/services/networking/cgit.nix
@@ -94,7 +94,16 @@ let
       # global settings
       ${lib.concatStringsSep "\n" (
         lib.flatten (
-          lib.mapAttrsToList cgitrcEntry ({ virtual-root = cfg.nginx.location; } // cfg.settings)
+          lib.mapAttrsToList cgitrcEntry (
+            {
+              virtual-root = cfg.nginx.location;
+              css = "${stripLocation cfg}/cgit.css";
+              favicon = "${stripLocation cfg}/favicon.ico";
+              js = "${stripLocation cfg}/cgit.js";
+              logo = "${stripLocation cfg}/cgit.png";
+            }
+            // cfg.settings
+          )
         )
       )}
       ${lib.optionalString (cfg.scanPath != null) (cgitrcLine "scan-path" cfg.scanPath)}
@@ -300,12 +309,27 @@ in
       lib.mapAttrsToList (name: cfg: {
         ${cfg.nginx.virtualHost} = {
           locations =
-            (genAttrs' [ "cgit.css" "cgit.js" "cgit.png" "favicon.ico" "robots.txt" ] (
-              fileName:
-              lib.nameValuePair "= ${stripLocation cfg}/${fileName}" {
-                alias = lib.mkDefault "${cfg.package}/cgit/${fileName}";
-              }
-            ))
+            # alias cgit's default assets
+            lib.mapAttrs'
+              (
+                option: fileName:
+                lib.nameValuePair "= ${stripLocation cfg}/${fileName}" {
+                  alias = lib.mkDefault "${cfg.package}/cgit/${fileName}";
+                }
+              )
+              (
+                lib.filterAttrs (option: fileName: !cfg.settings ? ${option}) {
+                  css = "cgit.css";
+                  favicon = "favicon.ico";
+                  js = "cgit.js";
+                  logo = "cgit.png";
+                }
+              )
+            # robots.txt
+            // lib.optionalAttrs (cfg.nginx.location == "/") {
+              "= /robots.txt".alias = lib.mkDefault "${cfg.package}/cgit/robots.txt";
+            }
+            # Git HTTP backend
             // lib.optionalAttrs cfg.gitHttpBackend.enable {
               "~ ${regexLocation cfg}/.+/(info/refs|git-upload-pack)" = {
                 fastcgiParams = rec {
@@ -319,6 +343,7 @@ in
                 extraConfig = mkFastcgiPass name cfg;
               };
             }
+            # cgit
             // {
               "${stripLocation cfg}/" = {
                 fastcgiParams = {

--- a/nixos/tests/cgit.nix
+++ b/nixos/tests/cgit.nix
@@ -4,6 +4,20 @@ let
     User-agent: *
     Disallow: /
   '';
+
+  cgitJS = pkgs.writeText "cgit.js" ''
+    /* overridden cgit javascript */
+  '';
+
+  cgitRobots = pkgs.cgit.overrideAttrs (
+    { postInstall, ... }:
+    {
+      postInstall = ''
+        ${postInstall}
+        cp ${robotsTxt} "$out/cgit/robots.txt"
+      '';
+    }
+  );
 in
 {
   name = "cgit";
@@ -13,19 +27,11 @@ in
 
   nodes = {
     server =
-      { ... }:
+      { config, ... }:
       {
         services.cgit."localhost" = {
           enable = true;
-          package = pkgs.cgit.overrideAttrs (
-            { postInstall, ... }:
-            {
-              postInstall = ''
-                ${postInstall}
-                cp ${robotsTxt} "$out/cgit/robots.txt"
-              '';
-            }
-          );
+          package = cgitRobots;
           nginx.location = "/(c)git/";
           repos = {
             some-repo = {
@@ -41,8 +47,26 @@ in
           };
           gitHttpBackend.checkExportOkFiles = false;
         };
+        services.cgit."localhost2" = {
+          enable = true;
+          package = pkgs.cgit.overrideAttrs (
+            { postInstall, ... }:
+            {
+              postInstall = ''
+                ${postInstall}
+                cp ${cgitJS} "$out/cgit/cgit.js"
+                truncate -s 0  "$out/cgit/robots.txt"
+              '';
+            }
+          );
+          nginx.virtualHost = "localhost";
+          nginx.location = "/2/";
+          scanPath = pkgs.emptyDirectory;
+          gitHttpBackend.checkExportOkFiles = false;
+        };
         services.cgit."check.localhost" = {
           enable = true;
+          package = cgitRobots;
           scanPath = "/tmp/git";
           settings = {
             strict-export = "git-daemon-export-ok";
@@ -54,9 +78,17 @@ in
           scanPath = "/tmp/git";
           settings = {
             strict-export = "git-daemon-export-ok";
+            logo = "nix-snowflake.png";
           };
           gitHttpBackend.enable = false;
         };
+
+        assertions = [
+          {
+            assertion = !config.services.nginx.virtualHosts."localhost".locations ? "= /cgit.png";
+            message = "The cgit logo at localhost was not overridden properly.";
+          }
+        ];
 
         environment.systemPackages = [ pkgs.git ];
       };
@@ -71,15 +103,20 @@ in
       server.wait_for_unit("network.target")
       server.wait_for_open_port(80)
 
+      # test assets
+      server.succeed("curl -fsS http://localhost/%28c%29git/ | grep -F '/(c)git/cgit.css'")
       server.succeed("curl -fsS http://localhost/%28c%29git/cgit.css")
-
-      server.succeed("curl -fsS http://localhost/%28c%29git/robots.txt | diff -u - ${robotsTxt}")
+      server.fail("curl -fsS http://localhost/cgit.css")
+      server.fail("curl -fsS http://localhost/cgit.js | diff -u - ${cgitJS}")
+      server.fail("curl -fsS http://localhost/%28c%29git/robots.txt")
+      server.fail("curl -fsS http://localhost/2/robots.txt")
+      server.succeed("curl -fsS http://localhost/2/cgit.js | diff -u - ${cgitJS}")
+      server.succeed("curl -fsS http://check.localhost/robots.txt | diff -u - ${robotsTxt}")
+      server.succeed("curl -sS http://no-git-http-backend.localhost/ | grep -F nix-snowflake.png")
 
       server.succeed(
           "curl -fsS http://localhost/%28c%29git/ | grep -F 'some-repo description'"
       )
-
-      server.fail("curl -fsS http://localhost/robots.txt")
 
       server.succeed("sudo -u cgit ${pkgs.writeShellScript "setup-cgit-test-repo" ''
         set -e


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

By default cgit expects assets to be located at `/cgit.css` and so on. This PR configures cgit to look for them at `${cfg.nginx.location}/cgit.css`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
