### PR TITLE
python3Packages.openfga-sdk: Fix tests on Python 3.12

### DIFF
--- a/pkgs/development/python-modules/openfga-sdk/default.nix
+++ b/pkgs/development/python-modules/openfga-sdk/default.nix
@@ -41,15 +41,9 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     mock
+    pytest-asyncio
     pytest-cov-stub
     pytestCheckHook
-  ]
-  ++ lib.optionals (pythonAtLeast "3.13") [ pytest-asyncio ];
-
-  disabledTests = lib.optionals (pythonAtLeast "3.13") [
-    # These fail due to a race condition in the test mocks
-    "test_client_batch_check_multiple_request"
-    "test_client_batch_check_multiple_request_fail"
   ];
 
   meta = {


### PR DESCRIPTION
Added pytest-asyncio as a dependency on all versions, which fixes the tests failing on Python 3.12. Also removed the test skips since they're passing now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
