### PR TITLE
journalist: fix malformed vendorHash (stray trailing "s")

### DIFF
--- a/pkgs/by-name/jo/journalist/package.nix
+++ b/pkgs/by-name/jo/journalist/package.nix
@@ -15,7 +15,7 @@ buildGoModule (finalAttrs: {
     hash = "sha256-3MnkndG2c4P3oprIRbzj26oAutEmAgsUx8mjlaDLrkI=";
   };
 
-  vendorHash = "sha256-2EJ96dhhU7FZxMkHOmQo79WCHu8U1AGgFf47FIuQdek=s";
+  vendorHash = "sha256-2EJ96dhhU7FZxMkHOmQo79WCHu8U1AGgFf47FIuQdek=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
## Description

The `vendorHash` for `journalist` has a stray `s` after the base64 padding:

```nix
vendorHash = "sha256-2EJ96dhhU7FZxMkHOmQo79WCHu8U1AGgFf47FIuQdek=s";
```

This is a typo. Nix's base64 decoder treats `=` as an end-of-data marker and ignores anything after it, so the malformed string still decodes to the correct 32-byte digest and the package builds normally. `builtins.convertHash` confirms both forms map to the same hash, so removing the `s` does not change the computed `drvPath` or any output path. This is a correctness cleanup with no rebuild.

I found this while running nixpkgs through a from-scratch Nix evaluator I'm building. Its base64 hash parser validates more strictly than Nix's and rejected the digest, which is how the stray character surfaced.

### Things done

- Confirmed via `builtins.convertHash` that `sha256-…Qdek=s` and `sha256-…Qdek=` decode to the same digest, so `journalist`'s `drvPath` is unchanged by this PR (no rebuild).
- Single-character change, no other edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)