### PR TITLE
python3Packages.pytouchline-extended: 1.0.2 -> 1.1.2

### DIFF
--- a/pkgs/development/python-modules/pytouchline-extended/default.nix
+++ b/pkgs/development/python-modules/pytouchline-extended/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "pytouchline-extended";
-  version = "1.0.2";
+  version = "1.1.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "brondum";
     repo = "pytouchline";
     tag = version;
-    hash = "sha256-7F8VeLrMgo54LQWG4BzxL6EgvthssAjUO65HSkXd2sk=";
+    hash = "sha256-sIrHvC+IkJWgNksgS5lB4IFP37xggVypMLmGjjLlaVQ=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/pytouchline-extended/default.nix
+++ b/pkgs/development/python-modules/pytouchline-extended/default.nix
@@ -9,7 +9,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pytouchline-extended";
   version = "1.1.2";
   pyproject = true;
@@ -17,13 +17,13 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "brondum";
     repo = "pytouchline";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-sIrHvC+IkJWgNksgS5lB4IFP37xggVypMLmGjjLlaVQ=";
   };
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace-fail '$GITHUB_REF_NAME' '${version}'
+      --replace-fail '$GITHUB_REF_NAME' '${finalAttrs.version}'
   '';
 
   build-system = [ setuptools ];
@@ -41,10 +41,10 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/brondum/pytouchline/releases/tag/${src.tag}";
+    changelog = "https://github.com/brondum/pytouchline/releases/tag/${finalAttrs.src.tag}";
     description = "Roth Touchline interface library";
     homepage = "https://github.com/brondum/pytouchline";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ dotlambda ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/brondum/pytouchline/compare/1.0.2...1.1.2

Changelog: https://github.com/brondum/pytouchline/releases/tag/1.1.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
