### PR TITLE
python3Packages.pims: fix broken tests

### DIFF
--- a/pkgs/development/python-modules/pims/default.nix
+++ b/pkgs/development/python-modules/pims/default.nix
@@ -7,20 +7,23 @@
   numpy,
   pytestCheckHook,
   scikit-image,
+  setuptools,
   slicerator,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pims";
   version = "0.7";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "soft-matter";
     repo = "pims";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-3SBZk11w6eTZFmETMRJaYncxY38CYne1KzoF5oRgzuY=";
   };
+
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [
     slicerator
@@ -40,6 +43,10 @@ buildPythonPackage rec {
     "-Wignore::Warning"
   ];
 
+  enabledTestPaths = [
+    "pims/tests"
+  ];
+
   disabledTests = [
     # NotImplementedError: Do not know how to deal with infinite readers
     "TestVideo_ImageIO"
@@ -54,8 +61,8 @@ buildPythonPackage rec {
   meta = {
     description = "Module to load video and sequential images in various formats";
     homepage = "https://github.com/soft-matter/pims";
-    changelog = "https://github.com/soft-matter/pims/releases/tag/v${version}";
+    changelog = "https://github.com/soft-matter/pims/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/pims/default.nix
+++ b/pkgs/development/python-modules/pims/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   imageio,
+  matplotlib,
   numpy,
   pytestCheckHook,
   scikit-image,
@@ -28,6 +29,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
+    matplotlib
     pytestCheckHook
     scikit-image
   ];
@@ -46,6 +48,7 @@ buildPythonPackage rec {
   disabledTestPaths = [
     # AssertionError: Tuples differ: (377, 505, 4) != (384, 512, 4)
     "pims/tests/test_display.py"
+    "pims/tests/test_imseq.py"
   ];
 
   meta = {


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/330630459

1. Tests: Add missing `matplotlib` dependency, disabled rendering tests (fail due to small rendering differences)
2. Modernize build

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
