### PR TITLE
python3Packages.cuda-tile: init at 1.4.0

### DIFF
--- a/pkgs/development/python-modules/cuda-tile/default.nix
+++ b/pkgs/development/python-modules/cuda-tile/default.nix
@@ -1,0 +1,127 @@
+{
+  lib,
+  config,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  typing-extensions,
+
+  # nativeBuildInputs
+  cmake,
+  cudaPackages,
+
+  # buildInputs
+  dlpack,
+
+  # tests
+  pytestCheckHook,
+  torch,
+
+  # passthru
+  cuda-tile,
+}:
+let
+  # https://github.com/NVIDIA/cutile-python/blob/v1.4.0/cmake/FetchXLAHeaders.cmake#L5-L6
+  xla = fetchFromGitHub {
+    owner = "openxla";
+    repo = "xla";
+    rev = "b6f37ab7767f428fd6f993de5e211643d47d4deb";
+    hash = "sha256-U4e3k4nm9gB1x5hahXwycWSryBQuxIPmOzVf6kuahY0=";
+  };
+in
+buildPythonPackage.override { stdenv = cudaPackages.backendStdenv; } (finalAttrs: {
+  pname = "cuda-tile";
+  version = "1.4.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = "cutile-python";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-R5V69nJLQ3/1995ezH1/WuueA6cm1vhKZdOECqbwPbU=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools==80.10.2" "setuptools"
+  ''
+  # Otherwise fails to find libc
+  # xla_ffi.cpp:(.text+0x308): undefined reference to `__stack_chk_fail'
+  + ''
+    substituteInPlace cext/CMakeLists.txt \
+      --replace-fail \
+        "target_link_libraries(_cext_shared _cext_static \''${Python_LIBRARIES} \''${asan_library})" \
+        "target_link_libraries(_cext_shared _cext_static \''${Python_LIBRARIES} \''${asan_library} c)"
+  ''
+  # Get rid of the vendored broken logic for finding the CUDA toolkit
+  + ''
+    rm cmake/FindCUDAToolkit.cmake
+  ''
+  # Manually inject the library version
+  + ''
+    echo "${finalAttrs.version}" >src/cuda/tile/VERSION
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  env = {
+    CUDA_TILE_CMAKE_DLPACK_PATH = dlpack;
+    CUDA_TILE_CMAKE_XLA_PATH = xla;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    cudaPackages.cuda_nvcc
+  ];
+  dontUseCmakeConfigure = true;
+
+  buildInputs = [
+    cudaPackages.cuda_cudart # cuda.h
+  ];
+
+  dependencies = [
+    typing-extensions
+  ];
+
+  optional-dependencies = {
+    tileiras = [
+      # unpackaged as it doesn't make sense to have it in nixpkgs
+      # cuda-toolkit
+    ];
+  };
+
+  pythonImportsCheck = [ "cuda.tile" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    torch
+  ];
+
+  # Tests require access to a physical GPU
+  doCheck = false;
+
+  passthru.gpuCheck = cuda-tile.overridePythonAttrs {
+    requiredSystemFeatures = [ "cuda" ];
+    doCheck = true;
+  };
+
+  meta = {
+    description = "Programming model for writing parallel kernels for NVIDIA GPUs";
+    homepage = "https://docs.nvidia.com/cuda/cutile-python/";
+    downloadPage = "https://github.com/NVIDIA/cutile-python";
+    changelog = "https://docs.nvidia.com/cuda/cutile-python/generated/release_notes.html";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+      prince213
+    ];
+    broken = !config.cudaSupport;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3438,6 +3438,8 @@ self: super: with self; {
 
   cuda-pathfinder = callPackage ../development/python-modules/cuda-pathfinder { };
 
+  cuda-tile = callPackage ../development/python-modules/cuda-tile { };
+
   cupy = callPackage ../development/python-modules/cupy { };
 
   curated-tokenizers = callPackage ../development/python-modules/curated-tokenizers { };


### PR DESCRIPTION
## Things done

Add [cutile-python](https://docs.nvidia.com/cuda/cutile-python), a parallel programming model for NVIDIA GPUs and a Python-based DSL.

cc @NixOS/cuda-maintainers 

Continuation from #526703.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
