### PR TITLE
john: fix yescrypt cracking

### DIFF
--- a/pkgs/by-name/jo/john/package.nix
+++ b/pkgs/by-name/jo/john/package.nix
@@ -18,6 +18,7 @@
   withOpenCL ? true,
   opencl-headers,
   ocl-icd,
+  libxcrypt-legacy,
   # include non-free ClamAV unrar code
   enableUnfree ? false,
   replaceVars,
@@ -65,6 +66,8 @@ stdenv.mkDerivation {
   configureFlags = [
     "--disable-native-tests"
     "--with-systemwide"
+    "LDFLAGS=-L${libxcrypt-legacy}/lib"
+    "CPPFLAGS=-I${libxcrypt-legacy}/include"
   ]
   ++ lib.optionals (!enableUnfree) [ "--without-unrar" ];
 
@@ -77,6 +80,7 @@ stdenv.mkDerivation {
     zlib
     libpcap
     re2
+    libxcrypt-legacy
   ]
   ++ lib.optionals withOpenCL [
     opencl-headers


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This fixes https://github.com/NixOS/nixpkgs/issues/384837

`libxcrypt` as pulled in by the environment has no support for old, bad hashes, but `john` tries some (DES via `crypt_r`), which fails. 

`libxcrypt-legacy` has support.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
