### PR TITLE
nixos/test-driver: rework timeout for wait_for_console_text

### DIFF
--- a/nixos/lib/test-driver/src/test_driver/machine/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/machine/__init__.py
@@ -1164,24 +1164,25 @@ class QemuMachine(BaseMachine):
         # to match multiline regexes.
         console = io.StringIO()
 
-        def console_matches(_last_try: bool) -> bool:
+        def console_matches(_last_try: bool, block: bool = False) -> bool:
             nonlocal console
             try:
-                # This will return as soon as possible and
-                # sleep 1 second.
-                console.write(self.last_lines.get(block=False))
+                while True:
+                    # This will return as soon as possible and
+                    # sleep 1 second.
+                    console.write(self.last_lines.get(block=block))
+                    console.seek(0)
+                    matches = re.search(regex, console.read())
+                    if matches is not None:
+                        return True
             except queue.Empty:
-                pass
-            console.seek(0)
-            matches = re.search(regex, console.read())
-            return matches is not None
+                return False
 
         with self.nested(f"waiting for {regex} to appear on console"):
             if timeout is not None:
                 retry(console_matches, timeout)
             else:
-                while not console_matches(False):
-                    pass
+                console_matches(False, block=True)
 
     def get_console_log(self) -> str:
         """

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -153,6 +153,7 @@ in
     console-log = runTest ./nixos-test-driver/console-log.nix;
     containers = runTest ./nixos-test-driver/containers.nix;
     skip-typecheck = runTest ./nixos-test-driver/skip-typecheck.nix;
+    console-timeout = runTest ./nixos-test-driver/console-timeout.nix;
     options-doc-regression = import ./nixos-test-driver/options-doc-regression.nix { inherit pkgs; };
     driver-timeout =
       pkgs.runCommand "ensure-timeout-induced-failure"

--- a/nixos/tests/nixos-test-driver/console-timeout.nix
+++ b/nixos/tests/nixos-test-driver/console-timeout.nix
@@ -1,0 +1,26 @@
+{ pkgs, lib, ... }:
+{
+  name = "console-timeout";
+
+  nodes.machine = {
+    systemd.services.generate-output.script = ''
+      echo "match that"
+      sleep 1
+
+      for i in $(seq 15); do
+        echo "line $i"
+      done
+
+      echo "match this"
+    '';
+  };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+
+    machine.systemctl("start generate-output")
+    machine.wait_for_console_text("match that")
+    machine.wait_for_console_text("match this", timeout=10)
+  '';
+}


### PR DESCRIPTION
Before this commit, `wait_for_console_text` would read one line every 900ms before trying again to read the next line.

This commit fixes that behavior by greedily reading all buffer that is available for match trying to find a match rather than reading one per retry iteration.

In effect this moves the loop inside the `console_matches` helper and makes the behavior of `wait_for_console_text` with timeout behave the same way as with timeout.

This also provides a test that showcases the problem.

This is a fixup of https://github.com/NixOS/nixpkgs/pull/234513

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
