### PR TITLE
emacsPackages.mozc: fix mozc_emacs_helper path

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/melpa-packages.nix
@@ -773,7 +773,7 @@ let
           mozc = super.mozc.overrideAttrs (attrs: {
             postPatch = attrs.postPatch or "" + ''
               substituteInPlace src/unix/emacs/mozc.el \
-                --replace '"mozc_emacs_helper"' '"${pkgs.ibus-engines.mozc}/lib/mozc/mozc_emacs_helper"'
+                --replace '"mozc_emacs_helper"' '"${pkgs.mozc}/bin/mozc_emacs_helper"'
             '';
           });
 


### PR DESCRIPTION
The substitution in melpa-packages.nix rewrote `"mozc_emacs_helper"` in
`mozc.el` to `${pkgs.ibus-engines.mozc}/lib/mozc/mozc_emacs_helper`,
but that path no longer exists.

Since the Bazel-based rewrite and the optional ibus split in #483843,
`mozc_emacs_helper` is installed at `$out/bin/` of the base `mozc` package,
while `$out/lib/mozc/` only contains `mozc_server`,
`mozc_renderer`, and `mozc_tool`.
As a result, `mozc.el` invoked a non-existent helper and `mozc-mode` failed to start with

> 変換エンジンプログラムの起動に失敗しました。

Switch the reference to `pkgs.mozc` so it points at the actual binary
location and avoids pulling in the IBus front-end for Emacs users.

Assisted-by: Claude Code (claude-opus-4-7)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Verification details:

- `nix-build -A emacs.pkgs.mozc` succeeds on `x86_64-linux`, and the resulting `mozc.el` has
  `mozc-helper-program-name` set to an existing executable under
  `/nix/store/...-mozc-.../bin/mozc_emacs_helper`.
- `nixpkgs-review pr 526967 --no-shell -p emacs.pkgs.mozc` reports `emacs.pkgs.mozc` as a rebuild
  on `x86_64-linux` and it builds successfully. Without `-p` nixpkgs-review's default scan does
  not include packages under `emacs.pkgs.*`, so the explicit attribute is needed for this PR.
- Running the resulting helper (`mozc_emacs_helper`) directly returns a valid Mozc response
  `((mozc-emacs-helper . t)(version . "...")(config . ...))`, confirming the binary itself is
  functional.
- `aarch64-linux` cross-compilation of `pkgs.mozc` (and therefore `emacs.pkgs.mozc`) fails on
  master as well with `makeWrapper/makeShellWrapper must be in nativeBuildInputs`; this is a
  pre-existing upstream issue in the `mozc` derivation, not a regression introduced by this PR.
- No NixOS test or `passthru.tests` exists for the Emacs Mozc helper, so the test boxes are left
  unchecked.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
