### PR TITLE
nmap: fix static build

### DIFF
--- a/pkgs/by-name/li/liblinear/package.nix
+++ b/pkgs/by-name/li/liblinear/package.nix
@@ -59,5 +59,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.bsd3;
     maintainers = [ ];
     platforms = lib.platforms.unix;
+    badPlatforms = [ lib.systems.inspect.platformPatterns.isStatic ];
   };
 })

--- a/pkgs/by-name/nm/nmap/package.nix
+++ b/pkgs/by-name/nm/nmap/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  pkgsStatic,
   fetchurl,
   versionCheckHook,
   libpcap,
@@ -53,11 +54,15 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     pcre2
-    liblinear
     libssh2
     libpcap
     openssl
     zlib
+  ]
+  ++ lib.filter (lib.meta.availableOn stdenv.hostPlatform) [
+    # If we omit liblinear, nmap will build it from vendored sources, which they patch for broader
+    # platform support v.s. upstream liblinear (e.g. it supports static linking).
+    liblinear
   ];
 
   enableParallelBuilding = true;
@@ -69,6 +74,10 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   versionCheckProgramArg = "-V";
   doInstallCheck = true;
+
+  passthru.tests = {
+    static = pkgsStatic.nmap;
+  };
 
   meta = {
     description = "Free and open source utility for network discovery and security auditing";


### PR DESCRIPTION
fixes `nix-build -A pkgsStatic.nmap`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
