### PR TITLE
libcmis: 0.6.2 -> 0.6.3

### DIFF
--- a/pkgs/by-name/li/libcmis/package.nix
+++ b/pkgs/by-name/li/libcmis/package.nix
@@ -2,39 +2,37 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   boost,
   libxml2,
   pkg-config,
-  docbook2x,
+  docbook_xml_dtd_43,
   curl,
   autoreconfHook,
   cppunit,
+  xmlto,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libcmis";
-  version = "0.6.2";
+  version = "0.6.3";
 
   src = fetchFromGitHub {
     owner = "tdf";
     repo = "libcmis";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-HXiyQKjOlQXWABY10XrOiYxPqfpmUJC3a6xD98LIHDw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-chLY9tbhVPIiP+twsNM2SM7Bqyau/evQGKHfjlac6ys=";
   };
 
-  patches = [
-    # Backport to fix build with boost 1.86
-    (fetchpatch {
-      url = "https://github.com/tdf/libcmis/commit/3659d32999ff7593662dcf5136bcb7ac15c13f61.patch";
-      hash = "sha256-EXmQcXCHaVnF/dwU3Z4WLtaiHjYHeeonlKdyK27UkiY=";
-    })
-  ];
+  postPatch = ''
+    substituteInPlace doc/cmis-client.xml.in \
+      --replace-fail "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd" \
+                     "${docbook_xml_dtd_43}/xml/dtd/docbook/docbookx.dtd"
+  '';
 
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
-    docbook2x
+    xmlto
   ];
   buildInputs = [
     boost
@@ -45,7 +43,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   configureFlags = [
     "--disable-werror"
-    "DOCBOOK2MAN=${docbook2x}/bin/docbook2man"
     "--with-boost=${boost.dev}"
   ];
 
@@ -54,6 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelBuilding = true;
 
   meta = {
+    changelog = "https://github.com/tdf/libcmis/blob/${finalAttrs.src.tag}/NEWS";
     description = "C++ client library for the CMIS interface";
     homepage = "https://github.com/tdf/libcmis";
     license = lib.licenses.gpl2;


### PR DESCRIPTION
Diff: https://github.com/tdf/libcmis/compare/v0.6.2...v0.6.3

Changelog: https://github.com/tdf/libcmis/blob/v0.6.3/NEWS
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
