### PR TITLE
home-assistant-custom-components.goodwe: init at 0.9.9.30

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19514,6 +19514,12 @@
     githubId = 1488603;
     name = "François Espinet";
   };
+  netpleb = {
+    email = "netpleb@proton.me";
+    github = "netpleb";
+    githubId = 130105838;
+    name = "netpleb";
+  };
   netthier = {
     email = "netthier@proton.me";
     name = "nett_hier";

--- a/pkgs/servers/home-assistant/custom-components/goodwe/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/goodwe/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildHomeAssistantComponent,
+  goodwe,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "mletenay";
+  domain = "goodwe";
+  version = "0.9.9.30";
+
+  src = fetchFromGitHub {
+    owner = "mletenay";
+    repo = "home-assistant-goodwe-inverter";
+    tag = "v${version}";
+    hash = "sha256-/R0HBR1369gjjdCInbFzUaBEclw4PJDmgRGHtlUNvCA=";
+  };
+
+  dependencies = [
+    goodwe
+  ];
+
+  ignoreVersionRequirement = [ "goodwe" ];
+
+  meta = {
+    changelog = "https://github.com/mletenay/home-assistant-goodwe-inverter/releases/tag/${src.tag}";
+    description = "Experimental version of Home Assistant integration for Goodwe solar inverters";
+    homepage = "https://github.com/mletenay/home-assistant-goodwe-inverter";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ netpleb ];
+  };
+}


### PR DESCRIPTION
Custom component for https://github.com/mletenay/home-assistant-goodwe-inverter which provides some more experimental features that may not yet be available in the the core goodwe integration.

@dotlambda

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
