### PR TITLE
komodo: fix core build by raising recursion_limit

### DIFF
--- a/pkgs/by-name/ko/komodo/core-recursion-limit.patch
+++ b/pkgs/by-name/ko/komodo/core-recursion-limit.patch
@@ -1,0 +1,7 @@
+--- a/bin/core/src/main.rs
++++ b/bin/core/src/main.rs
+@@ -1,2 +1,4 @@
++#![recursion_limit = "512"]
++
+ #[macro_use]
+ extern crate tracing;

--- a/pkgs/by-name/ko/komodo/package.nix
+++ b/pkgs/by-name/ko/komodo/package.nix
@@ -20,6 +20,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # Temporary fix to get build to pass until https://github.com/moghtech/komodo/pull/1122
   patches = [
     ./rustc-1_9_2-fixes.patch
+    # rustc 1.95 computes the listener router's async block layout deeply enough
+    # that komodo_core overflows the default recursion_limit (128). Raise it on
+    # the `core` crate so the binary compiles.
+    ./core-recursion-limit.patch
   ];
 
   cargoHash = "sha256-jf/Jp28g3inGn5jQp3cACdhl//tbXTMc1vP1K3g/CyQ=";


### PR DESCRIPTION
This PR fixes komodo, which [has been broken since february](https://hydra.nixos.org/job/nixos/unstable/nixpkgs.komodo.x86_64-linux), including on [26.05](https://hydra.nixos.org/build/329806676).

rustc 1.95 computes the listener router's async block layout deeply enough that komodo_core overflows the default recursion_limit (128):
```
  error: queries overflow the depth limit!
    = note: query depth increased by 130 when computing layout of
      `{async block@bin/core/src/listener/router.rs}`
```

Here we add a patch raising recursion_limit to 512 on the core crate so the binary compiles again. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
