### PR TITLE
vmlinux-to-elf: 0-unstable-2024-07-20 -> 1.3.6

### DIFF
--- a/pkgs/by-name/vm/vmlinux-to-elf/package.nix
+++ b/pkgs/by-name/vm/vmlinux-to-elf/package.nix
@@ -1,30 +1,68 @@
 {
-  lib,
   fetchFromGitHub,
+  gobject-introspection,
+  gtk4,
+  lib,
+  libadwaita,
   python3Packages,
+  withGui ? false,
+  wrapGAppsHook4,
 }:
-python3Packages.buildPythonApplication {
+python3Packages.buildPythonApplication (finalAttrs: rec {
   pname = "vmlinux-to-elf";
-  version = "0-unstable-2024-07-20";
+  version = "1.3.6";
+
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "marin-m";
     repo = "vmlinux-to-elf";
-    rev = "da14e789596d493f305688e221e9e34ebf63cbb8";
-    hash = "sha256-GVoUIeJeLWCEFzrwiLX2h627ygQ7lX1qMp3hHT5O8O0=";
+    rev = version;
+    hash = "sha256-6sA2cI9SGd77pLr+0g09ffqnOgbkdd+651ES+c24upw=";
   };
 
   build-system = with python3Packages; [
-    setuptools
+    setuptools-scm
   ];
 
-  dependencies = with python3Packages; [
-    setuptools
-    python-lzo
-    zstandard
-    lz4
+  nativeBuildInputs =
+    (with python3Packages; [
+      pythonRelaxDepsHook
+    ])
+    ++ lib.optionals withGui [
+      wrapGAppsHook4
+      gobject-introspection
+    ];
+
+  buildInputs = lib.optionals withGui [
+    gtk4
+    libadwaita
   ];
+
+  __structuredAttrs = true;
+
+  pythonRelaxDeps = [ "pygobject" ];
+
+  dependencies =
+    with python3Packages;
+    [
+      peewee_4
+      zstandard
+      lz4
+      minilzo
+    ]
+    ++ lib.optionals withGui optional-dependencies.gui;
+
+  optional-dependencies.gui = with python3Packages; [
+    pygobject3
+  ];
+
+  dontWrapGApps = true;
+  makeWrapperArgs = [ "\${gappsWrapperArgs[@]}" ];
+
+  postInstall = lib.optionalString (!withGui) ''
+    rm -f $out/bin/vmlinux-to-elf-gui
+  '';
 
   meta = {
     homepage = "https://github.com/marin-m/vmlinux-to-elf";
@@ -34,4 +72,4 @@ python3Packages.buildPythonApplication {
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.fidgetingbits ];
   };
-}
+})

--- a/pkgs/development/python-modules/minilzo/default.nix
+++ b/pkgs/development/python-modules/minilzo/default.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+}:
+buildPythonPackage rec {
+  pname = "minilzo";
+  version = "1.2";
+
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-TNzA3D6FWKKdim/tXGahrjyAFOEtCidVSJDEJI92sUE=";
+  };
+
+  build-system = [ setuptools ];
+
+  meta = {
+    description = "Library to deal with lzo files compressed with lzop";
+    license = lib.licenses.gpl2;
+    maintainers = [ lib.maintainers.fidgetingbits ];
+  };
+}

--- a/pkgs/development/python-modules/peewee/4.nix
+++ b/pkgs/development/python-modules/peewee/4.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "peewee";
-  version = "3.19.0";
+  version = "4.0.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "coleifer";
     repo = "peewee";
     tag = version;
-    hash = "sha256-EO8gS5fMZ1GgJV2YMjy15XQGZa72fZF7dgG7RZUE9dA=";
+    hash = "sha256-8roI2Hgbc2idLkt8wcLR+DQ+vQfr0ibKHF8srEySg4o=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11317,6 +11317,8 @@ with pkgs;
       }
     );
 
+  vmlinux-to-elf-gui = vmlinux-to-elf.override { withGui = true; };
+
   py-wacz = with python3Packages; toPythonApplication wacz;
 
   wibo = pkgsi686Linux.callPackage ../applications/emulators/wibo { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10064,6 +10064,8 @@ self: super: with self; {
 
   minikerberos = callPackage ../development/python-modules/minikerberos { };
 
+  minilzo = callPackage ../development/python-modules/minilzo { };
+
   minimal-snowplow-tracker = callPackage ../development/python-modules/minimal-snowplow-tracker { };
 
   minimock = callPackage ../development/python-modules/minimock { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12530,6 +12530,8 @@ self: super: with self; {
 
   peewee-migrate = callPackage ../development/python-modules/peewee-migrate { };
 
+  peewee_4 = callPackage ../development/python-modules/peewee/4.nix { };
+
   pefile = callPackage ../development/python-modules/pefile { };
 
   peft = callPackage ../development/python-modules/peft { };


### PR DESCRIPTION
This bumps vmlinux-to-elf to 1.3.6 and also adds support for building the optional gui app.

vmlinux-to-elf relies on a new python module minilzo that I've added. It also has a hard dependency on peewee 4.x, which is not backwards compatible with 3.x and breaks some dependencies, so I've added a peewee4 package for now.

I'm not sure why minilzo on python313 is failing according to nixpkgs-review? Seems fine locally.

```bash
❯ nix-build -A python313Packages.minilzo
/nix/store/kqzlzh15y6gjgjw3d3scdqxgkqqc33ln-python3.13-minilzo-1.2
❯ ls /nix/store/kqzlzh15y6gjgjw3d3scdqxgkqqc33ln-python3.13-minilzo-1.2/lib/python3.13/site-packages
__pycache__                               minilzo-1.2.dist-info
_minilzo.cpython-313-x86_64-linux-gnu.so  
minilzo.py
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
