### PR TITLE
libconfig: 1.8 -> 1.8.2

### DIFF
--- a/pkgs/by-name/li/libconfig/package.nix
+++ b/pkgs/by-name/li/libconfig/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  fetchpatch,
   # This also disables building tests.
   # on static windows cross-compile they fail to build
   doCheck ? with stdenv.hostPlatform; !(isWindows && isStatic),
@@ -10,23 +9,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libconfig";
-  version = "1.8";
+  version = "1.8.2";
 
   src = fetchurl {
     url = "https://hyperrealm.github.io/libconfig/dist/libconfig-${finalAttrs.version}.tar.gz";
-    hash = "sha256-BR4V3Q6QfESQXzF5M/VIcxTypW6MZybIMEzpkIhIUKo=";
+    hash = "sha256-5Z/7kC3Vcx1dTk+4HTuYlpdhX+q3Lf18MGGBZ7kaQu4=";
   };
-
-  patches = [
-    # Fix tests on i686-linux:
-    #   https://github.com/hyperrealm/libconfig/pull/260
-    # TODO: remove with a next release
-    (fetchpatch {
-      name = "32-bit-tests.patch";
-      url = "https://github.com/hyperrealm/libconfig/commit/b90c45a18110fcca415d00a98ff79c908c42544b.patch";
-      hash = "sha256-8CihXbpKx0Rn0CFxyP6+f6m8vUYehCl/1EtTo98VpfM=";
-    })
-  ];
 
   inherit doCheck;
 
@@ -38,6 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     homepage = "https://hyperrealm.github.io/libconfig/";
+    changelog = "https://github.com/hyperrealm/libconfig/blob/v${finalAttrs.version}/ChangeLog";
     description = "C/C++ library for processing configuration files";
     license = lib.licenses.lgpl3;
     maintainers = with lib.maintainers; [ stv0g ];


### PR DESCRIPTION
Changelog: https://github.com/hyperrealm/libconfig/blob/v1.8.2/ChangeLog


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
