### PR TITLE
vscode: append commandLineArgs after user args

### DIFF
--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -373,7 +373,7 @@ stdenv.mkDerivation (
           )
         }
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true --wayland-text-input-version=3}}"
-        --add-flags ${lib.escapeShellArg commandLineArgs}
+        --append-flags ${lib.escapeShellArg commandLineArgs}
       )
     '';
 


### PR DESCRIPTION
This changes the VS Code wrapper to append user-configured commandLineArgs after arguments passed at invocation time.

make-wrapper's --add-flags prepends arguments before "", so commandLineArgs currently appear before paths such as `code .`. With Electron/VS Code flags in commandLineArgs, this can cause VS Code to open an empty window instead of the requested folder.

Using --append-flags preserves user-provided paths first while still passing commandLineArgs to VS Code.

Tested:
- nix fmt pkgs/applications/editors/vscode/generic.nix
- NIXPKGS_ALLOW_UNFREE=1 nix build .#vscode --impure --no-link --print-out-paths
- NIXPKGS_ALLOW_UNFREE=1 nix build --impure --no-link --print-out-paths --expr '(import ./. { config.allowUnfree = true; }).vscode.override { commandLineArgs = [ "--enable-zero-copy" ]; }'