### PR TITLE
qemu-3dfx: init at 9.2.4-unstable-2026-04-30

### DIFF
--- a/pkgs/by-name/qe/qemu-3dfx/guest-wrappers/djgpp.nix
+++ b/pkgs/by-name/qe/qemu-3dfx/guest-wrappers/djgpp.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  stdenv,
+  djgpp,
+  gnumake,
+  which,
+  qemu-3dfx-src,
+  shortRev,
+}:
+
+stdenv.mkDerivation {
+  pname = "qemu-3dfx-guest-wrappers-djgpp";
+  version = "unstable-${shortRev}";
+
+  src = qemu-3dfx-src;
+
+  # `which` is required by dxe/Makefile's $(shell which $(CC) | sed ...)
+  # auto-derivation of DXE_LD_LIBRARY_PATH.
+  nativeBuildInputs = [
+    gnumake
+    djgpp
+    which
+  ];
+
+  dontConfigure = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    cp -r wrappers wrappers-build
+    chmod -R u+w wrappers-build
+
+    substituteInPlace wrappers-build/3dfx/dxe/Makefile \
+      --replace-fail 'git rev-parse --short HEAD' 'echo ${shortRev}'
+
+    cd wrappers-build/3dfx
+    mkdir build
+
+    # nixpkgs ships djgpp as the i586 cross-toolchain; override DXE_LD_LIBRARY_PATH
+    # explicitly because the Makefile's `which $(CC) | sed ...` derivation
+    # can produce a wrong path inside the nix-store layout.
+    make -C dxe OUTDIR=build X86=i586 \
+      DXE_LD_LIBRARY_PATH=${djgpp}/i586-pc-msdosdjgpp/lib
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 build/glide2x.dxe $out/glide2x.dxe
+    install -Dm644 build/glide3x.dxe $out/glide3x.dxe
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "kjliew/qemu-3dfx DOS DJGPP guest wrappers (DXE files)";
+    homepage = "https://github.com/kjliew/qemu-3dfx";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ io12 ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/qe/qemu-3dfx/guest-wrappers/iso.nix
+++ b/pkgs/by-name/qe/qemu-3dfx/guest-wrappers/iso.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  runCommand,
+  cdrkit,
+  dos2unix,
+  guest-wrappers-windows,
+  guest-wrappers-djgpp,
+  guest-wrappers-watcom,
+}:
+
+runCommand "qemu-3dfx-guest-wrappers-iso"
+  {
+    nativeBuildInputs = [ cdrkit ];
+
+    meta = {
+      description = "ISO containing kjliew/qemu-3dfx guest wrappers and an INSTALL.BAT for Windows guests";
+      homepage = "https://github.com/kjliew/qemu-3dfx";
+      license = lib.licenses.gpl2Plus;
+      maintainers = with lib.maintainers; [ io12 ];
+      platforms = lib.platforms.linux;
+    };
+  }
+  ''
+    mkdir -p root/{9X,NT,DOS,OPENGL32}
+
+    for f in fxmemmap.vxd glide.dll glide2x.dll glide3x.dll; do
+      install -m644 ${guest-wrappers-windows}/$f root/9X/"''${f^^}"
+    done
+    install -m644 ${guest-wrappers-watcom}/glide2x.ovl root/9X/GLIDE2X.OVL
+
+    for f in fxptl.sys instdrv.exe glide.dll glide2x.dll glide3x.dll; do
+      install -m644 ${guest-wrappers-windows}/$f root/NT/"''${f^^}"
+    done
+
+    install -m644 ${guest-wrappers-djgpp}/glide2x.dxe  root/DOS/GLIDE2X.DXE
+    install -m644 ${guest-wrappers-djgpp}/glide3x.dxe  root/DOS/GLIDE3X.DXE
+    install -m644 ${guest-wrappers-watcom}/glide2x.ovl root/DOS/GLIDE2X.OVL
+
+    install -m644 ${guest-wrappers-windows}/opengl32.dll root/OPENGL32/OPENGL32.DLL
+    cat > root/OPENGL32/README.TXT <<'EOF'
+    Copy OPENGL32.DLL into the installation folder of each game that
+    needs OpenGL. Do NOT copy it to %WINDIR%\SYSTEM (or system32) -
+    that would override the OS implementation system-wide.
+
+    If the game already has its own OPENGL32.DLL, back it up first
+    (rename to OPENGL32.DLL.BAK).
+    EOF
+    ${dos2unix}/bin/unix2dos root/OPENGL32/README.TXT
+
+    install -m644 ${../installer/INSTALL.BAT} root/INSTALL.BAT
+    install -m644 ${../installer/README.TXT}  root/README.TXT
+    ${dos2unix}/bin/unix2dos root/INSTALL.BAT
+    ${dos2unix}/bin/unix2dos root/README.TXT
+
+    mkdir -p $out
+    mkisofs \
+      -o $out/qemu-3dfx-wrappers.iso \
+      -V QEMU3DFX \
+      -J -r \
+      -iso-level 1 \
+      -input-charset ascii \
+      root/
+  ''

--- a/pkgs/by-name/qe/qemu-3dfx/guest-wrappers/watcom.nix
+++ b/pkgs/by-name/qe/qemu-3dfx/guest-wrappers/watcom.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  open-watcom-v2,
+  gnumake,
+  which,
+  qemu-3dfx-src,
+  shortRev,
+}:
+
+stdenv.mkDerivation {
+  pname = "qemu-3dfx-guest-wrappers-watcom";
+  version = "unstable-${shortRev}";
+
+  src = qemu-3dfx-src;
+
+  # `which` is required by ovl/Makefile's $(shell dirname `which wcc386`).
+  nativeBuildInputs = [
+    gnumake
+    open-watcom-v2
+    which
+  ];
+
+  dontConfigure = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    cp -r wrappers wrappers-build
+    chmod -R u+w wrappers-build
+
+    substituteInPlace wrappers-build/3dfx/ovl/Makefile \
+      --replace-fail 'git rev-parse --short HEAD' 'echo ${shortRev}'
+
+    cd wrappers-build/3dfx
+    mkdir build
+    make -C ovl OUTDIR=build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 build/glide2x.ovl $out/glide2x.ovl
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "kjliew/qemu-3dfx DOS Open-Watcom guest wrapper (GLIDE2X.OVL)";
+    homepage = "https://github.com/kjliew/qemu-3dfx";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ io12 ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/qe/qemu-3dfx/guest-wrappers/windows.nix
+++ b/pkgs/by-name/qe/qemu-3dfx/guest-wrappers/windows.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  stdenv,
+  pkgsCross,
+  gendef,
+  gnumake,
+  xxd,
+  perl,
+  qemu-3dfx-src,
+  shortRev,
+}:
+
+stdenv.mkDerivation {
+  pname = "qemu-3dfx-guest-wrappers-windows";
+  version = "unstable-${shortRev}";
+
+  src = qemu-3dfx-src;
+
+  # gendef extracts DLL exports for the cross-link step in the 3dfx and
+  # mesa Makefiles. xxd is used by drv/Makefile to decode the prebuilt
+  # VxD/SYS .xxd images.
+  nativeBuildInputs = [
+    gnumake
+    gendef
+    pkgsCross.mingw32.buildPackages.gcc
+    xxd
+    perl
+  ];
+
+  dontConfigure = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    cp -r wrappers wrappers-build
+    chmod -R u+w wrappers-build
+    cd wrappers-build
+
+    substituteInPlace {3dfx,mesa}/src/Makefile.in \
+      --replace-fail 'git rev-parse --short HEAD' 'echo ${shortRev}'
+
+    # Plumb the mingw cross-prefix into CROSS/RC/STRIP/DLLTOOL and drop
+    # the MSYSTEM check (we're not under MSYS).
+    patchMakefile() {
+      sed -i \
+        -e 's|^CROSS=$|CROSS=i686-w64-mingw32-|' \
+        -e 's|^RC=|RC=$(CROSS)|' \
+        -e 's|^STRIP=|STRIP=$(CROSS)|' \
+        -e 's|^DLLTOOL=|DLLTOOL=$(CROSS)|' \
+        -e '/MSYSTEM/d' \
+        "$1"
+    }
+
+    for sub in 3dfx mesa; do
+      mkdir "$sub/build"
+      cp "$sub/src/Makefile.in" "$sub/build/Makefile"
+      patchMakefile "$sub/build/Makefile"
+    done
+
+    # mesa-only: drop wglinfo.exe (TOOLS=), which would need Windows-side
+    # gdi32/opengl32 libs we don't ship.
+    sed -i 's|^TOOLS=wglinfo.exe.*|TOOLS=|' mesa/build/Makefile
+
+    make -C 3dfx/build fxlib glide.dll glide2x.dll glide3x.dll exports-check
+    make -C mesa/build fxlib opengl32.dll exports-check
+
+    # drv/Makefile xxd-decodes prebuilt VxD/SYS images and compiles
+    # instdrv.exe against fxlibnt.o (created above in 3dfx/build).
+    make -C 3dfx/drv OUTDIR=build CROSS=i686-w64-mingw32-
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    cp {mesa,3dfx}/build/*.{dll,vxd,sys,exe} $out
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "kjliew/qemu-3dfx Windows guest wrappers (Glide DLLs, MesaGL DLL, VxD, SYS, INSTDRV)";
+    homepage = "https://github.com/kjliew/qemu-3dfx";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ io12 ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/qe/qemu-3dfx/installer/INSTALL.BAT
+++ b/pkgs/by-name/qe/qemu-3dfx/installer/INSTALL.BAT
@@ -1,0 +1,35 @@
+@echo off
+echo QEMU-3dfx guest wrapper installer
+echo.
+if "%OS%"=="Windows_NT" goto NT
+goto W9X
+
+:W9X
+echo Detected Windows 9x/ME. Installing to %WINDIR%...
+copy /y 9X\FXMEMMAP.VXD %WINDIR%\SYSTEM
+copy /y 9X\GLIDE.DLL %WINDIR%\SYSTEM
+copy /y 9X\GLIDE2X.DLL %WINDIR%\SYSTEM
+copy /y 9X\GLIDE3X.DLL %WINDIR%\SYSTEM
+copy /y 9X\GLIDE2X.OVL %WINDIR%
+goto OPENGL_NOTE
+
+:NT
+echo Detected Windows NT/2k/XP. Installing to %SystemRoot%...
+copy /y NT\FXPTL.SYS %SystemRoot%\system32\drivers\
+copy /y NT\GLIDE.DLL %SystemRoot%\system32\
+copy /y NT\GLIDE2X.DLL %SystemRoot%\system32\
+copy /y NT\GLIDE3X.DLL %SystemRoot%\system32\
+echo Registering FXPTL kernel driver (requires Administrator)...
+NT\INSTDRV.EXE
+goto OPENGL_NOTE
+
+:OPENGL_NOTE
+echo.
+echo Glide wrappers installed. Reboot recommended.
+echo.
+echo NOTE: OPENGL32.DLL is NOT installed system-wide. Copy it from
+echo the OPENGL32 folder on this disc into each game's install
+echo folder if the game uses OpenGL.
+echo.
+echo DOS users: see DOS\ for GLIDE2X.DXE / GLIDE3X.DXE / GLIDE2X.OVL.
+pause

--- a/pkgs/by-name/qe/qemu-3dfx/installer/README.TXT
+++ b/pkgs/by-name/qe/qemu-3dfx/installer/README.TXT
@@ -1,0 +1,24 @@
+QEMU-3dfx Guest Wrapper Installer
+==================================
+
+To install the Glide wrappers:
+
+  - Mount this CD/ISO inside your guest VM.
+  - From a command prompt, navigate to the CD-ROM drive (e.g., D:).
+  - Run INSTALL.BAT.
+
+The installer copies the wrappers to the appropriate system directories
+based on the detected Windows version (9x/ME or NT/2k/XP), and on NT
+also registers the FXPTL kernel driver via INSTDRV.EXE (Administrator
+required).
+
+OPENGL32.DLL must be installed PER-GAME, not system-wide. Copy it from
+the OPENGL32\ folder on this disc into the install folder of each
+OpenGL game you want accelerated. If the game already has its own
+OPENGL32.DLL, back it up first (rename to OPENGL32.DLL.BAK).
+
+DOS games (DJGPP / Watcom): the wrappers in DOS\ are not auto-installed.
+Copy them next to the game's executable, or to a directory in the game's
+LD_LIBRARY_PATH equivalent.
+
+Source: https://github.com/kjliew/qemu-3dfx

--- a/pkgs/by-name/qe/qemu-3dfx/package.nix
+++ b/pkgs/by-name/qe/qemu-3dfx/package.nix
@@ -1,0 +1,110 @@
+# qemu-3dfx — QEMU 9.2.x with kjliew/qemu-3dfx 3Dfx Glide and MesaGL
+# pass-through device models for retro Windows and DOS games.
+#
+# Updating: run `./update.sh`. The five pinned values below
+# (qemu3dfxRev, qemu3dfxHash, qemu3dfxDate, qemuVersion, qemuHash) are
+# bumped in coordination by sed.
+#
+# When upstream qemu-3dfx adopts a new QEMU major.minor (e.g. 10.x),
+# the embedded patch filename also changes — this is a manual edit to
+# the `patches` line below and the version regex in `update.sh`.
+
+{
+  lib,
+  callPackage,
+  stdenv,
+  qemu,
+  fetchurl,
+  fetchFromGitHub,
+  libxxf86vm,
+}:
+
+let
+  qemu3dfxRev = "9ac7b6e441986f18a46059132c63fa877fb9a6d8";
+  qemu3dfxHash = "sha256-POxJPk/sGXFRn/AzpT1IjdFrV9abppf1eVneTpUNb6w=";
+  qemu3dfxDate = "2026-04-30";
+  qemuVersion = "9.2.4";
+  qemuHash = "sha256-88wcTqv9soghisPjN2Pb6eJ22LyJC4Z6IzXVjeLd05o=";
+
+  qemu-3dfx-src = fetchFromGitHub {
+    owner = "kjliew";
+    repo = "qemu-3dfx";
+    rev = qemu3dfxRev;
+    hash = qemu3dfxHash;
+  };
+  shortRev = lib.substring 0 7 qemu3dfxRev;
+
+  guestWrappersArgs = { inherit qemu-3dfx-src shortRev; };
+
+  guest-wrappers-windows = callPackage ./guest-wrappers/windows.nix guestWrappersArgs;
+  guest-wrappers-djgpp = callPackage ./guest-wrappers/djgpp.nix guestWrappersArgs;
+  guest-wrappers-watcom = callPackage ./guest-wrappers/watcom.nix guestWrappersArgs;
+  guest-wrappers-iso = callPackage ./guest-wrappers/iso.nix {
+    inherit guest-wrappers-windows guest-wrappers-djgpp guest-wrappers-watcom;
+  };
+in
+qemu.overrideAttrs (prev: {
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  pname = "qemu-3dfx";
+  version = "${qemuVersion}-unstable-${qemu3dfxDate}";
+
+  src = fetchurl {
+    url = "https://download.qemu.org/qemu-${qemuVersion}.tar.xz";
+    hash = qemuHash;
+  };
+
+  buildInputs = prev.buildInputs ++ [ libxxf86vm ];
+
+  # Replace (not append to) nixpkgs's qemu patches. kjliew/qemu-3dfx is
+  # developed against pristine upstream qemu source trees, and several of
+  # nixpkgs's patches target qemu 10.x and don't apply to 9.2.x.
+  patches = [ "${qemu-3dfx-src}/00-qemu92x-mesa-glide.patch" ];
+
+  postPatch = ''
+    cp -r ${qemu-3dfx-src}/qemu-0/hw/3dfx ./hw/
+    cp -r ${qemu-3dfx-src}/qemu-1/hw/mesa ./hw/
+    chmod -R u+w hw/3dfx hw/mesa
+
+    # sign_commit performs in-tree fix-ups for the patched device models
+    # (HASH_ALGO substitution, sysbus path rewrites, system_ss vs i386_ss
+    # selection) and stamps a `rev_[]` string into headers. Replace its
+    # single `git rev-parse` call so the build is hermetic.
+    cp ${qemu-3dfx-src}/scripts/sign_commit ./scripts/qemu-3dfx-sign
+    chmod u+w ./scripts/qemu-3dfx-sign
+    substituteInPlace ./scripts/qemu-3dfx-sign \
+      --replace-fail 'git rev-parse --short $ARG' 'echo ${shortRev}'
+    bash ./scripts/qemu-3dfx-sign
+  ''
+  + (prev.postPatch or "");
+
+  passthru = (prev.passthru or { }) // {
+    guestWrappers = {
+      windows = guest-wrappers-windows;
+      djgpp = guest-wrappers-djgpp;
+      watcom = guest-wrappers-watcom;
+      iso = guest-wrappers-iso;
+    };
+
+    tests = {
+      inherit
+        guest-wrappers-windows
+        guest-wrappers-djgpp
+        guest-wrappers-watcom
+        guest-wrappers-iso
+        ;
+    };
+
+    updateScript = ./update.sh;
+  };
+
+  meta = {
+    description = "QEMU ${qemuVersion} with kjliew/qemu-3dfx 3Dfx Glide and MesaGL pass-through for retro Windows/DOS games";
+    homepage = "https://github.com/kjliew/qemu-3dfx";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ io12 ];
+    mainProgram = "qemu-system-i386";
+  };
+})

--- a/pkgs/by-name/qe/qemu-3dfx/update.sh
+++ b/pkgs/by-name/qe/qemu-3dfx/update.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq nix coreutils gnused gnugrep git
+
+# Bump qemu-3dfx to the latest kjliew/qemu-3dfx commit on master and
+# the latest qemu 9.2.x point release. Edits the five pinned values
+# (qemu3dfxRev/Hash/Date, qemuVersion/Hash) at the top of package.nix.
+
+set -euo pipefail
+export NIX_CONFIG="experimental-features = nix-command"
+
+pkg="$(dirname "$(readlink -f "$0")")/package.nix"
+
+sriHashUrl() {
+  local hex
+  hex=$(nix-prefetch-url --type sha256 "$@" 2>/dev/null | tail -1)
+  nix hash convert --to sri --hash-algo sha256 "$hex"
+}
+
+setLetBinding() {
+  sed -i -E "s|^(  $1 = \")[^\"]*(\";)\$|\1$2\2|" "$pkg"
+}
+
+echo "Resolving latest kjliew/qemu-3dfx HEAD..."
+commit=$(curl -fsSL https://api.github.com/repos/kjliew/qemu-3dfx/commits/master)
+rev=$(jq -r .sha <<<"$commit")
+date=$(jq -r '.commit.committer.date[:10]' <<<"$commit")
+echo "  rev   $rev"
+echo "  date  $date"
+
+echo "Hashing kjliew/qemu-3dfx@${rev:0:7}..."
+srcHash=$(sriHashUrl --unpack "https://github.com/kjliew/qemu-3dfx/archive/$rev.tar.gz")
+echo "  hash  $srcHash"
+
+echo "Resolving latest qemu 9.2.x point release..."
+# git ls-remote on the upstream qemu repo, not the directory index at
+# download.qemu.org — the latter has a long-standing bug that omits
+# 9.2.x entries from the listing even though the files do exist.
+qver=$(git ls-remote --tags https://gitlab.com/qemu-project/qemu.git 'v9.2.*' |
+  grep -oE 'v9\.2\.[0-9]+$' | sort -Vu | tail -1 | sed 's|^v||')
+echo "  ver   $qver"
+
+echo "Hashing qemu-$qver.tar.xz..."
+qHash=$(sriHashUrl "https://download.qemu.org/qemu-$qver.tar.xz")
+echo "  hash  $qHash"
+
+echo "Updating $pkg..."
+setLetBinding qemu3dfxRev  "$rev"
+setLetBinding qemu3dfxHash "$srcHash"
+setLetBinding qemu3dfxDate "$date"
+setLetBinding qemuVersion  "$qver"
+setLetBinding qemuHash     "$qHash"
+
+echo "Done. Diff:"
+git --no-pager diff -- "$pkg"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add package for qemu-3dfx, a modified QEMU that allows GPU acceleration in Windows 9x/ME/2000/XP guests. There is also a set of packages of "guest wrappers" at `qemu-3dfx.guestWrappers` that are cross compiled for the guests, and an ISO file at `qemu-3dfx.guestWrappers.iso` that has an install script for moving all the wrappers to the right system directories. I tested the Half-Life: Uplink demo on Windows 98 SE (with [win98-quickinstall](https://github.com/oerg866/win98-quickinstall)), Windows ME (with [win98-quickinstall](https://github.com/oerg866/win98-quickinstall)), Windows 2000, and Windows XP, and everything seems to be working.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
