### PR TITLE
[25.11] angie: 1.10.2 -> 1.11.5

### DIFF
--- a/pkgs/servers/http/angie/default.nix
+++ b/pkgs/servers/http/angie/default.nix
@@ -9,11 +9,11 @@
 
 callPackage ../nginx/generic.nix args rec {
   pname = "angie";
-  version = "1.11.0";
+  version = "1.11.2";
 
   src = fetchurl {
     url = "https://download.angie.software/files/angie-${version}.tar.gz";
-    hash = "sha256-6ZR8gJZVufdGpyuQxbrcW3Us70rMiHztwGQImVlEVrM=";
+    hash = "sha256-Or6pG7lMlzs5SiQl5KYXyNViO6f82PtWLjIYRXDsvEc=";
   };
 
   configureFlags = lib.optionals withAcme [

--- a/pkgs/servers/http/angie/default.nix
+++ b/pkgs/servers/http/angie/default.nix
@@ -9,11 +9,11 @@
 
 callPackage ../nginx/generic.nix args rec {
   pname = "angie";
-  version = "1.11.2";
+  version = "1.11.3";
 
   src = fetchurl {
     url = "https://download.angie.software/files/angie-${version}.tar.gz";
-    hash = "sha256-Or6pG7lMlzs5SiQl5KYXyNViO6f82PtWLjIYRXDsvEc=";
+    hash = "sha256-CPqZ0YqQ9zhnSzAPZIZ0BgRa1cUY6VLNJOP/2wwUEX0=";
   };
 
   configureFlags = lib.optionals withAcme [

--- a/pkgs/servers/http/angie/default.nix
+++ b/pkgs/servers/http/angie/default.nix
@@ -9,11 +9,11 @@
 
 callPackage ../nginx/generic.nix args rec {
   pname = "angie";
-  version = "1.10.3";
+  version = "1.11.0";
 
   src = fetchurl {
     url = "https://download.angie.software/files/angie-${version}.tar.gz";
-    hash = "sha256-/4IOydx6yLDoc8Ut3EizQX9QVPFXtdLfXBuO1637IlY=";
+    hash = "sha256-6ZR8gJZVufdGpyuQxbrcW3Us70rMiHztwGQImVlEVrM=";
   };
 
   configureFlags = lib.optionals withAcme [

--- a/pkgs/servers/http/angie/default.nix
+++ b/pkgs/servers/http/angie/default.nix
@@ -8,12 +8,12 @@
 }@args:
 
 callPackage ../nginx/generic.nix args rec {
-  version = "1.10.2";
   pname = "angie";
+  version = "1.10.3";
 
   src = fetchurl {
     url = "https://download.angie.software/files/angie-${version}.tar.gz";
-    hash = "sha256-pcKrk33ySoDnhq9WOJIvRuqKc9FhQYPIyQKYrocwlLg=";
+    hash = "sha256-/4IOydx6yLDoc8Ut3EizQX9QVPFXtdLfXBuO1637IlY=";
   };
 
   configureFlags = lib.optionals withAcme [

--- a/pkgs/servers/http/angie/default.nix
+++ b/pkgs/servers/http/angie/default.nix
@@ -9,11 +9,11 @@
 
 callPackage ../nginx/generic.nix args rec {
   pname = "angie";
-  version = "1.11.3";
+  version = "1.11.5";
 
   src = fetchurl {
     url = "https://download.angie.software/files/angie-${version}.tar.gz";
-    hash = "sha256-CPqZ0YqQ9zhnSzAPZIZ0BgRa1cUY6VLNJOP/2wwUEX0=";
+    hash = "sha256-tfKXxt8qdLnQCRp83XR//9LQ4dC+Q2MtphwcdTnbIEM=";
   };
 
   configureFlags = lib.optionals withAcme [


### PR DESCRIPTION
Not a user of this package. Doing this due to the Label combination. Haven't validated wheter there is any breaking changes which prevents this.

Backport of:

- https://github.com/NixOS/nixpkgs/pull/461565
- https://github.com/NixOS/nixpkgs/pull/474172
- https://github.com/NixOS/nixpkgs/pull/475363
- https://github.com/NixOS/nixpkgs/pull/487948
- https://github.com/NixOS/nixpkgs/pull/503732


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
