### PR TITLE
podman-desktop: disable pnpm auto-bump & derive `.desktop` entry

### DIFF
--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -3,13 +3,11 @@
   stdenv,
   fetchFromGitHub,
   makeBinaryWrapper,
-  copyDesktopItems,
   electron_41,
   nodejs-slim_24,
   pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
-  makeDesktopItem,
   darwin,
   nix-update-script,
   _experimental-update-script-combinators,
@@ -96,9 +94,6 @@ stdenv.mkDerivation (finalAttrs: {
     pnpm
     pnpmConfigHook
   ]
-  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
-    copyDesktopItems
-  ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     darwin.autoSignDarwinBinariesHook
   ];
@@ -147,6 +142,13 @@ stdenv.mkDerivation (finalAttrs: {
 
         install -Dm644 buildResources/icon.svg "$out/share/icons/hicolor/scalable/apps/podman-desktop.svg"
 
+        # Derive the .desktop entry from upstream to keep it aligned and avoid regressions.
+        install -Dm644 .flatpak.desktop "$out/share/applications/podman-desktop.desktop"
+        substituteInPlace "$out/share/applications/podman-desktop.desktop" \
+          --replace-fail 'Exec=run.sh %U' 'Exec=podman-desktop %U' \
+          --replace-fail 'Icon=io.podman_desktop.PodmanDesktop' 'Icon=podman-desktop'
+        sed -i '/^X-Flatpak=/d' "$out/share/applications/podman-desktop.desktop"
+
         makeWrapper '${electron}/bin/electron' "$out/bin/podman-desktop" \
           --add-flags "$out/share/lib/podman-desktop/resources/app.asar" \
           --set XDG_SESSION_TYPE 'x11' \
@@ -158,20 +160,6 @@ stdenv.mkDerivation (finalAttrs: {
         runHook postInstall
       ''
     );
-
-  # see: https://github.com/podman-desktop/podman-desktop/blob/main/.flatpak.desktop
-  desktopItems = [
-    (makeDesktopItem {
-      name = "podman-desktop";
-      exec = "podman-desktop %U";
-      icon = "podman-desktop";
-      desktopName = appName;
-      genericName = "Desktop client for podman";
-      comment = finalAttrs.meta.description;
-      categories = [ "Utility" ];
-      startupWMClass = appName;
-    })
-  ];
 
   meta = {
     description = "Graphical tool for developing on containers and Kubernetes";

--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -6,7 +6,7 @@
   copyDesktopItems,
   electron_41,
   nodejs-slim_24,
-  pnpm_10_29_2,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   makeDesktopItem,
@@ -22,7 +22,7 @@
 
 let
   nodejs-slim = nodejs-slim_24;
-  pnpm = pnpm_10_29_2.override { inherit nodejs-slim; };
+  pnpm = pnpm_10.override { inherit nodejs-slim; };
   electron = electron_41;
   appName = "Podman Desktop";
 in


### PR DESCRIPTION
Carries the two independent changes from [the original PR](https://github.com/NixOS/nixpkgs/pull/508532) and a [followup PR](https://github.com/NixOS/nixpkgs/pull/526224) that stand on their own, split into atomic commits per `CONTRIBUTING.md` and updated for `podman-desktop` `1.27.2` (the tree moved from `1.26.2` while the old PR was in draft). The macOS tray deadlock fix is intentionally not included here; it is being handled separately, since it is a behavior change and does not need to block these.

Commits:

1. `podman-desktop: disable pnpm auto-bump in update script` - `pnpm` is pinned to a minor (`pnpm_10_29_2`). The updater extracted only the major version and rewrote it to `pnpm_10`, which does not exist in nixpkgs and breaks the build. Removes the `pnpm` rewrite from the updater.
2. `podman-desktop: derive .desktop entry from upstream .flatpak.desktop` - Generates the entry from upstream's `.flatpak.desktop` at install time, rewriting only the launcher command and icon name and dropping `X-Flatpak`. Keeps `Categories` and `Keywords` aligned with upstream; the `--replace-fail` patterns fail the build if upstream renames those lines.

## Deviations from the original PR

- Dropped the `installPhase` concatenation to `lib.optionalString` change. It was stylistic and equivalent, per @booxter's review.
- Dropped the version check. @booxter suggested `versionCheckHook` plus `writableTmpDirAsHomeHook` to run the check at build time. I implemented that, but it cannot pass for this package: `podman-desktop` is a GUI Electron app with no `--version` or `--help` flag that prints a version and exits. Every invocation boots the app and acquires the single-instance lock, so the check only produced `An instance of Podman Desktop is already running` and failed the build on Darwin. The main process has no headless version path, so the check was removed rather than forced.
- `.desktop` keywords and categories are now parsed from upstream's `.flatpak.desktop` instead of a hardcoded subset, which is @booxter's suggested approach to stay aligned and avoid regressions. This drops the previously hand-set `GenericName` and `Comment`, since upstream's file does not define them.
- The macOS tray deadlock fix from the original PR is not part of this PR. It is a behavior change (dropping the macOS tray) and is being pursued separately, including an upstream bug report.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test