### PR TITLE
nixos-rebuild-ng: disable flake auto-detection when --file or --attr is used

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
@@ -314,13 +314,16 @@ It must be one of the following:
 	be made using _nixos_ function in nixpkgs or importing and calling
 	nixos/lib/eval-config.nix from nixpkgs. If specified without *--attr*
 	option, builds the configuration from the top-level attribute set of the
-	file.
+	file. Using this option disables automatic flake detection, same as
+	*--no-flake*.
 
 *--attr* _attrPath_, *-A* _attrPath_
 	Build the NixOS system from a nix file and use the specified
 	attribute path from the file specified by the *--file* option.
 	If specified without *--file* option, uses _system.nix_ in current directory,
 	the system-wide _<nixos-system>_ file, or finally, /etc/nixos/system.nix.
+	Using this option disables automatic flake detection, same as
+	*--no-flake*.
 
 *--flake* _flake-uri[#name]_, *-F* _flake-uri[#name]_
 	Build the NixOS system from the specified flake. It defaults to the

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -329,6 +329,10 @@ def parse_args(
     if args.flake and (args.file or args.attr):
         parser.error("--flake cannot be used with --file or --attr")
 
+    if (args.file or args.attr) and args.flake is None:
+        # Disable flake auto-detection when --file or --attr is used
+        args.flake = False
+
     if args.store_path:
         if args.rollback:
             parser.error("--store-path and --rollback are mutually exclusive")

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -89,6 +89,22 @@ def test_parse_args() -> None:
     assert r_store_path.flake is False
     assert r_store_path.store_path == "/nix/store/foo"
 
+    # --file and --attr should disable flake auto-detection
+    r_file, _ = nr.parse_args(["nixos-rebuild", "switch", "--file", "foo.nix"])
+    assert r_file.flake is False
+    assert r_file.file == "foo.nix"
+
+    r_attr, _ = nr.parse_args(["nixos-rebuild", "switch", "--attr", "bar"])
+    assert r_attr.flake is False
+    assert r_attr.attr == "bar"
+
+    r_file_attr, _ = nr.parse_args(
+        ["nixos-rebuild", "switch", "--file", "foo.nix", "--attr", "bar"]
+    )
+    assert r_file_attr.flake is False
+    assert r_file_attr.file == "foo.nix"
+    assert r_file_attr.attr == "bar"
+
     r1, g1 = nr.parse_args(
         [
             "nixos-rebuild",


### PR DESCRIPTION
When --file or --attr is explicitly passed, flake auto-detection should not override the user's intent to use a non-flake configuration.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
