### PR TITLE
antigravity-cli: clean up derivation and updateScript

### DIFF
--- a/pkgs/by-name/an/antigravity-cli/package.nix
+++ b/pkgs/by-name/an/antigravity-cli/package.nix
@@ -6,7 +6,7 @@
   versionCheckHook,
 }:
 let
-  wholeVersion = "1.0.6-5359777384103936"; # unfortunately this has dumb versioning
+  wholeVersion = "1.0.7-5858071034068992"; # unfortunately this has dumb versioning
   version = builtins.head (lib.splitString "-" wholeVersion);
 
   throwSystem = throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}";
@@ -14,19 +14,19 @@ let
   sourceData = {
     x86_64-linux = fetchurl {
       url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/${wholeVersion}/linux-x64/cli_linux_x64.tar.gz";
-      hash = "sha256-ergNPn76DscF1zCrAOuRB+8Hv/6JrP4JCBoPAQRK574=";
+      hash = "sha256-8kaHmc0XPAPuATHb4rrkMhUzBqaLqi7n1UQPFcRB4Go=";
     };
     aarch64-linux = fetchurl {
       url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/${wholeVersion}/linux-arm/cli_linux_arm64.tar.gz";
-      hash = "sha256-Q4vTm3hlxJxGPaegWi/PiuevnehmRmMV6+PS0aN5OVQ=";
+      hash = "sha256-3ylG6ZW/9AuKydzzyMLtqC1ec2NnixFG/CJih26S0K0=";
     };
     aarch64-darwin = fetchurl {
       url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/${wholeVersion}/darwin-arm/cli_mac_arm64.tar.gz";
-      hash = "sha256-8dNBpYlJ44d4B6JDSMHRGRyBEvmV4EogK6L3y9YEVGM=";
+      hash = "sha256-e4VhL/9rUNgE2XyW8REz8QXEbzwsUFg41xNpUHfNLK0=";
     };
     x86_64-darwin = fetchurl {
       url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/${wholeVersion}/darwin-x64/cli_mac_x64.tar.gz";
-      hash = "sha256-hM6YIKBMqlRnB71f+nIMzgKqh9Lek/ByYYcC8XmlDbM=";
+      hash = "sha256-SECE7bAd0VneVeAvBs14Ortkcqg8CJy9xcq3ZnuqfKY=";
     };
   };
 in

--- a/pkgs/by-name/an/antigravity-cli/package.nix
+++ b/pkgs/by-name/an/antigravity-cli/package.nix
@@ -1,58 +1,50 @@
 {
   lib,
-  stdenv,
-  fetchzip,
+  stdenvNoCC,
+  fetchurl,
   autoPatchelfHook,
   versionCheckHook,
 }:
-
 let
-  # Version and platform-specific data retrieved from Google's manifests
-  version = "1.0.6";
+  wholeVersion = "1.0.6-5359777384103936"; # unfortunately this has dumb versioning
+  version = builtins.head (lib.splitString "-" wholeVersion);
+
+  throwSystem = throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}";
 
   sourceData = {
-    "x86_64-linux" = {
-      url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.6-5359777384103936/linux-x64/cli_linux_x64.tar.gz";
-      hash = "sha256-rxDLuuium+yQl3SiRcFhLzC5+ZCZU/tG2LQfFZMOYx4=";
+    x86_64-linux = fetchurl {
+      url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/${wholeVersion}/linux-x64/cli_linux_x64.tar.gz";
+      hash = "sha256-ergNPn76DscF1zCrAOuRB+8Hv/6JrP4JCBoPAQRK574=";
     };
-    "aarch64-linux" = {
-      url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.6-5359777384103936/linux-arm/cli_linux_arm64.tar.gz";
-      hash = "sha256-Mol5V3Lt2A89yrGdwWiOdv4y5dCZkMaT8onXG6IsQtc=";
+    aarch64-linux = fetchurl {
+      url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/${wholeVersion}/linux-arm/cli_linux_arm64.tar.gz";
+      hash = "sha256-Q4vTm3hlxJxGPaegWi/PiuevnehmRmMV6+PS0aN5OVQ=";
     };
-    "aarch64-darwin" = {
-      url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.6-5359777384103936/darwin-arm/cli_mac_arm64.tar.gz";
-      hash = "sha256-GmAxVP6KW0Zii2kSDvwwzsa88r/4ko2BVVpS8BeING4=";
+    aarch64-darwin = fetchurl {
+      url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/${wholeVersion}/darwin-arm/cli_mac_arm64.tar.gz";
+      hash = "sha256-8dNBpYlJ44d4B6JDSMHRGRyBEvmV4EogK6L3y9YEVGM=";
     };
-    "x86_64-darwin" = {
-      url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/1.0.6-5359777384103936/darwin-x64/cli_mac_x64.tar.gz";
-      hash = "sha256-RqjKhRqiW6Fg61eYzem+uXb5LXBYi5Cyv0hwtCaqomo=";
+    x86_64-darwin = fetchurl {
+      url = "https://storage.googleapis.com/antigravity-public/antigravity-cli/${wholeVersion}/darwin-x64/cli_mac_x64.tar.gz";
+      hash = "sha256-hM6YIKBMqlRnB71f+nIMzgKqh9Lek/ByYYcC8XmlDbM=";
     };
   };
-
-  sources = lib.mapAttrs (
-    _system: source:
-    fetchzip {
-      inherit (source) url hash;
-    }
-  ) sourceData;
-
-  source =
-    sources.${stdenv.hostPlatform.system}
-      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 in
-stdenv.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "antigravity-cli";
   inherit version;
-
-  src = source;
 
   strictDeps = true;
   __structuredAttrs = true;
 
-  nativeBuildInputs = lib.optionals stdenv.isLinux [ autoPatchelfHook ];
+  src = sourceData.${stdenvNoCC.hostPlatform.system} or throwSystem;
 
-  dontBuild = true;
+  sourceRoot = ".";
+
+  nativeBuildInputs = lib.optionals stdenvNoCC.hostPlatform.isLinux [ autoPatchelfHook ];
+
   dontConfigure = true;
+  dontBuild = true;
 
   installPhase = ''
     runHook preInstall
@@ -66,15 +58,8 @@ stdenv.mkDerivation (finalAttrs: {
   doInstallCheck = true;
 
   passthru = {
-    inherit sources;
-    updateScript = [
-      ./update.sh
-      version
-    ]
-    ++ lib.concatMap (system: [
-      system
-      sourceData.${system}.url
-    ]) (lib.attrNames sourceData);
+    inherit wholeVersion; # for the updateScript
+    updateScript = ./update.sh;
   };
 
   meta = {

--- a/pkgs/by-name/an/antigravity-cli/update.sh
+++ b/pkgs/by-name/an/antigravity-cli/update.sh
@@ -1,60 +1,29 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p bash common-updater-scripts coreutils curl gnutar nix
-# shellcheck shell=bash
+#!nix-shell -i bash -p bash nix-update common-updater-scripts nix jq
+
 set -euo pipefail
 
-script_dir="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-nixpkgs_root="$(realpath "$script_dir/../../../..")"
-package_file="$script_dir/package.nix"
-tmpdir="$(mktemp -d)"
-trap 'rm -rf "$tmpdir"' EXIT
+baseUrl=https://storage.googleapis.com/antigravity-public/antigravity-cli
 
-cd -- "$nixpkgs_root"
+currentVersion=$(nix-instantiate --eval --raw -E "with import ./. {}; antigravity-cli.version or (lib.getVersion antigravity-cli)")
+latestVersion=$(curl $baseUrl/latest)
 
-if (( $# < 3 || ($# - 1) % 2 != 0 )); then
-  echo "Usage: $0 <version> [<system> <url>]..." >&2
-  exit 1
+if [[ "$currentVersion" == "$latestVersion" ]]; then
+    echo "package is up-to-date: $currentVersion"
+    exit 0
 fi
 
-version="$1"
-shift
+# urls unfortunately include a weird buildid that make it hard to get
+latestWholeVersion=$(curl $baseUrl/$latestVersion/manifest.json | jq -r '.platforms."linux-x64".url' | cut -d/ -f6)
 
-export NIXPKGS_ALLOW_UNFREE=1
+update-source-version --version-key=wholeVersion antigravity-cli $latestWholeVersion || true
 
-hash_url() {
-  local system="$1"
-  local url="$2"
-  local archive="$tmpdir/$system.tar.gz"
-  local unpack_dir="$tmpdir/$system-unpack"
-
-  mkdir -p "$unpack_dir"
-  curl -fsSL "$url" -o "$archive" || return
-  tar -xzf "$archive" -C "$unpack_dir" || return
-
-  if [[ ! -x "$unpack_dir/antigravity" ]]; then
-    echo "Expected executable 'antigravity' in $url" >&2
-    exit 1
-  fi
-
-  nix hash path --type sha256 "$unpack_dir"
-}
-
-while (( $# > 0 )); do
-  system="$1"
-  url="$2"
-  shift 2
-
-  if [[ "$url" != *"/antigravity-cli/$version-"* ]]; then
-    echo "URL for $system does not match package version $version: $url" >&2
-    exit 1
-  fi
-
-  echo "Hashing $system from $url"
-  hash="$(hash_url "$system" "$url")"
-  update-source-version antigravity-cli "$version" "$hash" \
-    --file="$package_file" \
-    --ignore-same-hash \
-    --ignore-same-version \
-    --source-key="sources.$system" \
-    --system="$system"
+for system in \
+    x86_64-linux \
+    aarch64-linux \
+    x86_64-darwin \
+    aarch64-darwin; do
+    hash=$(nix store prefetch-file --json --hash-type sha256 \
+      $(nix-instantiate --eval --raw -E "with import ./. {}; antigravity-cli.src.url" --system "$system") | jq -r '.hash')
+    update-source-version --version-key=wholeVersion antigravity-cli $latestWholeVersion $hash --system=$system --ignore-same-version
 done


### PR DESCRIPTION
Closes: #529550
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
