### PR TITLE
[25.11] libaec: 1.1.4 -> 1.1.7

### DIFF
--- a/pkgs/by-name/li/libaec/package.nix
+++ b/pkgs/by-name/li/libaec/package.nix
@@ -7,14 +7,14 @@
 
 stdenv.mkDerivation rec {
   pname = "libaec";
-  version = "1.1.4";
+  version = "1.1.5";
 
   src = fetchFromGitLab {
     domain = "gitlab.dkrz.de";
     owner = "k202009";
     repo = "libaec";
     rev = "v${version}";
-    sha256 = "sha256-MJFx0gErfrSK6EeeGDk8CQWj6j4PVvFPJEI/iys3bI8=";
+    sha256 = "sha256-ADydaLu8fV0mKp3wZx10VS2I1GFwuLTpbxmRKCmgF0c=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libaec/package.nix
+++ b/pkgs/by-name/li/libaec/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation rec {
   pname = "libaec";
-  version = "1.1.6";
+  version = "1.1.7";
 
   src = fetchFromGitHub {
     owner = "Deutsches-Klimarechenzentrum";
     repo = "libaec";
     rev = "v${version}";
-    sha256 = "sha256-cxDP+JNwokxgzH9hO2zw+rIcz8XG7E8ujbAbWpgUEW8=";
+    sha256 = "sha256-aBm+CXCq7sdJb6Qq9sNuTzNj0nRwTJI20HsqUg1Qi/8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libaec/package.nix
+++ b/pkgs/by-name/li/libaec/package.nix
@@ -7,14 +7,14 @@
 
 stdenv.mkDerivation rec {
   pname = "libaec";
-  version = "1.1.5";
+  version = "1.1.6";
 
   src = fetchFromGitLab {
     domain = "gitlab.dkrz.de";
     owner = "k202009";
     repo = "libaec";
     rev = "v${version}";
-    sha256 = "sha256-ADydaLu8fV0mKp3wZx10VS2I1GFwuLTpbxmRKCmgF0c=";
+    sha256 = "sha256-cxDP+JNwokxgzH9hO2zw+rIcz8XG7E8ujbAbWpgUEW8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libaec/package.nix
+++ b/pkgs/by-name/li/libaec/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitLab,
+  fetchFromGitHub,
   cmake,
 }:
 
@@ -9,9 +9,8 @@ stdenv.mkDerivation rec {
   pname = "libaec";
   version = "1.1.6";
 
-  src = fetchFromGitLab {
-    domain = "gitlab.dkrz.de";
-    owner = "k202009";
+  src = fetchFromGitHub {
+    owner = "Deutsches-Klimarechenzentrum";
     repo = "libaec";
     rev = "v${version}";
     sha256 = "sha256-cxDP+JNwokxgzH9hO2zw+rIcz8XG7E8ujbAbWpgUEW8=";
@@ -24,7 +23,8 @@ stdenv.mkDerivation rec {
   doCheck = true;
 
   meta = {
-    homepage = "https://gitlab.dkrz.de/k202009/libaec";
+    changelog = "https://github.com/Deutsches-Klimarechenzentrum/libaec/blob/v${version}/CHANGELOG.md";
+    homepage = "https://github.com/Deutsches-Klimarechenzentrum/libaec";
     description = "Adaptive Entropy Coding library";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ tbenst ];


### PR DESCRIPTION
Doing this due to the failed security backport. Haven't read the Changelogs to make sure this is truly a good way to resolve this conflict.

Backport of
- #523133
- #483235
- #498218
- #522876 (went to staging, not quite sure why but from the rebuild count of this PR this doesn't seem neccesary here)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
