### PR TITLE
memtier-benchmark: update to 2.3.1

### DIFF
--- a/pkgs/by-name/me/memtier-benchmark/package.nix
+++ b/pkgs/by-name/me/memtier-benchmark/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "memtier-benchmark";
-  version = "2.2.2";
+  version = "2.3.1";
 
   src = fetchFromGitHub {
-    owner = "redislabs";
+    owner = "redis";
     repo = "memtier_benchmark";
     tag = finalAttrs.version;
-    hash = "sha256-/t7OY3N9VBa9o2amOFb2/MUr5Y4ep4HGUil8OtwKkng=";
+    hash = "sha256-N5oSAtlB8CSUSMQGxKHKHGakmUGJOq80LSkCdJw4H7U=";
   };
 
   patchPhase = ''
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Redis and Memcached traffic generation and benchmarking tool";
-    homepage = "https://github.com/redislabs/memtier_benchmark";
+    homepage = "https://github.com/redis/memtier_benchmark";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ thoughtpolice ];

--- a/pkgs/by-name/me/memtier-benchmark/package.nix
+++ b/pkgs/by-name/me/memtier-benchmark/package.nix
@@ -21,11 +21,6 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-N5oSAtlB8CSUSMQGxKHKHGakmUGJOq80LSkCdJw4H7U=";
   };
 
-  patchPhase = ''
-    substituteInPlace ./configure.ac \
-      --replace '1.2.8' '${finalAttrs.version}'
-  '';
-
   nativeBuildInputs = [
     autoreconfHook
     pkg-config


### PR DESCRIPTION
## Things done

- Updated memtier-benchmark from 2.2.2 to 2.3.1.
- Switched the source repository from redislabs/memtier_benchmark to redis/memtier_benchmark, reflecting the current upstream project location.
- Updated the source hash accordingly.
- Removed the configure.ac version patch, as upstream now correctly reports version 2.3.1.

Release notes:
- https://github.com/redis/memtier_benchmark/releases/tag/2.3.1

### Testing

- [x] Built successfully on x86_64-linux.
- [x] Verified the resulting memtier_benchmark binary was produced and is executable.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests.
  - [ ] Package tests at passthru.tests.
  - [ ] Tests in lib/tests or pkgs/test.
- [ ] Ran nixpkgs-review on this PR.
- [x] Tested basic functionality of the package binary (memtier_benchmark).
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition.
  - [ ] Module update.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.
- [x] Follows the automation/AI policy.