### PR TITLE
maven: provide default plugins per Maven version to buildMavenPackage

### DIFF
--- a/doc/languages-frameworks/maven.section.md
+++ b/doc/languages-frameworks/maven.section.md
@@ -55,6 +55,8 @@ maven.buildMavenPackage (finalAttrs: {
 
 This package calls `maven.buildMavenPackage` to do its work. The primary difference from `stdenv.mkDerivation` is the `mvnHash` variable, which is a hash of all of the Maven dependencies.
 
+Whenever the set of dependencies changes (for example when bumping the package version, or adding or removing a dependency), `mvnHash` must be recomputed: set it to an empty string `""`, run the build, and copy the corrected hash from the resulting error message.
+
 ::: {.tip}
 After setting `maven.buildMavenPackage`, we then do standard Java `.jar` installation by saving the `.jar` to `$out/share/java` and then making a wrapper which allows executing that file; see [](#sec-language-java) for additional generic information about packaging Java applications.
 :::
@@ -145,13 +147,25 @@ maven.buildMavenPackage {
 
 ### Stable Maven plugins {#stable-maven-plugins}
 
-Maven defines default versions for its core plugins, e.g. `maven-compiler-plugin`. If your project does not override these versions, an upgrade of Maven will change the version of the used plugins, and therefore the derivation and hash.
+Maven binds default versions for its core plugins (e.g. `maven-compiler-plugin`, `maven-resources-plugin`) for projects that do not pin these versions themselves. These defaults are baked into each Maven release, so they change whenever Maven is upgraded.
 
-When `maven` is upgraded, `mvnHash` for the derivation must be updated as well: otherwise, the project will be built on the derivation of old plugins, and fail because the requested plugins are missing.
+Historically this broke the offline build of any such project after a Maven upgrade: the `fetchedMavenDeps` [fixed-output derivation](https://nixos.org/manual/nix/stable/glossary.html#gloss-fixed-output-derivation) still contained the plugin versions captured with the old Maven, while the new Maven requested newer ones that were not present, so resolution failed unless every affected `mvnHash` was recomputed.
 
-This clearly prevents automatic upgrades of Maven: a manual effort must be made throughout nixpkgs by any maintainer wishing to push the upgrades.
+`buildMavenPackage` now handles this automatically. It merges the default plugins of the Maven version in use, exposed as `maven.defaultPluginsRepo`, into the local repository during the main build phase. Because this happens outside the fixed-output derivation, upgrading Maven no longer requires recomputing the `mvnHash` of projects that rely on these implicit plugin versions; only the single `maven.defaultPluginsRepo` hash is updated alongside the Maven version (handled by maven's update script).
 
-To make sure that your package does not add extra manual effort when upgrading Maven, explicitly define versions for all plugins. You can check if this is the case by adding the following plugin to your (parent) POM:
+If you need to opt out of this behaviour, set `useDefaultMavenPlugins = false`:
+
+```nix
+maven.buildMavenPackage {
+  useDefaultMavenPlugins = false;
+}
+```
+
+::: {.warning}
+If you opt out of `useDefaultMavenPlugins` and do not explicitly pin your plugin versions, your package will again require manual effort (recomputing `mvnHash`) on every Maven upgrade. In the future we may mark such packages as broken.
+:::
+
+Explicitly pinning plugin versions in your (parent) POM is still good practice, because it makes the build self-contained and independent of the packaged Maven version. You can enforce that every plugin has an explicit version by adding the following plugin to your (parent) POM:
 
 ```xml
 <plugin>

--- a/pkgs/by-name/ma/maven/build-maven-package.nix
+++ b/pkgs/by-name/ma/maven/build-maven-package.nix
@@ -34,6 +34,7 @@ let
       manualMvnArtifacts ? [ ],
       manualMvnSources ? [ ],
       mvnParameters ? "",
+      useDefaultMavenPlugins ? true,
       ...
     }@args:
 
@@ -42,6 +43,17 @@ let
 
     let
       mvnSkipTests = lib.optionalString (!doCheck) "-DskipTests";
+
+      # Path to this Maven version's implicit default plugins, or "" when it
+      # should not (or cannot) contribute any. Not every Maven exposes
+      # `defaultPluginsRepo` (e.g. maven_4, or a custom distribution built via
+      # `overrideMavenAttrs`), and this builder is shared across all of them via
+      # `mkBuildMavenPackage`; resolving to "" here lets the build phase skip the
+      # merge instead of failing to evaluate on a missing attribute. Laziness
+      # keeps `maven.defaultPluginsRepo` unforced when the guard is false.
+      defaultPluginsRepo = lib.optionalString (
+        useDefaultMavenPlugins && maven ? defaultPluginsRepo
+      ) "${maven.defaultPluginsRepo}/default-plugins-repo";
 
       writeProxySettings = writers.writePython3 "write-proxy-settings" { } ./maven-proxy.py;
 
@@ -152,6 +164,17 @@ let
           runHook preBuild
 
           mvnDeps=$(cp -dpR ${fetchedMavenDeps}/.m2 ./ && chmod +w -R .m2 && pwd)
+
+          # Merge this Maven version's implicit default plugins into the build
+          # repository. Empty when the Maven in use does not provide them (see
+          # the defaultPluginsRepo binding above), in which case the merge is
+          # skipped.
+          defaultPluginsRepo=${lib.escapeShellArg defaultPluginsRepo}
+          if [ -n "$defaultPluginsRepo" ]; then
+            cp -dpRn "$defaultPluginsRepo/." "$mvnDeps/.m2/"
+            chmod +w -R "$mvnDeps/.m2"
+          fi
+
           runHook afterDepsSetup
           mvn ${mvnGoal} ${
             if mvnOffline then "-o" else ""

--- a/pkgs/by-name/ma/maven/default-plugins.nix
+++ b/pkgs/by-name/ma/maven/default-plugins.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  stdenv,
+  jdk,
+  jre-generate-cacerts,
+  maven,
+  writers,
+}:
+# A local Maven repository (`$out/default-plugins-repo`) containing the plugins that this Maven
+# version binds *implicitly* for the standard lifecycles, plus the version
+# defaults from the super POM's `pluginManagement`. `buildMavenPackage` merges
+# this repository into the build-time local repository so that packages which
+# do not pin their plugin versions keep resolving after a Maven upgrade, without
+# baking the plugins into each package's fixed-output derivation (which would
+# force recomputing every `mvnHash` on a Maven bump).
+let
+  writeProxySettings = writers.writePython3 "write-proxy-settings" { } ./maven-proxy.py;
+  extractDefaultPlugins =
+    writers.writePython3 "extract-default-plugins" { }
+      ./extract-default-plugins.py;
+in
+stdenv.mkDerivation {
+  pname = "maven-default-plugins";
+  inherit (maven) version;
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ maven ];
+
+  env.JAVA_HOME = jdk;
+
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars;
+
+  buildPhase = ''
+    runHook preBuild
+
+    MAVEN_EXTRA_ARGS="-B"
+
+    # handle proxy
+    if [[ -n "''${HTTP_PROXY-}" ]] || [[ -n "''${HTTPS_PROXY-}" ]] || [[ -n "''${NO_PROXY-}" ]];then
+      mvnSettingsFile="$(mktemp -d)/settings.xml"
+      ${writeProxySettings} $mvnSettingsFile
+      MAVEN_EXTRA_ARGS="$MAVEN_EXTRA_ARGS -s=$mvnSettingsFile"
+    fi
+
+    # handle cacert by populating a trust store on the fly
+    if [[ -n "''${NIX_SSL_CERT_FILE-}" ]] && [[ "''${NIX_SSL_CERT_FILE-}" != "/no-cert-file.crt" ]];then
+      echo "using ''${NIX_SSL_CERT_FILE-} as trust store"
+      ${jre-generate-cacerts} ${lib.getBin jdk}/bin/keytool $NIX_SSL_CERT_FILE
+
+      MAVEN_EXTRA_ARGS="$MAVEN_EXTRA_ARGS -Djavax.net.ssl.trustStore=cacerts -Djavax.net.ssl.trustStorePassword=changeit"
+    fi
+
+    for artifact in $(${extractDefaultPlugins} ${maven}/maven/lib)
+    do
+      echo "downloading default plugin $artifact"
+      mvn $MAVEN_EXTRA_ARGS dependency:get -Dartifact="$artifact" -Dmaven.repo.local=$out/default-plugins-repo
+    done
+
+    runHook postBuild
+  '';
+
+  # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
+  installPhase = ''
+    runHook preInstall
+
+    find $out -type f \( \
+      -name \*.lastUpdated \
+      -o -name resolver-status.properties \
+      -o -name _remote.repositories \) \
+      -delete
+
+    runHook postInstall
+  '';
+
+  # don't do any fixup
+  dontFixup = true;
+  # The implicit plugin versions are baked into each Maven release, so this
+  # hash only changes when maven is upgraded. It is kept up to date by maven's
+  # passthru.updateScript (nix-update --subpackage defaultPluginsRepo).
+  outputHashMode = "recursive";
+  outputHash = "sha256-0wdHUTWO+sO8ZLKgMYB7XF3ExFNz/sxxhvPiLhm35Gk=";
+}

--- a/pkgs/by-name/ma/maven/extract-default-plugins.py
+++ b/pkgs/by-name/ma/maven/extract-default-plugins.py
@@ -1,0 +1,77 @@
+"""
+Extract the coordinates of the plugins that a given Maven distribution uses
+*implicitly* when a project does not pin their versions:
+
+  * the lifecycle bindings baked into ``maven-core``
+    (``META-INF/plexus/*.xml``), e.g. resources, compiler, surefire, jar,
+    install, deploy, clean, site and the packaging specific plugins
+    (war, ear, ejb, rar, plugin); and
+  * the ``pluginManagement`` versions from the super POM shipped in
+    ``maven-model-builder`` (e.g. assembly, dependency, antrun, release).
+
+These versions are baked into each Maven release and therefore change on
+every Maven upgrade. The coordinates are printed one
+``groupId:artifactId:version`` per line on stdout.
+"""
+
+import glob
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+import zipfile
+
+# Lifecycle bindings reference plugins as group:artifact:version[:goal].
+GAV_RE = re.compile(
+    r"org\.apache\.maven\.plugins:maven-[\w-]+-plugin:[0-9][\w.-]*"
+)
+
+
+def localname(tag):
+    return tag.rsplit("}", 1)[-1]
+
+
+def from_plexus(core_jar):
+    gavs = set()
+    with zipfile.ZipFile(core_jar) as jar:
+        for name in jar.namelist():
+            if name.startswith("META-INF/plexus/") and name.endswith(".xml"):
+                text = jar.read(name).decode("utf-8", "replace")
+                gavs.update(GAV_RE.findall(text))
+    return gavs
+
+
+def from_super_pom(model_jar):
+    gavs = set()
+    with zipfile.ZipFile(model_jar) as jar:
+        names = (n for n in jar.namelist() if n.endswith("pom-4.0.0.xml"))
+        for name in names:
+            root = ET.fromstring(jar.read(name))
+            for plugin in root.iter():
+                if localname(plugin.tag) != "plugin":
+                    continue
+                coords = {"groupId": "org.apache.maven.plugins"}
+                for child in plugin:
+                    field = localname(child.tag)
+                    if field in ("groupId", "artifactId", "version"):
+                        coords[field] = (child.text or "").strip()
+                artifact = coords.get("artifactId")
+                version = coords.get("version", "")
+                # Skip plugins without a concrete version (${...} refs).
+                if artifact and version and not version.startswith("${"):
+                    gavs.add(f"{coords['groupId']}:{artifact}:{version}")
+    return gavs
+
+
+def main(lib_dir):
+    gavs = set()
+    for jar in glob.glob(os.path.join(lib_dir, "maven-core-*.jar")):
+        gavs |= from_plexus(jar)
+    for jar in glob.glob(os.path.join(lib_dir, "maven-model-builder-*.jar")):
+        gavs |= from_super_pom(jar)
+    for gav in sorted(gavs):
+        print(gav)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/pkgs/by-name/ma/maven/package.nix
+++ b/pkgs/by-name/ma/maven/package.nix
@@ -4,6 +4,8 @@
   fetchurl,
   jdk_headless,
   makeWrapper,
+  nix-update-script,
+  runCommand,
   stdenvNoCC,
   testers,
 }:
@@ -67,6 +69,29 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
       buildMavenPackage = mkBuildMavenPackage finalAttrs.finalPackage;
 
+      # Local repository of the plugins this Maven version binds implicitly.
+      # Merged into the build-time repository by buildMavenPackage so a Maven
+      # upgrade does not require recomputing every package's mvnHash. The hash
+      # only changes when maven itself is upgraded.
+      defaultPluginsRepo = callPackage ./default-plugins.nix {
+        maven = finalAttrs.finalPackage;
+      };
+
+      # maven's src is a `mirror://apache` tarball, so the version is discovered
+      # from the upstream git tags instead, restricted to the 3.x series so it
+      # does not jump to the separate maven_4 package. The defaultPluginsRepo
+      # outputHash is bumped in the same run via --subpackage.
+      updateScript = nix-update-script {
+        extraArgs = [
+          "--url"
+          "https://github.com/apache/maven"
+          "--version-regex"
+          "maven-(3\\..*)"
+          "--subpackage"
+          "defaultPluginsRepo"
+        ];
+      };
+
       tests = {
         version = testers.testVersion {
           package = finalAttrs.finalPackage;
@@ -75,6 +100,37 @@ stdenvNoCC.mkDerivation (finalAttrs: {
               mvn --version
           '';
         };
+
+        # Regression test for defaultPluginsRepo: the plugins that Maven binds
+        # implicitly must actually be present and resolvable, otherwise offline
+        # builds of packages that do not pin plugin versions break after a
+        # Maven upgrade. Asserts against a fixed list of core lifecycle plugins
+        # (an independent source of truth, so a broken extractor cannot make
+        # the test vacuously pass).
+        defaultPlugins =
+          runCommand "maven-default-plugins-test"
+            {
+              repo = finalAttrs.finalPackage.defaultPluginsRepo;
+            }
+            ''
+              plugins="$repo/.m2/org/apache/maven/plugins"
+              for plugin in \
+                maven-resources-plugin \
+                maven-compiler-plugin \
+                maven-surefire-plugin \
+                maven-jar-plugin \
+                maven-install-plugin \
+                maven-deploy-plugin \
+                maven-clean-plugin
+              do
+                if ! ls "$plugins/$plugin"/*/"$plugin"-*.jar >/dev/null 2>&1; then
+                  echo "default plugin $plugin missing from defaultPluginsRepo" >&2
+                  exit 1
+                fi
+                echo "found $plugin"
+              done
+              touch "$out"
+            '';
       };
     };
 


### PR DESCRIPTION
`maven.buildMavenPackage` stores a package's Maven dependencies in a fixed-output derivation (`fetchedMavenDeps`). That FOD also captures the versions of the core plugins that Maven binds implicitly when a project does not pin them. Because the store path of a FOD depends only on `mvnHash`, bumping Maven reuses the old dependency repository, but the new Maven then requests newer implicit plugin versions that are missing from it, so the offline build fails to resolve them. This is the breakage tracked in #497416 (for example `kotlin-interactive-shell` failing with `maven-resources-plugin:3.4.0 has not been downloaded`).

This PR captures the implicitly bound plugins once per Maven version in a separate derivation, `maven.defaultPluginsRepo`, and merges it into the build-time local repository during the main build phase of `buildMavenPackage`. Because the merge happens outside the FOD, upgrading Maven no longer requires recomputing every package's `mvnHash`. Only the single `defaultPluginsRepo` hash changes, alongside the Maven version, and it is kept in sync by the new update script.

The idea of capturing the default plugins in a separate per-Maven-version repository is due to @msgilligan (Sean Gilligan); this PR implements it.

Details:

- The plugin coordinates are extracted from the Maven distribution itself (the lifecycle bindings in `maven-core` and the super POM's `pluginManagement`), so they always match the packaged Maven version.
- The merge is enabled by default and can be disabled per package with `useDefaultMavenPlugins = false`.
- `update.sh` discovers the latest 3.x release from the upstream git tags, because Maven's `mirror://apache` source is not a version source `nix-update` can read, and updates the version, `src` hash and `defaultPluginsRepo` hash in a single run.
- A regression test, `maven.tests.defaultPlugins`, checks that the core lifecycle plugins resolve in `defaultPluginsRepo`.
- The "Stable Maven plugins" section of the manual is updated to describe the new behaviour.

Verification: with Maven bumped to 3.9.16, `kotlin-interactive-shell` fails to build on master with the plugin resolution error above, and builds successfully with this change without changing its `mvnHash`.

## Things done

- Built on platform(s):
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
