### PR TITLE
vscode-extensions.ms-python.vscode-python-envs: switch to platform specific binaries

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/ms-python.vscode-python-envs/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-python.vscode-python-envs/default.nix
@@ -1,23 +1,53 @@
 {
+  stdenvNoCC,
   lib,
   vscode-utils,
 }:
 
 vscode-utils.buildVscodeMarketplaceExtension {
-  mktplcRef = {
-    name = "vscode-python-envs";
-    publisher = "ms-python";
-    version = "1.33.2026051501";
-    hash = "sha256-V5anlwzLt0V08HsO6TCBIUPD3VPhyohg7YnSc/1++GE=";
-  };
+  mktplcRef =
+    let
+      sources = {
+        "x86_64-linux" = {
+          arch = "linux-x64";
+          hash = "sha256-wIwNH57ABWXGHLzQWplrfdI075W/LXocscOJ0Pycev4=";
+        };
+        "aarch64-linux" = {
+          arch = "linux-arm64";
+          hash = "sha256-R4YLYHVeQOYvjaCJQajZ6+OPOqIWiCZjXmiAwfSJOFo=";
+        };
+        "x86_64-darwin" = {
+          arch = "darwin-x64";
+          hash = "sha256-t9XjC7oMd2Kpd8nXcdlnWB58A6NRU2hUA6g2c9IFaTw=";
+        };
+        "aarch64-darwin" = {
+          arch = "darwin-arm64";
+          hash = "sha256-PN4sV5qu+PhDB5TeDir51cmE3yYW1HdHRvE+950ty3k=";
+        };
+      };
+    in
+    {
+      name = "vscode-python-envs";
+      publisher = "ms-python";
+      version = "1.33.2026051501";
+    }
+    // sources.${stdenvNoCC.hostPlatform.system}
+      or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");
 
   meta = {
     description = "Provides a unified python environment experience";
     downloadPage = "https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs";
     homepage = "https://github.com/microsoft/vscode-python-environments";
+    changelog = "https://marketplace.visualstudio.com/items/ms-python.vscode-python-envs/changelog";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       Zocker1999NET
+    ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
     ];
   };
 }

--- a/pkgs/applications/editors/vscode/extensions/ms-python.vscode-python-envs/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-python.vscode-python-envs/default.nix
@@ -4,7 +4,7 @@
   vscode-utils,
 }:
 
-vscode-utils.buildVscodeMarketplaceExtension {
+vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
   mktplcRef =
     let
       sources = {
@@ -38,6 +38,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     description = "Provides a unified python environment experience";
     downloadPage = "https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs";
     homepage = "https://github.com/microsoft/vscode-python-environments";
+    changelog = "https://github.com/microsoft/vscode-python-environments/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       Zocker1999NET
@@ -49,4 +50,4 @@ vscode-utils.buildVscodeMarketplaceExtension {
       "aarch64-darwin"
     ];
   };
-}
+})

--- a/pkgs/applications/editors/vscode/extensions/ms-python.vscode-python-envs/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-python.vscode-python-envs/default.nix
@@ -10,26 +10,26 @@ vscode-utils.buildVscodeMarketplaceExtension {
       sources = {
         "x86_64-linux" = {
           arch = "linux-x64";
-          hash = "sha256-wIwNH57ABWXGHLzQWplrfdI075W/LXocscOJ0Pycev4=";
+          hash = "sha256-fOqG/GSQmKDHA3J10x/m9q5URjSPAoWHqg/OfZtz418=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
-          hash = "sha256-R4YLYHVeQOYvjaCJQajZ6+OPOqIWiCZjXmiAwfSJOFo=";
+          hash = "sha256-MA2kXhM6rSp9OPtDm4daFrBpH+CNNXLjSG095QndOvM=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
-          hash = "sha256-t9XjC7oMd2Kpd8nXcdlnWB58A6NRU2hUA6g2c9IFaTw=";
+          hash = "sha256-UiA9Ar34UuHKBKm0B6jc+qWwzxlJbXEG2FaMBV39AeI=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
-          hash = "sha256-PN4sV5qu+PhDB5TeDir51cmE3yYW1HdHRvE+950ty3k=";
+          hash = "sha256-+v8U/aFNp/b6Dj62J+MLYQ8dcfO4qinWd/XST6ntnNc=";
         };
       };
     in
     {
       name = "vscode-python-envs";
       publisher = "ms-python";
-      version = "1.33.2026051501";
+      version = "1.36.0";
     }
     // sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");

--- a/pkgs/applications/editors/vscode/extensions/ms-python.vscode-python-envs/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-python.vscode-python-envs/default.nix
@@ -1,15 +1,38 @@
 {
+  stdenvNoCC,
   lib,
   vscode-utils,
 }:
 
 vscode-utils.buildVscodeMarketplaceExtension {
-  mktplcRef = {
-    name = "vscode-python-envs";
-    publisher = "ms-python";
-    version = "1.33.2026051501";
-    hash = "sha256-V5anlwzLt0V08HsO6TCBIUPD3VPhyohg7YnSc/1++GE=";
-  };
+  mktplcRef =
+    let
+      sources = {
+        "x86_64-linux" = {
+          arch = "linux-x64";
+          hash = "sha256-wIwNH57ABWXGHLzQWplrfdI075W/LXocscOJ0Pycev4=";
+        };
+        "aarch64-linux" = {
+          arch = "linux-arm64";
+          hash = "sha256-R4YLYHVeQOYvjaCJQajZ6+OPOqIWiCZjXmiAwfSJOFo=";
+        };
+        "x86_64-darwin" = {
+          arch = "darwin-x64";
+          hash = "sha256-t9XjC7oMd2Kpd8nXcdlnWB58A6NRU2hUA6g2c9IFaTw=";
+        };
+        "aarch64-darwin" = {
+          arch = "darwin-arm64";
+          hash = "sha256-PN4sV5qu+PhDB5TeDir51cmE3yYW1HdHRvE+950ty3k=";
+        };
+      };
+    in
+    {
+      name = "vscode-python-envs";
+      publisher = "ms-python";
+      version = "1.33.2026051501";
+    }
+    // sources.${stdenvNoCC.hostPlatform.system}
+      or (throw "Unsupported system ${stdenvNoCC.hostPlatform.system}");
 
   meta = {
     description = "Provides a unified python environment experience";
@@ -18,6 +41,12 @@ vscode-utils.buildVscodeMarketplaceExtension {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       Zocker1999NET
+    ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
     ];
   };
 }


### PR DESCRIPTION
Fixes degraded Python environment discovery from `ms-python.vscode-python-envs`
on non-Windows-ARM platforms.

The extension bundles a native `pet` (python-env-tools) helper for fast
environment discovery, but the package fetched the generic marketplace VSIX,
which the gallery resolves to the **win32-arm64** artifact — so only `pet.exe`
shipped and the helper was unusable on every supported platform. VS Code logs
a "PET binary missing" warning and falls back to slow JS-based discovery.

This selects the platform-specific VSIX per system (linux/darwin × x64/arm64),
so the matching native `pet` binary ships, and bumps to the current release.

Changelog: https://marketplace.visualstudio.com/items/ms-python.vscode-python-envs/changelog

> Disclosure: this PR and its commits were prepared with the assistance of
> Claude Code (Claude Opus 4.8); the changes were reviewed and verified by me
> before submission (`Assisted-by:` trailers are present on both commits).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

