### PR TITLE
mattermost: add patches for user limit and free banner removal

### DIFF
--- a/pkgs/by-name/ma/mattermost/mattermost-remove-free-banner.patch
+++ b/pkgs/by-name/ma/mattermost/mattermost-remove-free-banner.patch
@@ -1,7 +1,7 @@
-diff --git a/webapp/channels/src/components/global_header/left_controls/product_menu/product_branding_team_edition/product_branding_free_edition.tsx b/webapp/channels/src/components/global_header/left_controls/product_menu/product_branding_team_edition/product_branding_free_edition.tsx
+diff --git a/channels/src/components/global_header/left_controls/product_menu/product_branding_team_edition/product_branding_free_edition.tsx b/channels/src/components/global_header/left_controls/product_menu/product_branding_team_edition/product_branding_free_edition.tsx
 index 93cb8ab263..3d12cd5e54 100644
---- a/webapp/channels/src/components/global_header/left_controls/product_menu/product_branding_team_edition/product_branding_free_edition.tsx
-+++ b/webapp/channels/src/components/global_header/left_controls/product_menu/product_branding_team_edition/product_branding_free_edition.tsx
+--- a/channels/src/components/global_header/left_controls/product_menu/product_branding_team_edition/product_branding_free_edition.tsx
++++ b/channels/src/components/global_header/left_controls/product_menu/product_branding_team_edition/product_branding_free_edition.tsx
 @@ -57,7 +57,6 @@ const ProductBrandingFreeEdition = (): JSX.Element => {
                  width={116}
                  height={20}
@@ -10,10 +10,10 @@ index 93cb8ab263..3d12cd5e54 100644
          </ProductBrandingFreeEditionContainer>
      );
  };
-diff --git a/webapp/channels/src/components/header_footer_route/header.scss b/webapp/channels/src/components/header_footer_route/header.scss
-index c2e6fbd187..bc1cedcff1 100644
---- a/webapp/channels/src/components/header_footer_route/header.scss
-+++ b/webapp/channels/src/components/header_footer_route/header.scss
+diff --git a/channels/src/components/header_footer_route/header.scss b/channels/src/components/header_footer_route/header.scss
+index c2e6fbd187..828955cc79 100644
+--- a/channels/src/components/header_footer_route/header.scss
++++ b/channels/src/components/header_footer_route/header.scss
 @@ -47,20 +47,7 @@
              }
  
@@ -36,23 +36,10 @@ index c2e6fbd187..bc1cedcff1 100644
              }
          }
      }
-@@ -83,12 +70,6 @@
-             margin-top: 12px;
-         }
-     }
--
--    &.has-free-banner.has-custom-site-name {
--        .header-back-button {
--            bottom: -20px;
--        }
--    }
- }
- 
- @media screen and (max-width: 699px) {
-diff --git a/webapp/channels/src/components/widgets/menu/menu_items/menu_item.scss b/webapp/channels/src/components/widgets/menu/menu_items/menu_item.scss
+diff --git a/channels/src/components/widgets/menu/menu_items/menu_item.scss b/channels/src/components/widgets/menu/menu_items/menu_item.scss
 index dee9b57f8c..8ef4aa073a 100644
---- a/webapp/channels/src/components/widgets/menu/menu_items/menu_item.scss
-+++ b/webapp/channels/src/components/widgets/menu/menu_items/menu_item.scss
+--- a/channels/src/components/widgets/menu/menu_items/menu_item.scss
++++ b/channels/src/components/widgets/menu/menu_items/menu_item.scss
 @@ -316,14 +316,7 @@
      }
  
@@ -69,11 +56,11 @@ index dee9b57f8c..8ef4aa073a 100644
  
          button {
              padding: 3px 0;
-diff --git a/webapp/channels/webpack.config.js b/webapp/channels/webpack.config.js
-index f29f19f9ab..ab85fc3b86 100644
---- a/webapp/channels/webpack.config.js
-+++ b/webapp/channels/webpack.config.js
-@@ -469,6 +469,9 @@ if (targetIsDevServer) {
+diff --git a/channels/webpack.config.js b/channels/webpack.config.js
+index 852046de70..cf28fdcbd6 100644
+--- a/channels/webpack.config.js
++++ b/channels/webpack.config.js
+@@ -470,6 +470,9 @@ if (targetIsDevServer) {
              historyApiFallback: {
                  index: '/static/root.html',
              },

--- a/pkgs/by-name/ma/mattermost/mattermost-remove-user-limit.patch
+++ b/pkgs/by-name/ma/mattermost/mattermost-remove-user-limit.patch
@@ -1,16 +1,46 @@
 diff --git a/server/channels/app/limits.go b/server/channels/app/limits.go
-index 4c88c1f049..3c1af8d02f 100644
+index 4c88c1f049..fb7d84ef05 100644
 --- a/server/channels/app/limits.go
 +++ b/server/channels/app/limits.go
-@@ -10,8 +10,8 @@ import (
- )
+@@ -18,23 +18,8 @@ func (a *App) GetServerLimits() (*model.ServerLimits, *model.AppError) {
+ 	limits := &model.ServerLimits{}
+ 	license := a.License()
  
- const (
--	maxUsersLimit     = 200
--	maxUsersHardLimit = 250
-+	maxUsersLimit     = 10000000
-+	maxUsersHardLimit = 10000000
- )
+-	if license == nil && maxUsersLimit > 0 {
+-		// Enforce hard-coded limits for unlicensed servers (no grace period).
+-		limits.MaxUsersLimit = maxUsersLimit
+-		limits.MaxUsersHardLimit = maxUsersHardLimit
+-	} else if license != nil && license.IsSeatCountEnforced && license.Features != nil && license.Features.Users != nil {
+-		// Enforce license limits as required by the license with configurable extra users.
+-		licenseUserLimit := int64(*license.Features.Users)
+-		limits.MaxUsersLimit = licenseUserLimit
+-
+-		// Use ExtraUsers if configured, otherwise default to 0 (no extra users)
+-		extraUsers := 0
+-		if license.ExtraUsers != nil {
+-			extraUsers = *license.ExtraUsers
+-		}
+-
+-		limits.MaxUsersHardLimit = licenseUserLimit + int64(extraUsers)
+-	}
++	limits.MaxUsersLimit = 0
++	limits.MaxUsersHardLimit = 0
  
- func (a *App) GetServerLimits() (*model.ServerLimits, *model.AppError) {
-    
+ 	// Check if license has post history limits and get the calculated timestamp
+ 	if license != nil && license.Limits != nil && license.Limits.PostHistory > 0 {
+@@ -99,14 +84,5 @@ func (a *App) GetPostHistoryLimit() int64 {
+ }
+ 
+ func (a *App) isAtUserLimit() (bool, *model.AppError) {
+-	userLimits, appErr := a.GetServerLimits()
+-	if appErr != nil {
+-		return false, appErr
+-	}
+-
+-	if userLimits.MaxUsersHardLimit == 0 {
+-		return false, nil
+-	}
+-
+-	return userLimits.ActiveUserCount >= userLimits.MaxUsersHardLimit, appErr
++	return false, nil
+ }

--- a/pkgs/by-name/ma/mattermost/package.nix
+++ b/pkgs/by-name/ma/mattermost/package.nix
@@ -138,13 +138,9 @@ buildMattermost rec {
     '';
   };
 
-  patches =
-    lib.optionals removeFreeBadge [
-      ./mattermost-remove-free-banner.patch
-    ]
-    ++ lib.optionals removeUserLimit [
-      ./mattermost-remove-user-limit.patch
-    ];
+  patches = lib.optionals removeUserLimit [
+    ./mattermost-remove-user-limit.patch
+  ];
 
   # Needed because buildGoModule does not support go workspaces yet.
   # We use go 1.22's workspace vendor command, which is not yet available
@@ -247,6 +243,10 @@ buildMattermost rec {
       inherit version src;
 
       sourceRoot = "${src.name}/webapp";
+
+      patches = lib.optionals removeFreeBadge [
+        ./mattermost-remove-free-banner.patch
+      ];
 
       # Remove deprecated image-webpack-loader causing build failures
       # See: https://github.com/tcoopman/image-webpack-loader#deprecated


### PR DESCRIPTION
Patches to remove free editions banner and users limit. Cleaner and more complete version of commit [fc9f1c9](https://github.com/NixOS/nixpkgs/commit/fc9f1c91b2a29ccf1741c0fcf99be7aae4f0b01f).

Example of edition removal
Before:
<img width="330" height="46" alt="image" src="https://github.com/user-attachments/assets/481bb708-1ce9-4a55-abfa-9991f9039db8" />
After:
<img width="330" height="46" alt="image" src="https://github.com/user-attachments/assets/79ff8594-8155-43ca-bb3e-09c15b36edac" />

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].