### PR TITLE
gemini-cli-bin: 0.42.0 -> 0.53.0 and deprecate

### DIFF
--- a/pkgs/by-name/ge/gemini-cli-bin/package.nix
+++ b/pkgs/by-name/ge/gemini-cli-bin/package.nix
@@ -97,6 +97,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     mainProgram = "gemini";
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+    problems.removal.message = "gemini-cli-bin is deprecated and will be removed in a future release. Use gemini-cli or antigravity-cli instead.";
     priority = 10;
   };
 })

--- a/pkgs/by-name/ge/gemini-cli-bin/package.nix
+++ b/pkgs/by-name/ge/gemini-cli-bin/package.nix
@@ -11,11 +11,11 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "gemini-cli-bin";
-  version = "0.42.0";
+  version = "0.53.0";
 
   src = fetchzip {
     url = "https://github.com/google-gemini/gemini-cli/releases/download/v${finalAttrs.version}/gemini-cli-bundle.zip";
-    hash = "sha256-Qkb39ehFabpRGxqpl3wCzoK3A2z5TMnKswngLz6kP/s=";
+    hash = "sha256-KjB9EKRZYOi3yIPeFfo3oekH6teXPTcAy17Vmkj9Vn8=";
     stripRoot = false;
   };
 
@@ -33,23 +33,57 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   patchPhase = ''
     runHook prePatch
 
-    # chunk filenames contain unpredictable hashes, use glob to iterate
+    chunkCount=0
+    autoUpdatePatches=0
+    rgCandidatePathPatches=0
+    trustedPrefixPatches=0
+
+    # Chunk filenames contain unpredictable hashes, use glob to iterate
     for chunk in ./chunk-*.js; do
 
-      # disable auto-update
-      if grep -q 'enableAutoUpdate: {' "$chunk"; then
+      chunkCount=$((chunkCount + 1))
+
+      # Disable auto-update
+      if sed -n '/enableAutoUpdate: {/,/}/p' "$chunk" | grep -Fq 'default: true'; then
         sed -i '/enableAutoUpdate: {/,/}/ s/default: true/default: false/' "$chunk"
+        autoUpdatePatches=$((autoUpdatePatches + 1))
       fi
 
-      # use `ripgrep` from `nixpkgs`, more dependencies but prevent downloading incompatible binary on NixOS
-      # this workaround can be removed once the following upstream issue is resolved:
-      # https://github.com/google-gemini/gemini-cli/issues/11438
-      if grep -q 'await resolveExistingRgPath();' "$chunk"; then
-        substituteInPlace "$chunk" \
-          --replace-fail 'const existingPath = await resolveExistingRgPath();' 'const existingPath = "${lib.getExe ripgrep}";'
+      # Prefer the Nix ripgrep binary by prepending it to candidate paths
+      if grep -Fq 'const candidatePaths = [' "$chunk"; then
+        substituteInPlace "$chunk" --replace-fail \
+          'const candidatePaths = [' 'const candidatePaths = ["${lib.getExe ripgrep}", '
+        rgCandidatePathPatches=$((rgCandidatePathPatches + 1))
+      fi
+
+      # Trust the Nix store path by adding it to standard system prefixes
+      if grep -Fq 'const trustedPrefixes = [' "$chunk"; then
+        substituteInPlace "$chunk" --replace-fail \
+          'const trustedPrefixes = [' 'const trustedPrefixes = ["/nix/store", '
+        trustedPrefixPatches=$((trustedPrefixPatches + 1))
       fi
 
     done
+
+    if (( chunkCount == 0 )); then
+      echo "error: no chunk files found" >&2
+      exit 1
+    fi
+
+    if (( autoUpdatePatches == 0 )); then
+      echo "error: failed to patch auto-update default" >&2
+      exit 1
+    fi
+
+    if (( rgCandidatePathPatches == 0 )); then
+      echo "error: failed to patch ripgrep candidate paths" >&2
+      exit 1
+    fi
+
+    if (( trustedPrefixPatches == 0 )); then
+      echo "error: failed to patch trusted prefixes" >&2
+      exit 1
+    fi
 
     runHook postPatch
   '';


### PR DESCRIPTION
Diff: https://github.com/google-gemini/gemini-cli/compare/v0.42.0..v0.53.0

- Update `ripgrep` patches for the new upstream implementation introduced in v0.44.0
- Add checks to ensure patches take effect

Add `meta.problems.removal` to warn about deprecation.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

---

I personally encountered the error "Your current account is not eligible for Gemini Code Assist for individuals because it is not currently available in your location." and thus could not test the basic functionality.
The changes here are aligned with #525473, thanks to @attilaolah.
I am deprecating this package. The source-based `gemini-cli` package now utilizes a bundled build, which resolves the closure size issue and is easier to maintain than dealing with the chunks in this `-bin` variant. And of course, there is the `antigravity-cli` factor.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
