### PR TITLE
python3Packages.btrfsutil: migrate to pyproject and update homepage

### DIFF
--- a/pkgs/development/python-modules/btrfsutil/default.nix
+++ b/pkgs/development/python-modules/btrfsutil/default.nix
@@ -45,7 +45,7 @@ buildPythonPackage {
 
   meta = {
     description = "Library for managing Btrfs filesystems";
-    homepage = "https://btrfs.wiki.kernel.org/";
+    homepage = "https://btrfs.readthedocs.io/";
     license = lib.licenses.lgpl21Plus;
     maintainers = with lib.maintainers; [
       raskin

--- a/pkgs/development/python-modules/btrfsutil/default.nix
+++ b/pkgs/development/python-modules/btrfsutil/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildPythonPackage,
+  setuptools,
   btrfs-progs,
   autoreconfHook,
   pkg-config,
@@ -11,8 +12,11 @@
 buildPythonPackage {
   pname = "btrfsutil";
   inherit (btrfs-progs) version src;
-  format = "setuptools";
+  pyproject = true;
 
+  build-system = [
+    setuptools
+  ];
   buildInputs = [
     btrfs-progs
     e2fsprogs


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974
- The [old homepage](https://btrfs.wiki.kernel.org/) states that the wiki has been archived and refers to https://btrfs.readthedocs.io/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
