### PR TITLE
urweb: add myself as maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4175,6 +4175,13 @@
     githubId = 18356186;
     name = "Gabriela Moreira";
   };
+  buggymcbugfix = {
+    email = "nix@vilem.net";
+    github = "buggymcbugfix";
+    matrix = "@buggymcbugfix:matrix.org";
+    githubId = 17603372;
+    name = "Vilem Liepelt";
+  };
   bugworm = {
     email = "bugworm@zoho.com";
     github = "bugworm";

--- a/pkgs/by-name/ur/urweb/package.nix
+++ b/pkgs/by-name/ur/urweb/package.nix
@@ -76,6 +76,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.bsd3;
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     maintainers = [
+      lib.maintainers.buggymcbugfix
       lib.maintainers.thoughtpolice
       lib.maintainers.sheganinans
     ];


### PR DESCRIPTION
To my best knowledge, I am pretty much the only person using nix + urweb in production (for https://liepelt.design). I am working with Nectry to upstream their internal changes to the Ur/Web compiler.

@infinisil
@thoughtpolice 
@sheganinans 