### PR TITLE
portfolio: use minimal JRE and avoid double wrapping

### DIFF
--- a/pkgs/by-name/po/portfolio/package.nix
+++ b/pkgs/by-name/po/portfolio/package.nix
@@ -4,10 +4,11 @@
   glib,
   glib-networking,
   gtk3,
+  jdk21_headless,
+  jre_minimal,
   lib,
   libsecret,
   makeDesktopItem,
-  openjdk21,
   stdenvNoCC,
   webkitgtk_4_1,
   wrapGAppsHook3,
@@ -15,6 +16,26 @@
   gitUpdater,
 }:
 let
+  jre = jre_minimal.override {
+    jdk = jdk21_headless;
+    modules = [
+      "java.base"
+      "java.desktop"
+      "jdk.localedata"
+      "java.management"
+      "java.naming"
+      "java.net.http"
+      "java.security.jgss"
+      "java.sql"
+      "java.xml"
+      "jdk.crypto.ec"
+      "jdk.net"
+      "jdk.httpserver"
+      "jdk.unsupported"
+      "jdk.xml.dom"
+    ];
+  };
+
   desktopItem = makeDesktopItem {
     name = "Portfolio";
     exec = "portfolio";
@@ -89,9 +110,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     win32-x86-64\
     }
 
+    # Eclipse source bundles are not needed at runtime.
+    rm -f $out/portfolio/plugins/*.source_*.jar
+    rm -rf $out/portfolio/configuration/org.eclipse.equinox.source
+
     makeWrapper $out/portfolio/PortfolioPerformance $out/bin/portfolio \
       --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
-      --prefix PATH : ${openjdk21}/bin
+      --prefix PATH : ${lib.makeBinPath [ jre ]} \
+      --set JAVA_HOME "${jre}"
 
     # Create desktop item
     mkdir -p $out/share/applications

--- a/pkgs/by-name/po/portfolio/package.nix
+++ b/pkgs/by-name/po/portfolio/package.nix
@@ -69,6 +69,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     imagemagick
   ];
 
+  dontWrapGApps = true;
+
   dontConfigure = true;
   dontBuild = true;
 
@@ -115,6 +117,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     rm -rf $out/portfolio/configuration/org.eclipse.equinox.source
 
     makeWrapper $out/portfolio/PortfolioPerformance $out/bin/portfolio \
+      "''${gappsWrapperArgs[@]}" \
       --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
       --prefix PATH : ${lib.makeBinPath [ jre ]} \
       --set JAVA_HOME "${jre}"


### PR DESCRIPTION
Clean up the package:
- use a minimal JRE, reducing the closure size from 1.5 GB to 1.0 GB, measured with `nix path-info --recursive --size --closure-size --human-readable .#portfolio`
- remove unused source files
- avoid double wrapping caused by `wrapGAppsHook`

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
