### PR TITLE
aflplusplus: 4.35c -> 4.40c

### DIFF
--- a/pkgs/tools/security/aflplusplus/aflpp-v4.40c.patch
+++ b/pkgs/tools/security/aflplusplus/aflpp-v4.40c.patch
@@ -1,0 +1,14 @@
+diff --git a/test/test-all.sh b/test/test-all.sh
+index 2a47b21e..a45ca580 100755
+--- a/test/test-all.sh
++++ b/test/test-all.sh
+@@ -15,7 +15,8 @@ for script in test-*.sh; do
+   # Skip exclusions
+   if [ "$script" = "test-pre.sh" ] || \
+      [ "$script" = "test-post.sh" ] || \
+-     [ "$script" = "test-all.sh" ]; then
++     [ "$script" = "test-all.sh" ] || \
++     [ "$script" = "test-performance.sh" ]; then
+     continue
+   fi
+ 

--- a/pkgs/tools/security/aflplusplus/default.nix
+++ b/pkgs/tools/security/aflplusplus/default.nix
@@ -53,7 +53,7 @@ let
 
   aflplusplus = stdenvNoCC.mkDerivation rec {
     pname = "aflplusplus";
-    version = "4.35c";
+    version = "4.40c";
 
     src = fetchFromGitHub {
       owner = "AFLplusplus";
@@ -61,9 +61,9 @@ let
       tag = "v${version}";
       hash =
         if withNyx then
-          "sha256-srHrYPEb0UAP/G9cOxJOZ9D6v9pxqez28suPsa70E2M="
+          "sha256-901rJfuMZvgUpQ6zzboa7lu9yhSyX+0u+HUk8oGsqgo="
         else
-          "sha256-j5YH39JKcjYuDqyl+KRMtgn3UoeWEW1z7m4ysf2uilc=";
+          "sha256-QtGazGShjybvjOONoWjqSg/c+l5sPpaFuuTI2S85YQM=";
       fetchSubmodules = withNyx;
     };
 
@@ -89,10 +89,16 @@ let
     # warning: "_FORTIFY_SOURCE" redefined
     hardeningDisable = [ "fortify" ];
 
-    # We build nyx mode dependencies ourselves, so this patch skips
-    # build_nyx_support.sh in the aflplusplus source code. It also skips
-    # test-nyx-mode.sh because we can't test nyx mode in the sandbox.
-    patches = lib.optional withNyx ./nyx_mode/nyx_mode.patch;
+    patches = [
+      # skip performance test: it's skipped anyway, but exits with code 1
+      ./aflpp-v4.40c.patch
+    ]
+    ++ lib.optionals withNyx [
+      # We build nyx mode dependencies ourselves, so this patch skips
+      # build_nyx_support.sh in the aflplusplus source code. It also skips
+      # test-nyx-mode.sh because we can't test nyx mode in the sandbox.
+      ./nyx_mode/nyx_mode.patch
+    ];
     postPatch = ''
       # Don't care about this.
       rm Android.bp


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Tested by building with and without nyx mode:

```
$ nix-build -E 'with import <nixpkgs> {}; callPackage ./default.nix { wine = null; }'
```

```
$ nix-build -E 'with import <nixpkgs> {}; callPackage ./default.nix { wine = null; withNyx = true; }'
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
