### PR TITLE
shadps4: 0.15.0 -> 0.16.0

### DIFF
--- a/nixos/tests/shadps4.nix
+++ b/nixos/tests/shadps4.nix
@@ -88,6 +88,9 @@
 
         machine.succeed("shadps4 /etc/openorbis-sample-packages/OpenOrbis-PNG-Sample/uroot/eboot.bin >&2 &")
 
+        machine.wait_for_text("Save Migration")
+        machine.succeed("xdotool mousemove 879 182 click 1")
+
         # Look for logo
         with machine.nested("Waiting for the screen to have openorbisColor {} on it:".format(openorbisColor)):
             retry(check_for_color(openorbisColor))

--- a/pkgs/by-name/mi/minimp3/package.nix
+++ b/pkgs/by-name/mi/minimp3/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "minimp3";
+  version = "0-unstable-2026-03-12";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "lieff";
+    repo = "minimp3";
+    rev = "7b590fdcfa5a79c033e76eacc05d0c3e4c79f536";
+    hash = "sha256-ZDYPan9f3Nx+JQpY44NmF9RkOa+MV7V0rOiPJ4pKyU0=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/include
+    install -Dm644 minimp3*.h -t $out/include
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Minimalistic MP3 decoder single header library";
+    homepage = "https://github.com/lieff/minimp3";
+    license = lib.licenses.cc0;
+    maintainers = [ lib.maintainers.ryand56 ];
+    platforms = lib.intersectLists lib.platforms.linux (
+      lib.platforms.x86 ++ lib.platforms.x86_64 ++ lib.platforms.aarch64
+    );
+  };
+})

--- a/pkgs/by-name/sh/shadps4-qtlauncher/package.nix
+++ b/pkgs/by-name/sh/shadps4-qtlauncher/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  clangStdenv,
   fetchFromGitHub,
 
   cmake,
@@ -13,15 +13,15 @@
 
   shadps4,
 }:
-stdenv.mkDerivation (finalAttrs: {
+clangStdenv.mkDerivation (finalAttrs: {
   pname = "shadps4-qtlauncher";
-  version = "224";
+  version = "0-unstable-2026-06-07";
 
   src = fetchFromGitHub {
     owner = "shadps4-emu";
     repo = "shadps4-qtlauncher";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-lRZH9fokUKN/n3m/ZkTsRHwkwZZ04buvqBMXYLrqqLE=";
+    rev = "eadffe744d6f2bb7b21aedeef2cc0f66cdffd6ed";
+    hash = "sha256-tlCP8Cu3UVoclaQ0cIVr89q7wwgkzFVwhMSqpVB6FnM=";
 
     postCheckout = ''
       cd "$out"
@@ -31,7 +31,9 @@ stdenv.mkDerivation (finalAttrs: {
 
       git -C externals submodule update --init --recursive \
         volk \
-        json
+        json \
+        openal-soft \
+        spdlog
     '';
   };
 

--- a/pkgs/by-name/sh/shadps4-qtlauncher/version-directory.patch
+++ b/pkgs/by-name/sh/shadps4-qtlauncher/version-directory.patch
@@ -2,7 +2,7 @@ diff --git a/src/qt_gui/game_install_dialog.cpp b/src/qt_gui/game_install_dialog
 index 8a9b94d..919d4a5 100644
 --- a/src/qt_gui/game_install_dialog.cpp
 +++ b/src/qt_gui/game_install_dialog.cpp
-@@ -144,7 +144,9 @@ void GameInstallDialog::Save() {
+@@ -148,7 +148,9 @@ void GameInstallDialog::Save() {
      // Check games directory.
      auto gamesDirectory = m_gamesDirectory->text();
      auto addonsDirectory = m_addonsDirectory->text();
@@ -12,7 +12,7 @@ index 8a9b94d..919d4a5 100644
  
      if (gamesDirectory.isEmpty() || !QDir(gamesDirectory).exists() ||
          !QDir::isAbsolutePath(gamesDirectory)) {
-@@ -167,6 +169,7 @@ void GameInstallDialog::Save() {
+@@ -171,6 +171,7 @@ void GameInstallDialog::Save() {
          }
      }
  
@@ -20,15 +20,15 @@ index 8a9b94d..919d4a5 100644
      if (versionDirectory.isEmpty() || !QDir::isAbsolutePath(versionDirectory)) {
          QMessageBox::critical(this, tr("Error"),
                                "The value for location to install emulator versions is not valid.");
-@@ -181,11 +184,14 @@ void GameInstallDialog::Save() {
+@@ -185,11 +188,14 @@ void GameInstallDialog::Save() {
              return;
          }
      }
 +#endif
  
      // Save the directories
-     Config::addGameInstallDir(Common::FS::PathFromQString(gamesDirectory));
-     Config::setAddonInstallDir(Common::FS::PathFromQString(addonsDirectory));
+     EmulatorSettings.AddGameInstallDir(Common::FS::PathFromQString(gamesDirectory));
+     EmulatorSettings.SetAddonInstallDir(Common::FS::PathFromQString(addonsDirectory));
 +#ifndef HIDE_VERSION_MANAGER
      m_gui_settings->SetValue(gui::vm_versionPath, versionDirectory);
 +#endif

--- a/pkgs/by-name/sh/shadps4/package.nix
+++ b/pkgs/by-name/sh/shadps4/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  clangStdenv,
   fetchFromGitHub,
   makeWrapper,
 
@@ -20,6 +20,7 @@
   libunwind,
   libusb1,
   magic-enum,
+  minimp3,
   miniz,
   nlohmann_json,
   libgbm,
@@ -52,15 +53,15 @@
   nix-update-script,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+clangStdenv.mkDerivation (finalAttrs: {
   pname = "shadps4";
-  version = "0.15.0";
+  version = "0.16.0";
 
   src = fetchFromGitHub {
     owner = "shadps4-emu";
     repo = "shadPS4";
     tag = "v.${finalAttrs.version}";
-    hash = "sha256-76rbxOf4grDWPVILy8nF35wQ6/NcxHQkmiQOB0u4oJo=";
+    hash = "sha256-SavSUHtnJeRi2mzIyUhLfLk37Y/PSuI3bbbqWA7qVbg=";
 
     postCheckout = ''
       cd "$out"
@@ -73,13 +74,16 @@ stdenv.mkDerivation (finalAttrs: {
         zydis \
         sirit \
         tracy \
-        ext-libusb \
+        libusb \
         discord-rpc \
         hwinfo \
         openal-soft \
         dear_imgui \
         LibAtrac9 \
-        aacdec/fdk-aac
+        aacdec/fdk-aac \
+        spdlog \
+        libressl \
+        ImGuiFileDialog
     '';
   };
 
@@ -90,10 +94,6 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail @GIT_BRANCH@ ${finalAttrs.version} \
       --replace-fail @GIT_DESC@ nixpkgs \
       --replace-fail @BUILD_DATE@ $(cat SOURCE_DATE_EPOCH)
-
-    substituteInPlace src/core/libraries/np/trophy_ui.cpp \
-      --replace-fail "MIX_SetMasterGain" "MIX_SetMixerGain" \
-      --replace-fail "MIX_GetMasterGain" "MIX_GetMixerGain"
   '';
 
   buildInputs = [
@@ -119,6 +119,7 @@ stdenv.mkDerivation (finalAttrs: {
     libxscrnsaver
     libxtst
     magic-enum
+    minimp3
     miniz
     libgbm
     nlohmann_json


### PR DESCRIPTION
https://github.com/shadps4-emu/shadPS4/releases/tag/v.0.16.0
Diff: https://github.com/shadps4-emu/shadPS4/compare/v.0.15.0...v.0.16.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
