### PR TITLE
zellij-unwrapped: split out from zellij wrapper

### DIFF
--- a/pkgs/by-name/ze/zellij-unwrapped/package.nix
+++ b/pkgs/by-name/ze/zellij-unwrapped/package.nix
@@ -10,6 +10,7 @@
   openssl,
   writableTmpDirAsHomeHook,
   versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -75,6 +76,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --fish <($out/bin/zellij setup --generate-completion fish) \
       --zsh <($out/bin/zellij setup --generate-completion zsh)
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Terminal workspace with batteries included";

--- a/pkgs/by-name/ze/zellij/package.nix
+++ b/pkgs/by-name/ze/zellij/package.nix
@@ -1,23 +1,19 @@
 {
   lib,
-  callPackage,
+  zellij-unwrapped,
   makeBinaryWrapper,
   stdenvNoCC,
-  nix-update-script,
 
   extraPackages ? [ ],
 }:
-let
-  unwrapped = callPackage ./unwrapped.nix { };
-in
 stdenvNoCC.mkDerivation {
-  inherit (unwrapped) version meta;
+  inherit (zellij-unwrapped) version meta;
   pname = "zellij";
 
   __structuredAttrs = true;
   strictDeps = true;
 
-  src = unwrapped;
+  src = zellij-unwrapped;
   dontUnpack = true;
 
   nativeBuildInputs = [ makeBinaryWrapper ];
@@ -27,9 +23,4 @@ stdenvNoCC.mkDerivation {
     wrapProgram "$out/bin/zellij" \
       --prefix PATH : '${lib.makeBinPath extraPackages}'
   '';
-
-  passthru = unwrapped.passthru or { } // {
-    inherit unwrapped;
-    updateScript = nix-update-script { attrPath = "zellij.unwrapped"; };
-  };
 }


### PR DESCRIPTION
Expose the actual rust build as a top-level by-name package and have
the wrapper take it as an argument, so overlays can patch or override
it without needing to thread the new drv through the wrapper explicitly.

`zellij.drvPath` is unchanged, so this is a zero-rebuild change.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
