### PR TITLE
pokemini: Add pokemini libretro core for RetroArch

### DIFF
--- a/pkgs/applications/emulators/libretro/cores/pokemini.nix
+++ b/pkgs/applications/emulators/libretro/cores/pokemini.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkLibretroCore,
+}:
+mkLibretroCore {
+  core = "pokemini";
+  version = "0-unstable-2026-04-20";
+
+  src = fetchFromGitHub {
+    owner = "libretro";
+    repo = "PokeMini";
+    rev = "bb009b1379ad15f1514f20ca7cbf710b4af42b3e";
+    hash = "sha256-iXHUk0gWciJCKfbfIa2pOBPIOeKg1yRahNKesLRC8v8=";
+  };
+
+  makefile = "Makefile";
+
+  meta = {
+    description = "Obscure nintendo handheld emulator";
+    homepage = "https://github.com/libretro/PokeMini";
+    license = lib.licenses.gpl3Only;
+  };
+}

--- a/pkgs/applications/emulators/libretro/default.nix
+++ b/pkgs/applications/emulators/libretro/default.nix
@@ -141,6 +141,8 @@ lib.makeScope newScope (self: {
 
   picodrive = self.callPackage ./cores/picodrive.nix { };
 
+  pokemini = self.callPackage ./cores/pokemini.nix { };
+
   play = self.callPackage ./cores/play.nix { };
 
   ppsspp = self.callPackage ./cores/ppsspp.nix { };


### PR DESCRIPTION
Added pokemini libretro core as it is missing from retroarch-full and I need it for my arcade build.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [X] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].