### PR TITLE
[release-25.11] incus-lts: mark knownVulnerabilities

### DIFF
--- a/pkgs/by-name/in/incus/generic.nix
+++ b/pkgs/by-name/in/incus/generic.nix
@@ -213,5 +213,20 @@ buildGoModule (finalAttrs: {
     teams = [ lib.teams.lxc ];
     platforms = lib.platforms.linux;
     mainProgram = "incus";
+    knownVulnerabilities = lib.optionals (lib.versions.major finalAttrs.version == "6") [
+      "CVE-2026-35527 (Moderate)"
+      "CVE-2026-40195 (Moderate)"
+      "CVE-2026-40197 (Moderate)"
+      "CVE-2026-40251 (Moderate)"
+      "CVE-2026-41647 (Moderate)"
+      "CVE-2026-41684 (Moderate)"
+      "CVE-2026-41685 (Moderate)"
+      "CVE-2026-40243 (Low)"
+      "CVE-2026-41648 (Low)"
+      ''
+        incus-lts v6 is no longer supported in nixpkgs given the unpatched security vulnerabilities.
+        Please upgrade to NixOS 26.05 which includes incus-lts v7 or switch to the incus package.
+      ''
+    ];
   };
 })


### PR DESCRIPTION
Upstream has yet to make progress on patching this release. LTS version 7 is now available in unstable/26.05 and 25.11 (as `incus`).

Closes: #518342
Closes: #518014
Closes: #518012
Closes: #518009
Closes: #517666
Closes: #517664
Closes: #517660

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
