### PR TITLE
steelix: add patch for correct grammar extensions on darwin

### DIFF
--- a/pkgs/by-name/st/steelix/package.nix
+++ b/pkgs/by-name/st/steelix/package.nix
@@ -1,5 +1,6 @@
 {
   fetchFromGitHub,
+  fetchpatch,
   helix,
   installShellFiles,
   lib,
@@ -17,6 +18,21 @@ rustPlatform.buildRustPackage (finalAttrs: {
     rev = "4d86612df48447088ef4190bf503fd54a7562aa9";
     hash = "sha256-qAUODNxHM9K6CrRCFgfBcbqzRd+YHiWn9fEfmIzrohA=";
   };
+
+  # This fork is built from Helix master, whose loader expects tree-sitter
+  # grammars with the platform-native extension (`.dylib` on Darwin) since
+  # helix-editor/helix#14982. We reuse the grammars from `helix.runtime`, built
+  # from the last Helix *release*, which still names them `.so` on Darwin, so
+  # revert that commit to make the loader look for `.so`. Remove once a Helix
+  # release ships #14982 and nixpkgs' grammars switch to `.dylib`.
+  patches = [
+    (fetchpatch {
+      name = "revert-dylib-grammar-extension.patch";
+      url = "https://github.com/helix-editor/helix/commit/430914b298a32653ab1847fdfdf2177a002be04c.patch";
+      revert = true;
+      hash = "sha256-4KUFppkso4/XwNU+mGIgLvl+mJXHZWkmaguYMy8oTyI=";
+    })
+  ];
 
   cargoHash = "sha256-6bu8sIM4So3AbnHHYbh8uu+rEB4IjMQjDgh7/AkLQs0=";
 

--- a/pkgs/by-name/st/steelix/package.nix
+++ b/pkgs/by-name/st/steelix/package.nix
@@ -73,6 +73,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.mpl20;
     mainProgram = "hx";
     maintainers = with lib.maintainers; [
+      aciceri
       Ra77a3l3-jar
     ];
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

On darwin syntax highligthing for this derivation doesn't work at the moment, this PR fixes it.

Copying the comment from the code:
  
>  This fork is built from Helix master, whose loader expects tree-sitter
>   grammars with the platform-native extension (`.dylib` on Darwin) since
>   helix-editor/helix#14982. We reuse the grammars from `helix.runtime`, built
>   from the last Helix *release*, which still names them `.so` on Darwin, so
>   revert that commit to make the loader look for `.so`. Remove once a Helix
>   release ships helix-editor/helix#14982 and nixpkgs' grammars switch to `.dylib`.


Also added myself to maintainers since I'm already maintaining `helix` and `helix-unwrapped.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
