### PR TITLE
python3Packages.docling-parse: 5.0.0 -> 6.2.0

### DIFF
--- a/pkgs/development/python-modules/docling-parse/default.nix
+++ b/pkgs/development/python-modules/docling-parse/default.nix
@@ -23,7 +23,7 @@
   docling-core,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "docling-parse";
   version = "6.2.0";
   pyproject = true;
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "docling-project";
     repo = "docling-parse";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-f6PoA+N/Idu9ImpdiZ0STQft7U+UyKNVcRbizDHXag0=";
   };
 
@@ -102,10 +102,10 @@ buildPythonPackage rec {
   doCheck = false;
 
   meta = {
-    changelog = "https://github.com/docling-project/docling-parse/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/docling-project/docling-parse/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "Simple package to extract text with coordinates from programmatic PDFs";
     homepage = "https://github.com/docling-project/docling-parse";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/docling-parse/default.nix
+++ b/pkgs/development/python-modules/docling-parse/default.nix
@@ -13,24 +13,26 @@
   libjpeg,
   qpdf,
   loguru-cpp,
+  openjpeg,
+  lcms2,
+  blend2d,
   # python dependencies
   tabulate,
   pillow,
   pydantic,
   docling-core,
-  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "docling-parse";
-  version = "5.0.0";
+  version = "6.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "docling-project";
     repo = "docling-parse";
     tag = "v${version}";
-    hash = "sha256-qxD3ryU1jXf8Gm5/IiG2NTOnRgA6HADPfgBj6Kn+Pj4=";
+    hash = "sha256-f6PoA+N/Idu9ImpdiZ0STQft7U+UyKNVcRbizDHXag0=";
   };
 
   postPatch = ''
@@ -62,6 +64,9 @@ buildPythonPackage rec {
     qpdf
     utf8cpp
     zlib
+    openjpeg
+    lcms2
+    blend2d
   ];
 
   env.USE_SYSTEM_DEPS = true;
@@ -92,18 +97,15 @@ buildPythonPackage rec {
     "docling_parse"
   ];
 
-  nativeCheckInputs = [
-    pytestCheckHook
-  ];
+  # The tests download a dataset from the Hugging Face at pytest session
+  # start (tests/conftest.py), which is not possible in the sandbox.
+  doCheck = false;
 
   meta = {
-    changelog = "https://github.com/DS4SD/docling-parse/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/docling-project/docling-parse/blob/${src.tag}/CHANGELOG.md";
     description = "Simple package to extract text with coordinates from programmatic PDFs";
-    homepage = "https://github.com/DS4SD/docling-parse";
+    homepage = "https://github.com/docling-project/docling-parse";
     license = lib.licenses.mit;
     maintainers = [ ];
-    # error: no matching conversion for functional-style cast from 'bool' to 'nlohmann::basic_json<>'
-    # See https://github.com/docling-project/docling-parse/issues/172 for context
-    broken = true;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Updat `python3Packages.docling-parse` from `v5.0.0` to `v6.2.0`.
The package was marked as broken, but https://github.com/docling-project/docling-parse/issues/172 has been fixed and now compiles successfully, so I dropped it.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
