### PR TITLE
_0xpropo: switch to finalAttrs pattern

### DIFF
--- a/pkgs/by-name/_0/_0xpropo/package.nix
+++ b/pkgs/by-name/_0/_0xpropo/package.nix
@@ -3,16 +3,16 @@
   stdenvNoCC,
   fetchzip,
 }:
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "0xpropo";
   version = "1.100";
 
   src =
     let
-      underscoreVersion = builtins.replaceStrings [ "." ] [ "_" ] version;
+      underscoreVersion = builtins.replaceStrings [ "." ] [ "_" ] finalAttrs.version;
     in
     fetchzip {
-      url = "https://github.com/0xType/0xPropo/releases/download/${version}/0xPropo_${underscoreVersion}.zip";
+      url = "https://github.com/0xType/0xPropo/releases/download/${finalAttrs.version}/0xPropo_${underscoreVersion}.zip";
       hash = "sha256-ZlZNvn9xiOxS+dfGI1rGbh6XlXo3/puAm2vhKh63sK4=";
     };
 
@@ -26,9 +26,9 @@ stdenvNoCC.mkDerivation rec {
   meta = {
     description = "Proportional version of the 0xProto font";
     homepage = "https://github.com/0xType/0xPropo";
-    changelog = "https://github.com/0xType/0xPropo/releases/tag/${version}";
+    changelog = "https://github.com/0xType/0xPropo/releases/tag/${finalAttrs.version}";
     license = lib.licenses.ofl;
     maintainers = with lib.maintainers; [ vinnymeller ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
migrate 0xpropo to finalAttrs pattern, move out of treewide PR #524874.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
