### PR TITLE
elastic-cli: init at 0.2.0

### DIFF
--- a/pkgs/by-name/el/elastic-cli/package.nix
+++ b/pkgs/by-name/el/elastic-cli/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  buildNpmPackage,
+  installShellFiles,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "elastic-cli";
+  version = "0.2.0";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "elastic";
+    repo = "cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-QWHRnvWSoJBxS9nKf+HsZdx1wiHwq/LykcCm9HxD3AQ=";
+  };
+
+  npmDepsFetcherVersion = 2;
+  makeCacheWritable = true;
+  dontNpmPrune = true;
+
+  npmDepsHash = "sha256-08Y952beQwtiHO+Bmyk0Wsh+YEPErjTkdqBIvWI0XcM=";
+
+  nativeBuildInputs = [ installShellFiles ];
+  postInstall = ''
+    # The workspace packages (@elastic/config-resolver, @elastic/es-schemas) are
+    # symlinked into node_modules during the build. npm pack doesn't include the
+    # symlink targets, so we copy the compiled workspace packages into the output
+    # to satisfy the symlinks.
+    cp -r packages $out/lib/node_modules/@elastic/cli/packages
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd elastic \
+      --bash <($out/bin/elastic completion bash) \
+      --fish <($out/bin/elastic completion fish) \
+      --zsh <($out/bin/elastic completion zsh)
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Interact with Elasticsearch, Elastic Serverless and Elastic Cloud APIs from the command line";
+    homepage = "https://github.com/elastic/cli";
+    changelog = "https://github.com/elastic/cli/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kpbaks ];
+    mainProgram = "elastic";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
