### PR TITLE
nixos/seerr: add PostgreSQL database support

### DIFF
--- a/nixos/modules/services/misc/seerr.nix
+++ b/nixos/modules/services/misc/seerr.nix
@@ -10,6 +10,7 @@ let
   # 26.05 introduced a breaking change which is guarded behind stateRevision to
   # avoid breaking users.
   useNewConfigLocation = cfg.stateRevision >= 1;
+  usePostgresql = cfg.database.type == "postgres";
 in
 {
   imports = [
@@ -57,9 +58,89 @@ in
         '';
       };
     };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/run/secrets/seerr.env";
+      description = ''
+        Path to an environment file (see {manpage}`systemd.exec(5)`) loaded by the
+        service. Use it to pass secrets such as `DB_PASS` (the PostgreSQL password
+        for TCP authentication) without writing them to the world-readable Nix
+        store. Not needed when {option}`services.seerr.database.socketPath` is used
+        with peer authentication.
+      '';
+    };
+
+    database = {
+      type = lib.mkOption {
+        type = lib.types.enum [
+          "sqlite"
+          "postgres"
+        ];
+        default = "sqlite";
+        description = ''
+          Database engine Seerr should use. With `sqlite` (the default) Seerr keeps
+          its data in a file under {option}`services.seerr.configDir`. With
+          `postgres` it connects to an external PostgreSQL server, which must be
+          provisioned separately (for example via {option}`services.postgresql`).
+        '';
+      };
+
+      host = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "127.0.0.1";
+        description = ''
+          PostgreSQL host to connect to over TCP. Ignored when
+          {option}`services.seerr.database.socketPath` is set.
+        '';
+      };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 5432;
+        description = "PostgreSQL TCP port. Ignored when {option}`services.seerr.database.socketPath` is set.";
+      };
+
+      socketPath = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        example = "/run/postgresql";
+        description = ''
+          Directory of the PostgreSQL Unix-domain socket to connect through. When
+          set it takes precedence over {option}`services.seerr.database.host` and
+          enables passwordless peer authentication for a local PostgreSQL server.
+        '';
+      };
+
+      name = lib.mkOption {
+        type = lib.types.str;
+        default = "seerr";
+        description = "PostgreSQL database name.";
+      };
+
+      user = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "seerr";
+        description = "PostgreSQL user name. Required when {option}`services.seerr.database.type` is `postgres`.";
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = usePostgresql -> cfg.database.user != null;
+        message = "services.seerr.database.user must be set when services.seerr.database.type is \"postgres\".";
+      }
+      {
+        assertion = usePostgresql -> (cfg.database.socketPath != null || cfg.database.host != null);
+        message = "services.seerr.database: set either socketPath (peer authentication) or host when type is \"postgres\".";
+      }
+    ];
+
     systemd.services.seerr = {
       description = "Seerr, a requests manager for Jellyfin";
       after = [ "network.target" ];
@@ -67,9 +148,26 @@ in
       environment = {
         PORT = toString cfg.port;
         CONFIG_DIRECTORY = cfg.configDir;
-      };
+      }
+      // lib.optionalAttrs usePostgresql (
+        {
+          DB_TYPE = "postgres";
+          DB_NAME = cfg.database.name;
+          DB_USER = cfg.database.user;
+        }
+        // (
+          if cfg.database.socketPath != null then
+            { DB_SOCKET_PATH = cfg.database.socketPath; }
+          else
+            {
+              DB_HOST = cfg.database.host;
+              DB_PORT = toString cfg.database.port;
+            }
+        )
+      );
       serviceConfig = {
         Type = "exec";
+        EnvironmentFile = lib.mkIf (cfg.environmentFile != null) cfg.environmentFile;
         # Note: this should be a parent of configDir.
         StateDirectory = if useNewConfigLocation then "seerr" else "jellyseerr";
         DynamicUser = true;

--- a/nixos/modules/services/misc/seerr.nix
+++ b/nixos/modules/services/misc/seerr.nix
@@ -155,6 +155,10 @@ in
         assertion = localPostgresql -> cfg.database.user == "seerr";
         message = "services.seerr.database.user must be \"seerr\" when services.seerr.database.createLocally is true.";
       }
+      {
+        assertion = localPostgresql -> builtins.match "[a-zA-Z_][a-zA-Z0-9_-]*" cfg.database.name != null;
+        message = "services.seerr.database.name must be a valid PostgreSQL identifier when services.seerr.database.createLocally is true.";
+      }
     ];
 
     services.postgresql = lib.mkIf localPostgresql {
@@ -163,10 +167,15 @@ in
       ensureUsers = [
         {
           name = cfg.database.user;
-          ensureDBOwnership = true;
         }
       ];
     };
+
+    systemd.services.postgresql-setup.postStart = lib.mkIf localPostgresql (
+      lib.mkAfter ''
+        psql -tAc 'ALTER DATABASE "${cfg.database.name}" OWNER TO "${cfg.database.user}";'
+      ''
+    );
 
     systemd.services.seerr = {
       description = "Seerr, a requests manager for Jellyfin";

--- a/nixos/modules/services/misc/seerr.nix
+++ b/nixos/modules/services/misc/seerr.nix
@@ -11,6 +11,7 @@ let
   # avoid breaking users.
   useNewConfigLocation = cfg.stateRevision >= 1;
   usePostgresql = cfg.database.type == "postgres";
+  localPostgresql = usePostgresql && cfg.database.createLocally;
 in
 {
   imports = [
@@ -73,6 +74,14 @@ in
     };
 
     database = {
+      createLocally = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to automatically create a local PostgreSQL database and user.
+        '';
+      };
+
       type = lib.mkOption {
         type = lib.types.enum [
           "sqlite"
@@ -105,7 +114,10 @@ in
 
       socketPath = lib.mkOption {
         type = lib.types.nullOr lib.types.path;
-        default = null;
+        default = if cfg.database.createLocally then "/run/postgresql" else null;
+        defaultText = lib.literalExpression ''
+          if config.services.seerr.database.createLocally then "/run/postgresql" else null
+        '';
         example = "/run/postgresql";
         description = ''
           Directory of the PostgreSQL Unix-domain socket to connect through. When
@@ -121,10 +133,10 @@ in
       };
 
       user = lib.mkOption {
-        type = lib.types.nullOr lib.types.str;
-        default = null;
+        type = lib.types.str;
+        default = "seerr";
         example = "seerr";
-        description = "PostgreSQL user name. Required when {option}`services.seerr.database.type` is `postgres`.";
+        description = "PostgreSQL user name.";
       };
     };
   };
@@ -132,18 +144,34 @@ in
   config = lib.mkIf cfg.enable {
     assertions = [
       {
-        assertion = usePostgresql -> cfg.database.user != null;
-        message = "services.seerr.database.user must be set when services.seerr.database.type is \"postgres\".";
+        assertion = cfg.database.createLocally -> usePostgresql;
+        message = "services.seerr.database.createLocally requires services.seerr.database.type to be \"postgres\".";
       }
       {
         assertion = usePostgresql -> (cfg.database.socketPath != null || cfg.database.host != null);
         message = "services.seerr.database: set either socketPath (peer authentication) or host when type is \"postgres\".";
       }
+      {
+        assertion = localPostgresql -> cfg.database.user == "seerr";
+        message = "services.seerr.database.user must be \"seerr\" when services.seerr.database.createLocally is true.";
+      }
     ];
+
+    services.postgresql = lib.mkIf localPostgresql {
+      enable = true;
+      ensureDatabases = [ cfg.database.name ];
+      ensureUsers = [
+        {
+          name = cfg.database.user;
+          ensureDBOwnership = true;
+        }
+      ];
+    };
 
     systemd.services.seerr = {
       description = "Seerr, a requests manager for Jellyfin";
-      after = [ "network.target" ];
+      after = [ "network.target" ] ++ lib.optional localPostgresql "postgresql.target";
+      requires = lib.optional localPostgresql "postgresql.target";
       wantedBy = [ "multi-user.target" ];
       environment = {
         PORT = toString cfg.port;

--- a/nixos/tests/seerr.nix
+++ b/nixos/tests/seerr.nix
@@ -6,16 +6,60 @@
     fallenbagel
   ];
 
-  nodes.machine =
-    { pkgs, ... }:
-    {
-      services.seerr.enable = true;
-    };
+  nodes = {
+    machine =
+      { ... }:
+      {
+        services.seerr.enable = true;
+      };
+
+    postgres =
+      { ... }:
+      {
+        services.postgresql = {
+          enable = true;
+          ensureDatabases = [ "seerr" ];
+          ensureUsers = [
+            {
+              name = "seerr";
+              ensureDBOwnership = true;
+            }
+          ];
+        };
+
+        services.seerr = {
+          enable = true;
+          database = {
+            type = "postgres";
+            socketPath = "/run/postgresql";
+            user = "seerr";
+            name = "seerr";
+          };
+        };
+
+        systemd.services.seerr.after = [ "postgresql.service" ];
+      };
+  };
 
   testScript = ''
-    machine.start()
-    machine.wait_for_unit("seerr.service")
-    machine.wait_for_open_port(5055)
-    machine.succeed("curl --fail http://localhost:5055/")
+    start_all()
+
+    with subtest("default sqlite backend serves the web UI"):
+        machine.wait_for_unit("seerr.service")
+        machine.wait_for_open_port(5055)
+        machine.succeed("curl --fail http://localhost:5055/")
+
+    with subtest("postgres backend serves the web UI and creates its schema"):
+        postgres.wait_for_unit("postgresql.service")
+        # Seerr runs its TypeORM migrations against PostgreSQL on startup; the
+        # unit only reaches "started" and opens its port once that succeeds.
+        postgres.wait_for_unit("seerr.service")
+        postgres.wait_for_open_port(5055)
+        postgres.succeed("curl --fail http://localhost:5055/")
+        # Prove the data really landed in PostgreSQL rather than a sqlite file.
+        postgres.succeed(
+            "test \"$(sudo -u postgres psql -tAc "
+            "\"select count(*) from information_schema.tables where table_schema = 'public'\" seerr)\" -gt 0"
+        )
   '';
 }

--- a/nixos/tests/seerr.nix
+++ b/nixos/tests/seerr.nix
@@ -16,28 +16,13 @@
     postgres =
       { ... }:
       {
-        services.postgresql = {
-          enable = true;
-          ensureDatabases = [ "seerr" ];
-          ensureUsers = [
-            {
-              name = "seerr";
-              ensureDBOwnership = true;
-            }
-          ];
-        };
-
         services.seerr = {
           enable = true;
           database = {
             type = "postgres";
-            socketPath = "/run/postgresql";
-            user = "seerr";
-            name = "seerr";
+            createLocally = true;
           };
         };
-
-        systemd.services.seerr.after = [ "postgresql.service" ];
       };
   };
 

--- a/nixos/tests/seerr.nix
+++ b/nixos/tests/seerr.nix
@@ -46,5 +46,13 @@
             "test \"$(sudo -u postgres psql -tAc "
             "\"select count(*) from information_schema.tables where table_schema = 'public'\" seerr)\" -gt 0"
         )
+        postgres.succeed("systemctl restart seerr.service")
+        postgres.wait_for_unit("seerr.service")
+        postgres.wait_for_open_port(5055)
+        postgres.succeed(
+            "test \"$(sudo -u postgres psql -tAc "
+            "\"select count(*) from information_schema.tables where table_schema = 'public'\" seerr)\" -gt 0",
+            "curl --fail http://localhost:5055/",
+        )
   '';
 }


### PR DESCRIPTION
## Summary

`services.seerr` defaults to SQLite and previously exposed no typed database options, so PostgreSQL required hand-written systemd environment overrides.

Seerr supports PostgreSQL natively. This PR adds a `services.seerr.database` submodule, optional local PostgreSQL provisioning, secret-bearing `environmentFile` support, configuration assertions, and a PostgreSQL NixOS test while leaving SQLite as the compatible default.

The updated branch passes the Seerr NixOS test and `nixpkgs-vet` at `d2d1a8113529`. The PostgreSQL test also exercises a service restart and a non-default local database name. A [new external `nixpkgs-review`](https://github.com/caniko/nixpkgs-review-gha/actions/runs/29595541406) passed on aarch64-linux, x86_64-linux, aarch64-darwin, and x86_64-darwin.

Development and this PR refresh were assisted by OpenAI Codex (GPT-5).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test



