### PR TITLE
nixos/virtualisation: (Aarch64) enable to remove -device virtio-gpu-pci

### DIFF
--- a/nixos/modules/virtualisation/qemu-vm.nix
+++ b/nixos/modules/virtualisation/qemu-vm.nix
@@ -774,6 +774,16 @@ in
         '';
       };
 
+      enableAarch64VirtioGpuPciDevice = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to add to QEMU's command arguments `-device virtio-gpu-pci`.
+          Relevant only for virtualisations of Aarch64 hosts.
+          The motivation for disabling this option is for cases where you don't need any display, or when you want to pass only `-device virtio-gpu-gl-pci`, without any other ``virtio-gpu` device argument.
+        '';
+      };
+
       options = mkOption {
         type = types.listOf types.str;
         default = [ ];
@@ -1378,8 +1388,10 @@ in
         "-usb"
         "-device usb-tablet,bus=usb-bus.0"
       ])
-      (mkIf pkgs.stdenv.hostPlatform.isAarch [
+      (mkIf (pkgs.stdenv.hostPlatform.isAarch && cfg.qemu.enableAarch64VirtioGpuPciDevice) [
         "-device virtio-gpu-pci"
+      ])
+      (mkIf pkgs.stdenv.hostPlatform.isAarch [
         "-device usb-ehci,id=usb0"
         "-device usb-kbd"
         "-device usb-tablet"


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test