### PR TITLE
stdenv: PURL fetcher inheritance feature flag

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -38,6 +38,7 @@
   Package-URLs allow reliably identifying and locating software packages.
   Maintainers of derivations using the adapted fetchers should rely on the `drv.src.meta.identifiers.v1.purl` default identifier and can enhance their `drv.meta.identifiers.v1.purls` list once they would like to have additional identifiers.
   Maintainers using `fetchurl` for `drv.src` are urged to adapt their `drv.meta.identifiers.purlParts` for proper identification.
+  Maintainers should check that their `drv.src` / `drv.srcs` either evaluate properly or that they throw an UnsupportedPlatform statement instead of a missing attribute error. The inheritance feature of `drv.src(s).meta.identifiers.purl(s)` for `drv.meta.identifiers.purl(s)` can get activated via `config.allowSrcEvalForDrvMeta`.
 
 ## Nixpkgs Library {#sec-nixpkgs-release-26.11-lib}
 

--- a/doc/stdenv/meta.chapter.md
+++ b/doc/stdenv/meta.chapter.md
@@ -348,6 +348,7 @@ A readonly attribute containing the list of guesses for what CPE for this packag
 [Package-URL](https://github.com/package-url/purl-spec) (PURL) is a specification to reliably identify and locate software packages.
 Through identification of software packages, additional (non-major) use cases are e.g. software license cross-verification via third party databases or initial vulnerability response management.
 Package-URLs shall default to the `mkDerivation.src`, as the original consumed software package is the single source of truth.
+The default inheritance must get enabled explicitly through the nixpkgs config parameter `allowSrcEvalForDrvMeta`.
 
 #### `meta.identifiers.purlParts` {#var-meta-identifiers-purlParts}
 

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -70,6 +70,8 @@ let
   allowlist = config.allowlistedLicenses or config.whitelistedLicenses or [ ];
   blocklist = config.blocklistedLicenses or config.blacklistedLicenses or [ ];
 
+  allowSrcEvalForDrvMeta = config.allowSrcEvalForDrvMeta;
+
   areLicenseListsValid =
     if mutuallyExclusive allowlist blocklist then
       true
@@ -632,6 +634,7 @@ let
                 }
               ) possibleCPEPartsFuns;
 
+          evaluateSrc = allowSrcEvalForDrvMeta && !isMarkedBroken attrs && !hasUnsupportedPlatform attrs;
           purlParts = attrs.meta.identifiers.purlParts or { };
           purlPartsFormatted =
             if purlParts ? type && purlParts ? spec then "pkg:${purlParts.type}/${purlParts.spec}" else null;
@@ -639,14 +642,35 @@ let
           # search for a PURL in the following order:
           purl =
             # 1) locally set through API
-            if purlPartsFormatted != null then purlPartsFormatted else null;
+            if purlPartsFormatted != null then
+              purlPartsFormatted
+            else if !evaluateSrc then
+              null
+            else
+              # 2) locally overwritten through meta.identifiers.purl
+              (attrs.src.meta.identifiers.purl or null);
 
           # search for a PURL in the following order:
           purls =
             # 1) locally overwritten through meta.identifiers.purls (e.g. extension of list)
             attrs.meta.identifiers.purls or (
               # 2) locally set through API
-              if purlPartsFormatted != null then [ purlPartsFormatted ] else [ ]
+              if purlPartsFormatted != null then
+                [ purlPartsFormatted ]
+              else if !evaluateSrc then
+                [ ]
+              else
+                # 3) src.meta.PURL
+                (attrs.src.meta.identifiers.purls or (
+                  # 4) srcs.meta.PURL
+                  if !attrs ? srcs then
+                    [ ]
+                  else if isList attrs.srcs then
+                    concatMap (drv: drv.meta.identifiers.purls or [ ]) attrs.srcs
+                  else
+                    attrs.srcs.meta.identifiers.purls or [ ]
+                )
+                )
             );
 
           v1 = {

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -472,6 +472,17 @@ let
     };
 
     problems = (import ../stdenv/generic/problems.nix { inherit lib; }).configOptions;
+
+    allowSrcEvalForDrvMeta = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enables evaluation of drv.src or drv.srcs, in order to generate parts of drv.meta. Most of the nixpkgs derivations have a drv.src or drv.srcs which properly evaluate, but there are some corner cases.
+
+        Background: Commonly PURL identifiers are based on the source of software. For example software distributed through github.com can get identified via pkg:github/org/repo.
+        This feature flag should get activated, once an SBOM tool is in use and where drv.meta.identifiers.purl(s) should inherit the informations from drv.src(s).meta.identifiers.purl(s).
+      '';
+    };
   };
 
 in


### PR DESCRIPTION
This reverts commit 7e7455d04291fa8cd55ad80b5f4445325d03d157.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
