### PR TITLE
strichliste: fix config keys, fix config reload, optimize autoloader

### DIFF
--- a/nixos/modules/services/web-apps/strichliste.nix
+++ b/nixos/modules/services/web-apps/strichliste.nix
@@ -478,20 +478,15 @@ in
         inherit (cfg) environment;
         serviceConfig = {
           Type = "oneshot";
+          RemainAfterExit = true;
           User = "strichliste";
           Group = "strichliste";
           EnvironmentFile = cfg.environmentFiles;
-          ExecStart = map toString [
-            [
-              (lib.getExe cfg.packages.backend)
-              "cache:clear"
-            ]
-            [
-              (lib.getExe cfg.packages.backend)
-              "doctrine:migrations:migrate"
-              "--allow-no-migration"
-              "--no-interaction"
-            ]
+          ExecStart = toString [
+            (lib.getExe cfg.packages.backend)
+            "doctrine:migrations:migrate"
+            "--allow-no-migration"
+            "--no-interaction"
           ];
         };
       };
@@ -499,6 +494,11 @@ in
       systemd.services.phpfpm-strichliste = {
         inherit (cfg) environment;
         serviceConfig.EnvironmentFile = cfg.environmentFiles;
+        restartTriggers = [ settingsFile ];
+        preStart = toString [
+          (lib.getExe cfg.packages.backend)
+          "cache:clear"
+        ];
       };
 
       services.phpfpm.pools.strichliste = {

--- a/nixos/modules/services/web-apps/strichliste.nix
+++ b/nixos/modules/services/web-apps/strichliste.nix
@@ -128,21 +128,23 @@ in
           };
 
           account = {
-            lower = mkOption {
-              type = types.int;
-              default = -200000;
-              example = 0;
-              description = ''
-                The credit limit for user accounts.
-              '';
-            };
+            boundary = {
+              lower = mkOption {
+                type = types.int;
+                default = -200000;
+                example = 0;
+                description = ''
+                  The credit limit for user accounts.
+                '';
+              };
 
-            upper = mkOption {
-              type = types.ints.positive;
-              default = 200000;
-              description = ''
-                The maximum balance on a user account.
-              '';
+              upper = mkOption {
+                type = types.ints.positive;
+                default = 200000;
+                description = ''
+                  The maximum balance on a user account.
+                '';
+              };
             };
           };
 
@@ -256,7 +258,7 @@ in
               };
             };
 
-            transaction = {
+            transactions = {
               enabled = mkOption {
                 type = types.bool;
                 default = true;

--- a/pkgs/by-name/st/strichliste/package.nix
+++ b/pkgs/by-name/st/strichliste/package.nix
@@ -21,7 +21,7 @@ php.buildComposerProject2 (finalAttrs: {
   vendorHash = "sha256-PLq+XiZIJyyzVq+87timGO/jbPB4ZYQqSZilZMIE4Cw=";
   composerNoDev = true;
   composerNoPlugins = false;
-  composerStrictValidation = false;
+  composerStrictValidation = true;
 
   postPatch = ''
     substituteInPlace config/services.yaml \

--- a/pkgs/by-name/st/strichliste/package.nix
+++ b/pkgs/by-name/st/strichliste/package.nix
@@ -28,6 +28,10 @@ php.buildComposerProject2 (finalAttrs: {
       --replace-fail "strichliste.yaml" "/etc/strichliste.yaml"
   '';
 
+  postBuild = ''
+    composer dump-autoload --optimize --no-dev --no-scripts --no-interaction --no-cache
+  '';
+
   postInstall = ''
     mkdir $out/bin
     ln -s $out/share/php/strichliste-backend/bin/console $out/bin/strichliste-console


### PR DESCRIPTION
### Config fixes

- transaction -> transaction**s**
- account.lower|upper -> account.**boundary**.lower|upper

### Stale cache on config change

An updated config (strichliste.yaml) is currently not picked up by the service.

Thus, `restartTriggers = [ settingsFile ];` was added to the systemd service. The service now also clear the cache of the application via `preStart`. Clearing the cache is also important when the backend version changes.

The service also got `RemainAfterExit = true`, because `nixos-rebuild ... switch` seems to only restart active units (without this line, the service is marked as inactive/dead).

### Optimized Autoloader

By default, `buildComposerProject2` does not generate an [optimized autoloader](https://getcomposer.org/doc/articles/autoloader-optimization.md) and also does not offer any setting to enable it (as far as I can see). I don't think adding `"classmap-authoritative": true` to the upstream composer.json is a good solution because then this setting would always be enabled, even during development.

Thus, I added a `postBuild` step to generate an optimized autoloader.

### Composer strict validation

The upstream composer.json passes strict validation since the 2.1.0 release, so set `composerStrictValidation` to `true`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
