### PR TITLE
some-sass-language-server: init at 2.3.8

### DIFF
--- a/pkgs/by-name/so/some-sass-language-server/package.nix
+++ b/pkgs/by-name/so/some-sass-language-server/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  pkg-config,
+  libsecret,
+  nix-update-script,
+}:
+buildNpmPackage (finalAttrs: {
+  pname = "some-sass-language-server";
+  version = "2.3.8";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "wkillerud";
+    repo = "some-sass";
+    rev = "some-sass-language-server@${finalAttrs.version}";
+    hash = "sha256-jmpkZReeVuf10juWMy7QO/q1Sm7kye3NTpMCeB8kG48=";
+  };
+
+  strictDeps = true;
+
+  npmDepsHash = "sha256-sSumbDqiztUuTs+amYv83I6odbrIOOawXeJxdF2xkA4=";
+  npmBuildScript = "build:production";
+  npmRebuildFlags = [ "--ignore-scripts" ];
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ libsecret ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{libexec,bin}
+    cp -r packages/language-server $out/libexec/some-sass-language-server
+    ln -s $out/libexec/some-sass-language-server/bin/some-sass-language-server $out/bin
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "some-sass-language-server@(.*)"
+    ];
+  };
+
+  meta = {
+    description = "Language server with improved support for SCSS, Sass indented and SassDoc";
+    homepage = "https://wkillerud.github.io/some-sass";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    mainProgram = "some-sass-language-server";
+    maintainers = [ lib.maintainers.bandithedoge ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
