### PR TITLE
brlcad: reduce bext source size

### DIFF
--- a/pkgs/by-name/br/brlcad/package.nix
+++ b/pkgs/by-name/br/brlcad/package.nix
@@ -46,8 +46,68 @@ let
     owner = "BRL-CAD";
     repo = "bext";
     rev = "f9074f84c87605f89d912069cee1b1e710ead635"; # must match brlcad_bext_init() in CMakeLists.txt
-    hash = "sha256-jCBw4aDk/bmz2Woe9qIA88mgLRRZSu7zDYM5pi3MbP8=";
+    hash = "sha256-wOzrHiEA+IVUnchSRRUAzIwKkGWtyvnrInnADi3KgiI=";
     fetchSubmodules = true;
+    # remove unneeded subprojects to reduce NAR size
+    postFetch =
+      let
+        subprojectsToRemove = toString [
+          "appleseed"
+          "astyle"
+          "boost"
+          "clipper2"
+          "deflate"
+          "eigen"
+          "embree"
+          "expat"
+          "flexbison"
+          "fmt"
+          "gdal"
+          "geogram"
+          "gte"
+          "icu"
+          "ispc"
+          "jpeg"
+          "lief"
+          "llvm"
+          "lmdb"
+          "lz4"
+          "minizip-ng"
+          "mmesh"
+          "ncurses"
+          "netpbm"
+          "onetbb"
+          "opencolorio"
+          "opencv"
+          "openexr"
+          "openimageio"
+          "openmesh"
+          "osl"
+          "ospray"
+          "patchelf"
+          "plief"
+          "png"
+          "poissonrecon"
+          "proj"
+          "pugixml"
+          "pystring"
+          "qt"
+          "rkcommon"
+          "sqlite3"
+          "stepcode"
+          "tiff"
+          "tinygltf"
+          "xerces-c"
+          "xmltools"
+          "yaml-cpp"
+          "zstd"
+        ];
+      in
+      ''
+        for name in ${subprojectsToRemove}; do
+          rm -r $out/$name
+        done
+      '';
   };
 in
 


### PR DESCRIPTION
- Continuation of #515775
- https://hydra.nixos.org/build/330698656

Reduce bext source size by stripping all subprojects we don't need.
This reduces the store size from ~5.5GB to ~600MB.
This should fix the "Output limit exceeded" hydra build error.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
