### PR TITLE
libdvdcss: 1.4.3 -> 1.5.0

### DIFF
--- a/pkgs/by-name/li/libdvdcss/package.nix
+++ b/pkgs/by-name/li/libdvdcss/package.nix
@@ -1,20 +1,31 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitLab,
+  meson,
+  ninja,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libdvdcss";
-  version = "1.4.3";
+  version = "1.5.0";
 
-  src = fetchurl {
-    url = "https://get.videolan.org/libdvdcss/${finalAttrs.version}/libdvdcss-${finalAttrs.version}.tar.bz2";
-    sha256 = "sha256-IzzJL13AHF06lvWzWCvn1c7lo1pS06CBWHRdPYYHAHk=";
+  src = fetchFromGitLab {
+    domain = "code.videolan.org";
+    owner = "videolan";
+    repo = "libdvdcss";
+    tag = finalAttrs.version;
+    hash = "sha256-xQWfAfxqsaLZN0HMozsqY5mSIO9KvZ5RAb4bj/f6WWo=";
   };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+  ];
 
   meta = {
     homepage = "http://www.videolan.org/developers/libdvdcss.html";
+    changelog = "https://code.videolan.org/videolan/libdvdcss/blob/${finalAttrs.src.tag}/NEWS";
     description = "Library for decrypting DVDs";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.unix;


### PR DESCRIPTION
Diff: https://code.videolan.org/videolan/libdvdcss/-/compare/1.4.3...1.5.0

Changelog: https://code.videolan.org/videolan/libdvdcss/blob/1.5.0/NEWS


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
