### PR TITLE
xvfb: 21.1.22 -> 21.1.23, drop rebuild avoidance

### DIFF
--- a/pkgs/by-name/xv/xvfb/package.nix
+++ b/pkgs/by-name/xv/xvfb/package.nix
@@ -38,13 +38,7 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "xvfb";
 
-  # TODO: rebuild avoidance. revert on staging.
-  # inherit (xorg-server) src version;
-  version = "21.1.22";
-  src = fetchurl {
-    url = "mirror://xorg/individual/xserver/xorg-server-${finalAttrs.version}.tar.xz";
-    hash = "sha256-GiQsiRfEm6KczB9gIWE9iiuYBd0NJxpmrp0J9LC7BrM=";
-  };
+  inherit (xorg-server) src version;
 
   strictDeps = true;
 


### PR DESCRIPTION
dropping the rebuild avoidance from #526959.

xorg announcement: https://lists.x.org/archives/xorg-announce/2026-June/003703.html
xorg advisory: https://lists.x.org/archives/xorg-announce/2026-June/003702.html

this should be backported to staging-26.05, but only once #527038 has been merged and reached staging-26.05 via periodic merges.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
