### PR TITLE
prek: 0.3.13 -> 0.4.4

### DIFF
--- a/pkgs/by-name/pr/prek/package.nix
+++ b/pkgs/by-name/pr/prek/package.nix
@@ -13,16 +13,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "prek";
-  version = "0.3.13";
+  version = "0.4.4";
 
   src = fetchFromGitHub {
     owner = "j178";
     repo = "prek";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-OPH1H571jw0b8EsyzRcVdG54sQ7KeOclmnHCeVGteRI=";
+    hash = "sha256-PAEmRQ5Vro83fkegOWsdY59U7WAQxBPSEalzxZV6K4o=";
   };
 
-  cargoHash = "sha256-lvB09qOvVXmSdhR1TRJQ3rvYyn6cFSOGpogJZDajPuQ=";
+  cargoHash = "sha256-EmlR6Lmt5XR0uS/y3FqY5yGNeVBSdtLtEGH9jZLcP2o=";
 
   nativeBuildInputs = [
     installShellFiles


### PR DESCRIPTION
Updates `prek` from `0.3.13` to `0.4.4`.

Notable upstream changes include (see [CHANGELOG.md]):

* `0.4.4` improves `prek run` observability by streaming hook output in the progress UI and showing a live preview for running hooks.
* `0.4.4` adds hook group filters (`groups`, `--group`, `--no-group`) so a single config can support different local, CI, slow-validation, or project-specific workflows.
* `0.4.4` fixes intent-to-add stash restore handling.
* `0.4.2` improves `prek run` performance in large repositories by reducing expensive `git diff` work, skipping diff checks for read-only hooks, optimizing clean-worktree checks, and running same-depth workspace projects concurrently.
* `0.4.1` improves hook/workspace behavior, including pre-push range handling after rebases and skipping installs for hooks that will not run.
* `0.4.0` and `0.4.3` fix runtime/toolchain edge cases, including npm config environment overrides for node hooks and stat-only hook rewrites.
* **Includes narrow breaking changes in `0.4.0`**: generated hook scripts no longer preserve `-q`, `-v`, or `--no-progress` from `prek install`, and `language_version` no longer accepts direct executable paths.

Targeting `staging` because `nixpkgs-branch-check` classified this update as a mass rebuild.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

AI assistance was used to draft this PR description; the package update and test results were reviewed before submission.

## Tests and validation

Tested on `aarch64-darwin`:

```console
$ nix-build -A prek
[...]
/nix/store/dhhylz5ygdiabczdsqk1n1pivmdphhvq-prek-0.4.4

$ ./result/bin/prek --version
prek 0.4.4
```

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CHANGELOG.md]: https://github.com/j178/prek/blob/v0.4.4/CHANGELOG.md
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test