### PR TITLE
nixos/tests/incus: pass package to releases config

### DIFF
--- a/nixos/tests/incus/incus-tests-module.nix
+++ b/nixos/tests/incus/incus-tests-module.nix
@@ -1,10 +1,12 @@
 {
+  config,
   lib,
   pkgs,
   ...
 }:
 let
   jsonFormat = pkgs.formats.json { };
+  cfg = config.tests.incus;
 in
 {
   options.tests.incus = {
@@ -74,7 +76,11 @@ in
             config =
               let
                 releases = import ../../release.nix {
-                  configuration = config.nixosConfig;
+                  configuration = lib.recursiveUpdate config.nixosConfig {
+                    virtualisation.incus = {
+                      inherit (cfg) package;
+                    };
+                  };
                 };
 
                 images = {


### PR DESCRIPTION
virtual-machine releases use virtualisation.incus.package to find where the agent-loader configuration is defined. In practice it's likely not a problem, but when marking lts v6 on 25.11 as vulnerable it exposed the mismatch. For correctness we should ensure the VM tests are using the agent loader from the relevant incus package.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
