### PR TITLE
libfreehand: 0.1.2 -> 0.1.3

### DIFF
--- a/pkgs/by-name/li/libfreehand/package.nix
+++ b/pkgs/by-name/li/libfreehand/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchzip,
-  fetchpatch,
   perl,
   pkg-config,
   boost,
@@ -16,11 +15,11 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "libfreehand";
-  version = "0.1.2";
+  version = "0.1.3";
 
   src = fetchzip {
     url = "https://dev-www.libreoffice.org/src/libfreehand/libfreehand-${finalAttrs.version}.tar.xz";
-    hash = "sha256-0icEGnTtYveP24FbYjRB7tFW/TquSOszbqZspHAhQ7I=";
+    hash = "sha256-ZcvG00JP3BoFv1PIeAhZyr7t1zANhTVluBZQqEbWCvY=";
   };
 
   nativeBuildInputs = [
@@ -40,13 +39,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   configureFlags = [ "--disable-werror" ];
-
-  patches = [
-    (fetchpatch {
-      url = "https://gitlab.archlinux.org/archlinux/packaging/packages/libfreehand/-/raw/main/libfreehand-0.1.2-icu-fix.patch?ref_type=heads";
-      hash = "sha256-SRkcF+FRkFdueLSTOMYWo6+CCl05f0OBP6G5VrXRyCw=";
-    })
-  ];
 
   meta = {
     description = "Adobe Freehand import library";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
