### PR TITLE
nixos/displayManager: interpolate option paths; improve `defaultSession` error

### DIFF
--- a/nixos/modules/services/display-managers/default.nix
+++ b/nixos/modules/services/display-managers/default.nix
@@ -10,6 +10,8 @@ let
   cfg = config.services.displayManager;
   opts = options.services.displayManager;
 
+  toPretty = lib.generators.toPretty { };
+
   installedSessions =
     pkgs.runCommand "desktops"
       {
@@ -193,9 +195,9 @@ in
       {
         assertion = cfg.defaultSession == null || lib.elem cfg.defaultSession cfg.sessionData.sessionNames;
         message = ''
-          Default graphical session, '${toString cfg.defaultSession}', not found.
+          Default graphical session, ${toPretty cfg.defaultSession}, not found. Definitions:${lib.options.showDefs opts.defaultSession.definitionsWithLocations}.
           Valid names for `${opts.defaultSession}` are:
-            ${lib.concatStringsSep "\n    " cfg.sessionData.sessionNames}
+              ${lib.concatMapStringsSep "\n    " toPretty cfg.sessionData.sessionNames}
         '';
       }
     ];

--- a/nixos/modules/services/display-managers/default.nix
+++ b/nixos/modules/services/display-managers/default.nix
@@ -1,5 +1,6 @@
 {
   config,
+  options,
   lib,
   pkgs,
   ...
@@ -7,6 +8,7 @@
 
 let
   cfg = config.services.displayManager;
+  opts = options.services.displayManager;
 
   installedSessions =
     pkgs.runCommand "desktops"
@@ -79,7 +81,7 @@ in
                 default = config.user != null;
                 defaultText = lib.literalExpression "config.${options.user} != null";
                 description = ''
-                  Automatically log in as {option}`autoLogin.user`.
+                  Automatically log in as {option}`${options.user}`.
                 '';
               };
 
@@ -185,14 +187,14 @@ in
       {
         assertion = cfg.autoLogin.enable -> cfg.autoLogin.user != null;
         message = ''
-          services.displayManager.autoLogin.enable requires services.displayManager.autoLogin.user to be set
+          `${opts.autoLogin}.enable` requires `${opts.autoLogin}.user` to be set
         '';
       }
       {
         assertion = cfg.defaultSession == null || lib.elem cfg.defaultSession cfg.sessionData.sessionNames;
         message = ''
           Default graphical session, '${toString cfg.defaultSession}', not found.
-          Valid names for 'services.displayManager.defaultSession' are:
+          Valid names for `${opts.defaultSession}` are:
             ${lib.concatStringsSep "\n    " cfg.sessionData.sessionNames}
         '';
       }


### PR DESCRIPTION
Follow up to https://github.com/NixOS/nixpkgs/pull/525738#discussion_r3327314024

- **nixos/displayManager: interpolate option paths in docs + errors**
- **nixos/displayManager: improve defaultSession error**

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
