### PR TITLE
jsmn: init at 1.1.0

### DIFF
--- a/pkgs/by-name/js/jsmn/package.nix
+++ b/pkgs/by-name/js/jsmn/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv, # for tests
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "jsmn";
+  version = "1.1.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "zserge";
+    repo = "jsmn";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Vv8Cqb+WZZVnmtVZ12JYd5/qUrqLqi4lvNsUyj9NnRQ=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 jsmn.h $out/include/jsmn.h
+
+    runHook postInstall
+  '';
+
+  passthru.tests.suite = stdenv.mkDerivation {
+    pname = "jsmn-tests";
+
+    inherit (finalAttrs) version src;
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    doCheck = true;
+    checkPhase = ''
+      runHook preCheck
+
+      make test
+
+      runHook postCheck
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      touch $out
+
+      runHook postInstall
+    '';
+  };
+
+  meta = {
+    description = "Minimalistic JSON parser in C";
+    maintainers = with lib.maintainers; [ BatteredBunny ];
+    homepage = "https://github.com/zserge/jsmn";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Part of my effort to eventually get nerf studio upstreamed. This is a dependency of filament, though i noticed box2d also vendors this, might be worth to unvendor it in box2d outside of this PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
