### PR TITLE
neovim-require-check-hook: make sure plugin scripts are sourced

### DIFF
--- a/pkgs/applications/editors/vim/plugins/hooks/neovim-require-check-hook.sh
+++ b/pkgs/applications/editors/vim/plugins/hooks/neovim-require-check-hook.sh
@@ -60,6 +60,15 @@ run_require_checks() {
         echo "WARNING: nvimSkipModule got renamed to nvimSkipModules, please update package $name"
     fi
 
+    # Some modules rely on things like globals or user commands being initialised by plugin/ scripts.
+    # So this hook sets up a dummy packpath containing only the plugin to be tested
+    # and adds it with packadd before requiring each module.
+    nvimDataDir=$(nvim -u NONE -i NONE --headless --cmd "lua io.write(vim.fn.stdpath('data'))" +q)
+    packPathDir="$nvimDataDir/site"
+    packdir="$nvimDataDir/site/pack/nvimRequireCheckHook/opt"
+    mkdir -p "$packdir"
+    ln -s "$out" "$packdir/testPlugin"
+
     for name in "${nvimRequireCheck[@]}"; do
         local skip=false
         for module in "${nvimSkipModules[@]}"; do
@@ -76,6 +85,8 @@ run_require_checks() {
                 --cmd "set rtp+=$out,${deps// /,}" \
                 --cmd "set rtp+=$out,${nativeCheckInputs// /,}" \
                 --cmd "set rtp+=$out,${checkInputs// /,}" \
+                --cmd "set packpath^=$packPathDir" \
+                --cmd "packadd testPlugin" \
                 --cmd "lua require('$name')"; then
                 check_passed=true
                 successful_modules+=("$name")

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -796,6 +796,10 @@ assertNoAdditions {
     checkInputs = [ self.nvim-cmp ];
   };
 
+  cmp-omni = super.cmp-omni.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
+
   cmp-pandoc-nvim = super.cmp-pandoc-nvim.overrideAttrs {
     checkInputs = [ self.nvim-cmp ];
     dependencies = [ self.plenary-nvim ];

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -668,6 +668,10 @@ assertNoAdditions {
     checkInputs = [ self.nvim-cmp ];
   };
 
+  cmp-calc = super.cmp-calc.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
+
   cmp-clippy = super.cmp-clippy.overrideAttrs {
     checkInputs = [ self.nvim-cmp ];
     dependencies = with self; [

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -683,6 +683,10 @@ assertNoAdditions {
     checkInputs = [ self.nvim-cmp ];
   };
 
+  cmp-cmdline-history = super.cmp-cmdline-history.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
+
   cmp-conjure = super.cmp-conjure.overrideAttrs {
     checkInputs = [ self.nvim-cmp ];
     dependencies = [ self.conjure ];

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -664,6 +664,10 @@ assertNoAdditions {
     checkInputs = [ self.nvim-cmp ];
   };
 
+  cmp-buffer = super.cmp-buffer.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
+
   cmp-clippy = super.cmp-clippy.overrideAttrs {
     checkInputs = [ self.nvim-cmp ];
     dependencies = with self; [

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -33,6 +33,7 @@
   libgit2,
   llvmPackages,
   neovim-unwrapped,
+  nix,
   nodejs,
   openscad,
   openssh,
@@ -766,6 +767,7 @@ assertNoAdditions {
   };
 
   cmp-nixpkgs-maintainers = super.cmp-nixpkgs-maintainers.overrideAttrs {
+    nativeCheckInputs = [ nix ];
     checkInputs = [ self.nvim-cmp ];
   };
 

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -845,6 +845,10 @@ assertNoAdditions {
     dependencies = [ tmux ];
   };
 
+  cmp-treesitter = super.cmp-treesitter.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
+
   cmp-vim-lsp = super.cmp-vim-lsp.overrideAttrs {
     checkInputs = [ self.nvim-cmp ];
     dependencies = [ self.vim-lsp ];

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -725,6 +725,10 @@ assertNoAdditions {
     checkInputs = [ self.nvim-cmp ];
   };
 
+  cmp-emoji = super.cmp-emoji.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
+
   cmp-fish = super.cmp-fish.overrideAttrs {
     checkInputs = [ self.nvim-cmp ];
   };

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -752,6 +752,10 @@ assertNoAdditions {
     checkInputs = [ self.nvim-cmp ];
   };
 
+  cmp-latex-symbols = super.cmp-look.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
+
   cmp-look = super.cmp-look.overrideAttrs {
     checkInputs = [ self.nvim-cmp ];
   };

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -822,6 +822,10 @@ assertNoAdditions {
     dependencies = [ self.nvim-snippy ];
   };
 
+  cmp-spell = super.cmp-spell.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
+
   cmp-tabby = super.cmp-tabby.overrideAttrs {
     checkInputs = [ self.nvim-cmp ];
   };

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -877,6 +877,10 @@ assertNoAdditions {
     dependencies = [ self.luasnip ];
   };
 
+  cmp_yanky = super.cmp_yanky.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
+
   cobalt2-nvim = super.cobalt2-nvim.overrideAttrs {
     dependencies = with self; [ colorbuddy-nvim ];
     # Few broken themes

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -776,6 +776,10 @@ assertNoAdditions {
     dependencies = [ self.plenary-nvim ];
   };
 
+  cmp-nvim-lsp-document-symbol = super.cmp-nvim-lsp-document-symbol.overrideAttrs {
+    checkInputs = [ self.nvim-cmp ];
+  };
+
   cmp-nvim-lsp-signature-help = super.cmp-nvim-lsp-signature-help.overrideAttrs {
     checkInputs = [ self.nvim-cmp ];
   };


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/524851#discussion_r3342906781.
Tested this by removing the `nvimSkipModules` from the `diffview-nvim` overlay (which we can do in a follow-up PR).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
