### PR TITLE
azimuth: 1.0.3 -> 1.0.4; enabled for darwin

### DIFF
--- a/pkgs/by-name/az/azimuth/package.nix
+++ b/pkgs/by-name/az/azimuth/package.nix
@@ -6,7 +6,6 @@
   pkg-config,
   libGL,
   which,
-  installTool ? false,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -33,16 +32,29 @@ stdenv.mkDerivation (finalAttrs: {
     SDL2
   ];
 
-  makeFlags = [
-    "BUILDTYPE=release"
-    "PREFIX=${placeholder "out"}"
-    "INSTALLTOOL=${if installTool then "true" else "false"}"
-  ];
+  makeFlags = [ "BUILDTYPE=release" ];
 
   enableParallelBuilding = true;
 
+  postPatch = ''
+    patchShebangs src/azimuth/system/generate_blob_index.sh
+
+    # Modern Clang over-erroring measures
+    substituteInPlace Makefile \
+      --replace-fail \
+        '-Werror' \
+        '-Werror -Wno-uninitialized-const-pointer -Wno-default-const-init-var-unsafe'
+  '';
+
   doCheck = true;
   checkTarget = "test";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install -m755 out/release/host/bin/azimuth $out/bin/
+    runHook postInstall
+  '';
 
   meta = {
     description = "Metroidvania game using only vectorial graphic";

--- a/pkgs/by-name/az/azimuth/package.nix
+++ b/pkgs/by-name/az/azimuth/package.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     makeBinaryWrapper
     which
+    SDL2
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     icnsify
@@ -47,11 +48,9 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     patchShebangs src/azimuth/system/generate_blob_index.sh
 
-    # Modern Clang over-erroring measures
+    # Remove over-erroring measures
     substituteInPlace Makefile \
-      --replace-fail \
-        '-Werror' \
-        '-Werror -Wno-uninitialized-const-pointer -Wno-default-const-init-var-unsafe'
+      --replace-fail "-Werror" ""
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
     # iconutil is not available in the build sandbox

--- a/pkgs/by-name/az/azimuth/package.nix
+++ b/pkgs/by-name/az/azimuth/package.nix
@@ -83,8 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "Metroidvania game using only vectorial graphic";
-    mainProgram = "azimuth";
+    description = "Metroidvania game with vector graphics, inspired by Super Metroid and Star Control II";
     longDescription = ''
       Azimuth is a metroidvania game, and something of an homage to the previous
       greats of the genre (Super Metroid in particular). You will need to pilot
@@ -94,10 +93,11 @@ stdenv.mkDerivation (finalAttrs: {
       weapons and upgrades to find and use, and a wide variety of enemies and
       bosses to tangle with.
     '';
-
+    homepage = "https://mdsteele.games/azimuth/";
+    changelog = "https://github.com/mdsteele/azimuth/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
-    homepage = "https://mdsteele.games/azimuth/index.html";
     maintainers = with lib.maintainers; [ marius851000 ];
+    mainProgram = "azimuth";
     platforms = lib.platforms.unix;
   };
 

--- a/pkgs/by-name/az/azimuth/package.nix
+++ b/pkgs/by-name/az/azimuth/package.nix
@@ -2,10 +2,10 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  libGL,
   SDL2,
-  which,
   pkg-config,
+  libGL,
+  which,
   installTool ? false,
 }:
 
@@ -32,8 +32,6 @@ stdenv.mkDerivation (finalAttrs: {
     libGL
     SDL2
   ];
-
-  env.NIX_CFLAGS_COMPILE = toString [ "-Wno-error=maybe-uninitialized" ];
 
   makeFlags = [
     "BUILDTYPE=release"

--- a/pkgs/by-name/az/azimuth/package.nix
+++ b/pkgs/by-name/az/azimuth/package.nix
@@ -96,7 +96,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://mdsteele.games/azimuth/";
     changelog = "https://github.com/mdsteele/azimuth/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ marius851000 ];
+    maintainers = with lib.maintainers; [
+      philocalyst
+      marius851000
+    ];
     mainProgram = "azimuth";
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/az/azimuth/package.nix
+++ b/pkgs/by-name/az/azimuth/package.nix
@@ -6,6 +6,8 @@
   pkg-config,
   libGL,
   which,
+  makeBinaryWrapper,
+  icnsify,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -24,12 +26,18 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     pkg-config
+    makeBinaryWrapper
     which
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    icnsify
   ];
 
   buildInputs = [
-    libGL
     SDL2
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    libGL
   ];
 
   makeFlags = [ "BUILDTYPE=release" ];
@@ -44,6 +52,13 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail \
         '-Werror' \
         '-Werror -Wno-uninitialized-const-pointer -Wno-default-const-init-var-unsafe'
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # iconutil is not available in the build sandbox
+    substituteInPlace Makefile \
+      --replace-fail \
+        'iconutil -c icns $(OUTDIR)/icon.iconset -o $@ 2> /dev/null' \
+        'icnsify $(OUTDIR)/icon.iconset/icon_128x128.png -o $@'
   '';
 
   doCheck = true;
@@ -53,7 +68,18 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
     mkdir -p $out/bin
     install -m755 out/release/host/bin/azimuth $out/bin/
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p $out/Applications
+    cp -R out/release/host/Azimuth.app $out/Applications/
+  ''
+  + ''
     runHook postInstall
+  '';
+
+  postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    makeBinaryWrapper "$out/Applications/Azimuth.app/Contents/MacOS/Azimuth" \
+      "$out/bin/azimuth"
   '';
 
   meta = {
@@ -72,7 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     homepage = "https://mdsteele.games/azimuth/index.html";
     maintainers = with lib.maintainers; [ marius851000 ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
   };
 
 })


### PR DESCRIPTION
azimuth: migrate from SDL to SDL2<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- Got this working on macos!
- This includes a migration to the latest version which also compelled an SDL migration.
- Some changes were made to the meta section for completeness purposes. (description was changed because i felt the old one was too brief.
- Big changes were made to the actual build process, including enabling the test suite and other nice things.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
