### PR TITLE
kwybars: init at 0.2.0

### DIFF
--- a/pkgs/by-name/kw/kwybars/package.nix
+++ b/pkgs/by-name/kw/kwybars/package.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  makeWrapper,
+  nix-update-script,
+  pkg-config,
+  cava,
+  gdk-pixbuf,
+  gtk4,
+  gtk4-layer-shell,
+  libnotify,
+  pipewire,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "kwybars";
+  version = "0.2.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "naurissteins";
+    repo = "Kwybars";
+    tag = finalAttrs.version;
+    hash = "sha256-2op54DbnLtp7L2yjLvzdaVG7eFlaW6JT5dCUXEgwWoU=";
+  };
+
+  cargoHash = "sha256-11+YsAHXaNOcJ6NB/5u39UHqwJsMJKGmO7DlBpZIh5E=";
+
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    gdk-pixbuf
+    gtk4
+    gtk4-layer-shell
+    libnotify
+    pipewire
+  ];
+
+  cargoBuildFlags = [ "--workspace" ];
+  cargoCheckFlags = [ "--workspace" ];
+
+  postInstall = ''
+    install -Dm644 assets/examples/*.toml -t "$out/share/kwybars/examples"
+    install -Dm644 assets/themes/*.toml -t "$out/share/kwybars/themes"
+    install -Dm644 docs/man/*.1 -t "$out/share/man/man1"
+
+    wrapProgram "$out/bin/kwybars-daemon" \
+      --set KWYBARS_THEMES_DIR "$out/share/kwybars/themes" \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          cava
+          libnotify
+        ]
+      }:$out/bin
+
+    wrapProgram "$out/bin/kwybars-overlay" \
+      --set KWYBARS_THEMES_DIR "$out/share/kwybars/themes" \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          cava
+          libnotify
+        ]
+      }:$out/bin
+
+    wrapProgram "$out/bin/kwybarsctl" \
+      --set KWYBARS_THEMES_DIR "$out/share/kwybars/themes"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "GTK4 real-time audio visualizer overlay for Wayland";
+    homepage = "https://github.com/naurissteins/Kwybars";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ naurissteins ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds [Kwybars](https://github.com/naurissteins/Kwybars) a GTK4 real-time audio visualizer overlay for Wayland.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test