### PR TITLE
system-syzygy: fix darwin build

### DIFF
--- a/pkgs/by-name/sy/system-syzygy/package.nix
+++ b/pkgs/by-name/sy/system-syzygy/package.nix
@@ -4,11 +4,14 @@
   rustPlatform,
   fetchFromGitHub,
   SDL2,
-  makeWrapper,
+  makeBinaryWrapper,
   copyDesktopItems,
   makeDesktopItem,
 }:
 
+let
+  dataDirFlag = "--set SYZYGY_DATA_DIR $out/share/syzygy";
+in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "system-syzygy";
   version = "1.0.2";
@@ -29,7 +32,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   nativeBuildInputs = [
-    makeWrapper
+    makeBinaryWrapper
     copyDesktopItems
   ];
   buildInputs = [ SDL2 ];
@@ -51,7 +54,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hicolor="$out/share/icons/hicolor"
     mkdir -p $out/share/syzygy/
     cp -r ${finalAttrs.src}/data/* $out/share/syzygy/
-    wrapProgram $out/bin/syzygy --set SYZYGY_DATA_DIR $out/share/syzygy
 
     for res in 128x128 32x32 512x512; do
       install -Dm644 data/icon/$res.png \
@@ -60,6 +62,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
     install -Dm644 data/icon/512x512@2x.png \
       "$hicolor/512x512@2/apps/syzygy.png"
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    wrapProgram $out/bin/syzygy ${dataDirFlag}
   '';
 
   meta = {

--- a/pkgs/by-name/sy/system-syzygy/package.nix
+++ b/pkgs/by-name/sy/system-syzygy/package.nix
@@ -93,7 +93,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://mdsteele.games/syzygy";
     changelog = "https://github.com/mdsteele/syzygy/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
-    maintainers = [ lib.maintainers.marius851000 ];
+    maintainers = with lib.maintainers; [
+      marius851000
+      philocalyst
+    ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/sy/system-syzygy/package.nix
+++ b/pkgs/by-name/sy/system-syzygy/package.nix
@@ -7,6 +7,7 @@
   makeBinaryWrapper,
   copyDesktopItems,
   makeDesktopItem,
+  desktopToDarwinBundle,
 }:
 
 let
@@ -34,6 +35,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeBuildInputs = [
     makeBinaryWrapper
     copyDesktopItems
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    desktopToDarwinBundle
   ];
   buildInputs = [ SDL2 ];
 
@@ -67,8 +71,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
     wrapProgram $out/bin/syzygy ${dataDirFlag}
   '';
 
+  postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    app="$out/Applications/System Syzygy.app/Contents"
+    install -m755 "$out/bin/syzygy" "$app/MacOS/System Syzygy"
+
+    makeBinaryWrapper "$app/MacOS/System Syzygy" "$out/bin/syzygy" \
+      ${dataDirFlag}
+
+    ln -s "$out/share/syzygy" "$app/Resources/data"
+  '';
+
   meta = {
-    broken = stdenv.hostPlatform.isDarwin;
     description = "Narrative meta-puzzle game in the style of The Fool's Errand";
     longDescription = ''
       System Syzygy is a story and a puzzle game, in the style of Cliff
@@ -81,5 +94,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/mdsteele/syzygy/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
     maintainers = [ lib.maintainers.marius851000 ];
+    platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/sy/system-syzygy/package.nix
+++ b/pkgs/by-name/sy/system-syzygy/package.nix
@@ -43,9 +43,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     broken = stdenv.hostPlatform.isDarwin;
-    description = "Story and a puzzle game, where you solve a variety of puzzle";
+    description = "Narrative meta-puzzle game in the style of The Fool's Errand";
+    longDescription = ''
+      System Syzygy is a story and a puzzle game, in the style of Cliff
+      Johnson's The Fool's Errand and 3 in Three, and of Andrew Plotkin's
+      System's Twilight.  By the end of the game, all the different puzzles and
+      pieces of the story come together into a single meta-puzzle.
+    '';
     mainProgram = "syzygy";
     homepage = "https://mdsteele.games/syzygy";
+    changelog = "https://github.com/mdsteele/syzygy/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
     maintainers = [ lib.maintainers.marius851000 ];
   };

--- a/pkgs/by-name/sy/system-syzygy/package.nix
+++ b/pkgs/by-name/sy/system-syzygy/package.nix
@@ -5,18 +5,10 @@
   fetchFromGitHub,
   SDL2,
   makeWrapper,
+  copyDesktopItems,
   makeDesktopItem,
 }:
 
-let
-  desktopFile = makeDesktopItem {
-    name = "system-syzygy";
-    exec = "@out@/bin/syzygy";
-    comment = "A puzzle game";
-    desktopName = "System Syzygy";
-    categories = [ "Game" ];
-  };
-in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "system-syzygy";
   version = "1.0.2";
@@ -28,17 +20,46 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-wxe9+r3tWRXiznvjvxsmTgUC7YVKgbt+I3Q8A/WtcN0=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  # nixpkgs SDL2 uses pkg-config, not the macOS SDL2 framework.
+  postPatch = ''
+    substituteInPlace Cargo.toml \
+      --replace-fail \
+        'features = ["unsafe_textures", "use_mac_framework"]' \
+        'features = ["unsafe_textures"]'
+  '';
+
+  nativeBuildInputs = [
+    makeWrapper
+    copyDesktopItems
+  ];
   buildInputs = [ SDL2 ];
 
   cargoHash = "sha256-H/iG6vsmtpBGYBBqNQG5EpyZaUtfXfVaHv4fkxwqrD0=";
 
+  desktopItems = [
+    (makeDesktopItem {
+      name = "system-syzygy";
+      exec = "syzygy";
+      icon = "syzygy";
+      comment = "A narrative meta-puzzle game";
+      desktopName = "System Syzygy";
+      categories = [ "Game" ];
+    })
+  ];
+
   postInstall = ''
+    hicolor="$out/share/icons/hicolor"
     mkdir -p $out/share/syzygy/
     cp -r ${finalAttrs.src}/data/* $out/share/syzygy/
     wrapProgram $out/bin/syzygy --set SYZYGY_DATA_DIR $out/share/syzygy
-    mkdir -p $out/share/applications
-    substituteAll ${desktopFile}/share/applications/system-syzygy.desktop $out/share/applications/system-syzygy.desktop
+
+    for res in 128x128 32x32 512x512; do
+      install -Dm644 data/icon/$res.png \
+        "$hicolor/$res/apps/syzygy.png"
+    done
+
+    install -Dm644 data/icon/512x512@2x.png \
+      "$hicolor/512x512@2/apps/syzygy.png"
   '';
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- Got everything ironed out for a real darwin build!
- Some general cleanup and fixes of that type
- Added some meta fields and improved descriptions (subjective, okay if co-maintainer disagrees)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
