### PR TITLE
Refactor rocq coq findlib

### DIFF
--- a/pkgs/applications/science/logic/coq/default.nix
+++ b/pkgs/applications/science/logic/coq/default.nix
@@ -135,11 +135,12 @@ let
     ocamlPackages.findlib
   ]
   ++ lib.optional (coqAtLeast "8.14") dune;
-  ocamlPropagatedBuildInputs =
-    [ ]
-    ++ lib.optional (!coqAtLeast "8.10") ocamlPackages.camlp5
-    ++ lib.optional (!coqAtLeast "8.13") ocamlPackages.num
-    ++ lib.optional (coqAtLeast "8.13") ocamlPackages.zarith;
+  ocamlPropagatedBuildInputs = [
+    ocamlPackages.findlib
+  ]
+  ++ lib.optional (!coqAtLeast "8.10") ocamlPackages.camlp5
+  ++ lib.optional (!coqAtLeast "8.13") ocamlPackages.num
+  ++ lib.optional (coqAtLeast "8.13") ocamlPackages.zarith;
   self = stdenv.mkDerivation {
     pname = "coq";
     inherit (fetched) version src;

--- a/pkgs/applications/science/logic/rocq-core/default.nix
+++ b/pkgs/applications/science/logic/rocq-core/default.nix
@@ -72,7 +72,10 @@ let
     ocamlPackages.findlib
     dune
   ];
-  ocamlPropagatedBuildInputs = [ ocamlPackages.zarith ];
+  ocamlPropagatedBuildInputs = [
+    ocamlPackages.findlib
+    ocamlPackages.zarith
+  ];
   self = stdenv.mkDerivation {
     pname = "rocq";
     inherit (fetched) version src;


### PR DESCRIPTION
Added findlib as a propagatedBuildInput to rocq and coq, see [https://rocq-prover.zulipchat.com/#narrow/channel/290990-Nix-and-Coq-Nix-Toolbox-devs-.26-users/topic/Add.20findlib.20as.20a.20propagatedBuildInput/with/596974707](https://rocq-prover.zulipchat.com/#narrow/channel/290990-Nix-and-Coq-Nix-Toolbox-devs-.26-users/topic/Add.20findlib.20as.20a.20propagatedBuildInput/with/596974707).

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
