### PR TITLE
nixosTests.gocryptfs: fix test

### DIFF
--- a/nixos/tests/gocryptfs.nix
+++ b/nixos/tests/gocryptfs.nix
@@ -14,7 +14,8 @@
       ];
 
       specialisation.fstab-test.configuration = {
-        fileSystems."/plain" = {
+        # This can't be fileSytems, as the qemu machinery doesn't honor it.
+        virtualisation.fileSystems."/plain" = {
           device = "/encrypted";
           fsType = "fuse.gocryptfs";
           options = [
@@ -27,31 +28,24 @@
     };
 
   testScript = ''
+    # Initialize a gocryptfs filesystem and mount it
+    machine.succeed("openssl rand -base64 32 > /tmp/password.txt")
+    machine.succeed("mkdir -p /encrypted /plain")
+    machine.succeed("gocryptfs -init /encrypted  -passfile /tmp/password.txt -quiet")
+    machine.succeed("gocryptfs /encrypted /plain  -passfile /tmp/password.txt -quiet")
 
-    # Generate a password
-    machine.execute("openssl rand -base64 32 > /tmp/password.txt")
+    # Drop a canary file and unmount
+    machine.succeed("echo success > /plain/data.txt")
+    machine.succeed("fusermount -u /plain")
 
-    # Initialize an encrypted vault
-    machine.execute("mkdir -p /encrypted /plain")
-    machine.execute("gocryptfs -init /encrypted  -passfile /password.txt -quiet")
+    # Switch to a specialisation that has this in /etc/fstab
+    machine.succeed("/run/current-system/specialisation/fstab-test/bin/switch-to-configuration switch")
 
-    # Open and mount vault
-    machine.execute("gocryptfs /encrypted /plain  -passfile /tmp/password.txt -quiet")
-
-    machine.execute("echo test > /plain/data.txt")
-    machine.execute("echo test > /tmp/data.txt")
-
-    # Unmount
-    machine.execute("fusermount -u /plain")
-
-    # Switch to the specialisation
-    machine.succeed("/run/current-system/specialisation/fstab-test/bin/switch-to-configuration test")
-
-    # Wait for mount
+    # Wait for mounts
     machine.wait_for_unit("local-fs.target")
 
-    # Check data
-    machine.succeed("diff /plain/data.txt /tmp/data.txt")
+    # Ensure the canary is alive
+    machine.succeed("grep -q success /plain/data.txt")
 
   '';
 }

--- a/pkgs/by-name/go/gocryptfs/package.nix
+++ b/pkgs/by-name/go/gocryptfs/package.nix
@@ -8,6 +8,7 @@
   pandoc,
   pkg-config,
   libfido2,
+  nixosTests,
 }:
 
 buildGoModule (finalAttrs: {
@@ -62,6 +63,8 @@ buildGoModule (finalAttrs: {
       --suffix PATH : ${lib.makeBinPath [ fuse ]}
     ln -s $out/bin/gocryptfs $out/bin/mount.fuse.gocryptfs
   '';
+
+  passthru.tests.gocryptfs = nixosTests.gocryptfs;
 
   meta = {
     description = "Encrypted overlay filesystem written in Go";


### PR DESCRIPTION
This actually didn't work due to multiple issues:

 - Some statements used machine.execute, swallowing nonzero exit codes. In this particular case, it caused the mountpoint to stick around.
 - using `fileSytems."/plain"` has no effect in VM tests, virtualisation.fileSystems."/plain" needs to be used instead
 - `switch-to-configuration test` was invoked, so not actually switching at all.
 - Checking for `data.txt` to be present is a bit brittle. /tmp can be cleaned up. We can just add a known text and grep for that.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
