### PR TITLE
`mkLibretroCore`: make `retroarch` dependency optional

### DIFF
--- a/pkgs/applications/emulators/libretro/mkLibretroCore.nix
+++ b/pkgs/applications/emulators/libretro/mkLibretroCore.nix
@@ -15,6 +15,7 @@ lib.extendMkDerivation {
     "core"
     "extraBuildInputs"
     "extraNativeBuildInputs"
+    "includeRetroArch"
     "libretroCore"
     "normalizeCore"
   ];
@@ -36,11 +37,13 @@ lib.extendMkDerivation {
       ## The core filename is derived from the core name
       ## Setting `normalizeCore` to `true` will convert `-` to `_` on the core filename
       normalizeCore ? true,
+      ## Whether to include a wrapper script which launches this core with RetroArch
+      includeRetroArch ? true,
       ...
     }:
     let
       d2u = if normalizeCore then (lib.replaceStrings [ "-" ] [ "_" ]) else (x: x);
-      coreDir = placeholder "out" + libretroCore;
+      coreDir = placeholder "lib" + libretroCore;
       coreFilename = "${d2u core}_libretro${stdenv.hostPlatform.extensions.sharedLibrary}";
       mainProgram = "retroarch-${core}";
     in
@@ -48,9 +51,19 @@ lib.extendMkDerivation {
       pname = "libretro-${core}";
 
       buildInputs = [ zlib ] ++ extraBuildInputs;
-      nativeBuildInputs = [ makeWrapper ] ++ extraNativeBuildInputs;
+      nativeBuildInputs = lib.optional finalAttrs.includeRetroArch makeWrapper ++ extraNativeBuildInputs;
 
-      inherit enableParallelBuilding makefile strictDeps;
+      outputs = [
+        "lib"
+        "out"
+      ];
+
+      inherit
+        enableParallelBuilding
+        includeRetroArch
+        makefile
+        strictDeps
+        ;
 
       makeFlags = [
         "platform=${
@@ -77,8 +90,12 @@ lib.extendMkDerivation {
         runHook preInstall
 
         install -Dt ${coreDir} ${coreFilename}
+      ''
+      + lib.optionalString finalAttrs.includeRetroArch ''
         makeWrapper ${retroarch-bare}/bin/retroarch $out/bin/${mainProgram} \
           --add-flags "-L ${coreDir}/${coreFilename}"
+      ''
+      + ''
 
         runHook postInstall
       '';
@@ -92,10 +109,10 @@ lib.extendMkDerivation {
       // passthru;
 
       meta = {
-        inherit mainProgram;
         inherit (retroarch-bare.meta) platforms;
         teams = [ lib.teams.libretro ];
       }
+      // lib.optionalAttrs finalAttrs.includeRetroArch { inherit mainProgram; }
       // meta;
     };
 }

--- a/pkgs/by-name/li/libretroPackages/mkLibretroCore.nix
+++ b/pkgs/by-name/li/libretroPackages/mkLibretroCore.nix
@@ -15,6 +15,7 @@ lib.extendMkDerivation {
     "core"
     "extraBuildInputs"
     "extraNativeBuildInputs"
+    "includeRetroArch"
     "libretroCore"
     "normalizeCore"
   ];
@@ -36,6 +37,8 @@ lib.extendMkDerivation {
       ## The core filename is derived from the core name
       ## Setting `normalizeCore` to `true` will convert `-` to `_` on the core filename
       normalizeCore ? true,
+      ## Whether to include a wrapper script which launches this core with RetroArch
+      includeRetroArch ? true,
       ...
     }:
     let
@@ -48,9 +51,14 @@ lib.extendMkDerivation {
       pname = "libretro-${core}";
 
       buildInputs = [ zlib ] ++ extraBuildInputs;
-      nativeBuildInputs = [ makeWrapper ] ++ extraNativeBuildInputs;
+      nativeBuildInputs = lib.optional finalAttrs.includeRetroArch makeWrapper ++ extraNativeBuildInputs;
 
-      inherit enableParallelBuilding makefile strictDeps;
+      inherit
+        enableParallelBuilding
+        includeRetroArch
+        makefile
+        strictDeps
+        ;
 
       makeFlags = [
         "platform=${
@@ -77,8 +85,12 @@ lib.extendMkDerivation {
         runHook preInstall
 
         install -Dt ${coreDir} ${coreFilename}
+      ''
+      + lib.optionalString finalAttrs.includeRetroArch ''
         makeWrapper ${retroarch-bare}/bin/retroarch $out/bin/${mainProgram} \
           --add-flags "-L ${coreDir}/${coreFilename}"
+      ''
+      + ''
 
         runHook postInstall
       '';
@@ -92,10 +104,10 @@ lib.extendMkDerivation {
       // passthru;
 
       meta = {
-        inherit mainProgram;
         inherit (retroarch-bare.meta) platforms;
         teams = [ lib.teams.libretro ];
       }
+      // lib.optionalAttrs finalAttrs.includeRetroArch { inherit mainProgram; }
       // meta;
     };
 }


### PR DESCRIPTION
~~Splits `/lib/retroarch/cores` to `!lib`, leaving `/bin` in `!out`. `!lib` is listed first so consumers shouldn't need to be updated.~~ Couldn't figure out how to do it in a backwards-compatible way, so leaving that for another PR.
Adds an option `includeRetroArch` which can be overridden to skip generating the wrapper in `/bin`, thereby removing the dependency on RetroArch.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
