### PR TITLE
Malayalam fonts from Swathanthra Malayalam Computing

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25,7 +25,7 @@
    - `keys` is a list of your PGP/GPG key fingerprints.
 
    Specifying a GitHub account is required, because:
-   - you will get invited to the @NixOS/nixpkgs-maintainers team
+   - you will get invited to the @NixOS/nixpkgs-maintainers team;
    - once you are part of the @NixOS org, you can be requested for review;
    - once you can be requested for review, CI will request you review pull requests that modify a package for which you are a maintainer.
 

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25,7 +25,7 @@
    - `keys` is a list of your PGP/GPG key fingerprints.
 
    Specifying a GitHub account is required, because:
-   - you will get invited to the @NixOS/nixpkgs-maintainers team;
+   - you will get invited to the @NixOS/nixpkgs-maintainers teamq;
    - once you are part of the @NixOS org, you can be requested for review;
    - once you can be requested for review, CI will request you review pull requests that modify a package for which you are a maintainer.
 
@@ -444,6 +444,12 @@
     github = "aaschmid";
     githubId = 567653;
     name = "Andreas Schmid";
+  };
+  aashiks = {
+    email = "services@inflo.ws";
+    github = "aashiks";
+    githubId = 202316; 
+    name = "Ashik Salahudeen";
   };
   abaldeau = {
     email = "andreas@baldeau.net";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25,7 +25,7 @@
    - `keys` is a list of your PGP/GPG key fingerprints.
 
    Specifying a GitHub account is required, because:
-   - you will get invited to the @NixOS/nixpkgs-maintainers teamq;
+   - you will get invited to the @NixOS/nixpkgs-maintainers team
    - once you are part of the @NixOS org, you can be requested for review;
    - once you can be requested for review, CI will request you review pull requests that modify a package for which you are a maintainer.
 

--- a/pkgs/by-name/fo/font-smc-anjalioldlipi/package.nix
+++ b/pkgs/by-name/fo/font-smc-anjalioldlipi/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "font-smc-anjalioldlipi";
+  version = "20241013";
+
+  src = fetchzip {
+    url = "https://smc.org.in/downloads/fonts/anjalioldlipi/anjalioldlipi.zip";
+    hash = "sha256-c3ScpdN2h39Q6GLFL97pBBGrsillcMXmhlGilOAdF1w=";
+    stripRoot = false;
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    find . -name "*.otf" -exec install -Dm644 {} -t "$out/share/fonts/opentype" \;
+    find . -name "*.ttf" -exec install -Dm644 {} -t "$out/share/fonts/truetype" \;
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Calligraphic-style Malayalam typeface by SMC";
+    homepage = "https://smc.org.in/fonts/anjalioldlipi";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ aashiks ];
+  };
+})

--- a/pkgs/by-name/fo/font-smc-anjalioldlipi/package.nix
+++ b/pkgs/by-name/fo/font-smc-anjalioldlipi/package.nix
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "Calligraphic-style Malayalam typeface by SMC";
+    description = "A traditional style Malayalam font, designed by Kevin Siji. Maintaines by SMC";
     homepage = "https://smc.org.in/fonts/anjalioldlipi";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/fo/font-smc-chilanka/package.nix
+++ b/pkgs/by-name/fo/font-smc-chilanka/package.nix
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "Casual handwriting-style Malayalam typeface by SMC";
+    description = "Chilanka is Malayalam handwriting style font designed by Santhosh Thottingal. It follows the common style one can see in everyday handwriting of Malayalam. It has a comprehensive Malayalam glyph set that contains most of the unique Malayalam conjuncts. Maintained by SMC";
     homepage = "https://smc.org.in/fonts/chilanka";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/fo/font-smc-chilanka/package.nix
+++ b/pkgs/by-name/fo/font-smc-chilanka/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "font-smc-chilanka";
+  version = "20241013";
+
+  src = fetchzip {
+    url = "https://smc.org.in/downloads/fonts/chilanka/chilanka.zip";
+    hash = "sha256-z+pRvm/8alA3TbUBuR4oDD/kpvuXJTqOBlzXEKBZvnE=";
+    stripRoot = false;
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    find . -name "*.otf" -exec install -Dm644 {} -t "$out/share/fonts/opentype" \;
+    find . -name "*.ttf" -exec install -Dm644 {} -t "$out/share/fonts/truetype" \;
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Casual handwriting-style Malayalam typeface by SMC";
+    homepage = "https://smc.org.in/fonts/chilanka";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ aashiks ];
+  };
+})

--- a/pkgs/by-name/fo/font-smc-dyuthi/package.nix
+++ b/pkgs/by-name/fo/font-smc-dyuthi/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "font-smc-dyuthi";
+  version = "20241013";
+
+  src = fetchzip {
+    url = "https://smc.org.in/downloads/fonts/dyuthi/dyuthi.zip";
+    hash = "sha256-H+2ccvHmlZjtH8KfWBSQKPtMkY/NsydHqFNaTzLS4S8=";
+    stripRoot = false;
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    find . -name "*.otf" -exec install -Dm644 {} -t "$out/share/fonts/opentype" \;
+    find . -name "*.ttf" -exec install -Dm644 {} -t "$out/share/fonts/truetype" \;
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Malayalam typeface for general use by SMC";
+    homepage = "https://smc.org.in/fonts/dyuthi";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ aashiks ];
+  };
+})

--- a/pkgs/by-name/fo/font-smc-dyuthi/package.nix
+++ b/pkgs/by-name/fo/font-smc-dyuthi/package.nix
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "Malayalam typeface for general use by SMC";
+    description = "Dyuthi is the first decorative Unicode font for Malayalam, designed by Hiran Venugopalan. Maintained by SMC";
     homepage = "https://smc.org.in/fonts/dyuthi";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/fo/font-smc-gayathri/package.nix
+++ b/pkgs/by-name/fo/font-smc-gayathri/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "font-smc-gayathri";
+  version = "20241013";
+
+  src = fetchzip {
+    url = "https://smc.org.in/downloads/fonts/gayathri/gayathri.zip";
+    hash = "sha256-p9KZi31Na4hfUuDsKj4OXjc9s6J/8xMeuszlL5oVauQ=";
+    stripRoot = false;
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    find . -name "*.otf" -exec install -Dm644 {} -t "$out/share/fonts/opentype" \;
+    find . -name "*.ttf" -exec install -Dm644 {} -t "$out/share/fonts/truetype" \;
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Thin Malayalam typeface with regular and bold styles by SMC";
+    homepage = "https://smc.org.in/fonts/gayathri";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ aashiks ];
+  };
+})

--- a/pkgs/by-name/fo/font-smc-gayathri/package.nix
+++ b/pkgs/by-name/fo/font-smc-gayathri/package.nix
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "Thin Malayalam typeface with regular and bold styles by SMC";
+    description = "A gentle and modern Malayalam display typeface. Available in three weights, Gayathri is best suited for headlines, posters, titles and captions. Unicode compliant and libre licensed. Designed by Binoy Dominic. Maintained by SMC";
     homepage = "https://smc.org.in/fonts/gayathri";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/fo/font-smc-karumbi/package.nix
+++ b/pkgs/by-name/fo/font-smc-karumbi/package.nix
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "Rounded Malayalam typeface by SMC";
+    description = "The Karumbi opentype font, is a Malayalam traditional script font designed by Kevin Siji. The characters are literally written directly into a computer by Kevin Siji using a tablet pen. Maintained by SMC";
     homepage = "https://smc.org.in/fonts/karumbi";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/fo/font-smc-karumbi/package.nix
+++ b/pkgs/by-name/fo/font-smc-karumbi/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "font-smc-karumbi";
+  version = "20241013";
+
+  src = fetchzip {
+    url = "https://smc.org.in/downloads/fonts/karumbi/karumbi.zip";
+    hash = "sha256-aeKH7CWbJNtkgv1PsaWWxyBZor+UO9q9Cctpc/qnEQU=";
+    stripRoot = false;
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    find . -name "*.otf" -exec install -Dm644 {} -t "$out/share/fonts/opentype" \;
+    find . -name "*.ttf" -exec install -Dm644 {} -t "$out/share/fonts/truetype" \;
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Rounded Malayalam typeface by SMC";
+    homepage = "https://smc.org.in/fonts/karumbi";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ aashiks ];
+  };
+})

--- a/pkgs/by-name/fo/font-smc-keraleeyam/package.nix
+++ b/pkgs/by-name/fo/font-smc-keraleeyam/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "font-smc-keraleeyam";
+  version = "20241013";
+
+  src = fetchzip {
+    url = "https://smc.org.in/downloads/fonts/keraleeyam/keraleeyam.zip";
+    hash = "sha256-UEhDtBaWof/2C36IapGhtYgdeQInUn+A/UAJIF7+RuA=";
+    stripRoot = false;
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    find . -name "*.otf" -exec install -Dm644 {} -t "$out/share/fonts/opentype" \;
+    find . -name "*.ttf" -exec install -Dm644 {} -t "$out/share/fonts/truetype" \;
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Traditional-style Malayalam typeface by SMC";
+    homepage = "https://smc.org.in/fonts/keraleeyam";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ aashiks ];
+  };
+})

--- a/pkgs/by-name/fo/font-smc-keraleeyam/package.nix
+++ b/pkgs/by-name/fo/font-smc-keraleeyam/package.nix
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "Traditional-style Malayalam typeface by SMC";
+    description = "Traditional-style Malayalam typeface designed by K H Hussain. This is the last version maintained by SMC";
     homepage = "https://smc.org.in/fonts/keraleeyam";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/fo/font-smc-malini/package.nix
+++ b/pkgs/by-name/fo/font-smc-malini/package.nix
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "Malayalam serif typeface by SMC";
+    description = "Malini is a variable typeface designed for reading — long-form Malayalam text set at body sizes, where clarity and typographic color matter most. The name means garland. Maintained by SMC";
     homepage = "https://smc.org.in/fonts/malini";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/fo/font-smc-malini/package.nix
+++ b/pkgs/by-name/fo/font-smc-malini/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "font-smc-malini";
+  version = "20241013";
+
+  src = fetchzip {
+    url = "https://smc.org.in/downloads/fonts/malini/Malini.zip";
+    hash = "sha256-2Go6HNy2s2ZcybkuhM62UhwLehnrMMoG89YHDldflZs=";
+    stripRoot = false;
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    find . -name "*.otf" -exec install -Dm644 {} -t "$out/share/fonts/opentype" \;
+    find . -name "*.ttf" -exec install -Dm644 {} -t "$out/share/fonts/truetype" \;
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Malayalam serif typeface by SMC";
+    homepage = "https://smc.org.in/fonts/malini";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ aashiks ];
+  };
+})

--- a/pkgs/by-name/fo/font-smc-manjari/package.nix
+++ b/pkgs/by-name/fo/font-smc-manjari/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "font-smc-manjari";
+  version = "20241013";
+
+  src = fetchzip {
+    url = "https://smc.org.in/downloads/fonts/manjari/manjari.zip";
+    hash = "sha256-Sq/7UOBO54c3id6FMZeOmnZTRceEkMAAN8W+C7v7Mtw=";
+    stripRoot = false;
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    find . -name "*.otf" -exec install -Dm644 {} -t "$out/share/fonts/opentype" \;
+    find . -name "*.ttf" -exec install -Dm644 {} -t "$out/share/fonts/truetype" \;
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Elegant Malayalam typeface with thin, regular, and bold styles by SMC";
+    homepage = "https://smc.org.in/fonts/manjari";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ aashiks ];
+  };
+})

--- a/pkgs/by-name/fo/font-smc-manjari/package.nix
+++ b/pkgs/by-name/fo/font-smc-manjari/package.nix
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "Elegant Malayalam typeface with thin, regular, and bold styles by SMC";
+    description = "This is a multipurpose font suitable for body and titles. This font is available in regular, bold, thin style variants. The glyph shapes follow a spiral theme, true to the beautiful curves of Malayalam. The glyphs are equal width with rounded terminals. The font has comprehensive glyph set including all widely used ligatures. Designed by Santhosh Thottingal. Maintained by SMC";
     homepage = "https://smc.org.in/fonts/manjari";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/fo/font-smc-meera/package.nix
+++ b/pkgs/by-name/fo/font-smc-meera/package.nix
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "Malayalam typeface for body text by SMC";
+    description = "Meera font is a Malayalam font designed by Hussain K H and maintained by Swathanthra Malayalam Computing project. This is a comprehensive Malayalam font with 1000+ glyphs for all common Malayalam ligatures. Malayalam typeface for body text by SMC";
     homepage = "https://smc.org.in/fonts/meera";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/fo/font-smc-meera/package.nix
+++ b/pkgs/by-name/fo/font-smc-meera/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "font-smc-meera";
+  version = "20241013";
+
+  src = fetchzip {
+    url = "https://smc.org.in/downloads/fonts/meera/meera.zip";
+    hash = "sha256-yaqA2gYKc4OJ9YxmvQPUZ3qZFyKj0YciMaUoY1SST4I=";
+    stripRoot = false;
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    find . -name "*.otf" -exec install -Dm644 {} -t "$out/share/fonts/opentype" \;
+    find . -name "*.ttf" -exec install -Dm644 {} -t "$out/share/fonts/truetype" \;
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Malayalam typeface for body text by SMC";
+    homepage = "https://smc.org.in/fonts/meera";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ aashiks ];
+  };
+})

--- a/pkgs/by-name/fo/font-smc-nupuram/package.nix
+++ b/pkgs/by-name/fo/font-smc-nupuram/package.nix
@@ -48,7 +48,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "Malayalam variable typeface with decorative variants by SMC";
+    description = "Nupuram is a Malayalam variable typeface inspired by the early Malayalam movie title designs of the 1960s–70s, particularly the work of title designer S. Appukkuttan Nair. This is a superfamily of related typefaces. Designed by Santhosh Thottingal. Maintained by SMC";
     homepage = "https://smc.org.in/fonts/nupuram";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/fo/font-smc-nupuram/package.nix
+++ b/pkgs/by-name/fo/font-smc-nupuram/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "font-smc-nupuram";
+  version = "20241013";
+
+  srcs = [
+    (fetchzip {
+      name = "Nupuram-Arrows-Color";
+      url = "https://smc.org.in/downloads/fonts/nupuram/Nupuram-Arrows-Color.zip";
+      hash = "sha256-tqDnDCvqE7TF0Yp4wdBfQRJKDfixftCzaXdOLQL9NLQ=";
+      stripRoot = false;
+    })
+    (fetchzip {
+      name = "Nupuram-Calligraphy";
+      url = "https://smc.org.in/downloads/fonts/nupuram/Nupuram-Calligraphy.zip";
+      hash = "sha256-Cc4A4qvbAUC2+e7HmMdRJtk8lR60UU4qcXbQIPhNCR0=";
+      stripRoot = false;
+    })
+    (fetchzip {
+      name = "Nupuram-Color";
+      url = "https://smc.org.in/downloads/fonts/nupuram/Nupuram-Color.zip";
+      hash = "sha256-vH+HQ38jgYVJ5c6jp7jXPjNNIjRFJ0MDGs62+rdUd5U=";
+      stripRoot = false;
+    })
+    (fetchzip {
+      name = "Nupuram-Dots";
+      url = "https://smc.org.in/downloads/fonts/nupuram/Nupuram-Dots.zip";
+      hash = "sha256-nlBAJUJru9q0F+nXJowAhCssN2DnunPei0ZhED2A2qA=";
+      stripRoot = false;
+    })
+  ];
+
+  sourceRoot = ".";
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    find . -name "*.otf" -exec install -Dm644 {} -t "$out/share/fonts/opentype" \;
+    find . -name "*.ttf" -exec install -Dm644 {} -t "$out/share/fonts/truetype" \;
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Malayalam variable typeface with decorative variants by SMC";
+    homepage = "https://smc.org.in/fonts/nupuram";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ aashiks ];
+  };
+})

--- a/pkgs/by-name/fo/font-smc-rachana/package.nix
+++ b/pkgs/by-name/fo/font-smc-rachana/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "font-smc-rachana";
+  version = "20241013";
+
+  src = fetchzip {
+    url = "https://smc.org.in/downloads/fonts/rachana/rachana.zip";
+    hash = "sha256-csfMs4B6BD+yap/AaWpm4kQDsR/WNMrym6szM5iZNJo=";
+    stripRoot = false;
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    find . -name "*.otf" -exec install -Dm644 {} -t "$out/share/fonts/opentype" \;
+    find . -name "*.ttf" -exec install -Dm644 {} -t "$out/share/fonts/truetype" \;
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Traditional orthographic Malayalam typeface by SMC";
+    homepage = "https://smc.org.in/fonts/rachana";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ aashiks ];
+  };
+})

--- a/pkgs/by-name/fo/font-smc-rachana/package.nix
+++ b/pkgs/by-name/fo/font-smc-rachana/package.nix
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "Traditional orthographic Malayalam typeface by SMC";
+    description = "Rachana is one of the first traditional orthographic Malayalam unicode typefaces and is still widely popular. Designed by K H Hussain. This is the last version maintained by SMC.";
     homepage = "https://smc.org.in/fonts/rachana";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/fo/font-smc-raghumalayalamsans/package.nix
+++ b/pkgs/by-name/fo/font-smc-raghumalayalamsans/package.nix
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "Malayalam sans-serif typeface by SMC";
+    description = "A collaborative effort of Hussain K H, Prof. R. K. Joshi (TypeFont Design Director), Mr. Rajith Kumar K. M. (TypeFont Designer), assisted by Mr. Nirmal Biswas, Ms. Jui Mhatre and Ms. Supriya Kharkar at C-DAC Mumbai. This is the last version maintained by SMC";
     homepage = "https://smc.org.in/fonts/raghumalayalamsans";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/fo/font-smc-raghumalayalamsans/package.nix
+++ b/pkgs/by-name/fo/font-smc-raghumalayalamsans/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "font-smc-raghumalayalamsans";
+  version = "20241013";
+
+  src = fetchzip {
+    url = "https://smc.org.in/downloads/fonts/raghumalayalamsans/raghumalayalamsans.zip";
+    hash = "sha256-rSM77MiFqRzs67mme8xkJZkw13esB9eG13j8OzytCaA=";
+    stripRoot = false;
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    find . -name "*.otf" -exec install -Dm644 {} -t "$out/share/fonts/opentype" \;
+    find . -name "*.ttf" -exec install -Dm644 {} -t "$out/share/fonts/truetype" \;
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Malayalam sans-serif typeface by SMC";
+    homepage = "https://smc.org.in/fonts/raghumalayalamsans";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ aashiks ];
+  };
+})

--- a/pkgs/by-name/fo/font-smc-suruma/package.nix
+++ b/pkgs/by-name/fo/font-smc-suruma/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "font-smc-suruma";
+  version = "20241013";
+
+  src = fetchzip {
+    url = "https://smc.org.in/downloads/fonts/suruma/suruma.zip";
+    hash = "sha256-x4ybBr5oCwD5Stu8rRGndOYRzaV6ikE+VnLJ/src+1U=";
+    stripRoot = false;
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    find . -name "*.otf" -exec install -Dm644 {} -t "$out/share/fonts/opentype" \;
+    find . -name "*.ttf" -exec install -Dm644 {} -t "$out/share/fonts/truetype" \;
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Malayalam typeface for body text by SMC";
+    homepage = "https://smc.org.in/fonts/suruma";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ aashiks ];
+  };
+})

--- a/pkgs/by-name/fo/font-smc-suruma/package.nix
+++ b/pkgs/by-name/fo/font-smc-suruma/package.nix
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "Malayalam typeface for body text by SMC";
+    description = "Suruma is a traditional orthography font designed by Suresh P. Maintained by SMC";
     homepage = "https://smc.org.in/fonts/suruma";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/fo/font-smc-uroob/package.nix
+++ b/pkgs/by-name/fo/font-smc-uroob/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "font-smc-uroob";
+  version = "20241013";
+
+  src = fetchzip {
+    url = "https://smc.org.in/downloads/fonts/uroob/uroob.zip";
+    hash = "sha256-IJcKD3cDRMA7G7foKtXtJxOrv6OeOujkq9+uGo+R/dY=";
+    stripRoot = false;
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    find . -name "*.otf" -exec install -Dm644 {} -t "$out/share/fonts/opentype" \;
+    find . -name "*.ttf" -exec install -Dm644 {} -t "$out/share/fonts/truetype" \;
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Stylistic Malayalam typeface by SMC";
+    homepage = "https://smc.org.in/fonts/uroob";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ aashiks ];
+  };
+})

--- a/pkgs/by-name/fo/font-smc-uroob/package.nix
+++ b/pkgs/by-name/fo/font-smc-uroob/package.nix
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "Stylistic Malayalam typeface by SMC";
+    description = "Uroob is Malayalam heading style font designed by Hussain K H. Maintained by SMC";
     homepage = "https://smc.org.in/fonts/uroob";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;


### PR DESCRIPTION
This PR aims to add fonts specific to [Malayalam](https://en.wikipedia.org/wiki/Malayalam), one of the major Dravidian languages. These are fonts maintained by a language computing community called Swathanthra Malayalam Computing (https://smc.org.in/en/). Their volunteers maintain these fonts in other major distros such as Debian, Fedora.

These pacakages are adapted from a flake here : https://gitlab.com/smc/smc-fonts-flake

## Things done



- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
