### PR TITLE
matridge: init at 0.3.3

### DIFF
--- a/pkgs/by-name/ma/matridge/package.nix
+++ b/pkgs/by-name/ma/matridge/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  python3Packages,
+  fetchFromCodeberg,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "matridge";
+  version = "0.4.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "slidge";
+    repo = "matridge";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OOyAMIsTEesuBdY35UTWru5mPkIKgeX8BZvpfz8PHbM=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = with python3Packages; [
+    (matrix-nio.override { withOlm = true; })
+    beautifulsoup4
+    async-lru
+    slidge-style-parser
+    slidge
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+    pytest-asyncio
+  ];
+
+  meta = {
+    changelog = "https://codeberg.org/slidge/matridge/releases/tag/${finalAttrs.src.tag}";
+    description = "Matrix to XMPP gateway";
+    homepage = "https://slidge.im/docs/matridge/main/";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ haansn08 ];
+    platforms = lib.platforms.all;
+    mainProgram = "matridge";
+  };
+})

--- a/pkgs/development/python-modules/slidge-style-parser/default.nix
+++ b/pkgs/development/python-modules/slidge-style-parser/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromCodeberg,
+
+  setuptools,
+  setuptools-scm,
+  setuptools-rust,
+  rustPlatform,
+  rustc,
+  cargo,
+
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "slidge-style-parser";
+  version = "0.2.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "slidge";
+    repo = "style-parser";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-T3kzi/fnu5bHB13Sn1Yk3VlSxneUORrqiy7Dh3Uxp2w=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) src;
+    hash = "sha256-9o9w2ZGYDoEKoG+lnNwT6L7uUxotKOp5h1ViQa0QtfY=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+    setuptools-rust
+    rustPlatform.cargoSetupHook
+    rustc
+    cargo
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = {
+    description = "A parsing library for Slidge";
+    homepage = "https://codeberg.org/slidge/style-parser";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ haansn08 ];
+  };
+
+})

--- a/pkgs/development/python-modules/slidge/default.nix
+++ b/pkgs/development/python-modules/slidge/default.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromCodeberg,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  aiohttp,
+  alembic,
+  configargparse,
+  defusedxml,
+  pillow,
+  python-magic,
+  qrcode,
+  slixmpp,
+  sqlalchemy,
+  thumbhash,
+
+  # check dependencies
+  pytestCheckHook,
+  pytest-asyncio,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "slidge";
+  version = "0.4.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "slidge";
+    repo = "slidge";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-VdK6GE3P9iZabR/qjaqkaq3VNRtDn0O7ty2NIHMOmBE=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    aiohttp
+    alembic
+    configargparse
+    defusedxml
+    pillow
+    python-magic
+    qrcode
+    slixmpp
+    sqlalchemy
+    thumbhash
+  ];
+
+  pythonRelaxDeps = true;
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+  ];
+
+  disabledTestPaths = [
+    # Using slixmpp.test.ComponentXMPP which was removed in latest slixmpp
+    "tests/test_adhoc/test_confirmation.py"
+    "tests/test_chat_commands.py"
+  ];
+
+  disabledTests = [
+    "test_vcard_temp"
+  ];
+
+  meta = {
+    changelog = "https://codeberg.org/slidge/slidge/releases/tag/${finalAttrs.src.tag}";
+    description = "Gateway Library for XMPP to Other Networks";
+    homepage = "https://slidge.im/";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ haansn08 ];
+  };
+
+})

--- a/pkgs/development/python-modules/thumbhash/default.nix
+++ b/pkgs/development/python-modules/thumbhash/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  hatchling,
+  pillow,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "thumbhash";
+  version = "0.1.2";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  # the pyproject.toml of GitHub release "v0.1.2" uses "thumbhash-py"
+  # for the project name and does not build.
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-705jmPk/O1rUgNyOOjs6IAgTyGqIV/sGn4R4voCfgkc=";
+  };
+
+  build-system = [ hatchling ];
+
+  optional-dependencies = [ pillow ];
+
+  meta = {
+    description = "Python port of thumbhash, a representation of an image placeholder";
+    homepage = "https://github.com/justinforlenza/thumbhash-py";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ haansn08 ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20230,6 +20230,8 @@ self: super: with self; {
 
   thttp = callPackage ../development/python-modules/thttp { };
 
+  thumbhash = callPackage ../development/python-modules/thumbhash { };
+
   tianshou = callPackage ../development/python-modules/tianshou { };
 
   tidalapi = callPackage ../development/python-modules/tidalapi { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18730,6 +18730,8 @@ self: super: with self; {
 
   slicerator = callPackage ../development/python-modules/slicerator { };
 
+  slidge = callPackage ../development/python-modules/slidge { };
+
   slip10 = callPackage ../development/python-modules/slip10 { };
 
   slither-analyzer = callPackage ../development/python-modules/slither-analyzer { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18732,6 +18732,8 @@ self: super: with self; {
 
   slidge = callPackage ../development/python-modules/slidge { };
 
+  slidge-style-parser = callPackage ../development/python-modules/slidge-style-parser { };
+
   slip10 = callPackage ../development/python-modules/slip10 { };
 
   slither-analyzer = callPackage ../development/python-modules/slither-analyzer { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Matridge is a feature-rich Matrix to XMPP gateway:
https://slidge.im/docs/matridge/main/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
