### PR TITLE
python3Packages.md-toc: fix build

### DIFF
--- a/pkgs/development/python-modules/md-toc/default.nix
+++ b/pkgs/development/python-modules/md-toc/default.nix
@@ -29,7 +29,10 @@ buildPythonPackage rec {
     pytestCheckHook
   ];
 
-  enabledTestPaths = [ "md_toc/tests/*.py" ];
+  # Only run the real unit-test module; the over-broad glob also collected
+  # md_toc/tests/fuzzer.py, which imports the unpackaged `atheris` engine.
+  # https://github.com/frnmst/md-toc/blob/9.0.0/md_toc/tests/fuzzer.py#L22
+  enabledTestPaths = [ "md_toc/tests/tests.py" ];
 
   pythonImportsCheck = [ "md_toc" ];
 


### PR DESCRIPTION
[![](https://hydra-banner.harinn.dev/build/329638843)](https://hydra.nixos.org/build/329638843)

This PR fixes the Hydra failure shown above (introduced by b30e8c9c1917014d6cb8fb9239d46e740d052bc4 as part of #482364) by switching to only run the [unit tests](https://github.com/frnmst/md-toc/blob/9.0.0/md_toc/tests/tests.py), not the [benchmark](https://github.com/frnmst/md-toc/blob/9.0.0/md_toc/tests/benchmark.py) or the [fuzzer](https://github.com/frnmst/md-toc/blob/9.0.0/md_toc/tests/fuzzer.py) which is responsible for breaking the build.

Simpler alternative to #509412.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
