### PR TITLE
ocamlPackages.lsp: 1.25.0 → 1.26.0

### DIFF
--- a/pkgs/applications/science/logic/coq/default.nix
+++ b/pkgs/applications/science/logic/coq/default.nix
@@ -105,11 +105,25 @@ let
     substituteInPlace plugins/micromega/sos.ml --replace "; csdp" "; ${csdp}/bin/csdp"
     substituteInPlace plugins/micromega/coq_micromega.ml --replace "System.is_in_system_path \"csdp\"" "true"
   '';
+  dune =
+    if lib.versions.isEq coq-version "8.20" then
+      args.dune.override { version = "3.21.1"; }
+    else
+      args.dune;
   ocamlPackages =
     if customOCamlPackages != null then
       customOCamlPackages
     else
       lib.switch coq-version [
+        {
+          case = lib.versions.isEq "8.20";
+          out = ocamlPackages_4_14.overrideScope (
+            self: super: {
+              inherit dune;
+              dune_3 = dune;
+            }
+          );
+        }
         {
           case = lib.versions.range "8.16" "9.1";
           out = ocamlPackages_4_14;

--- a/pkgs/by-name/du/dune/package.nix
+++ b/pkgs/by-name/du/dune/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   buildPackages,
-  version ? "3.21.1",
+  version ? "3.22.2",
 }:
 let
   # needed for pkgsStatic
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
       "https://github.com/ocaml/dune/releases/download/${version}/dune-${sfx}${version}.tbz";
     hash =
       {
-        "3.21.1" = "sha256-hPeoLG2ApxJPOEfppInoDPvq+3vtNXOsAShu9W/QjZQ=";
+        "3.22.2" = "sha256-wsz4vGsXr6R8RQKXNXSWMDqnyGgOMpt52Yxo41AToRg=";
         "2.9.3" = "sha256:1ml8bxym8sdfz25bx947al7cvsi2zg5lcv7x9w6xb01cmdryqr9y";
       }
       ."${version}";

--- a/pkgs/by-name/du/dune/package.nix
+++ b/pkgs/by-name/du/dune/package.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation {
     hash =
       {
         "3.22.2" = "sha256-wsz4vGsXr6R8RQKXNXSWMDqnyGgOMpt52Yxo41AToRg=";
+        "3.21.1" = "sha256-hPeoLG2ApxJPOEfppInoDPvq+3vtNXOsAShu9W/QjZQ=";
         "2.9.3" = "sha256:1ml8bxym8sdfz25bx947al7cvsi2zg5lcv7x9w6xb01cmdryqr9y";
       }
       ."${version}";

--- a/pkgs/development/coq-modules/coq-elpi/default.nix
+++ b/pkgs/development/coq-modules/coq-elpi/default.nix
@@ -2,6 +2,7 @@
   lib,
   mkCoqDerivation,
   which,
+  dune,
   coq,
   stdlib,
   version ? null,
@@ -33,7 +34,7 @@ let
   propagatedBuildInputs_wo_elpi = [
     coq.ocamlPackages.findlib
   ];
-  derivation = mkCoqDerivation {
+  derivation = mkCoqDerivation.override { dune = dune.override { version = "3.21.1"; }; } {
     pname = "elpi";
     repo = "coq-elpi";
     owner = "LPCIC";

--- a/pkgs/development/coq-modules/stalmarck/default.nix
+++ b/pkgs/development/coq-modules/stalmarck/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   mkCoqDerivation,
+  dune,
   coq,
   stdlib,
   version ? null,
@@ -38,7 +39,7 @@ let
         else
           "A two-level approach to prove tautologies using Stålmarck's algorithm in Coq.";
     in
-    mkCoqDerivation {
+    mkCoqDerivation.override { dune = dune.override { version = "3.21.1"; }; } {
       inherit
         version
         pname

--- a/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/default.nix
@@ -85,6 +85,6 @@ buildDunePackage (finalAttrs: {
   meta = lsp.meta // {
     description = "OCaml Language Server Protocol implementation";
     mainProgram = "ocamllsp";
-    broken = lib.versions.majorMinor ocaml.version == "4.13";
+    broken = lib.versionAtLeast ocaml.version "4.13" && lib.versionOlder ocaml.version "5.4";
   };
 })

--- a/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/jsonrpc.nix
@@ -10,7 +10,7 @@
   ocaml,
   version ?
     if lib.versionAtLeast ocaml.version "5.4" then
-      "1.25.0"
+      "1.26.0"
     else if lib.versionAtLeast ocaml.version "5.3" then
       "1.23.1"
     else if lib.versionAtLeast ocaml.version "5.2" then
@@ -28,6 +28,11 @@
 let
   params =
     {
+      "1.26.0" = {
+        name = "lsp";
+        minimalOCamlVersion = "5.3";
+        sha256 = "sha256-tMgQ1mZKW/F1pvmUbIDIzCsY5GqYWTTBRQss4IDkaDI=";
+      };
       "1.25.0" = {
         name = "lsp";
         minimalOCamlVersion = "5.3";

--- a/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
+++ b/pkgs/development/ocaml-modules/ocaml-lsp/lsp.nix
@@ -26,7 +26,7 @@
   ocaml,
   version ?
     if lib.versionAtLeast ocaml.version "5.4" then
-      "1.25.0"
+      "1.26.0"
     else if lib.versionAtLeast ocaml.version "5.3" then
       "1.23.1"
     else if lib.versionAtLeast ocaml.version "5.2" then

--- a/pkgs/development/tools/ocaml/merlin/4.x.nix
+++ b/pkgs/development/tools/ocaml/merlin/4.x.nix
@@ -31,8 +31,8 @@
       "5.2.0" = "5.3-502";
       "5.2.1" = "5.3-502";
       "5.3.0" = "5.6-503";
-      "5.4.0" = "5.6-504";
-      "5.4.1" = "5.6-504";
+      "5.4.0" = "5.7.1-504";
+      "5.4.1" = "5.7.1-504";
     }
     ."${ocaml.version}",
 }:
@@ -52,6 +52,7 @@ let
     "5.4.1-503" = "sha256-SbO0x3jBISX8dAXnN5CwsxLV15dJ3XPUg4tlYqJTMCI=";
     "5.6-503" = "sha256-sNytCSqq96I/ZauaCJ6HYb1mXMcjV5CeCsbCGC9PwtQ=";
     "5.6-504" = "sha256-gtZIpBgNbVqjoIMhjii/GX9OnxR4hN6TArtoEa2Yt38=";
+    "5.7.1-504" = "sha256-E5sHPPkUs4tyXFT3W4tkL2VMNJjQpLqM+oMf8CqJcNU=";
   };
 
 in

--- a/pkgs/top-level/coq-packages.nix
+++ b/pkgs/top-level/coq-packages.nix
@@ -17,6 +17,7 @@
   fetchpatch,
   makeWrapper,
   coq2html,
+  dune,
 }@args:
 let
   lib = import ../build-support/coq/extra-lib.nix { inherit (args) lib; };


### PR DESCRIPTION
dune: 3.21.1 -> 3.22.2

ocamlPackages.merlin: 5.6-504 → 5.7.1-504

ocaml-lsp-server: mark old versions as broken


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
