### PR TITLE
nixosTests.{podman,oci-containers}: use docker 29

### DIFF
--- a/nixos/tests/oci-containers.nix
+++ b/nixos/tests/oci-containers.nix
@@ -40,6 +40,8 @@ let
               };
             };
 
+            virtualisation.docker.package = lib.mkIf (backend == "docker") pkgs.docker_29;
+
             # Stop systemd from killing remaining processes if ExecStop script
             # doesn't work, so that proper stopping can be tested.
             systemd.services.${serviceName}.serviceConfig.KillSignal = "SIGCONT";

--- a/nixos/tests/podman/default.nix
+++ b/nixos/tests/podman/default.nix
@@ -62,7 +62,8 @@ import ../make-test-python.nix (
           virtualisation.podman.dockerSocket.enable = true;
 
           environment.systemPackages = [
-            pkgs.docker-client
+            # docker-client for docker 29
+            (pkgs.docker_29.override { clientOnly = true; })
           ];
 
           users.users.alice = {


### PR DESCRIPTION
fixes eval with disabled insecure packages

alternative to #526879

tested eval of `nixosTests.containers-bridge, nixosTests.containers-custom-pkgs, nixosTests.containers-ephemeral, nixosTests.containers-extra_veth, nixosTests.containers-hosts, nixosTests.containers-imperative, nixosTests.containers-ip, nixosTests.containers-macvlans, nixosTests.containers-names, nixosTests.containers-nested, nixosTests.containers-physical_interfaces, nixosTests.containers-portforward, nixosTests.containers-reloadable, nixosTests.containers-require-bind-mounts, nixosTests.containers-restart_networking, nixosTests.containers-tmpfs, nixosTests.containers-unified-hierarchy, nixosTests.containers-ip, nixosTests.containers-imperative, nixosTests.docker, nixosTests.oci-containers`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
