### PR TITLE
yaziPlugins.easyjump: init at 2.0.0

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/easyjump/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/easyjump/default.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkYaziPlugin,
+}:
+
+mkYaziPlugin {
+  pname = "easyjump.yazi";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "mikavilpas";
+    repo = "easyjump.yazi";
+    rev = "7c4056ec691c4da9c16dc98802366782e5e012a5";
+    hash = "sha256-uJRxk7kF0qn6WSP/2WhNnQK3kvsaUJfAozOGweSXiDA=";
+  };
+
+  sourceRoot = "source/easyjump.yazi";
+
+  meta = {
+    description = "Yazi plugin for quickly jumping to the visible files";
+    homepage = "https://github.com/mikavilpas/easyjump.yazi";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      philocalyst
+    ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
