### PR TITLE
_3270font: modernize derivation, add webfont output

### DIFF
--- a/pkgs/by-name/_3/_3270font/package.nix
+++ b/pkgs/by-name/_3/_3270font/package.nix
@@ -2,17 +2,28 @@
   lib,
   stdenvNoCC,
   fetchzip,
+  installFonts,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "3270font";
   version = "3.0.1";
 
+  # Added outputs to handle the web fonts
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
   src = fetchzip {
-    url = "https://github.com/rbanffy/3270font/releases/download/v${version}/3270_fonts_d916271.zip";
-    sha256 = "sha256-Zi6Lp5+sqfjIaHmnaaemaw3i+hXq9mqIsK/81lTkwfM=";
+    url = "https://github.com/rbanffy/3270font/releases/download/v${finalAttrs.version}/3270_fonts_d916271.zip";
+    hash = "sha256-Zi6Lp5+sqfjIaHmnaaemaw3i+hXq9mqIsK/81lTkwfM=";
     stripRoot = false;
   };
+
+  nativeBuildInputs = [
+    installFonts
+  ];
 
   dontPatch = true;
   dontConfigure = true;
@@ -20,19 +31,10 @@ stdenvNoCC.mkDerivation rec {
   doCheck = false;
   dontFixup = true;
 
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm644 -t $out/share/fonts/opentype/ *.otf
-    install -Dm644 -t $out/share/fonts/truetype/ *.ttf
-
-    runHook postInstall
-  '';
-
   meta = {
     description = "Monospaced font based on IBM 3270 terminals";
     homepage = "https://github.com/rbanffy/3270font";
-    changelog = "https://github.com/rbanffy/3270font/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/rbanffy/3270font/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = [
       lib.licenses.bsd3
       lib.licenses.ofl
@@ -40,4 +42,4 @@ stdenvNoCC.mkDerivation rec {
     maintainers = [ ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
migrate _3270font to finalAttrs, move out of treewide PR #524874 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
