### PR TITLE
semgrep: 1.161.0 -> 1.164.0

### DIFF
--- a/pkgs/development/python-modules/semgrep/common.nix
+++ b/pkgs/development/python-modules/semgrep/common.nix
@@ -1,9 +1,9 @@
 { lib }:
 
 rec {
-  version = "1.161.0";
+  version = "1.164.0";
 
-  srcHash = "sha256-WvvEn5PUEXgwtYd72IuEljHUxcJRJh7uHzNLFqaVEbc=";
+  srcHash = "sha256-ced287/jH+as/1rGBOfoZ06UuQ1sf1YI4AMHbHrtnHU=";
 
   # This tag is used to select the correct wheel from PyPI.
   # It is updated by the update.sh script.
@@ -17,8 +17,8 @@ rec {
     "cli/src/semgrep/semgrep_interfaces" = {
       owner = "semgrep";
       repo = "semgrep-interfaces";
-      rev = "8a09b2ed5838118f0ecc45305eb9d956aabcd700";
-      hash = "sha256-jWv0/DADhYmBGJdMpxX8Rq2KQ2wlYIrJGGeYikcskOM=";
+      rev = "f4a74a03e8ec3dd368b96101648a3210e03fa61e";
+      hash = "sha256-dy+oOB0QmZjMpTYINSPIjzhpN6d/45DaajqumKIYxC4=";
     };
   };
 
@@ -28,20 +28,20 @@ rec {
   # on github releases
   core = {
     x86_64-linux = {
-      platform = "manylinux_2_35_x86_64";
-      hash = "sha256-ioIlfWVDSPlCUPQQcB8RJNxwoMQzhGGsxe5xPhAbDZ0=";
+      platform = "manylinux_2_34_x86_64";
+      hash = "sha256-dFrlzhvvfJsDyStDHRdMpu54AaXioEfGSsIQTH5pUvs=";
     };
     aarch64-linux = {
-      platform = "manylinux_2_35_aarch64";
-      hash = "sha256-yDFnKdVIgt7eFNcWb0za9hdJJ7BYldEoiK46D0eRx4U=";
+      platform = "manylinux_2_34_aarch64";
+      hash = "sha256-N24E9xOyRO7pXopRs+gSQM2nwHE214GfcntcoH7H7Kk=";
     };
     x86_64-darwin = {
       platform = "macosx_10_14_x86_64";
-      hash = "sha256-NFBo32ZfO0h0KunOaWefWRnyuu1XkYku5RTxOpCfWWQ=";
+      hash = "sha256-O0kSaWou5GeoVo1UMP4J2m4RAQOQUqA+YG3PaOvjfAo=";
     };
     aarch64-darwin = {
       platform = "macosx_11_0_arm64";
-      hash = "sha256-H51DqX94yMqbwvDrlIa3D64hBtvYAvelK7HLnVj588g=";
+      hash = "sha256-AsKxA5Wmy3NEQJ0kS6ylE33d0W86e9F494aiIkwyrcA=";
     };
   };
 

--- a/pkgs/development/python-modules/semgrep/default.nix
+++ b/pkgs/development/python-modules/semgrep/default.nix
@@ -38,9 +38,11 @@
 
   # python check dependencies
   flaky,
+  pytest-asyncio,
   pytest-freezegun,
   pytest-mock,
   pytest-snapshot,
+  requests-mock,
   types-freezegun,
 }:
 
@@ -124,9 +126,11 @@ buildPythonPackage rec {
     pytestCheckHook
 
     flaky
+    pytest-asyncio
     pytest-freezegun
     pytest-mock
     pytest-snapshot
+    requests-mock
     types-freezegun
   ];
 

--- a/pkgs/development/python-modules/semgrep/default.nix
+++ b/pkgs/development/python-modules/semgrep/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildPythonPackage,
-  callPackage,
   fetchFromGitHub,
   semgrep-core,
 

--- a/pkgs/development/python-modules/semgrep/default.nix
+++ b/pkgs/development/python-modules/semgrep/default.nix
@@ -1,34 +1,31 @@
 {
   lib,
+  buildPythonPackage,
   callPackage,
   fetchFromGitHub,
   semgrep-core,
-  buildPythonPackage,
 
-  pytestCheckHook,
+  # check tools
   git,
+  pytestCheckHook,
 
-  # python packages
+  # python runtime dependencies
   attrs,
   boltons,
   click,
   click-option-group,
   colorama,
   defusedxml,
-  flaky,
   glom,
   jsonschema,
+  mcp,
   opentelemetry-api,
   opentelemetry-exporter-otlp-proto-http,
   opentelemetry-instrumentation-requests,
   opentelemetry-instrumentation-threading,
   opentelemetry-sdk,
-  mcp,
   packaging,
   peewee,
-  pytest-freezegun,
-  pytest-mock,
-  pytest-snapshot,
   python-lsp-jsonrpc,
   requests,
   rich,
@@ -36,10 +33,16 @@
   semantic-version,
   tomli,
   tqdm,
-  types-freezegun,
   typing-extensions,
   urllib3,
   wcmatch,
+
+  # python check dependencies
+  flaky,
+  pytest-freezegun,
+  pytest-mock,
+  pytest-snapshot,
+  types-freezegun,
 }:
 
 # testing locally post build:
@@ -89,30 +92,30 @@ buildPythonPackage rec {
   dependencies = [
     attrs
     boltons
-    colorama
     click
     click-option-group
+    colorama
+    defusedxml
     glom
+    jsonschema
+    mcp
+    opentelemetry-api
+    opentelemetry-exporter-otlp-proto-http
+    opentelemetry-instrumentation-requests
+    opentelemetry-instrumentation-threading
+    opentelemetry-sdk
+    packaging
+    peewee
+    python-lsp-jsonrpc
     requests
     rich
     ruamel-yaml
     semantic-version
-    tqdm
-    packaging
-    jsonschema
-    wcmatch
-    mcp
-    peewee
-    defusedxml
-    urllib3
-    typing-extensions
-    python-lsp-jsonrpc
     tomli
-    opentelemetry-api
-    opentelemetry-sdk
-    opentelemetry-exporter-otlp-proto-http
-    opentelemetry-instrumentation-requests
-    opentelemetry-instrumentation-threading
+    tqdm
+    typing-extensions
+    urllib3
+    wcmatch
   ];
 
   doCheck = true;
@@ -120,31 +123,32 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     git
     pytestCheckHook
+
     flaky
-    pytest-snapshot
-    pytest-mock
     pytest-freezegun
+    pytest-mock
+    pytest-snapshot
     types-freezegun
   ];
 
   disabledTestPaths = [
     "tests/default/e2e"
-    "tests/default/e2e-pysemgrep"
     "tests/default/e2e-other"
+    "tests/default/e2e-pysemgrep"
     "tests/default/mcp"
   ];
 
   disabledTests = [
-    # requires networking
-    "test_send"
-    # requires networking
-    "test_parse_exclude_rules_auto"
-    # many child tests require networking to download files
-    "TestConfigLoaderForProducts"
-    # doesn't start flaky plugin correctly
-    "test_debug_performance"
     # requires .git directory
     "clean_project_url"
+    # doesn't start flaky plugin correctly
+    "test_debug_performance"
+    # requires networking
+    "test_parse_exclude_rules_auto"
+    # requires networking
+    "test_send"
+    # many child tests require networking to download files
+    "TestConfigLoaderForProducts"
   ];
 
   preCheck = ''

--- a/pkgs/development/python-modules/semgrep/semgrep-core.nix
+++ b/pkgs/development/python-modules/semgrep/semgrep-core.nix
@@ -2,8 +2,9 @@
   lib,
   stdenv,
   fetchPypi,
-  unzip,
+
   autoPatchelfHook,
+  unzip,
 }:
 
 let


### PR DESCRIPTION
Updates `semgrep` from `1.161.0` to `1.164.0`.

Changelog: https://github.com/semgrep/semgrep/blob/v1.164.0/CHANGELOG.md

This PR also contains small packaging cleanups before the version bump:
- sort inputs, dependencies, and disabled tests;
- remove an unused `callPackage` binding;
- add pytest plugins used by the enabled checks.

`requests-mock` provides the `requests_mock` fixture used by upstream tests, and `pytest-asyncio` provides support for the `asyncio_mode` pytest configuration option.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

AI assistance was used to draft this PR description; the package update and test results were reviewed before submission.

Tested with:

```console
$ GITHUB_TOKEN=$(gh auth token) nix-update --format --build --test --review --use-update-script --print-commit-message semgrep
[...]

$ nix-build -A semgrep
/nix/store/25p868x9j9fi3189w93pkvh2y7rlagjn-python3.13-semgrep-1.164.0

$ ./result/bin/semgrep --version
1.164.0
```

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
