### PR TITLE
playerctl: unbreak on darwin

### DIFF
--- a/pkgs/by-name/pl/playerctl/package.nix
+++ b/pkgs/by-name/pl/playerctl/package.nix
@@ -25,6 +25,14 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-OiGKUnsKX0ihDRceZoNkcZcEAnz17h2j2QUOSVcxQEY=";
   };
 
+  # macOS's ld64 has no --version-script, so translate the data/playerctl.syms
+  # filter to an -exported_symbols_list to keep the same symbols exported on darwin
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    printf '%s\n' '_Playerctl*' '_PLAYERCTL*' '_playerctl_*' '_pctl_*' > data/playerctl.syms
+    substituteInPlace playerctl/meson.build \
+      --replace-fail '--version-script' '-exported_symbols_list'
+  '';
+
   nativeBuildInputs = [
     docbook_xsl
     gobject-introspection
@@ -49,8 +57,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/acrisci/playerctl";
     license = lib.licenses.lgpl3;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ puffnfresh ];
-    broken = stdenv.hostPlatform.isDarwin;
+    maintainers = with lib.maintainers; [
+      puffnfresh
+      anish
+    ];
     mainProgram = "playerctl";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

playerctl has been marked broken on darwin because its meson build links libplayerctl with GNU ld's --version-script, which macOS's ld64 rejects. This translates the symbol filter in data/playerctl.syms into an ld64 -exported_symbols_list on darwin, so the library links with the same export set. 

(the library and its introspection data are the cross-platform artifact consumers need on darwin (e.g. building Rust/Python MPRIS bindings on a macOS dev machine), independent of the CLI)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
