### PR TITLE
python3Packages.deptry: init at 0.25.1

### DIFF
--- a/pkgs/by-name/de/deptry/package.nix
+++ b/pkgs/by-name/de/deptry/package.nix
@@ -1,0 +1,5 @@
+{ python3Packages }:
+with python3Packages;
+(toPythonApplication deptry).overrideAttrs (_: {
+  __structuredAttrs = true;
+})

--- a/pkgs/development/python-modules/deptry/default.nix
+++ b/pkgs/development/python-modules/deptry/default.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  buildPythonPackage,
+  cargo,
+  click,
+  colorama,
+  fetchFromGitHub,
+  packaging,
+  python,
+  pytest-xdist,
+  pytestCheckHook,
+  requirements-parser,
+  rustc,
+  rustPlatform,
+  tomli,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "deptry";
+  version = "0.25.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "osprey-oss";
+    repo = "deptry";
+    tag = finalAttrs.version;
+    hash = "sha256-GQWivQMWQ8wi6cWsCbmvSSyPEx1yl9QidO+9mTDrN1c=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-axUqKks3vxiJF2bRI/Qwk7iKjoUNQQc3NynI60n3quY=";
+  };
+
+  build-system = [
+    cargo
+    rustPlatform.cargoSetupHook
+    rustPlatform.maturinBuildHook
+    rustc
+  ];
+
+  dependencies = [
+    click
+    colorama
+    packaging
+    requirements-parser
+    tomli
+  ];
+
+  nativeCheckInputs = [
+    pytest-xdist
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    cp $out/${python.sitePackages}/deptry/rust*.so python/deptry/
+  '';
+
+  disabledTestPaths = [
+    # Don't run CLI tests
+    "tests/functional/cli/"
+  ];
+
+  pythonImportsCheck = [ "deptry" ];
+
+  meta = {
+    description = "Find unused, missing and transitive dependencies in a Python project";
+    homepage = "https://github.com/osprey-oss/deptry";
+    changelog = "https://github.com/osprey-oss/deptry/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "deptry";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3884,6 +3884,8 @@ self: super: with self; {
 
   deprecation-alias = callPackage ../development/python-modules/deprecation-alias { };
 
+  deptry = callPackage ../development/python-modules/deptry { };
+
   depyf = callPackage ../development/python-modules/depyf { };
 
   derpconf = callPackage ../development/python-modules/derpconf { };


### PR DESCRIPTION
Find unused, missing and transitive dependencies in a Python project

https://github.com/osprey-oss/deptry


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
