### PR TITLE
_1password-gui: 8.12.21 -> 8.12.22

### DIFF
--- a/pkgs/by-name/_1/_1password-gui/sources.json
+++ b/pkgs/by-name/_1/_1password-gui/sources.json
@@ -1,28 +1,28 @@
 {
   "stable": {
     "linux": {
-      "version": "8.12.21",
+      "version": "8.12.22",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.12.21.x64.tar.gz",
-          "hash": "sha256-JwiMi2iozP6jWSIUtgXla86aSAhuUob7snqtUbeXPpI="
+          "url": "https://downloads.1password.com/linux/tar/stable/x86_64/1password-8.12.22.x64.tar.gz",
+          "hash": "sha256-dec+oqixlPAbHYWqOBEBNB9IU8+Hfz2W4bm1y6/CbuM="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.12.21.arm64.tar.gz",
-          "hash": "sha256-WPFUqKKfdadzF7BtR9gUm0SlYq4ZN36eICfGsPxirH0="
+          "url": "https://downloads.1password.com/linux/tar/stable/aarch64/1password-8.12.22.arm64.tar.gz",
+          "hash": "sha256-qPQbEkXZs0/D/PgDbepUWm5po/Jg42YvxT0a2A+9mOk="
         }
       }
     },
     "darwin": {
-      "version": "8.12.21",
+      "version": "8.12.22",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.12.21-x86_64.zip",
-          "hash": "sha256-1dAmyaBMo4re1aQTk16AMEol7GjeSVhx9F4SuYBGoso="
+          "url": "https://downloads.1password.com/mac/1Password-8.12.22-x86_64.zip",
+          "hash": "sha256-UR1urZS2WuTRrE3Tn3P/QaXKze6Wjrw0ZKEZc06Up8I="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.12.21-aarch64.zip",
-          "hash": "sha256-WrWbGzBK65tVNl9Dc3OnJURiPpfbNLOYUJcVT0ETaAs="
+          "url": "https://downloads.1password.com/mac/1Password-8.12.22-aarch64.zip",
+          "hash": "sha256-Rbac0JcB2kbH6EfEGkuKwhaIW0Bgkhyw7olSjqe1euE="
         }
       }
     }


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
