### PR TITLE
{libtiff, fontconfig}: add missing libraries to propagatedBuildInputs

### DIFF
--- a/pkgs/by-name/li/libtiff/package.nix
+++ b/pkgs/by-name/li/libtiff/package.nix
@@ -80,14 +80,17 @@ stdenv.mkDerivation (finalAttrs: {
     sphinx
   ];
 
-  buildInputs = [
-    libdeflate
+  # Things listed in the
+  # pkg-config file need to be propagated or else
+  # they will not be picked up properly
+  propagatedBuildInputs = [
     libjpeg
-    # libwebp depends on us; this will cause infinite recursion otherwise
-    (libwebp.override { tiffSupport = false; })
-    xz
     zlib
     zstd
+    libdeflate
+    xz
+    # libwebp depends on us; this will cause infinite recursion otherwise
+    (libwebp.override { tiffSupport = false; })
   ]
   ++ lib.optionals withLerc [
     lerc

--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -41,12 +41,9 @@ stdenv.mkDerivation (finalAttrs: {
     python3
   ];
 
-  buildInputs = [
-    expat
-  ];
-
   propagatedBuildInputs = [
     freetype
+    expat
   ];
 
   postPatch = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

While working on #527314 I noticed that fontconfig and libtiff are missing some libraries in their `propagatedBuildInputs`. These are required because the downstream derivation needs to be able to access the dependencies of these libraries at build time. Without them people building derivation must manually read the errors and add these libraries to their `buildInputs`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
