### PR TITLE
musescore: fix qtdeclarative crash

### DIFF
--- a/pkgs/by-name/mu/musescore/package.nix
+++ b/pkgs/by-name/mu/musescore/package.nix
@@ -166,7 +166,7 @@ stdenv.mkDerivation (finalAttrs: {
   # Don't run bundled upstreams tests, as they require a running X window system.
   doCheck = false;
 
-  passthru.tests = nixosTests.musescore;
+  passthru.tests.nixos = nixosTests.musescore;
 
   meta = {
     description = "Music notation and composition software";

--- a/pkgs/by-name/mu/musescore/package.nix
+++ b/pkgs/by-name/mu/musescore/package.nix
@@ -181,6 +181,9 @@ stdenv.mkDerivation (finalAttrs: {
     kdePackages'.qtwayland
   ];
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir -p "$out/Applications"
     mv "$out/mscore.app" "$out/Applications/mscore.app"

--- a/pkgs/by-name/mu/musescore/package.nix
+++ b/pkgs/by-name/mu/musescore/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
 
   # nativeBuildInputs
   cmake,
@@ -33,6 +34,53 @@
   nixosTests,
 }:
 
+let
+  # TODO(@doronbehar): Contribute this one day to lib/? See:
+  # https://discourse.nixos.org/t/rfc-nix-function-that-overrides-a-scope-with-automatic-inheritance-propagation/78025
+  overrideScopeFully =
+    s: scopeOverrideFunc:
+    let
+      partiallyOverriddenScope = s.overrideScope scopeOverrideFunc;
+      directlyOverriddenAttrs = builtins.attrNames (scopeOverrideFunc partiallyOverriddenScope s);
+    in
+    builtins.mapAttrs (
+      attrName: pkg:
+      pkg.override (
+        lib.pipe directlyOverriddenAttrs [
+          (builtins.filter (
+            oAttr:
+            # Don't include in this filter the attribute `attrName` from the
+            # full scope, if it is already part of the _directly_ overridden
+            # attributes.
+            !(builtins.elem attrName directlyOverriddenAttrs)
+            && pkg ? override
+            # Continue with the creation of the `.override` arguments only for
+            # overridden attributes (`oAttr`) which are possible arguments to the
+            # `.override` function of the `pkg` at hand.
+            && pkg.override.__functionArgs ? ${oAttr}
+          ))
+          # Generate the `.override` argument using the attribute names `aNames`
+          (aNames: lib.genAttrs aNames (oAttr: partiallyOverriddenScope.${oAttr}))
+        ]
+      )
+    ) partiallyOverriddenScope;
+  kdePackages' = overrideScopeFully kdePackages (
+    self: super: {
+      # Fix for: https://github.com/NixOS/nixpkgs/issues/526825
+      # reported upstream at: https://github.com/musescore/MuseScore/issues/33015
+      qtdeclarative = super.qtdeclarative.overrideAttrs (
+        new: old: {
+          patches = old.patches ++ [
+            (fetchpatch {
+              url = "https://github.com/qt/qtdeclarative/commit/9d4d376726a6ce15c429128dc65b927e411e40da.patch";
+              hash = "sha256-XhfliF5wZuN4/E55f8hfipIRjxBe9V7vL1cgn5p4xqA=";
+            })
+          ];
+        }
+      );
+    }
+  );
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "musescore";
   version = "4.7.2";
@@ -94,8 +142,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    kdePackages.qttools
-    kdePackages.wrapQtAppsHook
+    kdePackages'.qttools
+    kdePackages'.wrapQtAppsHook
     ninja
     pkg-config
   ]
@@ -108,12 +156,12 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     flac
     freetype
-    kdePackages.qt5compat
-    kdePackages.qtbase
-    kdePackages.qtdeclarative
-    kdePackages.qtnetworkauth
-    kdePackages.qtscxml
-    kdePackages.qtsvg
+    kdePackages'.qt5compat
+    kdePackages'.qtbase
+    kdePackages'.qtdeclarative
+    kdePackages'.qtnetworkauth
+    kdePackages'.qtscxml
+    kdePackages'.qtsvg
     lame
     libjack2
     libogg
@@ -130,7 +178,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     alsa-lib
-    kdePackages.qtwayland
+    kdePackages'.qtwayland
   ];
 
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test