### PR TITLE
mouser: init at 3.6.0

### DIFF
--- a/pkgs/by-name/mo/mouser/package.nix
+++ b/pkgs/by-name/mo/mouser/package.nix
@@ -1,0 +1,118 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  python3Packages,
+  copyDesktopItems,
+  makeDesktopItem,
+  nix-update-script,
+  xdotool,
+  kdotool,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "mouser";
+  version = "3.6.0";
+  pyproject = false;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "TomBadash";
+    repo = "Mouser";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ESfkpswENa91wL1WSfDL/Wpu4sjhT8qibJ0wsEYHX+0=";
+  };
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    copyDesktopItems
+  ];
+
+  dependencies =
+    (with python3Packages; [
+      pyside6
+      hidapi
+      pillow
+    ])
+    ++ lib.optionals stdenv.hostPlatform.isLinux (
+      with python3Packages;
+      [
+        evdev
+      ]
+    );
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/mouser
+    cp -r main_qml.py core ui images $out/share/mouser/
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    install -Dm644 images/logo_icon.png $out/share/pixmaps/mouser.png
+    install -Dm444 packaging/linux/69-mouser-logitech.rules \
+      -t $out/lib/udev/rules.d
+  ''
+  + ''
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    makeWrapper ${python3Packages.python.interpreter} $out/bin/mouser \
+      --prefix PYTHONPATH : "$PYTHONPATH" \
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    --prefix PATH : "${
+      lib.makeBinPath [
+        xdotool
+        kdotool
+      ]
+    }" \
+  ''
+  + ''
+    --add-flags "$out/share/mouser/main_qml.py"
+  '';
+
+  desktopItems = lib.optionals stdenv.hostPlatform.isLinux [
+    (makeDesktopItem {
+      name = "mouser";
+      desktopName = "Mouser";
+      comment = "Logitech mouse remapper";
+      exec = "mouser";
+      icon = "mouser";
+      terminal = false;
+      categories = [
+        "Settings"
+        "Utility"
+      ];
+      keywords = [
+        "mouse"
+        "logitech"
+        "buttons"
+        "remap"
+      ];
+      startupWMClass = "Mouser";
+    })
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Lightweight local alternative to Logitech Options+ for remapping HID++ mice";
+    longDescription = ''
+      Mouser is a fully-local, open-source alternative to Logitech Options+ for
+      remapping Logitech HID++ mice (MX Master / MX Anywhere families and other
+      Logitech devices). It supports per-application profiles, DPI / Smart Shift
+      control, scroll direction inversion, and gesture-button swipes.
+
+      On NixOS, add the package to `services.udev.packages` so the bundled
+      `69-mouser-logitech.rules` is loaded and the active local session can access
+      `/dev/hidraw*`, `/dev/input/event*`, and `/dev/uinput` without root.
+    '';
+    homepage = "https://github.com/TomBadash/Mouser";
+    changelog = "https://github.com/TomBadash/Mouser/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "mouser";
+    maintainers = with lib.maintainers; [ imcvampire ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
