### PR TITLE
python3Packages.datastar-py: 1.0.0 -> 1.0.2

### DIFF
--- a/pkgs/development/python-modules/datastar-py/default.nix
+++ b/pkgs/development/python-modules/datastar-py/default.nix
@@ -1,21 +1,28 @@
 {
+  anyio,
   buildPythonPackage,
+  django,
+  fastapi,
   fetchFromGitHub,
   hatchling,
+  httpx,
   lib,
+  litestar,
   pytestCheckHook,
+  starlette,
+  uvicorn,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "datastar-py";
-  version = "1.0.0";
+  version = "1.0.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "starfederation";
     repo = "datastar-python";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-79pdSzHwkF8JX3rF5PIEvx//rKRvX3H1B2382Wfbm9U=";
+    hash = "sha256-epshwHwpRnrgOQ6/jiy6Iyv4y1fa5ZipgiFShKEOxtA=";
   };
 
   build-system = [ hatchling ];
@@ -23,12 +30,15 @@ buildPythonPackage (finalAttrs: {
   pythonImportsCheck = [ "datastar_py" ];
 
   nativeCheckInputs = [
+    anyio
+    django
+    fastapi
+    httpx
+    litestar
     pytestCheckHook
+    starlette
+    uvicorn
   ];
-
-  # tests were only added after 1.0.0
-  # TODO enable after update
-  doCheck = false;
 
   meta = {
     changelog = "https://github.com/starfederation/datastar-python/releases/tag/${finalAttrs.src.tag}";


### PR DESCRIPTION
Diff: https://github.com/starfederation/datastar-python/compare/v1.0.0...v1.0.2

Changelog: https://github.com/starfederation/datastar-python/releases/tag/v1.0.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
