### PR TITLE
renderdoc: pcre -> pcre2

### DIFF
--- a/pkgs/by-name/re/renderdoc/package.nix
+++ b/pkgs/by-name/re/renderdoc/package.nix
@@ -24,6 +24,9 @@
 }:
 
 let
+  # forked from swig v3 in 2017
+  # primarily to include https://github.com/swig/swig/pull/251
+  # (cherry-picked as https://github.com/swig/swig/commit/8d79491a329825ad24294509fc6a0b0a0b8947c4)
   custom_swig = fetchFromGitHub {
     owner = "baldurk";
     repo = "swig";
@@ -101,7 +104,7 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   postUnpack = ''
-    cp -r ${custom_swig} swig
+    cp -r ${finalAttrs.passthru.custom_swig} swig
     chmod -R +w swig
     patchShebangs swig/autogen.sh
   '';
@@ -136,7 +139,10 @@ stdenv.mkDerivation (finalAttrs: {
     addDriverRunpath $out/lib/librenderdoc.so
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    inherit custom_swig;
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     homepage = "https://renderdoc.org/";

--- a/pkgs/by-name/re/renderdoc/package.nix
+++ b/pkgs/by-name/re/renderdoc/package.nix
@@ -12,7 +12,7 @@
   libpthread-stubs,
   makeWrapper,
   nix-update-script,
-  pcre,
+  pcre2,
   pkg-config,
   python312Packages,
   qt5,
@@ -61,6 +61,24 @@ stdenv.mkDerivation (finalAttrs: {
       revert = true;
     })
   ];
+  swig_patches = [
+    # use PCRE2 instead of PCRE
+    (fetchpatch {
+      name = "renderdoc-swig-pcre2-1.patch";
+      url = "https://src.fedoraproject.org/rpms/renderdoc/raw/19ce666d120a229e5c1ab62fc142610ab3b21b3c/f/renderdoc-swig-pcre2-1.patch";
+      hash = "sha256-xuqHu72vAbxFELNTfJT5SbQOsnG/ee++MZgpuEGLT/w=";
+    })
+    (fetchpatch {
+      name = "renderdoc-swig-pcre2-2.patch";
+      url = "https://src.fedoraproject.org/rpms/renderdoc/raw/19ce666d120a229e5c1ab62fc142610ab3b21b3c/f/renderdoc-swig-pcre2-2.patch";
+      hash = "sha256-LUm5Ekmccy4x+hR+iK49zJc75VxuhDhpNw8rkVnn4rc=";
+    })
+  ];
+  postPatch = ''
+    pushd ../swig
+    prePatch="" postPatch="" patches="$swig_patches" runPhase patchPhase
+    popd
+  '';
 
   buildInputs = [
     libxdmcp
@@ -83,7 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
     bison
     cmake
     makeWrapper
-    pcre
+    pcre2
     pkg-config
     python312Packages.python
     qt5.qtx11extras

--- a/pkgs/by-name/re/renderdoc/package.nix
+++ b/pkgs/by-name/re/renderdoc/package.nix
@@ -14,7 +14,7 @@
   nix-update-script,
   pcre2,
   pkg-config,
-  python312Packages,
+  python3,
   qt5,
   stdenv,
   vulkan-loader,
@@ -83,12 +83,14 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     libxdmcp
     libpthread-stubs
-    python312Packages.pyside2
-    python312Packages.pyside2-tools
-    python312Packages.shiboken2
     qt5.qtbase
     qt5.qtsvg
     vulkan-loader
+    # TODO: make sure pyrenderdoc is installed properly
+    # TODO: unbreak shiboken2 on python>3.12
+    # python312Packages.pyside2
+    # python312Packages.pyside2-tools
+    # python312Packages.shiboken2
   ]
   ++ lib.optionals waylandSupport [
     wayland
@@ -103,7 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
     pcre2
     pkg-config
-    python312Packages.python
+    python3
     qt5.qtx11extras
     qt5.wrapQtAppsHook
   ];
@@ -115,6 +117,10 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "BUILD_VERSION_DIST_CONTACT" "https://github.com/NixOS/nixpkgs/")
     (lib.cmakeBool "BUILD_VERSION_STABLE" true)
     (lib.cmakeBool "ENABLE_UNSUPPORTED_EXPERIMENTAL_POSSIBLY_BROKEN_WAYLAND" waylandSupport)
+    # TODO: build python bindings
+    # https://github.com/NixOS/nixpkgs/issues/525939
+    (lib.cmakeBool "ENABLE_PYRENDERDOC" false)
+    (lib.cmakeBool "QRENDERDOC_ENABLE_PYSIDE2" false)
   ];
 
   dontWrapQtApps = true;


### PR DESCRIPTION
- **renderdoc: move custom_swig to passthru**
- **renderdoc: pcre -> pcre2**
- **renderdoc: avoid building pyrenderdoc**
  (it never got installed correctly anyway, and the required dependencies are unmaintained)

Thanks @ShyAssassin for discovering these patches!

* part of https://github.com/NixOS/nixpkgs/issues/356387
* closes https://github.com/NixOS/nixpkgs/issues/525939
* closes https://github.com/NixOS/nixpkgs/issues/472838

This pcre migration should be safe, the author notes that it is only used at build time to generate bindings, bindings which we now don't even build.

(i tried [ripping out swig and pcre altogether](https://gist.github.com/pbsds/d80997eeca6d936ce0f889d7145b718f), but that proved to be a dead end with lots of linker errors. The builds seem to require some swig-generated files to be present)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
