### PR TITLE
python3Packages.graphite-web: 1.1.10-unstable-2025-02-24 -> 1.2.1-pre2

### DIFF
--- a/pkgs/development/python-modules/graphite-web/default.nix
+++ b/pkgs/development/python-modules/graphite-web/default.nix
@@ -34,14 +34,14 @@
 
 buildPythonPackage {
   pname = "graphite-web";
-  version = "1.1.10-unstable-2025-02-24";
+  version = "1.2.1-pre2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "graphite-project";
     repo = "graphite-web";
-    rev = "49c28e2015d605ad9ec93524f7076dd924a4731a";
-    hash = "sha256-TxsQPhnI5WhQvKKkDEYZ8xnyg/qf+N9Icej6d6A0jC0=";
+    tag = "1.2.1-pre2";
+    hash = "sha256-2C5iWn5/BoX0OPT/UQO94V1oZ/xiRzgoipp0551dnpM=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/graphite-web/default.nix
+++ b/pkgs/development/python-modules/graphite-web/default.nix
@@ -5,6 +5,9 @@
   buildPythonPackage,
   fetchFromGitHub,
 
+  # build-system
+  setuptools,
+
   # dependencies
   cairocffi,
   django,
@@ -53,6 +56,8 @@ buildPythonPackage {
     substituteInPlace webapp/tests/test_render.py \
       --replace-fail "test_render_view" "_dont_test_render_view"
   '';
+
+  build-system = [ setuptools ];
 
   dependencies = [
     cairocffi

--- a/pkgs/development/python-modules/graphite-web/default.nix
+++ b/pkgs/development/python-modules/graphite-web/default.nix
@@ -4,6 +4,7 @@
   pkgs,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
 
   # build-system
   setuptools,
@@ -43,6 +44,11 @@ buildPythonPackage {
     tag = "1.2.1-pre2";
     hash = "sha256-2C5iWn5/BoX0OPT/UQO94V1oZ/xiRzgoipp0551dnpM=";
   };
+
+  patches = [
+    # https://github.com/graphite-project/graphite-web/pull/2914
+    ./epoch-django5-localize-via-pytz.patch
+  ];
 
   postPatch = ''
     substituteInPlace webapp/graphite/settings.py \

--- a/pkgs/development/python-modules/graphite-web/default.nix
+++ b/pkgs/development/python-modules/graphite-web/default.nix
@@ -100,9 +100,12 @@ buildPythonPackage {
   ];
 
   preCheck =
-    # Start a redis server
+    # Start a redis server on a per-build port. Darwin builds share the host
+    # network (no netns isolation), so concurrent builds would otherwise
+    # collide on the default port 6379. test_redis_tagdb reads TEST_REDIS_PORT.
     ''
-      ${pkgs.valkey}/bin/redis-server &
+      export TEST_REDIS_PORT=$(( ($$ % 20000) + 20000 ))
+      ${pkgs.valkey}/bin/redis-server --port "$TEST_REDIS_PORT" &
       REDIS_PID=$!
     '';
 

--- a/pkgs/development/python-modules/graphite-web/epoch-django5-localize-via-pytz.patch
+++ b/pkgs/development/python-modules/graphite-web/epoch-django5-localize-via-pytz.patch
@@ -1,0 +1,13 @@
+diff --git a/webapp/graphite/util.py b/webapp/graphite/util.py
+index bb46fa16c..7152cb765 100644
+--- a/webapp/graphite/util.py
++++ b/webapp/graphite/util.py
+@@ -59,7 +59,7 @@ def epoch(dt):
+   if not dt.tzinfo:
+     tb = traceback.extract_stack(None, 2)
+     log.warning('epoch() called with non-timezone-aware datetime in %s at %s:%d' % (tb[0][2], tb[0][0], tb[0][1]))
+-    return calendar.timegm(make_aware(dt, pytz.timezone(settings.TIME_ZONE)).astimezone(pytz.utc).timetuple())
++    return calendar.timegm(pytz.timezone(settings.TIME_ZONE).localize(dt, is_dst=None).astimezone(pytz.utc).timetuple())
+   return calendar.timegm(dt.astimezone(pytz.utc).timetuple())
+ 
+ 


### PR DESCRIPTION
[![](https://hydra-banner.harinn.dev/build/329636259)](https://hydra.nixos.org/build/329636259)

As an alternative to #520862, this PR fixes this package after it was broken by #382964.

The initial build failure was caused by setting `pyproject = true` without adding `build-system = [ setuptools ]`. The first commit in this PR fixes that.

Later, #488406 included #486806 which brought in python/cpython#142744, breaking `test_standard_finder`. The second commit in this PR fixes that by updating to an upstream version that includes graphite-project/graphite-web#2904.

In the meantime, #471587 included #462746 which updated Django from version 4 to version 5 in NixOS/nixpkgs@bf99d6c4ca9a67ed22864bbe481fadb2b2f393c4, breaking `test_epoch_naive`. The third commit in this PR fixes that via graphite-project/graphite-web#2914.

Finally, the fourth commit in this PR fixes the following error that occurs if you e.g. try to build `python313Packages.graphite-web` and `python314Packages.graphite-web` concurrently on Darwin without sandboxing:

```
# Warning: Could not create server TCP listening socket *:6379: bind: Address already in use
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
