### PR TITLE
nixos-rebuild-ng: add env var to allow use without systemd-run

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
@@ -379,6 +379,10 @@ NIX_SSHOPTS
 NIX_SUDOOPTS
 	Additional options to be passed to sudo on the command line.
 
+NIXOS_REBUILD_NO_SYSTEMD_RUN
+	If set, then *nixos-rebuild* will run without the
+	_systemd-run_ wrapper.
+
 # FILES
 
 /etc/nixos/system.nix

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -708,6 +708,8 @@ def switch_to_configuration(
             "not working in target host"
         )
         cmd = []
+    elif os.environ.get("NIXOS_REBUILD_NO_SYSTEMD_RUN"):
+        cmd = []
 
     run_wrapper(
         [*cmd, path_to_config / "bin/switch-to-configuration", str(action)],

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -820,6 +820,38 @@ def test_switch_to_configuration_without_systemd_run(
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
+def test_switch_to_configuration_without_systemd_run_env_var(
+    mock_run: Any, monkeypatch: MonkeyPatch
+) -> None:
+    profile_path = Path("/path/to/profile")
+    mock_run.return_value = CompletedProcess([], 0)
+
+    with monkeypatch.context() as mp:
+        mp.setenv("LOCALE_ARCHIVE", "")
+        mp.setenv("NIXOS_REBUILD_NO_SYSTEMD_RUN", "1")
+
+        n.switch_to_configuration(
+            profile_path,
+            m.Action.SWITCH,
+            elevate=e.NO_ELEVATOR,
+            target_host=None,
+            specialisation=None,
+            install_bootloader=False,
+        )
+    mock_run.assert_called_with(
+        [profile_path / "bin/switch-to-configuration", "switch"],
+        env={
+            "LOCALE_ARCHIVE": e.PRESERVE_ENV,
+            "NIXOS_NO_CHECK": e.PRESERVE_ENV,
+            "NIXOS_INSTALL_BOOTLOADER": "0",
+        },
+        elevate=e.NO_ELEVATOR,
+        remote=None,
+        stdout=sys.stderr,
+    )
+
+
+@patch(get_qualified_name(n.run_wrapper, n), autospec=True)
 def test_switch_to_configuration_with_systemd_run(
     mock_run: Mock, monkeypatch: MonkeyPatch
 ) -> None:


### PR DESCRIPTION
useful if nixos-rebuild is already running under a systemd service, e.g. a pull deployment

I used an env var l as I thought that it may be preferred to not expose this (similar to `NIXOS_REBUILD_I_UNDERSTAND_THE_CONSEQUENCES_PLEASE_BREAK_MY_SYSTEM`) but I'm fine with changing it.

currently using this patch downstream: https://github.com/nix-community/infra/commit/d5eacf30e14c95b26167df582f1d664076052697

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`. (one of the VM tests is broken on master)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
