### PR TITLE
OpenRCT2: Allow Overriding Asset Sources

### DIFF
--- a/pkgs/by-name/op/openrct2/package.nix
+++ b/pkgs/by-name/op/openrct2/package.nix
@@ -128,12 +128,6 @@ stdenv.mkDerivation (finalAttrs: {
     unzip -o ${title-sequences} -d $sourceRoot/data/sequence
   '';
 
-  # Fix blank changelog & contributors screen. See https://github.com/OpenRCT2/OpenRCT2/issues/16988
-  postPatch = ''
-    substituteInPlace src/openrct2/platform/Platform.Linux.cpp \
-      --replace-fail "/usr/share/doc/openrct2" "$out/share/doc/openrct2"
-  '';
-
   preConfigure =
     # Verify that the correct version of each third party repository is used.
     (

--- a/pkgs/by-name/op/openrct2/package.nix
+++ b/pkgs/by-name/op/openrct2/package.nix
@@ -32,6 +32,7 @@
   speexdsp,
   versionCheckHook,
   zlib,
+  zstd,
 
   withDiscordRpc ? false,
   # Paths to RCT1 and RCT2 installs can be specified to have them added as a wrapped argument
@@ -107,6 +108,7 @@ stdenv.mkDerivation (finalAttrs: {
     openssl
     speexdsp
     zlib
+    zstd
   ]
   ++ lib.optional withDiscordRpc discord-rpc;
 

--- a/pkgs/by-name/op/openrct2/package.nix
+++ b/pkgs/by-name/op/openrct2/package.nix
@@ -35,6 +35,7 @@
   zstd,
 
   withDiscordRpc ? false,
+  verifyAssets ? true,
   # Paths to RCT1 and RCT2 installs can be specified to have them added as a wrapped argument
   rct1Path ? null,
   rct2Path ? null,
@@ -135,7 +136,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   preConfigure =
     # Verify that the correct version of each third party repository is used.
-    (
+    lib.optionalString verifyAssets (
       lib.concatStringsSep "\n" (
         lib.mapAttrsToList (assetName: asset: ''
           grep -qF '"${asset.url}"' assets.json \

--- a/pkgs/by-name/op/openrct2/package.nix
+++ b/pkgs/by-name/op/openrct2/package.nix
@@ -40,29 +40,6 @@
   rct2Path ? null,
 }:
 
-let
-  objects-version = "1.7.10";
-  openmusic-version = "1.6.1";
-  opensfx-version = "1.0.6";
-  title-sequences-version = "0.4.26";
-
-  objects = fetchurl {
-    url = "https://github.com/OpenRCT2/objects/releases/download/v${objects-version}/objects.zip";
-    hash = "sha256-9IO+Jm3CIHe6hRe78y/+OIw1Q7LuWF4K+9QQLbRSgCE=";
-  };
-  openmusic = fetchurl {
-    url = "https://github.com/OpenRCT2/OpenMusic/releases/download/v${openmusic-version}/openmusic.zip";
-    hash = "sha256-mUs1DTsYDuHLlhn+J/frrjoaUjKEDEvUeonzP6id4aE=";
-  };
-  opensfx = fetchurl {
-    url = "https://github.com/OpenRCT2/OpenSoundEffects/releases/download/v${opensfx-version}/opensound.zip";
-    hash = "sha256-BrkPPhnCFnUt9EHVUbJqnj4bp3Vb3SECUEtzv5k2CL4=";
-  };
-  title-sequences = fetchurl {
-    url = "https://github.com/OpenRCT2/title-sequences/releases/download/v${title-sequences-version}/title-sequences.zip";
-    hash = "sha256-2ruXh7FXY0L8pN2fZLP4z6BKfmzpwruWEPR7dikFyFg=";
-  };
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "openrct2";
   version = "0.5.3";
@@ -75,6 +52,34 @@ stdenv.mkDerivation (finalAttrs: {
     repo = "OpenRCT2";
     tag = "v${finalAttrs.version}";
     hash = "sha256-my7fPBD5N0bO1yPaxwHUFqw6TvayQs10kcAX/NqPpIg=";
+  };
+
+  passthru = {
+    updateScript = ./update.sh;
+
+    objects-version = "1.7.10";
+    openmusic-version = "1.6.1";
+    opensfx-version = "1.0.6";
+    title-sequences-version = "0.4.26";
+
+    assets = {
+      objects = fetchurl {
+        url = "https://github.com/OpenRCT2/objects/releases/download/v${finalAttrs.passthru.objects-version}/objects.zip";
+        hash = "sha256-9IO+Jm3CIHe6hRe78y/+OIw1Q7LuWF4K+9QQLbRSgCE=";
+      };
+      openmusic = fetchurl {
+        url = "https://github.com/OpenRCT2/OpenMusic/releases/download/v${finalAttrs.passthru.openmusic-version}/openmusic.zip";
+        hash = "sha256-mUs1DTsYDuHLlhn+J/frrjoaUjKEDEvUeonzP6id4aE=";
+      };
+      opensfx = fetchurl {
+        url = "https://github.com/OpenRCT2/OpenSoundEffects/releases/download/v${finalAttrs.passthru.opensfx-version}/opensound.zip";
+        hash = "sha256-BrkPPhnCFnUt9EHVUbJqnj4bp3Vb3SECUEtzv5k2CL4=";
+      };
+      title-sequences = fetchurl {
+        url = "https://github.com/OpenRCT2/title-sequences/releases/download/v${finalAttrs.passthru.title-sequences-version}/title-sequences.zip";
+        hash = "sha256-2ruXh7FXY0L8pN2fZLP4z6BKfmzpwruWEPR7dikFyFg=";
+      };
+    };
   };
 
   nativeBuildInputs = [
@@ -122,25 +127,21 @@ stdenv.mkDerivation (finalAttrs: {
 
   postUnpack = ''
     mkdir -p $sourceRoot/data/{object,sequence}
-    unzip -o ${objects} -d $sourceRoot/data/object
-    unzip -o ${openmusic} -d $sourceRoot/data
-    unzip -o ${opensfx} -d $sourceRoot/data
-    unzip -o ${title-sequences} -d $sourceRoot/data/sequence
+    unzip -o ${finalAttrs.passthru.assets.objects} -d $sourceRoot/data/object
+    unzip -o ${finalAttrs.passthru.assets.openmusic} -d $sourceRoot/data
+    unzip -o ${finalAttrs.passthru.assets.opensfx} -d $sourceRoot/data
+    unzip -o ${finalAttrs.passthru.assets.title-sequences} -d $sourceRoot/data/sequence
   '';
 
   preConfigure =
     # Verify that the correct version of each third party repository is used.
     (
-      let
-        versionCheck = assetKey: url: ''
-          grep -qF '"${url}"' assets.json \
-            || (echo "${assetKey} differs from expected version!"; exit 1)
-        '';
-      in
-      (versionCheck "objects" objects.url)
-      + (versionCheck "openmusic" openmusic.url)
-      + (versionCheck "opensfx" opensfx.url)
-      + (versionCheck "title-sequences" title-sequences.url)
+      lib.concatStringsSep "\n" (
+        lib.mapAttrsToList (assetName: asset: ''
+          grep -qF '"${asset.url}"' assets.json \
+            || (echo "${assetName} differs from expected version!"; exit 1)
+        '') finalAttrs.passthru.assets
+      )
     );
 
   doInstallCheck = true;
@@ -150,8 +151,6 @@ stdenv.mkDerivation (finalAttrs: {
       ${lib.optionalString (rct1Path != null) "--add-flags '--rct1-data-path=\"${rct1Path}\"'"} \
       ${lib.optionalString (rct2Path != null) "--add-flags '--rct2-data-path=\"${rct2Path}\"'"}
   '';
-
-  passthru.updateScript = ./update.sh;
 
   meta = {
     description = "Open source re-implementation of RollerCoaster Tycoon 2";

--- a/pkgs/by-name/op/openrct2/package.nix
+++ b/pkgs/by-name/op/openrct2/package.nix
@@ -66,6 +66,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "openrct2";
   version = "0.5.3";
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   src = fetchFromGitHub {
     owner = "OpenRCT2";
     repo = "OpenRCT2";


### PR DESCRIPTION
I noticed that https://github.com/NixOS/nixpkgs/pull/225894 appears to be abandoned, so I decided to make my own PR to attempt to address the underlying issue myself.

The review comments on the old PR suggested using `srcs` to handle the multiple source inputs. I experimented with that solution, but found it was some problems with using that:

* Using a list for the sources makes it more difficult to handle the multiple sources due to the different logic required for each. Essentially, the list must be kept in a consistent order, which makes it more prone to error, especially when overriding it.
* The different handling required causes the default unpacking phase to not work correctly. In particular, it just unpacks everything into the same directory, which causes complications with ensuring the data directory has the correct structure from all the different source zip files. (It's in theory possible to make it work by specifying which inner-directories go where, but that is more prone to error, and assumes that there's no overlap in directory names between the different zip files.)
* Lastly, the update script utilizes update-source-version, which requires the updated source (in this case, the actual source code) to be directly referencable (eg. as `<package>.src`). This is incompatible with `srcs`, since referencing a specific element requires a call to `elemAt`, which doesn't work for this.

Next, I considered using a `passthru.srcs` attrset for all the sources. This is most commonly used in nixpkgs for cases where the source is different for different platforms / architectures, but it seemed like a good option to resolve the above issues. While it worked, I found it wasn't ideal, because it made it less idiomatic, potentially broke backport-ability (since it changed how overriding the version worked), and required completely replacing the unpacking phase, making it less versatile (eg. you couldn't override the source code to load from an archive).

In the end, I decided on using an attrset in `passthru`, but only for the asset zip files. This makes it simple to override the asset versions used in the build without over-complicating the package script. This also allowed for modifying the version checks to use `mapAttrsToList` rather than explicitly checking each assets individually.

While I was in this file, I decided to make a few small, mostly unrelated changes as well:

* Added a `verifyAssets` argument (default `true`) to control whether to verify that the asset sources are correct. This allows overrides to disable the check, in case they are specifically trying to modify the default assets for the build.
* Removed the now unnecessary patch for loading the changelog. This issue was resolved upstream with https://github.com/OpenRCT2/OpenRCT2/pull/24878 (with it now first searching relative to the executable), and I confirmed that this now works without the patch applied.
* Added `zstd` as an explicit build input. This is now required as of https://github.com/OpenRCT2/OpenRCT2/pull/24734, and should be explicitly added to the build. This was working previously, I assume, because another build input itself used zstd (probably freetype?), but this could potentially change in the future, so adding this in now makes this build more stable.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
