### PR TITLE
 manpages-l10n: init at 4.30.2 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24537,6 +24537,12 @@
     githubId = 34161949;
     keys = [ { fingerprint = "155C F413 0129 C058 9A5F  5524 3658 73F2 F0C6 153B"; } ];
   };
+  sanae6 = {
+    name = "Aubrey";
+    email = "aubrey@hall.ly";
+    github = "Sanae6";
+    githubId = 32604996;
+  };
   sandarukasa = {
     name = "Sandaru Kasa";
     email = "SandaruKasa+nix@ya.ru";

--- a/pkgs/by-name/ma/manpages-l10n/package.nix
+++ b/pkgs/by-name/ma/manpages-l10n/package.nix
@@ -1,0 +1,46 @@
+{
+  stdenv,
+  fetchFromGitLab,
+  po4a,
+  gettext,
+  perl,
+  nix-update-script,
+  lib,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "manpages-l10n";
+  version = "4.30.2";
+
+  src = fetchFromGitLab {
+    domain = "salsa.debian.org";
+    owner = "manpages-l10n-team";
+    repo = "manpages-l10n";
+    tag = finalAttrs.version;
+    hash = "sha256-M1Br3+S6UEQUKV3kZOvkMat53khzdObQyTYX+E+lmtM=";
+  };
+
+  nativeBuildInputs = [
+    po4a
+    gettext
+    perl
+  ];
+
+  enableParallelBuilding = true;
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "manpages-l10n";
+    description = "Translation of manpages";
+    homepage = "https://manpages-l10n-team.pages.debian.net/manpages-l10n/";
+    changelog = "https://salsa.debian.org/manpages-l10n-team/manpages-l10n/-/releases/${finalAttrs.version}";
+    license = [ lib.licenses.gpl3Only ];
+    maintainers = with lib.maintainers; [ sanae6 ];
+  };
+})


### PR DESCRIPTION
quite surprised this hasn't been packaged yet. added myself as a maintainer :)
also ensured the update script works properly.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
