### PR TITLE
home-assistant-custom-lovelace-modules.lovelace-expander-card: init at 0.1.5

### DIFF
--- a/pkgs/servers/home-assistant/custom-lovelace-modules/lovelace-expander-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/lovelace-expander-card/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  pnpm_10,
+  nodejs,
+}:
+let
+  pnpm = pnpm_10;
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "lovelace-expander-card";
+  version = "0.1.5";
+
+  src = fetchFromGitHub {
+    owner = "Alia5";
+    repo = "lovelace-expander-card";
+    tag = finalAttrs.version;
+    hash = "sha256-D76gZR2yEZJrfaesomrpyMg/OPRfVjdDUwcl0EqqNmg=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpm;
+    fetcherVersion = 3;
+    hash = "sha256-L+lLJICyh7BhW9CF0+yhYginUx95EQ4de9gXQl8XmOo=";
+  };
+
+  nativeBuildInputs = [
+    pnpmConfigHook
+    pnpm
+    nodejs
+  ];
+
+  # Upstream tries to get the version via git; since Nix' fetchers don't give us
+  # the .git directory this'll fail, so we provide it manually
+  postPatch = ''
+    substituteInPlace package.json \
+      --replace-fail 'VERSION=$(git describe --tags)' 'VERSION=${finalAttrs.version}'
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm run build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out"
+    cp dist/*.js "$out"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Home Assistant Lovelace card that wraps other cards in a collapsible expander";
+    homepage = "https://github.com/Alia5/lovelace-expander-card";
+    changelog = "https://github.com/Alia5/lovelace-expander-card/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kilyanni ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Adds https://github.com/Alia5/lovelace-expander-card, a small custom Home Assistant lovelace card that allows collapsing/expanding content inside it.

Card works as expected in my Hassio setup

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
