### PR TITLE
neovim-require-check-hook: requiredLuaModules available during check

### DIFF
--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -444,4 +444,51 @@ pkgs.lib.recurseIntoAttrs rec {
   '';
 
   inherit (vimPlugins) corePlugins;
+
+  nvim_require_check_lua_module =
+    let
+      inherit (neovim-unwrapped.lua.pkgs) luaexpat luassert;
+    in
+    vimUtils.buildVimPlugin {
+      pname = "neovim-require-check-lua-module-test";
+      version = "0";
+      src = runCommandLocal "neovim-require-check-lua-module-src" { } ''
+        mkdir -p "$out/lua/require-check-luamods"
+        mkdir -p "$out/plugin"
+        cat > "$out/plugin/require-check-luamods.vim" <<'EOF'
+        let g:require_check_luamods_plugin_loaded = 1
+        EOF
+        cat > "$out/lua/require-check-luamods/init.lua" <<'EOF'
+        if vim.g.require_check_luamods_plugin_loaded ~= 1 then
+          error("plugin script was not sourced")
+        end
+        -- lxp: direct C dependency from luaexpat (package.cpath)
+        require("lxp")
+        -- say: transitive dependency of luassert (package.path closure)
+        require("say")
+        return {}
+        EOF
+      '';
+      requiredLuaModules = [
+        luaexpat
+        luassert
+      ];
+    };
+
+  nvim_require_check_passthru_lua_module =
+    let
+      inherit (neovim-unwrapped.lua.pkgs) luassert;
+    in
+    vimUtils.buildVimPlugin {
+      pname = "neovim-require-check-passthru-lua-module-test";
+      version = "0";
+      src = runCommandLocal "neovim-require-check-passthru-lua-module-src" { } ''
+        mkdir -p "$out/lua/require-check-passthru-luamods"
+        cat > "$out/lua/require-check-passthru-luamods/init.lua" <<'EOF'
+        require("say")
+        return {}
+        EOF
+      '';
+      passthru.requiredLuaModules = [ luassert ];
+    };
 }

--- a/pkgs/applications/editors/vim/plugins/hooks/neovim-require-check-hook.sh
+++ b/pkgs/applications/editors/vim/plugins/hooks/neovim-require-check-hook.sh
@@ -53,6 +53,12 @@ run_require_checks() {
     local deps="${dependencies[*]}"
     local nativeCheckInputs="${nativeBuildInputs[*]}"
     local checkInputs="${buildInputs[*]}"
+
+    local -a luaPathArgs=()
+    if [ -n "${nvimRequireCheckLuaPath:-}" ] || [ -n "${nvimRequireCheckLuaCPath:-}" ]; then
+        luaPathArgs=(--cmd "lua package.path='${nvimRequireCheckLuaPath:-}'..';'..package.path; package.cpath='${nvimRequireCheckLuaCPath:-}'..';'..package.cpath")
+    fi
+
     set +e
 
     if [ -v 'nvimSkipModule' ]; then
@@ -85,6 +91,7 @@ run_require_checks() {
                 --cmd "set rtp+=$out,${deps// /,}" \
                 --cmd "set rtp+=$out,${nativeCheckInputs// /,}" \
                 --cmd "set rtp+=$out,${checkInputs// /,}" \
+                "${luaPathArgs[@]}" \
                 --cmd "set packpath^=$packPathDir" \
                 --cmd "packadd testPlugin" \
                 --cmd "lua require('$name')"; then

--- a/pkgs/applications/editors/vim/plugins/utils/vim-utils.nix
+++ b/pkgs/applications/editors/vim/plugins/utils/vim-utils.nix
@@ -4,6 +4,7 @@
   stdenv,
   vim,
   vimPlugins,
+  neovim-unwrapped,
   buildEnv,
   symlinkJoin,
   writeText,
@@ -516,35 +517,47 @@ rec {
     drv:
     let
       drv-name = drv.name or "${drv.pname}-${drv.version}";
+      lua = neovim-unwrapped.lua;
     in
-    drv.overrideAttrs (oldAttrs: {
-      name = "vimplugin-${drv-name}";
-      # dont move the "doc" folder since vim expects it
-      forceShare = [
-        "man"
-        "info"
-      ];
-
-      nativeBuildInputs =
-        oldAttrs.nativeBuildInputs or [ ]
-        ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
-          vimGenDocHook
+    drv.overrideAttrs (
+      finalAttrs: oldAttrs:
+      let
+        getRequiredLuaModules = attrs: attrs.requiredLuaModules or attrs.passthru.requiredLuaModules or [ ];
+        modules = getRequiredLuaModules finalAttrs;
+        luaEnv = lua.withPackages (_: modules);
+      in
+      {
+        name = "vimplugin-${drv-name}";
+        # dont move the "doc" folder since vim expects it
+        forceShare = [
+          "man"
+          "info"
         ];
 
-      doCheck = oldAttrs.doCheck or true;
+        nativeBuildInputs =
+          oldAttrs.nativeBuildInputs or [ ]
+          ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+            vimGenDocHook
+          ];
 
-      nativeCheckInputs =
-        oldAttrs.nativeCheckInputs or [ ]
-        ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
-          vimCommandCheckHook
-          # many neovim plugins keep using buildVimPlugin
-          neovimRequireCheckHook
-        ];
+        doCheck = oldAttrs.doCheck or true;
 
-      passthru = (oldAttrs.passthru or { }) // {
-        vimPlugin = true;
-      };
-    });
+        nativeCheckInputs =
+          oldAttrs.nativeCheckInputs or [ ]
+          ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+            vimCommandCheckHook
+            # many neovim plugins keep using buildVimPlugin
+            neovimRequireCheckHook
+          ];
+
+        nvimRequireCheckLuaPath = lib.optionalString (modules != [ ]) (lua.pkgs.getLuaPath luaEnv);
+        nvimRequireCheckLuaCPath = lib.optionalString (modules != [ ]) (lua.pkgs.getLuaCPath luaEnv);
+
+        passthru = (oldAttrs.passthru or { }) // {
+          vimPlugin = true;
+        };
+      }
+    );
 }
 // lib.optionalAttrs config.allowAliases {
   vimWithRC = throw "vimWithRC was removed, please use vim.customize instead";


### PR DESCRIPTION
Mimic the neovim wrapper in the neovimRequireCheckHook so that lua dependencies are included in the check. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
