### PR TITLE
waypaper-engine: init at 3.0.0

### DIFF
--- a/pkgs/by-name/wa/waypaper-engine/0001-fix-null-strings.patch
+++ b/pkgs/by-name/wa/waypaper-engine/0001-fix-null-strings.patch
@@ -1,0 +1,22 @@
+From 838bedb814a20d0e0b3df98f6708610281560f48 Mon Sep 17 00:00:00 2001
+From: phanirithvij <phanirithvij2000@gmail.com>
+Date: Sun, 7 Jun 2026 18:09:39 +0530
+Subject: [PATCH] fix null strings
+
+Signed-off-by: phanirithvij <phanirithvij2000@gmail.com>
+---
+ src/hooks/useLiveWallpapers.ts | Bin 4054 -> 4056 bytes
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+
+diff --git a/src/hooks/useLiveWallpapers.ts b/src/hooks/useLiveWallpapers.ts
+index 4e5010833591915738e8aa8305956df107611187..f4b7a8e3f3494cd0698c7496cecc4a98b124e1de 100644
+GIT binary patch
+delta 23
+ccmca6e?xwQB|B4$!DcJ=HbxMAkVBLm0AH;K3;+NC
+
+delta 21
+ccmca1e@%XaB|9U-W^48~Mn;CshdD&q0ZhyV^#A|>
+
+-- 
+2.54.0
+

--- a/pkgs/by-name/wa/waypaper-engine/0002-fix-awww-require-WAYLAND_DISPLAY.patch
+++ b/pkgs/by-name/wa/waypaper-engine/0002-fix-awww-require-WAYLAND_DISPLAY.patch
@@ -1,0 +1,25 @@
+From ca72f91c758570545667779dd27085be838c759c Mon Sep 17 00:00:00 2001
+From: phanirithvij <phanirithvij2000@gmail.com>
+Date: Sun, 7 Jun 2026 22:43:51 +0530
+Subject: [PATCH] fix(awww): require WAYLAND_DISPLAY
+
+---
+ daemon/internal/backend/awww/awww.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/daemon/internal/backend/awww/awww.go b/daemon/internal/backend/awww/awww.go
+index 943cbe0..e582a8b 100644
+--- a/daemon/internal/backend/awww/awww.go
++++ b/daemon/internal/backend/awww/awww.go
+@@ -75,7 +75,7 @@ func (a *Awww) Name() string { return "awww" }
+ 
+ func (a *Awww) IsAvailable() bool {
+ 	_, err := exec.LookPath(cliBinary)
+-	return err == nil
++	return err == nil && os.Getenv("WAYLAND_DISPLAY") != ""
+ }
+ 
+ func (a *Awww) Capabilities() backend.Capabilities {
+-- 
+2.54.0
+

--- a/pkgs/by-name/wa/waypaper-engine/0003-fix-core-persist-active-backend-config-when-already.patch
+++ b/pkgs/by-name/wa/waypaper-engine/0003-fix-core-persist-active-backend-config-when-already.patch
@@ -1,0 +1,30 @@
+From ec7e69c096bd2dde94d35a46994737c3adce7723 Mon Sep 17 00:00:00 2001
+From: phanirithvij <phanirithvij2000@gmail.com>
+Date: Sun, 7 Jun 2026 22:43:51 +0530
+Subject: [PATCH] fix(core): persist active backend config when already active
+
+---
+ daemon/internal/control/controller.go | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/daemon/internal/control/controller.go b/daemon/internal/control/controller.go
+index 0782c94..811c18b 100644
+--- a/daemon/internal/control/controller.go
++++ b/daemon/internal/control/controller.go
+@@ -189,6 +189,13 @@ func (c *Controller) UpdateBackendConfig(ctx context.Context, name string, raw j
+ 
+ func (c *Controller) ActivateBackend(ctx context.Context, name string) (ActivationResult, error) {
+ 	if cur := c.registry.Active(); cur != nil && cur.Name() == name {
++		if c.cfg.GetActiveBackendType() != name {
++			_ = c.cfg.SetActiveBackendType(name)
++			c.bus.Publish(events.Event{
++				Type: events.ConfigChanged,
++				Data: map[string]any{"sections": []string{"backend"}},
++			})
++		}
+ 		return ActivationResult{Backend: name, AlreadyActive: true}, nil
+ 	}
+ 	if err := backend.SwitchActiveBackend(ctx, c.registry, name, c.cfg, backend.SwitchOpts{
+-- 
+2.54.0
+

--- a/pkgs/by-name/wa/waypaper-engine/package.nix
+++ b/pkgs/by-name/wa/waypaper-engine/package.nix
@@ -1,0 +1,142 @@
+{
+  fetchPnpmDeps,
+  lib,
+  nodejs,
+  pnpm_11,
+  pnpmConfigHook,
+  stdenv,
+  gitMinimal,
+  fetchFromGitHub,
+  electron,
+  makeWrapper,
+  buildGoModule,
+  wayland,
+  awww,
+  feh,
+}:
+let
+  pnpm = pnpm_11;
+
+  version = "3.0.0";
+
+  src = fetchFromGitHub {
+    owner = "0bCdian";
+    repo = "Waypaper-Engine";
+    tag = "v${version}";
+    hash = "sha256-oee44RABW+0BcirsJbc5WnLVQeyAamXfxj4Q1x4B2JA=";
+  };
+
+  backend = buildGoModule (finalAttrs: {
+    pname = "waypaper-daemon";
+    inherit version src;
+
+    sourceRoot = "${finalAttrs.src.name}/daemon";
+
+    patches = [
+      ./0002-fix-awww-require-WAYLAND_DISPLAY.patch
+      ./0003-fix-core-persist-active-backend-config-when-already.patch
+    ];
+
+    patchFlags = [ "-p2" ];
+
+    buildInputs = [ wayland ];
+
+    proxyVendor = true;
+    vendorHash = "sha256-KGyaZhWU5UOPV73MitA5eycy3ugH+rwgNu09r3ALtIo=";
+
+    subPackages = [ "cmd/daemon" ];
+
+    ldflags = [
+      "-s"
+      "-X main.version=${version}"
+    ];
+  });
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "waypaper-engine";
+  inherit version src;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    nodejs
+    pnpmConfigHook
+    pnpm
+    makeWrapper
+    gitMinimal
+  ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpm;
+    fetcherVersion = 3;
+    hash = "sha256-m/TtZ1rUXyzSYfxDMuZGW8d0Rl6T7qU+v4kRHAa6PM0=";
+  };
+
+  patchPhase = ''
+    # binary patch unsupported by patch command, requires git apply
+    git apply ${./0001-fix-null-strings.patch}
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    substituteInPlace globals/configReader.ts \
+      --replace-fail "process.resourcesPath" "\"$out/bin\""
+
+    pnpm exec vite build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir $out
+    mkdir -p $out/bin $out/share/applications $out/libexec/waypaper-engine/apps/desktop
+
+    cp -r node_modules $out/libexec/waypaper-engine
+    cp -r dist $out/libexec/waypaper-engine/apps/desktop
+    cp -r dist-electron $out/libexec/waypaper-engine/apps/desktop
+
+    for size in 16x16 32x32 64x64 128x128 256x256 512x512; do
+      mkdir -p "$out/share/icons/hicolor/$size/apps"
+      cp "build/icons/$size.png" "$out/share/icons/hicolor/$size/apps/waypaper-engine.png"
+    done
+
+    cp waypaper-engine.desktop $out/share/applications
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    makeWrapper ${electron}/bin/electron $out/bin/waypaper-engine \
+      --add-flags $out/libexec/waypaper-engine/apps/desktop/dist-electron/main.js
+
+    makeWrapper ${finalAttrs.passthru.backend}/bin/daemon $out/bin/waypaper-daemon \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          awww
+          feh
+        ]
+      }
+  '';
+
+  passthru = { inherit backend; };
+
+  meta = {
+    description = "Wallpaper setter GUI with playlist functionality for Wayland and X11";
+    longDescription = ''
+      Waypaper Engine is a wallpaper manager with playlist support, advanced filters, multiple backend support, and Wallhaven integration.
+    '';
+    homepage = "https://github.com/0bCdian/Waypaper-Engine";
+    license = lib.licenses.gpl3Plus;
+    changelog = "https://github.com/0bCdian/Waypaper-Engine/releases/tag/${finalAttrs.src.rev}";
+    maintainers = with lib.maintainers; [
+      zainkergaye
+      phanirithvij
+    ];
+    platforms = lib.platforms.linux;
+    mainProgram = "waypaper-engine";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adding [Waypaper Engine]( https://github.com/0bCdian/Waypaper-Engine ) to nixpkgs. This was really annoying to try and package. I have no prior experience to packaging like a npm and go app. No AI was used in the making of this package (I asked AI to see if it could but didn't work). Let me know if anything needs changing. Thank you. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
