### PR TITLE
ruby: 3_4 -> 4_0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -5,6 +5,7 @@
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 - The default PostgreSQL version for new NixOS installations (i.e. with `system.stateVersion >= 26.11`) is v18.
+- Ruby now defaults to 4.0. For more information, see the [official Ruby 4.0.0 release notes](https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/).
 
 - The {file}`nixexprs.tar.xz` tarball will be discontinued together with Nixpkgs
   27.05 after 2027-12-31. Migrate to the {file}`nixexprs.tar.zst` tarball

--- a/pkgs/by-name/as/asciidoctor/package.nix
+++ b/pkgs/by-name/as/asciidoctor/package.nix
@@ -2,9 +2,10 @@
   lib,
   bundlerApp,
   bundlerUpdateScript,
+  ruby_3_4,
 }:
 
-bundlerApp {
+(bundlerApp.override { ruby = ruby_3_4; }) {
   pname = "asciidoctor";
   gemdir = ./.;
 

--- a/pkgs/by-name/co/colorls/package.nix
+++ b/pkgs/by-name/co/colorls/package.nix
@@ -1,11 +1,10 @@
 {
   lib,
   bundlerApp,
-  ruby_3_4,
   bundlerUpdateScript,
 }:
 
-(bundlerApp.override { ruby = ruby_3_4; }) {
+bundlerApp {
   pname = "colorls";
 
   gemdir = ./.;
@@ -22,7 +21,6 @@
       nicknovitski
       cbley
     ];
-    platforms = ruby_3_4.meta.platforms;
     mainProgram = "colorls";
   };
 }

--- a/pkgs/by-name/da/dawarich/package.nix
+++ b/pkgs/by-name/da/dawarich/package.nix
@@ -7,7 +7,6 @@
   nixosTests,
   nodejs,
   npmHooks,
-  ruby_3_4,
   stdenv,
   tailwindcss_3,
   gemset ? import ./gemset.nix,
@@ -19,9 +18,6 @@
     inherit (sources) hash;
   },
 }:
-let
-  ruby = ruby_3_4;
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "dawarich";
   inherit (sources) version;
@@ -55,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   dawarichGems = bundlerEnv {
     name = "${finalAttrs.pname}-gems-${finalAttrs.version}";
-    inherit gemset ruby;
+    inherit gemset;
     inherit (finalAttrs) version;
     gemdir = finalAttrs.src;
   };

--- a/pkgs/by-name/le/ledger-web/package.nix
+++ b/pkgs/by-name/le/ledger-web/package.nix
@@ -2,7 +2,6 @@
   lib,
   bundlerApp,
   bundlerUpdateScript,
-  ruby_3_4,
   withPostgresql ? true,
   libpq,
   withSqlite ? false,
@@ -13,9 +12,6 @@ bundlerApp {
   pname = "ledger_web";
   gemdir = ./.;
   exes = [ "ledger_web" ];
-
-  # "Source locally installed gems is ignoring... because it is missing extensions"
-  ruby = ruby_3_4;
 
   buildInputs = lib.optional withPostgresql libpq ++ lib.optional withSqlite sqlite;
 

--- a/pkgs/by-name/lo/lolcat/package.nix
+++ b/pkgs/by-name/lo/lolcat/package.nix
@@ -1,11 +1,10 @@
 {
   lib,
   bundlerApp,
-  ruby_3_4,
   bundlerUpdateScript,
 }:
 
-(bundlerApp.override { ruby = ruby_3_4; }) {
+bundlerApp {
   pname = "lolcat";
   gemdir = ./.;
   exes = [ "lolcat" ];

--- a/pkgs/by-name/ma/mailcatcher/package.nix
+++ b/pkgs/by-name/ma/mailcatcher/package.nix
@@ -1,5 +1,5 @@
 {
-  ruby,
+  ruby_3_4,
   lib,
   bundlerApp,
   bundlerUpdateScript,
@@ -8,6 +8,7 @@
 
 bundlerApp {
   pname = "mailcatcher";
+  ruby = ruby_3_4;
   gemdir = ./.;
   exes = [
     "mailcatcher"

--- a/pkgs/by-name/op/openvox/package.nix
+++ b/pkgs/by-name/op/openvox/package.nix
@@ -3,10 +3,9 @@
   bundlerUpdateScript,
   lib,
   openvox,
-  ruby_3_4,
   testers,
 }:
-((bundlerApp.override { ruby = ruby_3_4; }) {
+(bundlerApp {
   pname = "openvox";
   gemdir = ./.;
   exes = [ "puppet" ];

--- a/pkgs/by-name/pg/pghero/package.nix
+++ b/pkgs/by-name/pg/pghero/package.nix
@@ -7,19 +7,20 @@
   makeBinaryWrapper,
   nixosTests,
   callPackage,
+  ruby_3_4,
 }:
 stdenv.mkDerivation (
   finalAttrs:
   let
     # Use bundlerEnvArgs from passthru to allow overriding bundlerEnv arguments.
-    rubyEnv = bundlerEnv finalAttrs.passthru.bundlerEnvArgs;
+    rubyEnv = bundlerEnv (finalAttrs.passthru.bundlerEnvArgs // { ruby = ruby_3_4; });
     # We also need a separate nativeRubyEnv to precompile assets on the build
     # host. If possible, reuse existing rubyEnv derivation.
     nativeRubyEnv =
       if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
         rubyEnv
       else
-        buildPackages.bundlerEnv finalAttrs.passthru.bundlerEnvArgs;
+        buildPackages.bundlerEnv (finalAttrs.passthru.bundlerEnvArgs // { ruby = buildPackages.ruby_3_4; });
 
     bundlerEnvArgs = {
       name = "${finalAttrs.pname}-${finalAttrs.version}-gems";

--- a/pkgs/by-name/ti/timetrap/package.nix
+++ b/pkgs/by-name/ti/timetrap/package.nix
@@ -1,7 +1,6 @@
 {
   stdenv,
   lib,
-  ruby_3_4,
   bundlerEnv,
   bundlerApp,
   bundlerUpdateScript,
@@ -11,7 +10,7 @@
 let
   pname = "timetrap";
 
-  ttBundlerApp = (bundlerApp.override { ruby = ruby_3_4; }) {
+  ttBundlerApp = bundlerApp {
     inherit pname;
     gemdir = ./.;
     exes = [
@@ -22,7 +21,7 @@ let
     passthru.updateScript = bundlerUpdateScript "timetrap";
   };
 
-  ttGem = (bundlerEnv.override { ruby = ruby_3_4; }) {
+  ttGem = bundlerEnv {
     inherit pname;
     gemdir = ./.;
   };

--- a/pkgs/by-name/za/zammad/package.nix
+++ b/pkgs/by-name/za/zammad/package.nix
@@ -8,7 +8,7 @@
   bundlerEnv,
   callPackage,
   procps,
-  ruby,
+  ruby_3_4,
   postgresql,
   jq,
   moreutils,
@@ -24,6 +24,7 @@
 let
   pname = "zammad";
   version = "7.1.1";
+  ruby = ruby_3_4;
 
   src = applyPatches {
     src = fetchFromGitHub (lib.importJSON ./source.json);

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4646,8 +4646,8 @@ with pkgs;
     ruby_4_0
     ;
 
-  ruby = ruby_3_4;
-  rubyPackages = rubyPackages_3_4;
+  ruby = ruby_4_0;
+  rubyPackages = rubyPackages_4_0;
 
   rubyPackages_3_3 = recurseIntoAttrs ruby_3_3.gems;
   rubyPackages_3_4 = recurseIntoAttrs ruby_3_4.gems;


### PR DESCRIPTION
targeting master while rebuilding and testing 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
