### PR TITLE
alsa-{lib,utils,ucm-conf}: 1.2.15.x -> 1.2.16

### DIFF
--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -110,13 +110,13 @@
     "vendorHash": null
   },
   "bpg_proxmox": {
-    "hash": "sha256-eOllsoXIHOym4pn2pBh5Air5eDvgvppVcnw+FfxRet4=",
+    "hash": "sha256-HQDXazrYuO4Sy2p5M3T+ic34GXaLuAt/oPlUPC6kHSk=",
     "homepage": "https://registry.terraform.io/providers/bpg/proxmox",
     "owner": "bpg",
     "repo": "terraform-provider-proxmox",
-    "rev": "v0.107.0",
+    "rev": "v0.108.0",
     "spdx": "MPL-2.0",
-    "vendorHash": "sha256-IbxQVfNvMiXGMkrNQoSBQW3VemK9NW8zs8o1epTZydE="
+    "vendorHash": "sha256-pk4FEx/GpI3pbRt1zXEnTwfEy2renn8gh0mVbBiwUE0="
   },
   "brightbox_brightbox": {
     "hash": "sha256-pwFbCP+qDL/4IUfbPRCkddkbsEEeAu7Wp12/mDL0ABA=",

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -1202,13 +1202,13 @@
     "vendorHash": "sha256-MIO0VHofPtKPtynbvjvEukMNr5NXHgk7BqwIhbc9+u0="
   },
   "selectel_selectel": {
-    "hash": "sha256-DdQKI9YQcOYNOGNS0uCXFl6rSLVB+YShR+PHSB+W4dY=",
+    "hash": "sha256-1KHFXjYJIWgdZo5nAsckQI9ff+74yO0A5Q65symJjlw=",
     "homepage": "https://registry.terraform.io/providers/selectel/selectel",
     "owner": "selectel",
     "repo": "terraform-provider-selectel",
-    "rev": "v7.8.0",
+    "rev": "v8.0.1",
     "spdx": "MPL-2.0",
-    "vendorHash": "sha256-U3v7oYqc3CJIFlNsUqy8ZLy7wRkgjIwLWjwU6eRYvzk="
+    "vendorHash": "sha256-ICMbdEr2vGKZ1ETZLmmrW8h+bzPkpSQk9U3qF+LHPzk="
   },
   "siderolabs_talos": {
     "hash": "sha256-/NACmEpodBNx+Q2M9y3JnKpw9a3Y1eFDdTQ+48MXAc8=",

--- a/pkgs/applications/networking/cluster/terraform/default.nix
+++ b/pkgs/applications/networking/cluster/terraform/default.nix
@@ -200,9 +200,9 @@ rec {
   mkTerraform = attrs: pluggable (generic attrs);
 
   terraform_1 = mkTerraform {
-    version = "1.15.4";
-    hash = "sha256-yZj/i/Fkd70y5dzQ7LoHVB8GfY0aaJ7LwmQrmR4DaKI=";
-    vendorHash = "sha256-aGkIsUxKHRgz8vxNO8RhXS0CH78Q14zSVANLrBGdhWw=";
+    version = "1.15.5";
+    hash = "sha256-U3A+Zwe+oj107z635uxzt4y06hvbv9sfokknYdFIglE=";
+    vendorHash = "sha256-3y9+KCmvskJ24X4F6gSLglmsl4hUlvzBb/ep4kcbS8A=";
     patches = [ ./provider-path-0_15.patch ];
     passthru = {
       inherit plugins;

--- a/pkgs/by-name/_1/_1password-gui/update.sh
+++ b/pkgs/by-name/_1/_1password-gui/update.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p jq curl
+#!nix-shell -i bash -p jq curl gawk
 #shellcheck shell=bash
 set -euo pipefail
 
-# For Linux version checks we rely on Repology API to check 1Password managed Arch User Repository.
-REPOLOGY_PROJECT_URI="https://repology.org/api/v1/project/1password"
+# For Linux version checks we query upstream's APT repository.
+#
+# Repository only offers amd64 packages for the desktop app.
+# We assume updates are always for both architectures.
+OP_APT_REPO_DIST_BASE="https://downloads.1password.com/linux/debian/amd64/dists"
+OP_APT_REPO_COMPONENT_INDEX="main/binary-amd64/Packages"
 
 # For Darwin version checks we query the same endpoint 1Password 8 for Mac queries.
 # This is the base URI. For stable channel an additional path of "N", for beta channel, "Y" is required.
@@ -33,25 +37,43 @@ read_local_versions() {
 
 read_remote_versions() {
   local channel="$1"
+  local apt_index="${OP_APT_REPO_DIST_BASE}/${channel}/${OP_APT_REPO_COMPONENT_INDEX}"
+  local apt_awk_prog=$'
+    /^Package: 1password$/ { pkg_is_1password_gui=1 }
+    /^Version/ && pkg_is_1password_gui { print $2; exit }
+  '
   local chan_os ver
 
   if [[ ${channel} == "stable" ]]; then
-    remote_versions["stable/linux"]=$(
-      "${CURL[@]}" "${REPOLOGY_PROJECT_URI}" \
-        | "${JQ[@]}" '.[] | select(.repo == "aur" and .srcname == "1password" and .status == "newest") | .version'
-    )
+    chan_os="${channel}/linux"
+    ver=$("${CURL[@]}" "${apt_index}" | awk "${apt_awk_prog}")
+    if [[ -n ${ver} ]]; then
+      remote_versions["${chan_os}"]="${ver}"
+    else
+      echo "No remote version for ${chan_os}" >&2
+    fi
 
-    remote_versions["stable/darwin"]=$(
+    chan_os="${channel}/darwin"
+    ver=$(
       "${CURL[@]}" "${APP_UPDATES_URI_BASE}/N" \
         | "${JQ[@]}" 'select(.available == "1") | .version'
     )
+    if [[ -n ${ver} ]]; then
+      remote_versions["${chan_os}"]="${ver}"
+    else
+      echo "No remote version for ${chan_os}" >&2
+    fi
   else
-    remote_versions["beta/linux"]=$(
-      # AUR version string uses underscores instead of dashes for betas.
-      # We fix that with a `sub` in jq query.
-      "${CURL[@]}" "${REPOLOGY_PROJECT_URI}" \
-        | "${JQ[@]}" '.[] | select(.repo == "aur" and .srcname == "1password-beta") | .version | sub("_"; "-")'
+    chan_os="${channel}/linux"
+    ver=$(
+      # Deb package version string uses tilde instead of dashes for betas.
+      "${CURL[@]}" "${apt_index}" | awk "${apt_awk_prog}" | sed 's/~/-/'
     )
+    if [[ -n ${ver} ]]; then
+      remote_versions["${chan_os}"]="${ver}"
+    else
+      echo "No remote version for ${chan_os}" >&2
+    fi
 
     # Handle macOS Beta app-update feed quirk.
     # If there is a newer release in the stable channel, queries for beta

--- a/pkgs/by-name/_1/_1password-gui/update.sh
+++ b/pkgs/by-name/_1/_1password-gui/update.sh
@@ -17,11 +17,7 @@ CURL=(
   "-H" "user-agent: nixpkgs#_1password-gui update.sh" # repology requires a descriptive user-agent
 )
 
-JQ=(
-  "jq"
-  "--raw-output"
-  "--exit-status" # exit non-zero if no output is produced
-)
+JQ=("jq" "--raw-output")
 
 
 read_local_versions() {
@@ -37,7 +33,7 @@ read_local_versions() {
 
 read_remote_versions() {
   local channel="$1"
-  local darwin_beta_maybe
+  local chan_os ver
 
   if [[ ${channel} == "stable" ]]; then
     remote_versions["stable/linux"]=$(
@@ -60,13 +56,15 @@ read_remote_versions() {
     # Handle macOS Beta app-update feed quirk.
     # If there is a newer release in the stable channel, queries for beta
     # channel will return the stable channel version; masking the current beta.
-    darwin_beta_maybe=$(
+    chan_os="${channel}/darwin"
+    ver=$(
       "${CURL[@]}" "${APP_UPDATES_URI_BASE}/Y" \
-        | "${JQ[@]}" 'select(.available == "1") | .version'
+        | "${JQ[@]}" 'select(.available == "1" and (.version | endswith(".BETA"))) | .version'
     )
-    # Only consider versions that end with '.BETA'
-    if [[ ${darwin_beta_maybe} =~ \.BETA$ ]]; then
-      remote_versions["beta/darwin"]=${darwin_beta_maybe}
+    if [[ -n ${ver} ]]; then
+      remote_versions["${chan_os}"]="${ver}"
+    else
+      echo "No remote version for ${chan_os}" >&2
     fi
   fi
 }

--- a/pkgs/by-name/al/alsa-lib/package.nix
+++ b/pkgs/by-name/al/alsa-lib/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  fetchpatch,
   alsa-topology-conf,
   alsa-ucm-conf,
   testers,
@@ -11,11 +10,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "alsa-lib";
-  version = "1.2.15.3";
+  version = "1.2.16";
 
   src = fetchurl {
     url = "mirror://alsa/lib/alsa-lib-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-ewedYU1YLK3nq42yNk5lJx0Id6N9+HV6xKwMiXC+hh4=";
+    hash = "sha256-EiseMWbVX+GbzeZWU116NvKrEOZscsatL0PyD/3tCpY=";
   };
 
   patches = [
@@ -24,11 +23,6 @@ stdenv.mkDerivation (finalAttrs: {
     # "libs" field to declare locations for both native and 32bit plugins, in
     # order to support apps with 32bit sound running on x86_64 architecture.
     ./alsa-plugin-conf-multilib.patch
-    (fetchpatch {
-      name = "CVE-2026-25068.patch";
-      url = "https://github.com/alsa-project/alsa-lib/commit/5f7fe33002d2d98d84f72e381ec2cccc0d5d3d40.patch";
-      hash = "sha256-4memtcg+FDOctX6wgiCdmnlG+IUS+5rL1f3LcsWS5lw=";
-    })
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/al/alsa-ucm-conf/package.nix
+++ b/pkgs/by-name/al/alsa-ucm-conf/package.nix
@@ -1,7 +1,6 @@
 {
   directoryListingUpdater,
   fetchurl,
-  fetchpatch,
   lib,
   stdenvNoCC,
   coreutils,
@@ -10,19 +9,15 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "alsa-ucm-conf";
-  version = "1.2.15.3";
+  version = "1.2.16";
 
   src = fetchurl {
     url = "mirror://alsa/lib/alsa-ucm-conf-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-n3noE8CPyGz6Rt11xPzaGkpRtILbJgfh/PqvuS9YijE=";
+    hash = "sha256-rLyXLW5x7fo0Xnav3xDDmf0PHzz5DYSv20z1G/xKZUg=";
   };
 
   patches = [
-    # fix for typo in 1.2.15.3 – remove with subsequent release
-    (fetchpatch {
-      url = "https://github.com/alsa-project/alsa-ucm-conf/commit/95377000e849259764f37295e0ddd58fd8a55a76.patch";
-      hash = "sha256-o2qR69jiGXFWM0mxeIhXd+tCvGikYqnoalce1UOVppw=";
-    })
+
   ];
 
   dontBuild = true;

--- a/pkgs/by-name/al/alsa-utils/package.nix
+++ b/pkgs/by-name/al/alsa-utils/package.nix
@@ -32,11 +32,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "alsa-utils";
-  version = "1.2.15.2";
+  version = "1.2.16";
 
   src = fetchurl {
     url = "mirror://alsa/utils/alsa-utils-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-eqqvv7AZQhE+wMMeUfcFkQ6BB5IFCIyi+PE3o4aeGjo=";
+    hash = "sha256-CSOZ1eh0mh1eGI45MVdSHOxLdWk7YOu3m7znKM/yIyw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/di/direwolf-unstable/package.nix
+++ b/pkgs/by-name/di/direwolf-unstable/package.nix
@@ -12,13 +12,13 @@
   inherit hamlibSupport gpsdSupport extraScripts;
 }).overrideAttrs
   (oldAttrs: {
-    version = "1.8.1-unstable-2026-03-18";
+    version = "1.8.1-unstable-2026-05-27";
 
     src = fetchFromGitHub {
       owner = "wb2osz";
       repo = "direwolf";
-      rev = "78d6559c67b94568b2f093fc9b4d4965749387ae";
-      hash = "sha256-sSXvDTnrOHplmg86kZ+ppPD0Y6JuhHBfrXZToK8EqmY=";
+      rev = "d6151874ecf202cbb401a671a90b15d0fab92fa9";
+      hash = "sha256-t19AjQzjkpteqwfRVI/tM5wCVNeFceWPHjq0UtdevXg=";
     };
 
     dontVersionCheck = true;

--- a/pkgs/by-name/fr/fresh-editor/package.nix
+++ b/pkgs/by-name/fr/fresh-editor/package.nix
@@ -12,16 +12,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "fresh";
-  version = "0.3.8";
+  version = "0.3.10";
 
   src = fetchFromGitHub {
     owner = "sinelaw";
     repo = "fresh";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-HMKvqJ69EvlAK2Tc4yeY0mfJgUwFIGyhUWdqqOgu6Ec=";
+    hash = "sha256-5gMrQOhQVyIJuv5QAPOyiTFcY4RntmQV0Mtue1x8aAs=";
   };
 
-  cargoHash = "sha256-n48tWnb9NuPC9VET/LfcJD5ub8IZ62PvvqcQ5d5Pkg8=";
+  cargoHash = "sha256-5QHNIt7PoB2IhQU6IyL5Ljax0/CzVMHvMcNDfM9st7U=";
 
   __structuredAttrs = true;
 

--- a/pkgs/by-name/hy/hydralauncher/package.nix
+++ b/pkgs/by-name/hy/hydralauncher/package.nix
@@ -6,10 +6,10 @@
 }:
 let
   pname = "hydralauncher";
-  version = "3.9.8";
+  version = "3.9.9";
   src = fetchurl {
     url = "https://github.com/hydralauncher/hydra/releases/download/v${version}/hydralauncher-${version}.AppImage";
-    hash = "sha256-jKhmcHfi3QuihTxIX73QRLfs8K7iH+lKxhCNpKJsumk=";
+    hash = "sha256-ZdrsEyJkenQbWTYEsgSaiMPx3JksHwjwti3HSb21iOw=";
   };
 
   appimageContents = appimageTools.extractType2 { inherit pname src version; };

--- a/pkgs/by-name/ir/irpf/package.nix
+++ b/pkgs/by-name/ir/irpf/package.nix
@@ -17,7 +17,7 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "irpf";
-  version = "2026-1.3";
+  version = "2026-1.4";
 
   # https://www.gov.br/receitafederal/pt-br/centrais-de-conteudo/download/pgd/dirpf
   # Para outros sistemas operacionais -> Multi
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     in
     fetchzip {
       url = "https://downloadirpf.receita.fazenda.gov.br/irpf/${year}/irpf/arquivos/IRPF${finalAttrs.version}.zip";
-      hash = "sha256-5CX+HaIfQRoeWQHvXTGBhqRAaCM7UH2Duq8+6+3Ai7o=";
+      hash = "sha256-tPIu1nt1FtGyjM1vnzAHenjlKeAKJfqPus+XsP2CH5g=";
     };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/mi/mirrord/manifest.json
+++ b/pkgs/by-name/mi/mirrord/manifest.json
@@ -1,21 +1,21 @@
 {
-  "version": "3.211.0",
+  "version": "3.213.0",
   "assets": {
     "x86_64-linux": {
-      "url": "https://github.com/metalbear-co/mirrord/releases/download/3.211.0/mirrord_linux_x86_64",
-      "hash": "sha256-5ke7ZXbqGAWcwUNW5ofrc0Ez7XS9oekHFuVagFeMwKA="
+      "url": "https://github.com/metalbear-co/mirrord/releases/download/3.213.0/mirrord_linux_x86_64",
+      "hash": "sha256-Bm4dLCd4u6WouFfgfMlyrM9HxiL1u3V+i31H0DDYYRE="
     },
     "aarch64-linux": {
-      "url": "https://github.com/metalbear-co/mirrord/releases/download/3.211.0/mirrord_linux_aarch64",
-      "hash": "sha256-o9Hu5TqPzcOmbwAG40f6CDw5VE/3v3ggXJ6/2RPuReU="
+      "url": "https://github.com/metalbear-co/mirrord/releases/download/3.213.0/mirrord_linux_aarch64",
+      "hash": "sha256-5GhBdNgd60WGlaZmGM/Ck4qxbna6E07p9dxx9CfgDRg="
     },
     "aarch64-darwin": {
-      "url": "https://github.com/metalbear-co/mirrord/releases/download/3.211.0/mirrord_mac_universal",
-      "hash": "sha256-aOPjhsMAVP5Jn8pjxRyr/92HXlMB5nix9BwHoc2uf8A="
+      "url": "https://github.com/metalbear-co/mirrord/releases/download/3.213.0/mirrord_mac_universal",
+      "hash": "sha256-iW22NPH2cwiWRMlc+fOWkkn3OCbRmzYL4oFkau9QtFQ="
     },
     "x86_64-darwin": {
-      "url": "https://github.com/metalbear-co/mirrord/releases/download/3.211.0/mirrord_mac_universal",
-      "hash": "sha256-aOPjhsMAVP5Jn8pjxRyr/92HXlMB5nix9BwHoc2uf8A="
+      "url": "https://github.com/metalbear-co/mirrord/releases/download/3.213.0/mirrord_mac_universal",
+      "hash": "sha256-iW22NPH2cwiWRMlc+fOWkkn3OCbRmzYL4oFkau9QtFQ="
     }
   }
 }

--- a/pkgs/by-name/ox/oxlint/package.nix
+++ b/pkgs/by-name/ox/oxlint/package.nix
@@ -23,25 +23,25 @@
 # runs without an external linter, which leaves `jsPlugins` configs inert.
 stdenv.mkDerivation (finalAttrs: {
   pname = "oxlint";
-  version = "1.66.0";
+  version = "1.68.0";
 
   src = fetchFromGitHub {
     owner = "oxc-project";
     repo = "oxc";
     tag = "oxlint_v${finalAttrs.version}";
-    hash = "sha256-Z2NLzW5e83Mdoj1B0dkJ17FBGGXLH4BH+BJcLjGV1Hk=";
+    hash = "sha256-/AXBMb+EEpA10omlpxG1jkCqMrhbB8AdEewyQrMJqTk=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-TLdLpOsZswVhi9F+wT9Jbx212wIUl/604sOfhOvoWLY=";
+    hash = "sha256-JHTbbVzXWyigk8NGqvBjVKUuR2p6+gpFRY1GWZEvEFk=";
   };
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
     fetcherVersion = 3;
-    hash = "sha256-i626Dy+J5bEqncxQrBV5mZCP09DwW7iF5fYLc8mvKG4=";
+    hash = "sha256-mYwkBQZ3ik3yGoPXc3BtLFhavmkj+QzZNMnYG3qyzyc=";
   };
 
   dontUseCmakeConfigure = true;

--- a/pkgs/by-name/vc/vcpkg/package.nix
+++ b/pkgs/by-name/vc/vcpkg/package.nix
@@ -9,13 +9,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "vcpkg";
-  version = "2026.04.27";
+  version = "2026.05.25";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "vcpkg";
     tag = finalAttrs.version;
-    hash = "sha256-UyT2+dm3h4w2sHzERPYYTe8QNqODBhbnT8I8cLD3/CY=";
+    hash = "sha256-UoskFd2Pmdr7U0y9x5AgNNTIWlJuk1lTY3Q/kxb+c7I=";
     leaveDotGit = true;
     postFetch = ''
       cd "$out"

--- a/pkgs/development/python-modules/lxmf/default.nix
+++ b/pkgs/development/python-modules/lxmf/default.nix
@@ -4,11 +4,12 @@
   fetchFromGitHub,
   rns,
   setuptools,
+  versionCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "lxmf";
-  version = "1.0.0";
+  version = "1.0.1";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -16,17 +17,18 @@ buildPythonPackage (finalAttrs: {
     owner = "markqvist";
     repo = "lxmf";
     tag = finalAttrs.version;
-    hash = "sha256-ohbZSpjIyCiiwXUjvr0UBXKN4OScdTzxx5QimPWnCAI=";
+    hash = "sha256-Lx7eG7idbqjJrOE15/OJ8kh++4STQHxNVMTRVXdAEYE=";
   };
 
   build-system = [ setuptools ];
 
+  pythonRelaxDeps = [ "rns" ];
+
   dependencies = [ rns ];
 
-  # Module has no tests
-  doCheck = false;
-
   pythonImportsCheck = [ "LXMF" ];
+
+  nativeCheckInputs = [ versionCheckHook ];
 
   meta = {
     description = "Lightweight Extensible Message Format for Reticulum";

--- a/pkgs/development/python-modules/rns/default.nix
+++ b/pkgs/development/python-modules/rns/default.nix
@@ -16,6 +16,7 @@ buildPythonPackage (finalAttrs: {
   pname = "rns";
   version = "1.3.4";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "markqvist";

--- a/pkgs/servers/sql/postgresql/ext/timescaledb.nix
+++ b/pkgs/servers/sql/postgresql/ext/timescaledb.nix
@@ -13,13 +13,13 @@
 
 postgresqlBuildExtension (finalAttrs: {
   pname = "timescaledb${lib.optionalString (!enableUnfree) "-apache"}";
-  version = "2.27.1";
+  version = "2.27.2";
 
   src = fetchFromGitHub {
     owner = "timescale";
     repo = "timescaledb";
     tag = finalAttrs.version;
-    hash = "sha256-wZGb2UPYUi0lQ7S+kjhlkVCIAP+JZ/8uSJUkIf357a8=";
+    hash = "sha256-/z8qr+56svxnUrnmh0uetPPttXdc1B8aDKZ5mtZpTt4=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
## Summary

Bumps the ALSA suite to 1.2.16, released 2 days ago upstream.

- alsa-lib: 1.2.15.3 -> 1.2.16
- alsa-utils: 1.2.15.2 -> 1.2.16
- alsa-ucm-conf: 1.2.15.3 -> 1.2.16

## Changelogs

- alsa-lib: https://github.com/alsa-project/alsa-lib/releases/tag/v1.2.16
- alsa-utils: https://github.com/alsa-project/alsa-utils/releases/tag/v1.2.16
- alsa-ucm-conf: https://github.com/alsa-project/alsa-ucm-conf/releases/tag/v1.2.16

## Security

Fixes: #488125 (CVE-2026-25068) Without Patch

The CVE-2026-25068 fetchpatch previously applied against 1.2.15.3 has
been dropped as this is now native
(topology: decoder - add boundary check for channel mixer count).

## Additional cleanup

The alsa-ucm-conf typo fix patch (95377000) carried against 1.2.15.3
with the comment "remove with subsequent release" has been dropped as
intended

## Testing

- Built and tested on x86_64-linux
- alsa-lib multilib patch applies just fine

## Notes

Targeting staging due to the large rebuild footprint of alsa-lib.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
