### PR TITLE
alsa-{lib,utils,ucm-conf}: 1.2.15.x -> 1.2.16

### DIFF
--- a/pkgs/by-name/al/alsa-lib/package.nix
+++ b/pkgs/by-name/al/alsa-lib/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  fetchpatch,
   alsa-topology-conf,
   alsa-ucm-conf,
   testers,
@@ -11,11 +10,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "alsa-lib";
-  version = "1.2.15.3";
+  version = "1.2.16";
 
   src = fetchurl {
     url = "mirror://alsa/lib/alsa-lib-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-ewedYU1YLK3nq42yNk5lJx0Id6N9+HV6xKwMiXC+hh4=";
+    hash = "sha256-EiseMWbVX+GbzeZWU116NvKrEOZscsatL0PyD/3tCpY=";
   };
 
   patches = [
@@ -24,11 +23,6 @@ stdenv.mkDerivation (finalAttrs: {
     # "libs" field to declare locations for both native and 32bit plugins, in
     # order to support apps with 32bit sound running on x86_64 architecture.
     ./alsa-plugin-conf-multilib.patch
-    (fetchpatch {
-      name = "CVE-2026-25068.patch";
-      url = "https://github.com/alsa-project/alsa-lib/commit/5f7fe33002d2d98d84f72e381ec2cccc0d5d3d40.patch";
-      hash = "sha256-4memtcg+FDOctX6wgiCdmnlG+IUS+5rL1f3LcsWS5lw=";
-    })
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/al/alsa-lib/package.nix
+++ b/pkgs/by-name/al/alsa-lib/package.nix
@@ -60,6 +60,8 @@ stdenv.mkDerivation (finalAttrs: {
       "alsa-topology"
     ];
     platforms = with lib.platforms; linux ++ freebsd;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      nick-linux
+    ];
   };
 })

--- a/pkgs/by-name/al/alsa-ucm-conf/package.nix
+++ b/pkgs/by-name/al/alsa-ucm-conf/package.nix
@@ -58,6 +58,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       roastiek
       mvs
+      nick-linux
     ];
 
     platforms = lib.platforms.linux ++ lib.platforms.freebsd;

--- a/pkgs/by-name/al/alsa-ucm-conf/package.nix
+++ b/pkgs/by-name/al/alsa-ucm-conf/package.nix
@@ -1,7 +1,6 @@
 {
   directoryListingUpdater,
   fetchurl,
-  fetchpatch,
   lib,
   stdenvNoCC,
   coreutils,
@@ -10,19 +9,15 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "alsa-ucm-conf";
-  version = "1.2.15.3";
+  version = "1.2.16";
 
   src = fetchurl {
     url = "mirror://alsa/lib/alsa-ucm-conf-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-n3noE8CPyGz6Rt11xPzaGkpRtILbJgfh/PqvuS9YijE=";
+    hash = "sha256-rLyXLW5x7fo0Xnav3xDDmf0PHzz5DYSv20z1G/xKZUg=";
   };
 
   patches = [
-    # fix for typo in 1.2.15.3 – remove with subsequent release
-    (fetchpatch {
-      url = "https://github.com/alsa-project/alsa-ucm-conf/commit/95377000e849259764f37295e0ddd58fd8a55a76.patch";
-      hash = "sha256-o2qR69jiGXFWM0mxeIhXd+tCvGikYqnoalce1UOVppw=";
-    })
+
   ];
 
   dontBuild = true;

--- a/pkgs/by-name/al/alsa-utils/package.nix
+++ b/pkgs/by-name/al/alsa-utils/package.nix
@@ -32,11 +32,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "alsa-utils";
-  version = "1.2.15.2";
+  version = "1.2.16";
 
   src = fetchurl {
     url = "mirror://alsa/utils/alsa-utils-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-eqqvv7AZQhE+wMMeUfcFkQ6BB5IFCIyi+PE3o4aeGjo=";
+    hash = "sha256-CSOZ1eh0mh1eGI45MVdSHOxLdWk7YOu3m7znKM/yIyw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/al/alsa-utils/package.nix
+++ b/pkgs/by-name/al/alsa-utils/package.nix
@@ -98,6 +98,8 @@ stdenv.mkDerivation (finalAttrs: {
     ];
 
     platforms = lib.platforms.linux;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      nick-linux
+    ];
   };
 })


### PR DESCRIPTION
### Summary
Bumps the ALSA suite to 1.2.16, released 2 days ago upstream.

- alsa-lib: 1.2.15.3 -> 1.2.16
- alsa-utils: 1.2.15.2 -> 1.2.16
- alsa-ucm-conf: 1.2.15.3 -> 1.2.16

### Changelogs

- alsa-lib: https://github.com/alsa-project/alsa-lib/releases/tag/v1.2.16
- alsa-utils: https://github.com/alsa-project/alsa-utils/releases/tag/v1.2.16
- alsa-ucm-conf: https://github.com/alsa-project/alsa-ucm-conf/releases/tag/v1.2.16

### Security
Fixes: #488125 (CVE-2026-25068) Without Patch

The CVE-2026-25068 fetchpatch previously applied against 1.2.15.3 has
been dropped as this is now native
(topology: decoder - add boundary check for channel mixer count).

### Additional cleanup
The alsa-ucm-conf typo fix patch (95377000) carried against 1.2.15.3
with the comment "remove with subsequent release" has been dropped as
intended

### Testing
- Built and tested on x86_64-linux
- alsa-lib multilib patch applies just fine

### Notes
Targeting staging due to the large rebuild footprint of alsa-lib. Since the patch was in the package when it hit stable release I did not see it necessary to add a backport label

### Things done
Built on platform:
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
Tested, as applicable:
- [ ] NixOS tests in nixos/tests
- [ ] Package tests at passthru.tests
- [ ] Tests in lib/tests or pkgs/test
- [ ] Ran nixpkgs-review on this PR
- [x] Tested basic functionality of all binary files, usually in ./result/bin/
Nixpkgs Release Notes
- [ ] Package update: when the change is major or breaking
NixOS Release Notes
- [ ] Module addition: when adding a new NixOS module
- [ ] Module update: when the change is significant
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs
- [x] Follows the automation/AI policy