### PR TITLE
nixos/weblate: ensure ssh wrappers are up to date

### DIFF
--- a/nixos/modules/services/web-apps/weblate.nix
+++ b/nixos/modules/services/web-apps/weblate.nix
@@ -9,6 +9,7 @@ let
   cfg = config.services.weblate;
 
   dataDir = "/var/lib/weblate";
+  cacheDir = "${dataDir}/cache";
   settingsDir = "${dataDir}/settings";
 
   finalPackage = cfg.package.overridePythonAttrs (old: {
@@ -362,6 +363,18 @@ in
       ];
       inherit environment;
       path = weblatePath;
+      # Weblate generates SSH wrappers with some preset options that use the
+      # absolute paths of the ssh and scp binaries internally.
+      # As the wrapper is only regenerated when the generator itself is changed,
+      # this absolute nix store path becomes unusable once ssh is updated and
+      # the path is garbage collected.
+      # As generating the wrappers is a quick operation, simply deleting the
+      # wrapper directory before service start ensures they are up to date.
+      preStart = ''
+        if [ -d "${cacheDir}/ssh" ]; then
+          rm -r "${cacheDir}/ssh"
+        fi
+      '';
       serviceConfig = {
         Type = "notify";
         NotifyAccess = "all";


### PR DESCRIPTION
Weblate generates an SSH wrapper with some preset options that uses the absolute path of the ssh binary internally. As the wrapper is only regenerated when the generator itself is changed, this absolute nix store path becomes unusable once ssh is updated and the path is garbage collected.
As generating the wrappers is a quick operation, simply deleting the wrapper directory before service start ensures they are up to date.

Fixes #437065

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
