### PR TITLE
nixos/all-hardware: Enable of_pmem/nd_pmem for U-Boot netinst

### DIFF
--- a/nixos/modules/hardware/all-hardware.nix
+++ b/nixos/modules/hardware/all-hardware.nix
@@ -167,6 +167,13 @@ in
       # Misc "weak" dependencies
       "analogix-dp"
       "analogix-anx6345" # For DP or eDP (e.g. integrated display)
+    ]
+    ++ lib.optionals pkgs.stdenv.hostPlatform.is64bit [
+      # (In the kernel config, LIBNVDIMM requires PHYS_ADDR_T_64BIT, which is not *exactly* is64bit but close enough.)
+      # Enables use of NixOS as U-Boot netinst images, which uses fake "pmem" block devices.
+      # See https://docs.u-boot.org/en/stable/develop/uefi/uefi.html#uefi-http-boot-using-the-legacy-tcp-stack
+      "of_pmem"
+      "nd_pmem"
     ];
 
     # Include lots of firmware.


### PR DESCRIPTION
If you have enough RAM to put an entire installation ISO into RAM, and with a cooperative enough U-Boot, you can load an ISO as a "netinst" image into RAM and boot into it.

This requires the of_pmem and nd_pmem drivers in Linux, so add them into hardware.enableAllHardware to enable this for NixOS.

See https://docs.u-boot.org/en/stable/develop/uefi/uefi.html#uefi-http-boot-using-the-legacy-tcp-stack

Suggested by @ld-cd. As the docs above suggests this already works with the Debian ISO and seems to work with [Fedora as well, according to this Linaro article](https://www.linaro.org/blog/installing-fedora-with-uefi-http-boot/)

This adds ~200KB to an `enableAllHardware` initrd.

I hope this condition makes sense. Since it wasn't arch-specific, for maintainability i didn't want to restrict it to `isAarch64`, but it does depend on `PHYS_ADDR_T_64BIT` which is theoretically a superset of 64-bit platforms (basically anything with something like x86 PAE enabled in the kernel), but I checked a few platforms on whether they have `of_pmem`/`nd_pmem` on our default kernel and:

- Yes: x86_64, aarch64, riscv64, ppc64
- No: i686, arm32, arc

So I'm deeming this close enough to `is64bit`.

Regarding docs / release notes, I don't know if this is generally useful enough as a way to install NixOS on arm64, given that the much harder part is building a cooperative U-Boot, so I haven't written that (yet). Maybe things would be a bit better if we had some sort of fdt-loading EFI driver/wrapper. More real hardware testing is appreciated!

## Example usage

```console
$ # Build ./nixos-minimal-26.11pre-git-aarch64-linux.iso
$ sudo python3 -m http.server -b 127.0.0.1 80 &    # Sorry, has to be port 80
$ nix build ubootQemuAarch64    # Or pkgsCross.aarch64-multiplatform.ubootQemuAarch64 if not on arm64
$ qemu-system-aarch64 \
    -M virt,accel=tcg -smp 4 -m 4G -cpu max \
    -device virtio-net-device,netdev=usernet \
    -netdev user,id=usernet \
    -serial mon:stdio \
    -bios result/u-boot.bin
```

(I couldn't get U-Boot to work with KVM, so using TCG - ~~TODO investigate, but that's irrelevant here.~~ **edit**: Likely because of hard-coded addresses) Inside U-Boot:

```
=> efidebug boot add -u 1 netinst http://10.0.2.2/nixos-minimal-26.11pre-git-aarch64-linux.iso
(Ignore these benign errors)
Cannot persist EFI variables without system partition
Missing TPMv2 device for EFI_TCG_PROTOCOL
Missing RNG device for EFI_RNG_PROTOCOL
=> efidebug boot order 1
=> bootefi bootmgr
```

(Note that by default neither HTTPS nor a custom port is not supported. It will have to be 80. U-Boot is just like that. You can enable HTTPS with some config tweaks but I have not tried since I'm just doing it locally: https://docs.u-boot.org/en/stable/develop/uefi/uefi.html#uefi-http-s-boot-using-lwip)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux (minimal ISO)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant. (See above)
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
