### PR TITLE
jol: use finalAttrs

### DIFF
--- a/pkgs/by-name/jo/jol/package.nix
+++ b/pkgs/by-name/jo/jol/package.nix
@@ -6,14 +6,14 @@
   makeWrapper,
   nix-update-script,
 }:
-maven.buildMavenPackage rec {
+maven.buildMavenPackage (finalAttrs: {
   pname = "jol";
   version = "0.17";
 
   src = fetchFromGitHub {
     owner = "OpenJDK";
     repo = "jol";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-ZJFuY2QYB8eUS3y3VRMGGwklCS93HHVkNe/dhyIx0SY=";
   };
 
@@ -46,7 +46,7 @@ maven.buildMavenPackage rec {
       This makes JOL much more accurate than other tools relying on heap dumps, specification assumptions, etc.
     '';
     homepage = "https://openjdk.org/projects/code-tools/jol/";
-    changelog = "https://github.com/openjdk/jol/releases/tag/${version}";
+    changelog = "https://github.com/openjdk/jol/releases/tag/${finalAttrs.version}";
     license = with lib.licenses; [
       gpl2Plus
       classpathException20
@@ -62,4 +62,4 @@ maven.buildMavenPackage rec {
     ];
     inherit (jre_minimal.meta) platforms;
   };
-}
+})


### PR DESCRIPTION
Builds upon #513696.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
