### PR TITLE
python3Packages.scp: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/scp/default.nix
+++ b/pkgs/development/python-modules/scp/default.nix
@@ -4,7 +4,7 @@
   fetchPypi,
   setuptools,
   paramiko,
-  python,
+  testers,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -21,14 +21,10 @@ buildPythonPackage (finalAttrs: {
 
   dependencies = [ paramiko ];
 
-  checkPhase = ''
-    SCPPY_PORT=10022 ${python.interpreter} test.py
-  '';
-
-  #The Pypi package doesn't include the test
-  doCheck = false;
-
   pythonImportsCheck = [ "scp" ];
+
+  # The test needs a running sshd
+  passthru.tests.test = testers.runNixOSTest ./test.nix;
 
   meta = {
     homepage = "https://github.com/jbardin/scp.py";

--- a/pkgs/development/python-modules/scp/default.nix
+++ b/pkgs/development/python-modules/scp/default.nix
@@ -7,19 +7,19 @@
   python,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "scp";
   version = "0.15.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-8bIumTISPM8X7r8Z4JU8bpFI9Yn5PZG4cpQaaWMFyD8=";
   };
 
   build-system = [ setuptools ];
 
-  propagatedBuildInputs = [ paramiko ];
+  dependencies = [ paramiko ];
 
   checkPhase = ''
     SCPPY_PORT=10022 ${python.interpreter} test.py
@@ -36,4 +36,4 @@ buildPythonPackage rec {
     license = lib.licenses.lgpl21Only;
     maintainers = with lib.maintainers; [ xnaveira ];
   };
-}
+})

--- a/pkgs/development/python-modules/scp/default.nix
+++ b/pkgs/development/python-modules/scp/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   paramiko,
   python,
 }:
@@ -9,12 +10,14 @@
 buildPythonPackage rec {
   pname = "scp";
   version = "0.15.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-8bIumTISPM8X7r8Z4JU8bpFI9Yn5PZG4cpQaaWMFyD8=";
   };
+
+  build-system = [ setuptools ];
 
   propagatedBuildInputs = [ paramiko ];
 

--- a/pkgs/development/python-modules/scp/default.nix
+++ b/pkgs/development/python-modules/scp/default.nix
@@ -33,6 +33,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     homepage = "https://github.com/jbardin/scp.py";
     description = "SCP module for paramiko";
+    changelog = "https://github.com/jbardin/scp.py/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.lgpl21Only;
     maintainers = with lib.maintainers; [ xnaveira ];
   };

--- a/pkgs/development/python-modules/scp/test.nix
+++ b/pkgs/development/python-modules/scp/test.nix
@@ -1,0 +1,44 @@
+{
+  pkgs,
+  ...
+}:
+let
+  scp-test-script = pkgs.python3Packages.buildPythonApplication {
+    inherit (pkgs.python3Packages.scp) src version;
+
+    pname = "scp-test";
+    pyproject = false;
+
+    dependencies = with pkgs.python3Packages; [
+      scp
+    ];
+
+    # Add a shebang to test.py so that patchShebangs can replace it with the correct one
+    postPatch = ''
+      sed -i "1i #!/usr/bin/env python3" test.py
+    '';
+
+    installPhase = ''
+      install -Dm755 "./test.py" "$out/bin/scp-test"
+    '';
+  };
+in
+{
+  name = "Python SCP Library Test";
+
+  nodes.machine = {
+    environment.systemPackages = [ scp-test-script ];
+
+    services.openssh.enable = true;
+  };
+
+  testScript = ''
+    start_all()
+    machine.wait_for_unit("multi-user.target")
+
+    machine.succeed("ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519 -P \"\"")
+    machine.succeed("cat ~/.ssh/id_ed25519.pub >> ~/.ssh/authorized_keys")
+
+    machine.succeed("${scp-test-script}/bin/scp-test")
+  '';
+}


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
