### PR TITLE
nixos/emptty: Add Emptty Display Manager

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -620,6 +620,7 @@
   ./services/display-managers/cosmic-greeter.nix
   ./services/display-managers/default.nix
   ./services/display-managers/dms-greeter.nix
+  ./services/display-managers/emptty.nix
   ./services/display-managers/gdm.nix
   ./services/display-managers/generic.nix
   ./services/display-managers/greetd.nix

--- a/nixos/modules/services/display-managers/emptty.nix
+++ b/nixos/modules/services/display-managers/emptty.nix
@@ -1,0 +1,111 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.services.displayManager.emptty;
+  desktops = config.services.displayManager.sessionData.desktops;
+
+  settingsFormat =
+    name: settings:
+    pkgs.writeText name ''
+      ${lib.concatMapAttrsStringSep "\n" (
+        n: v:
+        if lib.isString v || lib.isPath v then
+          "${n}=${v}"
+        else if lib.isInt v then
+          "${n}=${toString v}"
+        else if lib.isBool v then
+          "${n}=${if v then "true" else "false"}"
+        else
+          ""
+      ) settings}
+    '';
+in
+{
+  options = {
+    services.displayManager.emptty = {
+      enable = lib.mkEnableOption "emptty as the display manager";
+
+      package = lib.mkPackageOption pkgs [ "emptty" ] { };
+
+      settings = lib.mkOption {
+        type =
+          with lib.types;
+          attrsOf (
+            nullOr (oneOf [
+              str
+              int
+              bool
+              path
+            ])
+          );
+        default = { };
+        description = ''
+          Configuration for emptty, provided as a Nix attribute set and automatically
+          serialized to simple key-value pair.
+          See [emptty configuration documentation](https://github.com/tvrzna/emptty/blob/master/README.md) for available options.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    security.pam.services = {
+      emptty = {
+        unixAuth = true;
+        startSession = true;
+        enableGnomeKeyring = lib.mkDefault config.services.gnome.gnome-keyring.enable;
+      };
+    };
+
+    environment.systemPackages = [ cfg.package ];
+
+    services = {
+      dbus.packages = [ cfg.package ];
+      xserver = {
+        display = null;
+      };
+      displayManager = {
+        enable = true;
+        generic = {
+          enable = true;
+          execCmd = "exec ${lib.getExe cfg.package} --daemon --config ${settingsFormat "config" cfg.settings}";
+        };
+        emptty = {
+          settings = {
+            TTY_NUMBER = 1;
+            SWITCH_TTY = lib.mkDefault true;
+            XORG_ARGS = toString config.services.xserver.displayManager.xserverArgs;
+            XORG_SESSIONS_PATH = "${desktops}/share/xsessions";
+            WAYLAND_SESSIONS_PATH = "${desktops}/share/wayland-sessions";
+          };
+        };
+      };
+    };
+
+    systemd.services.display-manager = {
+      unitConfig = {
+        Wants = [ "systemd-user-sessions.service" ];
+        After = [
+          "systemd-user-sessions.service"
+          "plymouth-quit-wait.service"
+        ];
+      };
+      serviceConfig = {
+        Type = "idle";
+        StandardInput = "tty";
+        TTYPath = "/dev/tty${toString cfg.settings.TTY_NUMBER or 1}";
+        TTYReset = "yes";
+        TTYVHangup = "yes";
+        TTYVTDisallocate = true;
+        KillMode = "process";
+        IgnoreSIGPIPE = "no";
+        SendSIGHUP = "yes";
+      };
+      restartIfChanged = false;
+    };
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added a NixOS module for [emptty](https://github.com/tvrzna/emptty).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
