### PR TITLE
usbeehive: init at 0.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16537,6 +16537,11 @@
     github = "Macbucheron1";
     githubId = 95475157;
   };
+  mach = {
+    name = "Mach";
+    github = "MachXNU";
+    githubId = 42501418;
+  };
   macronova = {
     name = "Sicheng Pan";
     email = "trivial@invariantspace.com";

--- a/pkgs/by-name/us/usbeehive/package.nix
+++ b/pkgs/by-name/us/usbeehive/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  udev,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "usbeehive";
+  version = "0.6.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "abrauchli";
+    repo = "usbeehive";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OQtAZnoQOQWlMY51JoaGDPHXjYtwHXu4cnzuEzcblWU=";
+  };
+
+  cargoHash = "sha256-wiIc7ofX57nL2931P/tIom3SibmuuFqShXG4r/FKzEA=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    udev
+  ];
+
+  passthru.tests.dbus = rustPlatform.buildRustPackage {
+    pname = "usbeehive-dbus-test";
+    inherit (finalAttrs) version src cargoHash;
+
+    cargoBuildNoDefaultFeatures = true;
+    cargoBuildFeatures = [ "dbus" ];
+
+    nativeBuildInputs = [ pkg-config ];
+    buildInputs = [ udev ];
+
+    doCheck = true;
+
+  };
+
+  meta = {
+    description = "Inspect USB-C cables and devices on Linux";
+    homepage = "https://github.com/abrauchli/usbeehive";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "usbeehive";
+    maintainers = with lib.maintainers; [ mach ];
+  };
+})


### PR DESCRIPTION
Porting [usbeehive](https://github.com/abrauchli/usbeehive), a tool that tells you what each USB cable / device on Linux can actually do.

Cargo tests pass, and the output binary is functional.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
