### PR TITLE
python3Packages.torchtitan: make test dependency on triton explicit

### DIFF
--- a/pkgs/development/python-modules/torchtitan/default.nix
+++ b/pkgs/development/python-modules/torchtitan/default.nix
@@ -22,6 +22,7 @@
   # tests
   pytestCheckHook,
   tomli-w,
+  triton,
   writableTmpDirAsHomeHook,
 }:
 
@@ -60,6 +61,7 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
     tomli-w
     transformers
+    triton
     writableTmpDirAsHomeHook
   ];
 


### PR DESCRIPTION
## Things done

Importing `torchtitan` requires `triton`.
Currently, `triton` is provided transitively through `torch`, but only on Linux.
This means that the import check fails on darwin where `torch` does not propagate `triton`:
```
Check whether the following modules can be imported: torchtitan
W0603 08:47:22.006000 23213 torch/distributed/elastic/multiprocessing/redirects.py:29] NOTE: Redirects are currently not supported in Windows or MacOs.
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import sys; import importlib; list(map(lambda mod: importlib.import_module(mod), sys.argv[1:]))
                                  ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<string>", line 1, in <lambda>
    import sys; import importlib; list(map(lambda mod: importlib.import_module(mod), sys.argv[1:]))
                                                       ~~~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1395, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 1023, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/nix/store/03w280cqv3l5papi3smxf768abxs7r0q-python3.13-torchtitan-0.2.2/lib/python3.13/site-packages/torchtitan/__init__.py", line 10, in <module>
    import torchtitan.components.quantization  # noqa: F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/03w280cqv3l5papi3smxf768abxs7r0q-python3.13-torchtitan-0.2.2/lib/python3.13/site-packages/torchtitan/components/quantization/__init__.py", line 61, in <module>
    import torchtitan.components.quantization.float8  # noqa: F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/03w280cqv3l5papi3smxf768abxs7r0q-python3.13-torchtitan-0.2.2/lib/python3.13/site-packages/torchtitan/components/quantization/float8.py", line 18, in <module>
    from torchtitan.models.moe.utils import set_token_group_alignment_size_m
  File "/nix/store/03w280cqv3l5papi3smxf768abxs7r0q-python3.13-torchtitan-0.2.2/lib/python3.13/site-packages/torchtitan/models/moe/__init__.py", line 7, in <module>
    from .moe import build_moe, FeedForward, MoE, MoEArgs
  File "/nix/store/03w280cqv3l5papi3smxf768abxs7r0q-python3.13-torchtitan-0.2.2/lib/python3.13/site-packages/torchtitan/models/moe/moe.py", line 18, in <module>
    from .utils import indices_padding_wrapper
  File "/nix/store/03w280cqv3l5papi3smxf768abxs7r0q-python3.13-torchtitan-0.2.2/lib/python3.13/site-packages/torchtitan/models/moe/utils.py", line 13, in <module>
    from .kernels import generate_permute_indices
  File "/nix/store/03w280cqv3l5papi3smxf768abxs7r0q-python3.13-torchtitan-0.2.2/lib/python3.13/site-packages/torchtitan/models/moe/kernels.py", line 8, in <module>
    import triton
ModuleNotFoundError: No module named 'triton'
```

This PR makes `triton` an explicit check dependency of `torchtitan` leading to it being disabled on darwin.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
