### PR TITLE
moodle: fix module and package for Moodle 5.1+

### DIFF
--- a/nixos/modules/services/web-apps/moodle.nix
+++ b/nixos/modules/services/web-apps/moodle.nix
@@ -325,20 +325,29 @@ in
       extraModules = [ "proxy_fcgi" ];
       virtualHosts.${cfg.virtualHost.hostName} = mkMerge [
         cfg.virtualHost
-        {
-          documentRoot = mkForce "${cfg.package}/share/moodle";
-          extraConfig = ''
-            <Directory "${cfg.package}/share/moodle">
-              <FilesMatch "\.php$">
-                <If "-f %{REQUEST_FILENAME}">
-                  SetHandler "proxy:unix:${fpm.socket}|fcgi://localhost/"
-                </If>
-              </FilesMatch>
-              Options -Indexes
-              DirectoryIndex index.php
-            </Directory>
-          '';
-        }
+        (
+          let
+            documentRoot =
+              if lib.versionAtLeast cfg.package.version "5.1" then
+                "${cfg.package}/share/moodle/public"
+              else
+                "${cfg.package}/share/moodle";
+          in
+          {
+            documentRoot = mkForce documentRoot;
+            extraConfig = ''
+              <Directory "${documentRoot}">
+                <FilesMatch "\.php$">
+                  <If "-f %{REQUEST_FILENAME}">
+                    SetHandler "proxy:unix:${fpm.socket}|fcgi://localhost/"
+                  </If>
+                </FilesMatch>
+                Options -Indexes
+                DirectoryIndex index.php
+              </Directory>
+            '';
+          }
+        )
       ];
     };
 

--- a/nixos/tests/moodle.nix
+++ b/nixos/tests/moodle.nix
@@ -19,6 +19,6 @@
   testScript = ''
     start_all()
     machine.wait_for_unit("phpfpm-moodle.service", timeout=1800)
-    machine.wait_until_succeeds("curl http://localhost/ | grep 'You are not logged in'")
+    machine.wait_until_succeeds("curl -f http://localhost/ | grep 'You are not logged in'")
   '';
 }

--- a/pkgs/servers/web-apps/moodle/default.nix
+++ b/pkgs/servers/web-apps/moodle/default.nix
@@ -123,8 +123,8 @@ stdenv.mkDerivation rec {
           # we have to copy it, because the plugins have refrences to .. inside
         in
         ''
-          mkdir -p $out/share/moodle/${dir}/${p.name}
-          cp -r ${p}/* $out/share/moodle/${dir}/${p.name}/
+          mkdir -p $out/share/moodle/public/${dir}/${p.name}
+          cp -r ${p}/* $out/share/moodle/public/${dir}/${p.name}/
         ''
       ) plugins
     )}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes #527266

- Updated the `moodle` module and package to use the new `public` directory introduced in Moodle 5.1 when using a matching `moodle` package version
- Updated the `moodle` test to fail on non-2XX HTTP status codes, which would have helped to notice the issue in #527266 early because Moodle returned a 404 while still including the string "You are not logged in" in the response.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (I did setup a VM and browsed Moodle a bit, also installed some plugins)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy]. (none was used)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
