### PR TITLE
python3Packages.deep-gemm: patch runtime cudatoolkit discovery logic

### DIFF
--- a/pkgs/development/python-modules/deep-gemm/default.nix
+++ b/pkgs/development/python-modules/deep-gemm/default.nix
@@ -2,6 +2,8 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  replaceVars,
+  symlinkJoin,
 
   # build-system
   setuptools,
@@ -47,6 +49,23 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
 
   patches = [
     ./use-system-libraries.patch
+
+    # DeepGEMM does JIT compilation and needs to access the NVIDIA compiler and some libraries at
+    # runtime.
+    # Instead of letting it search for the cuda toolkit on the host, hardcode the path to a custom
+    # closure.
+    (replaceVars ./patch-runtime-cuda-home-path.patch {
+      cuda_home = symlinkJoin {
+        name = "cuda-toolkit";
+        paths = with cudaPackages; [
+          (lib.getBin cuda_nvcc) # bin/nvcc, bin/ptxas, nvvm/, nvcc.profile
+          (lib.getBin cutlass) # include/cute, include/cutlass
+          (lib.getInclude cuda_cccl) # include/cuda/std/* (libcu++)
+          (lib.getInclude cuda_cudart) # include/cuda_runtime.h, cuda_bf16.h, cuda_fp8.h
+          (lib.getInclude cuda_cuobjdump) # bin/cuobjdump
+        ];
+      };
+    })
   ];
 
   env = optionalAttrs cudaSupport {

--- a/pkgs/development/python-modules/deep-gemm/patch-runtime-cuda-home-path.patch
+++ b/pkgs/development/python-modules/deep-gemm/patch-runtime-cuda-home-path.patch
@@ -1,0 +1,27 @@
+diff --git a/deep_gemm/__init__.py b/deep_gemm/__init__.py
+index a4633ae..6508865 100644
+--- a/deep_gemm/__init__.py
++++ b/deep_gemm/__init__.py
+@@ -62,21 +62,7 @@ from .utils import *
+ 
+ # Initialize CPP modules
+ def _find_cuda_home() -> str:
+-    # TODO: reuse PyTorch API later
+-    # For some PyTorch versions, the original `_find_cuda_home` will initialize CUDA, which is incompatible with process forks
+-    cuda_home = os.environ.get('CUDA_HOME') or os.environ.get('CUDA_PATH')
+-    if cuda_home is None:
+-        # noinspection PyBroadException
+-        try:
+-            with open(os.devnull, 'w') as devnull:
+-                nvcc = subprocess.check_output(['which', 'nvcc'], stderr=devnull).decode().rstrip('\r\n')
+-                cuda_home = os.path.dirname(os.path.dirname(nvcc))
+-        except Exception:
+-            cuda_home = '/usr/local/cuda'
+-            if not os.path.exists(cuda_home):
+-                cuda_home = None
+-    assert cuda_home is not None
+-    return cuda_home
++    return "@cuda_home@"
+ 
+ 
+ deep_gemm_cpp.init(


### PR DESCRIPTION
## Things done

DeepGEMM does JIT compilation and needs to access the NVIDIA compiler and some libraries at runtime.
Instead of letting it search for the cuda toolkit on the host, hardcode the path to a custom closure.

cc @NixOS/cuda-maintainers

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
