### PR TITLE
nixos/gokapi: build more consistent with upstream

### DIFF
--- a/pkgs/by-name/go/gokapi/package.nix
+++ b/pkgs/by-name/go/gokapi/package.nix
@@ -22,23 +22,8 @@ buildGoModule (finalAttrs: {
 
   proxyVendor = true;
 
-  patches = [ ];
-
-  # This is the go generate is ran in the upstream builder, but we have to run the components separately for things to work.
   preBuild = ''
-    # Some steps expect GOROOT to be set.
-    export GOROOT="$(go env GOROOT)"
-    # Go generate runs from this working dir upstream
-    cd ./cmd/gokapi/
-    go run ../../build/go-generate/updateVersionNumbers.go
-    # Tries to download "golang.org/x/exp/slices", and fails
-    # go run ../../build/go-generate/updateProtectedUrls.go
-    go run ../../build/go-generate/buildWasm.go
-    go run ../../build/go-generate/copyStaticFiles.go
-    # Attempts to download program to minify content, and fails
-    # go run ../../build/go-generate/minifyStaticContent.go
-    go run ../../build/go-generate/updateApiRouting.go
-    cd ../..
+    go generate ./...
   '';
 
   subPackages = [


### PR DESCRIPTION
now their build steps do not touch the internet, we can do this 

Should ease maintenance.

Solves https://github.com/NixOS/nixpkgs/issues/512879

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
