### PR TITLE
python3Packages.pyautogui: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/pyautogui/default.nix
+++ b/pkgs/development/python-modules/pyautogui/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   mouseinfo,
   pygetwindow,
   pymsgbox,
@@ -16,7 +17,7 @@
 buildPythonPackage {
   pname = "pyautogui";
   version = "0.9.53";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "asweigart";
@@ -40,7 +41,11 @@ buildPythonPackage {
     ./fix-locateOnWindow-and-xlib.patch
   ];
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
     mouseinfo
     pygetwindow
     pymsgbox

--- a/pkgs/development/python-modules/pyautogui/default.nix
+++ b/pkgs/development/python-modules/pyautogui/default.nix
@@ -26,16 +26,6 @@ buildPythonPackage {
     hash = "sha256-R9tcTqxUaqw63FLOGFRaO/Oz6kD7V6MPHdQ8A29NdXw=";
   };
 
-  nativeCheckInputs = [
-    xvfb-run
-    scrot
-  ];
-  checkPhase = ''
-    xvfb-run python -c 'import pyautogui'
-    # The tests depend on some specific things that xvfb cant provide, like keyboard and mouse
-    # xvfb-run python -m unittest tests.test_pyautogui
-  '';
-
   patches = [
     # https://github.com/asweigart/pyautogui/issues/598
     ./fix-locateOnWindow-and-xlib.patch
@@ -55,6 +45,17 @@ buildPythonPackage {
     pyscreeze
     pytweening
   ];
+
+  nativeCheckInputs = [
+    xvfb-run
+    scrot
+  ];
+
+  checkPhase = ''
+    xvfb-run python -c 'import pyautogui'
+    # The tests depend on some specific things that xvfb cant provide, like keyboard and mouse
+    # xvfb-run python -m unittest tests.test_pyautogui
+  '';
 
   meta = {
     description = "PyAutoGUI lets Python control the mouse and keyboard, and other GUI automation tasks";

--- a/pkgs/development/python-modules/pyautogui/default.nix
+++ b/pkgs/development/python-modules/pyautogui/default.nix
@@ -14,7 +14,7 @@
   xvfb-run,
   scrot,
 }:
-buildPythonPackage {
+buildPythonPackage (finalAttrs: {
   pname = "pyautogui";
   version = "0.9.53";
   pyproject = true;
@@ -60,7 +60,8 @@ buildPythonPackage {
   meta = {
     description = "PyAutoGUI lets Python control the mouse and keyboard, and other GUI automation tasks";
     homepage = "https://github.com/asweigart/pyautogui";
+    changelog = "https://github.com/asweigart/pyautogui/blob/${finalAttrs.src.rev}/CHANGES.txt";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ lucasew ];
   };
-}
+})


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
