### PR TITLE
google-cloud-sdk: fix withExtraComponents build

### DIFF
--- a/pkgs/by-name/go/google-cloud-sdk/components.json
+++ b/pkgs/by-name/go/google-cloud-sdk/components.json
@@ -1577,169 +1577,6 @@
     },
     {
       "dependencies": [
-        "bundled-python3-windows-x86",
-        "bundled-python3-windows-x86_64",
-        "core"
-      ],
-      "details": {
-        "description": "Provides stand-alone Python 3.14 install.",
-        "display_name": "Bundled Python 3.14"
-      },
-      "gdu_only": false,
-      "id": "bundled-python3",
-      "is_configuration": false,
-      "is_hidden": true,
-      "is_required": false,
-      "platform": {
-        "architectures": [
-          "x86",
-          "x86_64"
-        ],
-        "operating_systems": [
-          "WINDOWS"
-        ]
-      },
-      "platform_required": false,
-      "version": {
-        "build_number": 0,
-        "version_string": "3.14.4"
-      }
-    },
-    {
-      "dependencies": [
-        "bundled-python3-unix-linux-x86_64",
-        "core"
-      ],
-      "details": {
-        "description": "Provides stand-alone Python 3.14.5 installation for UNIX.",
-        "display_name": "Bundled Python 3.14"
-      },
-      "gdu_only": false,
-      "id": "bundled-python3-unix",
-      "is_configuration": false,
-      "is_hidden": false,
-      "is_required": false,
-      "platform": {
-        "architectures": [
-          "x86_64"
-        ],
-        "operating_systems": [
-          "LINUX"
-        ]
-      },
-      "platform_required": false,
-      "version": {
-        "build_number": 0,
-        "version_string": "3.14.5"
-      }
-    },
-    {
-      "data": {
-        "checksum": "5c4ce4eb75b99cd5e06fae99f6e45c42b88df3225699629715dba64a85a7fd39",
-        "contents_checksum": "f23b948b0e0ed0d93d7e3e51375347b1f72212ce6b5d70b4e8729e404e415b8f",
-        "size": 27198113,
-        "source": "components/google-cloud-sdk-bundled-python3-unix-linux-x86_64-20260522195849.tar.gz",
-        "type": "tar"
-      },
-      "dependencies": [
-        "bundled-python3-unix",
-        "core"
-      ],
-      "details": {
-        "description": "Provides stand-alone Python 3.14.5 installation for UNIX.",
-        "display_name": "Bundled Python 3.14 (Platform Specific)"
-      },
-      "gdu_only": false,
-      "id": "bundled-python3-unix-linux-x86_64",
-      "is_configuration": false,
-      "is_hidden": true,
-      "is_required": false,
-      "platform": {
-        "architectures": [
-          "x86_64"
-        ],
-        "operating_systems": [
-          "LINUX"
-        ]
-      },
-      "platform_required": false,
-      "version": {
-        "build_number": 20260522195849,
-        "version_string": "3.14.5"
-      }
-    },
-    {
-      "data": {
-        "checksum": "393967c25a467c4faaadda895810a1f725d1c2416fc29e1a4f3c08c57e0c6949",
-        "contents_checksum": "78156598f73fc69a32f30a5efac14c526cf8f44ccf2a7e0ef2db75b915331772",
-        "size": 21432688,
-        "source": "components/google-cloud-sdk-bundled-python3-windows-x86-20260522195849.tar.gz",
-        "type": "tar"
-      },
-      "dependencies": [
-        "bundled-python3",
-        "core"
-      ],
-      "details": {
-        "description": "Provides stand-alone Python 3.14 install.",
-        "display_name": "Bundled Python 3.14 (Platform Specific)"
-      },
-      "gdu_only": false,
-      "id": "bundled-python3-windows-x86",
-      "is_configuration": false,
-      "is_hidden": true,
-      "is_required": false,
-      "platform": {
-        "architectures": [
-          "x86"
-        ],
-        "operating_systems": [
-          "WINDOWS"
-        ]
-      },
-      "platform_required": false,
-      "version": {
-        "build_number": 20260522195849,
-        "version_string": "3.14.4"
-      }
-    },
-    {
-      "data": {
-        "checksum": "dbe1d783730a03c1fe04b47a1e8611754ee021433e2dbbaf8194fc958355f148",
-        "contents_checksum": "0b369522fe69d7c12f178e1ed3b15f6dd15e8fa94d05f1be10c96e75930f81f4",
-        "size": 23967274,
-        "source": "components/google-cloud-sdk-bundled-python3-windows-x86_64-20260522195849.tar.gz",
-        "type": "tar"
-      },
-      "dependencies": [
-        "bundled-python3",
-        "core"
-      ],
-      "details": {
-        "description": "Provides stand-alone Python 3.14 install.",
-        "display_name": "Bundled Python 3.14 (Platform Specific)"
-      },
-      "gdu_only": false,
-      "id": "bundled-python3-windows-x86_64",
-      "is_configuration": false,
-      "is_hidden": true,
-      "is_required": false,
-      "platform": {
-        "architectures": [
-          "x86_64"
-        ],
-        "operating_systems": [
-          "WINDOWS"
-        ]
-      },
-      "platform_required": false,
-      "version": {
-        "build_number": 20260522195849,
-        "version_string": "3.14.4"
-      }
-    },
-    {
-      "dependencies": [
         "cbt-darwin-arm",
         "cbt-darwin-x86",
         "cbt-darwin-x86_64",
@@ -3265,7 +3102,6 @@
         "type": "tar"
       },
       "dependencies": [
-        "bundled-python3-unix",
         "core-nix",
         "core-win",
         "gcloud-deps",
@@ -3296,7 +3132,6 @@
         "type": "tar"
       },
       "dependencies": [
-        "bundled-python3-unix",
         "core",
         "gcloud-deps",
         "ssh-tools"
@@ -3333,7 +3168,6 @@
         "type": "tar"
       },
       "dependencies": [
-        "bundled-python3-unix",
         "core",
         "gcloud-deps",
         "ssh-tools"

--- a/pkgs/by-name/go/google-cloud-sdk/components.nix
+++ b/pkgs/by-name/go/google-cloud-sdk/components.nix
@@ -6,8 +6,6 @@
   autoPatchelfHook,
   python3,
   libxcrypt-legacy,
-  tcl-8_6,
-  tclPackages,
 }:
 
 let
@@ -179,8 +177,6 @@ let
       ];
       buildInputs = [
         libxcrypt-legacy
-        tcl-8_6
-        tclPackages.tk
       ];
       passthru = {
         dependencies = filterForSystem dependencies;

--- a/pkgs/by-name/go/google-cloud-sdk/package.nix
+++ b/pkgs/by-name/go/google-cloud-sdk/package.nix
@@ -79,6 +79,7 @@ stdenv.mkDerivation rec {
     if [ -d platform/bundledpythonunix ]; then
       rm -r platform/bundledpythonunix
     fi
+    rm -f .install/bundled-python*
     cp -R * .install $out/google-cloud-sdk/
 
     # Resolve readlink noise in shell initialization
@@ -199,6 +200,9 @@ stdenv.mkDerivation rec {
 
   passthru = {
     inherit components withExtraComponents;
+    tests.gke-gcloud-auth-plugin = withExtraComponents [
+      components.gke-gcloud-auth-plugin
+    ];
     updateScript = ./update.sh;
   };
 

--- a/pkgs/by-name/go/google-cloud-sdk/update.sh
+++ b/pkgs/by-name/go/google-cloud-sdk/update.sh
@@ -47,4 +47,10 @@ EOF
 
 } > "${PACKAGE_DIR}/data.nix"
 
-curl "${CHANNEL_URL}/components-v${VERSION}.json" -w "\n" > "${PACKAGE_DIR}/components.json"
+# nixpkgs uses its own Python wrapper; do not generate bundled Python components.
+curl -s "${CHANNEL_URL}/components-v${VERSION}.json" | jq '
+    .components |= map(
+      select(.id | startswith("bundled-python3") | not)
+      | .dependencies = ((.dependencies // []) | map(select(startswith("bundled-python3") | not)))
+    )
+' > "${PACKAGE_DIR}/components.json"


### PR DESCRIPTION
Fixes `google-cloud-sdk.withExtraComponents` builds by preventing Google’s bundled Python component from being reintroduced through the component dependency graph.

`package.nix` already removes `platform/bundledpythonunix` from the main SDK output because nixpkgs wraps the SDK with its own Python(#303426 #344957). However, `withExtraComponents` builds components from `components.json`, and the default `alpha`/`beta -> core` dependency closure pulled in `bundled-python3-unix` again.

This PR strips `bundled-python3*` components and dependency edges when `update.sh` generates `components.json`, removes stale `.install/bundled-python*` metadata from the installed SDK, and adds a passthru test for the failing `gke-gcloud-auth-plugin` component.

This also reverts the Tcl/Tk component inputs added by ed4596bd9611 (google-cloud-sdk: fix build, #468388), since the bundled Python component that needed _tkinter support is no longer generated.

Resolves #527193

Related old issue/pr:
- #468388
- #469521

## Verification

Built the originally failing expression against this checkout:

```bash
nix build --impure --expr '
  let
    p = import ./. { system = builtins.currentSystem; };
  in
    p.google-cloud-sdk.withExtraComponents [
      p.google-cloud-sdk.components.gke-gcloud-auth-plugin
    ]
'
```

Also built the new passthru test:

```bash
nix build .#google-cloud-sdk.tests.gke-gcloud-auth-plugin
```

Both builds pass.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
