### PR TITLE
Revert "[Backport release-25.11] tyrolienne: 1.2.0 -> 1.2.2"

### DIFF
--- a/pkgs/by-name/ty/tyrolienne/package.nix
+++ b/pkgs/by-name/ty/tyrolienne/package.nix
@@ -15,17 +15,17 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tyrolienne";
-  version = "1.2.2";
+  version = "1.2.0";
 
   src = fetchFromGitea {
     domain = "git.uku3lig.net";
     owner = "uku";
     repo = "tyrolienne";
     tag = finalAttrs.version;
-    hash = "sha256-JdXamx+pwUEJWSbPFvROrx/XJojZ5sC+MEH0QVpKD+Y=";
+    hash = "sha256-jl1h7L+Ae28A7YFoIsQqxbx2XmxxjUHebD5Xba0cB5o=";
   };
 
-  cargoHash = "sha256-JM4Y0FyqVYqChpPh9p/QulfV8IesUJ0p/ooxAJLfo6I=";
+  cargoHash = "sha256-J/gS8tyy+5ZG1xl4NrYCU26lD0yvsVyRUoOXntCgVSE=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
Reverts NixOS/nixpkgs#519132

It broke the build; see discussion on the original PR.