### PR TITLE
proton-vpn: 4.15.3 -> 4.16.5, proton-vpn-api-core: 5.0.1 -> 5.2.4, proton-vpn-local-agent: 1.6.2 -> 1.6.3

### DIFF
--- a/pkgs/by-name/pr/proton-vpn/linux.nix
+++ b/pkgs/by-name/pr/proton-vpn/linux.nix
@@ -14,14 +14,14 @@
 }:
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "proton-vpn";
-  version = "4.15.3";
+  version = "4.16.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ProtonVPN";
     repo = "proton-vpn-gtk-app";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2v8BckNmm7Ecw+uAgOyfofHDPWgXkJJ8DmhMszb0tg0=";
+    hash = "sha256-wClBUF5bz+bVt9w7LQGfU3mKnEtgax8GXnGNyH2/obU=";
   };
 
   nativeBuildInputs = [
@@ -85,6 +85,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
   disabledTestPaths = [
     # Segmentation fault during widgets tests
     "tests/unit/widgets"
+    # Segmentation fault during GObject signal test
+    "tests/unit/utils/test_safe_signal_connect.py"
   ];
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/development/python-modules/proton-vpn-api-core/default.nix
+++ b/pkgs/development/python-modules/proton-vpn-api-core/default.nix
@@ -10,6 +10,7 @@
   iproute2,
   jinja2,
   networkmanager,
+  packaging,
   proton-core,
   proton-vpn-local-agent,
   pycairo,
@@ -27,14 +28,14 @@
 
 buildPythonPackage rec {
   pname = "proton-vpn-api-core";
-  version = "5.0.1";
+  version = "5.2.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ProtonVPN";
     repo = "python-proton-vpn-api-core";
     rev = "v${version}";
-    hash = "sha256-XdQLgHKNqBNwY51niSiE1HHxLJ3efipS03IUiyHQCiY=";
+    hash = "sha256-Z1+HhHYrRcqo3IPodXk7GQyxb6XutBZBUeNLskLzAzI=";
   };
 
   postPatch = ''
@@ -61,6 +62,7 @@ buildPythonPackage rec {
     distro
     fido2
     jinja2
+    packaging
     proton-core
     proton-vpn-local-agent
     pycairo

--- a/pkgs/development/python-modules/proton-vpn-local-agent/default.nix
+++ b/pkgs/development/python-modules/proton-vpn-local-agent/default.nix
@@ -11,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "proton-vpn-local-agent";
-  version = "1.6.2";
+  version = "1.6.3";
   pyproject = false;
   withDistOutput = false;
 
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "ProtonVPN";
     repo = "local-agent-rs";
     rev = version;
-    hash = "sha256-VmZ8nsKqP8jyNe7Rl+PHsXhsjgchq3rKmTtAqFEe7yM=";
+    hash = "sha256-y2FEfICwWa/GgaKkq8CR+lVDYIsk0HsuKuGUsUQZAFo=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
@@ -29,7 +29,7 @@ buildPythonPackage rec {
       src
       sourceRoot
       ;
-    hash = "sha256-MOCLMQ8mqv8Q3I3bIS0ynfpPmrULMA+80RHZBeu7r5s=";
+    hash = "sha256-y8I806dbC7n3eMFyrzGJokfVDwEGFdC7NgzSA0G8hkQ=";
   };
 
   sourceRoot = "${src.name}/python-proton-vpn-local-agent";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelogs:

- https://github.com/ProtonVPN/local-agent-rs/blob/stable/python-proton-vpn-local-agent/versions.yml
- https://github.com/ProtonVPN/proton-vpn-gtk-app/blob/stable/versions.yml
- https://github.com/ProtonVPN/python-proton-vpn-api-core/blob/stable/versions.yml

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
