### PR TITLE
corrscope: Add explicit passthru.updateScript

### DIFF
--- a/pkgs/by-name/co/corrscope/package.nix
+++ b/pkgs/by-name/co/corrscope/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  gitUpdater,
   ffmpeg,
   python3Packages,
   qt6Packages,
@@ -74,12 +75,18 @@ python3Packages.buildPythonApplication (finalAttrs: {
     )
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = corrscope;
-    # Tries writing to
-    # - $HOME/.local/share/corrscope on Linux
-    # - $HOME/Library/Application Support/corrscope on Darwin
-    command = "env HOME=$TMPDIR ${lib.getExe corrscope} --version";
+  passthru = {
+    tests.version = testers.testVersion {
+      package = corrscope;
+      # Tries writing to
+      # - $HOME/.local/share/corrscope on Linux
+      # - $HOME/Library/Application Support/corrscope on Darwin
+      command = "env HOME=$TMPDIR ${lib.getExe corrscope} --version";
+    };
+
+    updateScript = gitUpdater {
+      allowedVersions = "^[0-9.]+$";
+    };
   };
 
   meta = {


### PR DESCRIPTION
Whatever `updateScript` this was inheriting from being a Python package produced changes that were nonsense.
(attempts to bump from 0.11.0 (2025) to python5-macos (2023))

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
