### PR TITLE
nixos/btrfs: add services.btrfs.autoReclaim option

### DIFF
--- a/nixos/modules/tasks/filesystems/btrfs.nix
+++ b/nixos/modules/tasks/filesystems/btrfs.nix
@@ -26,9 +26,11 @@ let
   inSystem = config.boot.supportedFilesystems.btrfs or false;
 
   cfgScrub = config.services.btrfs.autoScrub;
+  cfgReclaim = config.services.btrfs.autoReclaim;
 
   enableAutoScrub = cfgScrub.enable;
-  enableBtrfs = inInitrd || inSystem || enableAutoScrub;
+  enableAutoReclaim = cfgReclaim.enable;
+  enableBtrfs = inInitrd || inSystem || enableAutoScrub || enableAutoReclaim;
 
 in
 
@@ -75,6 +77,71 @@ in
         '';
       };
 
+    };
+
+    services.btrfs.autoReclaim = {
+      enable = mkEnableOption "automatic background reclaim threshold for btrfs filesystems" // {
+        description = ''
+          Whether to enable automatic background reclaim for btrfs filesystems.
+
+          When enabled, a udev rule is installed that sets the
+          {file}`bg_reclaim_threshold` sysfs attribute on every btrfs
+          filesystem as it becomes available. This instructs the kernel to
+          automatically start a balance operation on block groups that exceed
+          the configured usage threshold.
+
+          For a more detailed explanation of btrfs balance and reclaim see
+          https://wiki.tnonline.net/w/Btrfs/Balance.
+        '';
+      };
+
+      dataThreshold = mkOption {
+        default = 10;
+        type = types.ints.between 0 100;
+        example = 75;
+        description = ''
+          Percentage of a data block group's space usage that triggers automatic
+          background reclaim via {command}`btrfs balance`.
+
+          This sets the {file}`allocation/data/bg_reclaim_threshold` sysfs
+          attribute on all btrfs filesystems, which is only available on Linux
+          kernel 5.19 and later. When the threshold is reached, btrfs will
+          automatically attempt to reclaim the data block group in the
+          background.
+
+          For more details on the reclaim mechanism see
+          https://btrfs.readthedocs.io/en/latest/Administration.html#uuid.
+
+          ::: {.warning}
+          Setting this value too high can cause excessive write amplification
+          on SSDs due to frequent block group reclaims.
+          :::
+        '';
+      };
+
+      metadataThreshold = mkOption {
+        default = 50;
+        type = types.ints.between 0 100;
+        example = 75;
+        description = ''
+          Percentage of a metadata block group's space usage that triggers automatic
+          background reclaim via {command}`btrfs balance`.
+
+          This sets the {file}`allocation/metadata/bg_reclaim_threshold` sysfs
+          attribute on all btrfs filesystems, which is only available on Linux
+          kernel 5.19 and later. When the threshold is reached, btrfs will
+          automatically attempt to reclaim the metadata block group in the
+          background.
+
+          For more details on the reclaim mechanism see
+          https://btrfs.readthedocs.io/en/latest/Administration.html#uuid.
+
+          ::: {.warning}
+          Setting this value too high can cause excessive write amplification
+          on SSDs due to frequent block group reclaims.
+          :::
+        '';
+      };
     };
   };
 
@@ -205,6 +272,21 @@ in
             };
         in
         listToAttrs (map scrubService cfgScrub.fileSystems);
+    })
+
+    (mkIf enableAutoReclaim {
+      assertions = [
+        {
+          assertion = lib.versionAtLeast config.boot.kernelPackages.kernel.version "5.19";
+          message = ''
+            services.btrfs.autoReclaim requires Linux kernel 5.19 or later.
+          '';
+        }
+      ];
+
+      services.udev.extraRules = ''
+        SUBSYSTEM=="btrfs", ACTION=="add", ATTR{allocation/data/bg_reclaim_threshold}="${toString cfgReclaim.dataThreshold}", ATTR{allocation/metadata/bg_reclaim_threshold}="${toString cfgReclaim.metadataThreshold}"
+      '';
     })
   ];
 }


### PR DESCRIPTION
Btrfs uses fixed-size chunks for storing data and metadata. On write-heavy and file-churn systems like NixOS (due to frequent `/nix/store` generation creation and garbage collection), metadata or data blocks can easily become stranded with small amounts of actual data, [eventually leading to `No space left on device` (ENOSPC) lockups](https://discourse.nixos.org/t/no-space-on-btrfs-although-there-is-plenty-of-free-disk-space/76669?u=yajo), even when the drive reports plenty of physical free space.

While scheduled btrfs balances (e.g., cron/systemd timers) provide a blind, periodic workaround, modern Linux Kernels (>= 5.19) introduce a native, reactive approach via the `bg_reclaim_threshold` sysfs interface. This feature automatically relocates mostly empty chunks in the background as soon as they fall below a specific usage threshold.

This PR introduces a native NixOS service module option to easily configure this kernel-level behavior via Udev rules, ensuring an automated, non-blocking, and UUID-agnostic way to maintain Btrfs health.

Assisted-by: OpenCode + deepseek-v4-flash

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
