### PR TITLE
python3Packages.asn1ate: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/asn1ate/default.nix
+++ b/pkgs/development/python-modules/asn1ate/default.nix
@@ -3,12 +3,13 @@
   buildPythonPackage,
   fetchFromGitHub,
   pyparsing,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "asn1ate";
-  format = "setuptools";
   version = "0.6";
+  pyproject = true;
 
   src = fetchFromGitHub {
     sha256 = "1p8hv4gsyqsdr0gafcq497n52pybiqmc22di8ai4nsj60fv0km45";
@@ -17,7 +18,11 @@ buildPythonPackage rec {
     repo = "asn1ate";
   };
 
-  propagatedBuildInputs = [ pyparsing ];
+  build-system = [ setuptools ];
+
+  dependencies = [ pyparsing ];
+
+  pythonImportsCheck = [ "asn1ate" ];
 
   meta = {
     description = "Python library for translating ASN.1 into other forms";

--- a/pkgs/development/python-modules/asn1ate/default.nix
+++ b/pkgs/development/python-modules/asn1ate/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage (finalAttrs: {
 
   src = fetchFromGitHub {
     sha256 = "1p8hv4gsyqsdr0gafcq497n52pybiqmc22di8ai4nsj60fv0km45";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     owner = "schneider-electric";
     repo = "asn1ate";
   };

--- a/pkgs/development/python-modules/asn1ate/default.nix
+++ b/pkgs/development/python-modules/asn1ate/default.nix
@@ -12,7 +12,7 @@ buildPythonPackage (finalAttrs: {
   pyproject = true;
 
   src = fetchFromGitHub {
-    sha256 = "1p8hv4gsyqsdr0gafcq497n52pybiqmc22di8ai4nsj60fv0km45";
+    hash = "sha256-hdQJtgNGakuiQrEJwSqOy19R7EkEM6ceyE1jrx/ZEN0=";
     tag = "v${finalAttrs.version}";
     owner = "schneider-electric";
     repo = "asn1ate";

--- a/pkgs/development/python-modules/asn1ate/default.nix
+++ b/pkgs/development/python-modules/asn1ate/default.nix
@@ -6,14 +6,14 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "asn1ate";
   version = "0.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     sha256 = "1p8hv4gsyqsdr0gafcq497n52pybiqmc22di8ai4nsj60fv0km45";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     owner = "schneider-electric";
     repo = "asn1ate";
   };
@@ -31,4 +31,4 @@ buildPythonPackage rec {
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
