### PR TITLE
python3Packages.pphart: 1.1.4 -> 2.0.6

### DIFF
--- a/pkgs/development/python-modules/phart/default.nix
+++ b/pkgs/development/python-modules/phart/default.nix
@@ -4,18 +4,20 @@
   fetchPypi,
   hatchling,
   networkx,
+  numpy,
   pytestCheckHook,
   pytest-cov-stub,
   pydot,
+  pythonAtLeast,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "phart";
-  version = "1.1.4";
+  version = "2.0.6";
 
   src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-JpHjEVKpOPSNUdUjZxWBHt6AFCpci1nSRWhDXxG6nyw=";
+    inherit (finalAttrs) pname version;
+    hash = "sha256-PSYth5QlxvSmrMIehIAS4Pv307x6XluMg0JMSq1TZnE=";
   };
 
   pyproject = true;
@@ -28,32 +30,16 @@ buildPythonPackage rec {
     export PATH=$out/bin:$PATH
   '';
 
-  postPatch = ''
-    # pythonRelaxDeps = true; didn't work
-    substituteInPlace pyproject.toml \
-      --replace-fail 'hatchling==1.26.3' 'hatchling'
-
-    # This line makes the cli tool not work, removing it fixes it
-    substituteInPlace src/phart/cli.py \
-      --replace-fail "renderer.options.use_ascii = args.ascii" ""
-  '';
-
   dependencies = [
     networkx
   ];
 
-  disabledTestPaths = [
-    # Many of the tests are stale
-    "tests/test_cli.py"
-  ];
-
   nativeCheckInputs = [
+    numpy
     pytestCheckHook
     pytest-cov-stub
     pydot
   ];
-
-  pytestFlags = [ "-Wignore::DeprecationWarning" ];
 
   pythonImportsCheck = [
     "phart"
@@ -64,5 +50,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/scottvr/phart";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ b-rodrigues ];
+    broken = !pythonAtLeast "3.14";
   };
-}
+})


### PR DESCRIPTION
Changelog: https://github.com/scottvr/phart/blob/main/PYPI-RELEASE-NOTES-2.0.6.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
