### PR TITLE
swipeaerospace: init at 0.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14319,6 +14319,12 @@
     githubId = 691290;
     name = "Keshav Kini";
   };
+  kinnrai = {
+    email = "me@kinnrai.com";
+    github = "kinnrai";
+    githubId = 72676584;
+    name = "kinnrai";
+  };
   kintrix = {
     email = "kintrix007@proton.me";
     github = "kintrix007";

--- a/pkgs/by-name/sw/swipeaerospace/package.nix
+++ b/pkgs/by-name/sw/swipeaerospace/package.nix
@@ -85,7 +85,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "swipeaerospace";
-  version = "0.3.0";
+  version = "0.3.1";
 
   strictDeps = true;
   __structuredAttrs = true;
@@ -93,8 +93,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "MediosZ";
     repo = "SwipeAeroSpace";
-    tag = finalAttrs.version;
-    hash = "sha256-wm2fx0co7oETr8CDV4ie0rjZylUrWB/j4r9D/wwnSso=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-468QGWjbRtA9Fml6jjeJZBTCUEp227cQPckqwyLK0dM=";
   };
 
   # Keep SettingsView unchanged, but open it through a regular WindowGroup.

--- a/pkgs/by-name/sw/swipeaerospace/package.nix
+++ b/pkgs/by-name/sw/swipeaerospace/package.nix
@@ -1,0 +1,174 @@
+{
+  actool,
+  darwin,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  swiftPackages,
+}:
+
+let
+  inherit (swiftPackages) stdenv swift;
+
+  blueSocket = stdenv.mkDerivation (finalAttrs: {
+    pname = "blue-socket";
+    version = "2.0.4";
+
+    strictDeps = true;
+    __structuredAttrs = true;
+
+    src = fetchFromGitHub {
+      owner = "Kitura";
+      repo = "BlueSocket";
+      tag = finalAttrs.version;
+      hash = "sha256-Bru14uTGvmAeRLjbFYhWKfRjQcj5cZzp9jzyg5o7EHs=";
+    };
+
+    nativeBuildInputs = [
+      swift
+      darwin.autoSignDarwinBinariesHook
+    ];
+
+    dontConfigure = true;
+
+    buildPhase = ''
+      runHook preBuild
+
+      buildDir="$PWD/build"
+      mkdir -p "$buildDir"
+
+      swiftc \
+        -O \
+        -swift-version 5 \
+        -emit-library \
+        -emit-module \
+        -module-name Socket \
+        -emit-module-path "$buildDir/Socket.swiftmodule" \
+        -Xlinker -install_name -Xlinker "$out/lib/swift/libSocket.dylib" \
+        Sources/Socket/*.swift \
+        -o "$buildDir/libSocket.dylib"
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p "$out/lib/swift"
+      cp build/libSocket.dylib "$out/lib/swift/"
+      cp build/Socket.* "$out/lib/swift/"
+
+      runHook postInstall
+    '';
+  });
+
+  infoPlist =
+    version:
+    lib.generators.toPlist { escape = true; } {
+      CFBundleDevelopmentRegion = "en";
+      CFBundleDisplayName = "SwipeAeroSpace";
+      CFBundleExecutable = "SwipeAeroSpace";
+      CFBundleIconFile = "AppIcon";
+      CFBundleIconName = "AppIcon";
+      CFBundleIdentifier = "club.mediosz.SwipeAeroSpace";
+      CFBundleInfoDictionaryVersion = "6.0";
+      CFBundleName = "SwipeAeroSpace";
+      CFBundlePackageType = "APPL";
+      CFBundleShortVersionString = version;
+      CFBundleSupportedPlatforms = [ "MacOSX" ];
+      CFBundleVersion = "18";
+      LSApplicationCategoryType = "public.app-category.developer-tools";
+      LSMinimumSystemVersion = "13.5";
+      LSUIElement = true;
+      NSHumanReadableCopyright = "©Tricster";
+    };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "swipeaerospace";
+  version = "0.3.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "MediosZ";
+    repo = "SwipeAeroSpace";
+    tag = finalAttrs.version;
+    hash = "sha256-wm2fx0co7oETr8CDV4ie0rjZylUrWB/j4r9D/wwnSso=";
+  };
+
+  # Keep SettingsView unchanged, but open it through a regular WindowGroup.
+  # @Environment(\.openSettings) does not compile with nixpkgs' SwiftUI SDK.
+  patches = [ ./settings-window.patch ];
+
+  nativeBuildInputs = [
+    swift
+    actool
+    darwin.autoSignDarwinBinariesHook
+  ];
+
+  buildInputs = [ blueSocket ];
+
+  dontConfigure = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    buildDir="$PWD/build"
+    mkdir -p "$buildDir"
+
+    swiftFiles=()
+    while IFS= read -r -d "" f; do
+      swiftFiles+=("$f")
+    done < <(find SwipeAeroSpace -name '*.swift' -print0)
+
+    swiftc \
+      -O \
+      -swift-version 5 \
+      -parse-as-library \
+      -module-name SwipeAeroSpace \
+      -Xlinker -platform_version -Xlinker macos -Xlinker 13.5 -Xlinker 26.0 \
+      -framework AppKit \
+      -framework Cocoa \
+      -framework SwiftUI \
+      -framework ServiceManagement \
+      -lSocket \
+      "''${swiftFiles[@]}" \
+      -o "$buildDir/SwipeAeroSpace"
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    app="$out/Applications/SwipeAeroSpace.app"
+    mkdir -p "$app/Contents/"{MacOS,Resources}
+
+    cp build/SwipeAeroSpace "$app/Contents/MacOS/SwipeAeroSpace"
+    printf '%s' ${lib.escapeShellArg (infoPlist finalAttrs.version)} > "$app/Contents/Info.plist"
+    printf 'APPL????' > "$app/Contents/PkgInfo"
+
+    actool --compile "$app/Contents/Resources" \
+      --platform macosx \
+      --minimum-deployment-target 13.5 \
+      --app-icon AppIcon \
+      --output-partial-info-plist /dev/null \
+      SwipeAeroSpace/Assets.xcassets
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Switch AeroSpace workspaces by swiping";
+    homepage = "https://github.com/MediosZ/SwipeAeroSpace";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [ kinnrai ];
+    platforms = lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/sw/swipeaerospace/settings-window.patch
+++ b/pkgs/by-name/sw/swipeaerospace/settings-window.patch
@@ -1,0 +1,36 @@
+--- a/SwipeAeroSpace/SwipeAeroSpaceApp.swift
++++ b/SwipeAeroSpace/SwipeAeroSpaceApp.swift
+@@ -10,10 +10,0 @@ import SwiftUI
+-@available(macOS 14.0, *)
+-struct SettingsButton: View {
+-    @Environment(\.openSettings) private var openSettings
+-
+-    var body: some View {
+-        Button("Settings") {
+-            openSettings()
+-        }
+-    }
+-}
+@@ -64,16 +54,4 @@ struct SwipeAeroSpaceApp: App {
+-            if #available(macOS 14.0, *) {
+-                SettingsButton()
+-            } else {
+-                Button(
+-                    action: {
+-                        NSApp.sendAction(
+-                            Selector(("showSettingsWindow:")),
+-                            to: nil,
+-                            from: nil
+-                        )
+-                    },
+-                    label: {
+-                        Text("Settings")
+-                    }
+-                )
++            Button("Settings") {
++                NSApp.activate(ignoringOtherApps: true)
++                openWindow(id: "settings")
+             }
+@@ -92 +70 @@ struct SwipeAeroSpaceApp: App {
+-        Settings {
++        WindowGroup(id: "settings") {


### PR DESCRIPTION
This PR adds [SwipeAeroSpace](https://github.com/MediosZ/SwipeAeroSpace), a macOS menu bar helper for switching [AeroSpace](https://github.com/nikitabobko/AeroSpace) workspaces with trackpad swipe gestures.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
