### PR TITLE
cargo-upgrades: init at 3.1.0

### DIFF
--- a/pkgs/by-name/ca/cargo-upgrades/package.nix
+++ b/pkgs/by-name/ca/cargo-upgrades/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitLab,
+  cargo,
+  makeWrapper,
+  openssl,
+  pkg-config,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cargo-upgrades";
+  version = "3.1.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    owner = "kornelski";
+    repo = "cargo-upgrades";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RRH71+BdKCfLD5DnlQzTJYPbZS6G4E/NvXrC51iPTYs=";
+  };
+  cargoHash = "sha256-FSDjHrRZy4Nn3XYXSJuz46FjGDqn+NfD89koGGKURPw=";
+  doCheck = false; # 1 test fails at the current revision, but its not fatal and the main binary works as expected;
+  buildFeatures = [ "native-tls" ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+  ];
+  buildInputs = [ openssl ];
+
+  # The `cargo-upgrades` binary requires `cargo` in its PATH.
+  postInstall = ''
+    wrapProgram $out/bin/cargo-upgrades \
+     --prefix PATH : ${lib.makeBinPath [ cargo ]}
+  '';
+
+  meta = {
+    description = "Checks if dependencies in Cargo.toml are up to date. Compatible with workspaces and path dependencies.";
+    mainProgram = "cargo-upgrades";
+    homepage = "https://gitlab.com/kornelski/cargo-upgrades";
+    changelog = "https://gitlab.com/kornelski/cargo-upgrades/-/tags/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ wellmannmathis ];
+  };
+})


### PR DESCRIPTION
New package `cargo-upgrades` which I prefer using over `cargo-outdated` since it handles workspace dependencies better.
I was including the nix module in every repo I develop for about a year now and its time to upstream it,
so it becomes a one line import instead of maintaining n separate module files myself.

Ran `nix run ~/nixpkgs/#cargo-upgrades` locally against a rust workspace to confirm its working in its final form. Includes `native-tls` feature and `openssl` dependency so fetching https resources works properly. It also requires `cargo` to be in its path as it calls `cargo metadata` at runtime, hence why Its included the `postInstall` section.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
