### PR TITLE
distrho-ports: 2021-03-15-unstable-2024-05-01 -> 2024-03-15-unstable-2025-08-15

### DIFF
--- a/pkgs/by-name/di/distrho-ports/package.nix
+++ b/pkgs/by-name/di/distrho-ports/package.nix
@@ -10,6 +10,7 @@
   libxcursor,
   libxext,
   libxrender,
+  lv2,
   meson,
   ninja,
   pkg-config,
@@ -31,13 +32,14 @@ let
 in
 stdenv.mkDerivation {
   pname = "distrho-ports";
-  version = "2021-03-15-unstable-2024-05-01";
+  version = "2021-03-15-unstable-2025-08-15";
 
   src = fetchFromGitHub {
     owner = "DISTRHO";
     repo = "DISTRHO-Ports";
-    rev = "b3596e6a690eb0556e69e8b6d943fee2dfbb04fb";
-    sha256 = "00fgqwayd20akww3n2imyqscmyrjyc9jj0ar13k9dhpaxqk2jxbf";
+    rev = "d3b62da2e83c69b0866af5bb2e29ac78dc8014cf";
+    sha256 = "sha256-wlppmRTdgA/9wWqFp75UyDLYJOqzg1aY+w97wTgJ8lk=";
+    fetchSubmodules = true;
   };
 
   nativeBuildInputs = [
@@ -54,14 +56,20 @@ stdenv.mkDerivation {
     libxcursor
     libxext
     libxrender
+    lv2
   ];
 
   env.NIX_CFLAGS_COMPILE = toString [ "-fpermissive" ];
 
+  postPatch = ''
+    chmod +x scripts/*.sh
+    patchShebangs scripts
+  '';
+
   postFixup =
     let
       files = [
-        (lib.optionalString buildLV2 "$out/lib/lv2/vitalium.lv2/vitalium.so")
+        (lib.optionalString buildLV2 "$out/lib/lv2/vitalium.lv2/vitalium-lv2.so")
         (lib.optionalString buildVST2 "$out/lib/vst/vitalium.so")
         (lib.optionalString buildVST3 "$out/lib/vst3/vitalium.vst3/Contents/x86_64-linux/vitalium.so")
       ];


### PR DESCRIPTION
Trivial distrho-ports update 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
