### PR TITLE
claude-code-log: init at 1.4.0

### DIFF
--- a/pkgs/by-name/cl/claude-code-log/package.nix
+++ b/pkgs/by-name/cl/claude-code-log/package.nix
@@ -1,0 +1,51 @@
+{
+  fetchFromGitHub,
+  lib,
+  python3Packages,
+  versionCheckHook,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "claude-code-log";
+  version = "1.4.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "daaain";
+    repo = "claude-code-log";
+    tag = finalAttrs.version;
+    hash = "sha256-ZKf3y9AI3xiez2zIWWEmqJnJgLrPy+Dx52Bi8ryhPiY=";
+  };
+
+  build-system = [ python3Packages.hatchling ];
+
+  dependencies = with python3Packages; [
+    click
+    dateparser
+    gitpython
+    jinja2
+    mistune
+    packaging
+    pydantic
+    pygments
+    textual
+    toml
+  ];
+
+  nativeCheckInputs = [ versionCheckHook ];
+
+  pythonImportsCheck = [
+    "claude_code_log.cli" # Entrypoint.
+    "claude_code_log.tui" # Not eagerly imported by the CLI module.
+  ];
+
+  meta = {
+    description = "Convert Claude Code transcript JSONL files into HTML, Markdown, or JSON";
+    homepage = "https://github.com/daaain/claude-code-log";
+    changelog = "https://github.com/daaain/claude-code-log/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "claude-code-log";
+    maintainers = with lib.maintainers; [ samestep ];
+  };
+})


### PR DESCRIPTION
Claude Code's [builtin `/export` command](https://code.claude.com/docs/en/commands#all-commands) only shows activity since the most recent context compaction, and uses a bespoke nonstandard format. This [Claude Code Log](https://github.com/daaain/claude-code-log) tool can produce a Markdown file of an entire conversation, and also has other features.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
