### PR TITLE
trusttunnel-endpoint: init at 1.0.33

### DIFF
--- a/pkgs/by-name/tr/trusttunnel-endpoint/package.nix
+++ b/pkgs/by-name/tr/trusttunnel-endpoint/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  boringssl,
+  cacert,
+  python3,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "trusttunnel-endpoint";
+  version = "1.0.33";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "TrustTunnel";
+    repo = "TrustTunnel";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-uTAjZbPBCVucjjrl3cYCT6+6cSxiIe/Q3jm+Oa+Fl7E=";
+  };
+
+  cargoHash = "sha256-njQL6YtnRtfpyvsxoTmsSILvyKwYqg42DXsZ8zkhBWo=";
+
+  postPatch = ''
+    substituteInPlace $cargoDepsCopy/*/boring-sys-*/build/main.rs $cargoDepsCopy/*/quiche-*/src/build.rs \
+      --replace-fail "cargo:rustc-link-lib=static=crypto" "cargo:rustc-link-lib=dylib=crypto" \
+      --replace-fail "cargo:rustc-link-lib=static=ssl" "cargo:rustc-link-lib=dylib=ssl"
+  '';
+
+  env = {
+    BORING_BSSL_PATH = boringssl;
+    BORING_BSSL_INCLUDE_PATH = "${boringssl.dev}/include";
+  };
+
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    boringssl
+  ];
+
+  nativeCheckInputs = [
+    cacert
+    python3
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Modern, fast and obfuscated VPN protocol - endpoint component";
+    homepage = "https://github.com/TrustTunnel/TrustTunnel";
+    changelog = "https://github.com/TrustTunnel/TrustTunnel/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ k900 ];
+    mainProgram = "trusttunnel_endpoint";
+  };
+})


### PR DESCRIPTION
This is just the server bits, the client is incredibly annoying to build cleanly. NixOS module later maybe.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
