### PR TITLE
python3Packages.asyncio-throttle: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/asyncio-throttle/default.nix
+++ b/pkgs/development/python-modules/asyncio-throttle/default.nix
@@ -4,12 +4,13 @@
   fetchFromGitHub,
   pytestCheckHook,
   pytest-asyncio,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "asyncio-throttle";
   version = "1.0.2";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "hallazzang";
@@ -17,6 +18,8 @@ buildPythonPackage rec {
     rev = "v${version}";
     sha256 = "1hsjcymdcm0hf4l68scf9n8j7ba89azgh96xhxrnyvwxfs5acnmv";
   };
+
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [
     pytest-asyncio

--- a/pkgs/development/python-modules/asyncio-throttle/default.nix
+++ b/pkgs/development/python-modules/asyncio-throttle/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage (finalAttrs: {
     owner = "hallazzang";
     repo = "asyncio-throttle";
     tag = "v${finalAttrs.version}";
-    sha256 = "1hsjcymdcm0hf4l68scf9n8j7ba89azgh96xhxrnyvwxfs5acnmv";
+    hash = "sha256-u1qminadb29zh90k+L5KSK0jkU2OaWQocRBU1qpnUsM=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/asyncio-throttle/default.nix
+++ b/pkgs/development/python-modules/asyncio-throttle/default.nix
@@ -7,7 +7,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "asyncio-throttle";
   version = "1.0.2";
   pyproject = true;
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "hallazzang";
     repo = "asyncio-throttle";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "1hsjcymdcm0hf4l68scf9n8j7ba89azgh96xhxrnyvwxfs5acnmv";
   };
 
@@ -34,4 +34,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ hexa ];
   };
-}
+})

--- a/pkgs/development/python-modules/asyncio-throttle/default.nix
+++ b/pkgs/development/python-modules/asyncio-throttle/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "hallazzang";
     repo = "asyncio-throttle";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "1hsjcymdcm0hf4l68scf9n8j7ba89azgh96xhxrnyvwxfs5acnmv";
   };
 


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
