### PR TITLE
python3Packages.autograd-gamma: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/autograd-gamma/default.nix
+++ b/pkgs/development/python-modules/autograd-gamma/default.nix
@@ -5,12 +5,13 @@
   pytestCheckHook,
   autograd,
   scipy,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "autograd-gamma";
   version = "0.4.3";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "CamDavidsonPilon";
@@ -19,7 +20,9 @@ buildPythonPackage rec {
     sha256 = "0v03gly5k3a1hzb54zpw6409m3riak49qd27hkq2f66ai42ivqz2";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     autograd
     scipy
   ];

--- a/pkgs/development/python-modules/autograd-gamma/default.nix
+++ b/pkgs/development/python-modules/autograd-gamma/default.nix
@@ -8,7 +8,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "autograd-gamma";
   version = "0.4.3";
   pyproject = true;
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "CamDavidsonPilon";
     repo = "autograd-gamma";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "0v03gly5k3a1hzb54zpw6409m3riak49qd27hkq2f66ai42ivqz2";
   };
 
@@ -37,4 +37,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ swflint ];
   };
-}
+})

--- a/pkgs/development/python-modules/autograd-gamma/default.nix
+++ b/pkgs/development/python-modules/autograd-gamma/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage (finalAttrs: {
     owner = "CamDavidsonPilon";
     repo = "autograd-gamma";
     tag = "v${finalAttrs.version}";
-    sha256 = "0v03gly5k3a1hzb54zpw6409m3riak49qd27hkq2f66ai42ivqz2";
+    hash = "sha256-4uMdBYnKGCfwhEc0nMhUMY+aADH8flLWh0GNWTx9A2w=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/autograd-gamma/default.nix
+++ b/pkgs/development/python-modules/autograd-gamma/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "CamDavidsonPilon";
     repo = "autograd-gamma";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "0v03gly5k3a1hzb54zpw6409m3riak49qd27hkq2f66ai42ivqz2";
   };
 


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
