### PR TITLE
python3Packages.autologging: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/autologging/default.nix
+++ b/pkgs/development/python-modules/autologging/default.nix
@@ -20,8 +20,9 @@ buildPythonPackage (finalAttrs: {
   build-system = [ setuptools ];
 
   meta = {
-    homepage = "https://ninthtest.info/python-autologging/";
     description = "Easier logging and tracing for Python classes";
+    homepage = "https://github.com/mzipay/Autologging";
+    changelog = "https://github.com/mzipay/Autologging/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ twey ];
   };

--- a/pkgs/development/python-modules/autologging/default.nix
+++ b/pkgs/development/python-modules/autologging/default.nix
@@ -13,7 +13,7 @@ buildPythonPackage (finalAttrs: {
   src = fetchPypi {
     pname = "Autologging";
     inherit (finalAttrs) version;
-    sha256 = "117659584d8aab8cf62046f682f8e57b54d958b8571c737fa8bf15c32937fbb6";
+    hash = "sha256-EXZZWE2Kq4z2IEb2gvjle1TZWLhXHHN/qL8Vwyk3+7Y=";
     extension = "zip";
   };
 

--- a/pkgs/development/python-modules/autologging/default.nix
+++ b/pkgs/development/python-modules/autologging/default.nix
@@ -2,12 +2,13 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "autologging";
   version = "1.3.2";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     pname = "Autologging";
@@ -15,6 +16,8 @@ buildPythonPackage rec {
     sha256 = "117659584d8aab8cf62046f682f8e57b54d958b8571c737fa8bf15c32937fbb6";
     extension = "zip";
   };
+
+  build-system = [ setuptools ];
 
   meta = {
     homepage = "https://ninthtest.info/python-autologging/";

--- a/pkgs/development/python-modules/autologging/default.nix
+++ b/pkgs/development/python-modules/autologging/default.nix
@@ -5,14 +5,14 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "autologging";
   version = "1.3.2";
   pyproject = true;
 
   src = fetchPypi {
     pname = "Autologging";
-    inherit version;
+    inherit (finalAttrs) version;
     sha256 = "117659584d8aab8cf62046f682f8e57b54d958b8571c737fa8bf15c32937fbb6";
     extension = "zip";
   };
@@ -25,4 +25,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ twey ];
   };
-}
+})


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
