### PR TITLE
_90secondportraits: modernize derivation

### DIFF
--- a/pkgs/by-name/_9/_90secondportraits/package.nix
+++ b/pkgs/by-name/_9/_90secondportraits/package.nix
@@ -13,34 +13,19 @@
 }:
 
 let
-  pname = "90secondportraits";
-
   icon = fetchurl {
     url = "http://tangramgames.dk/img/thumb/90secondportraits.png";
-    sha256 = "13k6cq8s7jw77j81xfa5ri41445m778q6iqbfplhwdpja03c6faw";
+    hash = "sha256-XDnDBlDyNg7pdQtHg9E5tRASSMxFuR6QPIfLoxFmZo4=";
   };
-
-  desktopItems = [
-    (makeDesktopItem {
-      name = "90secondportraits";
-      exec = pname;
-      icon = icon;
-      comment = "A silly speed painting game";
-      desktopName = "90 Second Portraits";
-      genericName = "90secondportraits";
-      categories = [ "Game" ];
-    })
-  ];
-
 in
-stdenv.mkDerivation rec {
-  inherit pname desktopItems;
+stdenv.mkDerivation (finalAttrs: {
+  pname = "90secondportraits";
   version = "1.01b";
 
   src = fetchFromGitHub {
     owner = "SimonLarsen";
     repo = "90-Second-Portraits";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-xxgB8Aw7QTK9lPus7Q4E7iP2/rRfCwwiYbk5NqzujHI=";
     fetchSubmodules = true;
   };
@@ -58,6 +43,18 @@ stdenv.mkDerivation rec {
     copyDesktopItems
     strip-nondeterminism
     zip
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "90secondportraits";
+      exec = finalAttrs.pname;
+      icon = icon;
+      comment = "A silly speed painting game";
+      desktopName = "90 Second Portraits";
+      genericName = "90secondportraits";
+      categories = [ "Game" ];
+    })
   ];
 
   buildPhase = ''
@@ -90,4 +87,4 @@ stdenv.mkDerivation rec {
     downloadPage = "http://tangramgames.dk/games/90secondportraits";
   };
 
-}
+})


### PR DESCRIPTION
switch to finalAttrs pattern and move pname and desktopItems out of let binding, use SRI hash for icons, move out of treewide PR #524874 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
