### PR TITLE
python3Packages.avro-python3: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/avro-python3/default.nix
+++ b/pkgs/development/python-modules/avro-python3/default.nix
@@ -16,7 +16,7 @@ buildPythonPackage (finalAttrs: {
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    sha256 = "3b63f24e6b04368c3e4a6f923f484be0230d821aad65ac36108edbff29e9aaab";
+    hash = "sha256-O2PyTmsENow+Sm+SP0hL4CMNghqtZaw2EI7b/ynpqqs=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/avro-python3/default.nix
+++ b/pkgs/development/python-modules/avro-python3/default.nix
@@ -8,14 +8,14 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "avro-python3";
   version = "1.10.2";
   pyproject = true;
   disabled = !isPy3k;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     sha256 = "3b63f24e6b04368c3e4a6f923f484be0230d821aad65ac36108edbff29e9aaab";
   };
 
@@ -38,4 +38,4 @@ buildPythonPackage rec {
       lib.maintainers.timma
     ];
   };
-}
+})

--- a/pkgs/development/python-modules/avro-python3/default.nix
+++ b/pkgs/development/python-modules/avro-python3/default.nix
@@ -5,18 +5,21 @@
   isPy3k,
   pycodestyle,
   isort,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "avro-python3";
   version = "1.10.2";
-  format = "setuptools";
+  pyproject = true;
   disabled = !isPy3k;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "3b63f24e6b04368c3e4a6f923f484be0230d821aad65ac36108edbff29e9aaab";
   };
+
+  build-system = [ setuptools ];
 
   buildInputs = [
     pycodestyle


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
