### PR TITLE
nixos/calamares-plasma6: replace activation script with tmpfiles

### DIFF
--- a/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares-plasma6.nix
+++ b/nixos/modules/installer/cd-dvd/installation-cd-graphical-calamares-plasma6.nix
@@ -36,25 +36,22 @@
   # Avoid bundling an entire MariaDB installation on the ISO.
   programs.kde-pim.enable = false;
 
-  system.activationScripts.installerDesktop =
+  systemd.tmpfiles.settings."10-installer-desktop" =
     let
-
       # Comes from documentation.nix when xserver and nixos.enable are true.
       manualDesktopFile = "/run/current-system/sw/share/applications/nixos-manual.desktop";
-
-      homeDir = "/home/nixos/";
-      desktopDir = homeDir + "Desktop/";
-
     in
-    ''
-      mkdir -p ${desktopDir}
-      chown nixos ${homeDir} ${desktopDir}
-
-      ln -sfT ${manualDesktopFile} ${desktopDir + "nixos-manual.desktop"}
-      ln -sfT ${pkgs.gparted}/share/applications/gparted.desktop ${desktopDir + "gparted.desktop"}
-      ln -sfT ${pkgs.calamares-nixos}/share/applications/calamares.desktop ${
-        desktopDir + "calamares.desktop"
-      }
-    '';
+    {
+      "/home/nixos/Desktop".d = {
+        user = "nixos";
+        group = "users";
+        mode = "0755";
+      };
+      "/home/nixos/Desktop/nixos-manual.desktop"."L+".argument = manualDesktopFile;
+      "/home/nixos/Desktop/gparted.desktop"."L+".argument =
+        "${pkgs.gparted}/share/applications/gparted.desktop";
+      "/home/nixos/Desktop/calamares.desktop"."L+".argument =
+        "${pkgs.calamares-nixos}/share/applications/calamares.desktop";
+    };
 
 }


### PR DESCRIPTION
Part of #475305.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
