### PR TITLE
neovim-require-check-hook: discover modules from output

### DIFF
--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -9,6 +9,7 @@
 */
 {
   vimUtils,
+  neovimUtils,
   writeText,
   neovim,
   vimPlugins,
@@ -491,4 +492,37 @@ pkgs.lib.recurseIntoAttrs rec {
       '';
       passthru.requiredLuaModules = [ luassert ];
     };
+
+  nvim_require_check_neovim_plugin =
+    let
+      luaPkg = neovim-unwrapped.lua.pkgs.buildLuarocksPackage {
+        pname = "neovim-require-check-fails";
+        version = "0.0.1-1";
+        src = runCommandLocal "neovim-require-check-fails-src" { } ''
+          mkdir -p "$out"
+          cat > "$out/neovim-require-check-fails-0.0.1-1.rockspec" <<'EOF'
+          package = "neovim-require-check-fails"
+          version = "0.0.1-1"
+          source = {
+            url = "."
+          }
+          build = {
+            type = "none"
+          }
+          EOF
+        '';
+      };
+    in
+    testers.testBuildFailure (
+      neovimUtils.buildNeovimPlugin {
+        luaAttr = luaPkg;
+        doCheck = true;
+        postInstall = ''
+          mkdir -p "$out/lua"
+          cat > "$out/lua/require_check_fails.lua" <<'EOF'
+          error("neovimRequireCheckHook required installed module")
+          EOF
+        '';
+      }
+    );
 }

--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -525,4 +525,37 @@ pkgs.lib.recurseIntoAttrs rec {
         '';
       }
     );
+
+  nvim_require_check_ignores_test_modules = vimUtils.buildVimPlugin {
+    pname = "neovim-require-check-ignores-test-modules";
+    version = "0";
+    src = runCommandLocal "neovim-require-check-ignores-test-modules-src" { } ''
+      mkdir -p \
+        "$out/lua/require-check-ignores"/{debug,script,scripts,test,tests,spec,_meta} \
+        "$out/lua/require-check-ignores"
+      cat > "$out/lua/require-check-ignores/init.lua" <<'EOF'
+      return {}
+      EOF
+      for dir in debug script scripts test tests spec _meta; do
+        cat > "$out/lua/require-check-ignores/$dir/failing.lua" <<EOF
+      error("excluded $dir directory was required")
+      EOF
+      done
+      cat > "$out/lua/require-check-ignores/failing_meta.lua" <<'EOF'
+      error("excluded _meta module was required")
+      EOF
+      cat > "$out/lua/require-check-ignores/failing_spec.lua" <<'EOF'
+      error("excluded _spec module was required")
+      EOF
+      cat > "$out/lua/require-check-ignores/failing.spec.lua" <<'EOF'
+      error("excluded .spec module was required")
+      EOF
+      cat > "$out/lua/require-check-ignores/failing.test.lua" <<'EOF'
+      error("excluded .test module was required")
+      EOF
+      cat > "$out/lua/require-check-ignores/meta.lua" <<'EOF'
+      error("excluded meta module was required")
+      EOF
+    '';
+  };
 }

--- a/pkgs/applications/editors/vim/plugins/hooks/neovim-require-check-hook.sh
+++ b/pkgs/applications/editors/vim/plugins/hooks/neovim-require-check-hook.sh
@@ -4,7 +4,7 @@ echo "Sourcing neovim-require-check-hook.sh"
 
 # Discover modules automatically if nvimRequireCheck is not set
 discover_modules() {
-    echo "Running module discovery in source directory..."
+    echo "Running module discovery in output directory..."
 
     # Create unique lists so we can organize later
     modules=()
@@ -30,7 +30,7 @@ discover_modules() {
             echo "$lua_file"
             modules+=("${BASH_REMATCH[1]}")
         fi
-    done < <(find "$src" -name '*.lua' | xargs -n 1 realpath --relative-to="$src")
+    done < <(find "$out" -name '*.lua' -exec realpath --relative-to="$out" {} +)
 
     nvimRequireCheck=("${modules[@]}")
     echo "Discovered modules: ${nvimRequireCheck[*]}"

--- a/pkgs/applications/editors/vim/plugins/hooks/neovim-require-check-hook.sh
+++ b/pkgs/applications/editors/vim/plugins/hooks/neovim-require-check-hook.sh
@@ -10,11 +10,21 @@ discover_modules() {
     modules=()
 
     while IFS= read -r lua_file; do
-        # Ignore certain infra directories
-        if [[ "$lua_file" =~ (^|/)(debug|script|scripts|test|tests|spec)(/|$) || "$lua_file" =~ .*\meta.lua ]]; then
-            continue
+        # Ignore infrastructure directories and non-runtime module files
+        case "/$lua_file/" in
+            */debug/* | */script/* | */scripts/* | */test/* | */tests/* | */spec/* | */_meta/*)
+                continue
+                ;;
+        esac
+
+        case "${lua_file##*/}" in
+            *meta.lua | *_spec.lua | *.spec.lua | *.test.lua)
+                continue
+                ;;
+        esac
+
         # Ignore optional telescope and lualine modules
-        elif [[ "$lua_file" =~ ^lua/telescope/_extensions/(.+)\.lua || "$lua_file" =~ ^lua/lualine/(.+)\.lua ]]; then
+        if [[ "$lua_file" =~ ^lua/telescope/_extensions/(.+)\.lua || "$lua_file" =~ ^lua/lualine/(.+)\.lua ]]; then
             continue
         # Grab main module names
         elif [[ "$lua_file" =~ ^lua/([^/]+)/init.lua$ ]]; then


### PR DESCRIPTION
Fix `neovim-require-check-hook` module discovery to scan the installed plugin output instead of the source tree.

`buildNeovimPlugin` installs luarocks packages into the Vim plugin layout during install/fixup. The require check runs after that, so discovery should inspect `$out`, not `$src`. This makes the check cover the modules users actually get.

For example, `vimPlugins.rocks-nvim` demonstrates why `$src` is the wrong discovery root: source-tree discovery includes `bootstrap` and `installer`, but those modules are not present in the installed plugin output. Scanning `$out` makes the hook check only modules users actually receive.

Also tighten automatic discovery to skip common test and metadata Lua files that can appear in installed outputs.

Did a slight refactor of how I do the skip condition so it's easier to parse what's skipping what. 

Plan on going through and cleaning up overrides after. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
