### PR TITLE
arti: 2.3.0 -> 2.4.0, add patch for TROVE-2026-024

### DIFF
--- a/pkgs/by-name/ar/arti/package.nix
+++ b/pkgs/by-name/ar/arti/package.nix
@@ -13,7 +13,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "arti";
-  version = "2.3.0";
+  version = "2.4.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.torproject.org";
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "core";
     repo = "arti";
     tag = "arti-v${finalAttrs.version}";
-    hash = "sha256-OEGKjYJ3p4g0ZfeK6k8IJJPjgSBMrSlKlxsCw1OwyaI=";
+    hash = "sha256-YLOdrHstmN2pLl75uclkbpN5h3iBs3xpraZ8XN6R/+Q=";
   };
 
   # Working around a bug in cargo that appears with cargo-auditable, see
@@ -31,22 +31,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail '"tor-rpcbase"' '"dep:tor-rpcbase"'
   '';
 
-  cargoHash = "sha256-OJgrIXL185W9rcQd7XZsgiqN4in74Oc2jDT1ZmcCC6E=";
+  buildAndTestSubdir = "crates/arti";
+  cargoHash = "sha256-7X3JJbt0/jxaMvBR3XQvguR7tqd96kiqX66G2byvPjM=";
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ pkg-config ];
 
   buildInputs = [ sqlite ] ++ lib.optionals stdenv.hostPlatform.isLinux [ openssl ];
-
-  cargoBuildFlags = [
-    "--package"
-    "arti"
-  ];
-
-  cargoTestFlags = [
-    "--package"
-    "arti"
-  ];
-
   # `full` includes all stable and non-conflicting feature flags. the primary
   # downsides are increased binary size and memory usage for building, but
   # those are acceptable for nixpkgs
@@ -69,9 +59,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # sandbox. this does NOT affect downstream users of Arti.
   env.ARTI_FS_DISABLE_PERMISSION_CHECKS = 1;
 
-  nativeInstallCheckInputs = [
-    versionCheckHook
-  ];
+  nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
 
   passthru = {
@@ -84,10 +72,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mainProgram = "arti";
     homepage = "https://arti.torproject.org/";
     changelog = "https://gitlab.torproject.org/tpo/core/arti/-/blob/arti-v${finalAttrs.version}/CHANGELOG.md";
-    license = with lib.licenses; [
-      asl20
-      mit
-    ];
+    license =
+      with lib.licenses;
+      OR [
+        asl20
+        mit
+      ];
     maintainers = with lib.maintainers; [
       rapiteanu
       whispersofthedawn

--- a/pkgs/by-name/ar/arti/package.nix
+++ b/pkgs/by-name/ar/arti/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   rustPlatform,
   fetchFromGitLab,
+  fetchpatch,
   pkg-config,
   sqlite,
   openssl,
@@ -23,6 +24,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
     tag = "arti-v${finalAttrs.version}";
     hash = "sha256-YLOdrHstmN2pLl75uclkbpN5h3iBs3xpraZ8XN6R/+Q=";
   };
+
+  patches = [
+    # Fixes a panic that could allow malicious directory caches to crash
+    # clients.
+    # https://gitlab.torproject.org/tpo/core/arti/-/merge_requests/4062
+    (fetchpatch {
+      name = "TROVE-2026-024.patch";
+      url = "https://gitlab.torproject.org/tpo/core/arti/-/commit/f69be8c70561629e63004788f0aa4bf898025f93.patch";
+      hash = "sha256-P0sXTKOBW7ulqQZwmTVJfrpLksLyaonuDpxGF2keDqE=";
+    })
+  ];
 
   # Working around a bug in cargo that appears with cargo-auditable, see
   # https://github.com/rust-secure-code/cargo-auditable/issues/124.


### PR DESCRIPTION
announcement: https://blog.torproject.org/arti_2_4_0_released/
changelog: https://gitlab.torproject.org/tpo/core/arti/-/blob/arti-v2.4.0/CHANGELOG.md
diff: https://gitlab.torproject.org/tpo/core/arti/-/compare/arti-v2.3.0...arti-v2.4.0
trove: https://gitlab.torproject.org/tpo/core/team/-/wikis/NetworkTeam/TROVE

also threw in some small derivation cleanups that should not cause any user-facing changes.

additionally, an invalid assumption of ASCII in port policies could allow a malicious directory cache to crash arti clients since v2.3.0. this issue was originally publicly reported at https://gitlab.torproject.org/tpo/core/arti/-/merge_requests/4049 and the final fix was merged as https://gitlab.torproject.org/tpo/core/arti/-/merge_requests/4062. this allows for DoSing clients, and has been allocated the the TROVE-2026-024 id with medium severity. we fetch the patch for it here, and may upgrade to 2.4.1 or similar later if upstream releases one.

tested:
- with `tor-browser` as a standalone proxy
- with `curl` as a socks5 proxy to connect to clearnet sites and onion services
- running a regular onion service
- running an onion service with restricted discovery/client authorization
- as a client in a test network as part of `nixosTests.tor`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
