### PR TITLE
acl2.libipasir: switch to finalAttrs pattern, switch to SRI hash

### DIFF
--- a/pkgs/by-name/ac/acl2/libipasirglucose4/default.nix
+++ b/pkgs/by-name/ac/acl2/libipasirglucose4/default.nix
@@ -6,18 +6,18 @@
   unzip,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libipasirglucose4";
   # This library has no version number AFAICT (beyond generally being based on
   # Glucose 4.x), but it was submitted to the 2017 SAT competition so let's use
   # that as the version number, I guess.
   version = "2017";
 
-  libname = pname + stdenv.hostPlatform.extensions.sharedLibrary;
+  libname = finalAttrs.pname + stdenv.hostPlatform.extensions.sharedLibrary;
 
   src = fetchurl {
     url = "https://baldur.iti.kit.edu/sat-competition-2017/solvers/incremental/glucose-ipasir.zip";
-    sha256 = "0xchgady9vwdh8frmc8swz6va53igp2wj1y9sshd0g7549n87wdj";
+    hash = "sha256-svGDbCLlPNCg1skHycV9cRS1zecasZodgo3v5Jt6kHU=";
   };
   nativeBuildInputs = [ unzip ];
 
@@ -29,13 +29,13 @@ stdenv.mkDerivation rec {
   makeFlags = [ "CXX=${stdenv.cc.targetPrefix}c++" ];
 
   postBuild = ''
-    $CXX -shared -o ${libname} \
-        ${lib.optionalString (!stdenv.cc.isClang) "-Wl,-soname,${libname}"} \
+    $CXX -shared -o ${finalAttrs.libname} \
+        ${lib.optionalString (!stdenv.cc.isClang) "-Wl,-soname,${finalAttrs.libname}"} \
         ipasirglucoseglue.o libipasirglucose4.a
   '';
 
   installPhase = ''
-    install -D ${libname} $out/lib/${libname}
+    install -D ${finalAttrs.libname} $out/lib/${finalAttrs.libname}
   '';
 
   meta = {
@@ -44,4 +44,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ kini ];
   };
-}
+})


### PR DESCRIPTION
switch to finalAttrs pattern and use SRI format hash, move out of treewide PR #524874 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
