### PR TITLE
nixos/clashtui: add module and test

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1165,6 +1165,7 @@
   ./services/networking/cgit.nix
   ./services/networking/chisel-server.nix
   ./services/networking/cjdns.nix
+  ./services/networking/clashtui.nix
   ./services/networking/clatd.nix
   ./services/networking/cloudflare-ddns.nix
   ./services/networking/cloudflare-dyndns.nix

--- a/nixos/modules/services/networking/clashtui.nix
+++ b/nixos/modules/services/networking/clashtui.nix
@@ -1,0 +1,335 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.clashtui;
+
+  mihomoAutostart = cfg.enableMihomo && cfg.defaultCore == "mihomo";
+  singboxAutostart = cfg.enableSingbox && cfg.defaultCore == "sing-box";
+
+  defaultConfigs = "${cfg.package}/share/clashtui/default_configs";
+  mihomoConfigDir = "${cfg.stateDir}/mihomo/config";
+  singboxConfigDir = "${cfg.stateDir}/sing-box/config";
+
+  installIfMissing =
+    {
+      target,
+      source,
+      user,
+      group,
+      mode,
+    }:
+    ''
+      if [ ! -e ${lib.escapeShellArg target} ]; then
+        ${pkgs.coreutils}/bin/install -D -m ${mode} -o ${lib.escapeShellArg user} -g ${lib.escapeShellArg group} \
+          ${lib.escapeShellArg source} ${lib.escapeShellArg target}
+      fi
+    '';
+
+  # Seed core config files only once. Users and clashtui may edit them later.
+  # `clashtui` also checks the core config directory's group access in system mode.
+  # Keep the SGID bit so files created there remain readable by cfg.users.
+  ensureMihomoConfig = ''
+    ${pkgs.coreutils}/bin/install -d -m 2775 -o ${lib.escapeShellArg cfg.mihomoUser} -g ${lib.escapeShellArg cfg.mihomoGroup} \
+      ${lib.escapeShellArg mihomoConfigDir}
+    ${installIfMissing {
+      target = "${mihomoConfigDir}/config.yaml";
+      source = "${defaultConfigs}/mihomo/core_override_config.yaml";
+      user = cfg.mihomoUser;
+      group = cfg.mihomoGroup;
+      mode = "0660";
+    }}
+  '';
+
+  ensureSingboxConfig = ''
+    ${pkgs.coreutils}/bin/install -d -m 2775 -o ${lib.escapeShellArg cfg.singboxUser} -g ${lib.escapeShellArg cfg.singboxGroup} \
+      ${lib.escapeShellArg singboxConfigDir}
+    ${installIfMissing {
+      target = "${singboxConfigDir}/config.json";
+      source = "${defaultConfigs}/sing-box/core_override_config.json";
+      user = cfg.singboxUser;
+      group = cfg.singboxGroup;
+      mode = "0660";
+    }}
+  '';
+
+  initializeScript = ''
+    ${lib.optionalString cfg.enableMihomo ensureMihomoConfig}
+    ${lib.optionalString cfg.enableSingbox ensureSingboxConfig}
+  '';
+in
+{
+  options.services.clashtui = {
+    enable = lib.mkEnableOption "clashtui system core services";
+
+    package = lib.mkPackageOption pkgs "clashtui" { };
+
+    stateDir = lib.mkOption {
+      type = lib.types.str;
+      # NixOS services normally store mutable state in /var/lib, but upstream's
+      # generated system-mode config hard-codes /opt/clashtui.
+      default = "/opt/clashtui";
+      example = "/opt/clashtui";
+      description = ''
+        System core state directory, corresponding to upstream's system-mode
+        `INSTALL_DIR`. Mihomo uses `''${stateDir}/mihomo/config`; sing-box uses
+        `''${stateDir}/sing-box/config`.
+      '';
+    };
+
+    initializeCoreConfig = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Whether to create missing core configuration files from upstream
+        defaults in `stateDir`. Existing files are never overwritten.
+      '';
+    };
+
+    enableMihomo = lib.mkEnableOption "the Mihomo core managed by clashtui";
+
+    defaultCore = lib.mkOption {
+      type = lib.types.enum [
+        "mihomo"
+        "sing-box"
+        "none"
+      ];
+      default = "mihomo";
+      description = "Core service to start automatically at boot.";
+    };
+
+    enableSingbox = lib.mkEnableOption "the sing-box core managed by clashtui";
+
+    users = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "alice" ];
+      description = "Normal users allowed to access clashtui core state via the enabled core groups.";
+    };
+
+    mihomoPackage = lib.mkPackageOption pkgs "mihomo" { };
+
+    mihomoUser = lib.mkOption {
+      type = lib.types.str;
+      default = "mihomo";
+      description = "User account under which the Mihomo core service runs.";
+    };
+
+    mihomoGroup = lib.mkOption {
+      type = lib.types.str;
+      default = "mihomo";
+      description = "Group account under which the Mihomo core service runs.";
+    };
+
+    singboxPackage = lib.mkPackageOption pkgs "sing-box" { };
+
+    singboxUser = lib.mkOption {
+      type = lib.types.str;
+      default = "sing-box";
+      description = "User account under which the sing-box core service runs.";
+    };
+
+    singboxGroup = lib.mkOption {
+      type = lib.types.str;
+      default = "sing-box";
+      description = "Group account under which the sing-box core service runs.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion =
+          (cfg.defaultCore == "none")
+          || (cfg.defaultCore == "mihomo" && cfg.enableMihomo)
+          || (cfg.defaultCore == "sing-box" && cfg.enableSingbox);
+        message = "services.clashtui.defaultCore must be enabled by services.clashtui.enableMihomo or services.clashtui.enableSingbox.";
+      }
+    ];
+
+    environment.systemPackages = [
+      cfg.package
+    ]
+    ++ lib.optional cfg.enableMihomo cfg.mihomoPackage
+    ++ lib.optional cfg.enableSingbox cfg.singboxPackage;
+
+    users.groups = lib.mkMerge [
+      (lib.mkIf cfg.enableMihomo { ${cfg.mihomoGroup} = { }; })
+      (lib.mkIf cfg.enableSingbox { ${cfg.singboxGroup} = { }; })
+    ];
+
+    users.users = lib.mkMerge [
+      (lib.mkIf cfg.enableMihomo {
+        ${cfg.mihomoUser} = {
+          isSystemUser = true;
+          group = cfg.mihomoGroup;
+        };
+      })
+      (lib.mkIf cfg.enableSingbox {
+        ${cfg.singboxUser} = {
+          isSystemUser = true;
+          group = cfg.singboxGroup;
+        };
+      })
+      (lib.genAttrs cfg.users (_: {
+        extraGroups =
+          lib.optional cfg.enableMihomo cfg.mihomoGroup ++ lib.optional cfg.enableSingbox cfg.singboxGroup;
+      }))
+    ];
+
+    # clashtui records core binary paths under stateDir. Point those paths back
+    # to the NixOS packages instead of copying binaries into mutable storage.
+    systemd.tmpfiles.settings."10-clashtui" = {
+      ${cfg.stateDir}.d = {
+        mode = "0755";
+        user = "root";
+        group = "root";
+      };
+    }
+    // lib.optionalAttrs cfg.enableMihomo {
+      "${cfg.stateDir}/mihomo".d = {
+        mode = "0755";
+        user = cfg.mihomoUser;
+        group = cfg.mihomoGroup;
+      };
+      ${mihomoConfigDir}.d = {
+        mode = "2775";
+        user = cfg.mihomoUser;
+        group = cfg.mihomoGroup;
+      };
+      "${cfg.stateDir}/mihomo/mihomo"."L+".argument = lib.getExe cfg.mihomoPackage;
+      "${mihomoConfigDir}/config.yaml".z = {
+        mode = "0660";
+        user = cfg.mihomoUser;
+        group = cfg.mihomoGroup;
+      };
+    }
+    // lib.optionalAttrs cfg.enableSingbox {
+      "${cfg.stateDir}/sing-box".d = {
+        mode = "0755";
+        user = cfg.singboxUser;
+        group = cfg.singboxGroup;
+      };
+      ${singboxConfigDir}.d = {
+        mode = "2775";
+        user = cfg.singboxUser;
+        group = cfg.singboxGroup;
+      };
+      "${cfg.stateDir}/sing-box/sing-box"."L+".argument = lib.getExe cfg.singboxPackage;
+      "${singboxConfigDir}/config.json".z = {
+        mode = "0660";
+        user = cfg.singboxUser;
+        group = cfg.singboxGroup;
+      };
+    };
+
+    systemd.services = lib.mkMerge [
+      (lib.mkIf cfg.initializeCoreConfig {
+        clashtui-init = {
+          description = "Initialize clashtui core configuration";
+          wantedBy = lib.optionals (mihomoAutostart || singboxAutostart) [ "multi-user.target" ];
+          before =
+            lib.optional cfg.enableMihomo "clashtui_mihomo.service"
+            ++ lib.optional cfg.enableSingbox "clashtui_singbox.service";
+          serviceConfig = {
+            Type = "oneshot";
+            RemainAfterExit = true;
+            ExecStart = pkgs.writeShellScript "clashtui-init" initializeScript;
+          };
+        };
+      })
+
+      (lib.mkIf cfg.enableMihomo {
+        clashtui_mihomo = {
+          description = "Mihomo core for clashtui";
+          documentation = [ "https://github.com/JohanChane/clashtui" ];
+          wantedBy = lib.optionals mihomoAutostart [ "multi-user.target" ];
+          after = [ "network-online.target" ];
+          wants = [ "network-online.target" ];
+          requires = lib.optional cfg.initializeCoreConfig "clashtui-init.service";
+
+          serviceConfig = {
+            Type = "simple";
+            User = cfg.mihomoUser;
+            Group = cfg.mihomoGroup;
+            ExecStart = lib.escapeShellArgs [
+              (lib.getExe cfg.mihomoPackage)
+              "-d"
+              mihomoConfigDir
+            ];
+            ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+            Restart = "always";
+            LimitNPROC = 500;
+            LimitNOFILE = 1000000;
+            AmbientCapabilities = [
+              "CAP_NET_ADMIN"
+              "CAP_NET_RAW"
+              "CAP_NET_BIND_SERVICE"
+              "CAP_SYS_TIME"
+              "CAP_SYS_PTRACE"
+              "CAP_DAC_READ_SEARCH"
+              "CAP_DAC_OVERRIDE"
+            ];
+            CapabilityBoundingSet = [
+              "CAP_NET_ADMIN"
+              "CAP_NET_RAW"
+              "CAP_NET_BIND_SERVICE"
+              "CAP_SYS_TIME"
+              "CAP_SYS_PTRACE"
+              "CAP_DAC_READ_SEARCH"
+              "CAP_DAC_OVERRIDE"
+            ];
+          };
+        };
+      })
+
+      (lib.mkIf cfg.enableSingbox {
+        clashtui_singbox = {
+          description = "sing-box core for clashtui";
+          documentation = [ "https://github.com/JohanChane/clashtui" ];
+          wantedBy = lib.optionals singboxAutostart [ "multi-user.target" ];
+          after = [ "network-online.target" ];
+          wants = [ "network-online.target" ];
+          requires = lib.optional cfg.initializeCoreConfig "clashtui-init.service";
+
+          serviceConfig = {
+            Type = "simple";
+            User = cfg.singboxUser;
+            Group = cfg.singboxGroup;
+            ExecStart = lib.escapeShellArgs [
+              (lib.getExe cfg.singboxPackage)
+              "run"
+              "-D"
+              singboxConfigDir
+              "-c"
+              "${singboxConfigDir}/config.json"
+            ];
+            ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+            Restart = "on-failure";
+            RestartSec = "10s";
+            LimitNOFILE = "infinity";
+            AmbientCapabilities = [
+              "CAP_NET_ADMIN"
+              "CAP_NET_RAW"
+              "CAP_NET_BIND_SERVICE"
+              "CAP_SYS_PTRACE"
+              "CAP_DAC_READ_SEARCH"
+            ];
+            CapabilityBoundingSet = [
+              "CAP_NET_ADMIN"
+              "CAP_NET_RAW"
+              "CAP_NET_BIND_SERVICE"
+              "CAP_SYS_PTRACE"
+              "CAP_DAC_READ_SEARCH"
+            ];
+          };
+        };
+      })
+    ];
+  };
+
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -368,6 +368,7 @@ in
   cinnamon-wayland = runTest ./cinnamon-wayland.nix;
   cjdns = runTest ./cjdns.nix;
   clamav = runTest ./clamav.nix;
+  clashtui = runTest ./clashtui.nix;
   clatd = runTest ./clatd.nix;
   clickhouse = import ./clickhouse {
     inherit runTest;

--- a/nixos/tests/clashtui.nix
+++ b/nixos/tests/clashtui.nix
@@ -1,0 +1,87 @@
+{ pkgs, ... }:
+{
+  name = "clashtui";
+
+  nodes.machine = {
+    environment.systemPackages = [ pkgs.curl ];
+
+    users.users.alice = {
+      isNormalUser = true;
+      group = "users";
+    };
+
+    services.clashtui = {
+      enable = true;
+      enableMihomo = true;
+      enableSingbox = true;
+      defaultCore = "none";
+      users = [ "alice" ];
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
+    machine.succeed("clashtui --version")
+    machine.succeed("mihomo -v")
+    machine.succeed("sing-box version")
+
+    machine.fail("systemctl is-active --quiet clashtui_mihomo.service")
+    machine.fail("systemctl is-active --quiet clashtui_singbox.service")
+
+    machine.succeed("""
+      set +e
+      sudo -u alice env CLASHTUI_CONFIG_DIR=/home/alice/.config/clashtui timeout 5 clashtui >/dev/null 2>&1
+      status=$?
+      # Upstream currently exits with 134 without a TTY, after initializing the config directory.
+      test "$status" = 0 -o "$status" = 124 -o "$status" = 134
+    """)
+    machine.succeed("test -s /home/alice/.config/clashtui/config.yaml")
+    machine.succeed("test -s /home/alice/.config/clashtui/mihomo/core_override_config.yaml")
+    machine.succeed("test -s /home/alice/.config/clashtui/sing-box/core_override_config.json")
+    machine.succeed("test -d /home/alice/.config/clashtui/mihomo/templates")
+    machine.succeed("test -d /home/alice/.config/clashtui/sing-box/templates")
+    machine.succeed("test -d /home/alice/.config/clashtui/mihomo/profiles")
+    machine.succeed("test -d /home/alice/.config/clashtui/sing-box/profiles")
+    machine.succeed("test -s /home/alice/.config/clashtui/clashtui.db")
+    machine.succeed("grep -q 'mihomo:' /home/alice/.config/clashtui/config.yaml")
+    machine.succeed("grep -q 'singbox:' /home/alice/.config/clashtui/config.yaml")
+
+    machine.succeed("systemctl start clashtui-init.service")
+    machine.succeed("systemctl is-active --quiet clashtui-init.service")
+
+    machine.succeed("test -f /opt/clashtui/mihomo/config/config.yaml")
+    machine.succeed("test -f /opt/clashtui/sing-box/config/config.json")
+    machine.succeed("test -L /opt/clashtui/mihomo/mihomo")
+    machine.succeed("test -L /opt/clashtui/sing-box/sing-box")
+    machine.succeed("test -x /opt/clashtui/mihomo/mihomo")
+    machine.succeed("test -x /opt/clashtui/sing-box/sing-box")
+
+    machine.succeed("grep -q 'mixed-port: 7890' /opt/clashtui/mihomo/config/config.yaml")
+    machine.succeed("grep -q 'external_controller' /opt/clashtui/sing-box/config/config.json")
+    machine.succeed("test \"$(stat -c '%U:%G:%a' /opt/clashtui/mihomo/config/config.yaml)\" = mihomo:mihomo:660")
+    machine.succeed("test \"$(stat -c '%U:%G:%a' /opt/clashtui/sing-box/config/config.json)\" = sing-box:sing-box:660")
+    machine.succeed("test \"$(stat -c '%U:%G:%a' /opt/clashtui/mihomo/config)\" = mihomo:mihomo:2775")
+    machine.succeed("test \"$(stat -c '%U:%G:%a' /opt/clashtui/sing-box/config)\" = sing-box:sing-box:2775")
+
+    machine.succeed("id -nG alice | grep -w mihomo")
+    machine.succeed("id -nG alice | grep -w sing-box")
+    machine.succeed("sudo -u alice test -r /opt/clashtui/mihomo/config/config.yaml")
+    machine.succeed("sudo -u alice test -r /opt/clashtui/sing-box/config/config.json")
+
+    machine.succeed("mihomo -t -d /opt/clashtui/mihomo/config")
+    machine.succeed("sing-box check -D /opt/clashtui/sing-box/config -c /opt/clashtui/sing-box/config/config.json")
+
+    machine.succeed("systemctl start clashtui_mihomo.service")
+    machine.wait_for_unit("clashtui_mihomo.service")
+    machine.wait_for_open_port(7890)
+    machine.wait_for_open_port(9090)
+    machine.succeed("curl --fail --max-time 10 --proxy http://localhost:7890 http://localhost:9090")
+    machine.succeed("systemctl stop clashtui_mihomo.service")
+
+    machine.succeed("systemctl start clashtui_singbox.service")
+    machine.wait_for_unit("clashtui_singbox.service")
+    machine.wait_for_open_port(2080)
+    machine.wait_for_open_port(9090)
+  '';
+}

--- a/pkgs/by-name/cl/clashtui/package.nix
+++ b/pkgs/by-name/cl/clashtui/package.nix
@@ -32,6 +32,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     versionCheckHook
   ];
 
+  # Copy the default configs so the mihomo/sing-box service can read.
+  postInstall = ''
+    mkdir -p $out/share/clashtui
+    cp -r contrib/default_configs $out/share/clashtui/default_configs
+  '';
+
   passthru.updateScript = nix-update-script { };
 
   meta = {

--- a/pkgs/by-name/cl/clashtui/package.nix
+++ b/pkgs/by-name/cl/clashtui/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitHub,
   rustPlatform,
+  nixosTests,
   versionCheckHook,
   nix-update-script,
 }:
@@ -38,10 +39,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
     cp -r contrib/default_configs $out/share/clashtui/default_configs
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    tests.clashtui = nixosTests.clashtui;
+    updateScript = nix-update-script { };
+  };
 
   meta = {
-    description = "Mihomo (Clash.Meta) TUI Client";
+    description = "Mihomo (Clash.Meta) / sing-box TUI Client";
     homepage = "https://github.com/JohanChane/clashtui";
     changelog = "https://github.com/JohanChane/clashtui/releases/tag/v${finalAttrs.version}";
     mainProgram = "clashtui";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add a NixOS module for intergating mihomo or sing-box service and VM test for `clashtui`

Detailed:
- install upstream `contrib/default_configs` in the `clashtui` package as the default config for mihomo/sing-box service.
- add `services.clashtui` for enabling integrated service `clashtui_mihomo` and `clashtui_singbox`.
- add a VM test for this module.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
