### PR TITLE
beamMinimal27Packages.erlang: use upstream doc target patch

### DIFF
--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -21,6 +21,7 @@
   parallelBuild ? true,
 
   fetchFromGitHub,
+  fetchpatch2,
   gawk,
   gnum4,
   gnused,
@@ -111,14 +112,18 @@ stdenv.mkDerivation {
   ++ optionals javacSupport [ openjdk11 ]
   ++ optionals enableSystemd [ systemd ];
 
+  patches = lib.optionals (!wxSupport && major == "27") [
+    # https://github.com/erlang/otp/pull/11162
+    (fetchpatch2 {
+      name = "otp-27-doc-target-fix.patch";
+      url = "https://github.com/erlang/otp/commit/7ce587b61a2557fca79f1c130794abf834f37ee1.patch?full_index=1";
+      hash = "sha256-Ce6tWUzeF6TQMxus7ultxG2piFllw/xa5IPLCxSd024=";
+    })
+  ];
+
   # disksup requires a shell
   postPatch = ''
     substituteInPlace lib/os_mon/src/disksup.erl --replace-fail '"sh ' '"${runtimeShell} '
-  ''
-  # https://github.com/erlang/otp/issues/11151
-  + lib.optionalString (!wxSupport && major == "27") ''
-    substituteInPlace lib/wx/doc/Makefile \
-      --replace-fail $'ifneq ($(CAN_BUILD_DRIVER), true)\nDOC_TARGETS=\nendif\n' ""
   '';
 
   debugInfo = enableDebugInfo;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Follow up to https://github.com/NixOS/nixpkgs/pull/524973 but use the official fix now. Ensures it'll cause a hard failure on next version bump.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
