### PR TITLE
isolate: 2.3 -> 2.5

### DIFF
--- a/pkgs/by-name/is/isolate/package.nix
+++ b/pkgs/by-name/is/isolate/package.nix
@@ -8,17 +8,18 @@
   systemdLibs,
   installShellFiles,
   nixosTests,
+  libseccomp,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "isolate";
-  version = "2.3";
+  version = "2.5";
 
   src = fetchFromGitHub {
     owner = "ioi";
     repo = "isolate";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-z/23k6F9XHbJDFld9tjIafUZzbUDEWAnbLvAoaEAilQ=";
+    hash = "sha256-a6FQxyClE9cXB0wHV0Z4kjYY6S1+mUE4ReroOifNjKg=";
   };
 
   nativeBuildInputs = [
@@ -30,6 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     libcap.dev
     systemdLibs.dev
+    libseccomp
   ];
 
   patches = [


### PR DESCRIPTION
Update to 2.5

add libseccomp dependency

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
