### PR TITLE
{palemoon-bin,palemoon-gtk2-bin}: 34.2.2 -> 34.3.0

### DIFF
--- a/pkgs/by-name/pa/palemoon-bin/package.nix
+++ b/pkgs/by-name/pa/palemoon-bin/package.nix
@@ -5,7 +5,6 @@
   alsa-lib,
   autoPatchelfHook,
   copyDesktopItems,
-  dbus-glib,
   # ffmpeg 7 not supported yet, results in MP4 playback being unavailable
   # https://repo.palemoon.org/MoonchildProductions/UXP/issues/2523
   ffmpeg_6,
@@ -23,7 +22,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "palemoon-bin";
-  version = "34.2.2";
+  version = "34.3.0";
 
   src = finalAttrs.passthru.sources."gtk${if withGTK3 then "3" else "2"}";
 
@@ -39,7 +38,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     alsa-lib
-    dbus-glib
     gtk2-x11
     libxt
     (lib.getLib stdenv.cc.cc)
@@ -173,11 +171,11 @@ stdenv.mkDerivation (finalAttrs: {
       {
         gtk3 = fetchzip {
           urls = urlRegionVariants "gtk3";
-          hash = "sha256-KUlok5T+gf1qgRdivCx2uLijyO0bfurLHfrIgELK//A=";
+          hash = "sha256-yoZqZJLxgDIxIeyrn6VW6c6iKpU84ZDsJbCz3yf4gdU=";
         };
         gtk2 = fetchzip {
           urls = urlRegionVariants "gtk2";
-          hash = "sha256-iSQDrlLkTxHNFFZC5X/OKMem2Zk213it1Ki7ADw+Opg=";
+          hash = "sha256-QhrW1ZD1ouPvWJLvnIEMHgTViGNBshFlT6Ax0l0xGv8=";
         };
       };
 


### PR DESCRIPTION
https://www.palemoon.org/releasenotes.shtml#v34.3.0

<img width="1060" height="920" alt="image" src="https://github.com/user-attachments/assets/71a55e25-a6e6-4c28-80e5-b7c4a15dc421" />

Ran `palemoon-bin.passthru.updateScript` for `version` and `src.hash` updates.

---

Build system is now compatible with Python3, so we could try to revive the source-built version (#232571). Not right now though…

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
