### PR TITLE
showtime: drop unreproducible __pycache__ hack

### DIFF
--- a/pkgs/by-name/sh/showtime/package.nix
+++ b/pkgs/by-name/sh/showtime/package.nix
@@ -69,13 +69,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     export HOME="$TEMPDIR"
   '';
 
-  # HACK: To get rid of unreproducible __pycache__ created by pythonImportsCheck.
-  # See https://github.com/NixOS/nixpkgs/issues/469081
-  deletePycachePhase = ''
-    find $out/lib -type d -name __pycache__ -prune -exec rm -vr {} \;
-  '';
-  postPhases = [ "deletePycachePhase" ];
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "showtime";


### PR DESCRIPTION
This is fixed with the showtime 50.0 release.

This reverts commit e38446f1750f9f7ae0ed4eb2558b30d1b49ed1f5.

The workaround introduced in https://github.com/NixOS/nixpkgs/pull/471170 is no longer needed.
I sent a patch upstream https://gitlab.gnome.org/GNOME/showtime/-/merge_requests/84, which is now in version 50.0.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

CC: @raboof