### PR TITLE
agi: migrate to finalAttrs

### DIFF
--- a/pkgs/by-name/ag/agi/package.nix
+++ b/pkgs/by-name/ag/agi/package.nix
@@ -13,13 +13,13 @@
   android-tools,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "agi";
   version = "3.3.1";
 
   src = fetchzip {
-    url = "https://github.com/google/agi/releases/download/${version}/agi-${version}-linux.zip";
-    sha256 = "sha256-Yawl6InBYSWNw3clHyGAeC2PVfXEzWmbd6vcYrqAPO0=";
+    url = "https://github.com/google/agi/releases/download/${finalAttrs.version}/agi-${finalAttrs.version}-linux.zip";
+    hash = "sha256-Yawl6InBYSWNw3clHyGAeC2PVfXEzWmbd6vcYrqAPO0=";
   };
 
   nativeBuildInputs = [
@@ -39,7 +39,7 @@ stdenvNoCC.mkDerivation rec {
     cp -r lib $out
 
     for i in 16 32 48 64 96 128 256 512 1024; do
-      install -D ${src}/icon.png $out/share/icons/hicolor/''${i}x$i/apps/agi.png
+      install -D ${finalAttrs.src}/icon.png $out/share/icons/hicolor/''${i}x$i/apps/agi.png
     done
 
     runHook postInstall
@@ -71,7 +71,7 @@ stdenvNoCC.mkDerivation rec {
   meta = {
     description = "Android GPU Inspector";
     homepage = "https://gpuinspector.dev";
-    changelog = "https://github.com/google/agi/releases/tag/v${version}";
+    changelog = "https://github.com/google/agi/releases/tag/v${finalAttrs.version}";
     platforms = [ "x86_64-linux" ];
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ kashw2 ];
@@ -80,4 +80,4 @@ stdenvNoCC.mkDerivation rec {
       binaryNativeCode
     ];
   };
-}
+})


### PR DESCRIPTION
migrate to finalAttrs, move out of treewide PR #524874 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
