### PR TITLE
python3Packages.plopp: correct package hash

### DIFF
--- a/pkgs/development/python-modules/plopp/default.nix
+++ b/pkgs/development/python-modules/plopp/default.nix
@@ -43,7 +43,7 @@ buildPythonPackage (finalAttrs: {
     owner = "scipp";
     repo = "plopp";
     tag = finalAttrs.version;
-    hash = "sha256-UYEbJtWSTwF4z8Ga+IsCk+yQVT5xMvEENqT+hrbxPEc=";
+    hash = "sha256-8rwF40aeJMyIcmMsSyea42B6poXHxHQlPIlw0ROeyzY=";
   };
 
   build-system = [


### PR DESCRIPTION
Package has been failing to build with a hash error after #524831:
```sh
error: hash mismatch in fixed-output derivation '/nix/store/knrrgrz9gp0qjdwchf1iawgdp3nm3zzy-source.drv':
           likely URL: (unknown)
            specified: sha256-UYEbJtWSTwF4z8Ga+IsCk+yQVT5xMvEENqT+hrbxPEc=
                  got: sha256-8rwF40aeJMyIcmMsSyea42B6poXHxHQlPIlw0ROeyzY=
        expected path: /nix/store/px35240yxkyzan7bsspdklxrfl3m5iqn-source
             got path: /nix/store/bdqz362bfakj2wfkjpzlkk2f6mgw2026-source
```

Checked that the issue and fix are the same on `x86_64-linux` and `aarch64-darwin`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
