### PR TITLE
nixos/opensnitch: don't rely on systemd-tmpfiles for service setup

### DIFF
--- a/nixos/modules/services/security/opensnitch.nix
+++ b/nixos/modules/services/security/opensnitch.nix
@@ -106,10 +106,9 @@ in
                 "iptables"
                 "nftables"
               ];
-              default = if config.networking.nftables.enable then "nftables" else "iptables";
-              defaultText = lib.literalExpression ''if config.networking.nftables.enable then "nftables" else "iptables"'';
+              default = "nftables";
               description = ''
-                Which firewall backend to use.
+                Which firewall backend to use. `nftables` ruleset can be used for `iptables` firewall too, if `iptables` is built with nftables compatibility.
               '';
             };
             Ebpf.ModulesPath = lib.mkOption {

--- a/nixos/modules/services/security/opensnitch.nix
+++ b/nixos/modules/services/security/opensnitch.nix
@@ -13,6 +13,7 @@ let
       file = pkgs.writeText "rule" (builtins.toJSON cfg);
     }
   );
+  stateDir = lib.strings.match "/var/lib/([^/]+)/.+" cfg.settings.Rules.Path;
 in
 {
   options = {
@@ -139,7 +140,10 @@ in
             };
 
             Rules.Path = lib.mkOption {
-              type = lib.types.path;
+              type = lib.types.pathWith {
+                inStore = false;
+                absolute = true;
+              };
               default = "/var/lib/opensnitch/rules";
               description = ''
                 Path to the directory where firewall rules can be found and will
@@ -158,6 +162,12 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = stateDir != null;
+        message = "`config.services.opensnitch.settings.Rules.Path` must be a sub-directory of /var/lib/, currently is ${cfg.settings.Rules.Path}";
+      }
+    ];
 
     security.auditd = lib.mkIf (cfg.settings.ProcMonitorMethod == "audit") {
       enable = true;
@@ -174,8 +184,14 @@ in
             ""
             "${lib.getExe' cfg.package "opensnitchd"} --config-file ${cfg.configFile}"
           ];
+          StateDirectory = builtins.head stateDir; # match produces a list. Null case covered by assertion.
         };
-        preStart = lib.mkIf (cfg.rules != { }) (
+        preStart = ''
+          # assert rules directory exists before service starts
+          # will be in StateDirectory due to assertion
+          mkdir -p ${cfg.settings.Rules.Path}
+        ''
+        + lib.optionalString (cfg.rules != { }) (
           let
             rules = lib.flip lib.mapAttrsToList predefinedRules (
               file: content: {
@@ -205,9 +221,6 @@ in
           ''
         );
       };
-      tmpfiles.rules = [
-        "d ${cfg.settings.Rules.Path} 0750 root root - -"
-      ];
     };
 
     environment.etc."opensnitchd/network_aliases.json".source =

--- a/nixos/modules/services/security/opensnitch.nix
+++ b/nixos/modules/services/security/opensnitch.nix
@@ -207,11 +207,13 @@ in
       };
       tmpfiles.rules = [
         "d ${cfg.settings.Rules.Path} 0750 root root - -"
-        "L+ /etc/opensnitchd/network_aliases.json - - - - ${cfg.package}/etc/opensnitchd/network_aliases.json"
-        "L+ /etc/opensnitchd/system-fw.json - - - - ${cfg.package}/etc/opensnitchd/system-fw.json"
       ];
     };
 
+    environment.etc."opensnitchd/network_aliases.json".source =
+      "${cfg.package}/etc/opensnitchd/network_aliases.json";
+    environment.etc."opensnitchd/system-fw.json".source =
+      "${cfg.package}/etc/opensnitchd/system-fw.json";
   };
 
   meta.maintainers = with lib.maintainers; [

--- a/nixos/tests/opensnitch.nix
+++ b/nixos/tests/opensnitch.nix
@@ -11,7 +11,10 @@ in
   name = "opensnitch";
 
   meta = with pkgs.lib.maintainers; {
-    maintainers = [ onny ];
+    maintainers = [
+      onny
+      grimmauld
+    ];
   };
 
   nodes = {

--- a/nixos/tests/opensnitch.nix
+++ b/nixos/tests/opensnitch.nix
@@ -1,11 +1,14 @@
 { pkgs, lib, ... }:
 let
+  # opensnitch ebpf seems to handle non-x86 syscalls incorrectly
+  test_ebpf = pkgs.stdenv.hostPlatform.isx86;
+
   monitorMethods = [
-    "ebpf"
     "proc"
     "ftrace"
     "audit"
-  ];
+  ]
+  ++ lib.optional test_ebpf "ebpf";
 in
 {
   name = "opensnitch";
@@ -97,7 +100,7 @@ in
         client_allowed_${m}.succeed("curl http://server")
       '') monitorMethods
     )
-    + ''
+    + lib.optionalString test_ebpf ''
       # make sure the kernel modules were actually properly loaded
       client_blocked_ebpf.succeed(r"journalctl -u opensnitchd --grep '\[eBPF\] module loaded: /nix/store/.*/etc/opensnitchd/opensnitch\.o'")
       client_blocked_ebpf.succeed(r"journalctl -u opensnitchd --grep '\[eBPF\] module loaded: /nix/store/.*/etc/opensnitchd/opensnitch-procs\.o'")


### PR DESCRIPTION
Applies the changes i suggested in https://github.com/NixOS/nixpkgs/pull/525887, with some extra assertions.

- ebpf backend on aarch64 seems broken, disabled the test for now
- add myself to the test maintainers list
- assert `settings.rules.Path` is in a possible directory for systemd `StateDirectory` (this ensures it is writable and clearly associated with the opensnitch service)
- set service `StateDirectory` depending on `settings.Rules.Path`
- create rules directory in `preStart` instead of systemd tmpfiles. This may even make it possible to run the opensnitch service as a non-root user eventually.
- link `/etc/opensnitch` using `environment.etc`. This allows force-replacing the file if necessary.

cc @cmfcmf

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
