### PR TITLE
hut: add versionCheckHook

### DIFF
--- a/pkgs/by-name/hu/hut/package.nix
+++ b/pkgs/by-name/hu/hut/package.nix
@@ -3,6 +3,7 @@
   buildGoModule,
   fetchFromSourcehut,
   scdoc,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -18,6 +19,14 @@ buildGoModule (finalAttrs: {
 
   vendorHash = "sha256-7N+Zn7tzEG3dGeqNWmY98XUUKV7Y6g8wFZcQP9wea/8=";
 
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  versionCheckProgramArg = "version";
+
+  doInstallCheck = true;
+
   nativeBuildInputs = [
     scdoc
   ];
@@ -25,8 +34,8 @@ buildGoModule (finalAttrs: {
   makeFlags = [ "PREFIX=$(out)" ];
 
   ldflags = [
-    # Recommended in 0.8.0 release notes https://git.sr.ht/~xenrox/hut/refs/v0.8.0
-    "-X main.version=v${finalAttrs.version}"
+    # Recommended in 0.7.0 release notes https://git.sr.ht/~xenrox/hut/refs/v0.7.0
+    "-X main.version=${finalAttrs.version}"
   ];
 
   postBuild = ''


### PR DESCRIPTION
Also fixes the embedded version string which was clarified [1] shall not
include the 'v' prefix.

[1]: https://todo.sr.ht/~xenrox/hut/72


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
