### PR TITLE
liblangtag: 0.6.7 -> 0.6.8

### DIFF
--- a/pkgs/by-name/li/liblangtag/package.nix
+++ b/pkgs/by-name/li/liblangtag/package.nix
@@ -16,18 +16,18 @@
 
 stdenv.mkDerivation rec {
   pname = "liblangtag";
-  version = "0.6.7";
+  version = "0.6.8";
 
   # Artifact tarball contains lt-localealias.h needed for darwin
   src = fetchurl {
-    url = "https://bitbucket.org/tagoh/liblangtag/downloads/liblangtag-${version}.tar.bz2";
-    hash = "sha256-Xta81K4/PAXJEuYvIWzRpEEjhGFH9ymkn7VmjaUeAw4=";
+    url = "https://gitlab.com/tagoh/liblangtag/-/releases/${version}/downloads/liblangtag-${version}.tar.bz2";
+    hash = "sha256-qWl1t53dj+9tkpXAg/4/GvoaiJilcjXUBpJVreROXPI=";
   };
 
   core_zip = fetchurl {
     # please update if an update is available
-    url = "http://www.unicode.org/Public/cldr/46/core.zip";
-    hash = "sha256-+86cInWGKtJmaPs0eD/mwznz2S3f61oQoXdftYGBoV0=";
+    url = "http://www.unicode.org/Public/cldr/48/core.zip";
+    hash = "sha256-BsfGmNb9jWfO+sFaAgawEJsA4O8WNvhvhESfqVlWH3Q=";
   };
 
   language_subtag_registry = fetchurl {
@@ -66,11 +66,11 @@ stdenv.mkDerivation rec {
   ];
 
   meta = {
+    changelog = "https://gitlab.com/tagoh/liblangtag/-/blob/${version}/NEWS";
     description = "Interface library to access tags for identifying languages";
     license = lib.licenses.mpl20;
     maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.unix;
-    # There are links to a homepage that are broken by a BitBucket change
-    homepage = "https://bitbucket.org/tagoh/liblangtag/overview";
+    homepage = "https://gitlab.com/tagoh/liblangtag";
   };
 }


### PR DESCRIPTION
Changelog: https://gitlab.com/tagoh/liblangtag/-/blob/0.6.8/NEWS


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
