### PR TITLE
mail-tlsa-check-exporter: init at 0-unstable-2025-06-12, nixos/prometheus-exporters/mail-tlsa-check: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -16,6 +16,8 @@
 
 - [Nezha](https://github.com/nezhahq/nezha), a self-hosted, lightweight server and website monitoring and O&M tool. Available as [services.nezha](#opt-services.nezha.enable).
 
+- [mail-tlsa-check-exporter](https://github.com/ietf-tools/mail-tlsa-check-exporter), validates SMTP / IMAP server certificates against a TLSA record as a Prometheus exporter. Available as [services.prometheus.exporters.mail-tlsa-check](#opt-services.prometheus.exporters.mail-tlsa-check.enable).
+
 - [CastSponsorSkip](https://github.com/gabe565/CastSponsorSkip/), skips YouTube sponsorships (and sometimes ads) on all local Google Cast devices.
 
 - [Stump](https://www.stumpapp.dev/), a free and open source comics, manga and digital book server with OPDS support. Available as [services.stump](#opt-services.stump.enable).

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -86,6 +86,7 @@ let
         "lnd"
         "mail"
         "mailman3"
+        "mail-tlsa-check"
         "mikrotik"
         "modemmanager"
         "mongodb"

--- a/nixos/modules/services/monitoring/prometheus/exporters/mail-tlsa-check.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/mail-tlsa-check.nix
@@ -1,0 +1,164 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.prometheus.exporters.mail-tlsa-check;
+
+  inherit (lib)
+    boolToString
+    collect
+    concatStringsSep
+    getExe
+    isBool
+    isList
+    isString
+    listToAttrs
+    mapAttrsRecursive
+    mkForce
+    mkOption
+    mkPackageOption
+    optionalAttrs
+    pipe
+    toUpper
+    types
+    ;
+
+  environment = pipe cfg.settings [
+    (mapAttrsRecursive (
+      path: value:
+      optionalAttrs (value != null) {
+        name = toUpper "MTCE_${concatStringsSep "_" path}";
+        value =
+          if isList value then
+            concatStringsSep "," value
+          else if isBool value then
+            boolToString value
+          else
+            toString value;
+      }
+    ))
+    (collect (x: isString x.name or false && isString x.value or false))
+    listToAttrs
+  ];
+in
+{
+  port = 19309;
+  extraOpts = {
+    package = mkPackageOption pkgs "mail-tlsa-check-exporter" { };
+    settings = mkOption {
+      description = "Settings for the mail-tlsa-check-exporter";
+      type = types.submodule {
+        freeformType = types.attrs;
+
+        options = {
+          tlsa.record = mkOption {
+            description = "The TLSA record to monitor";
+            type = types.str;
+            example = "_25._tcp.smtp.example.org";
+          };
+          check.timeout = mkOption {
+            description = "Timeout for validation checks to complete before giving up, in milliseconds (e.g. 15000 for 15 seconds)";
+            type = types.ints.positive;
+            default = 15000;
+            example = 10000;
+          };
+          ipv4.enabled = mkOption {
+            description = "Whether to enable monitoring over IPv4";
+            type = types.bool;
+            default = true;
+            example = false;
+          };
+          ipv6.enabled = mkOption {
+            description = "Whether to enable monitoring over IPv6";
+            type = types.bool;
+            default = true;
+            example = false;
+          };
+          server.port = mkOption {
+            description = ''
+              The port that the exporter listens on.
+
+              ::: {.note}
+              This is a read-only option that is read from {option}`services.prometheus.exporters.mail-tlsa-check.port`.
+              :::
+            '';
+            type = types.port;
+            default = cfg.port;
+            defaultText = lib.literalExpression "config.services.prometheus.exporters.mail-tlsa-check.port";
+            readOnly = true;
+          };
+          smtp = {
+            hostname = mkOption {
+              description = "The SMTP hostname to monitor";
+              type = types.nullOr types.str;
+              default = null;
+              example = "smtp.example.org";
+            };
+            port = mkOption {
+              description = ''
+                The SMTP port to monitor
+
+                ::: {.note}
+                The exporter currently only supports explicit TLS (StartTLS), see <https://github.com/ietf-tools/mail-tlsa-check-exporter/issues/6>
+                :::
+              '';
+              type = types.port;
+              default = 587;
+              example = 465;
+            };
+            client = mkOption {
+              description = "The host to send in the SMTP EHLO command (name/domain/IP address)";
+              type = types.str;
+              default = "tlsa-smtp-synthetics-probe";
+              example = "tlsa-exporter";
+            };
+          };
+          imap = {
+            hostname = mkOption {
+              description = "The IMAP hostname to monitor";
+              type = types.nullOr types.str;
+              default = null;
+              example = "imap.example.org";
+            };
+            port = mkOption {
+              description = ''
+                The IMAP port to monitor
+
+                ::: {.note}
+                The exporter currently only supports explicit TLS (StartTLS), see <https://github.com/ietf-tools/mail-tlsa-check-exporter/issues/6>
+                :::
+              '';
+              type = types.port;
+              default = 143;
+            };
+          };
+        };
+      };
+    };
+  };
+
+  assertions = [
+    {
+      assertion = cfg.settings.ipv4.enabled || cfg.ipv6.enabled;
+      message = "Both IPv4 and IPv6 are disabled, this is not possible as it won't monitor anything";
+    }
+    {
+      assertion = cfg.settings.smtp.hostname != null || cfg.settings.imap.hostname != null;
+      message = "Both SMTP and IMAP are disabled, this is not possible as it won't monitor anything";
+    }
+  ];
+
+  serviceOpts = {
+    inherit environment;
+
+    serviceConfig = {
+      ExecStart = getExe cfg.package;
+      MemoryDenyWriteExecute = mkForce false; # because v8 won't start otherwise
+      Restart = "always"; # because apparently, this service crashes and is intended to do so, see the upstream systemd unit
+    };
+  };
+}

--- a/pkgs/by-name/ma/mail-tlsa-check-exporter/package.nix
+++ b/pkgs/by-name/ma/mail-tlsa-check-exporter/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  makeWrapper,
+  nodejs,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mail-tlsa-check-exporter";
+  version = "0-unstable-2025-06-12";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "ietf-tools";
+    repo = "mail-tlsa-check-exporter";
+    rev = "9843bf85971fbe130e8cd32e6fcf0dfcee92e929";
+    hash = "sha256-5c3epExz3tv6gRiIfpDyV1pkfcRVWjtNpl93LWsYKdk=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/libexec
+    cp $src/index.mjs $out/libexec
+
+    makeWrapper ${lib.getExe nodejs} $out/bin/mail-tlsa-check-exporter \
+      --append-flag $out/libexec/index.mjs
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch=main" ];
+  };
+
+  meta = {
+    description = "Validate SMTP / IMAP server certificates against a TLSA record as a Prometheus exporter";
+    homepage = "https://github.com/ietf-tools/mail-tlsa-check-exporter";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ bartoostveen ];
+    mainProgram = "mail-tlsa-check-exporter";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
- **mail-tlsa-check-exporter: init at 0-unstable-2025-06-12**
- **nixos/prometheus-exporters/mail-tlsa-check: init**

Still needs some [work upstream](https://github.com/ietf-tools/mail-tlsa-check-exporter/issues/5), but works perfectly fine for now.

Example of how it works right now.

```nix
services.prometheus.exporters.mail-tlsa-check = {
  enable = true;
  settings = {
    smtp.hostname = cfg.fqdn;
    imap.hostname = cfg.fqdn;
    tlsa.record = "_25._tcp.${cfg.fqdn}";
  };
};
```

cc @mweinelt

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
