### PR TITLE
grafana-loki: split outputs

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -24,6 +24,8 @@
 
 - Python 2 has been removed from the top-level package set, as it is long past end-of-life. The `python2`, `python27`, `python2Full`, `python27Full`, `python2Packages`, and `python27Packages` attributes, along with the legacy `python`, `pythonFull`, and `pythonPackages` aliases, now throw an error directing you to `python3`. The `isPy2` and `isPy27` package flags have been removed accordingly. The only remaining Python 2 interpreter is vendored inside the `resholve` package for its `oil` dependency and is not exposed for general use.
 
+- `grafana-loki` now splits its executables into separate outputs. The `loki`server remains in the default output. `logcli`, `lokitool` and `loki-canary` moved into the `logcli`, `lokitool` and `canary` outputs respectively. Configurations that relied on these binaries being in the default output must reference the corresponding output, such as `pkgs.grafana-loki.logcli`.
+
 - `services.timesyncd.extraConfig` has been removed in favor of the structured [](#opt-services.timesyncd.settings.Time) option. Use `services.timesyncd.settings.Time` to set any `timesyncd.conf(5)` option directly. For example, replace `services.timesyncd.extraConfig = "PollIntervalMaxSec=180";` with `services.timesyncd.settings.Time.PollIntervalMaxSec = 180;`.
 
 ## Other Notable Changes {#sec-release-26.11-notable-changes}

--- a/nixos/modules/services/monitoring/loki.nix
+++ b/nixos/modules/services/monitoring/loki.nix
@@ -101,7 +101,7 @@ in
       }
     ];
 
-    environment.systemPackages = [ cfg.package ]; # logcli
+    environment.systemPackages = [ cfg.package.logcli ];
 
     users.groups.${cfg.group} = { };
     users.users.${cfg.user} = {

--- a/pkgs/by-name/gr/grafana-loki/package.nix
+++ b/pkgs/by-name/gr/grafana-loki/package.nix
@@ -22,12 +22,24 @@ buildGoModule (finalAttrs: {
   vendorHash = null;
 
   subPackages = [
-    # TODO split every executable into its own package
     "cmd/loki"
     "cmd/loki-canary"
     "cmd/logcli"
     "cmd/lokitool"
   ];
+
+  outputs = [
+    "out"
+    "logcli"
+    "lokitool"
+    "canary"
+  ];
+
+  postInstall = ''
+    moveToOutput bin/logcli "$logcli"
+    moveToOutput bin/lokitool "$lokitool"
+    moveToOutput bin/loki-canary "$canary"
+  '';
 
   passthru = {
     tests = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Resolve the TODO in the loki package by splitting up the outputs. This enables installing loki tooling `logcli`,`canary` and `lokitool` as singel binary.

AI-Disclosure:
Claude:Opus-4.8 has been used to guide me through the process of creating this MR and review my changes.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
