### PR TITLE
{lomiri,lomiri-qt6}.lomiri-ui-toolkit: 1.3.5905 -> 1.3.5906

### DIFF
--- a/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/default.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  fetchpatch,
   gitUpdater,
   replaceVars,
   testers,
@@ -75,13 +74,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-ui-toolkit";
-  version = "1.3.5905";
+  version = "1.3.5906";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lomiri-ui-toolkit";
     rev = finalAttrs.version;
-    hash = "sha256-59Q7Atxt6CfR0LgNa6keGDY+HpV/eOdTngVHcUJEesg=";
+    hash = "sha256-OT3XH1NRnLHP80rgPllXfuos7vG3DHX95CXWm2fvwvI=";
   };
 
   outputs = [
@@ -93,13 +92,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   patches = [
-    # Remove when version > 1.3.5905
-    (fetchpatch {
-      name = "0001-lomiri-ui-toolkit-Fix-compatibility-with-Qt-6.11.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri-ui-toolkit/-/commit/57303d2b01549ef78b029ed05babbc9400e102f3.patch";
-      hash = "sha256-22QSOaYZ+hsctLt8+ffrzBIY3btp+rM6NBsu0gvQMeM=";
-    })
-
     ./2001-Mark-problematic-tests.patch
 
     (replaceVars ./2002-Nixpkgs-versioned-QML-path.patch.in {


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/lomiri-ui-toolkit/-/blob/1.3.5906/ChangeLog

Ran `lomiri.lomiri-ui-toolkit.passthru.updateScript` for `version` and `src.hash` updates.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
