### PR TITLE
ryubing: general refactor and fixes

### DIFF
--- a/pkgs/by-name/ry/ryubing/package.nix
+++ b/pkgs/by-name/ry/ryubing/package.nix
@@ -24,10 +24,12 @@
   gtk3,
   wrapGAppsHook3,
 }:
-
-buildDotnetModule rec {
+let
   pname = "ryubing";
   version = "1.3.3";
+in
+buildDotnetModule {
+  inherit pname version;
 
   src = fetchFromForgejo {
     domain = "git.ryujinx.app";
@@ -47,7 +49,9 @@ buildDotnetModule rec {
   ];
 
   nativeBuildInputs =
-    lib.optional stdenv.hostPlatform.isLinux wrapGAppsHook3
+    lib.optionals stdenv.hostPlatform.isLinux [
+      wrapGAppsHook3
+    ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       cctools
       darwin.sigtool
@@ -80,19 +84,17 @@ buildDotnetModule rec {
     ffmpeg_6
     libsoundio
   ]
-  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
-    udev
-  ]
-  ++ lib.optional stdenv.hostPlatform.isDarwin moltenvk;
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ udev ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ moltenvk ];
 
-  projectFile = "Ryujinx.sln";
+  projectFile = "src/Ryujinx/Ryujinx.csproj";
   testProjectFile = "src/Ryujinx.Tests/Ryujinx.Tests.csproj";
 
   # Tests on Darwin currently fail because of Ryujinx.Tests.Unicorn
   doCheck = !stdenv.hostPlatform.isDarwin;
 
   dotnetFlags = [
-    "/p:ExtraDefineConstants=DISABLE_UPDATER%2CFORCE_EXTERNAL_BASE_DIR"
+    "/p:ExtraDefineConstants=DISABLE_UPDATER"
   ];
 
   executables = [
@@ -101,28 +103,27 @@ buildDotnetModule rec {
 
   makeWrapperArgs = lib.optional stdenv.hostPlatform.isLinux [
     # Without this Ryujinx fails to start on wayland. See https://github.com/Ryujinx/Ryujinx/issues/2714
-    "--set SDL_VIDEODRIVER x11"
+    "--set"
+    "SDL_VIDEODRIVER"
+    "x11"
+    # From upstream wrapper script
+    "--set"
+    "DOTNET_EnableAlternateStackCheck"
+    "1"
   ];
 
   # Remove vendored SDL.
-  preFixup = "rm $out/lib/${pname}/libSDL2.*";
+  preFixup = ''
+    rm $out/lib/${pname}/libSDL2.*
+  '';
 
-  postFixup = ''
-    ${lib.optionalString stdenv.hostPlatform.isLinux ''
-      mkdir -p $out/share/{applications,icons/hicolor/scalable/apps,mime/packages}
-
-      pushd ${src}/distribution/linux
-
-      install -D ./Ryujinx.desktop  $out/share/applications/Ryujinx.desktop
-      install -D ./Ryujinx.sh       $out/bin/Ryujinx.sh
-      install -D ./mime/Ryujinx.xml $out/share/mime/packages/Ryujinx.xml
-      install -D ../misc/Logo.svg   $out/share/icons/hicolor/scalable/apps/Ryujinx.svg
-
-      popd
-    ''}
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    install -D distribution/linux/Ryujinx.desktop $out/share/applications/Ryujinx.desktop
+    install -D distribution/linux/mime/Ryujinx.xml $out/share/mime/packages/Ryujinx.xml
+    install -D distribution/misc/Logo.svg $out/share/icons/hicolor/scalable/apps/Ryujinx.svg
 
     # Don't make a softlink on OSX because of its case insensitivity
-    ${lib.optionalString (!stdenv.hostPlatform.isDarwin) "ln -s $out/bin/Ryujinx $out/bin/ryujinx"}
+    ln -s $out/bin/Ryujinx $out/bin/ryujinx
   '';
 
   passthru.updateScript = ./updater.sh;
@@ -130,7 +131,7 @@ buildDotnetModule rec {
   meta = {
     homepage = "https://ryujinx.app";
     # historical changelog https://git.ryujinx.app/projects/Ryubing/wiki/Changelog
-    changelog = "https://git.ryujinx.app/projects/Ryubing/releases/tag/${src.tag}";
+    changelog = "https://git.ryujinx.app/projects/Ryubing/releases/tag/${version}";
     description = "Experimental Nintendo Switch Emulator written in C# (community fork of Ryujinx)";
     longDescription = ''
       Ryujinx is an open-source Nintendo Switch emulator, created by gdkchan,

--- a/pkgs/by-name/ry/ryubing/package.nix
+++ b/pkgs/by-name/ry/ryubing/package.nix
@@ -6,16 +6,12 @@
   dotnetCorePackages,
   fetchFromForgejo,
   libx11,
-  libgdiplus,
   moltenvk,
-  ffmpeg,
+  ffmpeg_6,
   openal,
   libsoundio,
-  sndio,
   stdenv,
-  pulseaudio,
   vulkan-loader,
-  glew,
   libGL,
   libice,
   libsm,
@@ -25,7 +21,6 @@
   libxrandr,
   udev,
   SDL2,
-  SDL2_mixer,
   gtk3,
   wrapGAppsHook3,
 }:
@@ -41,6 +36,15 @@ buildDotnetModule rec {
     tag = version;
     hash = "sha256-LhQaXxmj5HIgfmrsDN8GhhVXlXHpDO2Q8JtNLaCq0mk=";
   };
+
+  patches = [
+    # Includes a few packages which only vendor deps
+    ./remove-dependency-nuget-pkgs.patch
+    # libsoundio is handled differently, and may be removed in the future
+    ./remove-vendored-libsoundio.patch
+    # Vendored glfw is unused
+    ./remove-unused-glfw.patch
+  ];
 
   nativeBuildInputs =
     lib.optional stdenv.hostPlatform.isLinux wrapGAppsHook3
@@ -58,16 +62,11 @@ buildDotnetModule rec {
 
   runtimeDeps = [
     libx11
-    libgdiplus
-    SDL2_mixer
     openal
-    libsoundio
-    sndio
     vulkan-loader
-    ffmpeg
+    libGL
 
     # Avalonia UI
-    glew
     libice
     libsm
     libxcursor
@@ -76,13 +75,13 @@ buildDotnetModule rec {
     libxrandr
     gtk3
 
-    # Headless executable
-    libGL
+    # Devendoring
     SDL2
+    ffmpeg_6
+    libsoundio
   ]
   ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     udev
-    pulseaudio
   ]
   ++ lib.optional stdenv.hostPlatform.isDarwin moltenvk;
 
@@ -105,13 +104,10 @@ buildDotnetModule rec {
     "--set SDL_VIDEODRIVER x11"
   ];
 
-  preInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
-    # workaround for https://github.com/Ryujinx/Ryujinx/issues/2349
-    mkdir -p $out/lib/sndio-6
-    ln -s ${sndio}/lib/libsndio.so $out/lib/sndio-6/libsndio.so.6
-  '';
+  # Remove vendored SDL.
+  preFixup = "rm $out/lib/${pname}/libSDL2.*";
 
-  preFixup = ''
+  postFixup = ''
     ${lib.optionalString stdenv.hostPlatform.isLinux ''
       mkdir -p $out/share/{applications,icons/hicolor/scalable/apps,mime/packages}
 
@@ -149,6 +145,7 @@ buildDotnetModule rec {
       jk
       artemist
       willow
+      ranidspace
     ];
     platforms = [
       "x86_64-linux"

--- a/pkgs/by-name/ry/ryubing/package.nix
+++ b/pkgs/by-name/ry/ryubing/package.nix
@@ -48,6 +48,9 @@ buildDotnetModule {
     ./remove-unused-glfw.patch
   ];
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   nativeBuildInputs =
     lib.optionals stdenv.hostPlatform.isLinux [
       wrapGAppsHook3

--- a/pkgs/by-name/ry/ryubing/remove-dependency-nuget-pkgs.patch
+++ b/pkgs/by-name/ry/ryubing/remove-dependency-nuget-pkgs.patch
@@ -1,0 +1,14 @@
+diff --git a/src/Ryujinx/Ryujinx.csproj b/src/Ryujinx/Ryujinx.csproj
+index 480d14781..dac8ff111 100644
+--- a/src/Ryujinx/Ryujinx.csproj
++++ b/src/Ryujinx/Ryujinx.csproj
+@@ -62,9 +62,6 @@
+     <PackageReference Include="Projektanker.Icons.Avalonia.FontAwesome" />
+     <PackageReference Include="Projektanker.Icons.Avalonia.MaterialDesign" />
+     <PackageReference Include="OpenTK.Core" />
+-    <PackageReference Include="Ryujinx.Audio.OpenAL.Dependencies" Condition="'$(RuntimeIdentifier)' != 'linux-x64' AND '$(RuntimeIdentifier)' != 'linux-arm64' AND '$(RuntimeIdentifier)' != 'osx-x64' AND '$(RuntimeIdentifier)' != 'osx-arm64'" />
+-    <PackageReference Include="Ryujinx.Graphics.Nvdec.Dependencies.AllArch" />
+-    <PackageReference Include="Ryujinx.Graphics.Vulkan.Dependencies.MoltenVK" Condition="'$(RuntimeIdentifier)' != 'linux-x64' AND '$(RuntimeIdentifier)' != 'linux-arm64' AND '$(RuntimeIdentifier)' != 'win-x64' AND '$(RuntimeIdentifier)' != 'win-arm64'" />
+     <PackageReference Include="Ryujinx.UpdateClient" />
+     <PackageReference Include="Ryujinx.Systems.Update.Common" />
+     <PackageReference Include="securifybv.ShellLink" />

--- a/pkgs/by-name/ry/ryubing/remove-unused-glfw.patch
+++ b/pkgs/by-name/ry/ryubing/remove-unused-glfw.patch
@@ -1,0 +1,12 @@
+diff --git a/src/Ryujinx.Graphics.Vulkan/Ryujinx.Graphics.Vulkan.csproj b/src/Ryujinx.Graphics.Vulkan/Ryujinx.Graphics.Vulkan.csproj
+index 5481e57f2..867f5a2b1 100644
+--- a/src/Ryujinx.Graphics.Vulkan/Ryujinx.Graphics.Vulkan.csproj
++++ b/src/Ryujinx.Graphics.Vulkan/Ryujinx.Graphics.Vulkan.csproj
+@@ -51,7 +51,6 @@
+   </ItemGroup>
+ 
+   <ItemGroup>
+-    <PackageReference Include="OpenTK.Windowing.GraphicsLibraryFramework" />
+     <PackageReference Include="shaderc.net" />
+     <PackageReference Include="Silk.NET.Vulkan" />
+     <PackageReference Include="Silk.NET.Vulkan.Extensions.EXT" />

--- a/pkgs/by-name/ry/ryubing/remove-vendored-libsoundio.patch
+++ b/pkgs/by-name/ry/ryubing/remove-vendored-libsoundio.patch
@@ -1,0 +1,24 @@
+diff --git a/src/Ryujinx.Audio.Backends.SoundIo/Ryujinx.Audio.Backends.SoundIo.csproj b/src/Ryujinx.Audio.Backends.SoundIo/Ryujinx.Audio.Backends.SoundIo.csproj
+index 911401338..ec56f0f52 100644
+--- a/src/Ryujinx.Audio.Backends.SoundIo/Ryujinx.Audio.Backends.SoundIo.csproj
++++ b/src/Ryujinx.Audio.Backends.SoundIo/Ryujinx.Audio.Backends.SoundIo.csproj
+@@ -10,19 +10,5 @@
+     <ProjectReference Include="..\Ryujinx.Audio\Ryujinx.Audio.csproj" />
+   </ItemGroup>
+ 
+-  <ItemGroup>
+-    <ContentWithTargetPath Include="Native\libsoundio\libs\libsoundio.dll" Condition="'$(RuntimeIdentifier)' != 'linux-x64' AND '$(RuntimeIdentifier)' != 'linux-arm64' AND '$(RuntimeIdentifier)' != 'osx-x64' AND '$(RuntimeIdentifier)' != 'osx-arm64'">
+-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+-      <TargetPath>libsoundio.dll</TargetPath>
+-    </ContentWithTargetPath>
+-    <ContentWithTargetPath Include="Native\libsoundio\libs\libsoundio.dylib" Condition="'$(RuntimeIdentifier)' != 'linux-x64' AND '$(RuntimeIdentifier)' != 'linux-arm64' AND '$(RuntimeIdentifier)' != 'win-x64' AND '$(RuntimeIdentifier)' != 'win-arm64'">
+-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+-      <TargetPath>libsoundio.dylib</TargetPath>
+-    </ContentWithTargetPath>
+-    <ContentWithTargetPath Include="Native\libsoundio\libs\libsoundio.so" Condition="'$(RuntimeIdentifier)' != 'win-x64' AND '$(RuntimeIdentifier)' != 'win-arm64' AND '$(RuntimeIdentifier)' != 'osx-x64' AND '$(RuntimeIdentifier)' != 'osx-arm64' AND '$(RuntimeIdentifier)' != 'linux-arm64'">
+-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+-      <TargetPath>libsoundio.so</TargetPath>
+-    </ContentWithTargetPath>
+-  </ItemGroup>
+ 
+ </Project>

--- a/pkgs/by-name/ry/ryubing/updater.sh
+++ b/pkgs/by-name/ry/ryubing/updater.sh
@@ -28,7 +28,7 @@ cd ../../../..
 
 if [[ "${1-default}" != "--deps-only" ]]; then
     SHA="$(nix-prefetch-git https://git.ryujinx.app/projects/Ryubing --rev "$NEW_VERSION" --quiet | jq -r '.sha256')"
-    SRI=$(nix --experimental-features nix-command hash to-sri "sha256:$SHA")
+    SRI=$(nix --experimental-features nix-command hash convert --hash-algo sha256 --to sri "$SHA")
     update-source-version ryubing "$NEW_VERSION" "$SRI"
 fi
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Removes dependencies which weren't used, and removes vendored libraries to allow the system libraries to be used instead where applicable. The vendored SDL was unable to detect which audio server was available, requiring sndio or pipewire to be added as a dependency. This has been fixed and those packages have been removed.

Changes the build project from the entire sln to just the csproj for the emulator itself. This cuts down the final size of the package and mirrors the upstream releases.

Includes a lot of small fixes and formatting changes

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
