### PR TITLE
alienarea: switch to finalAttrs, fix compiliation, add glPath

### DIFF
--- a/pkgs/by-name/al/alienarena/package.nix
+++ b/pkgs/by-name/al/alienarena/package.nix
@@ -8,24 +8,32 @@
   libogg,
   libvorbis,
   libx11,
+  libxext,
   libxxf86vm,
+  makeWrapper,
+  mesa,
   openal,
   pkg-config,
   stdenv,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "alienarena";
   version = "7.71.7";
 
   src = fetchFromGitHub {
     owner = "alienarena";
     repo = "alienarena";
-    rev = version;
-    hash = "sha256-ri0p/0onI5DU7kDxwdFxRyT1LQLVe89VNEYPXPgilOs=";
+    tag = finalAttrs.version;
+    hash = "sha256-uuCjpmU7ZrWrO79bhDRUzZF1pXkHHZRjf5UFKoHmh4A=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  env.NIX_CFLAGS_COMPILE = "-Wno-incompatible-pointer-types -Wno-return-mismatch -Wno-int-conversion";
 
   buildInputs = [
     curl
@@ -35,9 +43,26 @@ stdenv.mkDerivation rec {
     libogg
     libvorbis
     libx11
+    libxext
     libxxf86vm
     openal
   ];
+
+  postFixup = ''
+    glPath=${
+      lib.makeLibraryPath [
+        libGL
+        mesa
+      ]
+    }
+    for bin in alienarena alienarena-ded; do
+      wrapProgram $out/bin/$bin \
+        --prefix LD_LIBRARY_PATH : "$glPath" \
+        --prefix LIBGL_DRIVERS_PATH : "${mesa}/lib/dri" \
+        --prefix LIBGL_DRIVERS_PATH : "/run/opengl-driver/lib/dri" \
+        --set-default __GLX_VENDOR_LIBRARY_NAME mesa
+    done
+  '';
 
   patchPhase = ''
     substituteInPlace ./configure \
@@ -46,7 +71,7 @@ stdenv.mkDerivation rec {
   '';
 
   meta = {
-    changelog = "https://github.com/alienarena/alienarena/releases/tag/${version}";
+    changelog = "https://github.com/alienarena/alienarena/releases/tag/${finalAttrs.version}";
     description = "Free, stand-alone first-person shooter computer game";
     longDescription = ''
       Do you like old school deathmatch with modern features? How
@@ -63,4 +88,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     hydraPlatforms = [ ];
   };
-}
+})


### PR DESCRIPTION
migrate to finalAttrs, fix alienarena build, move out of treewide PR #524874 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
