### PR TITLE
algol68g: 3.12.1->3.12.2

### DIFF
--- a/pkgs/by-name/al/algol68g/package.nix
+++ b/pkgs/by-name/al/algol68g/package.nix
@@ -15,12 +15,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "algol68g";
-  version = "3.12.1";
+  version = "3.12.2";
 
   src = fetchurl {
     # Uses archive.org because the original site removes older versions.
-    url = "https://web.archive.org/web/20260515052918/https://algol68genie.nl/algol68g-3.12.1.tar.gz";
-    hash = "sha256-Mdoca6W1Wyyv7WrmzaAW/fn0uLkXy6MwSDImVwB+mBk";
+    url = "https://web.archive.org/web/20260515052918/https://algol68genie.nl/algol68g-3.12.2.tar.gz";
+    hash = "sha256-4fiubqpgoH3YOlCg1bJHQ3kOayKNulW3CYbOK1awE7k";
   };
 
   outputs = [


### PR DESCRIPTION
Update to 3.12.2

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
