### PR TITLE
bloaty: 1.1-unstable-2024-09-23 -> 1.1-unstable-2026-05-31

### DIFF
--- a/pkgs/by-name/bl/bloaty/package.nix
+++ b/pkgs/by-name/bl/bloaty/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   cmake,
   zlib,
+  zstd,
   fetchFromGitHub,
   re2,
   abseil-cpp,
@@ -18,19 +19,19 @@ let
   demumble = fetchFromGitHub {
     owner = "nico";
     repo = "demumble";
-    rev = "01098eab821b33bd31b9778aea38565cd796aa85";
-    hash = "sha256-605SsXd7TSdm3BH854ChHIZbOXcHI/n8RN+pFMz4Ex4=";
+    rev = "10e00fb708a3d24c1bb16682cac76925ffb76af5";
+    hash = "sha256-JNSSvYE5bh/9RVLQXVNmWRKAzidg4ktmqLI7pcUATDs=";
   };
 in
 stdenv.mkDerivation {
   pname = "bloaty";
-  version = "1.1-unstable-2024-09-23";
+  version = "1.1-unstable-2026-05-31";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "bloaty";
-    rev = "0c89acd7e8b9d91fd1e9c8c129be627b4e47f1ea";
-    hash = "sha256-txZDPytWnkjkiVkPL2SWLwCPEtVvqoI/MVRvbJ2kBGw=";
+    rev = "4a601b636e2347322d0371c8bf8ca5eaeaca4bac";
+    hash = "sha256-16Ic2x5JctSCuHJZjK96xkgJw8qyy8GqFupwWuc2U/k=";
   };
 
   cmakeFlags = [
@@ -43,7 +44,6 @@ stdenv.mkDerivation {
     # Build system relies on some of those source files
     rm -rf third_party/googletest third_party/abseil-cpp third_party/demumble
     ln -s ${gtest.src} third_party/googletest
-    ln -s ${abseil-cpp.src} third_party/abseil-cpp
     ln -s ${demumble} third_party/demumble
     substituteInPlace CMakeLists.txt \
       --replace "find_package(Python COMPONENTS Interpreter)" "" \
@@ -60,6 +60,7 @@ stdenv.mkDerivation {
 
   buildInputs = [
     zlib
+    zstd
     re2
     abseil-cpp
     protobuf


### PR DESCRIPTION
Update bloaty to the latest version from GitHub. This adds support for binaries with DWARF5 debug info.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
