### PR TITLE
gocryptfs: stop depending on fuse

### DIFF
--- a/nixos/tests/gocryptfs.nix
+++ b/nixos/tests/gocryptfs.nix
@@ -44,6 +44,9 @@
     # Wait for mounts
     machine.wait_for_unit("local-fs.target")
 
+    # Sometimes gocryptfs files are slow to appear
+    machine.wait_for_file("/plain/data.txt")
+
     # Ensure the canary is alive
     machine.succeed("grep -q success /plain/data.txt")
 

--- a/pkgs/by-name/go/gocryptfs/0001-mount.go-try-fusermount3-suid-wrapper-and-fallback-t.patch
+++ b/pkgs/by-name/go/gocryptfs/0001-mount.go-try-fusermount3-suid-wrapper-and-fallback-t.patch
@@ -1,0 +1,43 @@
+From ac51f09a9e1a1307ebaf38ffab66eb729cf1b0a5 Mon Sep 17 00:00:00 2001
+From: Florian Klink <flokli@flokli.de>
+Date: Tue, 2 Jun 2026 20:17:25 +0200
+Subject: [PATCH] mount.go: try fusermount3 suid wrapper and fallback to
+ fusermount from $PATH
+
+On NixOS, we want to use the fusermount3 suid wrapper to allow mounting
+as non-root user.
+
+We still want to try fusermount from `$PATH` to work on non-NixOS, and
+keep the /bin/fusermount fallback as a last resort.
+---
+ mount.go | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/mount.go b/mount.go
+index 2508409..defc967 100644
+--- a/mount.go
++++ b/mount.go
+@@ -526,14 +526,16 @@ func initGoFuse(rootNode fs.InodeEmbedder, args *argContainer) *fuse.Server {
+ 
+ // haveFusermount2 finds out if the "fusermount" binary is from libfuse 2.x.
+ func haveFusermount2() bool {
+-	path, err := exec.LookPath("fusermount")
+-	if err != nil {
+-		path = "/bin/fusermount"
++	path := "/bin/fusermount"
++	if _, err := os.Stat("/run/wrappers/bin/fusermount3"); err == nil {
++		path = "/run/wrappers/bin/fusermount3"
++	} else if newPath, err := exec.LookPath("fusermount"); err == nil {
++		path = newPath
+ 	}
+ 	cmd := exec.Command(path, "-V")
+ 	var out bytes.Buffer
+ 	cmd.Stdout = &out
+-	err = cmd.Run()
++	err := cmd.Run()
+ 	if err != nil {
+ 		tlog.Warn.Printf("warning: haveFusermount2: %v", err)
+ 		return false
+-- 
+2.53.0
+

--- a/pkgs/by-name/go/gocryptfs/package.nix
+++ b/pkgs/by-name/go/gocryptfs/package.nix
@@ -2,7 +2,6 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  fuse,
   makeWrapper,
   openssl,
   pandoc,
@@ -21,6 +20,8 @@ buildGoModule (finalAttrs: {
     rev = "v${finalAttrs.version}";
     sha256 = "sha256-uQLFcabN418m1dvogJ71lJeTF3F9JycK/8qCPaXblSU=";
   };
+
+  patches = [ ./0001-mount.go-try-fusermount3-suid-wrapper-and-fallback-t.patch ];
 
   vendorHash = "sha256-dvOROh5TsMl+52RvKmDG4ftNv3WF19trgttu5BGWktU=";
 
@@ -56,11 +57,7 @@ buildGoModule (finalAttrs: {
     popd
   '';
 
-  # use --suffix here to ensure we don't shadow /run/wrappers/bin/fusermount,
-  # as the setuid wrapper is required to use gocryptfs as non-root on NixOS
   postInstall = ''
-    wrapProgram $out/bin/gocryptfs \
-      --suffix PATH : ${lib.makeBinPath [ fuse ]}
     ln -s $out/bin/gocryptfs $out/bin/mount.fuse.gocryptfs
   '';
 


### PR DESCRIPTION
Part of #526161.

The previous approach prefixed $PATH to make a fusermount available, but this would be gone if we'd just replace it to fuse3, as #526670 attempted (which would break mounting via fstab).

Instead, patch the source to try our suid wrapper (which is always preferred so mounting as non-root still works), and then fallback to a fusermount from $PATH (to work on non-NixOS distros)

Ideally this would also try fusermount3, but whether to do that is probably something for upstream to decide, and other distros probably also provide a symlink for compatibility reasons.

Closes #526670.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
