### PR TITLE
amiri: switch to finalAttrs

### DIFF
--- a/pkgs/by-name/am/amiri/package.nix
+++ b/pkgs/by-name/am/amiri/package.nix
@@ -4,12 +4,12 @@
   fetchzip,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "amiri";
   version = "1.003";
 
   src = fetchzip {
-    url = "https://github.com/aliftype/amiri/releases/download/${version}/Amiri-${version}.zip";
+    url = "https://github.com/aliftype/amiri/releases/download/${finalAttrs.version}/Amiri-${finalAttrs.version}.zip";
     hash = "sha256-BsYPMBlRdzlkvyleZIxGDuGjmqhDlEJ4udj8zoKUSzA=";
   };
 
@@ -18,8 +18,8 @@ stdenvNoCC.mkDerivation rec {
 
     mkdir -p $out/share/fonts/truetype
     mv *.ttf $out/share/fonts/truetype/
-    mkdir -p $out/share/doc/${pname}-${version}
-    mv {*.html,*.txt,*.md} $out/share/doc/${pname}-${version}/
+    mkdir -p $out/share/doc/amiri-${finalAttrs.version}
+    mv {*.html,*.txt,*.md} $out/share/doc/amiri-${finalAttrs.version}/
 
     runHook postInstall
   '';
@@ -31,4 +31,4 @@ stdenvNoCC.mkDerivation rec {
     maintainers = [ lib.maintainers.vbgl ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
switch to finalAttrs, move out of treewide PR #524874 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
