### PR TITLE
deadlock-mod-manager: 0.18.0 -> 1.0.0

### DIFF
--- a/pkgs/by-name/de/deadlock-mod-manager/package.nix
+++ b/pkgs/by-name/de/deadlock-mod-manager/package.nix
@@ -4,7 +4,7 @@
   rustPlatform,
   cargo-tauri,
   nodejs,
-  pnpm_9,
+  pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
   pkg-config,
@@ -27,26 +27,26 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "deadlock-mod-manager";
-  version = "0.18.0";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "deadlock-mod-manager";
     repo = "deadlock-mod-manager";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-+64Y6BFwgQIQhmFzZXOeJ/IGFn+OXV58I/ZdARVFt4w=";
+    hash = "sha256-tSOSjapAlAd63Xkc+MNFVKn1k4+AtW3w3GhicRTV9Pg=";
   };
 
   cargoRoot = "apps/desktop";
   buildAndTestSubdir = finalAttrs.cargoRoot;
 
-  cargoHash = "sha256-6ljyPdobcoBaYyarc7Iin5N24y1YXPafrYAk2xvBtvY=";
+  cargoHash = "sha256-x0lhn8nAV9xTgWbRAabJscATSCNpkKpzWvdnuZ4BEvw=";
 
   nativeBuildInputs = [
     rustPlatform.cargoSetupHook
     cargo-tauri.hook
     nodejs
     pnpmConfigHook
-    pnpm_9
+    pnpm_11
     pkg-config
     wrapGAppsHook3
   ];
@@ -76,10 +76,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
       version
       src
       ;
-    pnpm = pnpm_9;
+    pnpm = pnpm_11;
     fetcherVersion = 3;
     sourceRoot = "source";
-    hash = "sha256-6lMTvlkIeM9kkbFhHzS9jJsHk2bVZWZs6GPgn+X3Rss=";
+    hash = "sha256-zl+ZrI21EnMBeMInKvEkUObiZ0OA5SJLJjnHwu/Dagc=";
   };
 
   patches = [
@@ -88,9 +88,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   env.VITE_API_URL = "https://api.deadlockmods.app";
 
-  # Skip tests that require network access
   checkFlags = [
+    # Requires network access
     "--skip=download_manager::downloader::tests::test_download_file"
+    # Asserts that set_steam_dir rejects a non-Steam directory, but steamlocate
+    # 2.1.0's SteamDir::from_dir only checks that the path is a directory
+    # (further validation is an upstream TODO), so this fails in any environment.
+    "--skip=mod_manager::steam_manager::tests::set_steam_dir_rejects_invalid_directory"
   ];
 
   preFixup = ''


### PR DESCRIPTION
Updates deadlock-mod-manager to v1.0.0.

The automated update couldn't handle this release because v1.0.0 bumps the upstream package manager from pnpm 9 to pnpm 11.2.2, so pnpm_9 is switched to pnpm_11 along with the recomputed pnpmDeps/cargo/src hashes.

v1.0.0 also adds a unit test ([`set_steam_dir_rejects_invalid_directory`](https://github.com/deadlock-mod-manager/deadlock-mod-manager/blob/main/apps/desktop/src-tauri/src/mod_manager/steam_manager.rs#L366)) that fails in every environment: it expects [`set_steam_dir`](https://github.com/deadlock-mod-manager/deadlock-mod-manager/blob/main/apps/desktop/src-tauri/src/mod_manager/steam_manager.rs#L113) to reject a non-Steam directory, but steamlocate 2.1.0's  [`SteamDir::from_dir`](https://github.com/WilliamVenner/steamlocate-rs/blob/master/src/lib.rs#L218) only checks that the path is a directory (deeper validation is an upstream TODO). The test is bypassed in checkFlags with an explanatory comment.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
