### PR TITLE
pacman-game: build for Linux too, not just Darwin

### DIFF
--- a/pkgs/by-name/pa/pacman-game/package.nix
+++ b/pkgs/by-name/pa/pacman-game/package.nix
@@ -1,4 +1,5 @@
 {
+  installShellFiles,
   lib,
   stdenv,
   fetchFromGitHub,
@@ -7,6 +8,8 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "pacman-game";
   version = "0-unstable-2017-01-30";
+  strictDeps = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "justinjo";
@@ -15,10 +18,18 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-2GwIv8XMbd8WZBaPp4tOblAzku49UilHmv6bG9A1y+4=";
   };
 
+  # The upstream Makefile hardcodes clang++, which is the default compiler on
+  # Darwin but not on Linux. Use the stdenv compiler so it builds everywhere.
+  postPatch = ''
+    substituteInPlace Makefile --replace-fail "clang++" "c++"
+  '';
+
+  nativeBuildInputs = [ installShellFiles ];
+
   installPhase = ''
     runHook preInstall
 
-    install -Dm755 pacman $out/bin/pacman
+    installBin pacman
 
     runHook postInstall
   '';
@@ -27,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Command line pacman game";
     homepage = "https://github.com/justinjo/Pacman";
     license = lib.licenses.unlicense;
-    platforms = lib.platforms.darwin;
+    platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ ethancedwards8 ];
     mainProgram = "pacman";
   };


### PR DESCRIPTION
This is one of the two (!) packages I could find that support `aarch64-darwin` and/or `aarch64-linux` but not `x86_64-linux`, without a good reason:

- #527746
- #527760

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
