### PR TITLE
installIconsHook: init

### DIFF
--- a/doc/hooks/index.md
+++ b/doc/hooks/index.md
@@ -22,6 +22,7 @@ gnome.section.md
 haredo.section.md
 installShellFiles.section.md
 installFonts.section.md
+installIconsHook.section.md
 julec.section.md
 just.section.md
 libglycin.section.md

--- a/doc/hooks/installIconsHook.section.md
+++ b/doc/hooks/installIconsHook.section.md
@@ -1,0 +1,213 @@
+# installIconsHook {#install-icons-hook}
+
+This hook attempts to detect icons in a project, and install them in the [standard freedesktop locations](https://specifications.freedesktop.org/icon-theme/latest/#directory_layout)
+
+This hook runs in the [`postInstall`](#var-stdenv-postInstall) stdenv phase.
+
+This hook will install the icons to the stdenv-standard prefix location.
+
+:::{.note}
+This hook requires `__structuredAttrs` to be enabled.
+:::
+
+## Examples {#install-icons-hook-examples}
+
+:::{.example #exinstall-icons-hook-examples-manual}
+# Installing icons with manual specification
+
+Imagine a package source directory with the following layout:
+```
+$sourceRoot
+└── assets
+   ├── icon16.png
+   ├── icon32.png
+   ├── icon64.png
+   ├── icon126.png
+   ├── icon256.png
+   └── icon.svg
+```
+The following derivation would install the icons:
+```nix
+{
+  lib,
+  stdenv,
+  installIconsHook,
+  emptyDir,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "example1";
+  version = "1.0";
+
+  src = emptyDir;
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    installIconsHook
+  ];
+
+  # Paths are all relative to the derivations CWD
+  iconsToInstall = {
+    "16x16" = "asssets/icon16.png";
+    "32x32" = "asssets/icon32.png";
+    "64x64" = "assets/icon64.png";
+    "128x128" = "asssets/icon128.png";
+    "256x256" = "asssets/icon256.png";
+    "svg" = "assets/icon.svg";
+  };
+})
+```
+:::
+
+:::{.example #exinstall-icons-hook-examples-detection}
+# Installing icons with automatic detection
+This hook can also detect name matches for icons as well.
+
+Imagine a package source directory with the following layout:
+```
+$sourceRoot
+└── assets
+   └── icons
+      ├── icon16x16.png
+      ├── icon32x32.png
+      ├── icon64x64.png
+      ├── icon128x128.png
+      ├── icon256x256.png
+      └── icon.svg
+```
+The following derivation would detect the icons, and install them.
+```nix
+{
+  lib,
+  stdenv,
+  installIconsHook,
+  emptyDir,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "example2";
+  version = "1.0";
+
+  src = emptyDir;
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    installIconsHook
+  ];
+
+  # Paths are all relative to the derivations CWD
+  #
+  # This narrows the search in case there are other
+  # potential matches in other directories
+  iconSearchDir = "assets/icons";
+})
+```
+:::
+
+## Variables controlling `installIconsHook` {#install-icons-hook-variables}
+
+### `installIconsHook` Exclusive Variables {#install-icons-hook-exclusive-variables}
+
+#### `iconsToInstall` {#install-icons-hook-icons-to-install}
+
+An attribute set of icons to install, and the path to install them from.
+This path is relative to the current working directory, usually [`sourceRoot`](#var-stdenv-sourceRoot).
+
+There are specific attributes that are looked at by the hook, any others will be ignored.
+
+All of the attributes are optional, and do not need to all be filled in. Any combination is valid.
+
+The following attributes interpreted as PNG images.
+
+* 8x8
+* 16x16
+* 32x32
+* 48x48
+* 64x64
+* 72x72
+* 96x96
+* 128x128
+* 256x256
+* 512x512
+
+The following other attributes are also accepted:
+
+* svg
+
+Path to an [SVG](https://en.wikipedia.org/wiki/SVG) file of the icon.
+
+* ico
+
+Path to an [ICO](https://en.wikipedia.org/wiki/ICO_(file_format)) archive of icons, usually created for Windows installations.
+This hook can unpack these archives and install the icons inside.
+
+
+The following attribute set informs the hook of icons that are at `$CWD/assets`, as well as an addtional icon that is fetched.
+The paths can be store paths, and do not need to be in the source directory.
+
+```
+iconsToInstall = {
+  "16x16" = "asssets/icon16.png";
+  "32x32" = "asssets/icon32.png";
+  "256x256" = "asssets/icon256.png";
+  "64x64" = fetchurl {
+    url = "somewebsite.com/icon.png";
+    hash = lib.fakeHash;
+  };
+  "svg" = "assets/icon.svg";
+  "ico" = "assets/icon.ico"
+};
+```
+
+#### `installIconsSearchDir` {#install-icons-hook-search-dir}
+
+The directory to search for icons in. This directory is relative to the current working directory, but can also be an absolute path or store directory.
+By default it is the current working directory.
+
+#### `installIconName` {#install-icons-name}
+
+The name to install the icons with. This is not usually needed, as by default it is set to the value of `meta.mainProgram.
+But if installing icons for something else, or for a program that is not the main program, this will set the names.
+
+```
+installIconName = "someProgram";
+```
+
+#### `extraIconsToInstall` {#install-icons-hook-extra}
+
+These are icons that do not fit in with the freedesktop hicolor standard.
+These icons will be placed at `$prefix/share/icons/$icon.png`.
+A single png and a single svg can be used as extra icons.
+This is due to how freedesktop specifies icon lookup.
+It is keyed by application name, and also only allows png and svg extensions.
+
+Examples of what these could be are very large icons and icons of non-standard sizes.
+
+```
+{
+  extraIconsToInstall = {
+    png = "assets/weird-icon.png";
+    svg = "assets/weird-icon.svg"
+  };
+}
+```
+#### `dontInstallIcons` {#install-icons-hook-dont}
+
+Disable automatic installing of icons.
+Allows usage of the Bash icon installation helpers.
+
+```nix
+{
+  dontInstallIcons = true;
+  postInstall = ''
+    installHicolorIcon "$out" "assets/icon1.png" "cool_program_name" "16x16"
+    installHicolorIcon "$out" "assets/icon2.png" "cool_program_name" "32x32"
+    installHicolorIcon "$out" "assets/icon3.png" "cool_program_name" "64x64"
+
+    installOtherIcon "$out" "assets/other.png" "cool_program_name.png"
+  '';
+}
+```
+

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -140,6 +140,12 @@
   "ex-writeShellApplication": [
     "index.html#ex-writeShellApplication"
   ],
+  "exinstall-icons-hook-examples-detection": [
+    "index.html#exinstall-icons-hook-examples-detection"
+  ],
+  "exinstall-icons-hook-examples-manual": [
+    "index.html#exinstall-icons-hook-examples-manual"
+  ],
   "first-package-go": [
     "index.html#first-package-go"
   ],
@@ -154,6 +160,33 @@
   ],
   "inkscape-plugins": [
     "index.html#inkscape-plugins"
+  ],
+  "install-icons-hook": [
+    "index.html#install-icons-hook"
+  ],
+  "install-icons-hook-dont": [
+    "index.html#install-icons-hook-dont"
+  ],
+  "install-icons-hook-examples": [
+    "index.html#install-icons-hook-examples"
+  ],
+  "install-icons-hook-exclusive-variables": [
+    "index.html#install-icons-hook-exclusive-variables"
+  ],
+  "install-icons-hook-extra": [
+    "index.html#install-icons-hook-extra"
+  ],
+  "install-icons-hook-icons-to-install": [
+    "index.html#install-icons-hook-icons-to-install"
+  ],
+  "install-icons-hook-search-dir": [
+    "index.html#install-icons-hook-search-dir"
+  ],
+  "install-icons-hook-variables": [
+    "index.html#install-icons-hook-variables"
+  ],
+  "install-icons-name": [
+    "index.html#install-icons-name"
   ],
   "installfonts": [
     "index.html#installfonts"

--- a/pkgs/by-name/in/installIconsHook/icon-install-hook.sh
+++ b/pkgs/by-name/in/installIconsHook/icon-install-hook.sh
@@ -1,0 +1,329 @@
+# shellcheck shell=bash
+
+# Looks for a path with the pattern
+# *${NAME}*.*${EXTENSION}
+#
+# So that both files containing a fragment, and directories are matched.
+#
+# Args:
+# 1 = The directory to search
+# 2 = The name to glob for
+# 3 = The extension to glob for
+#
+# Returns:
+# str -> The path found
+findIcon() {
+  local -r searchDir="$1"
+  local -r name="$2"
+  local -r extension="$3"
+
+  local -a resultArray=()
+
+  local -ra findArgs=(
+   # Search for files in the the user-provided dir, or the cwd if not provided
+   "${searchDir}" "-type" "f"
+   # Search for name and extension
+   "-ipath" "*${name}*.*${extension}"
+   # print them with null seperating
+   "-print0"
+  )
+
+  # If not, try searching for a file to use
+  # We are looking for an SVG file specifically.
+  readarray -td '' resultArray < <(find "${findArgs[@]}")
+
+  if [[ ${#resultArray[@]} -eq 1 ]]; then
+    # Found exactly one item
+    echo "${resultArray[0]}"
+  elif [[ ${#resultArray[@]} -eq 0 ]]; then
+    echo ""
+  else
+    echo "${resultArray[*]}"
+    exit 1
+  fi
+}
+
+# Checks whether an icon is a png or SVG
+# Techinically we could allow XPM, but freedesktop
+# recommends not using those.
+#
+# $1 = path to icon
+getMime() {
+  local -r iconPath="$1"
+
+  file -b --mime-type "$iconPath"
+}
+
+# The default for almost all icons that will be installed.
+# This should be preferred.
+#
+# Installs to
+# "$prefix/share/icons/hicolor/*/app/$name.*"
+#
+# Args:
+# $1 = Prefix to install it to (usually $out or $bin)
+# $2 = Path to install it from
+# $3 = Name to install it with (excluding the extension!)
+# $4 = Type of icon to install [ "scalable", "NxN" ]
+#
+# Return:
+#  * Ignore stdout, it is for logging
+#  * Calls `exit 1` if invalid type is provided
+#
+# Examples:
+#
+#   installHicolorIcon "$out" "assets/icon.png" "cool_project" "64x64"
+#
+#   installHicolorIcon "$bin" "assets/icon.svg" "cooler_project" "scalable"
+installHicolorIcon() {
+  local -r prefix="$1"
+  local -r location="$2"
+  local -r name="$3"
+  local -r type="$4"
+
+  local -r path="share/icons/hicolor"
+
+  case "${type,,}" in
+    "scalable")
+      >&2 echo "installHicolorIcon: installing SVG '$location' to '$prefix/$path/scalable/apps/$name.svg'"
+      install -Dm444 "$location" "$prefix/$path/scalable/apps/$name.svg"
+      ;;
+    *x*)
+      >&2 echo "installHicolorIcon: installing png '$location' to '$prefix/$path/$type/apps/$name.png'"
+      install -Dm444 "$location" "$prefix/$path/$type/apps/$name.png"
+      ;;
+    *)
+      >&2 echo "installHicolorIcon: invalid icon type '$type'"
+      exit 1
+      ;;
+  esac
+}
+
+# For other icons that are too large or weird
+# in other ways.
+#
+# https://github.com/NixOS/nixpkgs/issues/428824#issuecomment-4255463416
+#
+# Installs to
+# "$prefix/share/icons/$name"
+#
+# Args:
+# $1 = Prefix to install it to (usually $out or $bin)
+# $2 = Path to install it from
+# $3 = Name to install it with (including the extension!)
+#
+# Return:
+#  * Ignore stdout, it is for logging
+#  * Returns `1` if unknown type is provided
+#
+# Examples:
+#
+#   installOtherIcon "$out" "assets/icon.png" "project.png"
+installOtherIcon() {
+  local -r prefix="$1"
+  local -r location="$2"
+  local -r name="$3"
+
+  local -r path="$prefix/share/icons/$name"
+
+  >&2 echo "installOtherIcon: '$location' to '$path'"
+  install -Dm444 "$location" "$path"
+}
+
+installIconsHook() {
+  echo "installIconsHook: Running..."
+
+  local -ra RASTER_SIZES=(
+    "16x16"
+    "32x32"
+    "48x48"
+    "64x64"
+    "72x72"
+    "96x96"
+    "128x128"
+    "256x256"
+    "512x512"
+  )
+
+  # Directory to search. Default to CWD
+  local -r searchDir="${installIconsSearchDir:-.}"
+
+  # Must eagerly fail for this as we'll just spit out nonsense otherwise
+  if [[ ! $__structuredAttrs ]]; then
+    >&2 echo "installIconsHook: structuredAttrs is required"
+    exit 1
+  fi
+
+  # Make sure the name exists and is an assoc array
+  declare -gA iconsToInstall
+
+  # Make an assoc array of each icon type to lookup
+  local -A foundIcons=()
+
+  # Don't eagerly fail so we can output errors for all icons
+  # if there is more than one error to occur.
+  local failedFind=false
+
+  # The name to install the icons under
+  local -r iconName="${installIconName:-"$NIX_MAIN_PROGRAM"}"
+  if [[ -z "$iconName" ]]; then
+    >&2 echo "installIconsHook: ERROR: meta.mainProgram is unset, please set it so the icon name is valid"
+    >&2 echo "installIconsHook: If meta.mainProgram cannot be set, please use 'installIconName' instead."
+    failedFind=true
+  fi
+
+  # Get the user input, and if not try to find the file
+  for size in "${RASTER_SIZES[@]}"; do
+    if [[ -v iconsToInstall["$size"] ]]; then
+      # If key exists, use it.
+      >&2 echo "installIconsHook: user supplied $size"
+      foundIcons["$size"]="${iconsToInstall["$size"]}"
+    else
+
+      # Try to find the size of icon
+      local findResult
+      if
+        ! findResult="$(findIcon "$searchDir" "$size" "png")"
+      then
+        failedFind=true
+        >&2 echo "installIconsHook: ERROR: Found multiple icons for size '$size'"
+        >&2 echo "installIconsHook: disambiguate with attribute set \`iconsToInstall\`"
+        >&2 echo "$findResult"
+      else
+        if [[ -n $findResult ]]; then
+          # If we found it, use it.
+          foundIcons["$size"]="$findResult"
+          >&2 echo "installIconsHook: Found icon of size '$size'"
+        else
+          # Found nothing
+          >&2 echo "installIconsHook: Unable to find icon size '$size'"
+        fi
+      fi
+    fi
+  done
+
+  # Look for SVG and ICO files
+  for type in "svg" "ico"; do
+    if [[ -v iconsToInstall["$type"] ]]; then
+      # If supplied, we shall use it
+      >&2 echo "installIconsHook: user supplied $type"
+      foundIcons["$type"]="${iconsToInstall["$type"]}"
+    else
+      # Try to find the icon
+      local found
+      if
+        ! found="$(findIcon "$searchDir" "" "$type")"
+      then
+        failedFind=true
+        >&2 echo "installIconsHook: ERROR: Found multiple icons for type '$type'"
+        >&2 echo "installIconsHook: disambiguate with attribute set \`iconsToInstall\`"
+        >&2 echo "$found"
+      else
+        if [[ -n $found ]]; then
+          # If we found it, use it.
+          foundIcons["$type"]="$found"
+          >&2 echo "installIconsHook: Found icon type '$type'"
+        else
+          # Found nothing
+          >&2 echo "installIconsHook: Unable to find icon type '$type'"
+        fi
+      fi
+    fi
+  done
+
+  if $failedFind; then
+    >&2 echo "installIconsHook: Errors found, exiting"
+    exit 1
+  fi
+
+  # Do ICO install first so that it is the lowest priority of the icons found
+  if [[ -v foundIcons["ico"]  ]]; then
+    icoFileToHiColorTheme "${foundIcons["ico"]}" "$iconName" "$prefix"
+  fi
+
+  # Just install whatever we found or created
+  for key in "${!foundIcons[@]}"; do
+    # Must declare seperately to get return code
+    local mimeType
+    if
+      ! mimeType="$(getMime "${foundIcons["$key"]}")"
+    then
+      >&2 echo "Unable to get mime of '${foundIcons["$key"]}'"
+      >&2 echo "$mimeType"
+      exit 1
+    fi
+
+    case "$key" in
+      "ico")
+        # Do nothing, we already installed it above
+        ;;
+      "svg")
+        local correctMime="image/svg+xml"
+
+        if [[ "$mimeType" == "$correctMime" ]]; then
+          installHicolorIcon "$prefix" "${foundIcons["$key"]}" "$iconName" "scalable"
+        else
+          >&2 echo "installIconsHook: ERROR: '${foundIcons["$key"]}' is not a '$correctMime'" 2>&1
+          exit 1
+        fi
+        ;;
+      *)
+        local correctMime="image/png"
+
+        if [[ "$mimeType" == "$correctMime" ]]; then
+          installHicolorIcon "$prefix" "${foundIcons["$key"]}" "$iconName" "$key"
+        else
+          >&2 echo "installIconsHook: ERROR: '${foundIcons["$key"]}' is not a '$correctMime'" 2>&1
+          exit 1
+        fi
+        ;;
+    esac
+  done
+
+  # Check if there are "other" icons. These will be too large
+  # or some other quirk that means they cannot be installed in
+  # hicolor paths.
+  declare -gA extraIconsToInstall
+  for extension in "${!extraIconsToInstall[@]}"; do
+    local correctMime=""
+
+    case "$extension" in
+      svg)
+        correctMime="image/svg+xml"
+        ;;
+      png)
+        correctMime="image/png"
+        ;;
+      *)
+      >&2 echo "installIconsHooks: ERROR: '$extension' is not a valid format, only png and svg are allowed."
+      exit 1
+      ;;
+    esac
+
+    local icon="${extraIconsToInstall["$extension"]}"
+
+    # Must declare seperately to get return code
+    local mimeType
+    if
+      ! mimeType="$(getMime "$icon")"
+    then
+      >&2 echo "Unable to get mime of '$icon'"
+      >&2 echo "$mimeType"
+      exit 1
+    fi
+
+    if [[ "$mimeType" != "$correctMime" ]]; then
+      echo "installIconsHook: ERROR: '$icon' is not a $extension file"
+      exit 1
+    fi
+
+    installOtherIcon "$prefix" "$icon" "$iconName.$extension"
+  done
+
+  echo "installIconsHook: Finished."
+}
+
+if [ -z "${dontInstallIcons-}" ]; then
+  postInstallHooks+=(installIconsHook)
+fi
+

--- a/pkgs/by-name/in/installIconsHook/package.nix
+++ b/pkgs/by-name/in/installIconsHook/package.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  callPackage,
+  makeSetupHook,
+  iconConvTools,
+}:
+makeSetupHook {
+  name = "install-icons-hook";
+  propagatedBuildInputs = [
+    iconConvTools
+  ];
+
+  __structuredAttrs = true;
+
+  passthru.tests = lib.filterAttrs (_: lib.isDerivation) (callPackage ./tests.nix { });
+
+  meta = {
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.RossSmyth ];
+  };
+} ./icon-install-hook.sh

--- a/pkgs/by-name/in/installIconsHook/tests.nix
+++ b/pkgs/by-name/in/installIconsHook/tests.nix
@@ -1,0 +1,184 @@
+{
+  lib,
+  stdenvNoCC,
+  testers,
+  installIconsHook,
+  emptyDirectory,
+  nixos-icons,
+}:
+let
+  mkTest = lib.extendMkDerivation {
+    constructDrv = stdenvNoCC.mkDerivation;
+
+    excludeDrvArgNames = [
+      "name"
+      "test"
+    ];
+
+    extendDrvArgs =
+      finalAttrs:
+      {
+        name,
+        test,
+        nativeBuildInputs ? [ ],
+        setMeta ? true,
+        ...
+      }:
+      {
+        pname = name + "-test";
+        version = "none";
+
+        __structuredAttrs = true;
+        strictDeps = true;
+
+        nativeBuildInputs = nativeBuildInputs ++ [
+          installIconsHook
+        ];
+
+        doInstallCheck = true;
+        installCheckPhase = test;
+
+        meta = lib.optionalAttrs setMeta {
+          mainProgram = "test";
+        };
+      };
+  };
+
+  withFail = testers.testBuildFailure;
+  nixos-icons-list = {
+    "16x16" = "share/icons/hicolor/16x16/apps/nix-snowflake.png";
+    "32x32" = "share/icons/hicolor/32x32/apps/nix-snowflake.png";
+    "48x48" = "share/icons/hicolor/48x48/apps/nix-snowflake.png";
+    "64x64" = "share/icons/hicolor/64x64/apps/nix-snowflake.png";
+    "72x72" = "share/icons/hicolor/72x72/apps/nix-snowflake.png";
+    "96x96" = "share/icons/hicolor/96x96/apps/nix-snowflake.png";
+    "128x128" = "share/icons/hicolor/128x128/apps/nix-snowflake.png";
+    "256x256" = "share/icons/hicolor/256x256/apps/nix-snowflake.png";
+    "512x512" = "share/icons/hicolor/512x512/apps/nix-snowflake.png";
+    "svg" = "share/icons/hicolor/scalable/apps/nix-snowflake.svg";
+  };
+
+  happyTest = ''
+    find "$out/share/icons/hicolor/16x16/apps" -name test.png
+    find "$out/share/icons/hicolor/32x32/apps" -name test.png
+    find "$out/share/icons/hicolor/48x48/apps" -name test.png
+    find "$out/share/icons/hicolor/64x64/apps" -name test.png
+    find "$out/share/icons/hicolor/72x72/apps" -name test.png
+    find "$out/share/icons/hicolor/96x96/apps" -name test.png
+    find "$out/share/icons/hicolor/128x128/apps" -name test.png
+    find "$out/share/icons/hicolor/256x256/apps" -name test.png
+    find "$out/share/icons/hicolor/512x512/apps" -name test.png
+    find "$out/share/icons/hicolor/scalable/apps" -name test.svg
+  '';
+in
+{
+  # This should all be happy-path
+  disambiguation-success = mkTest {
+    name = "disambiguation-success";
+    src = nixos-icons;
+
+    iconsToInstall = nixos-icons-list;
+
+    test = happyTest;
+  };
+
+  # nixos-icons need disambiguation, so it must fail
+  disambiguation-error = withFail (mkTest {
+    name = "disambiguation-error";
+    src = nixos-icons;
+    test = "";
+  });
+
+  # If only one needs disambiguation, fail
+  disam-one-unset = withFail (mkTest {
+    name = "disam-one-unset";
+    src = nixos-icons;
+
+    iconsToInstall = removeAttrs nixos-icons-list [ "96x96" ];
+
+    test = "";
+  });
+
+  # Fail if no mainProgram is set
+  no-main = withFail (mkTest {
+    name = "no-main";
+    src = nixos-icons;
+    setMeta = false;
+    test = happyTest;
+  });
+
+  # If meta.mainProgram is unset, but iconInstallName is, don't fail
+  with-icon-name = mkTest {
+    name = "with-icon-name";
+    src = nixos-icons;
+    setMeta = false;
+
+    iconsToInstall = nixos-icons-list;
+
+    installIconName = "test2";
+
+    test = lib.replaceStrings [ "test.png" ] [ "test2.png" ] happyTest;
+  };
+
+  # If there are no icons to install, don't fail
+  no-icons = mkTest {
+    name = "no-icons";
+    src = emptyDirectory;
+    test = ''
+      touch "$out"
+    '';
+  };
+
+  # Test adding some extra icons
+  extra-icons = mkTest {
+    name = "extra-icons";
+
+    src = nixos-icons;
+
+    iconsToInstall = nixos-icons-list;
+
+    extraIconsToInstall = {
+      png = "share/icons/hicolor/16x16/apps/nix-snowflake.png";
+      svg = "share/icons/hicolor/scalable/apps/nix-snowflake.svg";
+    };
+
+    test = happyTest + ''
+      if [[ -f "$out/share/icons/test.png" ]]; then
+        echo "png success"
+      else
+        echo "png fail"
+        ls -alR "$out"
+        exit 1
+      fi
+
+      if [[ -f "$out/share/icons/test.svg" ]]; then
+        echo "svg success"
+      else
+        echo "svg fail"
+        ls -alR "$out"
+        exit 1
+      fi
+    '';
+  };
+
+  # Test adding some extra icons
+  extra-icons-one = mkTest {
+    name = "extra-icons-one";
+
+    src = nixos-icons;
+
+    iconsToInstall = nixos-icons-list;
+
+    extraIconsToInstall.svg = "share/icons/hicolor/scalable/apps/nix-snowflake.svg";
+
+    test = happyTest + ''
+      if [[ -f "$out/share/icons/test.svg" ]]; then
+        echo "svg success"
+      else
+        echo "svg fail"
+        ls -alR "$out"
+        exit 1
+      fi
+    '';
+  };
+}

--- a/pkgs/by-name/tr/transito/package.nix
+++ b/pkgs/by-name/tr/transito/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildGoModule,
   fetchFromSourcehut,
+  installIconsHook,
   pkg-config,
   vulkan-headers,
   libxkbcommon,
@@ -27,7 +28,13 @@ buildGoModule (finalAttrs: {
   };
   vendorHash = "sha256-mgvfrNKvdjLa7O0oTSec8u3eHHU66ZDqpKzNeeyy2J0=";
 
-  nativeBuildInputs = [ pkg-config ];
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    installIconsHook
+    pkg-config
+  ];
   buildInputs = [
     vulkan-headers
     libxkbcommon
@@ -41,14 +48,13 @@ buildGoModule (finalAttrs: {
   ];
 
   tags = [ "sqlite_math_functions" ];
-  ldflags = [ "-X git.sr.ht/~mil/transito/src/uipages/pageconfig.Commit=${finalAttrs.version}" ];
+  ldflags = [
+    "-X"
+    "git.sr.ht/~mil/transito/src/uipages/pageconfig.Commit=${finalAttrs.version}"
+  ];
 
   postInstall = ''
     install -Dm644 -t $out/share/applications assets/transito.desktop
-    for icon in assets/transito_*.png; do
-      name=$(basename $icon .png)
-      install -Dm644 $icon $out/share/icons/hicolor/''${name#transito_}/apps/transito.png
-    done
   '';
 
   doCheck = false; # no test


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

There are so many ad-hoc icon installation things in various postInstall hooks. So here's my take on a hook for automating it. 

I picked transito as an example package just by luck of the draw after a ripgrep.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
