### PR TITLE
tests/pnpm: add opencloud

### DIFF
--- a/pkgs/test/pnpm/default.nix
+++ b/pkgs/test/pnpm/default.nix
@@ -1,8 +1,18 @@
-{ callPackage, lib }:
+{
+  callPackage,
+  lib,
+  opencloud,
+}:
+
 {
   pnpm-empty-lockfile = callPackage ./pnpm-empty-lockfile { };
   pnpm-fixup-state-db = callPackage ./pnpm-fixup-state-db { };
   pnpm-workspaces = lib.recurseIntoAttrs (callPackage ./pnpm-workspaces { });
   pnpm_11_v3 = callPackage ./pnpm_11_v3 { };
   pnpm_11_v4 = callPackage ./pnpm_11_v4 { };
+
+  # pnpm reverse dependencies that don't have a top-level package
+  opencloud = lib.recurseIntoAttrs {
+    inherit (opencloud.passthru) web idp-web;
+  };
 }


### PR DESCRIPTION
This will prevent https://github.com/NixOS/nixpkgs/pull/487046#issuecomment-4611503213 in the future
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
