### PR TITLE
bencher-cli: init at 0.6.8

### DIFF
--- a/pkgs/by-name/be/bencher-cli/package.nix
+++ b/pkgs/by-name/be/bencher-cli/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  mold,
+  nix-update-script,
+  versionCheckHook,
+  rustc,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "bencher-cli";
+  version = "0.6.8";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "bencherdev";
+    repo = "bencher";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-MlRj56QXRrvfBxi6+B6vpEKlDWMFB+V1CzQYOiGFpHE=";
+  };
+
+  cargoHash = "sha256-biCHEePgVxrnGUj94bwWrp9GVhspiMjcMRdp3A7O2h0=";
+
+  nativeBuildInputs = [ mold ];
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  cargoBuildFlags = [ "--package=bencher_cli" ];
+  cargoTestFlags = [ "--package=bencher_cli" ];
+  # Build the open-source version
+  buildNoDefaultFeatures = true;
+  checkNoDefaultFeatures = finalAttrs.buildNoDefaultFeatures;
+
+  postPatch = lib.optionalString finalAttrs.buildNoDefaultFeatures ''
+    # Replaces the proprietary Rust files with empty files
+    # This is just a safeguard, the build shouldn't touch these files anyways
+    echo "find . -path '*/plus/*' -type f ! -name Cargo.toml -exec truncate -s 0 {} +"
+    find . -path '*/plus/*' -type f ! -name Cargo.toml -exec truncate -s 0 {} +
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Command-Line interface for the Bencher continuous benchmarking platform";
+    mainProgram = "bencher";
+    longDescription = ''
+      Bencher is a suite of continuous benchmarking tools.
+      Bencher allows you to detect and prevent performance regressions
+      *before* they hit production.
+
+      - Run: Run your benchmarks locally or in CI using your favorite
+        benchmarking tools. The bencher CLI simply wraps your existing
+        benchmark harness and stores its results.
+      - Track: Track the results of your benchmarks over time. Monitor, query,
+        and graph the results using the Bencher web console based on the source
+        branch, testbed, benchmark, and measure.
+      - Catch: Catch performance regressions in CI. Bencher uses state of the
+        art, customizable analytics to detect performance regressions before
+        they make it to production.
+
+      Bencher's source repo includes non-free features, included in the build
+      as the Cargo feature "plus".
+      Files in the plus directories are proprietary, while the other files
+      are dual Apache-2.0/MIT licensed.
+      The Nix derivation does not compile the proprietary features.
+    '';
+    homepage = "https://bencher.dev";
+    license =
+      if finalAttrs.buildNoDefaultFeatures then
+        lib.licenses.OR [
+          lib.licenses.asl20
+          lib.licenses.mit
+        ]
+      else
+        lib.licenses.unfree;
+    platforms = rustc.meta.platforms;
+    maintainers = [ lib.maintainers.skyesoss ];
+  };
+})


### PR DESCRIPTION
Bencher is a continuous benchmarking platform.

The repo contains proprietary code along with open-source code.
To make sure nixpkgs doesn't redistribute the proprietary build, the patch phase replaces all the proprietary Rust code with empty files, similar to how GitLab is handled.

#455920 is an existing PR for this package, but is out-of-date and has some issues (ex. the platform list is incorrect, and it avoids using the recommended `mold` linker).
Though if @michaelvanstraten would like to be a maintainer on this package, that's okay with me.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
