### PR TITLE
changedetection-io options - Update Playwright driver URL and image source

### DIFF
--- a/nixos/modules/services/web-apps/changedetection-io.nix
+++ b/nixos/modules/services/web-apps/changedetection-io.nix
@@ -150,7 +150,7 @@ in
             ++ lib.optional (cfg.baseURL != null) "BASE_URL=${cfg.baseURL}"
             ++ lib.optional cfg.behindProxy "USE_X_SETTINGS=1"
             ++ lib.optional cfg.webDriverSupport "WEBDRIVER_URL=http://127.0.0.1:${toString cfg.chromePort}/wd/hub"
-            ++ lib.optional cfg.playwrightSupport "PLAYWRIGHT_DRIVER_URL=ws://127.0.0.1:${toString cfg.chromePort}/?stealth=1&--disable-web-security=true";
+            ++ lib.optional cfg.playwrightSupport "PLAYWRIGHT_DRIVER_URL=ws://127.0.0.1:${toString cfg.chromePort}/?stealth=1";
             EnvironmentFile = mkIf (cfg.environmentFile != null) cfg.environmentFile;
             ExecStart = ''
               ${cfg.package}/bin/changedetection.py \
@@ -202,7 +202,7 @@ in
 
         (mkIf cfg.playwrightSupport {
           changedetection-io-playwright = {
-            image = "browserless/chrome";
+            image = "ghcr.io/browserless/chromium";
             environment = {
               SCREEN_WIDTH = "1920";
               SCREEN_HEIGHT = "1024";


### PR DESCRIPTION
### 1st change - Docker Image:
The old image states its deprecated and to be replaced in favor of the "chromium" image
source of info: https://hub.docker.com/r/browserless/chrome
` NOTE: This is the old v1 of Browserless. We would recommend using version 2 instead.`

### 2nd change - playwright URL:
To me it looks like "--disable-web-security" is not a valid option anymore. 
Well at least I get better results removing that option.


## Things done

- [x] overwrote (lib.mkForce) those options in my setup, works pretty well. But I did not overlay my options with this change. AFAIK options can't be overlayed do they?

<details><summary>Template</summary>
<p>

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

</p>
</details> 

### Package Maintainers
@MikaelFangel @thanegill