### PR TITLE
roapi-http: build from source

### DIFF
--- a/pkgs/by-name/ro/roapi-http/package.nix
+++ b/pkgs/by-name/ro/roapi-http/package.nix
@@ -1,56 +1,42 @@
 {
-  stdenv,
+  cmake,
+  fetchFromGitHub,
   lib,
-  fetchurl,
+  rustPlatform,
 }:
-let
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "roapi-http";
   version = "0.6.0";
-  target = lib.optionalString stdenv.hostPlatform.isDarwin "apple-darwin";
-in
-# TODO build from source, currently compilation fails on darwin on snmalloc with
-#  ./mem/../ds/../pal/pal_apple.h:277:64: error: use of undeclared identifier 'kCCSuccess'
-#            reinterpret_cast<void*>(&result), sizeof(result)) != kCCSuccess)
-#
-# rustPlatform.buildRustPackage {
-#   pname = "roapi-http";
-#   inherit version;
 
-#   src = fetchFromGitHub {
-#     owner = "roapi";
-#     repo = "roapi";
-#     rev = "roapi-http-v${version}";
-#     sha256 = "sha256-qHAO3h+TTCQQ7vdd4CoXVGfKZ1fIxTWKqbUNnRsJaok=";
-#   };
-
-#   cargoHash = "sha256-qDJKC6MXeKerPFwJsNND3WkziFtGkTvCgVEsdPbBGAo=";
-
-#   buildAndTestSubdir = "roapi-http";
-
-#   nativeBuildInputs = [ cmake ];
-
-stdenv.mkDerivation rec {
-  inherit pname version;
-
-  src = fetchurl {
-    url = "https://github.com/roapi/roapi/releases/download/${pname}-v${version}/${pname}-${target}.tar.gz";
-    sha256 = "sha256-lv6BHg/LkrOlyq8D1udAYW8/AbZRb344YCcVnwo3ZHk=";
+  src = fetchFromGitHub {
+    owner = "roapi";
+    repo = "roapi";
+    rev = "roapi-http-v${finalAttrs.version}";
+    sha256 = "sha256-qHAO3h+TTCQQ7vdd4CoXVGfKZ1fIxTWKqbUNnRsJaok=";
   };
-  dontUnpack = true;
-  dontConfigure = true;
-  dontBuild = true;
 
-  installPhase = ''
-    tar xvzf $src
-    mkdir -p "$out/bin"
-    cp roapi-http $out/bin
-  '';
+  cargoHash = "sha256-PlQq2zttiheQ0WFBLuH4dBSuExK+7hP22aLfmtNtLCk=";
+
+  buildAndTestSubdir = "roapi-http";
+
+  nativeBuildInputs = [ cmake ];
+
+  # snmalloc fails to compile on Darwin, and upstream doesn't use it for Linux
+  buildNoDefaultFeatures = true;
+  buildFeatures = [ "rustls" ];
+
+  # the crate uses `#![deny(warnings)]`, which breaks with lints added by
+  # newer rustc releases than the code was written against
+  env.RUSTFLAGS = "--cap-lints warn";
+
+  checkFlags = [ "--skip=test_http2" ]; # this test tries `curl` and fails
 
   meta = {
     description = "Create full-fledged APIs for static datasets without writing a single line of code";
     homepage = "https://roapi.github.io/docs/";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ happysalada ];
-    platforms = lib.platforms.darwin;
+    platforms = lib.platforms.unix;
+    mainProgram = "roapi-http";
   };
-}
+})


### PR DESCRIPTION
This is one of the two (!) packages I could find that support `aarch64-darwin` and/or `aarch64-linux` but not `x86_64-linux`, without a good reason:

- #527746
- #527760

Note that building from source does introduce a couple minor changes from the prebuilt binary we've been downloading so far:

- We use whatever version of the Rust compiler we get from Nixpkgs, instead of [specifically the 2022-01-05 nightly](https://github.com/roapi/roapi/blob/roapi-http-v0.6.0/.github/workflows/roapi_http_release.yml#L15).
- We build without [snmalloc on Darwin](https://github.com/roapi/roapi/blob/roapi-http-v0.6.0/.github/workflows/roapi_http_release.yml#L65).
  - For Linux, [upstream didn't build with snmalloc anyway](https://github.com/roapi/roapi/blob/roapi-http-v0.6.0/.github/workflows/roapi_http_release.yml#L201).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
