### PR TITLE
nixos/nix-channel: substitute getent path in preSwitchCheck

### DIFF
--- a/nixos/modules/config/nix-channel.nix
+++ b/nixos/modules/config/nix-channel.nix
@@ -6,7 +6,12 @@
   - ./nix.nix
   - ./nix-flakes.nix
 */
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   inherit (lib)
     mkIf
@@ -98,7 +103,9 @@ in
     ];
 
     system.preSwitchChecks.no-nix-channel = mkIf (!cfg.channel.enable) (
-      builtins.readFile ./nix-channel/pre-switch-check.sh
+      lib.replaceStrings [ "@getent@" ] [ (lib.getExe pkgs.getent) ] (
+        builtins.readFile ./nix-channel/pre-switch-check.sh
+      )
     );
   };
 }

--- a/nixos/modules/config/nix-channel/pre-switch-check.sh
+++ b/nixos/modules/config/nix-channel/pre-switch-check.sh
@@ -16,7 +16,7 @@ while IFS=: read -r _ _ _ _ _ home _ ; do
         warn "$home/.nix-defexpr/channels exists, but channels have been disabled."
         explainChannelWarning=1
     fi
-done < <(getent passwd)
+done < <(@getent@ passwd)
 if [[ $explainChannelWarning -eq 1 ]]; then
     echo "Due to https://github.com/NixOS/nix/issues/9574, Nix may still use these channels when NIX_PATH is unset." >&2
     echo "Delete the above directory or directories to prevent this." >&2


### PR DESCRIPTION
Follow-up to #527658.

The `preSwitchChecks` `writeShellApplication` has no `runtimeInputs`, so `getent` was not on `PATH`.
The per-user scan iterated zero times and printed `getent: command not found` during `nixos-rebuild switch`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
