### PR TITLE
{lomiri,lomiri-qt6}.lomiri-thumbnailer: 3.1.0 -> 3.1.1

### DIFF
--- a/pkgs/desktops/lomiri/services/lomiri-thumbnailer/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-thumbnailer/default.nix
@@ -37,13 +37,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-thumbnailer";
-  version = "3.1.0";
+  version = "3.1.1";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lomiri-thumbnailer";
     tag = finalAttrs.version;
-    hash = "sha256-lXvXK7UCLX5aoGID8sOoeHBEMhdle7RUMACLHiWpcEo=";
+    hash = "sha256-NEFwNofW0Ry9V0oUiUeuzs7q6+Ht2B0oCEGjmc3ywck=";
   };
 
   outputs = [
@@ -66,27 +66,21 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace plugins/Lomiri/Thumbnailer*/CMakeLists.txt \
       --replace-fail "\''${CMAKE_INSTALL_LIBDIR}/qt\''${QT_VERSION_MAJOR}/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"
-
-    # I think this variable fails to be populated because of our toolchain, while upstream uses Debian / Ubuntu where this works fine
-    # https://cmake.org/cmake/help/v3.26/variable/CMAKE_LIBRARY_ARCHITECTURE.html
-    # > If the <LANG> compiler passes to the linker an architecture-specific system library search directory such as
-    # > <prefix>/lib/<arch> this variable contains the <arch> name if/as detected by CMake.
+  ''
+  # I think this variable fails to be populated because of our toolchain, while upstream uses Debian / Ubuntu where this works fine
+  # https://cmake.org/cmake/help/v3.26/variable/CMAKE_LIBRARY_ARCHITECTURE.html
+  # > If the <LANG> compiler passes to the linker an architecture-specific system library search directory such as
+  # > <prefix>/lib/<arch> this variable contains the <arch> name if/as detected by CMake.
+  + ''
     substituteInPlace tests/qml/CMakeLists.txt \
       --replace-fail 'CMAKE_LIBRARY_ARCHITECTURE' 'CMAKE_SYSTEM_PROCESSOR' \
       --replace-fail 'powerpc-linux-gnu' 'ppc' \
       --replace-fail 's390x-linux-gnu' 's390x'
-
-    # Tests run in parallel to other builds, don't suck up cores
+  ''
+  # Tests run in parallel to other builds, don't suck up cores
+  + ''
     substituteInPlace tests/headers/compile_headers.py \
       --replace-fail 'max_workers=multiprocessing.cpu_count()' "max_workers=1"
-  ''
-  # https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/merge_requests/31
-  # Too simple to bother with fetchpatch
-  + ''
-    substituteInPlace CMakeLists.txt \
-      --replace-fail \
-        'find_package(Boost COMPONENTS filesystem iostreams regex system REQUIRED)' \
-        'find_package(Boost COMPONENTS filesystem iostreams regex REQUIRED)'
   '';
 
   strictDeps = true;


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/blob/3.1.1/ChangeLog

Ran `lomiri.lomiri-thumbnailer.passthru.updateScript` for `version` and `src.hash` updates.

---

~~Qt6 version still fails on #520537~~ Qt6 failure resolved for now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
