### PR TITLE
python3Packages.django_6: 6.0.5 -> 6.0.6

### DIFF
--- a/pkgs/development/python-modules/django-formtools/default.nix
+++ b/pkgs/development/python-modules/django-formtools/default.nix
@@ -40,6 +40,9 @@ buildPythonPackage (finalAttrs: {
   disabledTests = [
     # mismatch between test collection of django and pytest-django
     "TestStorage"
+    # Django 6.0.6/5.2.15 compat issue
+    # https://github.com/jazzband/django-formtools/issues/298
+    "test_reset_cookie"
   ];
 
   pythonImportsCheck = [ "formtools" ];

--- a/pkgs/development/python-modules/django/6.nix
+++ b/pkgs/development/python-modules/django/6.nix
@@ -62,6 +62,9 @@ buildPythonPackage (finalAttrs: {
     ./6.x/pythonpath.patch
     # test_incorrect_timezone should raise but doesn't
     ./6.x/disable-failing-test.patch
+    # https://code.djangoproject.com/ticket/36997
+    # https://github.com/django/django/pull/21019
+    ./6.x/invalidate-importlib-cache.patch
   ]
   ++ lib.optionals withGdal [
     (replaceVars ./6.x/gdal.patch {

--- a/pkgs/development/python-modules/django/6.nix
+++ b/pkgs/development/python-modules/django/6.nix
@@ -42,7 +42,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "django";
-  version = "6.0.5";
+  version = "6.0.6";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
@@ -51,7 +51,7 @@ buildPythonPackage (finalAttrs: {
     owner = "django";
     repo = "django";
     tag = finalAttrs.version;
-    hash = "sha256-jII/aoJ75sS+ig4iVZmTcsEE76aC8Om/k2J+LnRj+cE=";
+    hash = "sha256-hLnTqY64PfaGJ1JJccrxYms41Jp4E4pVq6rmrtFpESE=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/django/6.x/invalidate-importlib-cache.patch
+++ b/pkgs/development/python-modules/django/6.x/invalidate-importlib-cache.patch
@@ -1,0 +1,54 @@
+From 130ccbf51a5ad4810dcef46584661a818b7964d3 Mon Sep 17 00:00:00 2001
+From: gghezext <gghezext@comgest.com>
+Date: Sun, 29 Mar 2026 03:46:48 +0200
+Subject: [PATCH 1/2] Fixed #36997 -- Invalidated importlib caches after
+ writing migration files.
+
+---
+ django/core/management/commands/makemigrations.py   | 3 +++
+ django/core/management/commands/squashmigrations.py | 2 ++
+ docs/releases/6.1.txt                               | 5 ++++-
+ 3 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/django/core/management/commands/makemigrations.py b/django/core/management/commands/makemigrations.py
+index 7f711ed7aec4..355d626ce2c4 100644
+--- a/django/core/management/commands/makemigrations.py
++++ b/django/core/management/commands/makemigrations.py
+@@ -1,3 +1,4 @@
++import importlib
+ import os
+ import sys
+ import warnings
+@@ -395,6 +396,7 @@ def write_migration_files(self, changes, update_previous_migration_paths=None):
+                     )
+                     self.log(writer.as_string())
+         run_formatters(self.written_files, stderr=self.stderr)
++        importlib.invalidate_caches()
+ 
+     @staticmethod
+     def get_relative_path(path):
+@@ -502,6 +504,7 @@ def all_items_equal(seq):
+                     with open(writer.path, "w", encoding="utf-8") as fh:
+                         fh.write(writer.as_string())
+                     run_formatters([writer.path], stderr=self.stderr)
++                    importlib.invalidate_caches()
+                     if self.verbosity > 0:
+                         self.log("\nCreated new merge migration %s" % writer.path)
+                         if self.scriptable:
+diff --git a/django/core/management/commands/squashmigrations.py b/django/core/management/commands/squashmigrations.py
+index 9845b4d4567b..abc87717b66b 100644
+--- a/django/core/management/commands/squashmigrations.py
++++ b/django/core/management/commands/squashmigrations.py
+@@ -1,3 +1,4 @@
++import importlib
+ import os
+ import shutil
+ 
+@@ -208,6 +209,7 @@ def handle(self, **options):
+         with open(writer.path, "w", encoding="utf-8") as fh:
+             fh.write(writer.as_string())
+         run_formatters([writer.path], stderr=self.stderr)
++        importlib.invalidate_caches()
+ 
+         if self.verbosity > 0:
+             self.stdout.write(


### PR DESCRIPTION
https://docs.djangoproject.com/en/6.0/releases/6.0.6/ https://www.djangoproject.com/weblog/2026/jun/03/security-releases/

Fixes:
CVE-2026-6873, CVE-2026-7666, CVE-2026-8404, CVE-2026-35193, CVE-2026-48587


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
