### PR TITLE
nixos/preSwitchChecks: actually set errexit inside check bodies

### DIFF
--- a/nixos/modules/system/activation/pre-switch-check.nix
+++ b/nixos/modules/system/activation/pre-switch-check.nix
@@ -8,9 +8,18 @@ let
   preSwitchCheckScript = lib.concatLines (
     lib.mapAttrsToList (name: text: ''
       # pre-switch check ${name}
-      if ! (
+      #
+      # Run with errexit in a subshell that is not part of an `if`/`||`
+      # condition, so that `set -e` is actually honoured inside the
+      # check body.
+      set +e
+      (
+        set -e
         ${text}
-      ) >&2 ; then
+      ) >&2
+      _rc=$?
+      set -e
+      if [ "$_rc" -ne 0 ]; then
         echo "Pre-switch check '${name}' failed" >&2
         exit 1
       fi

--- a/nixos/tests/switch-test.nix
+++ b/nixos/tests/switch-test.nix
@@ -788,6 +788,11 @@ in
         echo this will fail
         false
       '';
+      specialisation.failingMidCheck.configuration.system.preSwitchChecks.failsInTheMiddle = ''
+        echo before
+        nonexistent-command
+        echo after
+      '';
     };
   };
 
@@ -888,6 +893,11 @@ in
           machine.succeed("${stderrRunner} ${otherSystem}/bin/switch-to-configuration check")
           out = switch_to_specialisation("${otherSystem}", "failingCheck", action="check", fail=True)
           assert_contains(out, "this will fail")
+          # errexit must be honoured inside the check body
+          out = switch_to_specialisation("${otherSystem}", "failingMidCheck", action="check", fail=True)
+          assert_contains(out, "before")
+          assert_contains(out, "Pre-switch check 'failsInTheMiddle' failed")
+          assert_lacks(out, "after")
 
       with subtest("switch inhibitors"):
           # Start without any inhibitors


### PR DESCRIPTION
The previous `if ! ( ... )` wrapper put the check body in a context where bash ignores `set -e`, so a failing command in the middle of a check would not abort it and the switch would proceed. Run the subshell outside any conditional and capture `$?` explicitly instead.

Adds a regression case to `nixosTests.switchTest`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
