### PR TITLE
libultrahdr: Restrict meta.platforms, imagemagick: Enable libultrahdr only when it's available

### DIFF
--- a/pkgs/by-name/im/imagemagick/package.nix
+++ b/pkgs/by-name/im/imagemagick/package.nix
@@ -41,7 +41,7 @@
   pango,
   libtiffSupport ? true,
   libtiff,
-  libultrahdrSupport ? true,
+  libultrahdrSupport ? lib.meta.availableOn stdenv.hostPlatform libultrahdr,
   libultrahdr,
   libxml2Support ? true,
   libxml2,

--- a/pkgs/by-name/li/libultrahdr/package.nix
+++ b/pkgs/by-name/li/libultrahdr/package.nix
@@ -102,7 +102,33 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       yzx9
     ];
-    platforms = lib.platforms.all;
+    # CMake script rejects non-approved platform targets
+    # https://github.com/google/libultrahdr/pull/383 would get rid of that
+    platforms =
+      let
+        # Values from the "Detect system" section in /CMakeLists.txt
+        # https://github.com/google/libultrahdr/blob/d52a0d13814ca399fc8a07e23de1d2c63f0e8404/CMakeLists.txt#L34
+        oss = [
+          "linux"
+          "windows"
+          "darwin"
+        ];
+        archs = [
+          "i686"
+          "x86_64"
+          "aarch64"
+          "armv7l"
+          "riscv64"
+          "riscv32"
+          "loongarch64"
+        ];
+      in
+      lib.lists.intersectLists lib.platforms.all (
+        lib.lists.crossLists (arch: os: "${arch}-${os}") [
+          archs
+          oss
+        ]
+      );
     license = with lib.licenses; [
       asl20
     ];


### PR DESCRIPTION
`libultrahdr` only supports a hardcoded-and-checked-at-configure-time list of OS' and architectures, and anything outside of that list leads to a configuration failure: https://github.com/google/libultrahdr/blob/d52a0d13814ca399fc8a07e23de1d2c63f0e8404/CMakeLists.txt#L33-L69. https://github.com/google/libultrahdr/pull/383 would get rid of this hardcoded list, but that has not been merged so far.

Now that `imagemagick` depends on `libultrahdr` (#499115), `imagemagick` is no longer buildable on more exotic platforms.

1. Limit `libultrahdr.meta.platforms` to upstream's list of allowed OS' and architectures
2. Make `libultrahdrSupport` in `imagemagick` depend on `lib.meta.availableOn stdenv.hostPlatform libultrahdr`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (no rebuild)
  - [ ] aarch64-linux
  - [ ] powerpc64-linux (still building other dependencies of `imagemagick`, but `libultrahdr` no longer gets pulled in)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
