### PR TITLE
_1password-gui-beta: 8.12.22-16.BETA -> 8.12.24-24.BETA

### DIFF
--- a/pkgs/by-name/_1/_1password-gui/sources.json
+++ b/pkgs/by-name/_1/_1password-gui/sources.json
@@ -29,28 +29,28 @@
   },
   "beta": {
     "linux": {
-      "version": "8.12.22-16.BETA",
+      "version": "8.12.24-24.BETA",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/linux/tar/beta/x86_64/1password-8.12.22-16.BETA.x64.tar.gz",
-          "hash": "sha256-Kpmexrq6WpGpanTIYKaMIpM4rJiy8NV2TR8TILmuhr0="
+          "url": "https://downloads.1password.com/linux/tar/beta/x86_64/1password-8.12.24-24.BETA.x64.tar.gz",
+          "hash": "sha256-2pdVY7X2qfSkxhSEIKod9+8zGsJ91r9rY3ODTjA4Bw8="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/linux/tar/beta/aarch64/1password-8.12.22-16.BETA.arm64.tar.gz",
-          "hash": "sha256-7ZxrPLPdGizexCRMHkufi9WapFMApxwDw0VgBTpQ7bM="
+          "url": "https://downloads.1password.com/linux/tar/beta/aarch64/1password-8.12.24-24.BETA.arm64.tar.gz",
+          "hash": "sha256-HIFlrclzIHZftUtYKyMRX9s1UjS//sibTFyhi0NU4pE="
         }
       }
     },
     "darwin": {
-      "version": "8.12.22-16.BETA",
+      "version": "8.12.24-24.BETA",
       "sources": {
         "x86_64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.12.22-16.BETA-x86_64.zip",
-          "hash": "sha256-Ce9A3UKGxJvABDlMhlw9gElGc2iKS+j+CvBnohij4mg="
+          "url": "https://downloads.1password.com/mac/1Password-8.12.24-24.BETA-x86_64.zip",
+          "hash": "sha256-KXgqH7bFCIMdmruqnCel7tCWa8YdwKtajFv/HGxb7AE="
         },
         "aarch64": {
-          "url": "https://downloads.1password.com/mac/1Password-8.12.22-16.BETA-aarch64.zip",
-          "hash": "sha256-sfBVX171OQfxh+v8367nmeVNATMRAJdIk+bS2KXF+BA="
+          "url": "https://downloads.1password.com/mac/1Password-8.12.24-24.BETA-aarch64.zip",
+          "hash": "sha256-u8uRcR7z65Hs0jq3dXz4HNgI4UH4+AJjtPBH2keUXZI="
         }
       }
     }


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
