### PR TITLE
style50: 2.11.0 -> 3.0.0

### DIFF
--- a/pkgs/by-name/st/style50/package.nix
+++ b/pkgs/by-name/st/style50/package.nix
@@ -2,20 +2,21 @@
   lib,
   python3Packages,
   fetchFromGitHub,
+  djhtml,
   libclang,
   versionCheckHook,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "style50";
-  version = "2.11.0";
+  version = "3.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "cs50";
     repo = "style50";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-THmxq69peJwT3XQKEpT+ooBYaDDkn1HHGVH5rvM/FF8=";
+    hash = "sha256-D2ucfVVGZFzmcAUyOfu97QJ8x9pzRo1hYrwZlV8MRN8=";
   };
 
   build-system = [
@@ -24,11 +25,14 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   dependencies = with python3Packages; [
     autopep8
+    cssbeautifier
+    djhtml
     icdiff
     jinja2
     jsbeautifier
     pycodestyle
     python-magic
+    sqlparse
     termcolor
   ];
 
@@ -50,9 +54,10 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   pythonImportsCheck = [ "style50" ];
 
-  nativeCheckInputs = [ versionCheckHook ];
-
-  # no python tests
+  nativeCheckInputs = [
+    python3Packages.pytestCheckHook
+    versionCheckHook
+  ];
 
   meta = {
     description = "Tool for checking code against the CS50 style guide";


### PR DESCRIPTION
Changelog: https://github.com/cs50/style50/releases/tag/v3.0.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
