### PR TITLE
python3Packages.harlequin-odbc: init at 0.4.0 and add flag

### DIFF
--- a/pkgs/by-name/ha/harlequin/package.nix
+++ b/pkgs/by-name/ha/harlequin/package.nix
@@ -9,8 +9,8 @@
   writableTmpDirAsHomeHook,
   withPostgresAdapter ? true,
   withBigQueryAdapter ? true,
+  withOdbcAdapter ? true,
 }:
-
 let
   python = python3.override {
     packageOverrides = _final: prev: {
@@ -75,7 +75,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
       tree-sitter-sql
     ]
     ++ lib.optionals withPostgresAdapter [ harlequin-postgres ]
-    ++ lib.optionals withBigQueryAdapter [ harlequin-bigquery ];
+    ++ lib.optionals withBigQueryAdapter [ harlequin-bigquery ]
+    ++ lib.optionals withOdbcAdapter [ harlequin-odbc ];
 
   pythonImportsCheck = [
     "harlequin"

--- a/pkgs/development/python-modules/harlequin-odbc/default.nix
+++ b/pkgs/development/python-modules/harlequin-odbc/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonAtLeast,
+  hatchling,
+  duckdb,
+  pyodbc,
+}:
+buildPythonPackage rec {
+  pname = "harlequin-odbc";
+  version = "0.4.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "harlequin_odbc";
+    inherit version;
+    hash = "sha256-mDVsXrqswj2v814WXUSQ4eoQ3FkfqcsIJPQScrOdE/A=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    pyodbc
+  ]
+  ++ lib.optional (pythonAtLeast "3.14") duckdb;
+
+  doCheck = false;
+  pythonRemoveDeps = [
+    "harlequin"
+  ];
+
+  meta = {
+    description = "A Harlequin adapter for ODBC drivers.";
+    homepage = "https://pypi.org/project/harlequin-odbc/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ c4patino ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7001,6 +7001,8 @@ self: super: with self; {
 
   harlequin-bigquery = callPackage ../development/python-modules/harlequin-bigquery { };
 
+  harlequin-odbc = callPackage ../development/python-modules/harlequin-odbc { };
+
   harlequin-postgres = callPackage ../development/python-modules/harlequin-postgres { };
 
   hass-client = callPackage ../development/python-modules/hass-client { };


### PR DESCRIPTION
## Summary

- Added `python3Packages.harlequin-odbc` at version 0.4.0.
- Added a `withOdbcAdapter` flag to `harlequin`, enabled by default, to include the ODBC adapter alongside the existing PostgreSQL and BigQuery adapters.

`harlequin-odbc` is a Harlequin adapter for ODBC drivers: https://pypi.org/project/harlequin-odbc/

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
