### PR TITLE
super-productivity: 18.5.0 -> 18.12.0

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -51,6 +51,8 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `super-productivity` has been updated. The binary has been renamed from `super-productivity` to `superproductivity`. A symlink from the old name is provided for backward compatibility.
+
 - Package-URL (PURL, https://github.com/package-url/purl-spec) metadata identifier has been added for `fetchgit`, `fetchpypi` and `fetchFromGithub` fetchers.
   `mkDerivation` has been adjusted to reuse this information.
   Package-URLs allow reliably identifying and locating software packages.

--- a/pkgs/by-name/su/super-productivity/package.nix
+++ b/pkgs/by-name/su/super-productivity/package.nix
@@ -6,19 +6,21 @@
   lib,
   makeDesktopItem,
   nix-update-script,
-  npm-lockfile-fix,
   prefetch-npm-deps,
   rsync,
   stdenv,
-  nodejs_24,
+  nodejs_22,
+  rustPlatform,
+  cacert,
+  cargo,
 }:
 let
   electron = electron_41;
-  nodejs = nodejs_24;
+  nodejs = nodejs_22;
 in
 buildNpmPackage rec {
   pname = "super-productivity";
-  version = "18.5.0";
+  version = "18.12.0";
 
   inherit nodejs;
 
@@ -26,11 +28,7 @@ buildNpmPackage rec {
     owner = "johannesjo";
     repo = "super-productivity";
     tag = "v${version}";
-    hash = "sha256-LPLbHmUsFS0iw0iUfWrc4fXJ+/R33ne7aWcPKEtgtyc=";
-
-    postFetch = ''
-      find $out -name package-lock.json -exec ${lib.getExe npm-lockfile-fix} -r {} \;
-    '';
+    hash = "sha256-v4/fPfgiUMOWAcmWdr13oCmu7NTZI3ki6uWJPWTcWzM=";
   };
 
   # Use custom fetcher for deps because super-productivity uses multiple
@@ -47,14 +45,21 @@ buildNpmPackage rec {
         rsync
       ];
 
-      # Some lockfiles do not include any dependencies to install so
-      # prefertch-npm-deps produces an error.  Those can be ignored with
-      # this flag.
-      env.FORCE_EMPTY_CACHE = true;
+      __structuredAttrs = true;
+      strictDeps = true;
+
+      env = {
+        # Some lockfiles do not include any dependencies to install so
+        # prefertch-npm-deps produces an error.  Those can be ignored with
+        # this flag.
+        FORCE_EMPTY_CACHE = true;
+        NPM_FETCHER_VERSION = "2";
+        SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+      };
 
       buildPhase = ''
         mkdir -p $out
-        find -name package-lock.json | while read -r lockfile; do
+        find -name package-lock.json | sort | while read -r lockfile; do
           prefetch-npm-deps $lockfile /tmp/cache
           # Merge output
           rsync -a /tmp/cache/ $out
@@ -69,22 +74,44 @@ buildNpmPackage rec {
       dontInstall = true;
 
       outputHashMode = "recursive";
-      hash = "sha256-/hv9ItFH6k3Gn94/j2dp51LdVoGrUgDRHWewsLjq1Lg=";
+      hash = "sha256-inutOgoQ+xvdVizK2ff6Ro4F/5n4l6dAYjfXJTHWfpo=";
     }
   );
 
   makeCacheWritable = true;
+  npmDepsFetcherVersion = 2;
+
+  cargoRoot = "electron/wayland-idle-helper";
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit
+      pname
+      version
+      src
+      cargoRoot
+      ;
+    hash = "sha256-u/GjzX8zykIqJlMR/611ADX2EcD1cb4Qr94EkI2sdlA=";
+  };
 
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
     CHROMEDRIVER_SKIP_DOWNLOAD = "true";
   };
 
-  nativeBuildInputs = [ copyDesktopItems ];
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    cargo
+    copyDesktopItems
+    rustPlatform.cargoSetupHook
+  ];
 
   postPatch = ''
     substituteInPlace electron-builder.yaml \
       --replace-fail "notarize: true" "notarize: false"
+
+    # At runtime the helper is looked up via app.getAppPath() (the dirname of
+    # the asar file).  process.execPath points to the system electron binary,
+    # not our app directory, so it would search the wrong location.
+    substituteInPlace electron/idle-time-handler.ts \
+      --replace-fail "path.dirname(process.execPath)" "path.dirname(app.getAppPath())"
   '';
 
   buildPhase = ''
@@ -120,40 +147,42 @@ buildNpmPackage rec {
         ''
           mkdir -p $out/Applications
           cp -r ".tmp/app-builds/mac"*"/Super Productivity.app" "$out/Applications"
-          makeWrapper "$out/Applications/Super Productivity.app/Contents/MacOS/Super Productivity" "$out/bin/super-productivity"
+          makeWrapper "$out/Applications/Super Productivity.app/Contents/MacOS/Super Productivity" "$out/bin/superproductivity"
         ''
       else
         ''
-          mkdir -p $out/share/{super-productivity,icons/hicolor/scalable/apps}
-          cp -r .tmp/app-builds/*-unpacked/resources/app.asar $out/share/super-productivity
-          cp electron/assets/icons/ico-circled.svg $out/share/icons/hicolor/scalable/apps/super-productivity.svg
-
-          makeWrapper '${lib.getExe electron}' "$out/bin/super-productivity" \
-            --add-flags "$out/share/super-productivity/app.asar" \
+          mkdir -p $out/share/{superproductivity,icons/hicolor/scalable/apps}
+          cp -r .tmp/app-builds/*-unpacked/{resources/app.asar,wayland-idle-helper} $out/share/superproductivity
+          cp electron/assets/icons/ico-circled.svg $out/share/icons/hicolor/scalable/apps/superproductivity.svg
+          makeWrapper '${lib.getExe electron}' "$out/bin/superproductivity" \
+            --add-flags "$out/share/superproductivity/app.asar" \
             --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
             --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
             --inherit-argv0
         ''
     }
 
+    # backward compat symlink for the old binary name
+    ln -s superproductivity "$out"/bin/super-productivity
+
     runHook postInstall
   '';
 
-  # copied from deb file
+  # matches upstream electron-builder.yaml linux.desktop config
   desktopItems = [
     (makeDesktopItem {
-      name = "super-productivity";
-      desktopName = "superProductivity";
-      exec = "super-productivity %u";
+      name = "superproductivity";
+      desktopName = "Super Productivity";
+      exec = "superproductivity %U";
       terminal = false;
       type = "Application";
-      icon = "super-productivity";
-      startupWMClass = "superProductivity";
-      comment = "ToDo list and Time Tracking";
+      icon = "superproductivity";
+      startupWMClass = "superproductivity";
       categories = [
         "Office"
         "ProjectManagement"
       ];
+      mimeTypes = [ "x-scheme-handler/superproductivity" ];
     })
   ];
 
@@ -174,6 +203,6 @@ buildNpmPackage rec {
       pineapplehunter
       tebriel
     ];
-    mainProgram = "super-productivity";
+    mainProgram = "superproductivity";
   };
 }


### PR DESCRIPTION
Upstream v18.8.0 added an ext-idle-notify helper for Wayland idle detection, built from electron/wayland-idle-helper/ with Rust. The helper is built separately as an inline rustPlatform.buildRustPackage derivation.

Assisted-by: opencode deepseek-v4-flash-free


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
