### PR TITLE
iocaine: 2.5.1 -> 3.5.1; nixos/iocaine: init module

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -150,6 +150,8 @@
 
 - `pdfium` is now built from source instead of packaging prebuilt binaries. `pdfium-binaries` has been renamed to `pdfium`, and `pdfium-binaries-v8` has been removed.
 
+- `iocaine` has been updated to `3.5.1`.
+
 - `librest` providing 0.7 ABI was removed. `librest_1_0` providing 1.0 ABI was renamed to `librest` and `librest_1_0` was kept as an alias.
 
 - `luaPackages.lrexlib-pcre` has been removed as part of the process to fully migrate from the end-of-life PRCE library to PCRE2. `luaPackages.lrexlib-pcre2` and multiple other versions of lrexlib can be used instead.

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -100,6 +100,8 @@
 
 - [vellum](https://github.com/greyxp1/vellum) is a live screen annotation overlay for Wayland. Available as [programs.vellum](#opt-programs.vellum.enable).
 
+- [iocaine](https://git.madhouse-project.org/iocaine/iocaine) is a defense mechanism against unwanted scrapers. Available as [services.iocaine](#opt-services.iocaine.enable).
+
 - [stash-clipboard](https://github.com/NotAShelf/stash), a Wayland clipboard "manager" with fast persistent history and multi-media support. Available as [services.stash-clipboard](#opt-services.stash-clipboard.enable).
 
 - [OO7](https://github.com/linux-credentials/oo7) is a desktop-agnostic Secret Service provider. Available as [services.oo7](#opt-services.oo7.enable)

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1282,6 +1282,7 @@
   ./services/networking/imaginary.nix
   ./services/networking/inadyn.nix
   ./services/networking/inspircd.nix
+  ./services/networking/iocaine.nix
   ./services/networking/iodine.nix
   ./services/networking/iperf3.nix
   ./services/networking/ircd-hybrid/default.nix

--- a/nixos/modules/services/networking/iocaine.nix
+++ b/nixos/modules/services/networking/iocaine.nix
@@ -1,0 +1,226 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    any
+    getExe
+    hasPrefix
+    mapAttrsToList
+    mkIf
+    literalExpression
+    mkEnableOption
+    mkMerge
+    mkOption
+    mkPackageOption
+    optional
+    optionals
+    ;
+
+  inherit (lib.types)
+    attrsOf
+    bool
+    listOf
+    nullOr
+    path
+    str
+    submodule
+    ;
+
+  cfg = config.services.iocaine;
+
+  jsonFormat = pkgs.formats.json { };
+
+  hasUDSbind = any (hasPrefix "/") (
+    mapAttrsToList (_server: cfg: cfg.bind) (cfg.settings.server or { })
+  );
+
+  ifHasSettings = optional (cfg.settings != null);
+
+  hasFirewall = cfg.settings.firewall.enable;
+
+  description = "iocaine, the deadliest poison known to AI";
+in
+{
+  options.services.iocaine = {
+    enable = mkEnableOption description;
+
+    package = mkPackageOption pkgs "iocaine" { };
+
+    environment = mkOption {
+      default = { };
+      type = attrsOf str;
+      description = "Environment variables for iocaine.";
+      example = literalExpression ''
+        {
+          RUST_LOG = "info";
+          RUST_BACKTRACE = "1";
+        }
+      '';
+    };
+
+    settings = mkOption {
+      type = nullOr (submodule {
+        freeformType = jsonFormat.type;
+
+        options = {
+          firewall.enable = mkOption {
+            default = false;
+            type = bool;
+            description = "Enables the firewall";
+            example = true;
+          };
+        };
+      });
+      default = null;
+      description = ''
+        The configuration for iocaine.
+        See [the configuration reference](https://iocaine.madhouse-project.org/documentation/3/configuration/)
+        for full documentation on the fields.
+      '';
+      example = literalExpression ''
+        {
+          server.default = {
+            bind = "localhost:2137";
+            mode = "http";
+            use.handler-from = "default";
+          };
+
+          handler.default = {
+            settings = {
+              "ai-robots-txt-path" = "/etc/iocaine/data/ai.robots.txt-robots.json";
+              sources = {
+                training-corpus = [
+                  "/data/corpus/1984.txt"
+                  "/data/corpus/brave-new-world.txt"
+                ];
+                wordlists = [ "/data/corpus/words.txt" ];
+              };
+            };
+          };
+        }
+      '';
+    };
+
+    extraSettingsPaths = mkOption {
+      type = listOf path;
+      default = [ ];
+      description = "Configuration paths to run iocaine with. Useful for secrets";
+      example = literalExpression ''
+        [
+          "/etc/iocaine/iocaine.json"
+          ./iocaine.json
+        ]
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.etc."iocaine/iocaine.json" = mkIf (cfg.settings != null) {
+      source = jsonFormat.generate "iocaine.json" cfg.settings;
+    };
+
+    systemd.services = mkMerge [
+      {
+        iocaine = {
+          inherit description;
+
+          wantedBy = [ "multi-user.target" ];
+          after = [ "network.target" ];
+
+          environment = {
+            HOME = "%S/home";
+          }
+          // cfg.environment;
+
+          restartTriggers =
+            (ifHasSettings config.environment.etc."iocaine/iocaine.json".source) ++ cfg.extraSettingsPaths;
+
+          stopIfChanged = false;
+
+          serviceConfig = {
+            Type = "notify";
+            ExecStart = toString (
+              [
+                (getExe cfg.package)
+              ]
+              ++ (map (path: "--config-path=${path}") (
+                (ifHasSettings "/etc/iocaine/iocaine.json") ++ cfg.extraSettingsPaths
+              ))
+              ++ [ "start" ]
+            );
+
+            Restart = "on-failure";
+            DynamicUser = true;
+            UMask = "0077";
+            LimitNOFILE = 524288;
+
+            StateDirectory = "iocaine";
+            WorkingDirectory = "%S/iocaine";
+            RuntimeDirectory = "iocaine";
+
+            ProtectSystem = "strict";
+            ProtectClock = true;
+            ProtectHostname = true;
+            ProtectProc = "invisible";
+            ProtectControlGroups = true;
+            ProtectKernelModules = true;
+            ProtectKernelTunables = true;
+            ProtectKernelLogs = true;
+            ProtectHome = true;
+
+            PrivateTmp = true;
+            PrivateDevices = true;
+            PrivateUsers = !hasFirewall;
+
+            SystemCallArchitectures = "native";
+            DevicePolicy = "closed";
+            LockPersonality = true;
+            MemoryDenyWriteExecute = false;
+            NoNewPrivileges = true;
+
+            RestrictAddressFamilies =
+              (optionals hasUDSbind [
+                "AF_INET"
+                "AF_INET6"
+                "AF_UNIX"
+              ])
+              ++ (optionals hasFirewall [ "AF_NETLINK" ]);
+
+            RestrictNamespaces = true;
+            RestrictRealtime = true;
+            SystemCallFilter = [
+              "@system-service"
+              "~@privileged"
+              "~@resources"
+            ];
+
+            CapabilityBoundingSet = mkIf hasFirewall [ "CAP_NET_ADMIN" ];
+            AmbientCapabilities = mkIf hasFirewall [ "CAP_NET_ADMIN" ];
+          };
+        };
+      }
+
+      (
+        let
+          iocaineDep = {
+            requires = [ "iocaine.service" ];
+            after = [ "iocaine.service" ];
+            serviceConfig.SupplementaryGroups = [ "iocaine" ];
+          };
+        in
+        {
+          nginx = mkIf (config.services.nginx.enable && hasUDSbind) iocaineDep;
+          caddy = mkIf (config.services.caddy.enable && hasUDSbind) iocaineDep;
+        }
+      )
+    ];
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ poz ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -927,6 +927,7 @@ in
   inventree = runTest ./inventree.nix;
   invidious = runTest ./invidious.nix;
   invoiceplane = runTest ./invoiceplane.nix;
+  iocaine = runTest ./iocaine.nix;
   iodine = runTest ./iodine.nix;
   iosched = runTest ./iosched.nix;
   ipget = runTest ./ipget.nix;

--- a/nixos/tests/iocaine.nix
+++ b/nixos/tests/iocaine.nix
@@ -1,0 +1,61 @@
+{ lib, ... }:
+{
+  name = "iocaine";
+  meta.maintainers = with lib.maintainers; [ poz ];
+
+  nodes = {
+    iocaine_default = {
+      services.iocaine = {
+        enable = true;
+      };
+    };
+
+    reverse_proxy_integration = {
+      services.iocaine = {
+        enable = true;
+        settings.server.main = {
+          bind = "/run/iocaine/iocaine.socket";
+          unix-socket-access = "group";
+          mode = "http";
+          use = {
+            handler-from = "default";
+          };
+        };
+        settings.handler.default = { };
+      };
+
+      services.caddy = {
+        enable = true;
+        globalConfig = ''
+          http_port 8080
+          https_port 8081
+        '';
+      };
+
+      services.nginx.enable = true;
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    iocaine_default.wait_for_unit("iocaine.service")
+    iocaine_default.fail("curl -s --show-error --fail http://127.0.0.1:42069/random-path/yes/")
+    iocaine_default.fail("curl -s --show-error --fail http://127.0.0.1:42069/ -A 'Googlebot'")
+    iocaine_default.succeed("curl -s --show-error --fail http://127.0.0.1:42069/a/path/very/deep/into/the/forest/ -A 'Perplexity'")
+    iocaine_default.fail("curl -s --show-error --fail http://127.0.0.1:42042/metrics")
+
+    reverse_proxy_integration.wait_for_unit("iocaine.service")
+    reverse_proxy_integration.wait_for_unit("caddy.service")
+    reverse_proxy_integration.wait_for_unit("nginx.service")
+    reverse_proxy_integration.stop_job("nginx")
+    reverse_proxy_integration.stop_job("caddy")
+    reverse_proxy_integration.stop_job("iocaine")
+    reverse_proxy_integration.start_job("nginx")
+    reverse_proxy_integration.succeed("systemctl is-active iocaine.service")
+    reverse_proxy_integration.stop_job("nginx")
+    reverse_proxy_integration.stop_job("iocaine")
+    reverse_proxy_integration.start_job("caddy")
+    reverse_proxy_integration.succeed("systemctl is-active iocaine.service")
+  '';
+}

--- a/pkgs/by-name/io/iocaine/package.nix
+++ b/pkgs/by-name/io/iocaine/package.nix
@@ -1,32 +1,48 @@
 {
-  stdenv,
   lib,
-  rustPlatform,
   fetchFromGitea,
+  nftables,
+  nixosTests,
+  pkg-config,
+  rustPlatform,
+  ...
 }:
-
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "iocaine";
-  version = "2.5.1";
+  version = "3.5.1";
 
   src = fetchFromGitea {
     domain = "git.madhouse-project.org";
     owner = "iocaine";
     repo = "iocaine";
     tag = "iocaine-${finalAttrs.version}";
-    hash = "sha256-213QLpGBKSsT9r8O27PyMom5+OGPz0VtRBevxswISZA=";
+    hash = "sha256-FkIgrptTiYZwHBa6blFeB4HrgTpMREbW004hKpcAKx0=";
   };
 
-  cargoHash = "sha256-EgPGDlJX/m+v3f/tGIO+saGHoYrtiWLZuMlXEvsgnxE=";
+  cargoHash = "sha256-GHveoZ19VaQie9D9i+yoKevB/cnxKd7GLnNOZcAqtJ0=";
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    nftables
+  ];
+
+  passthru = {
+    tests = { inherit (nixosTests) iocaine; };
+  };
 
   meta = {
     description = "Deadliest poison known to AI";
     homepage = "https://iocaine.madhouse-project.org/";
     changelog = "https://git.madhouse-project.org/iocaine/iocaine/src/tag/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ sugar700 ];
     mainProgram = "iocaine";
-    # Lacking OS access to fix, and upstream doesn't support macOS.
-    broken = stdenv.hostPlatform.isDarwin;
   };
 })


### PR DESCRIPTION
this PR updates `iocaine` to `3.5.0` (the latest release at the moment) ~~and adds `iocaine_2` at `2.5.1` to give users time to migrate from `2.x.x` to `3.x.x`, as per https://github.com/NixOS/nixpkgs/pull/467331#issuecomment-3608448404~~

this change has been documented in the release notes

it also ports over the nixos module found at https://git.madhouse-project.org/iocaine/nixocaine/ with the author's consent (see https://git.madhouse-project.org/iocaine/nixocaine/issues/12, ~~I've also left the original copyright text from the author, even though the module has changed a bit from that repo's `stable` branch~~)

I added the same tests for the module found in that repo and info about the module being added to the release notes

I'm also running iocaine on my server from this branch, it seems to be working

first module contribution, so please make sure I've done everything properly :3

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
