### PR TITLE
python3Packages: uefi-firmware-parser: 1.13 -> 1.16 and updateScript

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7941,6 +7941,11 @@
     githubId = 18375468;
     name = "Elliot Xu";
   };
+  elliotberman = {
+    name = "Elliot Berman";
+    github = "elliotberman";
+    githubId = 210410075;
+  };
   elliottslaughter = {
     name = "Elliott Slaughter";
     email = "elliottslaughter@gmail.com";

--- a/pkgs/development/python-modules/uefi-firmware-parser/default.nix
+++ b/pkgs/development/python-modules/uefi-firmware-parser/default.nix
@@ -2,20 +2,21 @@
   fetchFromGitHub,
   lib,
   buildPythonPackage,
+  nix-update-script,
   setuptools,
   wheel,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "uefi-firmware-parser";
-  version = "1.13";
+  version = "1.16";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "theopolis";
     repo = "uefi-firmware-parser";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Yiw9idmvSpx4CcVrXHznR8vK/xl7DTL+L7k4Nvql2B8=";
+    hash = "sha256-2vYTOC7cOiQXPMhYM+hqmFyCJeXCkx6RSxgaTIZqbds=";
   };
 
   build-system = [
@@ -27,13 +28,15 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "uefi_firmware" ];
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Tool for parsing, extracting, and recreating UEFI firmware volumes";
     homepage = "https://github.com/theopolis/uefi-firmware-parser";
     changelog = "https://github.com/theopolis/uefi-firmware-parser/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.mit;
     mainProgram = "uefi-firmware-parser";
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.elliotberman ];
     platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
Uprev uefi-firmware-parser to 1.16, add automatic updateScript, and
myself as maintainer.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
