### PR TITLE
picosnitch: 1.0.3 -> 2.1.1

### DIFF
--- a/pkgs/by-name/pi/picosnitch/package.nix
+++ b/pkgs/by-name/pi/picosnitch/package.nix
@@ -1,48 +1,80 @@
 {
   lib,
+  stdenv,
   python3,
   fetchPypi,
-  bcc,
+  llvmPackages,
+  libbpf,
+  libnotify,
+  makeWrapper,
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "picosnitch";
-  version = "1.0.3";
-  format = "setuptools";
+  version = "2.1.1";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "78285e91b5c4d8e07529a34a7c3fe606acb6f950ee3cc78bb6c346bc2195b68a";
+    sha256 = "1d13fc48280f6a355bcb155d193f93817c1225475ee9670846a56cbd39e2014d";
   };
 
-  propagatedBuildInputs = with python3.pkgs; [
-    setuptools
-    bcc
-    psutil
-    dbus-python
-    requests
-    pandas
-    plotly
-    dash
-    geoip2
+  build-system = with python3.pkgs; [ hatchling ];
+
+  nativeBuildInputs = [
+    # Unwrapped clang/llvm: cc-wrapper injects flags (hardening,
+    # --gcc-toolchain, fortify) that `clang -target bpf` rejects under -Werror.
+    llvmPackages.clang-unwrapped
+    llvmPackages.llvm
+    makeWrapper
   ];
 
-  postInstall = ''
-    substituteInPlace $out/${python3.sitePackages}/picosnitch.py --replace '/run/picosnitch.pid' '/run/picosnitch/picosnitch.pid'
+  buildInputs = [ libbpf ];
+
+  # The sdist ships vendored vmlinux_{x86,arm64}.h, so the BPF compile is
+  # fully offline. Pre-build the .bpf.o here with an explicit libbpf include
+  # path; the hatch build hook sees the existing .o (newer than the .c) and
+  # reuses it instead of invoking clang itself.
+  preBuild = ''
+    bpfTargetArch=${if stdenv.hostPlatform.isAarch64 then "arm64" else "x86"}
+    cp src/picosnitch/bpf/vmlinux_$bpfTargetArch.h src/picosnitch/bpf/vmlinux.h
+    clang -g -O2 -target bpf -D__TARGET_ARCH_$bpfTargetArch \
+      -Wall -Werror -Wno-missing-declarations \
+      -I${lib.getDev libbpf}/include \
+      -Isrc/picosnitch/bpf \
+      -c src/picosnitch/bpf/picosnitch.bpf.c \
+      -o src/picosnitch/bpf/picosnitch.bpf.o
+    llvm-strip -g src/picosnitch/bpf/picosnitch.bpf.o || true
   '';
+
+  # The build hook keys the wheel platform tag and BPF target arch off this var.
+  env.PICOSNITCH_BPF_TARGET_ARCH =
+    if stdenv.hostPlatform.isAarch64 then
+      "aarch64"
+    else if stdenv.hostPlatform.isx86_64 then
+      "x86_64"
+    else
+      throw "picosnitch: unsupported platform ${stdenv.hostPlatform.system}";
 
   pythonImportsCheck = [ "picosnitch" ];
 
+  # picosnitch loads libbpf via ctypes and shells out to `notify-send`.
+  postFixup = ''
+    wrapProgram $out/bin/picosnitch \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libbpf ]} \
+      --prefix PATH : ${lib.makeBinPath [ libnotify ]}
+  '';
+
   meta = {
-    description = "Monitor network traffic per executable with hashing";
+    description = "Monitor network traffic per executable using BPF";
     mainProgram = "picosnitch";
     homepage = "https://github.com/elesiuta/picosnitch";
     changelog = "https://github.com/elesiuta/picosnitch/releases";
     license = lib.licenses.gpl3Plus;
     maintainers = [ lib.maintainers.elesiuta ];
-    platforms = lib.platforms.linux;
-    knownVulnerabilities = [
-      "Allows an unprivileged user to write to arbitrary files as root; see https://github.com/elesiuta/picosnitch/issues/40"
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
     ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
