### PR TITLE
npq: init at 3.19.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15078,6 +15078,12 @@
 
     keys = [ { fingerprint = "5A9A 1C9B 2369 8049 3B48  CF5B 81A1 5409 4816 2372"; } ];
   };
+  kynsonszetau = {
+    name = "Kynson Szetau";
+    email = "nixpkgs@kynsonszetau.com";
+    github = "Kynson";
+    githubId = 46522440;
+  };
   l0b0 = {
     email = "victor@engmark.name";
     github = "l0b0";

--- a/pkgs/by-name/np/npq/package.nix
+++ b/pkgs/by-name/np/npq/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  fetchurl,
+  buildNpmPackage,
+  versionCheckHook,
+  nix-update-script,
+}:
+buildNpmPackage (finalAttrs: {
+  pname = "npq";
+  version = "3.19.6";
+
+  src = fetchFromGitHub {
+    owner = "lirantal";
+    repo = "npq";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-UCxo43RAJNH/60gDX99BPSCchvTb2wAJNcMXbQkROII=";
+  };
+
+  topPackagesFile = fetchurl {
+    # Note: There is only one tag called `latest`. Therefore, it cannot be pinned to a specific version.
+    url = "https://github.com/lirantal/npm-rank/releases/download/latest/list-package-names.json";
+    hash = "sha256-5EXd3kyhCUFXG/7pUxcs6FS7sRAZfRX0nNbzblCtkGI=";
+  };
+
+  # Skip the original npm build script
+  dontNpmBuild = true;
+
+  # npq uses semantic-release in CI so we need to patch the version in package.json and package-lock.json
+  postPatch = ''
+    echo "Patching package.json version to ${finalAttrs.version}..."
+    substituteInPlace package*.json \
+      --replace-fail '"version": "0.0.0-development"' '"version": "${finalAttrs.version}"'
+  '';
+
+  # This substitutes the original npm build script
+  preInstall = ''
+    echo "Copying list-package-names.json to data directory..."
+    cp ${finalAttrs.topPackagesFile} ./data/list-package-names.json
+  '';
+
+  stdenv = stdenvNoCC;
+
+  npmDepsHash = "sha256-vSj1aGxFL9l14eiJN1j8RvkMOpb+6KflhAX0BZ1znuw=";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  __structuredAttrs = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Marshall your npm/npm package installs";
+    homepage = "https://github.com/lirantal/npq";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kynsonszetau ];
+    changelog = "https://github.com/lirantal/npq/releases/tag/${finalAttrs.src.tag}";
+    mainProgram = "npq";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add a new package `npq` to nixpkgs. `npq` is a wrapper for node package managers like `npm` and `pnpm` and scans the packages before actually installing them.

Homepage: [https://github.com/lirantal/npq](https://github.com/lirantal/npq)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
