### PR TITLE
deja: 0.2.7 -> 0.3.0

### DIFF
--- a/pkgs/by-name/de/deja/package.nix
+++ b/pkgs/by-name/de/deja/package.nix
@@ -7,13 +7,13 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "deja";
-  version = "0.2.7";
+  version = "0.3.0";
   __structuredAttrs = true;
   src = fetchFromGitHub {
     owner = "Giammarco-Ferranti";
     repo = "deja";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-HHD9x7oM9b0Bt9QhtMhirwobW/o/zjiCVPCFKTn838g=";
+    hash = "sha256-xxbClKhhSwo+jUjAZ2gS4yOS5sSI76dfPpDzA3qdV18";
   };
 
   vendorHash = "sha256-KmLdMK94cGOXMPJwWS6NgLB5OiNmJbszHdnLzauqJm8=";


### PR DESCRIPTION
## [0.3.0](https://github.com/Giammarco-Ferranti/deja/compare/v0.2.7...v0.3.0) (2026-06-04)


### Features

* add fuzzy matching modes (smart/loose/tight) with cycle keybinding ([e6db73f](https://github.com/Giammarco-Ferranti/deja/commit/e6db73f5f94b0b74e0c8cfa4089cff10be33c447))
* configurable suggestion keybindings ([#54](https://github.com/Giammarco-Ferranti/deja/issues/54), [#52](https://github.com/Giammarco-Ferranti/deja/issues/52)) ([#60](https://github.com/Giammarco-Ferranti/deja/issues/60)) ([532ea39](https://github.com/Giammarco-Ferranti/deja/commit/532ea39090c0df2afc162091020c2f80c9bc8f99))
* implemented deja.plugin.zsh to ensure deja can be used as a cus… ([#61](https://github.com/Giammarco-Ferranti/deja/issues/61)) ([a35ba3c](https://github.com/Giammarco-Ferranti/deja/commit/a35ba3c138e0220618b77ea4da27cef3e4ef8807))
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
