### PR TITLE
python3Packages.wandb: 0.27.0 -> 0.27.1

### DIFF
--- a/pkgs/development/python-modules/wandb/default.nix
+++ b/pkgs/development/python-modules/wandb/default.nix
@@ -52,6 +52,7 @@
   jsonschema,
   kubernetes,
   kubernetes-asyncio,
+  looptime,
   matplotlib,
   moviepy,
   pandas,
@@ -76,12 +77,12 @@
 }:
 
 let
-  version = "0.27.0";
+  version = "0.27.1";
   src = fetchFromGitHub {
     owner = "wandb";
     repo = "wandb";
     tag = "v${version}";
-    hash = "sha256-A/tEyY47BDgahOhQWlmeF2koEDpIsV9QVoYMIBEbKqA=";
+    hash = "sha256-gaZUp4yOnajEyJ5pXXOMCPk7uQ5GEGPrrKMgC6NxIAY=";
   };
 
   wandb-xpu = rustPlatform.buildRustPackage {
@@ -143,7 +144,7 @@ let
       ''
         substituteInPlace go.mod \
           --replace-fail \
-            "go 1.26.3" \
+            "go 1.26.4" \
             "go 1.26.2"
       ''
       # hardcode the `wandb-xpu` binary path.
@@ -269,6 +270,7 @@ buildPythonPackage (finalAttrs: {
     jsonschema
     kubernetes
     kubernetes-asyncio
+    looptime
     matplotlib
     moviepy
     pandas

--- a/pkgs/development/python-modules/wandb/hardcode-git-path.patch
+++ b/pkgs/development/python-modules/wandb/hardcode-git-path.patch
@@ -1,8 +1,8 @@
 diff --git a/wandb/cli/cli.py b/wandb/cli/cli.py
-index a87b17c96..21c851992 100644
+index 2623a3d75..ea78e52b8 100644
 --- a/wandb/cli/cli.py
 +++ b/wandb/cli/cli.py
-@@ -2672,7 +2672,7 @@ def restore(ctx, run, no_git, branch, project, entity):
+@@ -3264,7 +3264,7 @@ def restore(ctx, run, no_git, branch, project, entity):
      commit, json_config, patch_content, metadata = api.run_config(
          project, run=run, entity=entity
      )
@@ -11,7 +11,7 @@ index a87b17c96..21c851992 100644
      image = metadata.get("docker")
      restore_message = f"""`wandb restore` needs to be run from the same git repository as the original run.
  Run `git clone {repo}` and restore from there or pass the --no-git flag."""
-@@ -2691,7 +2691,7 @@ Run `git clone {repo}` and restore from there or pass the --no-git flag."""
+@@ -3283,7 +3283,7 @@ Run `git clone {repo}` and restore from there or pass the --no-git flag."""
  
      if commit and git.enabled:
          wandb.termlog(f"Fetching origin and finding commit: {commit}")
@@ -20,7 +20,7 @@ index a87b17c96..21c851992 100644
          try:
              git.repo.commit(commit)
          except ValueError:
-@@ -2744,7 +2744,7 @@ Run `git clone {repo}` and restore from there or pass the --no-git flag."""
+@@ -3336,7 +3336,7 @@ Run `git clone {repo}` and restore from there or pass the --no-git flag."""
              # --reject is necessary or else this fails any time a binary file
              # occurs in the diff
              exit_code = subprocess.call(
@@ -29,16 +29,3 @@ index a87b17c96..21c851992 100644
              )
              if exit_code == 0:
                  wandb.termlog("Applied patch")
-diff --git a/wandb/vendor/promise-2.3.0/wandb_promise/pyutils/version.py b/wandb/vendor/promise-2.3.0/wandb_promise/pyutils/version.py
-index 47d439145..16118feb0 100644
---- a/wandb/vendor/promise-2.3.0/wandb_promise/pyutils/version.py
-+++ b/wandb/vendor/promise-2.3.0/wandb_promise/pyutils/version.py
-@@ -69,7 +69,7 @@ def get_git_changeset():
-     repo_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-     try:
-         git_log = subprocess.Popen(
--            "git log --pretty=format:%ct --quiet -1 HEAD",
-+            "@git@ log --pretty=format:%ct --quiet -1 HEAD",
-             stdout=subprocess.PIPE,
-             stderr=subprocess.PIPE,
-             shell=True,


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/wandb/wandb/compare/v0.27.0...v0.27.1
Changelog: https://github.com/wandb/wandb/raw/0.27.1/CHANGELOG.md

cc @samuela

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test