### PR TITLE
rgx: 0.12.4 -> 0.12.6

### DIFF
--- a/pkgs/by-name/rg/rgx/package.nix
+++ b/pkgs/by-name/rg/rgx/package.nix
@@ -8,7 +8,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rgx";
-  version = "0.12.4";
+  version = "0.12.6";
 
   __structuredAttrs = true;
 
@@ -16,10 +16,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "brevity1swos";
     repo = "rgx";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-wr2MPujzrDnuXDLp+moc2gQpjBrs7MIgSalkjuctQZU=";
+    hash = "sha256-YdbuyVhqu1LUaHecF1iFS62/qcW9IgXPlsEoWpNdrEQ=";
   };
 
-  cargoHash = "sha256-MIcIPQrYoCHKrsIJzMvozF3/00XYfqLBAyEtqlyfceI=";
+  cargoHash = "sha256-ILq0oB+Xq4agQMWqGLV0LC4NlMkUMVFppLJ+FJpsTRM=";
 
   buildInputs = [ pcre2 ];
 


### PR DESCRIPTION
Update rgx to v0.12.6

[Changelog v0.12.6](https://github.com/brevity1swos/rgx/releases/tag/v0.12.6)
[Changelog v0.12.5](https://github.com/brevity1swos/rgx/releases/tag/v0.12.5) (only test refactoring)
Diff: [https://github.com/brevity1swos/rgx/compare/v0.12.4...v0.12.6](https://github.com/brevity1swos/rgx/compare/v0.12.4...v0.12.6)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
