### PR TITLE
matomo: 5.10.0 -> 5.10.1

### DIFF
--- a/pkgs/by-name/ma/matomo/package.nix
+++ b/pkgs/by-name/ma/matomo/package.nix
@@ -10,11 +10,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "matomo";
-  version = "5.10.0";
+  version = "5.10.1";
 
   src = fetchurl {
     url = "https://builds.matomo.org/matomo-${finalAttrs.version}.tar.gz";
-    hash = "sha256-i7nRQRY2gAzMQmRNGaksq4B516MsQuXQZbzlEUWEsQw=";
+    hash = "sha256-TP1gQ3OAhdg2IEskocvP6VhBkHUEXFdq5+PvomjUnXA=";
   };
 
   nativeBuildInputs = [ makeWrapper ];


### PR DESCRIPTION
Simple version bump to 5.10.1

(i wonder why r-ryantm failed to update it https://nixpkgs-update-logs.nix-community.org/matomo/2026-05-30.log)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
