### PR TITLE
texlyre: init at 0.9.0

### DIFF
--- a/pkgs/by-name/te/texlyre/package.nix
+++ b/pkgs/by-name/te/texlyre/package.nix
@@ -3,6 +3,7 @@
   xsel,
   serve,
   fetchzip,
+  stdenvNoCC,
   makeWrapper,
   buildNpmPackage,
   fetchFromGitHub,
@@ -67,15 +68,31 @@ buildNpmPackage (finalAttrs: {
   '';
 
   passthru = {
-    drawioEmbed = fetchzip {
-      url = "https://github.com/TeXlyre/drawio-embed-mirror/archive/refs/tags/v29.7.9.zip";
-      hash = "sha256-mj+i+6n14Koo9TYaygrCgFg0OLfBZnnL6rE3PkJGa9w=";
-    };
-    busytexAssets = fetchzip {
-      url = "https://github.com/TeXlyre/texlyre-busytex/releases/download/assets-v1.1.1/busytex-assets.tar.gz";
-      hash = "sha256-CLhLYLNXsJflX6o642EEJu+hxwoy3zkzfAOShiZGVPg=";
-      stripRoot = false;
-    };
+    updateScript = ./update.sh;
+    drawioEmbed = stdenvNoCC.mkDerivation (finalAttrs: {
+      pname = "drawio-embed";
+      version = "29.7.9";
+      src = fetchFromGitHub {
+        owner = "TeXlyre";
+        repo = "drawio-embed-mirror";
+        tag = "v${finalAttrs.version}";
+        hash = "sha256-mj+i+6n14Koo9TYaygrCgFg0OLfBZnnL6rE3PkJGa9w=";
+      };
+      dontBuild = true;
+      installPhase = "cp -a . $out";
+    });
+    busytexAssets = stdenvNoCC.mkDerivation (finalAttrs: {
+      pname = "busytex-assets";
+      version = "1.1.1";
+      src = fetchFromGitHub {
+        owner = "TeXlyre";
+        repo = "texlyre-busytex";
+        tag = "assets-v${finalAttrs.version}";
+        hash = "sha256-vlLoJw5EX6x3nTQvBC8hntDa5QKtY46eJSxJLJzs4EE=";
+      };
+      dontBuild = true;
+      installPhase = "cp -a . $out";
+    });
   };
 
   meta = {

--- a/pkgs/by-name/te/texlyre/package.nix
+++ b/pkgs/by-name/te/texlyre/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  xsel,
+  serve,
+  fetchzip,
+  makeWrapper,
+  buildNpmPackage,
+  fetchFromGitHub,
+
+  baseUrl ? "/",
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "texlyre";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "TeXlyre";
+    repo = "texlyre";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-aBGhTJS/UDcWOhzP4HtIQO5ZjNGXTj3oPLje65HIhe4=";
+  };
+
+  npmDepsHash = "sha256-davqKXgSwjPM0QQ/moo5sjh7e9wVXjH30SrFC4opmuQ=";
+
+  postPatch = ''
+    sed -i 's/"version": ".*"/"version": "${finalAttrs.version}"/' package.json
+
+    substituteInPlace texlyre.config.ts \
+      --replace-fail "baseUrl: '/texlyre/'" "baseUrl: '${baseUrl}'"
+
+    # disable downloading assets
+    substituteInPlace scripts/setup-assets.cjs \
+      --replace-fail "await downloadCoreAssets();" ""
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  __structuredAttrs = true;
+
+  preBuild = ''
+    # put core assets in place
+    mkdir -p public/core
+    cp -r ${finalAttrs.passthru.drawioEmbed}/drawio-embed public/core/drawio-embed
+    cp -r ${finalAttrs.passthru.busytexAssets} public/core/busytex
+
+    npm run generate:configs
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    npm run test:check
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mv dist $out
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    makeWrapper ${lib.getExe serve} $out/bin/texlyre \
+      --prefix PATH : ${lib.makeBinPath [ xsel ]} \
+      --chdir $out
+  '';
+
+  passthru = {
+    drawioEmbed = fetchzip {
+      url = "https://github.com/TeXlyre/drawio-embed-mirror/archive/refs/tags/v29.7.9.zip";
+      hash = "sha256-mj+i+6n14Koo9TYaygrCgFg0OLfBZnnL6rE3PkJGa9w=";
+    };
+    busytexAssets = fetchzip {
+      url = "https://github.com/TeXlyre/texlyre-busytex/releases/download/assets-v1.1.1/busytex-assets.tar.gz";
+      hash = "sha256-CLhLYLNXsJflX6o642EEJu+hxwoy3zkzfAOShiZGVPg=";
+      stripRoot = false;
+    };
+  };
+
+  meta = {
+    changelog = "https://github.com/TeXlyre/texlyre/releases/tag/${finalAttrs.src.rev}";
+    description = "Local-first LaTeX & Typst web editor with real-time collaboration & offline support";
+    homepage = "https://github.com/TeXlyre/texlyre";
+    license = lib.licenses.agpl3Only;
+    platforms = lib.platforms.all;
+    mainProgram = "texlyre";
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/by-name/te/texlyre/package.nix
+++ b/pkgs/by-name/te/texlyre/package.nix
@@ -13,16 +13,16 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "texlyre";
-  version = "0.8.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "TeXlyre";
     repo = "texlyre";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-aBGhTJS/UDcWOhzP4HtIQO5ZjNGXTj3oPLje65HIhe4=";
+    hash = "sha256-sUyQYtTuE5bNEqxDw9DYT0KRiww7PmGnQ7CYt60EbSc=";
   };
 
-  npmDepsHash = "sha256-davqKXgSwjPM0QQ/moo5sjh7e9wVXjH30SrFC4opmuQ=";
+  npmDepsHash = "sha256-bOhK7kQWY3QYri9S+WoD8VyZXTGK5gcK/ixpGeeP4hg=";
 
   postPatch = ''
     sed -i 's/"version": ".*"/"version": "${finalAttrs.version}"/' package.json
@@ -71,12 +71,12 @@ buildNpmPackage (finalAttrs: {
     updateScript = ./update.sh;
     drawioEmbed = stdenvNoCC.mkDerivation (finalAttrs: {
       pname = "drawio-embed";
-      version = "29.7.9";
+      version = "30.2.2";
       src = fetchFromGitHub {
         owner = "TeXlyre";
         repo = "drawio-embed-mirror";
         tag = "v${finalAttrs.version}";
-        hash = "sha256-mj+i+6n14Koo9TYaygrCgFg0OLfBZnnL6rE3PkJGa9w=";
+        hash = "sha256-bdOhviJl0P/+GSJKaHMbGoPf+uEhoX5GeyY6bGBOpCg=";
       };
       dontBuild = true;
       installPhase = "cp -a . $out";

--- a/pkgs/by-name/te/texlyre/update.sh
+++ b/pkgs/by-name/te/texlyre/update.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-update jq gitMinimal
+
+set -euo pipefail
+
+nix-update texlyre
+
+PKG_DIR=$(realpath "$(dirname "$0")")
+NIXPKGS_ROOT="$(git rev-parse --show-toplevel)"
+SRC_DIR=$(nix-build -E "(import \"$NIXPKGS_ROOT\" {}).texlyre.src" --no-out-link)
+ASSETS_SCRIPT="$SRC_DIR/scripts/download-core-assets.cjs"
+
+DRAWIO_VERSION=$(grep -A 2 "name: 'drawio-embed'" "$ASSETS_SCRIPT" | grep "version:" | cut -d "'" -f 2 | sed 's/^v//')
+BUSYTEX_VERSION=$(grep -A 2 "name: 'texlyre-busytex'" "$ASSETS_SCRIPT" | grep "version:" | cut -d "'" -f 2 | sed 's/^v//')
+
+echo "Updating: drawio-embed=$DRAWIO_VERSION, busytex=$BUSYTEX_VERSION"
+
+nix-update texlyre.passthru.drawioEmbed --version "$DRAWIO_VERSION"
+nix-update texlyre.passthru.busytexAssets --version "$BUSYTEX_VERSION"


### PR DESCRIPTION
Thanks @blokyk for allowing to use the [derivation](https://github.com/blokyk/packages.nix/blob/main/pkgs/texlyre/package.nix) you have written.

- closes https://github.com/ngi-nix/projects/issues/1023

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core"
        functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in
      `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and
      other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
