### PR TITLE
webkitgtk_6_0: fix build with system malloc

### DIFF
--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -103,7 +103,16 @@ clangStdenv.mkDerivation (finalAttrs: {
     hash = "sha256-z0B2ocoqZHiO3KjEUtjrto1eKWXliP5Go4igFlE+3OQ=";
   };
 
-  patches = lib.optionals clangStdenv.hostPlatform.isLinux [
+  patches = [
+    # Fix build with system malloc
+    # See: https://bugs.webkit.org/show_bug.cgi?id=316083
+    (fetchpatch {
+      url = "https://github.com/WebKit/WebKit/commit/a6bc685a685c8f16c919dc6310a62a26971d396e.patch";
+      hash = "sha256-X3E9SYykYomoBeAL4vS1Iuw2fPdO8fI7MvAW/kEhTMc=";
+      name = "fix-build-with-system-malloc.patch";
+    })
+  ]
+  ++ lib.optionals clangStdenv.hostPlatform.isLinux [
     (replaceVars ./fix-bubblewrap-paths.patch {
       inherit (builtins) storeDir;
       inherit (addDriverRunpath) driverLink;


### PR DESCRIPTION
WebKitGTK 2.52.4 introduces a configure-phase regression on exotic platforms where `USE_SYSTEM_MALLOC` is off, see see https://bugs.webkit.org/show_bug.cgi?id=316083. Applying https://github.com/WebKit/WebKit/commit/a6bc685a685c8f16c919dc6310a62a26971d396e resolves the issue.

Resolves https://github.com/NixOS/nixpkgs/pull/527169#issuecomment-4617115030

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] loongarch64-linux
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
