### PR TITLE
python3Packages.iterable-io: 1.0.1 -> 1.0.4

### DIFF
--- a/pkgs/development/python-modules/iterable-io/default.nix
+++ b/pkgs/development/python-modules/iterable-io/default.nix
@@ -2,23 +2,23 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  setuptools,
+  hatchling,
   pytestCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "iterable-io";
-  version = "1.0.1";
+  version = "1.0.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pR0Ps";
     repo = "iterable-io";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-mS8x3M0DNnwW6Ov3TG8b2J702rjOnZT9r38fsIUXkro=";
+    hash = "sha256-6qhizeRZONxEthkk468U6Lh7ES7kgWDBfwsdZm5tuX8=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  nativeBuildInputs = [ hatchling ];
 
   pythonImportsCheck = [ "iterableio" ];
 


### PR DESCRIPTION
https://github.com/pR0Ps/iterable-io/blob/refs/tags/v1.0.4/CHANGELOG.md
https://github.com/pR0Ps/iterable-io/compare/refs/tags/v1.0.1...refs/tags/v1.0.4

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 527891 --additional-package nixosTests.magic-wormhole-mailbox-server`
Commit: `cfe306cfe52908320da49457d86c21fca9280e9e`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 test built:</summary>
  <ul>
    <li>nixosTests.magic-wormhole-mailbox-server</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>gnome-keysign</li>
    <li>magic-wormhole (python313Packages.magic-wormhole)</li>
    <li>python313Packages.iterable-io</li>
    <li>python314Packages.iterable-io</li>
    <li>python314Packages.magic-wormhole</li>
    <li>tahoe-lafs</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test