### PR TITLE
ollama: 0.24.0 -> 0.30.4

### DIFF
--- a/pkgs/by-name/ol/ollama/package.nix
+++ b/pkgs/by-name/ol/ollama/package.nix
@@ -21,6 +21,7 @@
   vulkan-tools,
   vulkan-headers,
   vulkan-loader,
+  spirv-headers,
   shaderc,
   ccache,
 
@@ -191,6 +192,10 @@ goBuild (finalAttrs: {
   ]
   ++ lib.optionals enableVulkan [
     ccache
+    # ggml-vulkan/CMakeLists.txt does `find_package(SPIRV-Headers REQUIRED)`
+    # at configure time (it builds shader code into the vulkan backend).
+    # Header-only — nativeBuildInputs is the right slot.
+    spirv-headers
   ];
 
   buildInputs =
@@ -276,6 +281,28 @@ goBuild (finalAttrs: {
 
     in
     ''
+      ${lib.optionalString enableVulkan ''
+        # Ollama builds each per-accelerator llama.cpp runner via
+        # cmake/local.cmake's ExternalProject_Add(ollama-llama-server-vulkan …).
+        # Two things need to cross the parent → child boundary:
+        #
+        # 1. The SPIRV-Headers cmake config — so `find_package(SPIRV-Headers
+        #    REQUIRED)` at ggml-vulkan/CMakeLists.txt:14 succeeds in the
+        #    child. CMAKE_PREFIX_PATH as a flag wouldn't propagate; as env
+        #    var it does.
+        # 2. The SPIRV-Headers include directory in the compile env. The
+        #    ggml-vulkan target's `target_link_libraries(... Vulkan::Vulkan)`
+        #    notably does NOT link `SPIRV-Headers::SPIRV-Headers`, so the
+        #    interface include directory the cmake config exports never
+        #    flows into the compile commands — even though the find_package
+        #    call succeeded. `#include <spirv/unified1/spirv.hpp>` then
+        #    fails at compile time. Patching upstream's CMakeLists for
+        #    one missing link line is fragile across llama.cpp pins;
+        #    NIX_CFLAGS_COMPILE forces the include path globally and
+        #    survives version bumps.
+        export CMAKE_PREFIX_PATH="${spirv-headers}''${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
+        export NIX_CFLAGS_COMPILE="-isystem ${spirv-headers}/include $NIX_CFLAGS_COMPILE"
+      ''}
       cmake -B build \
         -DCMAKE_SKIP_BUILD_RPATH=ON \
         -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \

--- a/pkgs/by-name/ol/ollama/package.nix
+++ b/pkgs/by-name/ol/ollama/package.nix
@@ -7,7 +7,6 @@
   stdenv,
   addDriverRunpath,
   nix-update-script,
-  coreutils,
 
   cmake,
   gitMinimal,
@@ -108,6 +107,17 @@ let
 
   cudaPath = lib.removeSuffix "-${cudaMajorVersion}" cudaToolkit;
 
+  # Since v0.30, llama.cpp is consumed via CMake FetchContent rather than
+  # vendored in-tree. Pre-stage the pinned commit (read from upstream's
+  # `LLAMA_CPP_VERSION` file — currently `b9493`) so the FetchContent step
+  # uses our copy instead of trying to clone over the network in the sandbox.
+  llamaCppSrc = fetchFromGitHub {
+    owner = "ggml-org";
+    repo = "llama.cpp";
+    rev = "a731805cedc83c0514cbd808a2e38ec46c759cc2"; # tag b9493
+    hash = "sha256-DO9J1mx9Jlp6qtCiJp2ZEi6R7H2YX1/sD7DGgBCtt0U=";
+  };
+
   wrapperOptions = [
     # ollama embeds llama-cpp binaries which actually run the ai models
     # these llama-cpp binaries are unaffected by the ollama binary's DT_RUNPATH
@@ -132,25 +142,25 @@ let
     if enableCuda then
       buildGoModule.override { stdenv = cudaPackages.backendStdenv; }
     else if enableRocm then
-      buildGoModule.override { stdenv = rocmPackages.stdenv; }
+      buildGoModule.override { inherit (rocmPackages) stdenv; }
     else if enableVulkan then
-      buildGoModule.override { stdenv = vulkan-tools.stdenv; }
+      buildGoModule.override { inherit (vulkan-tools) stdenv; }
     else
       buildGoModule;
   inherit (lib) licenses platforms maintainers;
 in
 goBuild (finalAttrs: {
   pname = "ollama";
-  version = "0.24.0";
+  version = "0.30.4";
 
   src = fetchFromGitHub {
     owner = "ollama";
     repo = "ollama";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-cSZtbF0oUI7a++baTipF6OUu+w8tBpILzE0Wm1Y6wUk=";
+    hash = "sha256-IHX8o1Ty4Sdht5YeUYLnNPjOV7O95WeNng/coO+MHS8=";
   };
 
-  vendorHash = "sha256-Lc1Ktdqtv2VhJQssk8K1UOimeEjVNvDWePE9WkamCos=";
+  vendorHash = "sha256-lZdGzGb9xRjTm1Rm7/wHjqM490gLznLEndmb4mNbCX0=";
   proxyVendor = true;
 
   env =
@@ -190,25 +200,31 @@ goBuild (finalAttrs: {
     ++ lib.optionals enableVulkan vulkanLibs;
 
   # replace inaccurate version number with actual release version
-  # and replace core utils tools from their FHS location to nix store
   postPatch = ''
     substituteInPlace version/version.go \
       --replace-fail 0.0.0 '${finalAttrs.version}'
-    substituteInPlace cmd/launch/openclaw_test.go \
-      --replace-fail '/bin/mkdir' '${coreutils}/bin/mkdir' \
-      --replace-fail '/bin/cat' '${coreutils}/bin/cat' \
-      --replace-fail '/usr/bin/env' '${coreutils}/bin/env' \
-      --replace-fail '/usr/bin/sort' '${coreutils}/bin/sort' \
-      --replace-fail '/bin/chmod' '${coreutils}/bin/chmod'
-    substituteInPlace cmd/launch/hermes_test.go \
-      --replace-fail '/bin/mkdir' '${coreutils}/bin/mkdir' \
-      --replace-fail '/bin/cat' '${coreutils}/bin/cat' \
-      --replace-fail '/bin/chmod' '${coreutils}/bin/chmod'
-    substituteInPlace cmd/launch/kimi_test.go \
-       --replace-fail '/bin/mkdir' '${coreutils}/bin/mkdir' \
-       --replace-fail '/bin/cat' '${coreutils}/bin/cat' \
-       --replace-fail '/bin/chmod' '${coreutils}/bin/chmod'
+
+    # cmd/launch/*_test.go are integration tests for user-facing CLI
+    # launchers (claude, qwen, cline, codex, kimi, droid, openclaw, hermes,
+    # …) that install the target binary via npm and then exec it on PATH.
+    # Both prerequisites are unavailable in the nix sandbox, so the launch
+    # subpackage's tests can't pass here. Drop them.
+    rm cmd/launch/*_test.go
+
     rm -r app
+
+    # Pre-stage llama.cpp for the FetchContent step and apply Ollama's
+    # compat patch. When FETCHCONTENT_SOURCE_DIR_LLAMA_CPP is set, neither
+    # `cmake/local.cmake` nor `llama/server/CMakeLists.txt` auto-applies
+    # the patch (the parent's ExternalProject_Add passes
+    # OLLAMA_LLAMA_CPP_SKIP_COMPAT_PATCH=ON to the child build) — the
+    # caller has to. The apply-patch.cmake script is idempotent so this
+    # is safe to re-run.
+    cp -r ${llamaCppSrc} $TMPDIR/llama-cpp-src
+    chmod -R +w $TMPDIR/llama-cpp-src
+    ( cd $TMPDIR/llama-cpp-src && \
+      cmake -DPATCH_DIR=$NIX_BUILD_TOP/source/llama/compat \
+        -P $NIX_BUILD_TOP/source/llama/compat/apply-patch.cmake )
   ''
   # disable tests that fail in sandbox due to Metal init failure
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
@@ -217,12 +233,10 @@ goBuild (finalAttrs: {
     rm model/models/nemotronh/model_omni_test.go
   '';
 
-  overrideModAttrs = (
-    finalAttrs: prevAttrs: {
-      # don't run llama.cpp build in the module fetch phase
-      preBuild = "";
-    }
-  );
+  overrideModAttrs = _: _: {
+    # don't run llama.cpp build in the module fetch phase
+    preBuild = "";
+  };
 
   preBuild =
     let
@@ -236,19 +250,52 @@ goBuild (finalAttrs: {
       cudaArchitectures = builtins.concatStringsSep ";" (map removeSMPrefix cudaArches);
       rocmTargets = builtins.concatStringsSep ";" rocmGpuTargets;
 
+      # Since 0.30, Ollama splits the llama.cpp build into per-accelerator
+      # "runners" gated by OLLAMA_LLAMA_BACKENDS. Without setting it the
+      # build silently produces only the CPU runner — ollama-cuda would
+      # ship without `libggml-cuda.so` and fall back to CPU at runtime.
+      # The accepted values map to cmake/local.cmake's elseif chain
+      # (cuda_v12 / cuda_v13 / rocm_v7_1 / rocm_v7_2 / vulkan / cuda_jetpack*).
+      rocmMajorVersion = lib.versions.major rocmPackages.clr.version;
+      rocmMinorVersion = lib.versions.minor rocmPackages.clr.version;
+      llamaBackend =
+        if enableCuda then
+          "cuda_v${cudaMajorVersion}"
+        else if enableRocm then
+          "rocm_v${rocmMajorVersion}_${rocmMinorVersion}"
+        else if enableVulkan then
+          "vulkan"
+        else
+          "";
+
       cmakeFlagsCudaArchitectures = lib.optionalString enableCuda "-DCMAKE_CUDA_ARCHITECTURES='${cudaArchitectures}'";
       cmakeFlagsRocmTargets = lib.optionalString enableRocm "-DAMDGPU_TARGETS='${rocmTargets}'";
+      cmakeFlagsBackend = lib.optionalString (
+        llamaBackend != ""
+      ) "-DOLLAMA_LLAMA_BACKENDS=${llamaBackend}";
 
     in
     ''
       cmake -B build \
         -DCMAKE_SKIP_BUILD_RPATH=ON \
         -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+        -DFETCHCONTENT_SOURCE_DIR_LLAMA_CPP="$TMPDIR/llama-cpp-src" \
         ${cmakeFlagsCudaArchitectures} \
         ${cmakeFlagsRocmTargets} \
+        ${cmakeFlagsBackend}
 
       cmake --build build -j $NIX_BUILD_CORES
     '';
+
+  # The llama.cpp sub-build is driven by ExternalProject_Add and does
+  # not inherit the parent's CMAKE_SKIP_BUILD_RPATH setting, so its
+  # `.so` payloads end up with build-dir entries in RPATH. Drop them
+  # before the forbidden-references check. $ORIGIN is preserved
+  # unconditionally; only absolute /nix/store entries are kept.
+  preFixup = ''
+    find $out/lib/ollama -type f \( -name '*.so' -o -name '*.so.*' \) \
+      -exec patchelf --shrink-rpath --allowed-rpath-prefixes /nix/store {} +
+  '';
 
   # ollama looks for acceleration libs in ../lib/ollama/ (now also for CPU-only with arch specific optimizations)
   # https://github.com/ollama/ollama/blob/v0.21.1/docs/development.md#library-detection


### PR DESCRIPTION
## Description of changes

Bump ollama from 0.24.0 to 0.30.4 (2026-06-03 final release, promoted from rc1 the same day).

Necessary downstream changes folded into the bump:

- **llama.cpp now consumed via CMake FetchContent**, not vendored. Pre-stage the pinned llama.cpp commit (read from upstream's `LLAMA_CPP_VERSION` file — currently `b9493`) as a `fetchFromGitHub` derivation, and apply Ollama's compat patch in `postPatch`. When `FETCHCONTENT_SOURCE_DIR_LLAMA_CPP` is set, neither `cmake/local.cmake` nor `llama/server/CMakeLists.txt` auto-applies the patch (the parent's `ExternalProject_Add` passes `OLLAMA_LLAMA_CPP_SKIP_COMPAT_PATCH=ON` to the child build), so the caller has to. The `apply-patch.cmake` script is idempotent.

- **Per-accelerator runner builds gated by `OLLAMA_LLAMA_BACKENDS`.** Since 0.30, `cmake/local.cmake` splits the llama.cpp build into per-runner sub-projects gated by an `OLLAMA_LLAMA_BACKENDS` cache list. Without setting it, only the CPU runner is built — `ollama-cuda` / `ollama-rocm` / `ollama-vulkan` would all silently fall back to CPU at runtime, with `libggml-{cuda,hip,vulkan}.so` absent from `$out/lib/ollama`. Map the package's `acceleration` value to the cmake backend name the elseif chain accepts:
  - `cuda` → `cuda_v${cudaMajor}` (cuda_v12 / cuda_v13)
  - `rocm` → `rocm_v${rocmMajor}_${rocmMinor}` (rocm_v7_1 / rocm_v7_2)
  - `vulkan` → `vulkan`

- **`cmd/launch/*_test.go` removed.** These are integration tests for user-facing CLI launchers (claude, qwen, cline, codex, kimi, droid, openclaw, hermes, …) that install the target binary via `npm` and then exec it on PATH. Both prerequisites are unavailable in the nix sandbox, so the launch subpackage's tests can't pass here. Same precedent as the existing darwin Metal test removals.

- **RPATH cleanup in `preFixup`.** The llama.cpp sub-build is driven by `ExternalProject_Add` and does not inherit the parent's `CMAKE_SKIP_BUILD_RPATH` setting, so its `.so` payloads end up with build-dir entries in RPATH. Strip with `patchelf --shrink-rpath --allowed-rpath-prefixes /nix/store` in `preFixup`; `$ORIGIN` is preserved unconditionally (non-absolute entries always allowed in patchelf's `shrinkRPath`) so peer-lib lookup in `$out/lib/ollama` still works.

Drive-by cleanup: deadnix + statix passes (overrideModAttrs unused lambda args → `_:_`, `inherit (rocmPackages) stdenv;` / `inherit (vulkan-tools) stdenv;` for `buildGoModule.override`, drop unused `coreutils` input — the old launch-test substitutions that needed coreutils are dropped along with the tests).

Release notes:
- https://github.com/ollama/ollama/releases/tag/v0.30.4
- https://github.com/ollama/ollama/releases/tag/v0.30.0

## Things done

- [x] Built on platform(s)
  - [x] x86_64-linux (CUDA variant deployed end-to-end against a real RTX 5060 Ti; daemon serves `{"version":"0.30.4"}`)
- [x] Tested via `nixpkgs-review rev HEAD` — all variants (`ollama`, `ollama-cuda`, `ollama-rocm`, `ollama-vulkan`) and their NixOS tests built green locally
- [x] `nix.conf` sandboxing enabled
- [x] Tested basic functionality (model load on GPU, version match)
- [x] Format/lint pass (`nixfmt`, `deadnix`, `statix`)

🤖 Assisted by Claude
