### PR TITLE
tcl.tclRequiresCheckHook: refer to tclsh by absolute path

### DIFF
--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -149,6 +149,9 @@ let
         makeSetupHook {
           name = "tcl-requires-check-hook";
           propagatedBuildInputs = [ buildPackages.makeBinaryWrapper ];
+          substitutions = {
+            tclsh = lib.getExe' baseInterp "tclsh";
+          };
           meta = {
             inherit (meta) maintainers platforms;
             license = lib.licenses.mit;

--- a/pkgs/development/interpreters/tcl/tcl-requires-check-hook.sh
+++ b/pkgs/development/interpreters/tcl/tcl-requires-check-hook.sh
@@ -6,7 +6,7 @@ tclRequiresCheckPhase () {
 
     if [ -n "$tclRequiresCheck" ]; then
         export TCLLIBPATH="$out/lib $TCLLIBPATH" # Redundant if tcl-package-hook is also used
-        tclsh <<'EOF'
+        @tclsh@ <<'EOF'
           if {[info exists env(NIX_ATTRS_JSON_FILE)]} {
             set nix_attrs_json_file [open $env(NIX_ATTRS_JSON_FILE)]
             set nix_attrs_json [read $nix_attrs_json_file]

--- a/pkgs/development/tcl-modules/by-name/rl/rl_json/package.nix
+++ b/pkgs/development/tcl-modules/by-name/rl/rl_json/package.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     autoreconfHook
     tcl.tclPackageHook
+    tcl.tclRequiresCheckHook
     pandoc
   ];
 
@@ -38,6 +39,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   doCheck = true;
+
+  tclRequiresCheck = [ "rl_json" ];
 
   meta = {
     homepage = "https://github.com/RubyLane/rl_json";


### PR DESCRIPTION
Without this, tcl has to be put in nativeBuildInputs or the hook fails.

The second commit demonstrates that this works.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
