### PR TITLE
rke2: update all packages

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -25,6 +25,12 @@
 
 - Support for the legacy U‐Boot image format has been removed from the Linux kernel builders, as it is deprecated upstream and no longer used by any platform in Nixpkgs.
 
+- `rke2` retires ingress-nginx and transitions to Traefik starting in `rke2_1_36`. Because ingress-nginx was retired upstream as of March 2026, Traefik is now the default
+  for new clusters starting in v1.36 (existing clusters will keep their current ingress upon upgrade to avoid breakage). This transition brings the following structural changes:
+  - Airgapped Environments: The rke2-images-core tarball now contains Traefik images instead of ingress-nginx. The standalone rke2-images-traefik tarball has been removed.
+    Users who must continue using ingress-nginx will now need to manually provide the rke2-images-ingress-nginx tarball.
+  - Future Removal: The ingress-nginx chart will not receive any additional updates and will be completely removed in v1.37 for community users.
+
 - `requireFile` now sets `meta.license = lib.licenses.unfree` by default. Users of `requireFile`-based derivations that preserve this default will need to explicitly allow their evaluation as described in [](#sec-allow-unfree).
 
 - `librest` providing 0.7 ABI was removed. `librest_1_0` providing 1.0 ABI was renamed to `librest` and `librest_1_0` was kept as an alias.
@@ -63,4 +69,3 @@
 ### Additions and Improvements {#sec-nixpkgs-release-26.11-lib-additions-improvements}
 
 - Create the first release note entry in this section!
-

--- a/pkgs/applications/networking/cluster/rke2/1_33/images-versions.json
+++ b/pkgs/applications/networking/cluster/rke2/1_33/images-versions.json
@@ -1,138 +1,138 @@
 {
   "images-calico-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
-    "sha256": "dd6d234775759b8abdd3a87a1a748f92db648f096cc9381eb27afd8ae8186f20"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-calico.linux-amd64.tar.gz",
+    "sha256": "f2341239b5fd73f2b07b074d88c7b34334a808684462f4a6e70fa27591e479a7"
   },
   "images-calico-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
-    "sha256": "1c10516660617d6db897bec16e362b4c4e4a0c1f43f08bb9a87663e051d8b806"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-calico.linux-amd64.tar.zst",
+    "sha256": "8b91f83ee480ae60cc85601e150a2bf412531763ab8e2eaab0b0e4cefa1a83a5"
   },
   "images-calico-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
-    "sha256": "02a2df53bea7805ee124e17db2263d17588a74d091c9656dd07052bcaf7fc159"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-calico.linux-arm64.tar.gz",
+    "sha256": "4fdf2f4bc634c60e6503c7ddd52042baa2d65570a8a0a41eb883bd34920e6766"
   },
   "images-calico-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
-    "sha256": "7b8e832bfde832d24335786c43a8c0aeede3c04e2aee4c8349822383f2fa390e"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-calico.linux-arm64.tar.zst",
+    "sha256": "dacd942276d2ffe8487bee4f7ff8df1522b935eed4eef2cae89f260580eb3305"
   },
   "images-canal-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
-    "sha256": "16275efc94e4a399f0edbbf5ebfe46d8c5c7784d5a4ea300c7313ebbb24190d8"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-canal.linux-amd64.tar.gz",
+    "sha256": "a3e0c2e05174839fe3e66639afa40bb96466a09e60fb73ec15685d1628f96191"
   },
   "images-canal-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-canal.linux-amd64.tar.zst",
     "sha256": "3a7828ce0143c3eb91cae940cebdfa0145960e91be056e88a8b077ee39ccc54d"
   },
   "images-canal-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
-    "sha256": "14fb90f2931bea3f030e7ba6c682013911260177bce91eadb2b45f23936465a5"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-canal.linux-arm64.tar.gz",
+    "sha256": "d86eb346ca1db9ab0efaaf5b4c3418cc096ffd476d2c57f9d4a98a3bab06ef32"
   },
   "images-canal-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
-    "sha256": "ede6d29451a99d7f4663b6a2b8eb0cfa093f83b7b025fd5c4899fb02edac703d"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-canal.linux-arm64.tar.zst",
+    "sha256": "63b0888d1adebb72a77c2d1f1eb1ced1519cfdeb57681026a94c1f53f87f5610"
   },
   "images-cilium-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
-    "sha256": "59f494c03d9aa0f96d99d28e505fae57dd2c30907ea055b888705555ae289d3c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-cilium.linux-amd64.tar.gz",
+    "sha256": "fd6f6e0051f68efd21425364f17156d58f605063f562069fddf398e208a08032"
   },
   "images-cilium-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
-    "sha256": "21ebfe2078b4ef92b2ac3dfe664fd48556cf2b79f9058dd3cd6ed5ed10fcbe1b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-cilium.linux-amd64.tar.zst",
+    "sha256": "3623e1e59fd4d4a47c4b5e4143d7a8ef31707efbca7d7bf9c299d700c0e1d291"
   },
   "images-cilium-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
-    "sha256": "766acd7cbff87a3eab89cc0dc433df34c5d44bfc5304872adfffa432f968450c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-cilium.linux-arm64.tar.gz",
+    "sha256": "70b362df86f882e64c4d7a8a01901a528bb22e12a28a6996d754bd04b9f396e5"
   },
   "images-cilium-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
-    "sha256": "6bd03722d01aa1d281da47318ddca6e1dafbac7acf23f7dc864c7799b4616479"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-cilium.linux-arm64.tar.zst",
+    "sha256": "030d22fd0cb52d90321b37e2d1cd9448b571ba5eeb6b1d68daba40ecff515214"
   },
   "images-core-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
-    "sha256": "4b61e3e97e6770b9a2625a21925282e1774bc9114f0a9df5392cd1199b4df744"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-core.linux-amd64.tar.gz",
+    "sha256": "4513f277d0380330eba4d31dc8096142c2a654a34f01f1c90ab167b78dc58181"
   },
   "images-core-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
-    "sha256": "c9a0fe7e3a747fb01d19b0a846df97d4d53a31f563e5308d86401d6b000b031b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-core.linux-amd64.tar.zst",
+    "sha256": "a82003606da83f683a7025de7481ef9939d1b10a9f9b222ca5e80f34885a87dc"
   },
   "images-core-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
-    "sha256": "899f8e8b8ece3d85384de407fd3f8d375daa9b6f0c1bbd54108426e22fa4a623"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-core.linux-arm64.tar.gz",
+    "sha256": "121690236b9c7f0dd094d4070e80cf9b624888e2418b10c66ebbf894d63c2788"
   },
   "images-core-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
-    "sha256": "be6bc62be91cef6ebb9f995fb4a3e7ca68ab485eec7eb304d129c9d44d543e0c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-core.linux-arm64.tar.zst",
+    "sha256": "26edec0d747a5578f7e638a36f54e8f301a06bcc87814d3b2274db571900f44f"
   },
   "images-flannel-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
-    "sha256": "56c322cf540988649257018f8be4cac80ff1fafb206c3efeb7cfc190d76eff6f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-flannel.linux-amd64.tar.gz",
+    "sha256": "cb33139d9e7569f9b6ad5822f481c83f259a6cd13639f3980e2ad8c2dabb8284"
   },
   "images-flannel-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
-    "sha256": "832aae87b5eba45be64b47a5ebc04824060095dbc79d58adb009dbc0b738252a"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-flannel.linux-amd64.tar.zst",
+    "sha256": "23695fd8c2a77f043a089c44437d12b5bde88422dbcd1d70edcda7a78f651137"
   },
   "images-flannel-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
-    "sha256": "ffc90536663d1edd4cd101e492d84dcd79dd1af1b3b16643786ab8a5d2fcccb7"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-flannel.linux-arm64.tar.gz",
+    "sha256": "a4d428464b3e3e11aafa8fab70a7f183d57d152049f02bd295a6bb4e925a4dbf"
   },
   "images-flannel-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
-    "sha256": "39b36764f09857c01eaa9520da3e2d5023d7df881bc72379e4c55d05ebde8f6f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-flannel.linux-arm64.tar.zst",
+    "sha256": "8aa8e19b739bc3fd897115f92d54acd081453441ee4dae8ca694ec47662838a7"
   },
   "images-harvester-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
-    "sha256": "93e0f6a8e5024f054cdce242aea4fdb833e476d7b2531b454f5f3267f724594e"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-harvester.linux-amd64.tar.gz",
+    "sha256": "97cd2eb0920d433ef57c1a8c8f4a6680faba9a0589c9605c30a56e2c09110c77"
   },
   "images-harvester-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
-    "sha256": "2b72f3bf1485a986d4a325cd15cb12163f4acabcdd4fcf77400a4c226a26c097"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-harvester.linux-amd64.tar.zst",
+    "sha256": "f16ef32d0b9586fb7e600013e56dd9098149dc5ce5239f4828ad03dc7463553f"
   },
   "images-harvester-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
-    "sha256": "4e675fca42ba1862810e021570f58462046e11fb92552d699e20d314be4dd54f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-harvester.linux-arm64.tar.gz",
+    "sha256": "86fe56d8a277208c26c13a9b04b18b4eb4f2b6debcc7ad754af873e4c64d66c5"
   },
   "images-harvester-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
-    "sha256": "c642cadb4f1ccf8439e3c47b10933cae6db0d29c2d9bb9b45267ca69191b0c3f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-harvester.linux-arm64.tar.zst",
+    "sha256": "dc8e9aa0dd1ce2a62b58b7ebfc673911364bd2c3228781f4a226e4796d0436be"
   },
   "images-multus-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
-    "sha256": "080cbffc7710eb25167e65619101b9cbfbd80d6510da2c857a7fe2d70140358d"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-multus.linux-amd64.tar.gz",
+    "sha256": "287437a99ff5c42516764d625571c10d2fbb44ef82cdb026d37b141e56305664"
   },
   "images-multus-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-multus.linux-amd64.tar.zst",
     "sha256": "108543225439fc50053a904b953813a39a0d0d4e6c7a76a2e99a8ee26a69f1a2"
   },
   "images-multus-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
-    "sha256": "1009e845edf77dbe04e8d815ce036c73f1309c0a4a2ec69abafb3e058365513c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-multus.linux-arm64.tar.gz",
+    "sha256": "98f213f7c8a70c4b0d0fb22329212190e08c82d6be482b227e3256637388c732"
   },
   "images-multus-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
-    "sha256": "f76f06cd2344a2c44283733c0e02a94b1bea6c63bc0b7cb6aa2871a474661628"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-multus.linux-arm64.tar.zst",
+    "sha256": "c310597f504b2dd8ac46cc2b87125dcf57a3ae77e4bbbeba4f436a598a2b96f3"
   },
   "images-traefik-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
-    "sha256": "4268db05101d1022ee1002f46516aebeac1b9f8171288ea2d14ddd4763b35ff1"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-traefik.linux-amd64.tar.gz",
+    "sha256": "86a46ecea0d7a60a68314a5794698d6421aa4ce69c05a1f836360e9be996a36b"
   },
   "images-traefik-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-traefik.linux-amd64.tar.zst",
     "sha256": "aec23459c8e51ec16491b4657a3b2a64e49357d3e6cef0a11ac7d3c2f285fe4b"
   },
   "images-traefik-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
-    "sha256": "39381c15bf462071edeb8f735d447ec6d750cc23f6dd3efb45d7b38193ccb7a2"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-traefik.linux-arm64.tar.gz",
+    "sha256": "29372e44e2c1b682c4bc070a764746138a850e24c2cef7edbc97bb2afae51bd8"
   },
   "images-traefik-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-traefik.linux-arm64.tar.zst",
     "sha256": "dd5efa19d02ca7a8a0bcb05febd2781e8ad85016c09b1defe09cdc5f494f05fc"
   },
   "images-vsphere-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
-    "sha256": "6bcd307750c4077eca4cf934dffa4e93277479512639f4c2458f0b0b0eb2cddb"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-vsphere.linux-amd64.tar.gz",
+    "sha256": "237d3f47fdbc2e511b002ed700536125ccb0fcf7c69f2b192db3bd351043d3cc"
   },
   "images-vsphere-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
-    "sha256": "707374e5a6066ec39b70f46ac43e5ca7c10a04811c509dbbacd3edd2cbc8fc0f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.12%2Brke2r2/rke2-images-vsphere.linux-amd64.tar.zst",
+    "sha256": "be5e7d4a33142cb07ac687b777c2c892354f44061d769a72b4731af49c307ec1"
   }
 }

--- a/pkgs/applications/networking/cluster/rke2/1_33/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_33/versions.nix
@@ -1,13 +1,13 @@
 {
-  rke2Version = "1.33.12+rke2r1";
-  rke2Commit = "2cf00d600ee7064fe19efee3e35195ad92c006ef";
-  rke2TarballHash = "sha256-CESLU8qyr0MnVmXRKaPZ7CFvBmIqpLAiklBrsuw9W/k=";
+  rke2Version = "1.33.12+rke2r2";
+  rke2Commit = "341f3e620b43d178daccfe5199f9cb752b0c3922";
+  rke2TarballHash = "sha256-fjhAeDjX8w3c943wjaOamlR4NXZEIhE68iSIP6co6OQ=";
   rke2VendorHash = "sha256-I09PTw359mW9b8j/tjbedu7gJ0cp+NPEvmikxJMOufQ=";
-  k8sImageTag = "v1.33.12-rke2r1-build20260512";
+  k8sImageTag = "v1.33.12-rke2r2-build20260521";
   etcdVersion = "v3.6.7-k3s1-build20260512";
   pauseVersion = "3.6";
   ccmVersion = "v1.33.11-0.20260415182038-2566e39d309b-build20260416";
-  dockerizedVersion = "v1.33.12-rke2r1";
+  dockerizedVersion = "v1.33.12-rke2r2";
   helmJobVersion = "v0.10.0-build20260513";
   imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }

--- a/pkgs/applications/networking/cluster/rke2/1_34/images-versions.json
+++ b/pkgs/applications/networking/cluster/rke2/1_34/images-versions.json
@@ -1,138 +1,138 @@
 {
   "images-calico-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
-    "sha256": "9191dccc4fa6bdb8bc589d20d34c643227fe2c1e3d198eaf600780a1c44dfd5d"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-calico.linux-amd64.tar.gz",
+    "sha256": "351e9047ce160cbf3b9ed4a32996f36bb4266c200e9957407178d2d28e55f8e5"
   },
   "images-calico-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
-    "sha256": "707eaba12e9e9d5e5090bb5fb3e066b893c0b0aeeee6f3627c1153e2db380567"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-calico.linux-amd64.tar.zst",
+    "sha256": "aa746ea4dd91422e37d2cac07b36854ddc1c551b4da061c261d1e0132a983656"
   },
   "images-calico-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
-    "sha256": "33421abe9967b3f00799b3251f84a3a36ab03378a4f1c556663ac2b829f59cf4"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-calico.linux-arm64.tar.gz",
+    "sha256": "96829f58e60b02ccee8e19b9ec4ad2ce7ade6f9030b1379eadedd42d151a783b"
   },
   "images-calico-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
-    "sha256": "f727fa092650bf685b68358cf41422c260fe9eee7a2aebecc68f14a2fd24a678"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-calico.linux-arm64.tar.zst",
+    "sha256": "6a7f4404f92e88eb515bbff4513b5771e82c69111dfdd7e88c7d83d4366480e6"
   },
   "images-canal-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
-    "sha256": "b46d57b12bd62a5f4c4227fc1339ba8785853e55f81031c97774f44844c6769d"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-canal.linux-amd64.tar.gz",
+    "sha256": "16bc527e0b4ab9612747534c2b5801487a12379a364da4936d01816fcb608040"
   },
   "images-canal-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-canal.linux-amd64.tar.zst",
     "sha256": "d4d14e4ae3f34d0615fd6007e7048b54bc5a15be9f57fa6be6cd72346c39ccdf"
   },
   "images-canal-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
-    "sha256": "977c126339368ac55ccd3cb658dcc6530d46426292735dc8cff95dad99543ebd"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-canal.linux-arm64.tar.gz",
+    "sha256": "ece067531498aec3847a73cd4e4e379c2bb3186f72717601b4766f2a50df0f3a"
   },
   "images-canal-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-canal.linux-arm64.tar.zst",
     "sha256": "ede6d29451a99d7f4663b6a2b8eb0cfa093f83b7b025fd5c4899fb02edac703d"
   },
   "images-cilium-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
-    "sha256": "2ad31cd1bcb0ba5ca050bda0942a0b6b79f21ae4dfc70f70001be08921c4c3cb"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-cilium.linux-amd64.tar.gz",
+    "sha256": "95d566220546d6b49f6b79fb729c976fc435ae85fcb39add9ca4e8cade953e8f"
   },
   "images-cilium-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
-    "sha256": "c812ea710fcac1dd25e1be8f45e9fd3218296fdd6414c90a5b856fc16a5835f5"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-cilium.linux-amd64.tar.zst",
+    "sha256": "fc146c92933270bd4291a75069f1d724629c84ebb6c8cd5549756a895a5a9e3d"
   },
   "images-cilium-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
-    "sha256": "07507811563e82578142bd56c2b394b32b55bd53c965f8fc9a9881570feac68d"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-cilium.linux-arm64.tar.gz",
+    "sha256": "d5bfc28db9031a8be3a5c325fe6f6cc6dca8f101af5fce394d11e00a0e866dc2"
   },
   "images-cilium-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
-    "sha256": "0d5813611f47a460c7762f1902e1be7785f52903b8340fc112dd67c5ba9e0adf"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-cilium.linux-arm64.tar.zst",
+    "sha256": "0590f43bf3d6ea590a9069d62170956d72f6ff1b1a45574ef7129a6fb07481ae"
   },
   "images-core-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
-    "sha256": "4716d37e4c4974c50d88a6c4a4dd1ae59e5d416b06161dc97af267ac91005200"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-core.linux-amd64.tar.gz",
+    "sha256": "2d89ef07043ee8475bd91c97c7419dcb068e089ba8d74f31a503749fdd29a700"
   },
   "images-core-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
-    "sha256": "c326f685c5037ae41a76d0a57d81ad365664fdb4f09dd8ed1c085daef6e8898c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-core.linux-amd64.tar.zst",
+    "sha256": "663f048d7ad31aeaf5820effc4e9fd6499ee038c2736afa6721c2384c049765c"
   },
   "images-core-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
-    "sha256": "8439de0d0159a2d0458a94c48d4f856dd499106bb97a1228315172a8ccf7a227"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-core.linux-arm64.tar.gz",
+    "sha256": "740bed7351bab07dbdaaef316d3c9c817c381fefff4ce43af78381596e1f34d6"
   },
   "images-core-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
-    "sha256": "dbfb0ba0d552b9f09d6fd7c3f1313c2d3a65b1fe9d003925f90206bb908ceb1c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-core.linux-arm64.tar.zst",
+    "sha256": "d224ffbf50eb2be8edaa1b923323df17336b8c435bce034e2ba4ae96a54244ec"
   },
   "images-flannel-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
-    "sha256": "2b65ebfff9edad28dc5df77d58a9f9191ae6ed1ffd47e001c61979940dbd30cc"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-flannel.linux-amd64.tar.gz",
+    "sha256": "1a84527d66538b5ff96e331493006bbd3ccc06529d51a8b7c9a3e0d219c25a6f"
   },
   "images-flannel-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-flannel.linux-amd64.tar.zst",
     "sha256": "832aae87b5eba45be64b47a5ebc04824060095dbc79d58adb009dbc0b738252a"
   },
   "images-flannel-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
-    "sha256": "17393dba1ce79c78739381ba2c6dc9383f41bf78e511b04a3eca0564d88a58d9"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-flannel.linux-arm64.tar.gz",
+    "sha256": "80d7ab29cce2d595926ed0999e663932489c62c9e4b818909a05739357e584bc"
   },
   "images-flannel-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
-    "sha256": "8aa8e19b739bc3fd897115f92d54acd081453441ee4dae8ca694ec47662838a7"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-flannel.linux-arm64.tar.zst",
+    "sha256": "39b36764f09857c01eaa9520da3e2d5023d7df881bc72379e4c55d05ebde8f6f"
   },
   "images-harvester-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
-    "sha256": "8d6e85fbf15c10faa6c50098f462e1f042e37e80df8aaa67f4e4a4cfbb61b3f7"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-harvester.linux-amd64.tar.gz",
+    "sha256": "86299476461d69c9db81c47f1bff915f122dd31f229679033cb9ac3888f34d20"
   },
   "images-harvester-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
-    "sha256": "44bca782f1503b189e17248edbfc344c129ffedeabf886c5ecae89717a68e6df"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-harvester.linux-amd64.tar.zst",
+    "sha256": "c3c2539999dbd963deb1533d76fef211902322d7204c977b7534c37342a6ccba"
   },
   "images-harvester-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
-    "sha256": "0af1f6bf05788880ac4617271b8896662c41ed3b099ad617bae21aa41f669f68"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-harvester.linux-arm64.tar.gz",
+    "sha256": "dadfbc1e60b11be02c186343748f3c5e6a7c03bedf4bf36b1007b6addafaf6e2"
   },
   "images-harvester-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
-    "sha256": "085489645c3bdeb44216be70e0194f6e356a4e0116e861fac7009dfc671f99b8"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-harvester.linux-arm64.tar.zst",
+    "sha256": "ec9d3370c2cb488fe98ed38688fd3cec14ba136783efd894b3bec2a5599f8c08"
   },
   "images-multus-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
-    "sha256": "6c759cc8ce3e9ae7b6aef0b5cdf4094762f6f69d55dd70b6d9a405db796f1cb3"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-multus.linux-amd64.tar.gz",
+    "sha256": "a4bbad1ab2c8d7f65e6cc9238d63f29524774bc07163a4a23688d9a0a63c4629"
   },
   "images-multus-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
-    "sha256": "530f83485923076b7769c4ced5c87b88979dff0e4d28faf33fc5e9b67fc5dadf"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-multus.linux-amd64.tar.zst",
+    "sha256": "98e17b69423ff3de402803a0ec2fb63748252c800c672a232f912d312cf41ff5"
   },
   "images-multus-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
-    "sha256": "efc94b4850aef8d2973f51bff0df31ce0689949e22bd05161fd5c12cfa9672ce"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-multus.linux-arm64.tar.gz",
+    "sha256": "1ec1676f8bcb054ab243cc7b3df555e0099fd2a227683615f15c8cbb95db040a"
   },
   "images-multus-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
-    "sha256": "883d23d8ef3733d9747251c8a1d223571153fd233eb93e5d32a76129a6c64f2c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-multus.linux-arm64.tar.zst",
+    "sha256": "c310597f504b2dd8ac46cc2b87125dcf57a3ae77e4bbbeba4f436a598a2b96f3"
   },
   "images-traefik-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
-    "sha256": "282c456cbcdaf42f2b4c62b110aaa459e5517dba0a7dd8c6fd539ce93c9fd632"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-traefik.linux-amd64.tar.gz",
+    "sha256": "288cb12a19e0419f91a56286c934823eda31c523f865bb24b66c9cdeb89cc73f"
   },
   "images-traefik-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-traefik.linux-amd64.tar.zst",
     "sha256": "aec23459c8e51ec16491b4657a3b2a64e49357d3e6cef0a11ac7d3c2f285fe4b"
   },
   "images-traefik-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
-    "sha256": "4ffe8a7b25bc4c116f34b29f51de69ffbe7702f473f8b68577ac086f88e0c5fb"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-traefik.linux-arm64.tar.gz",
+    "sha256": "f3d34ffea490540c028f800362862c74d1b45efb0acb3db072f5417443b71733"
   },
   "images-traefik-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-traefik.linux-arm64.tar.zst",
     "sha256": "dd5efa19d02ca7a8a0bcb05febd2781e8ad85016c09b1defe09cdc5f494f05fc"
   },
   "images-vsphere-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
-    "sha256": "b15c7523c8ece5525acdd1e04bdcde1a3e54435fcdb1a8ec949de9395f69a3aa"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-vsphere.linux-amd64.tar.gz",
+    "sha256": "c87a8f5b553e664f0c7dfa44b2fdea40b7bbe22bbf4d96667009a76f5b181f86"
   },
   "images-vsphere-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
-    "sha256": "ca086d7c16de41dfd1fd5f2e745949f0a51d4de45f9bacdaa3b1955936f595e9"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.8%2Brke2r2/rke2-images-vsphere.linux-amd64.tar.zst",
+    "sha256": "df524665950321e45d0b8521532263e969533af82f7c77dddc86b4b6dfa675a3"
   }
 }

--- a/pkgs/applications/networking/cluster/rke2/1_34/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_34/versions.nix
@@ -1,13 +1,13 @@
 {
-  rke2Version = "1.34.8+rke2r1";
-  rke2Commit = "4fdfd151975bbc58c8d392620db8eea72fea2abc";
-  rke2TarballHash = "sha256-n98pZhWARQMyKj8G9+ymmMZyzoiGo+KPMr0F5KDphqU=";
+  rke2Version = "1.34.8+rke2r2";
+  rke2Commit = "b227fefe1936a550450ce3b6248c559fa58b5cd3";
+  rke2TarballHash = "sha256-Ojc4PhsEYJBhgj+r+XEcdFEjZIlJCCVNC+w7mZWY2hA=";
   rke2VendorHash = "sha256-752RlnL+7reFk4G/X8kgHdad71fatY+Ss714MbJDvg8=";
-  k8sImageTag = "v1.34.8-rke2r1-build20260512";
+  k8sImageTag = "v1.34.8-rke2r2-build20260521";
   etcdVersion = "v3.6.7-k3s1-build20260512";
   pauseVersion = "3.6";
   ccmVersion = "v1.34.7-0.20260415182025-e7567db58dd7-build20260416";
-  dockerizedVersion = "v1.34.8-rke2r1";
+  dockerizedVersion = "v1.34.8-rke2r2";
   helmJobVersion = "v0.10.0-build20260513";
   imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }

--- a/pkgs/applications/networking/cluster/rke2/1_35/images-versions.json
+++ b/pkgs/applications/networking/cluster/rke2/1_35/images-versions.json
@@ -1,138 +1,138 @@
 {
   "images-calico-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
-    "sha256": "483d18ab6a64d279b4411098dec8b6f4219839bdb0d3e023f87679e6c71905de"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-calico.linux-amd64.tar.gz",
+    "sha256": "d53e659b7f934fb811eadeb7d6e348b12ef932b0a414073301bdf03d1501f32f"
   },
   "images-calico-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
-    "sha256": "c8ab27e9f5cd0d85cc20ed8c02c71128f021199a0256c5a051734817193e913c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-calico.linux-amd64.tar.zst",
+    "sha256": "b7cf99a56b03469169e8b1a32f9aa61b828268dd5aff9482503d00c884260f0e"
   },
   "images-calico-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
-    "sha256": "01339c90624d6745e16b7706585fdb32825df66adb892a9bd265257d2de315a5"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-calico.linux-arm64.tar.gz",
+    "sha256": "53a95f56dbd4aeefe631afdf05d00592da7bbb2c089e694d06ffd6c6c8665375"
   },
   "images-calico-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
-    "sha256": "9816fa61d5b89ab40ba59db3c0593ed37f712c6bfd1f3b763641b0bfad8b5d04"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-calico.linux-arm64.tar.zst",
+    "sha256": "c49ef55be8b1a30597e4315fac563282cac7870045a465ba7e1ee2c81db44cf6"
   },
   "images-canal-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
-    "sha256": "cc4d48fde0650c666f87322ef3fec4987de06d99b4f008a07b667a7650451069"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-canal.linux-amd64.tar.gz",
+    "sha256": "f6ffb60b14b0fda2e3a138f4d6a7e9cb71e8fc759d69cb0fda00aedcaa03ab0f"
   },
   "images-canal-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-canal.linux-amd64.tar.zst",
     "sha256": "3a7828ce0143c3eb91cae940cebdfa0145960e91be056e88a8b077ee39ccc54d"
   },
   "images-canal-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
-    "sha256": "977c126339368ac55ccd3cb658dcc6530d46426292735dc8cff95dad99543ebd"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-canal.linux-arm64.tar.gz",
+    "sha256": "2319ab1753330cb13ea7ac56198d9da78123aaa6a3b66ea3d970a6c57de9ce41"
   },
   "images-canal-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
-    "sha256": "ede6d29451a99d7f4663b6a2b8eb0cfa093f83b7b025fd5c4899fb02edac703d"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-canal.linux-arm64.tar.zst",
+    "sha256": "63b0888d1adebb72a77c2d1f1eb1ced1519cfdeb57681026a94c1f53f87f5610"
   },
   "images-cilium-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
-    "sha256": "0877802ec5502223f1b233573b2e87e3347a7922f2bb52702f9461958ac0c043"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-cilium.linux-amd64.tar.gz",
+    "sha256": "9c6ab1f22a157e7a74c35c4be3c025eb154e6315be9c2085451f59b11b63f8e1"
   },
   "images-cilium-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
-    "sha256": "345afdae010cf3c77e02c4e339749f3c3a5d4d62c3ed486edab0bb1d4089c67e"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-cilium.linux-amd64.tar.zst",
+    "sha256": "38892592ae5e45e27e4cad76d4364c549bdb386def54398cc26c9249bbd34760"
   },
   "images-cilium-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
-    "sha256": "00161836b5f27f1ce07be67337d08781033d6df4efe429bd922459738145ecdc"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-cilium.linux-arm64.tar.gz",
+    "sha256": "a0a02109ef5a5f4eae1a06003ba80544b405b155840ce5c3535b1c4e02d16f0e"
   },
   "images-cilium-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
-    "sha256": "32b275bc86c35471d9deea33b6119a33667a28477c06500db3ea9d1d0cdf7d4b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-cilium.linux-arm64.tar.zst",
+    "sha256": "8110fc9517469dad0c291258e0dbdece6e4e3c9a51d539531527f4236692b7bd"
   },
   "images-core-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
-    "sha256": "e0519dd39f2f3297a84fa7c2e9c6fdda508386169474a47ebbb570c66f51c27c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-core.linux-amd64.tar.gz",
+    "sha256": "2d32c6205a83ac776fe54d7777472725edfc204fd7a30befa0ee9c5f7fde80cc"
   },
   "images-core-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
-    "sha256": "6f63f6cf296f828ef1ff98041691e9a6126490000ae2e90648c0699ab1bde91f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-core.linux-amd64.tar.zst",
+    "sha256": "48bdbb2bc2652eb6647ce3f2ce215ac9bf12cf5fbe4936688e5de34605f0fb2c"
   },
   "images-core-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
-    "sha256": "b66332a3a903e1d18c783a7d58d9eb74aef9d4cb0fe91a4aa75a63cff5b3e92a"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-core.linux-arm64.tar.gz",
+    "sha256": "3e392555a295ec6f7e3ea477ded0bb71c04957dccd168de87d87226dfdbb753f"
   },
   "images-core-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
-    "sha256": "98abe8232378ef17f9890e3c77cd405a90e7aa2fdf5d612bd7d42ee174714cf6"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-core.linux-arm64.tar.zst",
+    "sha256": "29d28cb1b2035c1d5123fdb6bb0fa8cc647ad9cd570edf434bc7e560806426fa"
   },
   "images-flannel-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
-    "sha256": "4ea4b1fb4a653a5ad00dd206406482abddf9f53a1b1c4f884e7e7fb4fe720c90"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-flannel.linux-amd64.tar.gz",
+    "sha256": "e86e5631c691d2dcac99764542c875e4bed902f385f5a6e2f6e6b88facf114aa"
   },
   "images-flannel-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-flannel.linux-amd64.tar.zst",
     "sha256": "23695fd8c2a77f043a089c44437d12b5bde88422dbcd1d70edcda7a78f651137"
   },
   "images-flannel-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
-    "sha256": "d4dcaa35507a5f9d407a5d3a3fccee3e52061256bd0b420123bf888a24915758"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-flannel.linux-arm64.tar.gz",
+    "sha256": "396084ee38b31e5b78e3d8c3a015f8a56194119204aecb9de052a5be20c61e01"
   },
   "images-flannel-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-flannel.linux-arm64.tar.zst",
     "sha256": "39b36764f09857c01eaa9520da3e2d5023d7df881bc72379e4c55d05ebde8f6f"
   },
   "images-harvester-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
-    "sha256": "b47becfdf139af069eaf1f691498ff689b577af43ed934edba119257bf652cab"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-harvester.linux-amd64.tar.gz",
+    "sha256": "38eecc385bbb77bde48d7dec9aa48bc897136c5714e5eff9c56c9df580dfb35d"
   },
   "images-harvester-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
-    "sha256": "b00afa052e7b67d4111f19a4eefb22095c836a7972911880e65dee2044975898"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-harvester.linux-amd64.tar.zst",
+    "sha256": "20e7b012ab2802a057be6cf6ef3d8f04a65484403615ddd3c2852d59d3ed7453"
   },
   "images-harvester-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
-    "sha256": "1e9a034a075472ecaa6f9e66c7ff2ada6f97b4a02a5e070ce36208b4eb4f1fcc"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-harvester.linux-arm64.tar.gz",
+    "sha256": "8b712f389d2118a802a70ec4175e83be0557a4b699bc238bd228c862aa337419"
   },
   "images-harvester-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
-    "sha256": "8ddfde1b1ceea2f08db9fef9da9cb9745bbe74b2520cfceeb150c623102401a3"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-harvester.linux-arm64.tar.zst",
+    "sha256": "dfa539c18041a6e0ef1747c469c718f7e608e031dbc99eada2dbf56768f6de72"
   },
   "images-multus-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
-    "sha256": "b75549d8d650823ac9c8f5b5ba247901a8c5681ac91d909aea5a0d4f66d0b5bd"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-multus.linux-amd64.tar.gz",
+    "sha256": "48a6e3c5fc5534b6c77957dd82e488f46cd6c6a713233da32ab18e94961f33a2"
   },
   "images-multus-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
-    "sha256": "108543225439fc50053a904b953813a39a0d0d4e6c7a76a2e99a8ee26a69f1a2"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-multus.linux-amd64.tar.zst",
+    "sha256": "98e17b69423ff3de402803a0ec2fb63748252c800c672a232f912d312cf41ff5"
   },
   "images-multus-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
-    "sha256": "c0f20bbcc6b238af7249c265a7c6458c30f9358007c1380c7b99de01ee219398"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-multus.linux-arm64.tar.gz",
+    "sha256": "cf99f6af0ae8389926f9cba977370ffbe1ee261d429281957eb2b5cfb015a71e"
   },
   "images-multus-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
-    "sha256": "eee8c18cf3bfea3df603e2d9fb0c30c75fcc7e88dc58c1cab1b8d5926aa8dd52"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-multus.linux-arm64.tar.zst",
+    "sha256": "f76f06cd2344a2c44283733c0e02a94b1bea6c63bc0b7cb6aa2871a474661628"
   },
   "images-traefik-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
-    "sha256": "1aed02afe45b0f6abe3b8934bdd6beee5a8018b31e81be896e9bbfbf75cd2bc5"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-traefik.linux-amd64.tar.gz",
+    "sha256": "f77681adb7835d43c2eb77d189573990f32fa8b3d98bf7d8fb559788f0e30eea"
   },
   "images-traefik-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-traefik.linux-amd64.tar.zst",
     "sha256": "aec23459c8e51ec16491b4657a3b2a64e49357d3e6cef0a11ac7d3c2f285fe4b"
   },
   "images-traefik-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
-    "sha256": "4ffe8a7b25bc4c116f34b29f51de69ffbe7702f473f8b68577ac086f88e0c5fb"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-traefik.linux-arm64.tar.gz",
+    "sha256": "5a57534fd048ad725e15a38a8be65a642f6ad443cb55c9dad6eff276d704dd44"
   },
   "images-traefik-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-traefik.linux-arm64.tar.zst",
     "sha256": "dd5efa19d02ca7a8a0bcb05febd2781e8ad85016c09b1defe09cdc5f494f05fc"
   },
   "images-vsphere-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
-    "sha256": "4d1a7ba7c43d474d796d7b05a0f24a423b6c3a5a53388e9d803fd31c54efb912"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-vsphere.linux-amd64.tar.gz",
+    "sha256": "c3e5339a35bba7b7184850935bbfcda7d6c2dc7dd4e34d7c9f390a58766ac654"
   },
   "images-vsphere-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
-    "sha256": "d2f8909d694493222aa1051f8c013ffa73615567141336b872ada5c9e6312cd8"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.5%2Brke2r2/rke2-images-vsphere.linux-amd64.tar.zst",
+    "sha256": "f0a388912b6150d4ff820b53ee58c398d5572c325f381ad5ce4d82f0d10f5849"
   }
 }

--- a/pkgs/applications/networking/cluster/rke2/1_35/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_35/versions.nix
@@ -1,13 +1,13 @@
 {
-  rke2Version = "1.35.5+rke2r1";
-  rke2Commit = "e28e7c1a0404f1e9bf36e8b7222d64aec6b7a004";
-  rke2TarballHash = "sha256-t++HKNbR4WGzZiR6rVMke7lbixXA8H5ibovfitwPuXE=";
+  rke2Version = "1.35.5+rke2r2";
+  rke2Commit = "a779b949d9a7987fc51e7c71c146db4160d0e3bf";
+  rke2TarballHash = "sha256-eMqaz7DmIwANpvcQxEA6rJQcLmdBlEFT8Qju+Wr0dTo=";
   rke2VendorHash = "sha256-LV3ISu7bW6kxlKFe0GUqkB9Jte1Ey5DaWm+OKq1/1uY=";
-  k8sImageTag = "v1.35.5-rke2r1-build20260512";
+  k8sImageTag = "v1.35.5-rke2r2-build20260521";
   etcdVersion = "v3.6.7-k3s1-build20260512";
   pauseVersion = "3.6";
   ccmVersion = "v1.35.4-0.20260415195656-e51c0636351d-build20260415";
-  dockerizedVersion = "v1.35.5-rke2r1";
+  dockerizedVersion = "v1.35.5-rke2r2";
   helmJobVersion = "v0.10.0-build20260513";
   imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }

--- a/pkgs/applications/networking/cluster/rke2/1_36/images-versions.json
+++ b/pkgs/applications/networking/cluster/rke2/1_36/images-versions.json
@@ -1,138 +1,138 @@
 {
   "images-calico-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
-    "sha256": "bc9fb1ba72af6185de90e4e0f8a384993657c4b0fdedbb14e7ca5cf93bf2303d"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-calico.linux-amd64.tar.gz",
+    "sha256": "ec37f597d76bbe3f30b6108049faaf9f4a6e99b4d228f9b8485fb492c31aa0aa"
   },
   "images-calico-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
-    "sha256": "38fc5ecd017e9a66e3831ece42efedcfedaafc000759eaa4fb9f19a68122ec51"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-calico.linux-amd64.tar.zst",
+    "sha256": "5112e4bf4f4f5f553addb98abf53636b8ff57cbf18514d7537ec03c344d5b345"
   },
   "images-calico-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
-    "sha256": "e86ac7f4cf14e4f02fcdd0e3d74e832fa43654f592068c2b5d8c044c69e2b749"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-calico.linux-arm64.tar.gz",
+    "sha256": "7161e8af4ae5c45d480be7083f15d3e7992745e9559d460584c5136d9caca789"
   },
   "images-calico-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
-    "sha256": "03df93db61bc54f351bb6131c632279c265d4b71af0a90e2a6898f9b99b453f4"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-calico.linux-arm64.tar.zst",
+    "sha256": "f63ba6f6b30564626d6839002117325b3d48b2f2a131a8bfeb1192244da1de7e"
   },
   "images-canal-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
-    "sha256": "5cce5314ed6ff237c646723456c81876e89517b9164368728a9df00697655858"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-canal.linux-amd64.tar.gz",
+    "sha256": "7478fa0950554451cd856dbb8a800486f73fbb4758ccad28d1d218febe9b0b39"
   },
   "images-canal-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
-    "sha256": "3a7828ce0143c3eb91cae940cebdfa0145960e91be056e88a8b077ee39ccc54d"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-canal.linux-amd64.tar.zst",
+    "sha256": "d4d14e4ae3f34d0615fd6007e7048b54bc5a15be9f57fa6be6cd72346c39ccdf"
   },
   "images-canal-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
-    "sha256": "e8346348137747fbd626846e5b71d182c49e8a1dcb997ea9e91f50e7bd907129"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-canal.linux-arm64.tar.gz",
+    "sha256": "4a77a243413b7963e3f3a98fcdb1cc2bd96cbe83b6a3f3d7ca73f05c1d7bd855"
   },
   "images-canal-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
-    "sha256": "ede6d29451a99d7f4663b6a2b8eb0cfa093f83b7b025fd5c4899fb02edac703d"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-canal.linux-arm64.tar.zst",
+    "sha256": "63b0888d1adebb72a77c2d1f1eb1ced1519cfdeb57681026a94c1f53f87f5610"
   },
   "images-cilium-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
-    "sha256": "8c52261340b4af54186f83d2913c676a2dcef820f25a1b42b8c51cfef1dcdbc6"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-cilium.linux-amd64.tar.gz",
+    "sha256": "83642c47920ab60e3042895aee5e56914187c822ac279178096c5430ce655988"
   },
   "images-cilium-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
-    "sha256": "865913456dc55b2ba4748b0fe76489e4960a60990f207341c66bcbf9e93e95b3"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-cilium.linux-amd64.tar.zst",
+    "sha256": "442a391b5486a551fec98464a02396179e6f70a4cc41e0bb631b0ea70a8affc3"
   },
   "images-cilium-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
-    "sha256": "4170bfc7d0ebf9167a94d24e393fbff0fc7dce4da1443257709fdbe603ffc579"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-cilium.linux-arm64.tar.gz",
+    "sha256": "a5d7ec33831f617546aee8ad44a521e06cdef30c5ac9e3c23b1876dddacccb9b"
   },
   "images-cilium-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
-    "sha256": "016caf748e5c39460b9618d998d261c7db8fe8348f9fa43d35693a47d4913b86"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-cilium.linux-arm64.tar.zst",
+    "sha256": "d5b757ba6313c6bfb4e85b238aa318ac12aeed7ec8f1e4af825405648737e1bb"
   },
   "images-core-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
-    "sha256": "03a72f2c228131b7cb616c5b7758cd1c00b7f3e7d589573c5faf837e4e2ab764"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-core.linux-amd64.tar.gz",
+    "sha256": "30ff144583c0b3249b06801d78c902305e1a5009bf3ab7211862d989fca18267"
   },
   "images-core-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
-    "sha256": "37acd15d183693fb0bb465840590593ed78d72415752a052d282a418fdb905cf"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-core.linux-amd64.tar.zst",
+    "sha256": "e056f1ba054b8b39a68c4df19480d878327327583ea843f4a80ea0289e796e15"
   },
   "images-core-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
-    "sha256": "4798bf3293e7b5b62e694bee8a811c3ace86bb5c7516c9f196a4ba48dc947c3f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-core.linux-arm64.tar.gz",
+    "sha256": "54d0d3d97462f8f70c75479cc77edd482cf318bef31ecaa3063b354432d7af9a"
   },
   "images-core-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
-    "sha256": "ff8c770fa2b17151e333a0a4449bc4dc3cd5c65662ec88b2ffc31fde6a40d0ed"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-core.linux-arm64.tar.zst",
+    "sha256": "62528323277c307d46e0564288508d9203dc460f93be222075b5a1c1be1c910e"
   },
   "images-flannel-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
-    "sha256": "0e5c71c9ecd89f11bb1cc0ea72a0297090e7a44395efe5fd74e14af3db3581a8"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-flannel.linux-amd64.tar.gz",
+    "sha256": "b9742e4656c394dff69f7356e9fd22bc7ed4e0b4cac2d86e224cdbb5d793158e"
   },
   "images-flannel-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-flannel.linux-amd64.tar.zst",
     "sha256": "23695fd8c2a77f043a089c44437d12b5bde88422dbcd1d70edcda7a78f651137"
   },
   "images-flannel-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
-    "sha256": "d9f75aaace63bcba2cbaeba2662d9877d39ec822621fd96824e9ec3fbe62a79c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-flannel.linux-arm64.tar.gz",
+    "sha256": "e2ea34d8f0207197758c75dbadb1e6ea1e31758ea26f49ac6cd8cb5ea941e743"
   },
   "images-flannel-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
-    "sha256": "8aa8e19b739bc3fd897115f92d54acd081453441ee4dae8ca694ec47662838a7"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-flannel.linux-arm64.tar.zst",
+    "sha256": "39b36764f09857c01eaa9520da3e2d5023d7df881bc72379e4c55d05ebde8f6f"
   },
   "images-harvester-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
-    "sha256": "c9442d489c4170fc515d04c2c5c7c76ff3ca2fb4093a94aea0d0a6fb1719c5d3"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-harvester.linux-amd64.tar.gz",
+    "sha256": "34d08bdfe771f5d6c2c1a077519aa9dea2c4ec5ff6598812630b5175e15b0436"
   },
   "images-harvester-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
-    "sha256": "9551558d7baba1a78de7954f4801cf4329b5fb5ffd0cc3566b9fa32732ff950c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-harvester.linux-amd64.tar.zst",
+    "sha256": "04e83f1ee26a6e40cd4267025b85a8afba847e8b89bbf25ad33d3f598128c3d5"
   },
   "images-harvester-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
-    "sha256": "11ea150625fc1a4700cec2859367692d533f7f9288f7196b331a77682766d742"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-harvester.linux-arm64.tar.gz",
+    "sha256": "b56ec39e51d0f99a3bee9cb7b93fa5c07e4b91a2709bf6cca246d3c47f442c1d"
   },
   "images-harvester-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
-    "sha256": "045db3938a0a11f6d5b4936f63471fec48fd76d29ef85e9cfe6bae5bddd8525e"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-harvester.linux-arm64.tar.zst",
+    "sha256": "e8a51c1926db9e71ab970b0a08a2becb85b2c2aab0108120d1f3d6d21f17f1cd"
   },
   "images-ingress-nginx-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-ingress-nginx.linux-amd64.tar.gz",
-    "sha256": "0af77531d170d30b844518bb4665b29f3f386cf160f7c2b955467516f4d04dc3"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-ingress-nginx.linux-amd64.tar.gz",
+    "sha256": "100d6841727443cc9558a4aaed924c1f23e8d39e4302bd32dac6fbdebed940e9"
   },
   "images-ingress-nginx-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-ingress-nginx.linux-amd64.tar.zst",
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-ingress-nginx.linux-amd64.tar.zst",
     "sha256": "d5b7d3f12de0799cebf84fc6260fc4f093f2837c5fef6fc84849d8f1da5cbc22"
   },
   "images-ingress-nginx-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-ingress-nginx.linux-arm64.tar.gz",
-    "sha256": "8c5d5eea216102e5dd07621671f2e462dfade184f20c81adb8facbaa58e59c2c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-ingress-nginx.linux-arm64.tar.gz",
+    "sha256": "f10675c08075e5312f650bde022990e2122de979e4559f2c56aa1ec941516eb2"
   },
   "images-ingress-nginx-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-ingress-nginx.linux-arm64.tar.zst",
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-ingress-nginx.linux-arm64.tar.zst",
     "sha256": "363f42d83118e3398e72996f6b42477230000ffd50d93fdda570140ea020539b"
   },
   "images-multus-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
-    "sha256": "ec3d8557e36db43acd9a76c38242de6feea354e41ae3ff8b9ab55de82ee19026"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-multus.linux-amd64.tar.gz",
+    "sha256": "70dd5bf043e5ade8f15bf794ed68c2632fa168cdabb88a59e1664c21802b1b72"
   },
   "images-multus-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
-    "sha256": "8be7075092a5e179e50fb526ea730018103d9f8a609f22f0d1431482690a9d7f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-multus.linux-amd64.tar.zst",
+    "sha256": "98e17b69423ff3de402803a0ec2fb63748252c800c672a232f912d312cf41ff5"
   },
   "images-multus-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
-    "sha256": "caebabf77d9d3190d76156990d8eaa0c2df5cb563a8447f1e506b50f4104e1a0"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-multus.linux-arm64.tar.gz",
+    "sha256": "70dc7d7e6b5ceee67e1ea31a9fb8915b23697b46ab81962fcf2bc23994eadcdb"
   },
   "images-multus-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
-    "sha256": "39bd89d250894254f7c1f9b061401a574716574ab3f51cc3a82c03eb4e804825"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-multus.linux-arm64.tar.zst",
+    "sha256": "7d768e2a1ba9eeb051e2cc74e1886a21cef515230a531a300dfe8b988a426fdf"
   },
   "images-vsphere-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
-    "sha256": "d07ed8b72db67fae9024540fca3eed7990b4a4b3a7ba6eef78a2eae8e6b3b4d3"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-vsphere.linux-amd64.tar.gz",
+    "sha256": "a16d790a062b96f792952a8e87df314050032e1306d3f1b411c4c1e80cea574a"
   },
   "images-vsphere-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
-    "sha256": "4cd43197b21bd1344c0a7e87a7f28c8766b3edfab8e2fb2bb6954d144f3b44a7"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.36.1%2Brke2r2/rke2-images-vsphere.linux-amd64.tar.zst",
+    "sha256": "bb33b083c06d621bb430942aad52ddfe45fd4cff956072104d83ea22ef91be02"
   }
 }

--- a/pkgs/applications/networking/cluster/rke2/1_36/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_36/versions.nix
@@ -1,13 +1,13 @@
 {
-  rke2Version = "1.36.1+rke2r1";
-  rke2Commit = "b4a8e78038f35eb282a8d6e3c29797a1181fa961";
-  rke2TarballHash = "sha256-SD7+lNYu6/5iMxEmHEpkD8g9UCgN6gjkFsGdQn9o1Cc=";
+  rke2Version = "1.36.1+rke2r2";
+  rke2Commit = "05cf623e2245271b63d1d7ef2caced897636175c";
+  rke2TarballHash = "sha256-hxnO8w+ec9cx6betH2hdC50AO/VHmPlseeKV8HgH5ZE=";
   rke2VendorHash = "sha256-gUgRAC9yKDa8JYb/jdCxZdP6500XxjqHprmYlPv5A8c=";
-  k8sImageTag = "v1.36.1-rke2r1-build20260512";
+  k8sImageTag = "v1.36.1-rke2r2-build20260521";
   etcdVersion = "v3.6.7-k3s1-build20260512";
   pauseVersion = "3.6";
-  ccmVersion = "v1.36.0-rc2.0.20260427154526-d239025e2a23-build20260429";
-  dockerizedVersion = "v1.36.1-rke2r1";
+  ccmVersion = "v1.36.1-0.20260508014929-7bbbf7c9b258-build20260515";
+  dockerizedVersion = "v1.36.1-rke2r2";
   helmJobVersion = "v0.10.0-build20260513";
   imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- `rke2_1_33`: https://github.com/rancher/rke2/releases/tag/v1.33.12%2Brke2r2
- `rke2_1_34`: https://github.com/rancher/rke2/releases/tag/v1.34.8%2Brke2r2
- `rke2_1_35`: https://github.com/rancher/rke2/releases/tag/v1.35.5%2Brke2r2
- `rke2_1_36`: https://github.com/rancher/rke2/releases/tag/v1.36.1%2Brke2r2

**Note**: Upstream ingress-nginx Retirement & Transition to Traefik
Because ingress-nginx was retired upstream as of March 2026, Traefik is now the default for new clusters starting in v1.36 (existing clusters will keep their current ingress upon upgrade to avoid breakage). This transition brings the following structural changes:

- Airgapped Environments: The rke2-images-core tarball now contains Traefik images instead of ingress-nginx. The standalone rke2-images-traefik tarball has been removed. Users who must continue using ingress-nginx will now need to manually provide the rke2-images-ingress-nginx tarball.
- Future Removal: The ingress-nginx chart will not receive any additional updates and will be completely removed in v1.37 for community users.

@maevii @zimbatm @stefan-bordei 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
