### PR TITLE
maintainers: remove mkf

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18306,13 +18306,6 @@
     githubId = 52108954;
     name = "Matias Zwinger";
   };
-  mkf = {
-    email = "m@mikf.pl";
-    github = "mkf";
-    githubId = 7753506;
-    name = "Michał Krzysztof Feiler";
-    keys = [ { fingerprint = "1E36 9940 CC7E 01C4 CFE8  F20A E35C 2D7C 2C6A C724"; } ];
-  };
   mkg = {
     email = "mkg@vt.edu";
     github = "mkgvt";

--- a/pkgs/by-name/cw/cwm/package.nix
+++ b/pkgs/by-name/cw/cwm/package.nix
@@ -40,10 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Lightweight and efficient window manager for X11";
     homepage = "https://github.com/leahneukirchen/cwm";
-    maintainers = with lib.maintainers; [
-      _0x4A6F
-      mkf
-    ];
+    maintainers = with lib.maintainers; [ _0x4A6F ];
     license = lib.licenses.isc;
     platforms = lib.platforms.linux;
     mainProgram = "cwm";


### PR DESCRIPTION
## Reasons

- Last commented in [November 2020](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Amkf)
- Hasn't created any PRs / Issues since [September 2021](https://github.com/NixOS/nixpkgs/issues?q=author%3Amkf)
- About 5 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Amkf%20-commenter%3Amkf%20-author%3Amkf%20-reviewed-by%3Amkf) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.