### PR TITLE
musescore: remove qt6.qtdeclarative patch

### DIFF
--- a/pkgs/by-name/mu/musescore/package.nix
+++ b/pkgs/by-name/mu/musescore/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
 
   # nativeBuildInputs
   cmake,
@@ -35,24 +34,6 @@
   nixosTests,
 }:
 
-let
-  qt6' = qt6.overrideScope (
-    self: super: {
-      # Fix for: https://github.com/NixOS/nixpkgs/issues/526825
-      # reported upstream at: https://github.com/musescore/MuseScore/issues/33015
-      qtdeclarative = super.qtdeclarative.overrideAttrs (
-        new: old: {
-          patches = old.patches ++ [
-            (fetchpatch {
-              url = "https://github.com/qt/qtdeclarative/commit/9d4d376726a6ce15c429128dc65b927e411e40da.patch";
-              hash = "sha256-XhfliF5wZuN4/E55f8hfipIRjxBe9V7vL1cgn5p4xqA=";
-            })
-          ];
-        }
-      );
-    }
-  );
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "musescore";
   version = "4.7.3";
@@ -114,8 +95,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    qt6'.qttools
-    qt6'.wrapQtAppsHook
+    qt6.qttools
+    qt6.wrapQtAppsHook
     ninja
     pkg-config
   ]
@@ -128,12 +109,12 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     flac
     freetype
-    qt6'.qt5compat
-    qt6'.qtbase
-    qt6'.qtdeclarative
-    qt6'.qtnetworkauth
-    qt6'.qtscxml
-    qt6'.qtsvg
+    qt6.qt5compat
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qtnetworkauth
+    qt6.qtscxml
+    qt6.qtsvg
     lame
     libjack2
     libogg
@@ -150,7 +131,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     alsa-lib
-    qt6'.qtwayland
+    qt6.qtwayland
   ];
 
   # Put the default, `$prefix/lib` directory to look for ffmpeg shared objects,


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test