### PR TITLE
nixos/activation: use nixos-init during activation to deduplicate logic

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -62,6 +62,10 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- The core system activation steps (`/run/current-system`, `/bin/sh`, `/usr/bin/env`, the kernel modprobe and firmware paths) are now performed by `nixos-init` instead of `system.activationScripts` snippets. As a result, `/run/current-system` already points at the *new* generation while activation scripts run. Scripts that need the previous generation can read it from the exported `$oldSystemConfig` variable, but the recommended replacement for the common closure-diff pattern (`nvd`, `nix store diff-closures`) is [`system.preSwitchChecks`](#opt-system.preSwitchChecks), where `/run/current-system` still points at the old generation and `$1` is the new toplevel. `system.activationScripts` is deprecated.
+
+- Configurations that previously suppressed the `/bin/sh` or `/usr/bin/env` symlinks via `system.activationScripts.binsh = lib.mkForce ""` or `system.activationScripts.usrbinenv = lib.mkForce ""` (typically appliance images with a read-only `/usr`, or filesystems that provide `/bin` themselves) must now set `environment.createBinSh = false` or `environment.createUsrBinEnv = false` instead.
+
 - `boot.vesa` has been removed. It was deprecated in 2020 because Xorg now works better with kernel modesetting. If you still need the legacy VESA 800x600 fallback, set `boot.kernelParams = [ "vga=0x317" "nomodeset" ];` directly.
 
 - `authentik` has been updated to 2026.5.3, which changes the default listen address from `0.0.0.0` to `[::]`.

--- a/nixos/modules/config/shells-environment.nix
+++ b/nixos/modules/config/shells-environment.nix
@@ -200,9 +200,20 @@ in
       visible = false;
       description = ''
         The shell executable that is linked system-wide to
-        `/bin/sh`. Please note that NixOS assumes all
-        over the place that shell to be Bash, so override the default
-        setting only if you know exactly what you're doing.
+        `/bin/sh`. When set to `null`, `/bin/sh` is removed at
+        activation. Please note that NixOS assumes all over the place
+        that shell to be Bash, so override the default setting only if
+        you know exactly what you're doing.
+      '';
+    };
+
+    environment.createBinSh = lib.mkOption {
+      default = true;
+      type = lib.types.bool;
+      internal = true;
+      description = ''
+        Whether the system manages `/bin/sh` at activation. Modules
+        that provide `/bin` themselves set this to `false`.
       '';
     };
 
@@ -267,14 +278,16 @@ in
       ''}
     '';
 
-    system.activationScripts.binsh = lib.stringAfter [ "stdio" ] ''
-      # Create the required /bin/sh symlink; otherwise lots of things
-      # (notably the system() function) won't work.
-      mkdir -p /bin
-      chmod 0755 /bin
-      ln -sfn "${cfg.binsh}" /bin/.sh.tmp
-      mv /bin/.sh.tmp /bin/sh # atomically replace /bin/sh
-    '';
+    system.activationScripts.binsh = lib.stringAfter [ "stdio" ] (
+      lib.optionalString cfg.createBinSh ''
+        # Create the required /bin/sh symlink; otherwise lots of things
+        # (notably the system() function) won't work.
+        mkdir -p /bin
+        chmod 0755 /bin
+        ln -sfn "${cfg.binsh}" /bin/.sh.tmp
+        mv /bin/.sh.tmp /bin/sh # atomically replace /bin/sh
+      ''
+    );
 
   };
 

--- a/nixos/modules/config/shells-environment.nix
+++ b/nixos/modules/config/shells-environment.nix
@@ -278,16 +278,8 @@ in
       ''}
     '';
 
-    system.activationScripts.binsh = lib.stringAfter [ "stdio" ] (
-      lib.optionalString cfg.createBinSh ''
-        # Create the required /bin/sh symlink; otherwise lots of things
-        # (notably the system() function) won't work.
-        mkdir -p /bin
-        chmod 0755 /bin
-        ln -sfn "${cfg.binsh}" /bin/.sh.tmp
-        mv /bin/.sh.tmp /bin/sh # atomically replace /bin/sh
-      ''
-    );
+    # Handled by nixos-init activate, kept as an empty stub for deps compat.
+    system.activationScripts.binsh = lib.stringAfter [ "stdio" ] "";
 
   };
 

--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -522,17 +522,8 @@ in
       (isYes "NET")
     ];
 
-    system.activationScripts.udevd = lib.mkIf config.boot.kernel.enable ''
-      # The deprecated hotplug uevent helper is not used anymore
-      if [ -e /proc/sys/kernel/hotplug ]; then
-        echo "" > /proc/sys/kernel/hotplug
-      fi
-
-      # Allow the kernel to find our firmware.
-      if [ -e /sys/module/firmware_class/parameters/path ]; then
-        echo -n "${config.hardware.firmware}/lib/firmware" > /sys/module/firmware_class/parameters/path
-      fi
-    '';
+    # Handled by nixos-init activate, kept as an empty stub for deps compat.
+    system.activationScripts.udevd = "";
 
     systemd.services.systemd-udevd = {
       restartTriggers = [ config.environment.etc."udev/rules.d".source ];

--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -65,6 +65,16 @@ let
       # Ensure a consistent umask.
       umask 0022
 
+      # Capture the previous system before nixos-init updates
+      # /run/current-system, so snippets that need to compare against
+      # the old generation can use $oldSystemConfig.
+      oldSystemConfig="$(readlink -f /run/current-system 2>/dev/null || true)"
+      export oldSystemConfig
+
+      ${lib.optionalString (!onlyDry) ''
+        ${config.system.nixos-init.package}/bin/activate "$systemConfig"
+      ''}
+
       ${lib.concatStringsSep "\n" (
         lib.filter (v: v != "") (
           textClosureList withDrySnippets (attrNames (lib.filterAttrs (_: v: v.text != "") withDrySnippets))
@@ -72,12 +82,6 @@ let
       )}
     ''
     + optionalString (!onlyDry) ''
-      # Make this configuration the current configuration.
-      # The readlink is there to ensure that when $systemConfig = /system
-      # (which is a symlink to the store), /run/current-system is still
-      # used as a garbage collection root.
-      ln -sfn "$(readlink -f "$systemConfig")" /run/current-system
-
       exit $_status
     '';
 
@@ -295,40 +299,11 @@ in
       "L+ /nix/var/nix/gcroots/current-system - - - - /run/current-system"
     ];
 
-    system.activationScripts.usrbinenv =
-      if !config.environment.createUsrBinEnv then
-        ""
-      else if config.environment.usrbinenv != null then
-        ''
-          mkdir -p /usr/bin
-          chmod 0755 /usr/bin
-          ln -sfn ${config.environment.usrbinenv} /usr/bin/.env.tmp
-          mv /usr/bin/.env.tmp /usr/bin/env # atomically replace /usr/bin/env
-        ''
-      else
-        ''
-          rm -f /usr/bin/env
-          if test -d /usr/bin; then rmdir --ignore-fail-on-non-empty /usr/bin; fi
-          if test -d /usr; then rmdir --ignore-fail-on-non-empty /usr; fi
-        '';
+    # Handled by nixos-init activate, kept as an empty stub for deps compat.
+    system.activationScripts.usrbinenv = "";
 
-    system.activationScripts.specialfs = ''
-      specialMount() {
-        local device="$1"
-        local mountPoint="$2"
-        local options="$3"
-        local fsType="$4"
-
-        if mountpoint -q "$mountPoint"; then
-          local options="remount,$options"
-        else
-          mkdir -p "$mountPoint"
-          chmod 0755 "$mountPoint"
-        fi
-        mount -t "$fsType" -o "$options" "$device" "$mountPoint"
-      }
-      source ${config.system.build.earlyMountScript}
-    '';
+    # Handled by nixos-init activate, kept as an empty stub for deps compat.
+    system.activationScripts.specialfs = "";
 
     systemd.user = lib.mkIf config.system.activatable {
       services.nixos-activation = {

--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -237,7 +237,18 @@ in
       visible = false;
       description = ''
         The {manpage}`env(1)` executable that is linked system-wide to
-        `/usr/bin/env`.
+        `/usr/bin/env`. When set to `null`, `/usr/bin/env` is removed
+        at activation.
+      '';
+    };
+
+    environment.createUsrBinEnv = mkOption {
+      default = true;
+      type = types.bool;
+      internal = true;
+      description = ''
+        Whether the system manages `/usr/bin/env` at activation.
+        Modules that provide `/usr/bin` themselves set this to `false`.
       '';
     };
 
@@ -285,7 +296,9 @@ in
     ];
 
     system.activationScripts.usrbinenv =
-      if config.environment.usrbinenv != null then
+      if !config.environment.createUsrBinEnv then
+        ""
+      else if config.environment.usrbinenv != null then
         ''
           mkdir -p /usr/bin
           chmod 0755 /usr/bin

--- a/nixos/modules/system/activation/nixos-init.nix
+++ b/nixos/modules/system/activation/nixos-init.nix
@@ -2,14 +2,23 @@
   config,
   lib,
   pkgs,
+  utils,
   ...
 }:
 
 let
   cfg = config.system.nixos-init;
 
+  specialFileSystems =
+    (lib.toposort utils.fsBefore (lib.attrValues config.boot.specialFileSystems)).result;
+
   nixosInitConfig = {
     nix_store_mount_opts = config.boot.nixStoreMountOpts;
+    special_filesystems = map (fs: {
+      mountpoint = fs.mountPoint;
+      inherit (fs) device options;
+      fstype = fs.fsType;
+    }) specialFileSystems;
   }
   // lib.optionalAttrs config.boot.kernel.enable {
     firmware = "${config.hardware.firmware}/lib/firmware";

--- a/nixos/modules/system/activation/nixos-init.nix
+++ b/nixos/modules/system/activation/nixos-init.nix
@@ -7,6 +7,32 @@
 
 let
   cfg = config.system.nixos-init;
+
+  nixosInitConfig = {
+    nix_store_mount_opts = config.boot.nixStoreMountOpts;
+  }
+  // lib.optionalAttrs config.boot.kernel.enable {
+    firmware = "${config.hardware.firmware}/lib/firmware";
+  }
+  // lib.optionalAttrs config.boot.modprobeConfig.enable {
+    modprobe_binary = "${pkgs.kmod}/bin/modprobe";
+  }
+  // lib.optionalAttrs config.environment.createBinSh {
+    sh_binary = toString config.environment.binsh;
+  }
+  // lib.optionalAttrs config.environment.createUsrBinEnv {
+    env_binary = toString config.environment.usrbinenv;
+  }
+  // lib.optionalAttrs config.system.etc.overlay.enable {
+    etc_metadata_image = config.system.build.etcMetadataImage;
+    etc_basedir = config.system.build.etcBasedir;
+  };
+
+  # boot.json is not written for containers, so provide the same config
+  # in a standalone file in that case.
+  needsFallbackConfig = config.boot.isContainer;
+
+  nixosInitConfigFile = pkgs.writeText "nixos-init.json" (builtins.toJSON nixosInitConfig);
 in
 {
   options.system.nixos-init = {
@@ -22,27 +48,11 @@ in
 
   config = lib.mkMerge [
     {
-      boot.bootspec.extensions = {
-        "org.nixos.nixos-init.v1" = {
-          nix_store_mount_opts = config.boot.nixStoreMountOpts;
-        }
-        // lib.optionalAttrs config.boot.kernel.enable {
-          firmware = "${config.hardware.firmware}/lib/firmware";
-        }
-        // lib.optionalAttrs config.boot.modprobeConfig.enable {
-          modprobe_binary = "${pkgs.kmod}/bin/modprobe";
-        }
-        // lib.optionalAttrs config.environment.createBinSh {
-          sh_binary = toString config.environment.binsh;
-        }
-        // lib.optionalAttrs config.environment.createUsrBinEnv {
-          env_binary = toString config.environment.usrbinenv;
-        }
-        // lib.optionalAttrs config.system.etc.overlay.enable {
-          etc_metadata_image = config.system.build.etcMetadataImage;
-          etc_basedir = config.system.build.etcBasedir;
-        };
-      };
+      boot.bootspec.extensions."org.nixos.nixos-init.v1" = nixosInitConfig;
+
+      system.systemBuilderCommands = lib.optionalString needsFallbackConfig ''
+        ln -s ${nixosInitConfigFile} $out/nixos-init.json
+      '';
     }
     (lib.mkIf cfg.enable {
       assertions = [

--- a/nixos/modules/system/activation/nixos-init.nix
+++ b/nixos/modules/system/activation/nixos-init.nix
@@ -24,15 +24,19 @@ in
     {
       boot.bootspec.extensions = {
         "org.nixos.nixos-init.v1" = {
-          firmware = "${config.hardware.firmware}/lib/firmware";
-          modprobe_binary = "${pkgs.kmod}/bin/modprobe";
           nix_store_mount_opts = config.boot.nixStoreMountOpts;
         }
-        // lib.optionalAttrs (config.environment.binsh != null) {
-          sh_binary = config.environment.binsh;
+        // lib.optionalAttrs config.boot.kernel.enable {
+          firmware = "${config.hardware.firmware}/lib/firmware";
         }
-        // lib.optionalAttrs (config.environment.usrbinenv != null) {
-          env_binary = config.environment.usrbinenv;
+        // lib.optionalAttrs config.boot.modprobeConfig.enable {
+          modprobe_binary = "${pkgs.kmod}/bin/modprobe";
+        }
+        // lib.optionalAttrs config.environment.createBinSh {
+          sh_binary = toString config.environment.binsh;
+        }
+        // lib.optionalAttrs config.environment.createUsrBinEnv {
+          env_binary = toString config.environment.usrbinenv;
         }
         // lib.optionalAttrs config.system.etc.overlay.enable {
           etc_metadata_image = config.system.build.etcMetadataImage;

--- a/nixos/modules/system/boot/modprobe.nix
+++ b/nixos/modules/system/boot/modprobe.nix
@@ -89,13 +89,8 @@ in
 
     environment.systemPackages = [ pkgs.kmod ];
 
-    system.activationScripts.modprobe = stringAfter [ "specialfs" ] ''
-      # Allow the kernel to find our wrapped modprobe (which searches
-      # in the right location in the Nix store for kernel modules).
-      # We need this when the kernel (or some module) auto-loads a
-      # module.
-      echo ${pkgs.kmod}/bin/modprobe > /proc/sys/kernel/modprobe
-    '';
+    # Handled by nixos-init activate, kept as an empty stub for deps compat.
+    system.activationScripts.modprobe = stringAfter [ "specialfs" ] "";
 
   };
 

--- a/nixos/modules/system/etc/etc.nix
+++ b/nixos/modules/system/etc/etc.nix
@@ -287,7 +287,7 @@ in
           # it's relatively simple, however, we avoid the composefs dependency.
           # Since this script is not idempotent, it should not run when etc hasn't
           # changed.
-          if [[ ! $IN_NIXOS_SYSTEMD_STAGE1 ]] && [[ "${config.system.build.etc}/etc" != "$(readlink -f /run/current-system/etc)" ]]; then
+          if [[ ! $IN_NIXOS_SYSTEMD_STAGE1 ]] && [[ "${config.system.build.etc}/etc" != "$(readlink -f "''${oldSystemConfig:-/nonexistent}/etc" 2>/dev/null)" ]]; then
             echo "remounting /etc..."
 
             ${lib.optionalString config.system.etc.overlay.mutable ''

--- a/nixos/modules/tasks/filesystems/envfs.nix
+++ b/nixos/modules/tasks/filesystems/envfs.nix
@@ -71,13 +71,14 @@ in
     # we also want these mounts in virtual machines.
     fileSystems = if config.virtualisation ? qemu then lib.mkVMOverride mounts else mounts;
 
-    # We no longer need those when using envfs
-    system.activationScripts.usrbinenv = lib.mkForce "";
-    system.activationScripts.binsh = lib.mkForce "";
+    # envfs provides /bin and /usr/bin itself.
+    environment.createBinSh = false;
+    environment.createUsrBinEnv = false;
 
-    # Disabling the activation scripts above prevents the creation of 2
-    # directories, which would normally be created just before switch-root at
-    # stage1. This causes problems when systemd is used in the initrd.
+    # Disabling /bin/sh and /usr/bin/env creation above prevents the
+    # creation of 2 directories, which would normally be created just
+    # before switch-root at stage1. This causes problems when systemd
+    # is used in the initrd.
     #
     # This only affects fresh installations or systems using impermanence/tmpfs
     # root, where these directories don't persist from a previous activation.

--- a/nixos/tests/activation/nixos-init.nix
+++ b/nixos/tests/activation/nixos-init.nix
@@ -35,6 +35,12 @@
 
       with subtest("activation"):
         t.assertEqual("${nodes.machine.system.build.toplevel}", machine.succeed("readlink /run/current-system").strip())
+
+        # Verify journal priority prefixes are emitted (and parsed) when stderr
+        # is the journal: the message should be at info level (6) and the
+        # message text should not contain a literal "<6>".
+        machine.succeed("journalctl -b -p info..info -o cat | grep -F 'Setting up /run/current-system'")
+        machine.fail("journalctl -b -o cat | grep -F '<6>Setting up'")
         t.assertEqual("${nodes.machine.hardware.firmware}/lib/firmware", machine.succeed("cat /sys/module/firmware_class/parameters/path").strip())
         t.assertEqual("${pkgs.kmod}/bin/modprobe", machine.succeed("cat /proc/sys/kernel/modprobe").strip())
         t.assertEqual("${nodes.machine.environment.usrbinenv}", machine.succeed("readlink /usr/bin/env").strip())

--- a/nixos/tests/appliance-repart-image-verity-store.nix
+++ b/nixos/tests/appliance-repart-image-verity-store.nix
@@ -63,7 +63,7 @@
       # don't create /usr/bin/env
       # this would require some extra work on read-only /usr
       # and it is not a strict necessity
-      system.activationScripts.usrbinenv = lib.mkForce "";
+      environment.createUsrBinEnv = false;
     };
 
   nodes.machine = {

--- a/pkgs/by-name/ni/nixos-init/Cargo.lock
+++ b/pkgs/by-name/ni/nixos-init/Cargo.lock
@@ -139,6 +139,7 @@ dependencies = [
  "indoc",
  "log",
  "pathrs",
+ "rustix",
  "serde",
  "serde_json",
  "tempfile",

--- a/pkgs/by-name/ni/nixos-init/Cargo.toml
+++ b/pkgs/by-name/ni/nixos-init/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "1.0.98"
 log = "0.4.27"
 env_logger = { version = "0.11.8", default-features = false }
 pathrs = "0.2.2"
+rustix = { version = "1.1.3", features = ["fs"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 bootspec = "2.0.0"

--- a/pkgs/by-name/ni/nixos-init/Cargo.toml
+++ b/pkgs/by-name/ni/nixos-init/Cargo.toml
@@ -8,7 +8,7 @@ anyhow = "1.0.98"
 log = "0.4.27"
 env_logger = { version = "0.11.8", default-features = false }
 pathrs = "0.2.2"
-rustix = { version = "1.1.3", features = ["fs"] }
+rustix = { version = "1.1.3", features = ["fs", "mount"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 bootspec = "2.0.0"

--- a/pkgs/by-name/ni/nixos-init/package.nix
+++ b/pkgs/by-name/ni/nixos-init/package.nix
@@ -45,6 +45,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   binaries = [
+    "activate"
     "initrd-init"
     "find-etc"
     "clear-etc-opaque"

--- a/pkgs/by-name/ni/nixos-init/src/activate.rs
+++ b/pkgs/by-name/ni/nixos-init/src/activate.rs
@@ -35,11 +35,19 @@ pub fn activate(prefix: &str, toplevel: impl AsRef<Path>, config: &Config) -> Re
     let system_path = PathBuf::from(prefix).join("run/current-system");
     atomic_symlink(&toplevel, system_path)?;
 
-    log::info!("Setting up modprobe...");
-    setup_modprobe(&config.modprobe_binary)?;
+    if let Some(modprobe_binary) = &config.modprobe_binary {
+        log::info!("Setting up modprobe...");
+        setup_modprobe(modprobe_binary)?;
+    } else {
+        log::info!("No modprobe binary provided. Not setting up modprobe.");
+    }
 
-    log::info!("Setting up firmware search paths...");
-    setup_firmware_search_path(&config.firmware)?;
+    if let Some(firmware) = &config.firmware {
+        log::info!("Setting up firmware search paths...");
+        setup_firmware_search_path(firmware)?;
+    } else {
+        log::info!("No firmware path provided. Not setting up firmware search paths.");
+    }
 
     if let Some(env_path) = &config.env_binary {
         log::info!("Setting up /usr/bin/env...");

--- a/pkgs/by-name/ni/nixos-init/src/activate.rs
+++ b/pkgs/by-name/ni/nixos-init/src/activate.rs
@@ -49,18 +49,28 @@ pub fn activate(prefix: &str, toplevel: impl AsRef<Path>, config: &Config) -> Re
         log::info!("No firmware path provided. Not setting up firmware search paths.");
     }
 
-    if let Some(env_path) = &config.env_binary {
-        log::info!("Setting up /usr/bin/env...");
-        setup_usrbinenv(prefix, env_path)?;
-    } else {
-        log::info!("No env binary provided. Not setting up /usr/bin/env.");
+    match config.env_binary.as_deref() {
+        None => log::info!("/usr/bin/env not managed by nixos-init."),
+        Some("") => {
+            log::info!("Removing /usr/bin/env...");
+            remove_usrbinenv(prefix)?;
+        }
+        Some(path) => {
+            log::info!("Setting up /usr/bin/env...");
+            setup_usrbinenv(prefix, path)?;
+        }
     }
 
-    if let Some(sh_path) = &config.sh_binary {
-        log::info!("Setting up /bin/sh...");
-        setup_binsh(prefix, sh_path)?;
-    } else {
-        log::info!("No sh binary provided. Not setting up /bin/sh.");
+    match config.sh_binary.as_deref() {
+        None => log::info!("/bin/sh not managed by nixos-init."),
+        Some("") => {
+            log::info!("Removing /bin/sh...");
+            remove_binsh(prefix)?;
+        }
+        Some(path) => {
+            log::info!("Setting up /bin/sh...");
+            setup_binsh(prefix, path)?;
+        }
     }
 
     Ok(())
@@ -129,6 +139,16 @@ fn setup_usrbinenv(prefix: &str, env_binary: impl AsRef<Path>) -> Result<()> {
     atomic_symlink(&env_binary, usrbin_path.join("env"))
 }
 
+/// Remove `/usr/bin/env`.
+///
+/// `/usr/bin` is kept (and created if missing) so that `/usr` is never empty,
+/// which systemd treats as a fatal boot error.
+fn remove_usrbinenv(prefix: &str) -> Result<()> {
+    let usrbin = PathBuf::from(prefix).join("usr/bin");
+    fs::create_dir_all(&usrbin).context("Failed to create /usr/bin")?;
+    remove_if_exists(&usrbin.join("env"))
+}
+
 /// Setup /bin/sh.
 ///
 /// `/bin/sh` is an essential part of a Linux system as this path is hardcoded in the `system()` call
@@ -136,4 +156,19 @@ fn setup_usrbinenv(prefix: &str, env_binary: impl AsRef<Path>) -> Result<()> {
 fn setup_binsh(prefix: &str, sh_binary: impl AsRef<Path>) -> Result<()> {
     let binsh_path = PathBuf::from(prefix).join("bin/sh");
     atomic_symlink(&sh_binary, binsh_path)
+}
+
+/// Remove `/bin/sh`. `/bin` is kept (and created if missing).
+fn remove_binsh(prefix: &str) -> Result<()> {
+    let bin = PathBuf::from(prefix).join("bin");
+    fs::create_dir_all(&bin).context("Failed to create /bin")?;
+    remove_if_exists(&bin.join("sh"))
+}
+
+fn remove_if_exists(path: &Path) -> Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e).with_context(|| format!("Failed to remove {}", path.display())),
+    }
 }

--- a/pkgs/by-name/ni/nixos-init/src/activate.rs
+++ b/pkgs/by-name/ni/nixos-init/src/activate.rs
@@ -1,11 +1,16 @@
 use std::{
     env, fs,
+    os::unix::fs::PermissionsExt,
     path::{Path, PathBuf},
 };
 
 use anyhow::{Context, Result, bail};
 
-use crate::{config::Config, fs::atomic_symlink};
+use crate::{
+    config::{Config, SpecialMount},
+    fs::{atomic_symlink, mount},
+    proc_mounts::Mounts,
+};
 
 /// Entrypoint for the `activate` binary.
 ///
@@ -24,7 +29,38 @@ pub fn activate_main() -> Result<()> {
     let config =
         Config::from_toplevel(&toplevel, "/").context("Failed to load nixos-init config")?;
 
+    log::info!("Setting up special filesystems...");
+    setup_special_filesystems(&config.special_filesystems)?;
+
     activate("/", &toplevel, &config)
+}
+
+/// Mount or remount each entry in `boot.specialFileSystems`.
+fn setup_special_filesystems(mounts: &[SpecialMount]) -> Result<()> {
+    let existing = Mounts::parse_from_proc_mounts()?;
+    for m in mounts {
+        let opts = m.options.join(",");
+        if existing.find_mountpoint(&m.mountpoint).is_some() {
+            mount(&[
+                "-t",
+                &m.fstype,
+                "-o",
+                &format!("remount,{opts}"),
+                &m.device,
+                &m.mountpoint,
+            ])
+            .with_context(|| format!("Failed to remount {}", m.mountpoint))?;
+        } else {
+            fs::create_dir_all(&m.mountpoint)
+                .with_context(|| format!("Failed to create {}", m.mountpoint))?;
+            let mut perms = fs::metadata(&m.mountpoint)?.permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&m.mountpoint, perms)?;
+            mount(&["-t", &m.fstype, "-o", &opts, &m.device, &m.mountpoint])
+                .with_context(|| format!("Failed to mount {}", m.mountpoint))?;
+        }
+    }
+    Ok(())
 }
 
 /// Activate the system.

--- a/pkgs/by-name/ni/nixos-init/src/activate.rs
+++ b/pkgs/by-name/ni/nixos-init/src/activate.rs
@@ -6,9 +6,11 @@ use std::{
 
 use anyhow::{Context, Result, bail};
 
+use rustix::mount::{mount, mount_remount};
+
 use crate::{
     config::{Config, SpecialMount},
-    fs::{atomic_symlink, mount},
+    fs::{atomic_symlink, split_mount_opts},
     proc_mounts::Mounts,
 };
 
@@ -39,25 +41,24 @@ pub fn activate_main() -> Result<()> {
 fn setup_special_filesystems(mounts: &[SpecialMount]) -> Result<()> {
     let existing = Mounts::parse_from_proc_mounts()?;
     for m in mounts {
-        let opts = m.options.join(",");
+        let (flags, data) = split_mount_opts(&m.options);
         if existing.find_mountpoint(&m.mountpoint).is_some() {
-            mount(&[
-                "-t",
-                &m.fstype,
-                "-o",
-                &format!("remount,{opts}"),
-                &m.device,
-                &m.mountpoint,
-            ])
-            .with_context(|| format!("Failed to remount {}", m.mountpoint))?;
+            mount_remount(m.mountpoint.as_str(), flags, data.as_c_str())
+                .with_context(|| format!("Failed to remount {}", m.mountpoint))?;
         } else {
             fs::create_dir_all(&m.mountpoint)
                 .with_context(|| format!("Failed to create {}", m.mountpoint))?;
             let mut perms = fs::metadata(&m.mountpoint)?.permissions();
             perms.set_mode(0o755);
             fs::set_permissions(&m.mountpoint, perms)?;
-            mount(&["-t", &m.fstype, "-o", &opts, &m.device, &m.mountpoint])
-                .with_context(|| format!("Failed to mount {}", m.mountpoint))?;
+            mount(
+                m.device.as_str(),
+                m.mountpoint.as_str(),
+                m.fstype.as_str(),
+                flags,
+                data.as_c_str(),
+            )
+            .with_context(|| format!("Failed to mount {}", m.mountpoint))?;
         }
     }
     Ok(())

--- a/pkgs/by-name/ni/nixos-init/src/activate.rs
+++ b/pkgs/by-name/ni/nixos-init/src/activate.rs
@@ -1,11 +1,31 @@
 use std::{
-    fs,
+    env, fs,
     path::{Path, PathBuf},
 };
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 
 use crate::{config::Config, fs::atomic_symlink};
+
+/// Entrypoint for the `activate` binary.
+///
+/// Activate a `NixOS` system configuration on the running system.
+pub fn activate_main() -> Result<()> {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() != 2 {
+        bail!("Usage: {} <toplevel>", args[0]);
+    }
+
+    // Canonicalize so /run/current-system points at the resolved store path.
+    let toplevel = fs::canonicalize(&args[1])
+        .with_context(|| format!("Failed to canonicalize toplevel path {}", args[1]))?;
+
+    let config =
+        Config::from_toplevel(&toplevel, "/").context("Failed to load nixos-init config")?;
+
+    activate("/", &toplevel, &config)
+}
 
 /// Activate the system.
 ///

--- a/pkgs/by-name/ni/nixos-init/src/config.rs
+++ b/pkgs/by-name/ni/nixos-init/src/config.rs
@@ -7,8 +7,8 @@ use bootspec::BootJson;
 
 #[derive(Deserialize)]
 pub struct Config {
-    pub firmware: String,
-    pub modprobe_binary: String,
+    pub firmware: Option<String>,
+    pub modprobe_binary: Option<String>,
     pub nix_store_mount_opts: Vec<String>,
     pub env_binary: Option<String>,
     pub sh_binary: Option<String>,

--- a/pkgs/by-name/ni/nixos-init/src/config.rs
+++ b/pkgs/by-name/ni/nixos-init/src/config.rs
@@ -2,8 +2,10 @@ use serde::Deserialize;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use bootspec::BootJson;
+
+const EXTENSION_KEY: &str = "org.nixos.nixos-init.v1";
 
 #[derive(Deserialize)]
 pub struct Config {
@@ -17,23 +19,43 @@ pub struct Config {
 }
 
 impl Config {
-    /// Read the config from the metadata file in the toplevel directory.
+    /// Read the config from the toplevel directory.
+    ///
+    /// Tries the bootspec extension in `boot.json` first, falling back to
+    /// `nixos-init.json` for systems where `boot.json` is not written
+    /// (containers).
     pub fn from_toplevel(toplevel: impl AsRef<Path>, prefix: &str) -> Result<Self> {
-        let bootspec_path =
-            PathBuf::from(prefix).join(toplevel.as_ref().join("boot.json").strip_prefix("/")?);
+        let toplevel_in_prefix =
+            PathBuf::from(prefix).join(toplevel.as_ref().strip_prefix("/").with_context(|| {
+                format!("toplevel {} is not absolute", toplevel.as_ref().display())
+            })?);
 
-        let boot_json: BootJson = fs::read(bootspec_path)
-            .context("Failed to read bootspec file")
-            .and_then(|raw| serde_json::from_slice(&raw).context("Failed to read bootspec JSON"))?;
+        let bootspec_path = toplevel_in_prefix.join("boot.json");
+        if bootspec_path.exists() {
+            let boot_json: BootJson = fs::read(&bootspec_path)
+                .with_context(|| format!("Failed to read {}", bootspec_path.display()))
+                .and_then(|b| serde_json::from_slice(&b).context("Failed to parse boot.json"))?;
+            let extension = boot_json
+                .extensions
+                .get(EXTENSION_KEY)
+                .with_context(|| format!("boot.json has no {EXTENSION_KEY} extension"))?;
+            return serde_json::from_value(extension.clone())
+                .with_context(|| format!("Failed to deserialize {EXTENSION_KEY} extension"));
+        }
 
-        let config = boot_json
-            .extensions
-            .get("org.nixos.nixos-init.v1")
-            .context("Failed to extract nixos-init bootspec extension")
-            .and_then(|v| {
-                serde_json::from_value(v.clone()).context("Failed to deserialise config")
-            })?;
+        let fallback_path = toplevel_in_prefix.join("nixos-init.json");
+        if fallback_path.exists() {
+            return fs::read(&fallback_path)
+                .with_context(|| format!("Failed to read {}", fallback_path.display()))
+                .and_then(|b| {
+                    serde_json::from_slice(&b).context("Failed to parse nixos-init.json")
+                });
+        }
 
-        Ok(config)
+        bail!(
+            "Neither {} nor {} found in toplevel",
+            bootspec_path.display(),
+            fallback_path.display()
+        )
     }
 }

--- a/pkgs/by-name/ni/nixos-init/src/config.rs
+++ b/pkgs/by-name/ni/nixos-init/src/config.rs
@@ -16,6 +16,16 @@ pub struct Config {
     pub sh_binary: Option<String>,
     pub etc_basedir: Option<String>,
     pub etc_metadata_image: Option<String>,
+    #[serde(default)]
+    pub special_filesystems: Vec<SpecialMount>,
+}
+
+#[derive(Deserialize)]
+pub struct SpecialMount {
+    pub mountpoint: String,
+    pub device: String,
+    pub fstype: String,
+    pub options: Vec<String>,
 }
 
 impl Config {

--- a/pkgs/by-name/ni/nixos-init/src/fs.rs
+++ b/pkgs/by-name/ni/nixos-init/src/fs.rs
@@ -1,22 +1,37 @@
-use std::{fs, path::Path, process::Command};
+use std::{ffi::CString, fs, path::Path};
 
 use anyhow::{Context, Result, anyhow};
+use rustix::mount::MountFlags;
 
-/// Call `mount` with the provided `args`.
-pub fn mount(args: &[&str]) -> Result<()> {
-    let output = Command::new("mount")
-        .args(args)
-        .output()
-        .context("Failed to run mount. Most likely, the binary is not on PATH")?;
-
-    if !output.status.success() {
-        return Err(anyhow!(
-            "mount executed unsuccessfully: {}",
-            String::from_utf8_lossy(&output.stderr)
-        ));
+/// Split mount options into VFS flags and a filesystem data string for `mount(2)`.
+///
+/// # Panics
+///
+/// Panics if any option contains an interior NUL byte.
+pub fn split_mount_opts<S: AsRef<str>>(opts: &[S]) -> (MountFlags, CString) {
+    let mut flags = MountFlags::empty();
+    let mut data = Vec::new();
+    for opt in opts {
+        match opt.as_ref() {
+            "ro" => flags |= MountFlags::RDONLY,
+            "rw" => flags.remove(MountFlags::RDONLY),
+            "nosuid" => flags |= MountFlags::NOSUID,
+            "nodev" => flags |= MountFlags::NODEV,
+            "noexec" => flags |= MountFlags::NOEXEC,
+            "sync" => flags |= MountFlags::SYNCHRONOUS,
+            "dirsync" => flags |= MountFlags::DIRSYNC,
+            "noatime" => flags |= MountFlags::NOATIME,
+            "nodiratime" => flags |= MountFlags::NODIRATIME,
+            "relatime" => flags |= MountFlags::RELATIME,
+            "strictatime" => flags |= MountFlags::STRICTATIME,
+            "lazytime" => flags |= MountFlags::LAZYTIME,
+            other => data.push(other),
+        }
     }
-
-    Ok(())
+    (
+        flags,
+        CString::new(data.join(",")).expect("mount option contains NUL"),
+    )
 }
 
 /// Atomically symlink a file.

--- a/pkgs/by-name/ni/nixos-init/src/fs.rs
+++ b/pkgs/by-name/ni/nixos-init/src/fs.rs
@@ -1,6 +1,23 @@
-use std::{fs, path::Path};
+use std::{fs, path::Path, process::Command};
 
 use anyhow::{Context, Result, anyhow};
+
+/// Call `mount` with the provided `args`.
+pub fn mount(args: &[&str]) -> Result<()> {
+    let output = Command::new("mount")
+        .args(args)
+        .output()
+        .context("Failed to run mount. Most likely, the binary is not on PATH")?;
+
+    if !output.status.success() {
+        return Err(anyhow!(
+            "mount executed unsuccessfully: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    Ok(())
+}
 
 /// Atomically symlink a file.
 ///

--- a/pkgs/by-name/ni/nixos-init/src/init.rs
+++ b/pkgs/by-name/ni/nixos-init/src/init.rs
@@ -1,8 +1,13 @@
-use std::{fs, os::unix::fs::PermissionsExt, path::Path, process::Command};
+use std::{fs, os::unix::fs::PermissionsExt, path::Path};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 
-use crate::{activate::activate, config::Config, fs::atomic_symlink, proc_mounts::Mounts};
+use crate::{
+    activate::activate,
+    config::Config,
+    fs::{atomic_symlink, mount},
+    proc_mounts::Mounts,
+};
 
 const NIX_STORE_PATH: &str = "/nix/store";
 
@@ -83,23 +88,6 @@ fn remount_nix_store(prefix: &str, nix_store_mount_opts: &[String]) -> Result<()
             &format!("remount,bind,{}", missing_opts.join(",")),
             &nix_store_path,
         ])?;
-    }
-
-    Ok(())
-}
-
-/// Call `mount` with the provided `args`.
-fn mount(args: &[&str]) -> Result<()> {
-    let output = Command::new("mount")
-        .args(args)
-        .output()
-        .context("Failed to run mount. Most likely, the binary is not on PATH")?;
-
-    if !output.status.success() {
-        return Err(anyhow::anyhow!(
-            "mount executed unsuccessfully: {}",
-            String::from_utf8_lossy(&output.stdout)
-        ));
     }
 
     Ok(())

--- a/pkgs/by-name/ni/nixos-init/src/init.rs
+++ b/pkgs/by-name/ni/nixos-init/src/init.rs
@@ -1,11 +1,12 @@
 use std::{fs, os::unix::fs::PermissionsExt, path::Path};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+use rustix::mount::{MountFlags, mount_bind, mount_remount};
 
 use crate::{
     activate::activate,
     config::Config,
-    fs::{atomic_symlink, mount},
+    fs::{atomic_symlink, split_mount_opts},
     proc_mounts::Mounts,
 };
 
@@ -82,12 +83,14 @@ fn remount_nix_store(prefix: &str, nix_store_mount_opts: &[String]) -> Result<()
     if !missing_opts.is_empty() {
         log::info!("Remounting /nix/store with {}...", missing_opts.join(","));
 
-        mount(&["--bind", &nix_store_path, &nix_store_path])?;
-        mount(&[
-            "-o",
-            &format!("remount,bind,{}", missing_opts.join(",")),
-            &nix_store_path,
-        ])?;
+        mount_bind(&nix_store_path, &nix_store_path)
+            .with_context(|| format!("Failed to bind-mount {nix_store_path}"))?;
+
+        // MS_REMOUNT|MS_BIND sets the per-mount flags to exactly what is
+        // passed; any flag not included here is cleared.
+        let (flags, data) = split_mount_opts(nix_store_mount_opts);
+        mount_remount(&nix_store_path, MountFlags::BIND | flags, data.as_c_str())
+            .with_context(|| format!("Failed to remount {nix_store_path}"))?;
     }
 
     Ok(())

--- a/pkgs/by-name/ni/nixos-init/src/lib.rs
+++ b/pkgs/by-name/ni/nixos-init/src/lib.rs
@@ -15,7 +15,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, bail};
 
 pub use crate::{
-    activate::activate,
+    activate::{activate, activate_main},
     env_generator::env_generator,
     etc_overlay::clear_etc_opaque,
     find_etc::find_etc,

--- a/pkgs/by-name/ni/nixos-init/src/main.rs
+++ b/pkgs/by-name/ni/nixos-init/src/main.rs
@@ -1,4 +1,4 @@
-use std::{env, io::Write, process::ExitCode};
+use std::{env, io::Write, os::fd::AsFd, process::ExitCode};
 
 use log::Level;
 
@@ -35,25 +35,50 @@ fn main() -> ExitCode {
     }
 }
 
-// Setup the logger to use the kernel's `printk()` scheme.
+// Setup the logger.
 //
-// This way, systemd can interpret the levels correctly.
+// When stderr is connected to the journal, use the kernel `printk()` scheme
+// so systemd can interpret the levels. Otherwise (interactive switch, plain
+// terminal) use a plain format without the `<N>` prefix.
 fn setup_logger() {
     let env = env_logger::Env::default().filter_or("LOG_LEVEL", "info");
+    let to_journal = stderr_is_journal();
 
     env_logger::Builder::from_env(env)
-        .format(|buf, record| {
-            writeln!(
-                buf,
-                "<{}>{}",
-                match record.level() {
-                    Level::Error => 3,
-                    Level::Warn => 4,
-                    Level::Info => 6,
-                    Level::Debug | Level::Trace => 7,
-                },
-                record.args()
-            )
+        .format(move |buf, record| {
+            if to_journal {
+                writeln!(
+                    buf,
+                    "<{}>{}",
+                    match record.level() {
+                        Level::Error => 3,
+                        Level::Warn => 4,
+                        Level::Info => 6,
+                        Level::Debug | Level::Trace => 7,
+                    },
+                    record.args()
+                )
+            } else {
+                writeln!(buf, "{}", record.args())
+            }
         })
         .init();
+}
+
+// Check whether stderr is connected to the systemd journal.
+//
+// Per systemd.exec(5), $JOURNAL_STREAM holds the dev:ino of the journal
+// stream and must be compared against stderr's actual dev:ino, since the
+// variable is inherited across exec.
+fn stderr_is_journal() -> bool {
+    let Ok(var) = env::var("JOURNAL_STREAM") else {
+        return false;
+    };
+    let Some((dev, ino)) = var.split_once(':') else {
+        return false;
+    };
+    let (Ok(dev), Ok(ino)) = (dev.parse::<u64>(), ino.parse::<u64>()) else {
+        return false;
+    };
+    rustix::fs::fstat(std::io::stderr().as_fd()).is_ok_and(|s| s.st_dev == dev && s.st_ino == ino)
 }

--- a/pkgs/by-name/ni/nixos-init/src/main.rs
+++ b/pkgs/by-name/ni/nixos-init/src/main.rs
@@ -2,7 +2,9 @@ use std::{env, io::Write, process::ExitCode};
 
 use log::Level;
 
-use nixos_init::{clear_etc_opaque, env_generator, find_etc, initrd_init, resolve_in_root};
+use nixos_init::{
+    activate_main, clear_etc_opaque, env_generator, find_etc, initrd_init, resolve_in_root,
+};
 
 fn main() -> ExitCode {
     let arg0 = env::args()
@@ -12,6 +14,7 @@ fn main() -> ExitCode {
 
     setup_logger();
     let entrypoint = match arg0.as_str() {
+        "activate" => activate_main,
         "clear-etc-opaque" => clear_etc_opaque,
         "find-etc" => find_etc,
         "resolve-in-root" => resolve_in_root,


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Part of #475305.

We add an `activate` entrypoint to nixos-init that calls into the same code path as the initrd activation but with the appropriate arguments. We also add an extra function to setup special filesystems (which is done by systemd in initrd).

In order to be able to handle systems without bootspec, like containers, we extend the config generation and parsing such that without bootspec we generate and parse a dedicated nixos-init.json file. Bootspec enabled systems still use boot.json.

See the commit messages for more detail on the changes.

With this change we deduplicate the bash and rust implementations of a big part of the default nixos activation logic.

After this PR, the only in-tree activation scripts left are the etc setup and the user/group setup, which will be handled separately.

I ran the switch test, activation test, and container tests, and have been running this on my laptop for a couple of days now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
