### PR TITLE
treewide: drop some unnecessary toString calls

### DIFF
--- a/lib/sources.nix
+++ b/lib/sources.nix
@@ -43,7 +43,7 @@ let
   cleanSourceFilter =
     name: type:
     let
-      baseName = baseNameOf (toString name);
+      baseName = baseNameOf name;
     in
     !(
       # Filter out version control software files/directories
@@ -270,7 +270,7 @@ let
       filter =
         name: type:
         let
-          base = baseNameOf (toString name);
+          base = baseNameOf name;
         in
         type == "directory" || lib.any (ext: lib.hasSuffix ext base) exts;
     in

--- a/nixos/modules/services/hardware/fwupd.nix
+++ b/nixos/modules/services/hardware/fwupd.nix
@@ -35,7 +35,7 @@ let
     lib.listToAttrs (map mkEtcFile cfg.package.filesInstalledToEtc);
   extraTrustedKeys =
     let
-      mkName = p: "pki/fwupd/${baseNameOf (toString p)}";
+      mkName = p: "pki/fwupd/${baseNameOf p}";
       mkEtcFile = p: lib.nameValuePair (mkName p) { source = p; };
     in
     lib.listToAttrs (map mkEtcFile cfg.extraTrustedKeys);

--- a/pkgs/build-support/replace-vars/replace-vars-with.nix
+++ b/pkgs/build-support/replace-vars/replace-vars-with.nix
@@ -122,7 +122,7 @@ in
 
 stdenvNoCC.mkDerivation (
   {
-    name = baseNameOf (toString src);
+    name = baseNameOf src;
   }
   // optionalAttrs
   // forcedAttrs

--- a/pkgs/build-support/rust/build-rust-crate/test/rcgen-crates.nix
+++ b/pkgs/build-support/rust/build-rust-crate/test/rcgen-crates.nix
@@ -4347,7 +4347,7 @@ rec {
     sourceFilter =
       name: type:
       let
-        baseName = baseNameOf (toString name);
+        baseName = baseNameOf name;
       in
       !(
         # Filter out git

--- a/pkgs/build-support/substitute/substitute.nix
+++ b/pkgs/build-support/substitute/substitute.nix
@@ -29,7 +29,7 @@
 args:
 
 let
-  name = if args ? name then args.name else baseNameOf (toString args.src);
+  name = args.name or (baseNameOf args.src);
   deprecationReplacement = lib.pipe args.replacements [
     lib.toList
     (map (lib.splitString " "))

--- a/pkgs/development/compilers/llvm/common/default.nix
+++ b/pkgs/development/compilers/llvm/common/default.nix
@@ -71,7 +71,7 @@ let
       ;
     src = monorepoSrc;
     versionDir =
-      (toString ../.) + "/${if (gitRelease != null) then "git" else lib.versions.major release_version}";
+      ../. + "/${if (gitRelease != null) then "git" else lib.versions.major release_version}";
     getVersionFile =
       p:
       builtins.path {
@@ -95,15 +95,12 @@ let
               matchBefore && matchAfter;
 
             patchDir =
-              toString
-                (
-                  if constraints == null then
-                    { path = metadata.versionDir; }
-                  else
-                    (lib.findFirst matchConstraint { path = metadata.versionDir; } constraints)
-                ).path;
+              if constraints == null then
+                metadata.versionDir
+              else
+                (lib.findFirst matchConstraint { path = metadata.versionDir; } constraints).path;
           in
-          "${patchDir}/${p}";
+          patchDir + ("/" + p);
       };
   };
 

--- a/pkgs/kde/plasma/breeze-plymouth/default.nix
+++ b/pkgs/kde/plasma/breeze-plymouth/default.nix
@@ -26,7 +26,7 @@ let
   ];
   resolvedLogoName =
     if (logoFile != null && logoName == null) then
-      lib.strings.removeSuffix ".png" (baseNameOf (toString logoFile))
+      lib.strings.removeSuffix ".png" (baseNameOf logoFile)
     else
       logoName;
 in


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

(from the commit message)

Scope:
- Combination of
  - Textual matches of "baseNameOf (toString"
  - Redundant toString calls I've found with my latest "lazy paths" nix branch as they force lazy fetches into the store. More info and new PR soon.
- Only cases I believe are worthwhile or easily determined

I've determined the validity by
- testing llvmPackages instantiation
- figuring out which types can pass into any particular toString call - "human fuzzy type checker"

Behavior considerations by type:

- `path`: converted back to a string *without* context `baseNameOf` does not copy things to the store on its own, equivalent to its behavior for string inputs
- `null`: converted to `""` -> may be valid input! ok if "" would not have been acceptable anyway
- `string` itself: passed through identically -> trivial
- `attrset` with `outPath`: same coercion as built into the `baseNameOf` function -> trivial
- other atomic types: generally not sensible inputs to `baseNameOf` -> fuzzy but true

-----

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
  - I've done some exploration with an agent, but ended up selecting and writing the changes myself

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
