### PR TITLE
maintainers: drop frogamic

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9378,14 +9378,6 @@
     githubId = 1943632;
     name = "fro_ozen";
   };
-  frogamic = {
-    email = "frogamic@protonmail.com";
-    github = "frogamic";
-    githubId = 10263813;
-    name = "Dominic Shelton";
-    matrix = "@frogamic:beeper.com";
-    keys = [ { fingerprint = "779A 7CA8 D51C C53A 9C51  43F7 AAE0 70F0 67EC 00A5"; } ];
-  };
   frontear = {
     name = "Ali Rizvi";
     email = "perm-iterate-0b@icloud.com";

--- a/pkgs/by-name/li/libusbsio/package.nix
+++ b/pkgs/by-name/li/libusbsio/package.nix
@@ -52,8 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Library for communicating with devices connected via the USB bridge on LPC-Link2 and MCU-Link debug probes on supported NXP microcontroller evaluation boards";
     platforms = lib.platforms.all;
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [
-      frogamic
+    maintainers = [
     ];
   };
 })

--- a/pkgs/by-name/ni/nitrokey-udev-rules/package.nix
+++ b/pkgs/by-name/ni/nitrokey-udev-rules/package.nix
@@ -41,7 +41,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://github.com/Nitrokey/nitrokey-udev-rules";
     license = [ lib.licenses.cc0 ];
     maintainers = with lib.maintainers; [
-      frogamic
       robinkrahl
     ];
   };

--- a/pkgs/by-name/qu/quintom-cursor-theme/package.nix
+++ b/pkgs/by-name/qu/quintom-cursor-theme/package.nix
@@ -30,6 +30,6 @@ stdenvNoCC.mkDerivation {
       cc-by-sa-40
       gpl3Only
     ];
-    maintainers = with lib.maintainers; [ frogamic ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/sw/swaylock-fancy/package.nix
+++ b/pkgs/by-name/sw/swaylock-fancy/package.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/Big-B/swaylock-fancy";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ frogamic ];
+    maintainers = [ ];
     inherit mainProgram;
   };
 }

--- a/pkgs/development/python-modules/argparse-addons/default.nix
+++ b/pkgs/development/python-modules/argparse-addons/default.nix
@@ -21,8 +21,7 @@ buildPythonPackage rec {
     description = "Additional Python argparse types and actions";
     homepage = "https://github.com/eerimoq/argparse_addons";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [
-      frogamic
+    maintainers = [
     ];
   };
 }

--- a/pkgs/development/python-modules/bincopy/default.nix
+++ b/pkgs/development/python-modules/bincopy/default.nix
@@ -30,8 +30,7 @@ buildPythonPackage (finalAttrs: {
     mainProgram = "bincopy";
     homepage = "https://github.com/eerimoq/bincopy";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [
-      frogamic
+    maintainers = [
     ];
   };
 })

--- a/pkgs/development/python-modules/cmsis-pack-manager/default.nix
+++ b/pkgs/development/python-modules/cmsis-pack-manager/default.nix
@@ -67,8 +67,7 @@ buildPythonPackage rec {
     description = "Rust and Python module for handling CMSIS Pack files";
     homepage = "https://github.com/pyocd/cmsis-pack-manager";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [
-      frogamic
+    maintainers = [
     ];
   };
 }

--- a/pkgs/development/python-modules/hexdump/default.nix
+++ b/pkgs/development/python-modules/hexdump/default.nix
@@ -33,8 +33,7 @@ buildPythonPackage rec {
     description = "Library to dump binary data to hex format and restore from there";
     homepage = "https://pypi.org/project/hexdump/"; # BitBucket site returns 404
     license = lib.licenses.publicDomain;
-    maintainers = with lib.maintainers; [
-      frogamic
+    maintainers = [
     ];
   };
 }

--- a/pkgs/development/python-modules/libusbsio/default.nix
+++ b/pkgs/development/python-modules/libusbsio/default.nix
@@ -35,8 +35,7 @@ buildPythonPackage rec {
     description = "LIBUSBSIO Host Library for USB Enabled MCUs";
     homepage = "https://www.nxp.com/design/design-center/software/development-software/libusbsio-host-library-for-usb-enabled-mcus:LIBUSBSIO";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [
-      frogamic
+    maintainers = [
     ];
   };
 }

--- a/pkgs/development/python-modules/nethsm/default.nix
+++ b/pkgs/development/python-modules/nethsm/default.nix
@@ -58,6 +58,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Nitrokey/nethsm-sdk-py";
     changelog = "https://github.com/Nitrokey/nethsm-sdk-py/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ frogamic ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/nkdfu/default.nix
+++ b/pkgs/development/python-modules/nkdfu/default.nix
@@ -38,6 +38,6 @@ buildPythonPackage rec {
     mainProgram = "nkdfu";
     homepage = "https://github.com/Nitrokey/nkdfu";
     license = with lib.licenses; [ gpl2Only ];
-    maintainers = with lib.maintainers; [ frogamic ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pynitrokey/default.nix
+++ b/pkgs/development/python-modules/pynitrokey/default.nix
@@ -89,7 +89,6 @@ buildPythonPackage {
       mit
     ];
     maintainers = with lib.maintainers; [
-      frogamic
       panicgh
     ];
     inherit mainProgram;

--- a/pkgs/development/python-modules/pyocd/default.nix
+++ b/pkgs/development/python-modules/pyocd/default.nix
@@ -81,8 +81,7 @@ buildPythonPackage rec {
     downloadPage = "https://github.com/pyocd/pyOCD";
     homepage = "https://pyocd.io";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [
-      frogamic
+    maintainers = [
     ];
   };
 }

--- a/pkgs/development/python-modules/pypemicro/default.nix
+++ b/pkgs/development/python-modules/pypemicro/default.nix
@@ -27,8 +27,7 @@ buildPythonPackage rec {
       bsd3
       unfree
     ]; # it includes shared libraries for which no license is available (https://github.com/NXPmicro/pypemicro/issues/10)
-    maintainers = with lib.maintainers; [
-      frogamic
+    maintainers = [
     ];
   };
 }

--- a/pkgs/development/python-modules/pyudev/default.nix
+++ b/pkgs/development/python-modules/pyudev/default.nix
@@ -51,6 +51,6 @@ buildPythonPackage (finalAttrs: {
     description = "Pure Python libudev binding";
     changelog = "https://github.com/pyudev/pyudev/blob/v${finalAttrs.version}/CHANGES.rst";
     license = lib.licenses.lgpl21Plus;
-    maintainers = with lib.maintainers; [ frogamic ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/development/python-modules/spsdk/default.nix
+++ b/pkgs/development/python-modules/spsdk/default.nix
@@ -146,8 +146,7 @@ buildPythonPackage rec {
     description = "NXP Secure Provisioning SDK";
     homepage = "https://github.com/nxp-mcuxpresso/spsdk";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [
-      frogamic
+    maintainers = [
     ];
     mainProgram = "spsdk";
   };


### PR DESCRIPTION
No [comments](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Afrogamic) since November 2024 despite 11 [review requests](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+created%3A%3E%3D2025-12-01+user-review-requested%3Afrogamic). Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/33954594ec46166510795930ba8ebf0856249d4e/maintainers/README.md#losing-maintainer-status).

@frogamic if you object to being dropped please respond saying so within a week. Even if you don't make it, you are of course welcome back whenever you would like!




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
