### PR TITLE
factor: deploy script reports its path (fixes 0.101 compat) + setting 0.101 as the default 

### DIFF
--- a/pkgs/development/compilers/factor-lang/mk-factor-application.nix
+++ b/pkgs/development/compilers/factor-lang/mk-factor-application.nix
@@ -44,10 +44,15 @@ in
               file-name dup reload deploy
           ] bi ;
 
+      ! Factor 0.101 added a .out extension on not macOS. Rather than
+      ! having shell scripts dealing path name changes per-OS &
+      ! per-version, the deploy script prints its deploy path to a file.
       : deploy-vocab ( path/vocab path/target -- )
           normalize-path deploy-directory set
           f open-directory-after-deploy? set
-          load-and-deploy ;
+          dup file-name
+          [ load-and-deploy ] dip
+          deploy-path "deploy-path.txt" utf8 set-file-contents ;
 
       : deploy-me ( -- )
           command-line get dup length 2 = [
@@ -97,8 +102,15 @@ in
         mkdir -p "$out/lib/factor" "$TMPDIR/.cache"
         export XDG_CACHE_HOME="$TMPDIR/.cache"
 
+        # Deploy script writes the deploy path to to $PWD/deploy-path.txt
         factor "${deployScript}" "./$vocabName" "$out/lib/factor"
-        cp "$TMPDIR/factor-temp"/*.image "$out/lib/factor/$vocabBaseName"
+        deploy_path=$(cat "$PWD/deploy-path.txt")
+        if [ ! -x "$deploy_path" ]; then
+          echo "Not a valid deploy path for Factor: $deploy_path"
+          exit 1
+        fi
+
+        cp "$TMPDIR/factor-temp"/*.image "$(dirname "$deploy_path")/$(basename "$deploy_path").image"
         runHook postBuild
       '';
 
@@ -119,7 +131,7 @@ in
           appendToVar makeWrapperArgs --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath wrapped-factor.runtimeLibs}"
         ''}
         mkdir -p "$out/bin"
-        makeWrapper "$out/lib/factor/$vocabBaseName/$vocabBaseName" \
+        makeWrapper "$deploy_path" \
           "$out/bin/$binName" \
           --prefix PATH : "${lib.makeBinPath runtimePaths}" \
           "''${makeWrapperArgs[@]}"

--- a/pkgs/development/compilers/factor-lang/mk-factor-application.nix
+++ b/pkgs/development/compilers/factor-lang/mk-factor-application.nix
@@ -31,7 +31,7 @@ in
     extraPaths ? [ ],
     # Extra vocabularies needed by this application
     extraVocabs ? [ ],
-    deployScriptText ? ''
+    deployScriptText ? /* factor */ ''
       USING: command-line io io.backend io.pathnames kernel namespaces sequences
       tools.deploy tools.deploy.config tools.deploy.backend vocabs.loader ;
 
@@ -91,7 +91,7 @@ in
     buildInputs = (lib.optional enableUI gdk-pixbuf) ++ attrs.buildInputs or [ ];
 
     buildPhase =
-      attrs.buildPhase or ''
+      attrs.buildPhase or /* bash */ ''
         runHook preBuild
         vocabBaseName=$(basename "$vocabName")
         mkdir -p "$out/lib/factor" "$TMPDIR/.cache"
@@ -105,11 +105,11 @@ in
     __structuredAttrs = true;
 
     installPhase =
-      attrs.installPhase or (
-        ''
+      attrs.installPhase or
+        /* bash */ ''
           runHook preInstall
         ''
-        + (lib.optionalString finalAttrs.enableUI ''
+        + (lib.optionalString finalAttrs.enableUI /* bash */ ''
           # Set Gdk pixbuf loaders file to the one from the build dependencies here
           unset GDK_PIXBUF_MODULE_FILE
           # Defined in gdk-pixbuf setup hook
@@ -117,10 +117,10 @@ in
           appendToVar makeWrapperArgs --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
           appendToVar makeWrapperArgs --prefix LD_LIBRARY_PATH : /run/opengl-driver/lib
         '')
-        + (lib.optionalString (wrapped-factor.runtimeLibs != [ ])) ''
+        + (lib.optionalString (wrapped-factor.runtimeLibs != [ ])) /* bash */ ''
           appendToVar makeWrapperArgs --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath wrapped-factor.runtimeLibs}"
         ''
-        + ''
+        + /* bash */ ''
           mkdir -p "$out/bin"
           makeWrapper "$out/lib/factor/$vocabBaseName/$vocabBaseName" \
             "$out/bin/$binName" \

--- a/pkgs/development/compilers/factor-lang/mk-factor-application.nix
+++ b/pkgs/development/compilers/factor-lang/mk-factor-application.nix
@@ -105,30 +105,26 @@ in
     __structuredAttrs = true;
 
     installPhase =
-      attrs.installPhase or
-        /* bash */ ''
-          runHook preInstall
-        ''
-        + (lib.optionalString finalAttrs.enableUI /* bash */ ''
+      attrs.installPhase or /* bash */ ''
+        runHook preInstall
+        ${lib.optionalString finalAttrs.enableUI /* bash */ ''
           # Set Gdk pixbuf loaders file to the one from the build dependencies here
           unset GDK_PIXBUF_MODULE_FILE
           # Defined in gdk-pixbuf setup hook
           findGdkPixbufLoaders "${librsvg}"
           appendToVar makeWrapperArgs --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
           appendToVar makeWrapperArgs --prefix LD_LIBRARY_PATH : /run/opengl-driver/lib
-        '')
-        + (lib.optionalString (wrapped-factor.runtimeLibs != [ ])) /* bash */ ''
+        ''}
+        ${lib.optionalString (wrapped-factor.runtimeLibs != [ ]) /* bash */ ''
           appendToVar makeWrapperArgs --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath wrapped-factor.runtimeLibs}"
-        ''
-        + /* bash */ ''
-          mkdir -p "$out/bin"
-          makeWrapper "$out/lib/factor/$vocabBaseName/$vocabBaseName" \
-            "$out/bin/$binName" \
-            --prefix PATH : "${lib.makeBinPath runtimePaths}" \
-            "''${makeWrapperArgs[@]}"
-          runHook postInstall
-        ''
-      );
+        ''}
+        mkdir -p "$out/bin"
+        makeWrapper "$out/lib/factor/$vocabBaseName/$vocabBaseName" \
+          "$out/bin/$binName" \
+          --prefix PATH : "${lib.makeBinPath runtimePaths}" \
+          "''${makeWrapperArgs[@]}"
+        runHook postInstall
+      '';
 
     passthru = {
       vocab = finalAttrs.src;

--- a/pkgs/development/compilers/factor-lang/mk-factor-application.nix
+++ b/pkgs/development/compilers/factor-lang/mk-factor-application.nix
@@ -33,9 +33,21 @@ in
     extraVocabs ? [ ],
     deployScriptText ? /* factor */ ''
       USING: command-line io io.backend io.pathnames kernel namespaces sequences
-      tools.deploy tools.deploy.config tools.deploy.backend vocabs.loader ;
+      tools.deploy tools.deploy.config tools.deploy.backend vocabs.loader
+      io.directories.unix ;
 
       IN: deploy-me
+
+      ! The Nix sandbox’s seccomp filter blocks chmod(2). Factor’s
+      ! copy-file calls set-file-permissions which chmod’s the target
+      ! to the source’s mode, 0o444. The blocked syscall returns
+      ! EACCES, crashing the deploys. The method override skips the
+      ! set-file-permissions call (Nix will manage its output
+      ! permissions).
+      !
+      ! Surfaced with Factor 0.101 which added icon PNG resources to
+      ! the definitions.icons vocab to copy-vocab-resources.
+      M: unix copy-file call-next-method ;
 
       : load-and-deploy ( path/vocab -- )
           normalize-path [

--- a/pkgs/development/compilers/factor-lang/mk-factor-application.nix
+++ b/pkgs/development/compilers/factor-lang/mk-factor-application.nix
@@ -54,7 +54,7 @@ in
               first2 deploy-vocab
           ] [
               drop
-              "usage: deploy-me <PATH-TO-VOCAB> <TARGET-DIR>" print
+              "Usage: deploy-me <PATH-TO-VOCAB> <TARGET-DIR>" print
               nl
           ] if ;
 

--- a/pkgs/development/compilers/factor-lang/test/hello-world/default.nix
+++ b/pkgs/development/compilers/factor-lang/test/hello-world/default.nix
@@ -1,0 +1,56 @@
+# Builds hello-world Factor application using buildFactorApplication & verifies
+# source-to-binary that the resulting app prints "Hello, $NAME" depending on
+# `--name` flag.
+{
+  lib,
+  runCommandLocal,
+  buildFactorApplication,
+  buildFactorVocab,
+}:
+
+let
+  fs = lib.fileset;
+
+  factorFilter =
+    file:
+    lib.lists.any file.hasExt [
+      "factor"
+      "txt"
+    ];
+
+  version = "0-test";
+
+  vocab = buildFactorVocab {
+    inherit version;
+    pname = "hello";
+    src = fs.toSource {
+      root = ./extra;
+      fileset = fs.difference (fs.fileFilter factorFilter ./extra/hello) ./extra/hello/cli;
+    };
+    vocabName = "hello";
+  };
+
+  app = buildFactorApplication {
+    inherit version;
+    pname = "hello-cli";
+    src = fs.toSource {
+      root = ./extra;
+      fileset = fs.fileFilter factorFilter ./extra/hello/cli;
+    };
+    vocabName = "hello.cli";
+    binName = "hello";
+    extraVocabs = [ vocab ];
+  };
+in
+runCommandLocal "assert-factor-hello-world"
+  {
+    env.expected = "Hello, Nixpkgs";
+  }
+  ''
+    output="$(${lib.getExe app} --name "Nixpkgs")"
+    if [ "$output" != "$expected" ]; then
+      echo "FAIL: expected “$expected”; got “$output”" >&2
+      exit 1
+    fi
+    touch "$out"
+  ''

--- a/pkgs/development/compilers/factor-lang/test/hello-world/extra/hello/author.txt
+++ b/pkgs/development/compilers/factor-lang/test/hello-world/extra/hello/author.txt
@@ -1,0 +1,1 @@
+toastal

--- a/pkgs/development/compilers/factor-lang/test/hello-world/extra/hello/cli/author.txt
+++ b/pkgs/development/compilers/factor-lang/test/hello-world/extra/hello/cli/author.txt
@@ -1,0 +1,1 @@
+toastal

--- a/pkgs/development/compilers/factor-lang/test/hello-world/extra/hello/cli/cli.factor
+++ b/pkgs/development/compilers/factor-lang/test/hello-world/extra/hello/cli/cli.factor
@@ -1,0 +1,13 @@
+! SPDX-License-Identifier: 0BSD
+USING: command-line combinators io kernel namespaces sequences hello ;
+
+IN: hello.cli
+
+: main ( -- )
+    command-line get {
+        { [ dup empty? ] [ drop "world" ] }
+        { [ dup first "--name" = not ] [ drop "world" ] }
+        [ second ]
+    } cond greet ;
+
+MAIN: main

--- a/pkgs/development/compilers/factor-lang/test/hello-world/extra/hello/hello.factor
+++ b/pkgs/development/compilers/factor-lang/test/hello-world/extra/hello/hello.factor
@@ -1,0 +1,7 @@
+! SPDX-License-Identifier: 0BSD
+USING: io namespaces sequences ;
+
+IN: hello
+
+: greet ( name -- )
+    "Hello, " prepend print ;

--- a/pkgs/development/compilers/factor-lang/wrapper.nix
+++ b/pkgs/development/compilers/factor-lang/wrapper.nix
@@ -2,6 +2,9 @@
   lib,
   stdenv,
   makeWrapper,
+  runCommandLocal,
+  buildFactorApplication,
+  buildFactorVocab,
   buildEnv,
   copyDesktopItems,
   makeDesktopItem,
@@ -220,6 +223,16 @@ stdenv.mkDerivation (finalAttrs: {
       extraVocabs
       vocabTree
       ;
+    tests = {
+      hello-world = import ./test/hello-world {
+        inherit
+          lib
+          runCommandLocal
+          buildFactorApplication
+          buildFactorVocab
+          ;
+      };
+    };
   };
 
   meta = factor-unwrapped.meta // {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5851,7 +5851,7 @@ with pkgs;
       stdenv = clangStdenv;
     };
   };
-  factorPackages = factorPackages-0_100;
+  factorPackages = factorPackages-0_101;
 
   factor-lang-0_99 = factorPackages-0_99.factor-lang;
   factor-lang-0_100 = factorPackages-0_100.factor-lang;


### PR DESCRIPTION
First attempt was bad #522173 not fully understanding the problem, letting an LLM take the wheel too much & being gaslit into thinking the problem was fundamentally deeper than it needed to be—despite pointing out that the changes seemed to go beyond what is needed—so I started over, mostly on my own. The embedded image was marginally tidier with one less file, but didn’t meaningfully save space or time & had other unforeseen issues with `resources`. So to get something more to the point:

---

Provocation: 0.101 is the default `factor-lang`, but not the default Factor package set. I needed 0.101 vocabularies & my environment showed I was using, but was surprised to see the 0.100 vocabularies being unexpectedly referenced instead. Just swapping from 0.100 to 0.101 led to failed builds.

What caused the builds to suddenly fail on the version upgrade was something fairly benign: 0.101 introduced a `.out` extension to non-macOS deployments. While I don’t think the Factor setup is slated to have Darwin support, Nix is still supporting versions 0.99 & 0.100 so a more generic fix needs to exist instead of hardcoding a new path. The deployment already knows of its own path, so I modified the script a bit to print that path  to a file so that we can read that path for the rest of the build (versus switch-case on version+OS or handling shell globs). With the path in hand (& existence asserted), the build can continue working as before.

However, there was a permissions issue in the way that Factor copies files & then tries to copy ownership/permissions over from the original file that cause a failure since the Nix sandbox doesn’t allow the system call to `chmod` in the manner Factor uses. `copy-file` is modified to *skip* the set permissions phase in our deploy script since the sandbox already has the permissions it needs just fine. & AFAICT, this never worked properly; no one was testing copying over resources thru Factor, but 0.101 copies over icons now.

With the builds working, the default version could be bumped from 0.100 to 0.101, matching the stable version.

Additionally:

* `hello.factor` basic application was added to assert applications & CLI args work as a test
* readability tweaks


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.