### PR TITLE
nixos/security/wrappers: add more context to enableWrappers description

### DIFF
--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -181,8 +181,23 @@ in
   ###### interface
 
   options = {
-    security.enableWrappers = lib.mkEnableOption "SUID/SGID wrappers" // {
+    security.enableWrappers = lib.mkEnableOption "" // {
       default = true;
+      description = ''
+        Whether to enable SUID/SGID wrappers.
+
+        ::: {.warning}
+        ONLY DISABLE THIS OPTION IF YOU KNOW WHAT YOU'RE DOING.
+        :::
+
+        A normal interactive NixOS system requires SUID/SGID wrappers (e.g. for
+        PAM and sudo). Disabling them, thus will lock you out from your system.
+
+        Disabling the SUID/SGID binaries is useful for non-interactive systems
+        (like a firewall appliance) to minimize the attack surface. In the
+        future, this might become available for interactive systems as well
+        (e.g. with systemd's [run0](https://www.freedesktop.org/software/systemd/man/latest/run0)).
+      '';
     };
 
     security.wrappers = lib.mkOption {


### PR DESCRIPTION
Closes #518955

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
