### PR TITLE
python3Packages.ansicolors: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/ansicolors/default.nix
+++ b/pkgs/development/python-modules/ansicolors/default.nix
@@ -6,15 +6,15 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "ansicolors";
   version = "1.1.8";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     extension = "zip";
-    sha256 = "99f94f5e3348a0bcd43c82e5fc4414013ccc19d70bd939ad71e0133ce9c372e0";
+    hash = "sha256-mflPXjNIoLzUPILl/EQUATzMGdcL2TmtceATPOnDcuA=";
   };
 
   build-system = [ setuptools ];
@@ -25,10 +25,12 @@ buildPythonPackage rec {
     py.test
   '';
 
+  pythonImportsCheck = [ "colors" ];
+
   meta = {
     homepage = "https://github.com/verigak/colors/";
     description = "ANSI colors for Python";
     license = lib.licenses.isc;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/ansicolors/default.nix
+++ b/pkgs/development/python-modules/ansicolors/default.nix
@@ -29,6 +29,7 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     homepage = "https://github.com/verigak/colors/";
+    changelog = "https://pypi.org/project/ansicolors/${finalAttrs.version}/";
     description = "ANSI colors for Python";
     license = lib.licenses.isc;
     maintainers = [ ];

--- a/pkgs/development/python-modules/ansicolors/default.nix
+++ b/pkgs/development/python-modules/ansicolors/default.nix
@@ -3,18 +3,21 @@
   buildPythonPackage,
   fetchPypi,
   pytest,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "ansicolors";
   version = "1.1.8";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     extension = "zip";
     sha256 = "99f94f5e3348a0bcd43c82e5fc4414013ccc19d70bd939ad71e0133ce9c372e0";
   };
+
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [ pytest ];
 


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
