### PR TITLE
python3Packages.anyconfig: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/anyconfig/default.nix
+++ b/pkgs/development/python-modules/anyconfig/default.nix
@@ -51,6 +51,7 @@ buildPythonPackage (finalAttrs: {
     description = "Python library provides common APIs to load and dump configuration files in various formats";
     mainProgram = "anyconfig_cli";
     homepage = "https://github.com/ssato/python-anyconfig";
+    changelog = "https://github.com/ssato/python-anyconfig/releases/tag/RELEASE_${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ tboerger ];
   };

--- a/pkgs/development/python-modules/anyconfig/default.nix
+++ b/pkgs/development/python-modules/anyconfig/default.nix
@@ -42,7 +42,6 @@ buildPythonPackage (finalAttrs: {
   disabledTestPaths = [
     # NameError: name 'TT' is not defined
     "tests/schema/test_jsonschema.py"
-    "tests/backend/loaders/pickle/test_pickle_stdlib.py"
   ];
 
   pythonImportsCheck = [ "anyconfig" ];

--- a/pkgs/development/python-modules/anyconfig/default.nix
+++ b/pkgs/development/python-modules/anyconfig/default.nix
@@ -10,7 +10,7 @@
 buildPythonPackage (finalAttrs: {
   pname = "anyconfig";
   version = "0.14.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ssato";
@@ -23,7 +23,9 @@ buildPythonPackage (finalAttrs: {
     sed -i '/addopts =/d' setup.cfg
   '';
 
-  propagatedBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
+
+  dependencies = [ setuptools ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
