### PR TITLE
python3Packages.anyqt: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/anyqt/default.nix
+++ b/pkgs/development/python-modules/anyqt/default.nix
@@ -4,7 +4,9 @@
   fetchFromGitHub,
   pyqt5,
   pytestCheckHook,
+  qt5,
   setuptools,
+  writableTmpDirAsHomeHook,
   nix-update-script,
 }:
 
@@ -25,19 +27,13 @@ buildPythonPackage (finalAttrs: {
   nativeCheckInputs = [
     pyqt5
     pytestCheckHook
+    writableTmpDirAsHomeHook
   ];
 
-  # All of these fail because Qt modules cannot be imported
-  disabledTestPaths = [
-    "tests/test_qabstractitemview.py"
-    "tests/test_qaction_set_menu.py"
-    "tests/test_qactionevent_action.py"
-    "tests/test_qfontdatabase_static.py"
-    "tests/test_qpainter_draw_pixmap_fragments.py"
-    "tests/test_qsettings.py"
-    "tests/test_qstandarditem_insertrow.py"
-    "tests/test_qtest.py"
-  ];
+  preCheck = ''
+    export QT_PLUGIN_PATH="${lib.getBin qt5.qtbase}/${qt5.qtbase.qtPluginPrefix}"
+    export QT_QPA_PLATFORM=offscreen
+  '';
 
   pythonImportsCheck = [ "AnyQt" ];
 

--- a/pkgs/development/python-modules/anyqt/default.nix
+++ b/pkgs/development/python-modules/anyqt/default.nix
@@ -4,13 +4,14 @@
   fetchFromGitHub,
   pyqt5,
   pytestCheckHook,
+  setuptools,
   nix-update-script,
 }:
 
 buildPythonPackage rec {
   pname = "anyqt";
   version = "0.2.1";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ales-erjavec";
@@ -18,6 +19,8 @@ buildPythonPackage rec {
     rev = version;
     hash = "sha256-iDUgu+x9rnpxpHzO7Rf2rJFXsheivrK7HI3FUbomkTU=";
   };
+
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [
     pyqt5

--- a/pkgs/development/python-modules/anyqt/default.nix
+++ b/pkgs/development/python-modules/anyqt/default.nix
@@ -46,6 +46,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "PyQt/PySide compatibility layer";
     homepage = "https://github.com/ales-erjavec/anyqt";
+    changelog = "https://github.com/ales-erjavec/anyqt/releases/tag/${finalAttrs.version}";
     license = [ lib.licenses.gpl3Only ];
     maintainers = [ lib.maintainers.lucasew ];
   };

--- a/pkgs/development/python-modules/anyqt/default.nix
+++ b/pkgs/development/python-modules/anyqt/default.nix
@@ -8,7 +8,7 @@
   nix-update-script,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "anyqt";
   version = "0.2.1";
   pyproject = true;
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "ales-erjavec";
     repo = "anyqt";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-iDUgu+x9rnpxpHzO7Rf2rJFXsheivrK7HI3FUbomkTU=";
   };
 
@@ -49,4 +49,4 @@ buildPythonPackage rec {
     license = [ lib.licenses.gpl3Only ];
     maintainers = [ lib.maintainers.lucasew ];
   };
-}
+})

--- a/pkgs/development/python-modules/anyqt/default.nix
+++ b/pkgs/development/python-modules/anyqt/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   pyqt5,
@@ -34,6 +35,17 @@ buildPythonPackage (finalAttrs: {
     export QT_PLUGIN_PATH="${lib.getBin qt5.qtbase}/${qt5.qtbase.qtPluginPrefix}"
     export QT_QPA_PLATFORM=offscreen
   '';
+
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
+    "tests/test_qabstractitemview.py"
+    "tests/test_qaction_set_menu.py"
+    "tests/test_qactionevent_action.py"
+    "tests/test_qfontdatabase_static.py"
+    "tests/test_qpainter_draw_pixmap_fragments.py"
+    "tests/test_qsettings.py"
+    "tests/test_qstandarditem_insertrow.py"
+    "tests/test_qtest.py"
+  ];
 
   pythonImportsCheck = [ "AnyQt" ];
 


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
