### PR TITLE
python3Packages.apcaccess: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/apcaccess/default.nix
+++ b/pkgs/development/python-modules/apcaccess/default.nix
@@ -6,7 +6,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "apcaccess";
   version = "0.0.13";
   pyproject = true;
@@ -14,13 +14,13 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "flyte";
     repo = "apcaccess";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-XLoNRh6MgXCfRtWD9NpVZSyroW6E9nRYw6Grxa+AQkc=";
   };
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace "setup_requires='pytest-runner'," ""
+      --replace-fail "setup_requires='pytest-runner'," ""
   '';
 
   build-system = [ setuptools ];
@@ -36,4 +36,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ uvnikita ];
   };
-}
+})

--- a/pkgs/development/python-modules/apcaccess/default.nix
+++ b/pkgs/development/python-modules/apcaccess/default.nix
@@ -33,6 +33,7 @@ buildPythonPackage (finalAttrs: {
     description = "Library offers programmatic access to the status information provided by apcupsd over its Network Information Server";
     mainProgram = "apcaccess";
     homepage = "https://github.com/flyte/apcaccess";
+    changelog = "https://github.com/flyte/apcaccess/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ uvnikita ];
   };

--- a/pkgs/development/python-modules/apcaccess/default.nix
+++ b/pkgs/development/python-modules/apcaccess/default.nix
@@ -3,12 +3,13 @@
   buildPythonPackage,
   fetchFromGitHub,
   pytestCheckHook,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "apcaccess";
   version = "0.0.13";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "flyte";
@@ -21,6 +22,8 @@ buildPythonPackage rec {
     substituteInPlace setup.py \
       --replace "setup_requires='pytest-runner'," ""
   '';
+
+  build-system = [ setuptools ];
 
   pythonImportsCheck = [ "apcaccess" ];
 


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
