### PR TITLE
slurm: 25-11-6-1 -> 26.05.0.1

### DIFF
--- a/pkgs/by-name/sl/slurm-spank-stunnel/backward-compat.patch
+++ b/pkgs/by-name/sl/slurm-spank-stunnel/backward-compat.patch
@@ -1,0 +1,15 @@
+diff --git a/slurm-spank-stunnel.c b/slurm-spank-stunnel.c
+index b79cea0..c135bf5 100644
+--- a/slurm-spank-stunnel.c
++++ b/slurm-spank-stunnel.c
+@@ -41,6 +41,10 @@
+ #include <arpa/inet.h>
+ #include <errno.h>
+ 
++#ifndef SLURM_BACKWARD_COMPAT
++#define SLURM_BACKWARD_COMPAT 1
++#endif
++
+ #include <slurm/slurm.h>
+ #include <slurm/spank.h>
+ 

--- a/pkgs/by-name/sl/slurm-spank-stunnel/package.nix
+++ b/pkgs/by-name/sl/slurm-spank-stunnel/package.nix
@@ -16,7 +16,10 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "15cpd49ccvzsmmr3gk8svm2nz461rvs4ybczckyf4yla0xzp06gj";
   };
 
-  patches = [ ./hostlist.patch ];
+  patches = [
+    ./hostlist.patch
+    ./backward-compat.patch
+  ];
 
   buildPhase = ''
     gcc -I${lib.getDev slurm}/include -shared -fPIC -o stunnel.so slurm-spank-stunnel.c

--- a/pkgs/by-name/sl/slurm-spank-x11/backward-compat.patch
+++ b/pkgs/by-name/sl/slurm-spank-x11/backward-compat.patch
@@ -1,0 +1,15 @@
+diff --git a/slurm-spank-x11-plug.c b/slurm-spank-x11-plug.c
+index bef6c14..feaf041 100644
+--- a/slurm-spank-x11-plug.c
++++ b/slurm-spank-x11-plug.c
+@@ -36,6 +36,10 @@
+ 
+ #include <stdint.h>
+ 
++#ifndef SLURM_BACKWARD_COMPAT
++#define SLURM_BACKWARD_COMPAT 1
++#endif
++
+ #include <slurm/slurm.h>
+ #include <slurm/spank.h>
+ 

--- a/pkgs/by-name/sl/slurm-spank-x11/package.nix
+++ b/pkgs/by-name/sl/slurm-spank-x11/package.nix
@@ -15,7 +15,10 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "1dmsr7whxcxwnlvl1x4s3bqr5cr6q5ssb28vqi67w5hj4sshisry";
   };
 
-  patches = [ ./hostlist.patch ];
+  patches = [
+    ./hostlist.patch
+    ./backward-compat.patch
+  ];
 
   # Required for build with gcc-14
   env.NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";

--- a/pkgs/by-name/sl/slurm/package.nix
+++ b/pkgs/by-name/sl/slurm/package.nix
@@ -30,7 +30,7 @@
   libjwt,
   libyaml,
   json_c,
-  http-parser,
+  llhttp,
   # enable internal X11 support via libssh2
   enableX11 ? true,
   enablePAM ? true,
@@ -42,7 +42,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "slurm";
-  version = "25-11-6-1";
+  version = "26.05.0.1";
 
   # N.B. We use github release tags instead of https://www.schedmd.com/downloads.php
   # because the latter does not keep older releases.
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     repo = "slurm";
     # The release tags use - instead of .
     rev = "slurm-${builtins.replaceStrings [ "." ] [ "-" ] finalAttrs.version}";
-    hash = "sha256-8Op/HP0v+cqhdPP6ZLmw+e/SSlFUznydD2pHpqr6kfU=";
+    hash = "sha256-pEgSPaLGqPeNsw0DkxnZP4n6jx5fy+wTgAu0LZmxmW0=";
   };
 
   outputs = [
@@ -107,7 +107,7 @@ stdenv.mkDerivation (finalAttrs: {
     libyaml
     dbus
     libbpf
-    http-parser
+    llhttp
     s2n-tls
   ]
   ++ lib.optionals enableX11 [ xauth ]
@@ -121,7 +121,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   configureFlags = [
     "--with-freeipmi=${freeipmi}"
-    "--with-http-parser=${http-parser}"
+    "--with-llhttp-parser=${lib.getDev llhttp}"
     "--with-hwloc=${lib.getDev hwloc}"
     "--with-json=${lib.getDev json_c}"
     "--with-jwt=${libjwt}"
@@ -132,6 +132,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--sysconfdir=/etc/slurm"
     "--with-pmix=${lib.getDev pmix}"
     "--with-bpf=${libbpf}"
+    "--enable-slurmrestd"
     "--with-s2n=${
       symlinkJoin {
         name = s2n-tls.name;


### PR DESCRIPTION
Changelog: https://slurm.schedmd.com/release_notes.html
Superseedes: https://github.com/NixOS/nixpkgs/pull/524684

## Things done
* update slurm
* fix build of slurmrestd: replace deprecated http-parser with llhttp
* fix slurm spank-plugins

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
