### PR TITLE
[26.05] haskellPackgas.hakyll: 4.16.8.0 -> 4.17.0.0 

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -463,10 +463,6 @@ with haskellLib;
   # https://github.com/input-output-hk/io-sim/issues/248
   io-sim = dontCheck super.io-sim;
 
-  # Test suites broken by hakyll 4.16, but lib is still okay
-  # https://github.com/LaurentRDC/hakyll-images/issues/14
-  hakyll-images = dontCheck super.hakyll-images;
-
   # Too strict upper bound on hakyll (<4.17)
   # https://gitlab.com/lysxia/hakyll-alectryon/-/work_items/2
   hakyll-alectryon = doJailbreak super.hakyll-alectryon;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -467,6 +467,12 @@ with haskellLib;
   # https://github.com/LaurentRDC/hakyll-images/issues/14
   hakyll-images = dontCheck super.hakyll-images;
 
+  # Too strict upper bound on hakyll (<4.17)
+  # https://gitlab.com/lysxia/hakyll-alectryon/-/work_items/2
+  hakyll-alectryon = doJailbreak super.hakyll-alectryon;
+  # https://gitlab.com/aergus/hakyll-filestore/-/work_items/1
+  hakyll-filestore = doJailbreak super.hakyll-filestore;
+
   # 2024-06-23: Hourglass is archived and had its last commit 6 years ago.
   # Patch is needed to add support for time 1.10, which is only used in the tests
   # https://github.com/vincenthz/hs-hourglass/pull/56

--- a/pkgs/development/haskell-modules/replacements-by-name/hakyll-images.nix
+++ b/pkgs/development/haskell-modules/replacements-by-name/hakyll-images.nix
@@ -1,0 +1,50 @@
+{
+  mkDerivation,
+  base,
+  binary,
+  bytestring,
+  containers,
+  directory,
+  filepath,
+  hakyll,
+  HUnit-approx,
+  JuicyPixels,
+  JuicyPixels-extra,
+  lib,
+  tasty,
+  tasty-hunit,
+  vector,
+}:
+mkDerivation {
+  pname = "hakyll-images";
+  version = "1.3.1";
+  sha256 = "a4f55f08b10671795beab1e3d8496651e3c0a08799d26f36b6357480753e85a8";
+  enableSeparateDataOutput = true;
+  libraryHaskellDepends = [
+    base
+    binary
+    bytestring
+    hakyll
+    JuicyPixels
+    JuicyPixels-extra
+    vector
+  ];
+  testHaskellDepends = [
+    base
+    binary
+    bytestring
+    containers
+    directory
+    filepath
+    hakyll
+    HUnit-approx
+    JuicyPixels
+    JuicyPixels-extra
+    tasty
+    tasty-hunit
+    vector
+  ];
+  homepage = "https://github.com/LaurentRDC/hakyll-images#readme";
+  description = "Hakyll utilities to work with images";
+  license = lib.licensesSpdx."BSD-3-Clause";
+}

--- a/pkgs/development/haskell-modules/replacements-by-name/hakyll.nix
+++ b/pkgs/development/haskell-modules/replacements-by-name/hakyll.nix
@@ -1,0 +1,126 @@
+{
+  mkDerivation,
+  aeson,
+  base,
+  binary,
+  blaze-html,
+  bytestring,
+  containers,
+  contravariant,
+  data-default,
+  deepseq,
+  directory,
+  file-embed,
+  filepath,
+  fsnotify,
+  hashable,
+  http-conduit,
+  http-types,
+  lib,
+  lrucache,
+  mtl,
+  network-uri,
+  optparse-applicative,
+  pandoc,
+  pandoc-types,
+  parsec,
+  process,
+  QuickCheck,
+  random,
+  regex-tdfa,
+  resourcet,
+  scientific,
+  tagsoup,
+  tasty,
+  tasty-golden,
+  tasty-hunit,
+  tasty-quickcheck,
+  template-haskell,
+  text,
+  time,
+  time-locale-compat,
+  util-linux,
+  vector,
+  wai,
+  wai-app-static,
+  warp,
+  xml-conduit,
+  yaml,
+}:
+mkDerivation {
+  pname = "hakyll";
+  version = "4.17.0.0";
+  sha256 = "a02ae25cce5a1a64d1c0d0d1cac4290916e3839578c57f7efa999b1f4d56673e";
+  revision = "1";
+  editedCabalFile = "07i2fkgb12c2cijkc9lc840arabgm0sla7kmdz7jhhr9di4pndh5";
+  isLibrary = true;
+  isExecutable = true;
+  enableSeparateDataOutput = true;
+  libraryHaskellDepends = [
+    aeson
+    base
+    binary
+    blaze-html
+    bytestring
+    containers
+    contravariant
+    data-default
+    deepseq
+    directory
+    file-embed
+    filepath
+    fsnotify
+    hashable
+    http-conduit
+    http-types
+    lrucache
+    mtl
+    network-uri
+    optparse-applicative
+    pandoc
+    pandoc-types
+    parsec
+    process
+    random
+    regex-tdfa
+    resourcet
+    scientific
+    tagsoup
+    template-haskell
+    text
+    time
+    time-locale-compat
+    vector
+    wai
+    wai-app-static
+    warp
+    xml-conduit
+    yaml
+  ];
+  executableHaskellDepends = [
+    base
+    directory
+    filepath
+  ];
+  testHaskellDepends = [
+    aeson
+    base
+    bytestring
+    containers
+    filepath
+    pandoc
+    pandoc-types
+    QuickCheck
+    tagsoup
+    tasty
+    tasty-golden
+    tasty-hunit
+    tasty-quickcheck
+    yaml
+  ];
+  testToolDepends = [ util-linux ];
+  homepage = "http://jaspervdj.be/hakyll";
+  description = "A static website compiler library";
+  license = lib.licenses.bsd3;
+  mainProgram = "hakyll-init";
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

4.16.8.0 was a breaking release included before 26.05, but failed to update the version number correctly. 4.17.0.0 is basically the same release, but with the updated version number which should solve some weird problems downstream users may be having.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
