### PR TITLE
rns: workaround to add missing `lxmf` dependency

### DIFF
--- a/pkgs/by-name/rn/rns/package.nix
+++ b/pkgs/by-name/rn/rns/package.nix
@@ -1,1 +1,11 @@
-{ python3Packages }: with python3Packages; toPythonApplication rns
+{
+  lib,
+  python3Packages,
+}:
+
+python3Packages.toPythonApplication (
+  python3Packages.rns.overridePythonAttrs (old: {
+    dependencies = old.dependencies ++ lib.concatAttrValues old.optional-dependencies;
+    dontUsePythonCatchConflicts = true;
+  })
+)

--- a/pkgs/development/python-modules/lxmf/default.nix
+++ b/pkgs/development/python-modules/lxmf/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  qrcode,
   rns,
   setuptools,
   versionCheckHook,
@@ -24,7 +25,10 @@ buildPythonPackage (finalAttrs: {
 
   pythonRelaxDeps = [ "rns" ];
 
-  dependencies = [ rns ];
+  dependencies = [
+    qrcode
+    rns
+  ];
 
   pythonImportsCheck = [ "LXMF" ];
 

--- a/pkgs/development/python-modules/rns/default.nix
+++ b/pkgs/development/python-modules/rns/default.nix
@@ -7,6 +7,7 @@
   fetchFromGitHub,
   netifaces,
   pyserial,
+  lxmf,
   replaceVars,
   setuptools,
   versionCheckHook,
@@ -39,6 +40,10 @@ buildPythonPackage (finalAttrs: {
     netifaces
     pyserial
   ];
+
+  optional-dependencies = {
+    lxmf = [ lxmf ];
+  };
 
   pythonImportsCheck = [ "RNS" ];
 


### PR DESCRIPTION
Some people are doing shenanigans to make it work, so let's fix it properly at the source !

- see https://github.com/hzmmohamed/nixconf/blob/c1395851250657dfacf7c97d101a4b76e1b6ab74/modules/nixos/features/reticulum.nix#L42

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
