### PR TITLE
postgresqlPackages.pg_textsearch: fix broken test

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_textsearch.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_textsearch.nix
@@ -31,10 +31,11 @@ postgresqlBuildExtension (finalAttrs: {
         ('PostgreSQL is a powerful, open source object-relational database system');
       CREATE INDEX documents_content_bm25_idx ON documents USING bm25(content) WITH (text_config='english');
     '';
+
     asserts = [
       {
-        query = "SELECT count(*) FROM documents ORDER BY content <@> 'nix' LIMIT 10";
-        expected = "2";
+        query = "SELECT content FROM documents ORDER BY content <@> 'NixOS' LIMIT 1";
+        expected = "'NixOS provides declarative configuration and reproducible system builds with the Nix package manager'";
         description = "BM25 index can be queried successfully.";
       }
     ];


### PR DESCRIPTION
Should fix the integration tests that has been broken since init. I contemplated writing more complicated tests and/or safeguards, but in the end, I found it not to be worth it. This is the minimal change needed to get the tests working.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
