### PR TITLE
maintainers: drop callahad

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4377,12 +4377,6 @@
     githubId = 1516457;
     name = "Christian Albrecht";
   };
-  callahad = {
-    email = "dan.callahan@gmail.com";
-    github = "callahad";
-    githubId = 24193;
-    name = "Dan Callahan";
-  };
   callumio = {
     email = "git@cleslie.uk";
     github = "callumio";

--- a/pkgs/by-name/bo/bolt/package.nix
+++ b/pkgs/by-name/bo/bolt/package.nix
@@ -100,7 +100,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "boltctl";
     homepage = "https://gitlab.freedesktop.org/bolt/bolt";
     license = lib.licenses.lgpl21Plus;
-    maintainers = with lib.maintainers; [ callahad ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ds/dsseries/package.nix
+++ b/pkgs/by-name/ds/dsseries/package.nix
@@ -54,6 +54,6 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ callahad ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/no/noson/package.nix
+++ b/pkgs/by-name/no/noson/package.nix
@@ -51,6 +51,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "noson-app";
     platforms = with lib.platforms; linux ++ darwin;
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ callahad ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/development/python-modules/python-dbusmock/default.nix
+++ b/pkgs/development/python-modules/python-dbusmock/default.nix
@@ -73,7 +73,7 @@ buildPythonPackage rec {
     description = "Mock D-Bus objects for tests";
     homepage = "https://github.com/martinpitt/python-dbusmock";
     license = lib.licenses.lgpl3Plus;
-    maintainers = with lib.maintainers; [ callahad ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
No [comments](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Acallahad) since 2024 despite 7 [review requests](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+created%3A%3E%3D2025-01-01+user-review-requested%3Acallahad). Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/33954594ec46166510795930ba8ebf0856249d4e/maintainers/README.md#losing-maintainer-status).

@callahad if you object to being dropped please respond saying so within a week. Even if you don't make it, you are of course welcome back whenever you would like!


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
