### PR TITLE
mkjson: disable doctests and switch to Codeberg

### DIFF
--- a/pkgs/by-name/mk/mkjson/generated.nix
+++ b/pkgs/by-name/mk/mkjson/generated.nix
@@ -1,7 +1,7 @@
 {
   mkDerivation,
   lib,
-  fetchFromGitHub,
+  fetchFromCodeberg,
   aeson,
   base,
   bytestring,
@@ -26,7 +26,7 @@
 mkDerivation rec {
   pname = "mkjson";
   version = "0.4.0";
-  src = fetchFromGitHub {
+  src = fetchFromCodeberg {
     owner = "mfussenegger";
     repo = "mkjson";
     rev = "${version}";

--- a/pkgs/by-name/mk/mkjson/package.nix
+++ b/pkgs/by-name/mk/mkjson/package.nix
@@ -1,2 +1,19 @@
-{ haskell, haskellPackages }:
-haskell.lib.justStaticExecutables (haskellPackages.callPackage ./generated.nix { })
+{
+  haskell,
+  haskellPackages,
+  lib,
+}:
+let
+  inherit (haskell.lib.compose) justStaticExecutables overrideCabal;
+
+  # The mkjson-doctest suite depends on specific RNG results not provided by the
+  # GHC in Nixpkgs as of this writing.
+  overrides = {
+    testTargets = [ "mkjson-test" ];
+  };
+  raw-pkg = haskellPackages.callPackage ./generated.nix { };
+in
+lib.pipe raw-pkg [
+  (overrideCabal overrides)
+  justStaticExecutables
+]


### PR DESCRIPTION
## Things done

Fixes mkjson build error.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
