### PR TITLE
nodejs_26: build V8 as a separate derivation

### DIFF
--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  stdenvNoCC,
   fetchurl,
   fetchpatch2,
   fetchFromGitHub,
@@ -73,6 +74,8 @@
 {
   version,
   sha256,
+  v8Sha256 ? null,
+  v8Version ? null,
   patches ? [ ],
 }@args:
 
@@ -149,6 +152,8 @@ let
   useSharedTemporal = majorVersion == "26";
   useSharedZstd = lib.versionAtLeast version "22.15";
 
+  useSeparateV8Drv = lib.versionAtLeast version "26.3";
+
   sharedLibDeps = {
     inherit
       brotli
@@ -168,6 +173,8 @@ let
       ada
       simdjson
       ;
+  })
+  // (lib.optionalAttrs (useSharedAdaAndSimd && !useSeparateV8Drv) {
     simdutf = if lib.versionAtLeast version "25" then simdutf else simdutf_6;
   })
   // (lib.optionalAttrs useSharedSQLite {
@@ -235,6 +242,90 @@ let
     '';
 
   downloadDir = if lib.strings.hasInfix "-rc." version then "download/rc" else "dist";
+  src = fetchurl {
+    url = "https://nodejs.org/${downloadDir}/v${version}/node-v${version}.tar.xz";
+    inherit sha256;
+  };
+  configureScript = writeScript "nodejs-configure" ''
+    exec ${python.executable} configure.py "$@"
+  '';
+
+  libv8 = callPackage ./v8.nix {
+    inherit
+      configureScript
+      darwin-cctools-only-libtool
+      icu
+      python
+      ;
+    version = v8Version;
+    src = stdenvNoCC.mkDerivation {
+      pname = "nodejs-v8-src";
+      version = v8Version;
+      inherit src patches;
+
+      outputHashAlgo = "sha256";
+      outputHashMode = "recursive";
+      outputHash = v8Sha256;
+
+      dontBuild = true;
+      dontConfigure = true;
+      dontPatchShebangs = true;
+      dontFixup = true;
+
+      installPhase = ''
+        mkdir -p $out/tools/gyp
+        cp -r tools/gyp/pylib $out/tools/gyp/.
+
+        mkdir -p $out/deps/crates/vendor/zoneinfo64/src/data/
+        cp deps/crates/vendor/zoneinfo64/src/data/zoneinfo64.res $out/deps/crates/vendor/zoneinfo64/src/data/.
+        cp -r deps/v8 $out/deps/.
+
+        cp common.gypi $out/.
+        cp configure.py $out/.
+        sed "s#'includes' : \\[ 'src/inspector/node_inspector.gypi' \\]#'includes' : \\[\\]#" node.gyp > $out/node.gyp
+        cp node.gypi $out/.
+        cp tools/gyp_node.py $out/tools/.
+
+        mkdir $out/tools/icu
+        cp tools/icu/icu_versions.json $out/tools/icu/.
+        cp tools/icu/icu-system.gyp $out/tools/icu/.
+
+        mkdir $out/tools/v8_gypfiles
+        cp tools/v8_gypfiles/abseil.gyp $out/tools/v8_gypfiles/.
+        cp tools/v8_gypfiles/features.gypi $out/tools/v8_gypfiles/.
+        cp tools/v8_gypfiles/ForEachFormat.py $out/tools/v8_gypfiles/.
+        cp tools/v8_gypfiles/ForEachReplace.py $out/tools/v8_gypfiles/.
+        cp tools/v8_gypfiles/GN-scraper.py $out/tools/v8_gypfiles/.
+        cp tools/v8_gypfiles/inspector.gypi $out/tools/v8_gypfiles/.
+        cp tools/v8_gypfiles/toolchain.gypi $out/tools/v8_gypfiles/.
+        cp tools/v8_gypfiles/v8.gyp $out/tools/v8_gypfiles/.
+      ''
+      # We also need to mock some Python util files that are not used to configure Python.
+      # Mocking lets us avoid rebuilding the whole derivation if there's a unrelated
+      # change in one of those files.
+      + ''
+        mkdir -p $out/tools/configure.d
+        cat -> $out/tools/configure.d/nodedownload.py <<'EOF'
+        def parse(opt):
+          return {}
+        def help():
+          return ""
+        EOF
+        cat -> $out/tools/getmoduleversion.py <<'EOF'
+        def get_version():
+          return "99"
+        EOF
+        cat -> $out/tools/getnapibuildversion.py <<'EOF'
+        def get_napi_version():
+          return "9"
+        EOF
+        cat -> $out/tools/utils.py <<'EOF'
+        def SearchFiles(dir, ext):
+          return []
+        EOF
+      '';
+    };
+  };
 
   package = stdenv.mkDerivation (
     finalAttrs:
@@ -245,12 +336,12 @@ let
       self = finalAttrs.finalPackage;
     in
     {
-      inherit pname version;
-
-      src = fetchurl {
-        url = "https://nodejs.org/${downloadDir}/v${version}/node-v${version}.tar.xz";
-        inherit sha256;
-      };
+      inherit
+        pname
+        version
+        src
+        configureScript
+        ;
 
       strictDeps = true;
 
@@ -276,6 +367,7 @@ let
         bash
         icu
       ]
+      ++ lib.optional useSeparateV8Drv libv8
       ++ builtins.attrValues sharedLibDeps;
 
       nativeBuildInputs = [
@@ -318,6 +410,7 @@ let
         "--dest-os=${destOS}"
         "--dest-cpu=${stdenv.hostPlatform.node.arch}"
       ]
+      ++ lib.optional useSeparateV8Drv "--without-bundled-v8"
       ++ lib.optionals (destARMFPU != null) [ "--with-arm-fpu=${destARMFPU}" ]
       ++ lib.optionals (destARMFloatABI != null) [ "--with-arm-float-abi=${destARMFloatABI}" ]
       ++ lib.optionals (!canExecute && canEmulate) [
@@ -346,10 +439,6 @@ let
       configurePlatforms = [ ];
 
       dontDisableStatic = true;
-
-      configureScript = writeScript "nodejs-configure" ''
-        exec ${python.executable} configure.py "$@"
-      '';
 
       # In order to support unsupported cross configurations, we copy some intermediate executables
       # from a native build and replace all the build-system tools with a script which simply touches
@@ -599,7 +688,7 @@ let
             else
               "{bytecode_builtins_list_generator,mksnapshot,torque,node_js2c,gen-regexp-special-case}";
         in
-        lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+        lib.optionalString (!useSeparateV8Drv && stdenv.hostPlatform == stdenv.buildPlatform) ''
           mkdir -p $dev/bin
           cp out/Release/${tools} $dev/bin
         ''
@@ -618,36 +707,43 @@ let
           # TODO: use propagatedBuildInputs instead of copying headers.
           cp -r ${lib.concatStringsSep " " copyLibHeaders} $out/include/node
 
-          # assemble a static v8 library and put it in the 'libv8' output
-          mkdir -p $libv8/lib
-          pushd out/Release/obj
-          find . -path "**/torque_*/**/*.o" -or -path "**/v8*/**/*.o" \
-            -and -not -name "torque.*" \
-            -and -not -name "mksnapshot.*" \
-            -and -not -name "gen-regexp-special-case.*" \
-            -and -not -name "bytecode_builtins_list_generator.*" \
-            | sort -u >files
-          test -s files # ensure that the list is not empty
-          $AR -cqs $libv8/lib/libv8.a @files
-          popd
+          ${
+            if useSeparateV8Drv then
+              #FIXME: avoid duplicating those files
+              "cp -R ${libv8} $libv8"
+            else
+              ''
+                # assemble a static v8 library and put it in the 'libv8' output
+                mkdir -p $libv8/lib
+                pushd out/Release/obj
+                find . -path "**/torque_*/**/*.o" -or -path "**/v8*/**/*.o" \
+                  -and -not -name "torque.*" \
+                  -and -not -name "mksnapshot.*" \
+                  -and -not -name "gen-regexp-special-case.*" \
+                  -and -not -name "bytecode_builtins_list_generator.*" \
+                  | sort -u >files
+                test -s files # ensure that the list is not empty
+                $AR -cqs $libv8/lib/libv8.a @files
+                popd
 
-          # copy v8 headers
-          cp -r deps/v8/include $libv8/
+                # copy v8 headers
+                cp -r deps/v8/include $libv8/
 
-          # create a pkgconfig file for v8
-          major=$(grep V8_MAJOR_VERSION deps/v8/include/v8-version.h | cut -d ' ' -f 3)
-          minor=$(grep V8_MINOR_VERSION deps/v8/include/v8-version.h | cut -d ' ' -f 3)
-          patch=$(grep V8_PATCH_LEVEL deps/v8/include/v8-version.h | cut -d ' ' -f 3)
-          mkdir -p $libv8/lib/pkgconfig
-          cat > $libv8/lib/pkgconfig/v8.pc << EOF
-          Name: v8
-          Description: V8 JavaScript Engine
-          Version: $major.$minor.$patch
-          Libs: -L$libv8/lib -lv8 -pthread -licui18n -licuuc
-          Cflags: -I$libv8/include
-          EOF
+                # create a pkgconfig file for v8
+                major=$(grep V8_MAJOR_VERSION deps/v8/include/v8-version.h | cut -d ' ' -f 3)
+                minor=$(grep V8_MINOR_VERSION deps/v8/include/v8-version.h | cut -d ' ' -f 3)
+                patch=$(grep V8_PATCH_LEVEL deps/v8/include/v8-version.h | cut -d ' ' -f 3)
+                mkdir -p $libv8/lib/pkgconfig
+                cat > $libv8/lib/pkgconfig/v8.pc << EOF
+                Name: v8
+                Description: V8 JavaScript Engine
+                Version: $major.$minor.$patch
+                Libs: -L$libv8/lib -lv8 -pthread -licui18n -licuuc
+                Cflags: -I$libv8/include
+                EOF''
+          }
         ''
-        + lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+        + lib.optionalString (!useSeparateV8Drv && stdenv.hostPlatform == stdenv.buildPlatform) ''
           cp -r $out/include $dev/include
         '';
 

--- a/pkgs/development/web/nodejs/v26.nix
+++ b/pkgs/development/web/nodejs/v26.nix
@@ -25,6 +25,8 @@ in
 buildNodejs {
   version = "26.3.0";
   sha256 = "319ad5d7d20cc622e55eb75b9f1a2546b77a08bd462b67030d0c89316c2c2349";
+  v8Version = "14.6.202.34-node.20";
+  v8Sha256 = "sha256-8WEv1qMUER3cub7OB2LxNB6RYcQMSfs0sGU6rtb53DY=";
   patches =
     (
       if (stdenv.hostPlatform.emulatorAvailable buildPackages) then

--- a/pkgs/development/web/nodejs/v8.nix
+++ b/pkgs/development/web/nodejs/v8.nix
@@ -1,0 +1,185 @@
+# Derivation for Node.js CI (not officially supported for regular applications)
+{
+  stdenv,
+  lib,
+  icu,
+  ninja,
+  python,
+  symlinkJoin,
+  temporal_capi,
+  testers,
+  unixtools,
+  validatePkgConfig,
+  writeTextFile,
+
+  src,
+  version,
+  configureScript,
+  darwin-cctools-only-libtool,
+}:
+
+let
+  sharedLibsToMock =
+    let
+      sharedLibsToMock = {
+        zlib = [ "zlib" ];
+        http-parser = [ "libllhttp" ];
+        libuv = [ "libuv" ];
+        ada = [ "ada" ];
+        simdjson = [ "simdjson" ];
+        brotli = [
+          "libbrotlidec"
+          "libbrotlienc"
+        ];
+        cares = [ "libcares" ];
+        gtest = [ "gtest" ];
+        hdr-histogram = [ "hdr_histogram" ];
+        merve = [ "merve" ];
+        nbytes = [ "nbytes" ];
+        nghttp2 = [ "libnghttp2" ];
+        nghttp3 = [ "libnghttp3" ];
+        ngtcp2 = [ "libngtcp2" ];
+        uvwasi = [ "uvwasi" ];
+        zstd = [ "libzstd" ];
+      };
+    in
+    symlinkJoin (finalAttrs: {
+      pname = "non-v8-deps-mock";
+      version = "0.0.0-mock";
+
+      nativeBuildInputs = [ validatePkgConfig ];
+
+      paths = lib.concatMap (
+        sharedLibName:
+        (builtins.map (
+          pkgName:
+          writeTextFile {
+            name = "mock-${pkgName}.pc";
+            destination = "/lib/pkgconfig/${pkgName}.pc";
+            text = ''
+              Name: ${pkgName}
+              Description: Mock package for ${sharedLibName}
+              Version: ${finalAttrs.version}
+              Libs:
+              Cflags:
+            '';
+          }
+        ) sharedLibsToMock.${sharedLibName})
+      ) (builtins.attrNames sharedLibsToMock);
+      passthru = {
+        configureFlags = [
+          "--without-lief"
+          "--without-sqlite"
+          "--without-ffi"
+          "--without-ssl"
+        ]
+        ++ (lib.concatMap (sharedLibName: [
+          "--shared-${sharedLibName}"
+          "--shared-${sharedLibName}-libname="
+        ]) (builtins.attrNames sharedLibsToMock));
+
+        tests.pkg-config = testers.hasPkgConfigModules {
+          package = finalAttrs.finalPackage;
+        };
+      };
+
+      meta = {
+        description = "Mock of Node.js dependencies that are not needed for building V8";
+        license = lib.licenses.mit;
+        pkgConfigModules = lib.concatMap (x: x) (builtins.attrValues sharedLibsToMock);
+      };
+    });
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "v8";
+
+  inherit
+    version
+    src
+    configureScript
+    ;
+
+  buildInputs = [
+    icu
+    sharedLibsToMock
+    temporal_capi
+  ];
+
+  configureFlags = sharedLibsToMock.configureFlags ++ [
+    "--ninja"
+    "--with-intl=system-icu"
+    "--v8-enable-temporal-support"
+    "--shared-temporal_capi"
+  ];
+  nativeBuildInputs = [
+    ninja
+    python
+    validatePkgConfig
+  ]
+  ++ lib.optionals stdenv.buildPlatform.isDarwin [
+    # gyp checks `sysctl -n hw.memsize` if `sys.platform == "darwin"`.
+    unixtools.sysctl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # For gyp-mac-tool if `flavor == "mac"`.
+    darwin-cctools-only-libtool
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    ninja -v -C out/Release v8_snapshot v8_libplatform
+    runHook postBuild
+  '';
+  installPhase = ''
+    runHook preInstall
+
+    ${
+      if stdenv.hostPlatform.isDarwin then
+        # Darwin is excluded from creating thin archive in tools/gyp/pylib/gyp/generator/ninja.py:2488
+        "install -Dm644 out/Release/lib* -t $out/lib"
+      else
+        # On other platforms, we need to create non-thin archive.
+        ''
+          mkdir -p $out/lib
+          for a in out/Release/obj/tools/v8_gypfiles/lib*; do
+            base=$(basename "$a")
+            dir=$(dirname "$a")
+
+            (
+              cd "$dir"
+              "$AR" rc "$out/lib/$base" $("$AR" t "$base")
+            )
+
+            "$RANLIB" "$out/lib/$base"
+          done
+        ''
+    }
+
+    install -Dm644 deps/v8/third_party/simdutf/simdutf.h -t $out/include
+    find deps/v8/include -name '*.h' -print0 | while read -r -d "" file; do
+      install -Dm644 "$file" -T "$out/include/''${file#deps/v8/include/}"
+    done
+    find deps/v8/third_party/abseil-cpp/absl -name '*.h' -print0 | while read -r -d "" file; do
+      install -Dm644 "$file" -T "$out/include/''${file#deps/v8/third_party/abseil-cpp/}"
+    done
+
+    mkdir -p $out/lib/pkgconfig
+    cat -> $out/lib/pkgconfig/v8.pc << EOF
+    prefix=$out
+    exec_prefix=\''${prefix}
+    libdir=\''${exec_prefix}/lib
+    includedir=\''${prefix}/include
+
+    Name: v8
+    Description: V8 JavaScript Engine build for Node.js CI
+    Version: ${finalAttrs.version}
+    Libs: -L\''${libdir} $(for f in $out/lib/lib*.a; do
+      b=$(basename "$f" .a)
+      printf " -l%s" "''${b#lib}"
+    done) -lstdc++
+    Cflags: -I\''${includedir}
+    EOF
+
+    runHook postInstall
+  '';
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Building V8 is the most time consuming part of building `nodejs*` derivations, being able to skip building V8 when making an unrelated change would be huge. Upstream has recently introduced a `v8.nix` in their sources that they use in their CI to reuse V8 builds. This PR is (naively perhaps) plugging into that upstream [`v8.nix`](https://github.com/nodejs/node/blob/v26.x/tools/nix/v8.nix).

One drawback of this approach is that `v8.nix` is getting the unpatched `src`, and has its own set of patches, also maintained upstream. The upside is that it avoids duplicating the maintenance.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
