### PR TITLE
python3Packages.jax: 0.10.0 -> 0.10.2

### DIFF
--- a/pkgs/development/python-modules/blackjax/default.nix
+++ b/pkgs/development/python-modules/blackjax/default.nix
@@ -77,6 +77,7 @@ buildPythonPackage (finalAttrs: {
 
     # AssertionError on numerical values
     "test_barker"
+    "test_laps"
     "test_mclmc"
     "test_mcse4"
     "test_mean_and_std"

--- a/pkgs/development/python-modules/etils/default.nix
+++ b/pkgs/development/python-modules/etils/default.nix
@@ -1,17 +1,12 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
+
+  # build-system
   flit-core,
 
-  # tests
-  chex,
-  jaxlib,
-  pytest-xdist,
-  pytestCheckHook,
-  yapf,
-
-  # optional
+  # optional-dependencies
   jupyter,
   mediapy,
   numpy,
@@ -29,35 +24,41 @@
   dm-tree,
   jax,
   tensorflow,
+
+  # tests
+  chex,
+  ffmpeg,
+  jaxlib,
+  optree,
+  pydantic,
+  pytest-xdist,
+  pytestCheckHook,
+  torch,
+  yapf,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "etils";
-  version = "1.13.0";
+  version = "1.14.0";
   pyproject = true;
+  __structuredAttrs = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-pbYMcflbzS1D1On7PcOHkSDB9gRyu1zhn3qGCx1E9gc=";
+  src = fetchFromGitHub {
+    owner = "google";
+    repo = "etils";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-gjWA+y1dXihmOBzCxfgUZJLvtSHzpRLQIhNxzk+y11M=";
   };
-
-  postPatch = ''
-    # https://github.com/google/etils/pull/722
-    substituteInPlace etils/epath/resource_utils.py \
-      --replace-fail importlib_resources importlib.resources
-    substituteInPlace pyproject.toml \
-      --replace-fail '"importlib_resources",' ""
-  '';
 
   build-system = [ flit-core ];
 
-  optional-dependencies = rec {
-    array-types = enp;
+  optional-dependencies = lib.fix (self: {
+    array-types = self.enp;
     eapp = [
       absl-py
       simple-parsing
     ]
-    ++ epy;
+    ++ self.epy;
     ecolab = [
       jupyter
       numpy
@@ -65,73 +66,94 @@ buildPythonPackage rec {
       packaging
       protobuf
     ]
-    ++ enp
-    ++ epy
-    ++ etree;
-    edc = epy;
+    ++ self.enp
+    ++ self.epy
+    ++ self.etree;
+    edc = self.epy;
     enp = [
       numpy
       einops
     ]
-    ++ epy;
+    ++ self.epy;
     epath = [
       fsspec
       typing-extensions
       zipp
     ]
-    ++ epy;
-    epath-gcs = [ gcsfs ] ++ epath;
-    epath-s3 = [ s3fs ] ++ epath;
+    ++ self.epy;
+    epath-gcs = [ gcsfs ] ++ self.epath;
+    epath-s3 = [ s3fs ] ++ self.epath;
     epy = [ typing-extensions ];
     etqdm = [
       absl-py
       tqdm
     ]
-    ++ epy;
-    etree = array-types ++ epy ++ enp ++ etqdm;
-    etree-dm = [ dm-tree ] ++ etree;
-    etree-jax = [ jax ] ++ etree;
-    etree-tf = [ tensorflow ] ++ etree;
-    lazy-imports = ecolab;
+    ++ self.epy;
+    etree = self.array-types ++ self.epy ++ self.enp ++ self.etqdm;
+    etree-dm = [ dm-tree ] ++ self.etree;
+    etree-jax = [ jax ] ++ self.etree;
+    etree-tf = [ tensorflow ] ++ self.etree;
+    lazy-imports = self.ecolab;
     all =
-      array-types
-      ++ eapp
-      ++ ecolab
-      ++ edc
-      ++ enp
-      ++ epath
-      ++ epath-gcs
-      ++ epath-s3
-      ++ epy
-      ++ etqdm
-      ++ etree
-      ++ etree-dm
-      ++ etree-jax
-      ++ etree-tf;
-  };
+      self.array-types
+      ++ self.eapp
+      ++ self.ecolab
+      ++ self.edc
+      ++ self.enp
+      ++ self.epath
+      ++ self.epath-gcs
+      ++ self.epath-s3
+      ++ self.epy
+      ++ self.etqdm
+      ++ self.etree
+      ++ self.etree-dm
+      ++ self.etree-jax
+      ++ self.etree-tf;
+  });
 
   pythonImportsCheck = [ "etils" ];
 
   nativeCheckInputs = [
     chex
+    optree
+    ffmpeg
     jaxlib
+    torch
+    pydantic
     pytest-xdist
     pytestCheckHook
     yapf
   ]
-  ++ optional-dependencies.all;
+  ++ finalAttrs.passthru.optional-dependencies.all;
+
+  # enabledTestPaths = [ ];
 
   disabledTests = [
-    "test_public_access" # requires network access
+    # Requires network access
+    "test_public_access"
+
+    # AttributeError: module 'jax._src' has no attribute 'prng'
+    "test_array_spec_is_fake"
+    "test_array_spec_repr"
+    "test_array_spec_tensors"
+    "test_array_spec_valid"
+    "test_obj"
+    "test_spec_like"
   ];
 
-  doCheck = false; # error: infinite recursion encountered
+  disabledTestPaths = [
+    # Circular dependency with tensorflow-datasets
+    "etils/epy/lazy_imports_utils_test.py"
+
+    # Requires unpackaged fiddle
+    "etils/epy/text_utils_test.py"
+  ];
 
   meta = {
-    changelog = "https://github.com/google/etils/blob/v${version}/CHANGELOG.md";
     description = "Collection of eclectic utils";
     homepage = "https://github.com/google/etils";
+    changelog = "https://github.com/google/etils/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ mcwitt ];
   };
-}
+})

--- a/pkgs/development/python-modules/flax/default.nix
+++ b/pkgs/development/python-modules/flax/default.nix
@@ -46,6 +46,14 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-a78KiTsCCARWZvbxz9QKdUKnjkDJGXcPVVJu5rU4m/U=";
   };
 
+  # DeprecationWarning: `with mesh:` context manager has been deprecated. Please use `with jax.set_mesh(mesh):` instead.
+  postPatch = ''
+    substituteInPlace tests/nnx/transforms_test.py \
+      --replace-fail \
+        "with mesh:" \
+        "with jax.set_mesh(mesh):"
+  '';
+
   build-system = [
     setuptools
     setuptools-scm

--- a/pkgs/development/python-modules/jax-cuda12-pjrt/default.nix
+++ b/pkgs/development/python-modules/jax-cuda12-pjrt/default.nix
@@ -50,8 +50,8 @@ buildPythonPackage (finalAttrs: {
       .${stdenv.hostPlatform.system};
     hash =
       {
-        x86_64-linux = "sha256-MJUVRT9Zyq2Vv3bIvGScJLwOPRLQe68895K+CCq97js=";
-        aarch64-linux = "sha256-NqwxbFiKDgjrZPhoJwUmrco4VtS3CxN2C36bc76F0s8=";
+        x86_64-linux = "sha256-gG0f0pA4tqz1orKJ3WIZKr6pd+4mrvYOopWx0oojrPg=";
+        aarch64-linux = "sha256-tvLWZUjuHukQqDa1/j0Ou+HaBKYtD0aLpIIhiQNqMrM=";
       }
       .${stdenv.hostPlatform.system};
   };

--- a/pkgs/development/python-modules/jax-cuda12-plugin/default.nix
+++ b/pkgs/development/python-modules/jax-cuda12-plugin/default.nix
@@ -39,42 +39,42 @@ let
     "3.11-x86_64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_x86_64";
       dist = "cp311";
-      hash = "sha256-lXMXyv8eawBqE1UXM3cN8jWidHBkviawJ0YP46WPWO4=";
+      hash = "sha256-drv+zi9u/7TokI64pfvxq7wRJd5mdoPsL/ulHGPcV68=";
     };
     "3.11-aarch64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_aarch64";
       dist = "cp311";
-      hash = "sha256-GkpKVqgyrTDgHBQIWx+iRApV+kzggI5AXnNlDv+K+zE=";
+      hash = "sha256-nNCTcHC70o5EuRQ1tSxyJcjtbLN922qQ6cJGhzoD+c0=";
     };
     "3.12-x86_64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_x86_64";
       dist = "cp312";
-      hash = "sha256-oWugDXI2YUWCfKOajISfn+4Rd9ZzjJ7f1ys6n+31zxg=";
+      hash = "sha256-Trbo4Jkv2Yl9skaNoz8nauQU7ITcQ2gEEkQEQwUC7qw=";
     };
     "3.12-aarch64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_aarch64";
       dist = "cp312";
-      hash = "sha256-6vGmGVqg60i0IMcfIrktGXeNlIAkl3yuRkEnnV9sH4E=";
+      hash = "sha256-dnoUgtv2UmiEA8TiL/AUcOGt0TxI+dgXFp/Y90QK/OU=";
     };
     "3.13-x86_64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_x86_64";
       dist = "cp313";
-      hash = "sha256-7QdNN5Z7zmHBuv3fndCoMCMGwS+QcAylrfo9CP3Uruc=";
+      hash = "sha256-lIqYiSfLEIQ7UBohUYHMsdrtP6cFMbLxrghC/hwIsF4=";
     };
     "3.13-aarch64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_aarch64";
       dist = "cp313";
-      hash = "sha256-dHnmfZ2Y1KD1JflPi4GIDcwFhjH23hGLkd6R2xtAle0=";
+      hash = "sha256-aXdqyEkRL0/C1vphb4dyEG2v84/NuCXE459H6HjydhA=";
     };
     "3.14-x86_64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_x86_64";
       dist = "cp314";
-      hash = "sha256-96ahiBNJ3DnyRIGioBn/KUuUkJuAqIge/iHUW2pfaR0=";
+      hash = "sha256-DHoCBBVVhcwcT8swxmt/iBs45X4fDY6X1I4WVL8NJ/g=";
     };
     "3.14-aarch64-linux" = getSrcFromPypi {
       platform = "manylinux_2_27_aarch64";
       dist = "cp314";
-      hash = "sha256-iIb8V5df7gG+FyX4mLaSkvYVtwgwrvXC+95jgzNha10=";
+      hash = "sha256-SUbsV923leLagojOsc7d1YwqIEoPd2WvierkhqHTrOc=";
     };
   };
 in

--- a/pkgs/development/python-modules/jax/default.nix
+++ b/pkgs/development/python-modules/jax/default.nix
@@ -6,7 +6,6 @@
   lapack,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   cudaSupport ? config.cudaSupport,
 
   # build-system
@@ -41,7 +40,7 @@ let
 in
 buildPythonPackage (finalAttrs: {
   pname = "jax";
-  version = "0.10.0";
+  version = "0.10.2";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -50,17 +49,8 @@ buildPythonPackage (finalAttrs: {
     repo = "jax";
     # google/jax contains tags for jax and jaxlib. Only use jax tags!
     tag = "jax-v${finalAttrs.version}";
-    hash = "sha256-/RCihrjONN/+QwyQRNEmlIa7JsCLzz+SkBe5sd+ThgU=";
+    hash = "sha256-OQkh9uC8NsxoG3SByPybXQ81c11T3lYgjaU3tbB0+6E=";
   };
-
-  patches = [
-    # setup.py: Include only jax.* in the built wheel
-    # https://github.com/jax-ml/jax/pull/37182
-    (fetchpatch {
-      url = "https://github.com/jax-ml/jax/commit/cb5a91780f84f124090d8f94e99c8771e87590f6.patch";
-      hash = "sha256-p6X9IFe4YUb2MQp7YjJHme1dueZ1Y37IKnANGruW1cM=";
-    })
-  ];
 
   build-system = [ setuptools ];
 
@@ -135,6 +125,13 @@ buildPythonPackage (finalAttrs: {
   disabledTests = [
     # Exceeds tolerance when the machine is busy
     "test_custom_linear_solve_aux"
+
+    # pytest-xdist/execnet cannot serialize the numpy `type` objects this test passes to
+    # self.subTest(dtype=...) when shipping subtest reports between workers.
+    # The assertions themselves pass; the failure is a harness artifact of running with
+    # --numprocesses.
+    # New test in jax 0.10.2 (tests/random_impl_test.py).
+    "test_random_bits"
   ]
   ++ lib.optionals usingMKL [
     # See

--- a/pkgs/development/python-modules/jaxlib/bin.nix
+++ b/pkgs/development/python-modules/jaxlib/bin.nix
@@ -18,7 +18,7 @@
 }:
 
 let
-  version = "0.10.0";
+  version = "0.10.2";
   inherit (python) pythonVersion;
 
   # As of 2023-06-06, google/jax upstream is no longer publishing CPU-only wheels to their GCS bucket. Instead the
@@ -49,65 +49,65 @@ let
       "3.11-x86_64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_x86_64";
         dist = "cp311";
-        hash = "sha256-m+IpmTpB5bK4TyNOzBml3gLzXt2xGVzwJ71TnhYB4V0=";
+        hash = "sha256-H6yjxdRmLLSmEwpoEF1ou1IHZIF+Fl1u6/1nhsDR8w8=";
       };
       "3.11-aarch64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_aarch64";
         dist = "cp311";
-        hash = "sha256-PblOvIWTddlV3jUEGCrdfOFzPOPTDBXg7wMWAstRpVk=";
+        hash = "sha256-1EVl3P0bT2D3bZEcZRIRiopPx2S975JmP+y4v8zVTyM=";
       };
       "3.11-aarch64-darwin" = getSrcFromPypi {
         platform = "macosx_11_0_arm64";
         dist = "cp311";
-        hash = "sha256-J3Ay6fB0w/1f/R4MsD1P5m4nLeRyZnzbxBitmbIbZGo=";
+        hash = "sha256-WpiHP8hnYjuB8r7hXVVLjt1liKGD0B+lDSGx49uW/ys=";
       };
 
       "3.12-x86_64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_x86_64";
         dist = "cp312";
-        hash = "sha256-sL+4ZaB98ubXQYwLDCkt0pS1UAUjsd1YcrGA2yqkgNQ=";
+        hash = "sha256-/ojsRDcUxDeZaLbBCfn6YXx60ZuAKCjk17+GHNZtpLc=";
       };
       "3.12-aarch64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_aarch64";
         dist = "cp312";
-        hash = "sha256-qh1w8aTifrQDZU5x4vso1XhtPpt3/BhH6MU4mICSfKQ=";
+        hash = "sha256-U7cpd65YLAOp6OHN7h77+OvBQYJwllsOaereV6z0AzE=";
       };
       "3.12-aarch64-darwin" = getSrcFromPypi {
         platform = "macosx_11_0_arm64";
         dist = "cp312";
-        hash = "sha256-fB2bRjMnx6IzPyEBFOywTyj+/FG6gjOoWiKAzOdb20I=";
+        hash = "sha256-R7t8ARUV6oYr5+gxP0D5xWy+wJ3Jig/LUBZ4X81FTAE=";
       };
 
       "3.13-x86_64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_x86_64";
         dist = "cp313";
-        hash = "sha256-0wPcMbZei3k9VgD4GxWDvgPcm4dqTBCz4lm2YJocvjs=";
+        hash = "sha256-nkgYtKh1b9ORh2bKKqU0ISWAn08Ipv5GAm1DhufCNkQ=";
       };
       "3.13-aarch64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_aarch64";
         dist = "cp313";
-        hash = "sha256-bY14twcLNOTFu6X34Qkn5/Sqybab4X6bCliYVTpDOPM=";
+        hash = "sha256-RbKLAjhperdLvPIEEar7bbQqzDGDbML9cR5c8Fa/lVY=";
       };
       "3.13-aarch64-darwin" = getSrcFromPypi {
         platform = "macosx_11_0_arm64";
         dist = "cp313";
-        hash = "sha256-OEY1//VYmaKVu8gu5sb3c6MA54fcRyypK755q/qsg2k=";
+        hash = "sha256-TfUwr6NUoi3BdHpdVgZARQy7iV1JiJM4o/WMdqTHbI4=";
       };
 
       "3.14-x86_64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_x86_64";
         dist = "cp314";
-        hash = "sha256-KkLPBMD4i8A7FQoX+n3bsvQOCWZn7IobhA7YeRPm5zU=";
+        hash = "sha256-yjTzYxl/sKxAglgsp1UAeRA2njP4qLo9Ne2UtxBwEH0=";
       };
       "3.14-aarch64-linux" = getSrcFromPypi {
         platform = "manylinux_2_27_aarch64";
         dist = "cp314";
-        hash = "sha256-rUfgckMJeewhY3qkh9TcRkAouOm+JyaPN95pU2x240E=";
+        hash = "sha256-8Y9W/ukGmc+6m2YnBFp6KZcCyw4q+CzhgNmmp8gEgJM=";
       };
       "3.14-aarch64-darwin" = getSrcFromPypi {
         platform = "macosx_11_0_arm64";
         dist = "cp314";
-        hash = "sha256-mLJmcpQ2cnQoc/ZbwDIWgZ/FUyXJnxRlkNAHwBcr/zA=";
+        hash = "sha256-cuuiixL+4CYW+kKqS4gbSrYtd1fHhDxGJAHT+zSie+Q=";
       };
     };
 in

--- a/pkgs/development/python-modules/jaxopt/default.nix
+++ b/pkgs/development/python-modules/jaxopt/default.nix
@@ -95,6 +95,7 @@ buildPythonPackage (finalAttrs: {
     "test_inv_hessian_product_pytree3"
     "test_logreg_with_intercept_manual_loop3"
     "test_multiclass_logreg6"
+    "test_wrapper_grad"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/orbax-checkpoint/default.nix
+++ b/pkgs/development/python-modules/orbax-checkpoint/default.nix
@@ -42,7 +42,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "orbax-checkpoint";
-  version = "0.11.40";
+  version = "0.12.1";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -50,7 +50,7 @@ buildPythonPackage (finalAttrs: {
     owner = "google";
     repo = "orbax";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Z1T1mt12kdY6EMY+95m12kW9nHcGj77f87i4PY9ibBU=";
+    hash = "sha256-yE8M8f2c+4lTL56LrS57vU/MMM3NgYCZOuHZWbdODh0=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/checkpoint";
@@ -121,6 +121,7 @@ buildPythonPackage (finalAttrs: {
     "test_named_sharding"
 
     # ValueError: cannot reshape array of size 1 into shape (0,2)
+    "ArrayHandlerCallbackTest"
     "test_get_leaf_memory_per_device"
     "test_memory_size"
     "test_number_of_broadcasts"
@@ -152,14 +153,16 @@ buildPythonPackage (finalAttrs: {
     "orbax/checkpoint/_src/testing/oss/multiprocess_test.py"
     "orbax/checkpoint/experimental/emergency/"
 
-    # ImportError: cannot import name 'tiering_service_pb2' from
-    # 'orbax.checkpoint.experimental.tiering_service.proto'
-    # (the protobuf module is not generated from the .proto file)
-    "orbax/checkpoint/experimental/tiering_service/server_test.py"
+    # Some modules in this directory also require the unpackaged `fire` module.
+    "orbax/checkpoint/experimental/tiering_service/"
 
     # ValueError: Distributed system is not available; please initialize it via `jax.distributed.initialize()` at the start of your program.
     "orbax/checkpoint/_src/handlers/array_checkpoint_handler_test.py"
+    "orbax/checkpoint/checkpoint_manager_slice_test.py"
+    "orbax/checkpoint/experimental/v1/_src/handlers/pytree_handler_partial_save_test.py"
     "orbax/checkpoint/experimental/v1/_src/layout/safetensors_layout_multiprocess_test.py"
+    "orbax/checkpoint/experimental/v1/_src/partial/saving_multihost_test.py"
+    "orbax/checkpoint/experimental/v1/_src/synchronization/multihost_test.py"
 
     # import file mismatch:
     # imported module 'registry_test' has this __file__ attribute:
@@ -187,6 +190,7 @@ buildPythonPackage (finalAttrs: {
     "orbax/checkpoint/_src/checkpointers/async_checkpointer_test.py"
     "orbax/checkpoint/_src/checkpointers/checkpointer_test.py"
     "orbax/checkpoint/_src/handlers/pytree_checkpoint_handler_test.py"
+    "orbax/checkpoint/_src/handlers/standard_checkpoint_handler_test.py"
     "orbax/checkpoint/_src/metadata/empty_values_test.py"
     "orbax/checkpoint/_src/metadata/tree_rich_types_test.py"
     "orbax/checkpoint/_src/metadata/tree_test.py"
@@ -197,9 +201,12 @@ buildPythonPackage (finalAttrs: {
     "orbax/checkpoint/_src/tree/utils_test.py"
     "orbax/checkpoint/checkpoint_manager_test.py"
     "orbax/checkpoint/experimental/v1/_src/handlers/pytree_handler_test.py"
+    "orbax/checkpoint/experimental/v1/_src/loading/validation_test.py"
+    "orbax/checkpoint/experimental/v1/_src/saving/validation_test.py"
+    "orbax/checkpoint/experimental/v1/_src/testing/save_load_test.py"
     "orbax/checkpoint/single_host_test.py"
+    "orbax/checkpoint/testing/local_path_test.py"
     "orbax/checkpoint/transform_utils_test.py"
-    "orbax/checkpoint/_src/handlers/standard_checkpoint_handler_test.py"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
## Things done

- **python3Packages.jax: 0.10.0 -> 0.10.2** ([Diff](https://github.com/google/jax/compare/jax-v0.10.0...jax-v0.10.2), [Changelog](https://docs.jax.dev/en/latest/changelog.html))
- **python3Packages.etils: 1.13.0 -> 1.14.0** ([Diff](https://github.com/google/etils/compare/v1.13.0...v1.14.0), [Changelog](https://github.com/google/etils/blob/v1.14.0/CHANGELOG.md))
- **python3Packages.orbax-checkpoint: 0.11.40 -> 0.12.1** ([Diff](https://github.com/google/orbax/compare/v0.11.40...v0.12.1), [Changelog](https://github.com/google/orbax/blob/v0.12.1/checkpoint/CHANGELOG.md))
- **python3Packages.flax: fix test with new jax**
- **python3Packages.blackjax: skip failing test**

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
