### PR TITLE
nixos-render-docs: add viewport meta tag to manual

### DIFF
--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manual.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manual.py
@@ -372,6 +372,7 @@ class ManualHTMLRenderer(RendererMixin, HTMLRenderer):
             '<html xmlns="http://www.w3.org/1999/xhtml">',
             ' <head>',
             '  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />',
+            '  <meta name="viewport" content="width=device-width, initial-scale=1" />',
             f' <title>{toc.target.title}</title>',
             "".join((f'<link rel="stylesheet" type="text/css" href="{html.escape(style, True)}" />'
                      for style in self._html_params.stylesheets)),


### PR DESCRIPTION
This PR fixes how the Nixpkgs and NixOS manuals are rendered on mobile by adding the ["most common setting" for `<meta name="viewport">` according to MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/name/viewport#viewport_width_and_screen_width).

<div align="center">

| | command | before | after |
| - | - | - | - |
| Nixpkgs | `nix-build -A nixpkgs-manual` | <img height="200" src="https://github.com/user-attachments/assets/6608ec20-3bc0-400e-b5a3-37685b96157a"> | <img height="200" src="https://github.com/user-attachments/assets/867f1cbb-9a08-4366-9172-d287823e0e51"> |
| NixOS | `nix-build nixos/release.nix` | <img height="200" src="https://github.com/user-attachments/assets/c3fb59e3-cb9b-49e4-a1e6-b951b7c05044"> | <img height="200" src="https://github.com/user-attachments/assets/3e9553bd-0da9-4ff9-bd35-9412aa786bbd"> |

</div>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
