### PR TITLE
openexr: Disable more known-broken tests on big-endian

### DIFF
--- a/pkgs/development/libraries/openexr/3.nix
+++ b/pkgs/development/libraries/openexr/3.nix
@@ -78,6 +78,14 @@ stdenv.mkDerivation rec {
     "OpenEXR.testSampleImages"
     "OpenEXR.testSharedFrameBuffer"
     "OpenEXR.testTiledRgba"
+
+    # Lack of proper endianness handling in OpenJPH
+    # https://github.com/aous72/OpenJPH/issues/266
+    # "ojph error 0x00050041 at ojph_params.cpp:687: error reading SIZ marker", and similar errors
+    "OpenEXR.testConversion"
+    "OpenEXR.testExistingStreams"
+    "OpenEXR.testLargeDataWindowOffsets"
+    "OpenEXR.testTiledCompression"
   ];
 
   passthru.tests = {


### PR DESCRIPTION
Issue seems to come from OpenJPH lacking correct handling of endianness, leading to failures when OpenEXR tries to use it in tests.

OpenJPH ticket about this: https://github.com/aous72/OpenJPH/issues/266

(side note: we should maybe build against our `openjph` instead of building the vendored one)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (no rebuilds)
  - [ ] aarch64-linux
  - [x] powerpc64-linux (of 3.4.10 from nixos-unstable, but vendored OpenJPH is basically unchanged)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
