### PR TITLE
python3Packages.exllamav2: cleanup, fix

### DIFF
--- a/pkgs/development/python-modules/exllamav2/default.nix
+++ b/pkgs/development/python-modules/exllamav2/default.nix
@@ -1,16 +1,18 @@
 {
-  fetchFromGitHub,
   lib,
-  cudaPackages,
   buildPythonPackage,
-  nix-update-script,
+  fetchFromGitHub,
 
+  # build-system
   setuptools,
+  torch,
 
+  cudaPackages,
+
+  # nativeBuildInputs
   pybind11,
 
-  which,
-
+  # dependencies
   fastparquet,
   flash-attn,
   ninja,
@@ -22,13 +24,13 @@
   rich,
   safetensors,
   tokenizers,
-  torch,
   websockets,
 }:
 buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
   pname = "exllamav2";
   version = "0.3.2";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "turboderp-org";
@@ -39,32 +41,33 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
 
   build-system = [
     setuptools
+    torch
   ];
+
+  nativeBuildInputs = [
+    ninja
+  ];
+
+  preConfigure = ''
+    export MAX_JOBS="$NIX_BUILD_CORES"
+    export NVCC_THREADS=2
+  '';
 
   buildInputs = [
     pybind11
   ]
   ++ lib.optionals torch.cudaSupport [
-    cudaPackages.libcusparse # cusparse.h
-    cudaPackages.libcublas # cublas_v2.h
-    cudaPackages.libcusolver # cusolverDn.h
-    cudaPackages.libcurand # curand_kernel.h
     cudaPackages.cuda_cudart # cuda_runtime.h
+    cudaPackages.libcublas # cublas_v2.h
+    cudaPackages.libcurand # curand_kernel.h
+    cudaPackages.libcusolver # cusolverDn.h
+    cudaPackages.libcusparse # cusparse.h
   ];
 
   env = lib.optionalAttrs torch.cudaSupport {
     CUDA_HOME = lib.getDev cudaPackages.cuda_nvcc;
     TORCH_CUDA_ARCH_LIST = lib.concatStringsSep ";" torch.cudaCapabilities;
   };
-
-  nativeBuildInputs = [
-    ninja
-    which
-  ];
-
-  pythonRelaxDeps = [
-    "numpy" # Wants numpy 1.26.4
-  ];
 
   dependencies = [
     fastparquet
@@ -86,8 +89,6 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
 
   # Tests require GPU hardware and external model files
   doCheck = false;
-
-  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/turboderp-org/exllamav2";


### PR DESCRIPTION
## Things done

Fix and cleanup `exllamav2`.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
