### PR TITLE
lib.modules.collectStructuredModules: performance cleanups

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -509,6 +509,8 @@ let
                 # All modules imported by the module for key1
                 modules = [
                   {
+                    # no disabled attribute, since this module doesn't disable
+                    # anything
                     key = <key1-1>;
                     module = <module for key1-1>;
                     # All modules imported by the module for key1-1
@@ -521,13 +523,13 @@ let
             ];
           }
       */
-
       collectStructuredModules =
         initialModules: args:
         let
           recurse =
             parentFile: parentKey: imports:
             let
+              disabled = catAttrs "disabled" modules;
               modules = imap1 (
                 n: x:
                 let
@@ -538,7 +540,10 @@ let
                   key = module.key;
                   module = module;
                   modules = collectedImports.modules;
-                  disabled =
+                  # only include a disabled attribute if any modules have to be
+                  # disabled. most people don't disable any modules, which lets
+                  # us skip the work of merging the lists together
+                  ${if module.disabledModules != [ ] || collectedImports ? disabled then "disabled" else null} =
                     (
                       if module.disabledModules != [ ] then
                         [
@@ -550,16 +555,21 @@ let
                       else
                         [ ]
                     )
-                    ++ collectedImports.disabled;
+                    ++ collectedImports.disabled or [ ];
                 }
               ) imports;
             in
             {
-              disabled = concatLists (catAttrs "disabled" modules);
+              ${if disabled != [ ] then "disabled" else null} = concatLists disabled;
               inherit modules;
             };
+
+          result = recurse unknownModule "" initialModules;
         in
-        recurse unknownModule "" initialModules;
+        {
+          disabled = result.disabled or [ ];
+          inherit (result) modules;
+        };
 
       # filterModules :: String -> { disabled, modules } -> [ Module ]
       #

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -521,16 +521,11 @@ let
             ];
           }
       */
+
       collectStructuredModules =
-        let
-          collectResults = modules: {
-            disabled = concatLists (catAttrs "disabled" modules);
-            inherit modules;
-          };
-        in
         parentFile: parentKey: initialModules: args:
-        collectResults (
-          imap1 (
+        let
+          modules = imap1 (
             n: x:
             let
               module = checkModule (loadModule args parentFile "${parentKey}:anon-${toString n}" x);
@@ -554,8 +549,12 @@ let
                 )
                 ++ collectedImports.disabled;
             }
-          ) initialModules
-        );
+          ) initialModules;
+        in
+        {
+          disabled = concatLists (catAttrs "disabled" modules);
+          inherit modules;
+        };
 
       # filterModules :: String -> { disabled, modules } -> [ Module ]
       #

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -524,6 +524,11 @@ let
           }
       */
       collectStructuredModules =
+        let
+          defaultCollectedImports = {
+            modules = [ ];
+          };
+        in
         initialModules: args:
         let
           recurse =
@@ -534,7 +539,11 @@ let
                 n: x:
                 let
                   module = checkModule (loadModule args parentFile "${parentKey}:anon-${toString n}" x);
-                  collectedImports = recurse module._file module.key module.imports;
+                  collectedImports =
+                    if module ? imports then
+                      recurse module._file module.key module.imports
+                    else
+                      defaultCollectedImports;
                 in
                 {
                   key = module.key;
@@ -689,7 +698,7 @@ let
           _class = m._class or null;
           key = toString m.key or key;
           ${if m ? disabledModules then "disabledModules" else null} = m.disabledModules;
-          imports = m.imports or [ ];
+          ${if m ? imports then "imports" else null} = m.imports;
           options = m.options or { };
           config = addFreeformType (addMeta (m.config or { }));
         }
@@ -700,7 +709,7 @@ let
         _class = m._class or null;
         key = toString m.key or key;
         ${if m ? disabledModules then "disabledModules" else null} = m.disabledModules;
-        imports = m.require or [ ] ++ m.imports or [ ];
+        ${if m ? imports || m ? require then "imports" else null} = m.require or [ ] ++ m.imports or [ ];
         options = { };
         config = addFreeformType (
           removeAttrs m [

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -699,7 +699,7 @@ let
           key = toString m.key or key;
           ${if m ? disabledModules then "disabledModules" else null} = m.disabledModules;
           ${if m ? imports then "imports" else null} = m.imports;
-          options = m.options or { };
+          ${if m ? options then "options" else null} = m.options;
           config = addFreeformType (addMeta (m.config or { }));
         }
     else
@@ -812,21 +812,24 @@ let
       declsByName = zipAttrs (
         map (
           module:
-          let
-            subtree = module.options;
-          in
-          if !(isAttrs subtree) then
-            throw ''
-              An option declaration for `${concatStringsSep "." prefix}' has type
-              `${typeOf subtree}' rather than an attribute set.
-              Did you mean to define this outside of `options'?
-            ''
+          if !module ? options then
+            { }
           else
-            mapAttrs (n: option: {
-              inherit (module) _file;
-              pos = unsafeGetAttrPos n subtree;
-              options = option;
-            }) subtree
+            let
+              subtree = module.options;
+            in
+            if !(isAttrs subtree) then
+              throw ''
+                An option declaration for `${concatStringsSep "." prefix}' has type
+                `${typeOf subtree}' rather than an attribute set.
+                Did you mean to define this outside of `options'?
+              ''
+            else
+              mapAttrs (n: option: {
+                inherit (module) _file;
+                pos = unsafeGetAttrPos n subtree;
+                options = option;
+              }) subtree
         ) modules
       );
 

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -798,10 +798,13 @@ let
     mergeModules' prefix modules (
       concatMap (
         m:
-        map (config: {
-          file = m._file;
-          inherit config;
-        }) (pushDownProperties m.config)
+        if m.config != { } then
+          map (config: {
+            file = m._file;
+            inherit config;
+          }) (pushDownProperties m.config)
+        else
+          [ ]
       ) modules
     );
 

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -523,38 +523,43 @@ let
       */
 
       collectStructuredModules =
-        parentFile: parentKey: initialModules: args:
+        initialModules: args:
         let
-          modules = imap1 (
-            n: x:
+          recurse =
+            parentFile: parentKey: imports:
             let
-              module = checkModule (loadModule args parentFile "${parentKey}:anon-${toString n}" x);
-              collectedImports = collectStructuredModules module._file module.key module.imports args;
+              modules = imap1 (
+                n: x:
+                let
+                  module = checkModule (loadModule args parentFile "${parentKey}:anon-${toString n}" x);
+                  collectedImports = recurse module._file module.key module.imports;
+                in
+                {
+                  key = module.key;
+                  module = module;
+                  modules = collectedImports.modules;
+                  disabled =
+                    (
+                      if module.disabledModules != [ ] then
+                        [
+                          {
+                            file = module._file;
+                            disabled = module.disabledModules;
+                          }
+                        ]
+                      else
+                        [ ]
+                    )
+                    ++ collectedImports.disabled;
+                }
+              ) imports;
             in
             {
-              key = module.key;
-              module = module;
-              modules = collectedImports.modules;
-              disabled =
-                (
-                  if module.disabledModules != [ ] then
-                    [
-                      {
-                        file = module._file;
-                        disabled = module.disabledModules;
-                      }
-                    ]
-                  else
-                    [ ]
-                )
-                ++ collectedImports.disabled;
-            }
-          ) initialModules;
+              disabled = concatLists (catAttrs "disabled" modules);
+              inherit modules;
+            };
         in
-        {
-          disabled = concatLists (catAttrs "disabled" modules);
-          inherit modules;
-        };
+        recurse unknownModule "" initialModules;
 
       # filterModules :: String -> { disabled, modules } -> [ Module ]
       #
@@ -587,11 +592,11 @@ let
         map toModuleGraph (filter (x: x.key != "lib/modules.nix") modules);
     in
     modulesPath: initialModules: args: {
-      modules = filterModules modulesPath (collectStructuredModules unknownModule "" initialModules args);
+      modules = filterModules modulesPath (collectStructuredModules initialModules args);
       # Intentionally not shared with `modules` above: this allows
       # the return value of `collectStructuredModules`
       # to be garbage collected after `filterModules` returns.
-      graph = toGraph modulesPath (collectStructuredModules unknownModule "" initialModules args);
+      graph = toGraph modulesPath (collectStructuredModules initialModules args);
     };
 
   /**

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -543,9 +543,9 @@ let
                   # only include a disabled attribute if any modules have to be
                   # disabled. most people don't disable any modules, which lets
                   # us skip the work of merging the lists together
-                  ${if module.disabledModules != [ ] || collectedImports ? disabled then "disabled" else null} =
+                  ${if module ? disabledModules || collectedImports ? disabled then "disabled" else null} =
                     (
-                      if module.disabledModules != [ ] then
+                      if module ? disabledModules then
                         [
                           {
                             file = module._file;
@@ -688,7 +688,7 @@ let
           _file = toString m._file or file;
           _class = m._class or null;
           key = toString m.key or key;
-          disabledModules = m.disabledModules or [ ];
+          ${if m ? disabledModules then "disabledModules" else null} = m.disabledModules;
           imports = m.imports or [ ];
           options = m.options or { };
           config = addFreeformType (addMeta (m.config or { }));
@@ -699,7 +699,7 @@ let
         _file = toString m._file or file;
         _class = m._class or null;
         key = toString m.key or key;
-        disabledModules = m.disabledModules or [ ];
+        ${if m ? disabledModules then "disabledModules" else null} = m.disabledModules;
         imports = m.require or [ ] ++ m.imports or [ ];
         options = { };
         config = addFreeformType (


### PR DESCRIPTION
I wanted to stop calling this function altogether in the main path, since computing the structured representation is a waste of time if `disabled == []`, but I ran into some issues with recursive `disabledModules` that made it a more controversial patch than I'd like. Instead, I'm going for some incremental wins on collectStructuredModules. Since this is a relatively focused PR, I'm putting it up separately from my other patches.

We now don't include `disabledModules` and `imports` in a module if they're not defined in the original module definition. This lets us avoid recursing a layer deeper if a module has no imports. I think this only leaks to users via the `private` attribute - so I can add a release note if preferred, but there's already a warning on it.

Stats diff for my personal config:
```json
{
  "attrset": {
    "lookups": "-3.44%",
    "merges": "+0%",
    "mergeCopies": "-0.08%"
  },
  "list": {
    "concats": "-17.8%"
  },
  "parser": {
    "expressions": "-0.03%"
  },
  "memoryBytes": {
    "envs": "-1.83%",
    "list": "-2.27%",
    "sets": "-0.37%",
    "symbols": "-0.07%",
    "values": "-2.41%",
    "total": "-1.3%"
  },
  "speed": {
    "primops": "-4.1%",
    "functionCalls": "-3.07%",
    "thunksMade": "-3.38%",
    "thunksAvoided": "-1.71%"
  }
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
