### PR TITLE
openthread-border-router: 0-unstable-2025-06-12 -> 2026.06.0

### DIFF
--- a/nixos/modules/services/home-automation/openthread-border-router.nix
+++ b/nixos/modules/services/home-automation/openthread-border-router.nix
@@ -203,15 +203,6 @@ in
       ]) cfg.backboneInterfaces
     );
 
-    # OTBR uses avahi for mDNS service publishing
-    services.avahi = {
-      enable = lib.mkDefault true;
-      publish = {
-        enable = lib.mkDefault true;
-        userServices = lib.mkDefault true;
-      };
-    };
-
     # The upstream service files (src/agent/otbr-agent.service.in, src/web/otbr-web.service.in) use
     # EnvironmentFile and CMake-substituted platform scripts that don't translate to NixOS, so the
     # services are rebuilt here from typed module options instead.

--- a/pkgs/by-name/op/openthread-border-router/package.nix
+++ b/pkgs/by-name/op/openthread-border-router/package.nix
@@ -5,26 +5,23 @@
   cmake,
   pkg-config,
   systemdLibs,
-  avahi,
   dbus,
   protobuf,
   jsoncpp,
   boost,
-  libnetfilter_queue,
-  libnfnetlink,
   nodejs,
   bashNonInteractive,
   buildNpmPackage,
 }:
 let
   pname = "openthread-border-router";
-  version = "0-unstable-2025-06-12";
+  version = "2026.06.0";
 
   src = fetchFromGitHub {
     owner = "openthread";
     repo = "ot-br-posix";
-    rev = "thread-reference-20250612";
-    hash = "sha256-lPMMLtbPu9NpDcBCZE6XID7u1maCAhkZiSDEyFq7yvg=";
+    tag = "v${version}";
+    hash = "sha256-7si62h1nXnAzEmloThCcOeY3VhfSIFV+7kWKgJywcvk=";
     fetchSubmodules = true;
   };
 
@@ -41,9 +38,6 @@ stdenv.mkDerivation {
 
   strictDeps = true;
   __structuredAttrs = true;
-
-  # warning _FORTIFY_SOURCE requires compiling with optimization (-O)
-  env.NIX_CFLAGS_COMPILE = "-O";
 
   patches = [
     # Patch the firewall script so we can run it within the systemd start script
@@ -62,13 +56,10 @@ stdenv.mkDerivation {
   '';
 
   buildInputs = [
-    avahi # TODO: upstream deprecated OTBR_MDNS=avahi after this release (https://github.com/openthread/ot-br-posix/pull/3240)
     systemdLibs
     protobuf
     jsoncpp
     boost
-    libnetfilter_queue
-    libnfnetlink
     dbus
     (lib.getBin bashNonInteractive)
   ];
@@ -85,6 +76,9 @@ stdenv.mkDerivation {
     (lib.cmakeBool "Boost_USE_STATIC_LIBS" false)
     (lib.cmakeBool "OTBR_REST" true)
 
+    # OpenThread's built-in mDNS publisher (upstream default). No Avahi daemon needed.
+    (lib.cmakeFeature "OTBR_MDNS" "openthread")
+
     (lib.cmakeBool "OTBR_WEB" true)
     (lib.cmakeBool "OTBR_NAT64" true)
     (lib.cmakeBool "OTBR_BACKBONE_ROUTER" true)
@@ -93,9 +87,12 @@ stdenv.mkDerivation {
     (lib.cmakeBool "OTBR_TREL" true)
 
     (lib.cmakeFeature "OTBR_VERSION" version)
-    (lib.cmakeBool "OTBR_DNSSD_DISCOVERY_PROXY" true)
-    (lib.cmakeBool "OTBR_SRP_ADVERTISING_PROXY" true)
-    (lib.cmakeBool "OTBR_DUA_ROUTING" true)
+    # otbr-agent aborts on startup with "Vendor name must be set." unless a vendor
+    # and product name are baked in at build time.
+    (lib.cmakeFeature "OTBR_VENDOR_NAME" "NixOS")
+    (lib.cmakeFeature "OTBR_PRODUCT_NAME" "OpenThread Border Router")
+    # OTBR_MDNS=openthread turns on the OT-core advertising and discovery proxies by default.
+    # The discovery proxy gives us the DNS-SD server OTBR_DNS_UPSTREAM_QUERY needs.
     (lib.cmakeBool "OTBR_DNS_UPSTREAM_QUERY" true)
 
     (lib.cmakeBool "OT_CHANNEL_MANAGER" true)


### PR DESCRIPTION
Updates ot-br-posix to the 2026.06.0 release. Switches the mDNS backend to OpenThread's built-in publisher, since `OTBR_MDNS=avahi` was removed upstream. avahi and the netfilter inputs are dropped, and the NixOS module no longer enables avahi.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
