### PR TITLE
amrwb: migrate to finalAttrs, fix broken url, add strictDeps and structuredAttrs

### DIFF
--- a/pkgs/by-name/am/amrwb/package.nix
+++ b/pkgs/by-name/am/amrwb/package.nix
@@ -5,18 +5,21 @@
   unzip,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "amrwb";
   version = "11.0.0.0";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   srcAmr = fetchurl {
     url = "http://www.3gpp.org/ftp/Specs/archive/26_series/26.204/26204-b00.zip";
-    sha256 = "1v4zhs6f1mf1xkrzhljh05890in0rpr5d5pcak9h4igxhd2c91f8";
+    hash = "sha256-yIXERIP9RQLTVOyWVvLNwEaQUAFQUvjz7MHV4IyGn+w=";
   };
 
   src = fetchurl {
-    url = "http://www.penguin.cz/~utx/ftp/amr/amrwb-${version}.tar.bz2";
-    sha256 = "1p6m9nd08mv525w14py9qzs9zwsa5i3vxf5bgcmcvc408jqmkbsw";
+    url = "https://slackware.uk/sbosrcarch/by-name/audio/amrwb/amrwb-${finalAttrs.version}.tar.bz2";
+    hash = "sha256-XK9ZsUSAsM0qe6u4vkcsSvOf9MfJXxJ4EWVXBJpN1dw=";
   };
 
   nativeBuildInputs = [ unzip ];
@@ -38,4 +41,4 @@ stdenv.mkDerivation rec {
     # some countries, not redistributable.
     license = lib.licenses.unfree;
   };
-}
+})


### PR DESCRIPTION
migrate to finalAttrs, fix fetcher URL, move out of treewide PR #524874 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
