### PR TITLE
perl: backport security fixes

### DIFF
--- a/pkgs/development/interpreters/perl/CVE-2026-8376.patch
+++ b/pkgs/development/interpreters/perl/CVE-2026-8376.patch
@@ -1,0 +1,20 @@
+Targeted patch for CVE-2026-8376, based on 5e7f119eb2bb1181be908701f22bf7068e722f1c but avoids changes to t/re/pat_psycho.t as they do not apply cleanly.
+
+diff --git a/regcomp_study.c b/regcomp_study.c
+index b513454a4258..1602663f4b26 100644
+--- a/regcomp_study.c
++++ b/regcomp_study.c
+@@ -2784,6 +2784,13 @@ Perl_study_chunk(pTHX_
+                                                (U8 *) SvEND(data->last_found))
+                                 - (U8*)s;
+                         l -= old;
++
++                        if (l > 0 &&
++                            (mincount >= SSize_t_MAX / (SSize_t)l
++                             || old > SSize_t_MAX - mincount * (SSize_t)l)) {
++                            FAIL("Regexp out of space");
++                        }
++
+                         /* Get the added string: */
+                         last_str = newSVpvn_utf8(s  + old, l, UTF);
+                         last_chrs = UTF ? utf8_length((U8*)(s + old),

--- a/pkgs/development/interpreters/perl/interpreter.nix
+++ b/pkgs/development/interpreters/perl/interpreter.nix
@@ -36,6 +36,8 @@ let
   commonPatches = [
     # Do not look in /usr etc. for dependencies.
     ./no-sys-dirs.patch
+
+    ./CVE-2026-8376.patch
   ]
 
   # Fix build on Solaris on x86_64
@@ -78,6 +80,61 @@ let
   #
   # Some more details: https://arsv.github.io/perl-cross/modules.html
   ++ lib.optional crossCompiling ./cross.patch;
+
+  # Inject fixed CPAN releases for bundled dual-life distributions until the
+  # next perl maintenance release includes them.
+  vendoredPerlDistributions = [
+    {
+      # CVE-2026-7010
+      path = "cpan/HTTP-Tiny";
+      src = fetchurl {
+        url = "mirror://cpan/authors/id/H/HA/HAARG/HTTP-Tiny-0.094.tar.gz";
+        hash = "sha256-poQemfwbVdFd6VlHzL17dnvsxRxxAhl/qPBE333cB0M=";
+      };
+    }
+    {
+      # CVE-2026-3381, CVE-2026-4176
+      path = "cpan/Compress-Raw-Zlib";
+      src = fetchurl {
+        url = "mirror://cpan/authors/id/P/PM/PMQS/Compress-Raw-Zlib-2.222.tar.gz";
+        hash = "sha256-Hf19URplVifIGBXTDTurwo+luIRV/wP4sECZ3LUShrg=";
+      };
+    }
+    {
+      # Runtime dependency of IO-Compress 2.220.
+      path = "cpan/Compress-Raw-Bzip2";
+      src = fetchurl {
+        url = "mirror://cpan/authors/id/P/PM/PMQS/Compress-Raw-Bzip2-2.218.tar.gz";
+        hash = "sha256-iRU+ai69pSNJSTsHT6S3VJ/x+QU952E8GKXgXFtBX6g=";
+      };
+    }
+    {
+      # CVE-2026-48962, CVE-2026-48961, CVE-2026-48959
+      path = "cpan/IO-Compress";
+      src = fetchurl {
+        url = "mirror://cpan/authors/id/P/PM/PMQS/IO-Compress-2.220.tar.gz";
+        hash = "sha256-nZbqKR8sVO82fHOWuFfZO6GsHEsvG84T7Yo+Xz7rtic=";
+      };
+    }
+    {
+      # CVE-2026-42496, CVE-2026-42497, CVE-2026-9538
+      path = "cpan/Archive-Tar";
+      src = fetchurl {
+        url = "mirror://cpan/authors/id/B/BI/BINGOS/Archive-Tar-3.12.tar.gz";
+        hash = "sha256-ARTvObZfSfiWgoOrR3Gdfoj5jXNg/jZJvjMcf1PVgyw=";
+      };
+    }
+  ];
+
+  replaceVendoredPerlDistributions = lib.concatMapStringsSep "\n" (d: ''
+    rm -rf ${d.path}
+    mkdir -p ${d.path}
+
+    tar --strip-components=1 -C ${d.path} -xf ${d.src}
+
+    # Remove executable bits to make t/porting/exec-bit.t happy.
+    find ${d.path} -type f -exec chmod a-x {} +
+  '') vendoredPerlDistributions;
 
   libc = if stdenv.cc.libc or null != null then stdenv.cc.libc else "/usr";
   libcInc = lib.getDev libc;
@@ -136,10 +193,10 @@ stdenv.mkDerivation (
               --replace "/bin/pwd" "$(type -P pwd)"
           ''
       )
-      +
-      # Perl's build system uses the src variable, and its value may end up in
-      # the output in some cases (when cross-compiling)
-      ''
+      + replaceVendoredPerlDistributions
+      + ''
+        # Perl's build system uses the src variable, and its value may end up in
+        # the output in some cases (when cross-compiling).
         unset src
       '';
 


### PR DESCRIPTION
Perl ships with some CPAN modules vendored as "dual-life", this commit inject updated versions certain modules directly from CPAN rather than applying patches from upstream, as they can be tricky to maintain.

It also includes a patch for CVE-2026-8376 which affects 32-bit platforms.

- perl: CVE-2026-8376 
  https://github.com/Perl/perl5/commit/5e7f119eb2bb1181be908701f22bf7068e722f1c

- HTTP-Tiny 0.094: CVE-2026-7010
  https://metacpan.org/release/HAARG/HTTP-Tiny-0.094/changes

- Compress-Raw-Zlib 2.222: CVE-2026-3381, CVE-2026-4176   
  https://metacpan.org/release/PMQS/Compress-Raw-Zlib-2.222/changes

- Compress-Raw-Bzip2 2.218:
  https://metacpan.org/release/PMQS/Compress-Raw-Bzip2-2.218/changes

- IO-Compress 2.220: CVE-2026-48959, CVE-2026-48961, CVE-2026-48962
  https://metacpan.org/release/PMQS/IO-Compress-2.220/changes

- Archive-Tar 3.12: CVE-2026-42496, CVE-2026-42497, CVE-2026-9538
  https://metacpan.org/release/BINGOS/Archive-Tar-3.12/changes

Assisted-by: Codex (OpenAI)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
