### PR TITLE
ansiweather: init at 1.19.0-unstable-2025-12-29

### DIFF
--- a/pkgs/by-name/an/ansiweather/package.nix
+++ b/pkgs/by-name/an/ansiweather/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  curl,
+  jq,
+  bc,
+  coreutils,
+  findutils,
+  gnugrep,
+  gnused,
+  makeWrapper,
+  installShellFiles,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "ansiweather";
+  version = "1.19.0-unstable-2025-12-29";
+
+  src = fetchFromGitHub {
+    owner = "fcambus";
+    repo = "ansiweather";
+    rev = "39f43f31659972415be2d19889f0f9540db752d7";
+    hash = "sha256-buKfpzD4o+iQjX2djF3qF9HMb9qyU9OU5p8VnFxMv8s=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+    installShellFiles
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 ansiweather $out/bin/ansiweather
+
+    installManPage ansiweather.1
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/ansiweather \
+      --set PATH ${
+        lib.makeBinPath [
+          coreutils
+          findutils
+          gnugrep
+          gnused
+          jq
+          bc
+          curl
+        ]
+      }
+  '';
+
+  meta = {
+    description = "Display weather in terminal with ANSI colors and Unicode symbols";
+    homepage = "https://github.com/fcambus/ansiweather";
+    mainProgram = "ansiweather";
+    license = lib.licenses.bsd2;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ castorNova2 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add a package of [ansiweather](https://github.com/fcambus/ansiweather) which is a utility tool for displaying weather information in the terminal with ANSI colors and Unicode symbols. Supports configurable locations, forecasts, units, etc.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
