### PR TITLE
libtexprintf: init at 1.31

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25104,6 +25104,12 @@
     githubId = 2049686;
     name = "Sebastián Estrella";
   };
+  seudonym = {
+    name = "Wahid Khan";
+    email = "wk170179@gmail.com";
+    github = "Seudonym";
+    githubId = 80459261;
+  };
   seven_bear = {
     name = "Edmond Freeman";
     email = "edmondfreeman7@gmail.com";

--- a/pkgs/by-name/li/libtexprintf/package.nix
+++ b/pkgs/by-name/li/libtexprintf/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+}:
+stdenv.mkDerivation {
+  pname = "libtexprintf";
+  version = "1.31+1897783";
+
+  src = fetchFromGitHub {
+    owner = "bartp5";
+    repo = "libtexprintf";
+    rev = "18977837b20649d56a651eb6bf846f1c914db77a";
+    hash = "sha256-OXDcohfSfik0H1MpoznN267OVTYkW75N+TIF6lRRvZ0=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  preCheck = ''
+    patchShebangs .
+  '';
+
+  doCheck = true;
+
+  outputs = [
+    "out"
+    "dev"
+    "man"
+  ];
+
+  meta = {
+    description = "Library providing printf-style formatted output routines with tex-like syntax support";
+    homepage = "https://github.com/bartp5/libtexprintf";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.seudonym ];
+    platforms = lib.platforms.unix;
+    mainProgram = "utftex";
+  };
+}


### PR DESCRIPTION
The package provides a library for pretty-printing mathematical equations in monospace fonts using TeX-like syntax. It includes a CLI tool utftex for the same. It is used by some other projects, including a popular Neovim plugin for rendering markdown.

homepage: https://github.com/bartp5/libtexprintf
(added myself as maintainer, first time contributing)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
