### PR TITLE
git-surgeon: init at 0.1.17

### DIFF
--- a/pkgs/by-name/gi/git-surgeon/package.nix
+++ b/pkgs/by-name/gi/git-surgeon/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  git,
+  nix-update-script,
+  python3,
+  writableTmpDirAsHomeHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "git-surgeon";
+  version = "0.1.17";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "raine";
+    repo = "git-surgeon";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-SeXHYZwhwvkYxFHW694Cp1VKKeehxgOdfKqShuPI7M4=";
+  };
+
+  cargoHash = "sha256-PbhASsdDxmVcIzV+oHIbpX70zjSeNvkwGcbhQRi88rE=";
+
+  nativeCheckInputs = [
+    git
+    (python3.withPackages (p: [
+      p.pytest
+      p.pytest-xdist
+    ]))
+    writableTmpDirAsHomeHook
+  ];
+
+  postCheck = ''
+    export GIT_CONFIG_GLOBAL=$(mktemp)
+    git config --global init.defaultBranch main
+    mkdir -p target/debug
+    ln -s "$(pwd)/target/${stdenv.hostPlatform.rust.rustcTarget}/release/git-surgeon" target/debug/git-surgeon
+    pytest tests/ -x
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Git primitives for autonomous coding agents";
+    homepage = "https://github.com/raine/git-surgeon";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jhol ];
+    mainProgram = "git-surgeon";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
Adds git-surgeon: Git primitives for autonomous coding agents

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
