### PR TITLE
jj-hunk-tool: init at 0.1.0-unstable-2025-05-25

### DIFF
--- a/pkgs/by-name/jj/jj-hunk-tool/package.nix
+++ b/pkgs/by-name/jj/jj-hunk-tool/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  jujutsu,
+  git,
+  writableTmpDirAsHomeHook,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "jj-hunk-tool";
+  version = "0.1.0-unstable-2025-05-25";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "mvzink";
+    repo = "jj-hunk-tool";
+    rev = "4ca39466fe0eaefdb021be09b2d6b059ab375e6a";
+    hash = "sha256-nYQJ8RpONi5P7mrXAxAvNmTrAlcxh/6ykYQCyGb5ahA=";
+  };
+
+  cargoHash = "sha256-qH/R0+urKZX3qtD6wt42hjgBOtu170HaR3SegRNlkh4=";
+
+  nativeCheckInputs = [
+    jujutsu
+    git
+    writableTmpDirAsHomeHook
+  ];
+
+  meta = {
+    description = "Non-interactive hunk-level jj operations";
+    homepage = "https://github.com/mvzink/jj-hunk-tool";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jhol ];
+    mainProgram = "jj-hunk-tool";
+  };
+}


### PR DESCRIPTION
Adds jj-hunk-tool: Non-interactive hunk-level jujutsu operations.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
