### PR TITLE
cc-token: init at unstable-2025-12-04

### DIFF
--- a/pkgs/by-name/cc/cc-token/package.nix
+++ b/pkgs/by-name/cc/cc-token/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+}:
+
+buildGoModule {
+  pname = "cc-token";
+  version = "unstable-2025-12-04";
+
+  src = fetchFromGitHub {
+    owner = "iota-uz";
+    repo = "cc-token";
+    rev = "c833f5739c4f14c7091337d3291176bf566aed73";
+    hash = "sha256-BGeU6ewgoQlZl2LlNpEU2v6pT0wzQmcENnH02jQXpLQ=";
+  };
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  vendorHash = "sha256-isnQwGIFPon1STxHY/X87SYRMz8VqpBOJ0aeUF9hf9o=";
+
+  postInstall = ''
+    export ANTHROPIC_API_KEY=placeholder
+    installShellCompletion --cmd cc-token \
+      --bash <($out/bin/cc-token completion bash) \
+      --zsh  <($out/bin/cc-token completion zsh) \
+      --fish <($out/bin/cc-token completion fish)
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "CLI tool for counting tokens in files using Anthropic's Claude API";
+    homepage = "https://github.com/iota-uz/cc-token";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers._9999years ];
+    mainProgram = "cc-token";
+  };
+}


### PR DESCRIPTION
> CLI tool for counting tokens in files using Anthropic's Claude API 

See: https://github.com/iota-uz/cc-token

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
