### PR TITLE
apache-jena-fuseki: migrate to finalAttrs

### DIFF
--- a/pkgs/by-name/ap/apache-jena-fuseki/package.nix
+++ b/pkgs/by-name/ap/apache-jena-fuseki/package.nix
@@ -10,16 +10,19 @@
   pkgs,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "apache-jena-fuseki";
   version = "5.1.0";
+
   src = fetchurl {
-    url = "mirror://apache/jena/binaries/apache-jena-fuseki-${version}.tar.gz";
+    url = "mirror://apache/jena/binaries/apache-jena-fuseki-${finalAttrs.version}.tar.gz";
     hash = "sha256-GcwXcLVM2txPC+kkHjEIpqK9dTkQEN9Jkka0EaJRO7Q=";
   };
+
   nativeBuildInputs = [
     makeWrapper
   ];
+
   installPhase = ''
     cp -r . "$out"
     chmod +x $out/fuseki
@@ -34,11 +37,13 @@ stdenv.mkDerivation rec {
         ;
     done
   '';
+
   passthru = {
     tests = {
       basic-test = pkgs.callPackage ./basic-test.nix { };
     };
   };
+
   meta = {
     description = "SPARQL server";
     license = lib.licenses.asl20;
@@ -52,4 +57,4 @@ stdenv.mkDerivation rec {
     downloadPage = "https://archive.apache.org/dist/jena/binaries/";
     mainProgram = "fuseki";
   };
-}
+})


### PR DESCRIPTION
migrate to finalAttrs, move out of treewide PR #524874 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
