### PR TITLE
home-assistant-custom-components.blueprints-updater: 2.4.0 -> 2.7.2

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/blueprints-updater/allow-symlinked-blueprints.diff
+++ b/pkgs/servers/home-assistant/custom-components/blueprints-updater/allow-symlinked-blueprints.diff
@@ -1,12 +1,11 @@
 diff --git a/custom_components/blueprints_updater/coordinator.py b/custom_components/blueprints_updater/coordinator.py
-index 9cbbe32..92a5ab5 100644
+index 441b870..54551d1 100644
 --- a/custom_components/blueprints_updater/coordinator.py
 +++ b/custom_components/blueprints_updater/coordinator.py
-@@ -3234,21 +3234,6 @@ def scan_blueprints(
-                         continue
+@@ -3731,19 +3731,6 @@ def scan_blueprints(
  
                      full_path = os.path.join(root, file)
--                    real_full_path = os.path.realpath(full_path)
+                     real_full_path = os.path.realpath(full_path)
 -                    try:
 -                        if (
 -                            os.path.commonpath([real_full_path, real_blueprint_path])
@@ -20,7 +19,6 @@ index 9cbbe32..92a5ab5 100644
 -                    except (ValueError, OSError):
 -                        _LOGGER.warning("Skipping blueprint with invalid path: %s", full_path)
 -                        continue
--
+ 
                      if relative_path := get_blueprint_relative_path(hass, full_path):
                          try:
-                             with open(full_path, encoding="utf-8") as f:

--- a/pkgs/servers/home-assistant/custom-components/blueprints-updater/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/blueprints-updater/package.nix
@@ -13,13 +13,13 @@
 buildHomeAssistantComponent rec {
   owner = "luuquangvu";
   domain = "blueprints_updater";
-  version = "2.4.0";
+  version = "2.7.2";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "blueprints-updater";
     tag = version;
-    hash = "sha256-O5HGjnj9fz+RrCq6sgdYlU1r9qFJhmUdfYWdFrwFngw=";
+    hash = "sha256-qWWb4n20wFiunvjYUFWXnze3kqYF4n2GCNy5Q34+7ao=";
   };
 
   patches = [
@@ -31,10 +31,12 @@ buildHomeAssistantComponent rec {
   postPatch = ''
     # avoid dependency on rather big pytest-timeout
     substituteInPlace pyproject.toml \
-      --replace-fail '"--timeout=60"' ""
+      --replace-fail '"--timeout=60",' ""
   '';
 
   dependencies = [
+    # Uncodumented, but otherwise the home-assistant helpers/httpx_client.py fails like:
+    # ImportError: Using http2=True, but the 'h2' package is not installed. Make sure to install httpx using `pip install httpx[http2]`.
     h2
   ];
 
@@ -46,12 +48,11 @@ buildHomeAssistantComponent rec {
     pytestCheckHook
   ];
 
-  disabledTests = [
+  disabledTestPaths = [
     # pytest-homeassistant-custom-component tries to create temporary directories inside the nix store
-    "test_async_fetch_content_forum_invalid_json_sets_fetch_error"
-    "test_full_update_lifecycle"
-    "test_restore_blueprint_service"
-    "test_update_all_service"
+    "tests/integration/test_init.py::test_full_update_lifecycle"
+    "tests/integration/test_services.py::test_restore_blueprint_service"
+    "tests/integration/test_services.py::test_update_all_service"
   ];
 
   meta = {


### PR DESCRIPTION
Diff: https://github.com/luuquangvu/blueprints-updater/compare/2.4.0...2.7.2

Changelog: https://github.com/luuquangvu/blueprints-updater/releases/tag/2.7.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
