### PR TITLE
Bootstrap rust

### DIFF
--- a/pkgs/development/compilers/mrustc/bootstrap.nix
+++ b/pkgs/development/compilers/mrustc/bootstrap.nix
@@ -4,7 +4,7 @@
   fetchurl,
   mrustc,
   mrustc-minicargo,
-  #llvm_12,
+  llvmPackages_21,
   libffi,
   cmake,
   perl,
@@ -18,11 +18,34 @@
 }:
 
 let
-  mrustcTargetVersion = "1.54";
-  rustcVersion = "1.54.0";
+  # rustc 1.90 builds against LLVM 21, so the codegen backend is pinned to
+  # llvmPackages_21 explicitly. This currently coincides with the Nixpkgs
+  # default `llvmPackages`, but the pin is deliberate and must not be assumed to
+  # track that default: when the default moves ahead, this should stay on
+  # whatever LLVM the targeted rustc supports (bump it together with
+  # `rustcVersion`). mrustc builds rustc's LLVM codegen backend (minicargo
+  # `--features llvm`), so it needs a working llvm-config at build time and links
+  # libLLVM at runtime. Use a shared libLLVM, mirroring rust/1_95.nix's
+  # `llvmSharedFor`.
+  llvmShared = llvmPackages_21.libllvm.override { enableSharedLibraries = true; };
+
+  # mrustc v0.12.0 is tested upstream to fully bootstrap rustc 1.90.0; the mrustc
+  # README phrases this as "fully bootstrap (with a binary-equal 1.91.1) version
+  # 1.90.0". To verify that assertion: build rustc 1.90.0 with mrustc, use that
+  # rustc to build rustc 1.91.1 from source, and check the result is bit-
+  # identical to the official 1.91.1 release (the comparison mrustc's own
+  # bootstrap tests run; the same chain is exercised by dtolnay/bootstrap). Note
+  # this derivation does NOT itself depend on bit-identity -- the rustc it
+  # produces differs from the binary toolchain by construction (e.g. it reports
+  # "built from a source tarball"); the upstream reproduction is only what gives
+  # confidence mrustc compiles rustc faithfully. The per-version source patch
+  # `rustc-1.90.0-src.patch` and `rustc-1.90.0-overrides.toml` ship in the
+  # mrustc tree and are applied/used by the build below.
+  mrustcTargetVersion = "1.90";
+  rustcVersion = "1.90.0";
   rustcSrc = fetchurl {
     url = "https://static.rust-lang.org/dist/rustc-${rustcVersion}-src.tar.gz";
-    sha256 = "0xk9dhfff16caambmwij67zgshd8v9djw6ha0fnnanlv7rii31dc";
+    hash = "sha256-eZqfnLpO1TUeBxBIvPa1VgdV2QCWSN7zOkB91JYfm34=";
   };
   rustcDir = "rustc-${rustcVersion}-src";
   outputDir = "output-${rustcVersion}";
@@ -64,7 +87,7 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [
     # for rustc
-    #llvm_12
+    llvmShared.lib
     libffi
     zlib
     libxml2
@@ -75,8 +98,13 @@ stdenv.mkDerivation rec {
   makeFlags = [
     # Use shared mrustc/minicargo/llvm instead of rebuilding them
     "MRUSTC=${mrustc}/bin/mrustc"
-    #"MINICARGO=${mrustc-minicargo}/bin/minicargo"  # FIXME: we need to rebuild minicargo locally so --manifest-overrides is applied
-    #"LLVM_CONFIG=${llvm_12.dev}/bin/llvm-config"
+    # minicargo is intentionally NOT passed: it is rebuilt in-tree so that
+    # `--manifest-overrides rustc-1.90.0-overrides.toml` is honoured.
+    #"MINICARGO=${mrustc-minicargo}/bin/minicargo"
+    # Point at our LLVM so mrustc does not try to build rustc's vendored LLVM
+    # via cmake (which dontUseCmakeConfigure would break). Because this is an
+    # existing store path, Make treats the prerequisite as satisfied.
+    "LLVM_CONFIG=${llvmShared.dev}/bin/llvm-config"
     "RUSTC_TARGET=${stdenv.targetPlatform.rust.rustcTarget}"
   ];
 
@@ -118,10 +146,15 @@ stdenv.mkDerivation rec {
     runHook postBuild
   '';
 
+  # Bootstrapping rustc 1.90 through mrustc is a multi-hour, many-GB build.
+  requiredSystemFeatures = [ "big-parallel" ];
+
   doCheck = true;
   checkPhase = ''
     runHook preCheck
-    run_rustc/${outputDir}/prefix/bin/hello_world | grep "hello, world"
+    # samples/hello.rs prints "Hello, world!"; match case-insensitively and
+    # echo the output so the smoke test is debuggable.
+    run_rustc/${outputDir}/prefix/bin/hello_world | tee /dev/stderr | grep -iF "hello, world"
     runHook postCheck
   '';
 
@@ -153,24 +186,5 @@ stdenv.mkDerivation rec {
       asl20
     ];
     platforms = [ "x86_64-linux" ];
-    # rustc 1.54 only supports LLVM 12, which was removed from Nixpkgs.
-    # mrustc can bootstrap up to rustc 1.74, which supported LLVM 17,
-    # which has also been removed.
-    #
-    # 1.74 also shipped with the Cranelift backend, so perhaps that
-    # could be used instead? Alternatively, it may be possible to
-    # backport the upstream patches to support LLVM 18 to 1.74.
-    # Assuming LLVM 18 is still in Nixpkgs by the time you read this
-    # comment, anyway. But if not, then maybe mrustc has been updated
-    # to support newer rustc versions? Hope springs eternal.
-    #
-    # (Note that you still have to “draw the rest of the owl” to
-    # bootstrap the chain of rustc versions between this bootstrap
-    # and the version currently used in Nixpkgs, anyway, so this was
-    # already not useful for bootstrapping a Rust compiler for use with
-    # Nixpkgs without a lot of additional work. See Guix’s Rust
-    # bootstrap chain, or the non‐Rust minimal bootstrap in Guix and
-    # Nixpkgs, for inspiration.)
-    broken = true;
   };
 }

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -2,10 +2,21 @@
   rustcVersion,
   rustcSha256,
   enableRustcDev ? true,
+  # Build a reduced compiler (host target only, no docs/rustc-dev). Set for the
+  # intermediate links of the mrustc source-bootstrap chain.
+  minimal ? false,
   bootstrapVersion,
   bootstrapHashes,
   selectRustPackage,
   rustcPatches ? [ ],
+  # When non-null, bootstrap this rustc from the given { rustc; cargo; } set (the
+  # previous link in the mrustc source chain) instead of the prebuilt binary
+  # download in `packages.prebuilt`. Only `rustc` and `cargo` are required.
+  bootstrapPackagesOverride ? null,
+  # When non-null, forces cargo's `auditable` flag (the mrustc chain sets it
+  # false). null keeps cargo.nix's default. Avoids pulling the binary-bootstrapped
+  # cargo-auditable into the source-chain closure.
+  cargoAuditable ? null,
   llvmShared,
   llvmSharedForBuild,
   llvmSharedForHost,
@@ -80,6 +91,13 @@ in
         bootstrapRustPackages =
           if fastCross then
             pkgsBuildBuild.rustPackages
+          else if bootstrapPackagesOverride != null then
+            # Source-bootstrap chain link: bootstrap from the previous link's
+            # compiler (or, for the base link, an mrustc-built rustc+cargo)
+            # instead of the prebuilt binary download.
+            self.buildRustPackages.overrideScope (
+              _: _: lib.optionalAttrs (stdenv.buildPlatform == stdenv.hostPlatform) bootstrapPackagesOverride
+            )
           else
             self.buildRustPackages.overrideScope (
               _: _:
@@ -96,7 +114,7 @@ in
         rustc-unwrapped = self.callPackage ./rustc.nix {
           version = rustcVersion;
           sha256 = rustcSha256;
-          inherit enableRustcDev;
+          inherit enableRustcDev minimal;
           inherit
             llvmShared
             llvmSharedForBuild
@@ -120,10 +138,17 @@ in
         };
         cargo =
           if (!fastCross) then
-            self.callPackage ./cargo.nix {
-              # Use boot package set to break cycle
-              rustPlatform = bootRustPlatform;
-            }
+            self.callPackage ./cargo.nix (
+              {
+                # Use boot package set to break cycle
+                rustPlatform = bootRustPlatform;
+              }
+              # The default cargo-auditable is built with the binary-bootstrapped
+              # rustc; the mrustc source chain disables auditable to keep its
+              # closure free of any prebuilt rust binary. `null` keeps cargo.nix's
+              # own default (auditable iff cargo-auditable is not broken).
+              // lib.optionalAttrs (cargoAuditable != null) { auditable = cargoAuditable; }
+            )
           else
             self.callPackage ./cargo_cross.nix { };
         inherit cargo-auditable;

--- a/pkgs/development/compilers/rust/make-rustc-chain.nix
+++ b/pkgs/development/compilers/rust/make-rustc-chain.nix
@@ -1,0 +1,178 @@
+# Full-source Rust bootstrap chain via mrustc.
+#
+# mrustc (a C++ Rust compiler) builds a minimal rustc 1.90.0; that compiler then
+# builds rustc 1.90.0 from source, which bootstraps 1.91.1, and so on up to the
+# version used at the current rust path (1.96.0). No prebuilt rustc binary is
+# ever downloaded — the resulting compiler's closure contains no binaryNativeCode
+# rust toolchain.
+#
+# Each link reuses ./default.nix (and thus ./rustc.nix) the same way the
+# binary-bootstrapped compiler does. That binary bootstrap was the Nixpkgs
+# default up to at least 26.05, and stays the path on every platform mrustc
+# cannot bootstrap (see all-packages.nix). The differences here are:
+#   * its bootstrap compiler is the *previous* link (mrustc for the base link),
+#     via default.nix's `bootstrapPackagesOverride`;
+#   * intermediate links build with `minimal = true` (host target only, no docs,
+#     no rustc-dev); only the final link does the full build.
+#
+# `mrustcStage0` must be an attrset `{ rustc; cargo; }` exposing rustc 1.90.0 and
+# a matching cargo (e.g. `{ rustc = mrustc-bootstrap; cargo = mrustc-bootstrap; }`,
+# since that derivation provides both `bin/rustc` and `bin/cargo`).
+#
+# The whole chain is pinned to LLVM 21 (the version rustc 1.90–1.96 build with),
+# independent of the Nixpkgs default `llvmPackages`. It currently coincides with
+# that default, but the pin must move with the rustc versions, not with the
+# default.
+#
+# Currently x86_64-linux only, because that is the one target mrustc fully
+# bootstraps and CI-tests (its other targets are secondary and not bootstrap-
+# tested). This is a limitation of the entry point, not of the design: in
+# principle the x86_64-linux source-bootstrapped rustc could cross-compile rustc
+# for other hosts, removing the binary bootstrap there too. That work is out of
+# scope here, so non-x86_64-linux keeps the binary bootstrap.
+{
+  lib,
+  stdenv,
+  newScope,
+  callPackage,
+  pkgsBuildBuild,
+  pkgsBuildHost,
+  pkgsBuildTarget,
+  pkgsHostTarget,
+  pkgsTargetTarget,
+  makeRustPlatform,
+  wrapRustcWith,
+  llvmPackages_21,
+  cargo-auditable,
+  mrustcStage0,
+}@args:
+
+let
+  # Pin the whole chain to LLVM 21 regardless of the default `llvmPackages`.
+  llvmPackages = llvmPackages_21;
+
+  llvmSharedFor = pkgSet: pkgSet.llvmPackages_21.libllvm.override { enableSharedLibraries = true; };
+
+  # rustc.nix reads `targetPlatforms`/`targetPlatformsWithHostTools`/
+  # `badTargetPlatforms` off its bootstrap compiler for the built rustc's own
+  # passthru. mrustc-bootstrap is a plain derivation, so graft on the canonical
+  # lists — defined once in rust/binary.nix and carried by the prebuilt bootstrap
+  # compiler. They then propagate down the whole chain via each link's passthru
+  # and the rustc wrapper, while mrustc's own meta.platforms keeps the chain
+  # marked x86_64-linux-only.
+  baseRustc = mrustcStage0.rustc // {
+    inherit (pkgsBuildHost.rust_1_96.packages.prebuilt.rustc-unwrapped)
+      targetPlatforms
+      targetPlatformsWithHostTools
+      badTargetPlatforms
+      ;
+  };
+
+  # Ordered chain, base first. Each `hash` is of
+  # https://static.rust-lang.org/dist/rustc-<version>-src.tar.gz
+  # (fetch with `nix-prefetch-url --type sha256 <url>`).
+  versions = [
+    {
+      version = "1.90.0";
+      hash = "sha256-eZqfnLpO1TUeBxBIvPa1VgdV2QCWSN7zOkB91JYfm34=";
+    }
+    {
+      version = "1.91.1";
+      hash = "sha256-ONziBdOfYVcSYfBEQjehzp7+y5cOdg2OxNlXr1tEVyM=";
+    }
+    {
+      version = "1.92.0";
+      hash = "sha256-ng0sp1x+J1/cdYJVv0sDr7PWXRVDYCdGkHyTO2kBw7g=";
+    }
+    {
+      version = "1.93.1";
+      hash = "sha256-TCMKRLPZyfPO+VCUNxn4OABY0nyR/aXjapqUfvAT4B8=";
+    }
+    {
+      version = "1.94.1";
+      hash = "sha256-TBQqYl8S4833FsaK4Z9PYNmK0UgmJ7CFebFYOOla1RQ=";
+    }
+    {
+      version = "1.95.0";
+      hash = "sha256-6puCqD5GlnU3w1ac6db6FoEcBDqW5lE3bDSecCQcpRU=";
+    }
+    {
+      # Same source tarball as the binary-bootstrapped rust/1_96.nix.
+      version = "1.96.0";
+      hash = "sha256-6QqesVOylIr6yEDb6dd7ZON2cG8oZDh+53F/dFAEO0Q=";
+    }
+  ];
+
+  # "1.90.0" -> "rust_1_90", "1.94.1" -> "rust_1_94"
+  attrName = version: "rust_" + lib.concatStringsSep "_" (lib.take 2 (lib.splitString "." version));
+
+  nLinks = lib.length versions;
+
+  mkLink =
+    index: entry:
+    let
+      inherit (entry) version;
+      isFinal = index == nLinks - 1;
+      isBase = index == 0;
+      prevAttr = attrName (lib.elemAt versions (index - 1)).version;
+      # base link bootstraps from mrustc; later links from the previous link.
+      override =
+        if isBase then
+          {
+            rustc = baseRustc;
+            inherit (mrustcStage0) cargo;
+          }
+        else
+          {
+            inherit (chain.${prevAttr}.packages.stable) rustc cargo;
+          };
+    in
+    import ./default.nix
+      {
+        rustcVersion = version;
+        rustcSha256 = entry.hash;
+
+        # Intermediate links only need to compile the next rustc.
+        minimal = !isFinal;
+        enableRustcDev = isFinal;
+
+        # Keep the whole chain free of the binary-bootstrapped cargo-auditable.
+        cargoAuditable = false;
+
+        llvmSharedForBuild = llvmSharedFor pkgsBuildBuild;
+        llvmSharedForHost = llvmSharedFor pkgsBuildHost;
+        llvmSharedForTarget = llvmSharedFor pkgsBuildTarget;
+        llvmShared = llvmSharedFor pkgsHostTarget;
+        inherit llvmPackages cargo-auditable;
+
+        bootstrapPackagesOverride = override;
+
+        # Only consulted for `buildRustPackages` (build-time proc-macro/build.rs
+        # tooling) and cross; the override above is what actually breaks the
+        # bootstrap cycle for native build==host. Point each link at itself,
+        # mirroring rust/1_95.nix's `selectRustPackage = pkgs: pkgs.rust_1_95`.
+        selectRustPackage = pkgs: pkgs.rustcBootstrapChain.${attrName version};
+
+        # Unused by chain links (the override path wins), but default.nix's
+        # lazily-evaluated `packages.prebuilt` still references them.
+        bootstrapVersion = version;
+        bootstrapHashes = { };
+      }
+      (
+        removeAttrs args [
+          "llvmPackages_21"
+          "cargo-auditable"
+          "pkgsHostTarget"
+          "mrustcStage0"
+        ]
+      );
+
+  chain = lib.listToAttrs (
+    lib.imap0 (index: entry: lib.nameValuePair (attrName entry.version) (mkLink index entry)) versions
+  );
+in
+chain
+// {
+  # The fully source-bootstrapped compiler equivalent to the current rust path.
+  final = chain.${attrName (lib.last versions).version};
+}

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -29,6 +29,10 @@
   libffi,
   withBundledLLVM ? false,
   enableRustcDev ? true,
+  # Build a reduced compiler suitable only for bootstrapping the next rustc in a
+  # source chain: host target only, no docs, no rustc-dev. Used by the mrustc
+  # bootstrap chain's intermediate links; the final link builds normally.
+  minimal ? false,
   version,
   sha256,
   patches ? [ ],
@@ -151,7 +155,8 @@ stdenv.mkDerivation (finalAttrs: {
       "--target=${
         concatStringsSep "," (
           # Other targets that don't need any extra dependencies to build.
-          optionals (!fastCross) [
+          # Skipped for `minimal` chain links, which only need the host target.
+          optionals (!fastCross && !minimal) [
             "wasm32-unknown-unknown"
             "wasm32v1-none"
             "bpfel-unknown-none"
@@ -234,6 +239,11 @@ stdenv.mkDerivation (finalAttrs: {
       # Since fastCross only builds std, it doesn't make sense (and
       # doesn't work) to build a linker.
       "--disable-llvm-bitcode-linker"
+    ]
+    ++ optionals minimal [
+      # Intermediate chain links only need a working host compiler to
+      # bootstrap the next rustc version; skip docs to save build time.
+      "--disable-docs"
     ]
     ++ optionals (!fastCross && stdenv.targetPlatform.config != "wasm32-unknown-none") [
       # See https://github.com/rust-lang/rust/issues/132802
@@ -419,7 +429,12 @@ stdenv.mkDerivation (finalAttrs: {
   setOutputFlags = false;
 
   postInstall =
-    lib.optionalString (enableRustcDev && !fastCross) ''
+    lib.optionalString minimal ''
+      # `minimal` links build with --disable-docs; make sure the doc/man
+      # outputs still exist so Nix does not error on missing outputs.
+      mkdir -p $doc $man
+    ''
+    + lib.optionalString (enableRustcDev && !fastCross && !minimal) ''
       # install rustc-dev components. Necessary to build rls, clippy...
       python x.py dist rustc-dev
       tar xf build/dist/rustc-dev*tar.gz
@@ -469,7 +484,9 @@ stdenv.mkDerivation (finalAttrs: {
       lib.licenses.mit
       lib.licenses.asl20
     ];
-    platforms = rustc.targetPlatformsWithHostTools;
+    # The bootstrap compiler may run on fewer platforms than the rustc it can
+    # target, e.g. the mrustc source bootstrap chain is x86_64-linux-only.
+    platforms = rustc.meta.platforms or rustc.targetPlatformsWithHostTools;
     # If rustc can't target a platform, we also can't build rustc for
     # that platform.
     badPlatforms = rustc.badTargetPlatforms;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4349,14 +4349,19 @@ with pkgs;
   wrapRustc = rustc-unwrapped: wrapRustcWith { inherit rustc-unwrapped; };
 
   rust_1_96 = callPackage ../development/compilers/rust/1_96.nix { };
-  rust = rust_1_96;
+  # On x86_64-linux the default `rust` is the fully source-bootstrapped chain
+  # below (`rustcBootstrapChain.final`). mrustc only bootstraps x86_64-linux, so
+  # every other platform keeps the binary-bootstrapped `rust_1_96`.
+  rust =
+    if stdenv.hostPlatform.system == "x86_64-linux" then rustcBootstrapChain.final else rust_1_96;
 
   mrustc = callPackage ../development/compilers/mrustc { };
   mrustc-minicargo = callPackage ../development/compilers/mrustc/minicargo.nix { };
   mrustc-bootstrap = callPackage ../development/compilers/mrustc/bootstrap.nix { };
 
   # Full-source Rust bootstrap chain: mrustc -> rustc 1.90.0 -> ... -> 1.96.0.
-  # Opt-in; the default `rustc`/`rustPackages` above remain binary-bootstrapped.
+  # On x86_64-linux this is the default `rust`/`rustPackages` (wired above and
+  # below); `rust_1_96` stays available as the binary-bootstrapped variant.
   rustcBootstrapChain = callPackage ../development/compilers/rust/make-rustc-chain.nix {
     mrustcStage0 = {
       rustc = mrustc-bootstrap;
@@ -4364,7 +4369,7 @@ with pkgs;
     };
   };
   rustPackages_1_96 = rust_1_96.packages.stable;
-  rustPackages = rustPackages_1_96;
+  rustPackages = rust.packages.stable;
 
   inherit (rustPackages)
     cargo

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4355,6 +4355,14 @@ with pkgs;
   mrustc-minicargo = callPackage ../development/compilers/mrustc/minicargo.nix { };
   mrustc-bootstrap = callPackage ../development/compilers/mrustc/bootstrap.nix { };
 
+  # Full-source Rust bootstrap chain: mrustc -> rustc 1.90.0 -> ... -> 1.96.0.
+  # Opt-in; the default `rustc`/`rustPackages` above remain binary-bootstrapped.
+  rustcBootstrapChain = callPackage ../development/compilers/rust/make-rustc-chain.nix {
+    mrustcStage0 = {
+      rustc = mrustc-bootstrap;
+      cargo = mrustc-bootstrap;
+    };
+  };
   rustPackages_1_96 = rust_1_96.packages.stable;
   rustPackages = rustPackages_1_96;
 


### PR DESCRIPTION
## Things done

Bootstrap rust from mrustc -> rust 1.90 -> ... 1.96
I don't know if arm works on linux, README does not deny it either. We can enable more platforms as this is tested.

Did some general testing on the packages and they work fine. Causes 31k packages to be recompiled, therefor staging.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [o] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

i let review run for a few hours without errors.