### PR TITLE
python3Packages.executor: migrate to pyproject and fix for python3.13+

### DIFF
--- a/pkgs/development/python-modules/executor/default.nix
+++ b/pkgs/development/python-modules/executor/default.nix
@@ -2,8 +2,8 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
   setuptools,
-  pythonAtLeast,
   coloredlogs,
   humanfriendly,
   property-manager,
@@ -19,15 +19,21 @@ buildPythonPackage (finalAttrs: {
   version = "23.2";
   pyproject = true;
 
-  # pipes is removed in python 3.13
-  disabled = pythonAtLeast "3.13";
-
   src = fetchFromGitHub {
     owner = "xolox";
     repo = "python-executor";
     tag = finalAttrs.version;
     hash = "sha256-Gjv+sUtnP11cM8GMGkFzXHVx0c2XXSU56L/QwoQxINc=";
   };
+
+  patches = [
+    # https://github.com/xolox/python-executor/pull/26
+    (fetchpatch2 {
+      name = "python313-compat.patch";
+      url = "https://github.com/xolox/python-executor/commit/4c5f4b44543bfb48ad790c440d1d7d0933e12499.patch?full_index=1";
+      hash = "sha256-pfWdLaREikzBaey75Tb+GiE+pUCl1h2OmsjlpzKOlno=";
+    })
+  ];
 
   build-system = [
     setuptools

--- a/pkgs/development/python-modules/executor/default.nix
+++ b/pkgs/development/python-modules/executor/default.nix
@@ -14,7 +14,7 @@
   virtualenv,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "executor";
   version = "23.2";
   pyproject = true;
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "xolox";
     repo = "python-executor";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-Gjv+sUtnP11cM8GMGkFzXHVx0c2XXSU56L/QwoQxINc=";
   };
 
@@ -59,11 +59,11 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/xolox/python-executor/blob/${version}/CHANGELOG.rst";
+    changelog = "https://github.com/xolox/python-executor/blob/${finalAttrs.version}/CHANGELOG.rst";
     description = "Programmer friendly subprocess wrapper";
     mainProgram = "executor";
     homepage = "https://github.com/xolox/python-executor";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ eyjhb ];
   };
-}
+})

--- a/pkgs/development/python-modules/executor/default.nix
+++ b/pkgs/development/python-modules/executor/default.nix
@@ -17,7 +17,7 @@
 buildPythonPackage rec {
   pname = "executor";
   version = "23.2";
-  format = "setuptools";
+  pyproject = true;
 
   # pipes is removed in python 3.13
   disabled = pythonAtLeast "3.13";


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974
- There a multiple open PRs upstream to fix compatibility with python 3.13, the diff used here is taken from https://github.com/xolox/python-executor/pull/26
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
