### PR TITLE
rns: add optional dependency lxmf

### DIFF
--- a/pkgs/by-name/rn/rns/package.nix
+++ b/pkgs/by-name/rn/rns/package.nix
@@ -1,1 +1,20 @@
-{ python3Packages }: with python3Packages; toPythonApplication rns
+{
+  python3Packages,
+}:
+
+let
+  pythonPackages = python3Packages.overrideScope (
+    self: super: {
+      lxmf = super.lxmf.override {
+        propagateRns = false;
+      };
+    }
+  );
+in
+pythonPackages.toPythonApplication (
+  pythonPackages.rns.overridePythonAttrs (old: {
+    dependencies = old.dependencies ++ [
+      pythonPackages.lxmf
+    ];
+  })
+)

--- a/pkgs/development/python-modules/lxmf/default.nix
+++ b/pkgs/development/python-modules/lxmf/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  qrcode,
   rns,
   setuptools,
   versionCheckHook,
@@ -24,7 +25,10 @@ buildPythonPackage (finalAttrs: {
 
   pythonRelaxDeps = [ "rns" ];
 
-  dependencies = [ rns ];
+  dependencies = [
+    qrcode
+    rns
+  ];
 
   pythonImportsCheck = [ "LXMF" ];
 

--- a/pkgs/development/python-modules/lxmf/default.nix
+++ b/pkgs/development/python-modules/lxmf/default.nix
@@ -2,6 +2,8 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  # rns optionally depends on lxmf but we can't have two versions of rns in a closure
+  propagateRns ? false,
   qrcode,
   rns,
   setuptools,
@@ -25,14 +27,22 @@ buildPythonPackage (finalAttrs: {
 
   pythonRelaxDeps = [ "rns" ];
 
+  buildInputs = lib.optionals (!propagateRns) [
+    rns
+  ];
+
   dependencies = [
     qrcode
+  ]
+  ++ lib.optionals propagateRns [
     rns
   ];
 
   pythonImportsCheck = [ "LXMF" ];
 
-  nativeCheckInputs = [ versionCheckHook ];
+  nativeCheckInputs = lib.optionals propagateRns [
+    versionCheckHook
+  ];
 
   meta = {
     description = "Lightweight Extensible Message Format for Reticulum";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
