### PR TITLE
qt6Packages: define with callPackage

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6917,18 +6917,7 @@ with pkgs;
 
   qt5 = recurseIntoAttrs (__splicedPackages.callPackage ../development/libraries/qt-5/5.15 { });
 
-  libsForQt5 = recurseIntoAttrs (
-    import ./qt5-packages.nix {
-      inherit
-        lib
-        config
-        __splicedPackages
-        makeScopeWithSplicing'
-        generateSplicesForMkScope
-        pkgsHostTarget
-        ;
-    }
-  );
+  libsForQt5 = recurseIntoAttrs (callPackage ./qt5-packages.nix { });
 
   qtEnv = qt5.env;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6934,20 +6934,7 @@ with pkgs;
 
   qt6 = recurseIntoAttrs (callPackage ../development/libraries/qt-6 { });
 
-  qt6Packages = recurseIntoAttrs (
-    import ./qt6-packages.nix {
-      inherit
-        lib
-        config
-        __splicedPackages
-        makeScopeWithSplicing'
-        generateSplicesForMkScope
-        pkgsHostTarget
-        kdePackages
-        ;
-      inherit stdenv;
-    }
-  );
+  qt6Packages = recurseIntoAttrs (callPackage ./qt6-packages.nix { });
 
   readline70 = callPackage ../development/libraries/readline/7.0.nix { };
 

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -10,15 +10,12 @@
   __splicedPackages,
   makeScopeWithSplicing',
   generateSplicesForMkScope,
-  pkgsHostTarget,
+  # Make it possible to override this
+  qt5,
 }:
 
 let
   pkgs = __splicedPackages;
-  # qt5 set should not be pre-spliced to prevent spliced packages being a part of an unspliced set
-  # 'pkgsCross.aarch64-multiplatform.pkgsBuildTarget.targetPackages.libsForQt5.qtbase' should not have a `__spliced` but if qt5 is pre-spliced then it will have one.
-  # pkgsHostTarget == pkgs
-  qt5 = pkgsHostTarget.qt5;
 in
 
 makeScopeWithSplicing' {

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -10,7 +10,6 @@
   __splicedPackages,
   makeScopeWithSplicing',
   generateSplicesForMkScope,
-  stdenv,
   pkgsHostTarget,
   kdePackages,
 }:

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -10,16 +10,13 @@
   __splicedPackages,
   makeScopeWithSplicing',
   generateSplicesForMkScope,
-  pkgsHostTarget,
+  # Allow to override qt6 packages used within
+  qt6,
   kdePackages,
 }:
 
 let
   pkgs = __splicedPackages;
-  # qt6 set should not be pre-spliced to prevent spliced packages being a part of an unspliced set
-  # 'pkgsCross.aarch64-multiplatform.pkgsBuildTarget.targetPackages.qt6Packages.qtbase' should not have a `__spliced` but if qt6 is pre-spliced then it will have one.
-  # pkgsHostTarget == pkgs
-  qt6 = pkgsHostTarget.qt6;
 in
 
 makeScopeWithSplicing' {


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test