### PR TITLE
libjson-rpc-cpp: add support for darwin

### DIFF
--- a/pkgs/by-name/li/libjson-rpc-cpp/package.nix
+++ b/pkgs/by-name/li/libjson-rpc-cpp/package.nix
@@ -11,6 +11,7 @@
   hiredis,
   jsoncpp,
   libmicrohttpd,
+  patchelf,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -30,6 +31,9 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     cmake
     doxygen
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    patchelf
   ];
 
   buildInputs = [
@@ -70,32 +74,41 @@ stdenv.mkDerivation (finalAttrs: {
   configurePhase = ''
     runHook preConfigure
     cmake .. -DCMAKE_INSTALL_PREFIX=$(pwd)/Install \
-             -DCMAKE_BUILD_TYPE=Release
+             -DCMAKE_INSTALL_LIBDIR=lib \
+             -DCMAKE_BUILD_TYPE=Release \
+             -DWITH_COVERAGE=OFF \
+             ${lib.optionalString stdenv.hostPlatform.isDarwin "-DCMAKE_INSTALL_NAME_DIR=$out/lib -DCMAKE_INSTALL_RPATH=$out/lib"}
     runHook postConfigure
   '';
 
-  preInstall = ''
-    function fixRunPath {
-      p=$(patchelf --print-rpath $1)
-      q="$p:${
-        lib.makeLibraryPath [
-          jsoncpp
-          argtable
-          libmicrohttpd
-          curl
-        ]
-      }:$out/lib"
-      patchelf --set-rpath $q $1
-    }
-
-    mkdir -p $out
-  '';
+  preInstall =
+    lib.optionalString stdenv.hostPlatform.isLinux ''
+      function fixRunPath {
+        p=$(patchelf --print-rpath $1)
+        q="$p:${
+          lib.makeLibraryPath [
+            jsoncpp
+            argtable
+            libmicrohttpd
+            curl
+          ]
+        }:$out/lib"
+        patchelf --set-rpath $q $1
+      }
+    ''
+    + ''
+      mkdir -p $out
+    '';
 
   postInstall = ''
-    sed -i -re "s#-([LI]).*/Build/Install(.*)#-\1$out\2#g" Install/lib64/pkgconfig/*.pc
-    for f in Install/lib64/*.so* $(find Install/bin -executable -type f); do
+    sed -i -re "s#-([LI]).*/Build/Install(.*)#-\1$out\2#g" Install/lib*/pkgconfig/*.pc
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    for f in Install/lib*/*.so* $(find Install/bin -executable -type f); do
       fixRunPath $f
     done
+  ''
+  + ''
     cp -r Install/* $out
   '';
 
@@ -110,7 +123,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "jsonrpcstub";
     homepage = "https://github.com/cinemast/libjson-rpc-cpp";
     license = lib.licenses.mit;
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     maintainers = with lib.maintainers; [ robertrichter ];
   };


### PR DESCRIPTION
Update package `libjson-rpc-cpp` to build on darwin systems.

This patch removes linux-specific `patchelf` fixes.

It also adds the `-DWITH_COVERAGE=OFF` build flag.
This is not strictly required, but a nice to have for consumers to emit less noise when using the library.

This builds correctly on `aarch64-darwin` and was used to build [bitcoin-api-cpp](https://github.com/hkalodner/bitcoin-api-cpp/tree/952bef34a7ad63f752982afcc6231013db7a19dd) which is a dependency of [Blocksci](https://github.com/ClubeBitcoinUnB/BlockSci).
The tool can correctly access the `bitcoind` rpc, which gives me strong confidence this build is working well.

<details><summary>Basic checks</summary>
<p>

❯ nix build .#libjson-rpc-cpp -L
❯ ./result/bin/jsonrpcstub --help
Usage: ./result/bin/jsonrpcstub  [-hv] [<specfile>] [--version] [--cpp-server=<namespace::classname>] [--cpp-server-file=<filename.h>] [--cpp-client=<namespace::classname>] [--cpp-client-file=<filename.h>] [--js-client=<classname>] [--js-client-file=<filename.js>] [--py-client=<classname>] [--py-client-file=<filename.py>]

  <specfile>                path of input specification file
  -h, --help                print this help and exit
      --version             print version and exit
  -v, --verbose             print more information about what is happening
      --cpp-server=<namespace::classname>
                            name of the C++ server stub class
      --cpp-server-file=<filename.h>
                            name of the C++ server stub file
      --cpp-client=<namespace::classname>
                            name of the C++ client stub class
      --cpp-client-file=<filename.h>
                            name of the C++ client stub file
      --js-client=<classname>
                            name of the JavaScript client stub class
      --js-client-file=<filename.js>
                            name of the JavaScript client stub file
      --py-client=<classname>
                            name of the Python client stub class
      --py-client-file=<filename.py>
                            name of the Python client stub file

❯ ./result/bin/jsonrpcstub --version
jsonrpcstub version 1.4.1
❯ otool -L ./result/bin/jsonrpcstub
./result/bin/jsonrpcstub:
        /nix/store/kbnjamqwml6jrfxjpykqra8s93asmggy-libjson-rpc-cpp-1.4.1/lib/libjsonrpccpp-stub.1.dylib (compatibility version 1.0.0, current version 1.4.1)
        /nix/store/kbnjamqwml6jrfxjpykqra8s93asmggy-libjson-rpc-cpp-1.4.1/lib/libjsonrpccpp-common.1.dylib (compatibility version 1.0.0, current version 1.4.1)
        /nix/store/yv01s1m6dd69ggzs76ngdzm1sfrcbasj-jsoncpp-1.9.7/lib/libjsoncpp.27.dylib (compatibility version 27.0.0, current version 1.9.7)
        /nix/store/gi13rajhlvhnc0zgsff0dzidfgg3pkyl-argtable-3.3.1/lib/libargtable3.0.dylib (compatibility version 0.0.0, current version 0.0.0)
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 2100.43.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1345.100.2)
❯ PKG_CONFIG_PATH="$PWD/result/lib/pkgconfig" \
    nix shell .#pkg-config --command pkg-config --cflags --libs libjsonrpccpp-stub
-I/nix/store/kbnjamqwml6jrfxjpykqra8s93asmggy-libjson-rpc-cpp-1.4.1/include -L/nix/store/kbnjamqwml6jrfxjpykqra8s93asmggy-libjson-rpc-cpp-1.4.1/lib -ljsoncpp -ljsonrpccpp-common

</p>
</details> 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
