### PR TITLE
python3Packages.update-dotdee: modernize and migrate to pyproject and add changelog

### DIFF
--- a/pkgs/development/python-modules/update-dotdee/default.nix
+++ b/pkgs/development/python-modules/update-dotdee/default.nix
@@ -1,29 +1,35 @@
 {
   lib,
   buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+
+  setuptools,
   coloredlogs,
   executor,
-  fetchFromGitHub,
   humanfriendly,
   naturalsort,
   property-manager,
-  pytestCheckHook,
   six,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "update-dotdee";
   version = "6.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "xolox";
     repo = "python-update-dotdee";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-2k7FdgWM0ESHQb2za87yhXGaR/rbMYLVcv10QexUH1A=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
     coloredlogs
     executor
     humanfriendly
@@ -36,7 +42,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace tox.ini \
-      --replace " --cov --showlocals --verbose" ""
+      --replace-fail " --cov --showlocals --verbose" ""
   '';
 
   pythonImportsCheck = [ "update_dotdee" ];
@@ -53,4 +59,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ eyjhb ];
   };
-}
+})

--- a/pkgs/development/python-modules/update-dotdee/default.nix
+++ b/pkgs/development/python-modules/update-dotdee/default.nix
@@ -56,6 +56,7 @@ buildPythonPackage (finalAttrs: {
     description = "Generic modularized configuration file manager";
     mainProgram = "update-dotdee";
     homepage = "https://github.com/xolox/python-update-dotdee";
+    changelog = "https://github.com/xolox/python-update-dotdee/blob/${finalAttrs.version}/CHANGELOG.rst";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ eyjhb ];
   };


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974
- https://github.com/NixOS/nixpkgs/pull/528079 is necessary to build with python 3.13
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
