### PR TITLE
apparmor-parser: pick upstream patch for yacc format-security issues

### DIFF
--- a/pkgs/by-name/ap/apparmor-parser/package.nix
+++ b/pkgs/by-name/ap/apparmor-parser/package.nix
@@ -7,6 +7,7 @@
   linuxHeaders ? stdenv.cc.libc.linuxHeaders,
   buildPackages,
   zstd,
+  fetchpatch,
 
   # apparmor deps
   libapparmor,
@@ -34,14 +35,16 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace Makefile \
       --replace-fail "/usr/include/linux/capability.h" "${linuxHeaders}/include/linux/capability.h"
-
-    # strict format check causes yacc auto-generated code to fail.
-    # This is known, see https://gitlab.com/apparmor/apparmor/-/merge_requests/2039
-    # removing the compile-time check here downgrades the issue and allows compilation to succeed
-    substituteInPlace parser.h \
-      --replace-fail 'extern void yyerror(const char *msg, ...) __attribute__((noreturn, format(printf, 1, 2)));' \
-        'extern void yyerror(const char *msg, ...);'
   '';
+
+  patches = [
+    (fetchpatch {
+      # https://gitlab.com/apparmor/apparmor/-/merge_requests/2133
+      # Patches generated yacc parser code to compile with format-security
+      url = "https://gitlab.com/apparmor/apparmor/-/commit/6bdec74d5e74660b97e00b4b8fafc014b05907b7.diff";
+      hash = "sha256-7c5EFByrGIDj2lc31bRttyeybwndDm4iS4qdPMVaG/I=";
+    })
+  ];
 
   nativeBuildInputs = [
     bison


### PR DESCRIPTION
https://gitlab.com/apparmor/apparmor/-/merge_requests/2133

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
