### PR TITLE
pigz: adopt and touch up

### DIFF
--- a/pkgs/by-name/pi/pigz/package.nix
+++ b/pkgs/by-name/pi/pigz/package.nix
@@ -21,6 +21,12 @@ stdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
   enableParallelBuilding = true;
 
+  outputs = [
+    "out"
+    "doc"
+    "man"
+  ];
+
   buildInputs = [ zlib ] ++ lib.optional stdenv.hostPlatform.isLinux util-linux;
 
   makeFlags = [ "CC=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc" ];
@@ -32,9 +38,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     install -Dm755 pigz "$out/bin/pigz"
     ln -s pigz "$out/bin/unpigz"
-    install -Dm755 pigz.1 "$out/share/man/man1/pigz.1"
-    ln -s pigz.1 "$out/share/man/man1/unpigz.1"
-    install -Dm755 pigz.pdf "$out/share/doc/pigz/pigz.pdf"
+    install -Dm755 pigz.1 "$man/share/man/man1/pigz.1"
+    ln -s pigz.1 "$man/share/man/man1/unpigz.1"
+    install -Dm755 pigz.pdf "$doc/share/doc/pigz/pigz.pdf"
 
     runHook postInstall
   '';

--- a/pkgs/by-name/pi/pigz/package.nix
+++ b/pkgs/by-name/pi/pigz/package.nix
@@ -5,6 +5,7 @@
   zlib,
   ncompress,
   which,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -51,6 +52,10 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     homepage = "https://www.zlib.net/pigz/";

--- a/pkgs/by-name/pi/pigz/package.nix
+++ b/pkgs/by-name/pi/pigz/package.nix
@@ -41,7 +41,9 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.zlib.net/pigz/";
     description = "Parallel implementation of gzip for multi-core machines";
     mainProgram = "pigz";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      sandarukasa
+    ];
     license = lib.licenses.zlib;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/pi/pigz/package.nix
+++ b/pkgs/by-name/pi/pigz/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
     "man"
   ];
 
-  makeFlags = [ "CC=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc" ];
+  makeFlags = [ "CC=${lib.getExe stdenv.cc}" ];
   buildInputs = [
     zlib
   ];

--- a/pkgs/by-name/pi/pigz/package.nix
+++ b/pkgs/by-name/pi/pigz/package.nix
@@ -17,6 +17,8 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-PzdxyO4mCg2jE/oBk1MH+NUdWM95wIIIbncBg71BkmQ=";
   };
 
+  strictDeps = true;
+  __structuredAttrs = true;
   enableParallelBuilding = true;
 
   buildInputs = [ zlib ] ++ lib.optional stdenv.hostPlatform.isLinux util-linux;

--- a/pkgs/by-name/pi/pigz/package.nix
+++ b/pkgs/by-name/pi/pigz/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitHub,
   zlib,
-  util-linux,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -27,9 +26,10 @@ stdenv.mkDerivation (finalAttrs: {
     "man"
   ];
 
-  buildInputs = [ zlib ] ++ lib.optional stdenv.hostPlatform.isLinux util-linux;
-
   makeFlags = [ "CC=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc" ];
+  buildInputs = [
+    zlib
+  ];
 
   doCheck = stdenv.hostPlatform.isLinux;
   checkTarget = "tests";

--- a/pkgs/by-name/pi/pigz/package.nix
+++ b/pkgs/by-name/pi/pigz/package.nix
@@ -3,6 +3,8 @@
   stdenv,
   fetchFromGitHub,
   zlib,
+  ncompress,
+  which,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -33,6 +35,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = stdenv.hostPlatform.isLinux;
   checkTarget = "tests";
+  nativeCheckInputs = [
+    which
+    ncompress
+  ];
+
   installPhase = ''
     runHook preInstall
 


### PR DESCRIPTION
Split into separate commits.

I've also build `pkgsCross.aarch64-multiplatform.pigz` and `pkgsCross.mipsel-linux-gnu.pigz`. The former seems to work fine under userspace qemu.

- cc https://github.com/NixOS/nixpkgs/issues/515268
- cc https://github.com/NixOS/nixpkgs/issues/178468
- cc https://github.com/NixOS/nixpkgs/issues/205690


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
