### PR TITLE
balatro: rename conflicting src attribute

### DIFF
--- a/pkgs/by-name/ba/balatro/package.nix
+++ b/pkgs/by-name/ba/balatro/package.nix
@@ -10,7 +10,7 @@
   makeWrapper,
   makeDesktopItem,
   requireFile,
-  src ? null,
+  overriddenSrc ? null,
   withMods ? true,
   withBridgePatch ? true,
   withLinuxPatch ? true,
@@ -20,11 +20,11 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.0.1o";
 
   src =
-    if src != null then
-      src
+    if overriddenSrc != null then
+      overriddenSrc
     else
       requireFile {
-        name = "Balatro-${finalAttrs.version}.exe";
+        name = "Balatro.exe";
         url = "https://store.steampowered.com/app/2379780/Balatro/";
         message = ''
           You must own Balatro in order to install it with Nix.  The Steam,
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
           pass the resulting path to override:
 
             balatro.override {
-              src = /nix/store/g44bp7ymc7qlkfv5f03b55cgs1wdmkzl-com.playstack.balatro.android.apk;
+              overriddenSrc = /nix/store/g44bp7ymc7qlkfv5f03b55cgs1wdmkzl-com.playstack.balatro.android.apk;
             }
         '';
         # Use `nix --extra-experimental-features nix-command hash file --sri --type sha256` to get the correct hash


### PR DESCRIPTION
Fixes #527857

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
