### PR TITLE
kmscon: 10.0.0 -> 10.0.2

### DIFF
--- a/nixos/modules/services/ttys/kmscon.nix
+++ b/nixos/modules/services/ttys/kmscon.nix
@@ -110,15 +110,7 @@ in
             ]);
           options = {
             hwaccel = mkEnableOption "use hardware acceleration for rendering";
-            libseat = mkOption {
-              type = types.bool;
-              default = true;
-              description = ''
-                Whether to use libseat for session management.
-                This is the default for kmscon newer than 10.0.0 and prevents
-                launching another GUI from kmscon by `kmscon-launch-gui`.
-              '';
-            };
+            libseat = mkEnableOption "use libseat for seat management";
           };
         };
       };
@@ -171,7 +163,7 @@ in
           "" # override upstream default with an empty ExecStart
           (builtins.concatStringsSep " " (
             [
-              "${cfg.package}/bin/kmscon"
+              (lib.getExe cfg.package)
               "--configdir"
               configDir
               "--vt=%I"

--- a/pkgs/by-name/km/kmscon/package.nix
+++ b/pkgs/by-name/km/kmscon/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   meson,
   libtsm,
   systemdLibs,
@@ -21,10 +22,10 @@
   libxslt,
   libgbm,
   seatd,
+  dbus,
   ninja,
   check,
   bash,
-  gawk,
   inotify-tools,
   buildPackages,
   nix-update-script,
@@ -32,13 +33,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "kmscon";
-  version = "10.0.0";
+  version = "10.0.2";
 
   src = fetchFromGitHub {
     owner = "kmscon";
     repo = "kmscon";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-M3830e1GzzLT2fhheWwNRkURzYkHv4k8uEMoCqKkjJY=";
+    hash = "sha256-xUqPVI6pX0Chltq4Yt/J2HMv+zQ+IKI6kAbZrkd0wY4=";
   };
 
   strictDeps = true;
@@ -61,6 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
     systemdLibs
     libgbm
     seatd
+    dbus
     check
     # Needed for autoPatchShebangs when strictDeps = true
     bash
@@ -75,12 +77,24 @@ stdenv.mkDerivation (finalAttrs: {
     docbook_xml_dtd_42
     python3
     ncurses
+    zlib
+  ];
+
+  # remove in next release
+  patches = [
+    (fetchpatch2 {
+      name = "fix-use-after-free-in-seat-remove-video.patch";
+      url = "https://github.com/kmscon/kmscon/commit/eb353401f56c21cc602a738c3edaece30e5639d6.patch?full_index=1";
+      hash = "sha256-NbuRfwBHK7AMlBOrzZYp4bbpOeTTEwh+uYtWBzQo2fs=";
+    })
   ];
 
   outputs = [
     "out"
     "man"
   ];
+
+  mesonFlags = [ (lib.mesonEnable "libseat" true) ];
 
   env = {
     PKG_CONFIG_SYSTEMD_SYSTEMDSYSTEMUNITDIR = "${placeholder "out"}/lib/systemd/system";
@@ -92,8 +106,6 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   postFixup = ''
-    substituteInPlace $out/bin/kmscon \
-      --replace-fail "awk" "${lib.getExe gawk}"
     substituteInPlace $out/bin/kmscon-launch-gui \
       --replace-fail "inotifywait" "${lib.getExe' inotify-tools "inotifywait"}"
   '';
@@ -108,7 +120,11 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "kmscon";
     homepage = "https://www.freedesktop.org/wiki/Software/kmscon/";
     changelog = "https://github.com/kmscon/kmscon/releases/tag/v${finalAttrs.version}";
-    license = lib.licenses.mit;
+    license = with lib.licenses; [
+      mit
+      lgpl21Plus
+      ofl
+    ];
     maintainers = with lib.maintainers; [ ccicnce113424 ];
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/kmscon/kmscon/compare/v10.0.0...v10.0.2
Fixes #540854
libseat is disabled now. It breaks kmscon-launch-gui and causes #528069.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
