### PR TITLE
arena: refactor

### DIFF
--- a/pkgs/by-name/ar/arena/package.nix
+++ b/pkgs/by-name/ar/arena/package.nix
@@ -16,83 +16,83 @@
 # any way other than the original release tarball, so we cannot include its NAR
 # into the Nixpkgs channel.
 
-let
+stdenv.mkDerivation (
+  finalAttrs:
+  let
+    inherit (lib) makeLibraryPath;
+    libDir = "lib64";
+  in
+  {
+    pname = "arena";
+    version = "3.10-beta";
 
-  inherit (lib) makeLibraryPath;
-  libDir = "lib64";
+    src = fetchurl {
+      url = "http://www.playwitharena.de/downloads/arenalinux_64bit_${
+        lib.replaceStrings [ "-" ] [ "" ] finalAttrs.version
+      }.tar.gz";
+      hash = "sha256-DbjZ9/68ijlvWp53em1P1Hd0C1p0N7oeiWt9Sp5O698=";
+    };
 
-in
-stdenv.mkDerivation rec {
-  pname = "arena";
-  version = "3.10-beta";
+    # stdenv.cc.cc.lib is in that list to pick up libstdc++.so. Is there a better way?
+    buildInputs = [
+      gtk2-x11
+      glib
+      pango
+      cairo
+      atk
+      gdk-pixbuf
+      libx11
+      (lib.getLib stdenv.cc.cc)
+    ];
 
-  src = fetchurl {
-    url = "http://www.playwitharena.de/downloads/arenalinux_64bit_${
-      lib.replaceStrings [ "-" ] [ "" ] version
-    }.tar.gz";
-    sha256 = "1pzb9sg4lzbbi4gbldvlb85p8xyl9xnplxwyb9pkk2mwzvvxkf0d";
-  };
+    unpackPhase = ''
+      # This is is a tar bomb, i.e. it extract a dozen files and directories to
+      # the top-level, so we must create a sub-directory first.
+      mkdir -p $out/lib/arena-${finalAttrs.version}
+      tar -C $out/lib/arena-${finalAttrs.version} -xf ${finalAttrs.src}
 
-  # stdenv.cc.cc.lib is in that list to pick up libstdc++.so. Is there a better way?
-  buildInputs = [
-    gtk2-x11
-    glib
-    pango
-    cairo
-    atk
-    gdk-pixbuf
-    libx11
-    (lib.getLib stdenv.cc.cc)
-  ];
-
-  unpackPhase = ''
-    # This is is a tar bomb, i.e. it extract a dozen files and directories to
-    # the top-level, so we must create a sub-directory first.
-    mkdir -p $out/lib/${pname}-${version}
-    tar -C $out/lib/${pname}-${version} -xf ${src}
-
-    # Remove executable bits from data files. This matters for the find command
-    # we'll use below to find all bundled engines.
-    chmod -x $out/lib/${pname}-${version}/Engines/*/*.{txt,bin,bmp,zip}
-  '';
-
-  buildPhase = ''
-    # Arena has (at least) two executables plus a couple of bundled chess
-    # engines that we need to patch.
-    exes=( $(find $out -name '*x86_64_linux')
-           $(find $out/lib/${pname}-${version}/Engines -type f -perm /u+x)
-         )
-    for i in "''${exes[@]}"; do
-      # Arminius is statically linked.
-      if [[ $i =~ "Arminius_2017-01-01" ]]; then echo yo $i; continue; fi
-      echo Fixing interpreter and rpath paths in $i ...
-      patchelf                                                                                   \
-        --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)"                                \
-        --set-rpath ${makeLibraryPath buildInputs}:$(cat $NIX_CC/nix-support/orig-cc)/${libDir}  \
-        $i
-    done
-  '';
-
-  installPhase = ''
-    mkdir -p $out/bin
-    ln -s $out/lib/${pname}-${version}/Arena_x86_64_linux $out/bin/arena
-  '';
-
-  dontStrip = true;
-
-  meta = {
-    description = "Chess GUI for analyzing with and playing against various engines";
-    longDescription = ''
-      A free Graphical User Interface (GUI) for chess. Arena assists you in
-      analyzing and playing games as well as in testing chess engines. It runs
-      on Linux or Windows. Arena is compatible to Winboard protocol I, II and
-      UCI protocol I, II. Furthermore, compatible to Chess960, DGT electronic
-      chess board & DGT clocks and much more.
+      # Remove executable bits from data files. This matters for the find command
+      # we'll use below to find all bundled engines.
+      chmod -x $out/lib/arena-${finalAttrs.version}/Engines/*/*.{txt,bin,bmp,zip}
     '';
-    license = lib.licenses.unfree;
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    homepage = "http://www.playwitharena.de";
-    platforms = [ "x86_64-linux" ];
-  };
 
-}
+    buildPhase = ''
+      # Arena has (at least) two executables plus a couple of bundled chess
+      # engines that we need to patch.
+      exes=( $(find $out -name '*x86_64_linux')
+             $(find $out/lib/arena-${finalAttrs.version}/Engines -type f -perm /u+x)
+           )
+      for i in "''${exes[@]}"; do
+        # Arminius is statically linked.
+        if [[ $i =~ "Arminius_2017-01-01" ]]; then echo yo $i; continue; fi
+        echo Fixing interpreter and rpath paths in $i ...
+        patchelf                                                                                   \
+          --interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)"                                \
+          --set-rpath ${makeLibraryPath finalAttrs.buildInputs}:$(cat $NIX_CC/nix-support/orig-cc)/${libDir}  \
+          $i
+      done
+    '';
+
+    installPhase = ''
+      mkdir -p $out/bin
+      ln -s $out/lib/arena-${finalAttrs.version}/Arena_x86_64_linux $out/bin/arena
+    '';
+
+    dontStrip = true;
+
+    meta = {
+      description = "Chess GUI for analyzing with and playing against various engines";
+      longDescription = ''
+        A free Graphical User Interface (GUI) for chess. Arena assists you in
+        analyzing and playing games as well as in testing chess engines. It runs
+        on Linux or Windows. Arena is compatible to Winboard protocol I, II and
+        UCI protocol I, II. Furthermore, compatible to Chess960, DGT electronic
+        chess board & DGT clocks and much more.
+      '';
+      license = lib.licenses.unfree;
+      sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+      homepage = "http://www.playwitharena.de";
+      platforms = [ "x86_64-linux" ];
+    };
+  }
+)


### PR DESCRIPTION
migrate to finalAttrs, move out of treewide PR #524874 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
