### PR TITLE
nixos/bind: allow to patch the conf file for check phase and warn users

### DIFF
--- a/nixos/modules/services/networking/bind.nix
+++ b/nixos/modules/services/networking/bind.nix
@@ -87,9 +87,24 @@ let
     name = "named.conf";
     checkPhase = ''
       ${lib.optionalString cfg.checkConfig ''
+        cp $target $TMPDIR/target_unpatched
+
+        echo "Patching named configuration file...";
+        ${cfg.preCheckConfig}
+
         echo "Checking named configuration file...";
         mkdir -p ${testFakeDir}
-        ${lib.getExe' bindPkg "named-checkconf"} -z $target
+        if ! ${lib.getExe' bindPkg "named-checkconf"} -z $target; then
+          echo
+          echo "Check failed. Is your configuration using impure files?"
+          echo
+          echo "If your configuration is not checkable in sandbox, you can either:"
+          echo "- Disable the check with 'services.bind.checkConfig = false', or"
+          echo "- Patch your file for the check phase with 'services.bind.preCheckConfig'."
+          exit 1
+        fi
+
+        mv $TMPDIR/target_unpatched $target
       ''}
 
       substituteInPlace $target \
@@ -332,6 +347,21 @@ in
 
           The configuration will not be checked if you override the config file
           with `configFile`.
+        '';
+      };
+      preCheckConfig = lib.mkOption {
+        type = lib.types.lines;
+        default = "";
+        description = ''
+          Run a script during the configuration check phase.
+
+          This can be used to patch the configuration file if, for example, it
+          contains elements not available in the sandbox.
+          The configuration file is located in the variable `$target`.
+        '';
+        example = ''
+          substituteInPlace $target \
+            --replace-fail 'include "/secrets/domain.key"' ""
         '';
       };
     };


### PR DESCRIPTION
Multiple users made reports that the (recently fixed but long broken) check of the configuration file in the bind service caused them trouble.

These reports were made on the PR fixing the test (https://github.com/NixOS/nixpkgs/pull/501959) and on a separate issue (https://github.com/NixOS/nixpkgs/issues/527921).

This commit enhances the user experience regarding this check:
1. Introduce `preCheckConfig`, an option that allows users to patch the configuration file during the check phase using bash expressions (with, e.g. `substituteInPlace`).
2. Improve error reporting: when the check fails, the output now suggests two solutions, disable the check or patching the file during the check phase.

Previously, when the check failed, users would see something like this:
```
Checking named configuration file...
/nix/store/...-named.conf:21: parsing failed: file not found
```

Now, they will see:

```
Checking named configuration file...
/nix/store/...-named.conf:21: parsing failed: file not found

Check failed. Is your configuration using impure files?

If your configuration is not checkable in sandbox, you can either:
- Disable the check with 'services.bind.checkConfig = false', or
- Patch your file for the check phase with 'services.bind.preCheckConfig'.
```

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
