### PR TITLE
[Backport staging-26.05] systemd: 260.1 -> 260.2

### DIFF
--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -201,13 +201,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   inherit pname;
-  version = "260.1";
+  version = "260.2";
 
   src = fetchFromGitHub {
     owner = "systemd";
     repo = "systemd";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-FUKj3lvjz8TIsyu8NyJYtiNele+1BhdJPdw7r7nW6as=";
+    hash = "sha256-NXmmSV7/9WIW6C8wjdOwaerCy4v7Zcrd8+XDzcS8rEk=";
   };
 
   # PATCH POLICY


### PR DESCRIPTION
Manual backport of https://github.com/NixOS/nixpkgs/pull/524791 because the automatic one failed.

The second commit from that PR (dropping an upstreamed patch) is omitted since that patch was never present on 26.05.
