### PR TITLE
qt6Packages: avoid using kdePackages

### DIFF
--- a/nixos/modules/config/qt.nix
+++ b/nixos/modules/config/qt.nix
@@ -67,7 +67,7 @@ let
 
     kvantum = [
       libsForQt5.qtstyleplugin-kvantum
-      qt6Packages.qtstyleplugin-kvantum
+      kdePackages.qtstyleplugin-kvantum
     ];
   };
 in

--- a/pkgs/by-name/fc/fcitx5-configtool/package.nix
+++ b/pkgs/by-name/fc/fcitx5-configtool/package.nix
@@ -3,25 +3,12 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  extra-cmake-modules,
   pkg-config,
   fcitx5,
-  fcitx5-qt,
-  qtbase,
-  qtsvg,
-  qtwayland,
-  qtdeclarative,
-  kitemviews,
-  kwidgetsaddons,
-  kcmutils,
-  kcoreaddons,
-  kdeclarative,
-  kirigami ? null,
+  kdePackages,
   isocodes,
   xkeyboard-config,
   libxkbfile,
-  libplasma ? null,
-  wrapQtAppsHook,
   kcmSupport ? true,
 }:
 
@@ -43,30 +30,30 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    extra-cmake-modules
+    kdePackages.extra-cmake-modules
     pkg-config
-    wrapQtAppsHook
+    kdePackages.wrapQtAppsHook
   ];
 
   buildInputs = [
     fcitx5
-    fcitx5-qt
-    qtbase
-    qtsvg
-    qtwayland
-    kitemviews
-    kwidgetsaddons
+    kdePackages.fcitx5-qt
+    kdePackages.qtbase
+    kdePackages.qtsvg
+    kdePackages.qtwayland
+    kdePackages.kitemviews
+    kdePackages.kwidgetsaddons
     isocodes
     xkeyboard-config
     libxkbfile
   ]
   ++ lib.optionals kcmSupport [
-    qtdeclarative
-    kcoreaddons
-    kdeclarative
-    kcmutils
-    libplasma
-    kirigami
+    kdePackages.qtdeclarative
+    kdePackages.kcoreaddons
+    kdePackages.kdeclarative
+    kdePackages.kcmutils
+    kdePackages.libplasma
+    kdePackages.kirigami
   ];
 
   meta = {

--- a/pkgs/by-name/fc/fcitx5-with-addons/package.nix
+++ b/pkgs/by-name/fc/fcitx5-with-addons/package.nix
@@ -6,7 +6,7 @@
   withConfigtool ? true,
   fcitx5-configtool,
   libsForQt5,
-  qt6Packages,
+  kdePackages,
   fcitx5-gtk,
   librsvg,
   addons ? [ ],
@@ -18,7 +18,7 @@ symlinkJoin {
   paths = [
     fcitx5
     libsForQt5.fcitx5-qt
-    qt6Packages.fcitx5-qt
+    kdePackages.fcitx5-qt
     fcitx5-gtk
   ]
   ++ lib.optionals withConfigtool [

--- a/pkgs/desktops/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/default.nix
@@ -5,11 +5,11 @@
   ayatana-indicator-datetime,
   useQt6 ? false,
   libsForQt5,
-  qt6Packages,
+  kdePackages,
 }:
 
 let
-  qtPackages = if useQt6 then qt6Packages else libsForQt5;
+  qtPackages = if useQt6 then kdePackages else libsForQt5;
   packages =
     self:
     let

--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -95,6 +95,8 @@ let
         krohnkite = self.callPackage ./third-party/krohnkite { };
         kzones = self.callPackage ./third-party/kzones { };
         wallpaper-engine-plugin = self.callPackage ./third-party/wallpaper-engine-plugin { };
+
+        qtstyleplugin-kvantum = self.callPackage ../development/libraries/qtstyleplugin-kvantum { };
       }
     );
 in

--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -95,6 +95,7 @@ let
         krohnkite = self.callPackage ./third-party/krohnkite { };
         kzones = self.callPackage ./third-party/kzones { };
         wallpaper-engine-plugin = self.callPackage ./third-party/wallpaper-engine-plugin { };
+        sierra-breeze-enhanced = self.callPackage ./third-party/sierra-breeze-enhanced { };
 
         qtstyleplugin-kvantum = self.callPackage ../development/libraries/qtstyleplugin-kvantum { };
       }

--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -95,6 +95,7 @@ let
         kzones = self.callPackage ./third-party/kzones { };
         wallpaper-engine-plugin = self.callPackage ./third-party/wallpaper-engine-plugin { };
         sierra-breeze-enhanced = self.callPackage ./third-party/sierra-breeze-enhanced { };
+        ktactilefeedback = self.callPackage ./third-party/ktactilefeedback { };
 
         qtstyleplugin-kvantum = self.callPackage ../development/libraries/qtstyleplugin-kvantum { };
       }

--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -62,8 +62,7 @@ let
           zxing-cpp
           ;
 
-        # Alias to match metadata
-        kquickimageeditor = self.kquickimageedit;
+        kquickimageeditor = self.callPackage ./misc/kquickimageeditor { };
 
         selenium-webdriver-at-spi = null; # Used for integration tests that we don't run, stub
 

--- a/pkgs/kde/misc/kquickimageeditor/default.nix
+++ b/pkgs/kde/misc/kquickimageeditor/default.nix
@@ -1,18 +1,19 @@
 {
   lib,
-  stdenv,
+  mkKdeDerivation,
   fetchFromGitLab,
-  cmake,
-  kdePackages,
-  qtbase,
+  kirigami,
   qtdeclarative,
   opencv,
 }:
 
-stdenv.mkDerivation rec {
+mkKdeDerivation rec {
   pname = "kquickimageeditor";
   version = "0.6.1";
 
+  # Project doesn't appear in any ../../generated/sources/*.json files,
+  # although it appears in ../../generated/projects.json and
+  # ../../generated/dependencies.json
   src = fetchFromGitLab {
     domain = "invent.kde.org";
     owner = "libraries";
@@ -21,13 +22,8 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-MluY8nkMtg1uLAStDZFDxyJoeDrcp3smZ4U5IG5sXMk=";
   };
 
-  nativeBuildInputs = [
-    cmake
-    kdePackages.extra-cmake-modules
-  ];
-  buildInputs = [
-    kdePackages.kirigami
-    qtbase
+  extraBuildInputs = [
+    kirigami
     qtdeclarative
     (opencv.override {
       enableCuda = false; # fails to compile, disabled in case someone sets config.cudaSupport
@@ -40,6 +36,8 @@ stdenv.mkDerivation rec {
   ];
   dontWrapQtApps = true;
 
+  # Project doesn't exist in ../../generated/licenses.json so we write it
+  # ourselves.
   meta = {
     description = "Set of QtQuick components providing basic image editing capabilities";
     homepage = "https://invent.kde.org/libraries/kquickimageeditor";

--- a/pkgs/kde/third-party/ktactilefeedback/default.nix
+++ b/pkgs/kde/third-party/ktactilefeedback/default.nix
@@ -1,16 +1,16 @@
 {
   stdenv,
   lib,
+  mkKdeDerivation,
   fetchFromGitLab,
   unstableGitUpdater,
-  cmake,
   extra-cmake-modules,
   qtbase,
   qtdeclarative,
   qtmultimedia,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+mkKdeDerivation rec {
   pname = "ktactilefeedback";
   version = "0-unstable-2025-07-25";
 
@@ -27,22 +27,17 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ];
 
-  nativeBuildInputs = [
-    cmake
-  ];
-
-  buildInputs = [
+  extraBuildInputs = [
     extra-cmake-modules
-    qtbase
     qtmultimedia
   ];
 
   # Library
   dontWrapQtApps = true;
 
-  cmakeFlags = [
+  extraCmakeFlags = [
     # Need to run these post-install, so QML import path exists
-    (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doInstallCheck)
+    (lib.cmakeBool "BUILD_TESTING" doInstallCheck)
   ];
 
   doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
@@ -62,4 +57,4 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     platforms = lib.platforms.linux;
   };
-})
+}

--- a/pkgs/kde/third-party/sierra-breeze-enhanced/default.nix
+++ b/pkgs/kde/third-party/sierra-breeze-enhanced/default.nix
@@ -1,14 +1,13 @@
 {
-  stdenv,
-  fetchFromGitHub,
-  cmake,
-  extra-cmake-modules,
-  wrapQtAppsHook,
-  kwin,
   lib,
+  mkKdeDerivation,
+  fetchFromGitHub,
+  extra-cmake-modules,
+  kwin,
   fetchpatch2,
 }:
-stdenv.mkDerivation rec {
+
+mkKdeDerivation rec {
   pname = "sierra-breeze-enhanced";
   version = "2.1.1";
 
@@ -26,10 +25,8 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [
-    cmake
+  extraNativeBuildInputs = [
     extra-cmake-modules
-    wrapQtAppsHook
   ];
   buildInputs = [ kwin ];
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -765,7 +765,6 @@ mapAliases {
   fbpanel = throw "'fbpanel' has been removed as it was broken and unmaintained upstream"; # Added 2026-05-16
   fcitx5-catppuccin = throw "'fcitx5-catppuccin' has been renamed to/replaced by 'catppuccin-fcitx5'"; # Converted to throw 2025-10-27
   fcitx5-chinese-addons = throw "'fcitx5-chinese-addons' has been renamed to/replaced by 'qt6Packages.fcitx5-chinese-addons'"; # Converted to throw 2025-10-27
-  fcitx5-configtool = throw "'fcitx5-configtool' has been renamed to/replaced by 'qt6Packages.fcitx5-configtool'"; # Converted to throw 2025-10-27
   fcitx5-skk-qt = throw "'fcitx5-skk-qt' has been renamed to/replaced by 'qt6Packages.fcitx5-skk-qt'"; # Converted to throw 2025-10-27
   fcitx5-unikey = throw "'fcitx5-unikey' has been renamed to/replaced by 'qt6Packages.fcitx5-unikey'"; # Converted to throw 2025-10-27
   fcitx5-with-addons = throw "'fcitx5-with-addons' has been renamed to/replaced by 'qt6Packages.fcitx5-with-addons'"; # Converted to throw 2025-10-27

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -767,7 +767,6 @@ mapAliases {
   fcitx5-chinese-addons = throw "'fcitx5-chinese-addons' has been renamed to/replaced by 'qt6Packages.fcitx5-chinese-addons'"; # Converted to throw 2025-10-27
   fcitx5-skk-qt = throw "'fcitx5-skk-qt' has been renamed to/replaced by 'qt6Packages.fcitx5-skk-qt'"; # Converted to throw 2025-10-27
   fcitx5-unikey = throw "'fcitx5-unikey' has been renamed to/replaced by 'qt6Packages.fcitx5-unikey'"; # Converted to throw 2025-10-27
-  fcitx5-with-addons = throw "'fcitx5-with-addons' has been renamed to/replaced by 'qt6Packages.fcitx5-with-addons'"; # Converted to throw 2025-10-27
   fedifetcher = throw "'fedifetcher' has been removed because there is now a similar native feature in Mastodon."; # Added 2025-12-08
   fennel = throw "'fennel' has been renamed to/replaced by 'luaPackages.fennel'"; # Converted to throw 2025-10-27
   fetchbower = throw "fetchbower has been removed as bower was removed. It is recommended to migrate to yarn."; # Added 2025-09-17

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -154,7 +154,7 @@ makeScopeWithSplicing' {
         qtstyleplugins = callPackage ../development/libraries/qtstyleplugins { };
 
         qtstyleplugin-kvantum = callPackage ../development/libraries/qtstyleplugin-kvantum {
-          qt6Kvantum = pkgs.qt6Packages.qtstyleplugin-kvantum;
+          qt6Kvantum = pkgs.kdePackages.qtstyleplugin-kvantum;
         };
 
         quazip = callPackage ../development/libraries/quazip { };

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -63,8 +63,6 @@ makeScopeWithSplicing' {
 
       futuresql = callPackage ../development/libraries/futuresql { };
 
-      ktactilefeedback = kdePackages.callPackage ../development/libraries/ktactilefeedback { };
-
       libiodata = callPackage ../development/libraries/libiodata { };
 
       libqaccessibilityclient = callPackage ../development/libraries/libqaccessibilityclient { };
@@ -156,6 +154,9 @@ makeScopeWithSplicing' {
       fcitx5-configtool = throw ''
         'qt6Packages.fcitx5-configtool' has been replaced by top-level 'fcitx5-configtool'.
       ''; # Added 2026-06-06
+      ktactilefeedback = throw ''
+        'qt6Packages.ktactilefeedback' has been replaced by 'kdePackages.ktactilefeedback'.
+      ''; # Added 2026-06-04
       kquickimageedit = throw ''
         'qt6Packages.kquickimageedit' has been replaced by 'kdePackages.kquickimageeditor'.
       ''; # Added 2026-06-04

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -50,8 +50,6 @@ makeScopeWithSplicing' {
 
       fcitx5-chinese-addons = callPackage ../tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix { };
 
-      fcitx5-configtool = kdePackages.callPackage ../tools/inputmethods/fcitx5/fcitx5-configtool.nix { };
-
       fcitx5-qt = callPackage ../tools/inputmethods/fcitx5/fcitx5-qt.nix { };
 
       fcitx5-skk-qt = pkgs.fcitx5-skk.override { enableQt = true; };
@@ -161,6 +159,9 @@ makeScopeWithSplicing' {
       wayqt = callPackage ../development/libraries/wayqt { };
     }
     // lib.optionalAttrs config.allowAliases {
+      fcitx5-configtool = throw ''
+        'qt6Packages.fcitx5-configtool' has been replaced by top-level 'fcitx5-configtool'.
+      ''; # Added 2026-06-06
       qwlroots = throw ''
         'qt6Packages.qwlroots' has been removed because it has been merged into treeland upstream.
         The upstream no longer provides it as a standalone development library.

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -115,8 +115,6 @@ makeScopeWithSplicing' {
 
       qtpbfimageplugin = callPackage ../development/libraries/qtpbfimageplugin { };
 
-      qtstyleplugin-kvantum = kdePackages.callPackage ../development/libraries/qtstyleplugin-kvantum { };
-
       qtutilities = callPackage ../development/libraries/qtutilities { };
 
       qt-jdenticon = callPackage ../development/libraries/qt-jdenticon { };
@@ -163,6 +161,9 @@ makeScopeWithSplicing' {
       fcitx5-configtool = throw ''
         'qt6Packages.fcitx5-configtool' has been replaced by top-level 'fcitx5-configtool'.
       ''; # Added 2026-06-06
+      qtstyleplugin-kvantum = throw ''
+        'qt6Packages.qtstyleplugin-kvantum' has been replaced by 'kdePackages.qtstyleplugin-kvantum'.
+      ''; # Added 2026-06-04
       qwlroots = throw ''
         'qt6Packages.qwlroots' has been removed because it has been merged into treeland upstream.
         The upstream no longer provides it as a standalone development library.

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -144,10 +144,6 @@ makeScopeWithSplicing' {
       sddm-unwrapped = callPackage ../applications/display-managers/sddm/unwrapped.nix { };
       sddm = callPackage ../applications/display-managers/sddm { };
 
-      sierra-breeze-enhanced =
-        kdePackages.callPackage ../data/themes/kwin-decorations/sierra-breeze-enhanced
-          { };
-
       signond = callPackage ../development/libraries/signond { };
 
       timed = callPackage ../applications/system/timed { };
@@ -161,6 +157,9 @@ makeScopeWithSplicing' {
       fcitx5-configtool = throw ''
         'qt6Packages.fcitx5-configtool' has been replaced by top-level 'fcitx5-configtool'.
       ''; # Added 2026-06-06
+      sierra-breeze-enhanced = throw ''
+        'qt6Packages.sierra-breeze-enhanced' has been replaced by 'kdePackages.sierra-breeze-enhanced'.
+      ''; # Added 2026-06-04
       qtstyleplugin-kvantum = throw ''
         'qt6Packages.qtstyleplugin-kvantum' has been replaced by 'kdePackages.qtstyleplugin-kvantum'.
       ''; # Added 2026-06-04

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -56,8 +56,6 @@ makeScopeWithSplicing' {
 
       fcitx5-unikey = callPackage ../tools/inputmethods/fcitx5/fcitx5-unikey.nix { };
 
-      fcitx5-with-addons = callPackage ../tools/inputmethods/fcitx5/with-addons.nix { };
-
       kdsoap = callPackage ../development/libraries/kdsoap { };
 
       kcolorpicker = callPackage ../development/libraries/kcolorpicker { };
@@ -159,6 +157,9 @@ makeScopeWithSplicing' {
       wayqt = callPackage ../development/libraries/wayqt { };
     }
     // lib.optionalAttrs config.allowAliases {
+      fcitx5-with-addons = throw ''
+        'qt6Packages.fcitx5-with-addons' has been replaced by top-level 'fcitx5-with-addons'.
+      ''; # Added 2026-06-06
       fcitx5-configtool = throw ''
         'qt6Packages.fcitx5-configtool' has been replaced by top-level 'fcitx5-configtool'.
       ''; # Added 2026-06-06

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -62,7 +62,6 @@ makeScopeWithSplicing' {
       kimageannotator = callPackage ../development/libraries/kimageannotator { };
 
       futuresql = callPackage ../development/libraries/futuresql { };
-      kquickimageedit = callPackage ../development/libraries/kquickimageedit { };
 
       ktactilefeedback = kdePackages.callPackage ../development/libraries/ktactilefeedback { };
 
@@ -157,6 +156,9 @@ makeScopeWithSplicing' {
       fcitx5-configtool = throw ''
         'qt6Packages.fcitx5-configtool' has been replaced by top-level 'fcitx5-configtool'.
       ''; # Added 2026-06-06
+      kquickimageedit = throw ''
+        'qt6Packages.kquickimageedit' has been replaced by 'kdePackages.kquickimageeditor'.
+      ''; # Added 2026-06-04
       sierra-breeze-enhanced = throw ''
         'qt6Packages.sierra-breeze-enhanced' has been replaced by 'kdePackages.sierra-breeze-enhanced'.
       ''; # Added 2026-06-04


### PR DESCRIPTION
## Motivation

When `qt6Packages` is defined in `all-packages.nix`, it uses `kdePackages`. However `kdePackages` extends `qt6Packages`. This means that e.g:

```nix
self: super: {
  kdePackages = self.kdePackages.override {
    qt6Packages = qt6Packages.overrideScope (selfQt6: superQt6: {
      # ...
    };
  };
}
```

Will fail to propagate the changes to `qt6Packages` that use `kdePackages`. This confusing UX can be avoided if we'd avoid using `kdePackages` inside `qt6Packages`, and let only `kdePackages` extend `qt6Packages`.

This is not a hard task, and it is done here. ~~However it does create a slightly weird situation where e.g `fcitx5-qt` is defined in `qt6-packages.nix` and hence is available in `qt6Packages.fcitx5-qt` and `kdePackages.fcitx5-qt`, but in contrast `qt6Packages.fcitx5-configtool` is not defined, just because it requires 2 KDE dependencies.~~ Note that `fcitx5-{configtool,with-addons}` packages were moved from `qt6Packages` to top-level (see commit messages for details).

This behavior is ~~very~~ a bit consistent I think, but the drawback of it appears to the end user: As a user who runs e.g `nix search fcitx5`, it is not clear why `fcitx5-configtool` is ~~inside `kdePackages`~~ top-level, while many other `fcitx5` attributes are in `qt6Packages`.

I'm not sure we are all ready to pay this small price, so comments are desired from @NixOS/qt-kde, and the maintainers of the renamed packages:

- `qtstyleplugin-kvantum`: cc @romildo & @Scrumplex
- `sierra-breeze-enhanced`: cc @A1ca7raz 
- `ktactilefeedback`: cc @OPNA2608 
- `fcitx5`: cc @poscat0x04 

CC also @rhendric, per https://discourse.nixos.org/t/rfc-nix-function-that-overrides-a-scope-with-automatic-inheritance-propagation/78025 .

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
