### PR TITLE
python3Packages.snakemake-storage-plugin-xrootd: disable tests on darwin

### DIFF
--- a/pkgs/development/python-modules/snakemake-storage-plugin-xrootd/default.nix
+++ b/pkgs/development/python-modules/snakemake-storage-plugin-xrootd/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   pkgs,
   buildPythonPackage,
   fetchFromGitHub,
@@ -51,7 +52,9 @@ buildPythonPackage (finalAttrs: {
     xrootd
   ];
 
-  pythonImportsCheck = [ "snakemake_storage_plugin_xrootd" ];
+  # When doCheck is disabled, nnativeCheckInputs are not available and the package fails to import:
+  #   ModuleNotFoundError: No module named 'snakemake'
+  pythonImportsCheck = lib.optionals finalAttrs.doCheck [ "snakemake_storage_plugin_xrootd" ];
 
   nativeCheckInputs = [
     pytestCheckHook
@@ -59,6 +62,16 @@ buildPythonPackage (finalAttrs: {
   ];
 
   enabledTestPaths = [ "tests/tests.py" ];
+
+  # Tests fail on darwin even with:
+  # - __darwinAllowLocalNetworking = true;
+  # - sandbox = false
+  # - writableTmpDirAsHomeHook
+  #
+  # Failed: XRootD server terminated unexpectedly.
+  # 260604 22:16:56 259 XrdConfig: Unable to set permission for admin path /tmp/.xrd/; operation not permitted
+  # ------ xrootd anon@91-224-148-58.tetaneutral.net:32293 initialization failed.
+  doCheck = !stdenv.hostPlatform.isDarwin;
 
   meta = {
     description = "Snakemake storage plugin for handling input and output via XRootD";


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
