### PR TITLE
dinish: build from source, use installFonts

### DIFF
--- a/pkgs/by-name/di/dinish/package.nix
+++ b/pkgs/by-name/di/dinish/package.nix
@@ -3,10 +3,10 @@
   stdenvNoCC,
   fetchFromGitHub,
   installFonts,
-  git,
   nix-update-script,
   python3,
   ttfautohint,
+  replaceVarsWith,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -22,20 +22,35 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "playbeing";
     repo = "dinish";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-3kJlE7qCLoCtSZo4s7WgxTnj+H08UbVetGlDzb8xrEw=";
-    leaveDotGit = true;
-    fetchTags = true;
+    hash = "sha256-IoEeSB22rJh2J3EDD4T6uX65PhhnlllKBBKtRHLQP8I=";
   };
 
   strictDeps = true;
   __structuredAttrs = true;
 
-  postPatch = ''
-    patchShebangs tools
-    substituteInPlace Makefile \
-      --replace-fail 'build: sync_features $(OTFS) $(TTFS) $(WOFFS) $(WOFF2S) docs zips install_ofl' \
-      'build: sync_features $(OTFS) $(TTFS) $(WOFFS) $(WOFF2S) docs'
-  '';
+  # use a vendored version of update-version.sh that is simplified, and doesn't require reading info from .git/
+  # comment is from upstream script for reference
+
+  postPatch =
+    let
+      update-version = replaceVarsWith {
+        src = ./update-version.sh;
+        replacements = {
+          major = lib.versions.major finalAttrs.version;
+          minor = lib.versions.minor finalAttrs.version;
+          # this isn't the hash upstream would use, but we don't want to use fetchDotGit so let's just use a different hash
+          hash = lib.replaceString "sha256-" "" finalAttrs.src.hash;
+        };
+        isExecutable = true;
+      };
+    in
+    ''
+      cp -f ${update-version} tools/update-version.sh
+      patchShebangs tools
+      substituteInPlace Makefile \
+        --replace-fail 'build: sync_features $(OTFS) $(TTFS) $(WOFFS) $(WOFF2S) docs zips install_ofl' \
+        'build: sync_features $(OTFS) $(TTFS) $(WOFFS) $(WOFF2S) docs'
+    '';
 
   preInstall = ''
     rm -r ofl
@@ -47,7 +62,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     installFonts
-    git
     (python3.withPackages (
       ps: with ps; [
         fontmake

--- a/pkgs/by-name/di/dinish/package.nix
+++ b/pkgs/by-name/di/dinish/package.nix
@@ -2,36 +2,31 @@
   lib,
   stdenvNoCC,
   fetchzip,
+  installFonts,
   nix-update-script,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "dinish";
   version = "4.007";
 
   src = fetchzip {
-    url = "https://github.com/playbeing/dinish/releases/download/v${version}/dinish-ttf.zip";
+    url = "https://github.com/playbeing/dinish/releases/download/v${finalAttrs.version}/dinish-ttf.zip";
     stripRoot = false;
     hash = "sha256-u/AYA9/8piZ6hz4XD3uSruOM0deeXQ5Gb0N/8rlDiP0=";
   };
 
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm644 *.ttf -t $out/share/fonts/truetype
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/playbeing/dinish";
-    changelog = "https://github.com/playbeing/dinish/blob/v${version}/FONTLOG.txt";
+    changelog = "https://github.com/playbeing/dinish/blob/v${finalAttrs.version}/FONTLOG.txt";
     description = "Modern computer font inspired by DIN 1451";
     longDescription = "DINish is one of many modern computer fonts that were inspired by the lettering of the German Autobahn road signs. It is professionally designed, and usable for body text and captions, even spreadsheets. Its unadorned style is easy to read, and although it is close to a century old maintains a fresh look.";
     license = lib.licenses.ofl;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ vji ];
   };
-}
+})

--- a/pkgs/by-name/di/dinish/package.nix
+++ b/pkgs/by-name/di/dinish/package.nix
@@ -1,23 +1,64 @@
 {
   lib,
   stdenvNoCC,
-  fetchzip,
+  fetchFromGitHub,
   installFonts,
+  git,
   nix-update-script,
+  python3,
+  ttfautohint,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "dinish";
   version = "4.007";
 
-  src = fetchzip {
-    url = "https://github.com/playbeing/dinish/releases/download/v${finalAttrs.version}/dinish-ttf.zip";
-    stripRoot = false;
-    hash = "sha256-u/AYA9/8piZ6hz4XD3uSruOM0deeXQ5Gb0N/8rlDiP0=";
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "playbeing";
+    repo = "dinish";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-3kJlE7qCLoCtSZo4s7WgxTnj+H08UbVetGlDzb8xrEw=";
+    leaveDotGit = true;
+    fetchTags = true;
   };
 
-  nativeBuildInputs = [ installFonts ];
+  strictDeps = true;
+  __structuredAttrs = true;
 
+  postPatch = ''
+    patchShebangs tools
+    substituteInPlace Makefile \
+      --replace-fail 'build: sync_features $(OTFS) $(TTFS) $(WOFFS) $(WOFF2S) docs zips install_ofl' \
+      'build: sync_features $(OTFS) $(TTFS) $(WOFFS) $(WOFF2S) docs'
+  '';
+
+  preInstall = ''
+    rm -r ofl
+  '';
+  installPhase = ''
+    runHook preInstall
+    runHook postInstall
+  '';
+
+  nativeBuildInputs = [
+    installFonts
+    git
+    (python3.withPackages (
+      ps: with ps; [
+        fontmake
+        gftools
+      ]
+    ))
+    ttfautohint
+  ];
+  dontUseNinjaBuild = true;
+
+  env.PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION = "python";
   passthru.updateScript = nix-update-script { };
 
   meta = {

--- a/pkgs/by-name/di/dinish/update-version.sh
+++ b/pkgs/by-name/di/dinish/update-version.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Update the fontinfo.plist for all fonts:
+#   Version major/minor is set to the version from the git tag, e.g. v2.006
+#
+#   openTypeNameVersion is set to Version: tag; git-hash-release
+#   (e.g., Version: v2.006; git-1a2b3c4d-release) for releases built from
+#   the git tag, or to Version: tag; git-hash+revs-mods-dev for dev
+#   builds, e.g., Version 2.006; git-3ccbb4c+36-13-dev .
+#   The +36 indicates that this build is 36 commits ahead of 2.006.
+#   The -13 indicates that there are uncommitted changes to 13
+#   files, and that the build is not reproducable.
+#
+#   openTypeHeadCreated is set to the build date and time.
+
+major="@major@"
+minor="@minor@"
+hash="@hash@"
+status="release"
+
+version=$(printf "%d.%03d" $major $minor)
+versionstr="Version $version; git-$hash-$status"
+now=$(date -u -d "@$SOURCE_DATE_EPOCH" +'%Y/%m/%d %H:%M:%S')
+
+for ufo in sources/DINish*/DINish*.ufo; do
+  sed -i \
+    -e "\|versionMajor|,+1s|>[0-9]*<|>$major<|" \
+    -e "\|versionMinor|,+1s|>[0-9]*<|>$minor<|" \
+    -e "\|openTypeHeadCreated|,+1s|>[0-9].*<|>$now<|" \
+    -e "\|openTypeNameVersion|,+1s|>Version [^<]*<|>$versionstr<|" \
+    "$ufo/fontinfo.plist"
+done


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Part of #495640
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
