### PR TITLE
worm-hole: init at 4.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23500,6 +23500,11 @@
     githubId = 14910534;
     name = "Riey";
   };
+  rignchen = {
+    github = "Rignchen";
+    githubId = 119439839;
+    name = "Maggy Hofstetter";
+  };
   rika = {
     email = "rika@paymentswit.ch";
     github = "ScarletHg";

--- a/pkgs/by-name/wo/worm-hole/package.nix
+++ b/pkgs/by-name/wo/worm-hole/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitLab,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "worm-hole";
+  version = "4.0.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    owner = "Rignchen";
+    repo = "worm_hole";
+    tag = finalAttrs.version;
+    hash = "sha256-G19bHpHpyMAGJQ9JIKBXTJDEo+UU1mRWlNTmmSUNRWo=";
+  };
+
+  cargoHash = "sha256-Yo/vAO4rCPNKmVT8cxO7VjBvr3M8iYxPQanlJVc+e3E=";
+
+  meta = {
+    description = "CLI tool to easily jump between directories";
+    homepage = "https://gitlab.com/Rignchen/worm_hole";
+    changelog = "https://gitlab.com/Rignchen/worm_hole/-/releases/${finalAttrs.src.tag}";
+    mainProgram = "worm_hole";
+    maintainers = with lib.maintainers; [ rignchen ];
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/wo/worm-hole/package.nix
+++ b/pkgs/by-name/wo/worm-hole/package.nix
@@ -6,7 +6,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "worm-hole";
-  version = "4.0.1";
+  version = "4.1.0";
 
   __structuredAttrs = true;
 
@@ -14,10 +14,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "Rignchen";
     repo = "worm_hole";
     tag = finalAttrs.version;
-    hash = "sha256-G19bHpHpyMAGJQ9JIKBXTJDEo+UU1mRWlNTmmSUNRWo=";
+    hash = "sha256-9UYugWBKBWEjTrWkyOYTB9/0OF8xGTtbjU1Rqsu9vv4=";
   };
 
-  cargoHash = "sha256-Yo/vAO4rCPNKmVT8cxO7VjBvr3M8iYxPQanlJVc+e3E=";
+  cargoHash = "sha256-2bfcyDy9CW/pYWgcIdaWHKgU/ms+xgxa+5njxK7AyrM=";
 
   meta = {
     description = "CLI tool to easily jump between directories";

--- a/pkgs/by-name/wo/worm-hole/package.nix
+++ b/pkgs/by-name/wo/worm-hole/package.nix
@@ -6,7 +6,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "worm-hole";
-  version = "4.1.0";
+  version = "4.1.1";
 
   __structuredAttrs = true;
 
@@ -14,10 +14,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "Rignchen";
     repo = "worm_hole";
     tag = finalAttrs.version;
-    hash = "sha256-9UYugWBKBWEjTrWkyOYTB9/0OF8xGTtbjU1Rqsu9vv4=";
+    hash = "sha256-f8+PYPWzVMtBovgComgpKaibQhbxhmQjK6RKFpWU0CA=";
   };
 
-  cargoHash = "sha256-2bfcyDy9CW/pYWgcIdaWHKgU/ms+xgxa+5njxK7AyrM=";
+  cargoHash = "sha256-fCREYEFLkotyzaMv/ki/0Ht/TS1aXryaE5fapC3F5qs=";
 
   meta = {
     description = "CLI tool to easily jump between directories";

--- a/pkgs/by-name/wo/worm-hole/package.nix
+++ b/pkgs/by-name/wo/worm-hole/package.nix
@@ -6,7 +6,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "worm-hole";
-  version = "4.1.1";
+  version = "4.2.0";
 
   __structuredAttrs = true;
 
@@ -14,10 +14,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "Rignchen";
     repo = "worm_hole";
     tag = finalAttrs.version;
-    hash = "sha256-f8+PYPWzVMtBovgComgpKaibQhbxhmQjK6RKFpWU0CA=";
+    hash = "sha256-PcyvmpiagjLSJgAr1NPI5WJu/00sq8QpP+xwCHisRTU=";
   };
 
-  cargoHash = "sha256-fCREYEFLkotyzaMv/ki/0Ht/TS1aXryaE5fapC3F5qs=";
+  cargoHash = "sha256-SJyDFdxVS9UivE/jhxD98wfQjMjWjnTDG62M1+iZr9A=";
 
   meta = {
     description = "CLI tool to easily jump between directories";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds [`worm-hole`](https://gitlab.com/Rignchen/worm_hole.git) to the nixpkgs
Worm hole is a cli program I created to easily jump around your most used directories
```bash
eval "$(worm_hole init bash)" # initialize everything to be used
wh add config ~/.dotfiles # adds an alias to the database
whcd config # same as `cd ~/.dotfiles`
wh rm config # remove the alias from the database
```

I did use some AI as an autocomplete up to 4.0.1, mostly for the README but also for the code
I double checked everything the AI wrote to be sure the code was exactly what I had in mind

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
