### PR TITLE
ghostunnel: 1.8.4 -> 1.10.0

### DIFF
--- a/nixos/modules/services/networking/ghostunnel.nix
+++ b/nixos/modules/services/networking/ghostunnel.nix
@@ -196,7 +196,12 @@ let
               ++ optional (config.cacert != null) "cacert:${config.cacert}";
           };
           script = concatStringsSep " " (
-            [ "${mainCfg.package}/bin/ghostunnel" ]
+            [
+              "${mainCfg.package}/bin/ghostunnel"
+              # ghostunnel's landlock rules don't like reading the CA certs from /etc
+              # because they are links to /nix/store, which isn't part of its rules
+              "--disable-landlock"
+            ]
             ++ optional (config.keystore != null) "--keystore=$CREDENTIALS_DIRECTORY/keystore"
             ++ optional (config.cert != null) "--cert=$CREDENTIALS_DIRECTORY/cert"
             ++ optional (config.key != null) "--key=$CREDENTIALS_DIRECTORY/key"

--- a/pkgs/by-name/gh/ghostunnel/package.nix
+++ b/pkgs/by-name/gh/ghostunnel/package.nix
@@ -1,5 +1,4 @@
 {
-  stdenv,
   buildGoModule,
   fetchFromGitHub,
   lib,
@@ -9,16 +8,21 @@
 
 buildGoModule rec {
   pname = "ghostunnel";
-  version = "1.8.4";
+  version = "1.10.0";
 
   src = fetchFromGitHub {
     owner = "ghostunnel";
     repo = "ghostunnel";
     rev = "v${version}";
-    hash = "sha256-NnRm1HEdfK6WI5ntilLSwdR2B5czG5CIcMFzl2TzEds=";
+    hash = "sha256-BntQCauAgnaiNn31nrVEsHFvQv7zK6D0z/rInbCVTr0=";
   };
 
-  vendorHash = "sha256-vP8OtjpYNMm1KkNfD3pmNrHh3HRy1GkzUbfLKWKhHbo=";
+  patches = [
+    # upstream left an untidied go.mod/go.sum in v1.10.0
+    ./pkg-errors.patch
+  ];
+
+  vendorHash = "sha256-pd7fTP0BAgpd4mD8ZG8Ak9fFF2sC0JGCDbPG8tAnWvw=";
 
   deleteVendor = true;
 

--- a/pkgs/by-name/gh/ghostunnel/pkg-errors.patch
+++ b/pkgs/by-name/gh/ghostunnel/pkg-errors.patch
@@ -1,0 +1,26 @@
+diff --git a/go.mod b/go.mod
+index d06c2e9117..f560c1cc69 100644
+--- a/go.mod
++++ b/go.mod
+@@ -192,6 +192,7 @@
+ 	github.com/nwaples/rardecode v1.1.3 // indirect
+ 	github.com/pelletier/go-toml/v2 v2.3.0 // indirect
+ 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
++	github.com/pkg/errors v0.9.1 // indirect
+ 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+ 	github.com/prometheus/client_model v0.6.2 // indirect
+ 	github.com/prometheus/common v0.67.5 // indirect
+diff --git a/go.sum b/go.sum
+index 4dea0025f3..1edce71302 100644
+--- a/go.sum
++++ b/go.sum
+@@ -460,6 +460,9 @@
+ github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+ github.com/pires/go-proxyproto v0.11.0 h1:gUQpS85X/VJMdUsYyEgyn59uLJvGqPhJV5YvG68wXH4=
+ github.com/pires/go-proxyproto v0.11.0/go.mod h1:ZKAAyp3cgy5Y5Mo4n9AlScrkCZwUy0g3Jf+slqQVcuU=
++github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
++github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
++github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
+ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Same as #479200 but with an additional fix to disable landlock, since it causes ghostunnel to fail to start on NixOS because our CA cert bundle is a link to the store, which is not allowed by the landlock rules.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
