### PR TITLE
python3Packages.applicationinsights: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/applicationinsights/default.nix
+++ b/pkgs/development/python-modules/applicationinsights/default.nix
@@ -3,11 +3,12 @@
   lib,
   fetchPypi,
   portalocker,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   version = "0.11.10";
-  format = "setuptools";
+  pyproject = true;
   pname = "applicationinsights";
 
   src = fetchPypi {
@@ -15,7 +16,9 @@ buildPythonPackage rec {
     sha256 = "0b761f3ef0680acf4731906dfc1807faa6f2a57168ae74592db0084a6099f7b3";
   };
 
-  propagatedBuildInputs = [ portalocker ];
+  build-system = [ setuptools ];
+
+  dependencies = [ portalocker ];
 
   meta = {
     description = "This project extends the Application Insights API surface to support Python";

--- a/pkgs/development/python-modules/applicationinsights/default.nix
+++ b/pkgs/development/python-modules/applicationinsights/default.nix
@@ -11,6 +11,8 @@ buildPythonPackage (finalAttrs: {
   pyproject = true;
   pname = "applicationinsights";
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
     inherit (finalAttrs) pname version;
     hash = "sha256-C3YfPvBoCs9HMZBt/BgH+qbypXFornRZLbAISmCZ97M=";

--- a/pkgs/development/python-modules/applicationinsights/default.nix
+++ b/pkgs/development/python-modules/applicationinsights/default.nix
@@ -6,19 +6,21 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   version = "0.11.10";
   pyproject = true;
   pname = "applicationinsights";
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "0b761f3ef0680acf4731906dfc1807faa6f2a57168ae74592db0084a6099f7b3";
+    inherit (finalAttrs) pname version;
+    hash = "sha256-C3YfPvBoCs9HMZBt/BgH+qbypXFornRZLbAISmCZ97M=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [ portalocker ];
+
+  pythonImportsCheck = [ "applicationinsights" ];
 
   meta = {
     description = "This project extends the Application Insights API surface to support Python";
@@ -26,4 +28,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/applicationinsights/default.nix
+++ b/pkgs/development/python-modules/applicationinsights/default.nix
@@ -25,6 +25,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "This project extends the Application Insights API surface to support Python";
     homepage = "https://github.com/Microsoft/ApplicationInsights-Python";
+    changelog = "https://pypi.org/project/applicationinsights/${finalAttrs.version}/";
     license = lib.licenses.mit;
     maintainers = [ ];
   };


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
