### PR TITLE
python3Packages.aprslib: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/aprslib/default.nix
+++ b/pkgs/development/python-modules/aprslib/default.nix
@@ -28,7 +28,7 @@ buildPythonPackage (finalAttrs: {
 
   build-system = [ setuptools ];
 
-  doCheck = false; # mox3 is disabled on python311
+  doCheck = false; # mox3 is not packaged
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/aprslib/default.nix
+++ b/pkgs/development/python-modules/aprslib/default.nix
@@ -4,12 +4,13 @@
   fetchFromGitHub,
   fetchpatch,
   pytestCheckHook,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "aprslib";
   version = "0.7.2";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "rossengeorgiev";
@@ -24,6 +25,8 @@ buildPythonPackage rec {
       hash = "sha256-uxiLIagz1PIUUa6/qdBW15yhm/0QXqznVzZnzUVCWuQ=";
     })
   ];
+
+  build-system = [ setuptools ];
 
   doCheck = false; # mox3 is disabled on python311
 

--- a/pkgs/development/python-modules/aprslib/default.nix
+++ b/pkgs/development/python-modules/aprslib/default.nix
@@ -37,6 +37,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Module for accessing APRS-IS and parsing APRS packets";
     homepage = "https://github.com/rossengeorgiev/aprs-python";
+    changelog = "https://github.com/rossengeorgiev/aprs-python/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ dotlambda ];
   };

--- a/pkgs/development/python-modules/aprslib/default.nix
+++ b/pkgs/development/python-modules/aprslib/default.nix
@@ -7,7 +7,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "aprslib";
   version = "0.7.2";
   pyproject = true;
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "rossengeorgiev";
     repo = "aprs-python";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-2bYTnbJ8wF/smTpZ2tV+3ZRae7FpbNBtXoaR2Sc9Pek=";
   };
 
@@ -40,4 +40,4 @@ buildPythonPackage rec {
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ dotlambda ];
   };
-}
+})


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
