### PR TITLE
kdePackages: various: split `doc` and `man` outputs (from `out`) for some applicable packages

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/kded.nix
+++ b/pkgs/development/libraries/kde-frameworks/kded.nix
@@ -35,6 +35,7 @@ mkDerivation {
   outputs = [
     "out"
     "dev"
+    "man"
   ];
   setupHook = propagate "out";
   dontWrapGApps = true;

--- a/pkgs/kde/frameworks/kio/default.nix
+++ b/pkgs/kde/frameworks/kio/default.nix
@@ -14,6 +14,11 @@ mkKdeDerivation {
     ./allow-admin-from-store.patch
   ];
 
+  outputs = [
+    "out"
+    "doc"
+  ];
+
   extraBuildInputs = [
     qt5compat
     qttools

--- a/pkgs/kde/frameworks/kpackage/default.nix
+++ b/pkgs/kde/frameworks/kpackage/default.nix
@@ -2,5 +2,10 @@
 mkKdeDerivation {
   pname = "kpackage";
 
+  outputs = [
+    "out"
+    "man"
+  ];
+
   meta.mainProgram = "kpackagetool6";
 }

--- a/pkgs/kde/frameworks/kservice/default.nix
+++ b/pkgs/kde/frameworks/kservice/default.nix
@@ -7,5 +7,11 @@ mkKdeDerivation {
     # explode less when sycoca is deleted
     ./handle-sycoca-deletion.patch
   ];
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
   meta.mainProgram = "kbuildsycoca6";
 }

--- a/pkgs/kde/gear/ark/default.nix
+++ b/pkgs/kde/gear/ark/default.nix
@@ -6,6 +6,12 @@
 mkKdeDerivation {
   pname = "ark";
 
+  outputs = [
+    "out"
+    "man"
+    "doc"
+  ];
+
   extraBuildInputs = [
     libarchive
     (libzip.override { withOpenssl = true; })

--- a/pkgs/kde/gear/dolphin/default.nix
+++ b/pkgs/kde/gear/dolphin/default.nix
@@ -5,6 +5,11 @@
 mkKdeDerivation {
   pname = "dolphin";
 
+  outputs = [
+    "out"
+    "doc"
+  ];
+
   extraBuildInputs = [ qtmultimedia ];
 
   meta.mainProgram = "dolphin";

--- a/pkgs/kde/gear/filelight/default.nix
+++ b/pkgs/kde/gear/filelight/default.nix
@@ -7,6 +7,11 @@
 mkKdeDerivation {
   pname = "filelight";
 
+  outputs = [
+    "out"
+    "doc"
+  ];
+
   extraBuildInputs = [
     kirigami-addons
     kquickcharts

--- a/pkgs/kde/gear/gwenview/default.nix
+++ b/pkgs/kde/gear/gwenview/default.nix
@@ -15,6 +15,11 @@
 mkKdeDerivation {
   pname = "gwenview";
 
+  outputs = [
+    "out"
+    "doc"
+  ];
+
   extraNativeBuildInputs = [ pkg-config ];
   extraBuildInputs = [
     qtmultimedia

--- a/pkgs/kde/gear/kate/default.nix
+++ b/pkgs/kde/gear/kate/default.nix
@@ -1,4 +1,10 @@
 { mkKdeDerivation }:
 mkKdeDerivation {
   pname = "kate";
+
+  outputs = [
+    "out"
+    "doc"
+    "man"
+  ];
 }

--- a/pkgs/kde/gear/kcharselect/default.nix
+++ b/pkgs/kde/gear/kcharselect/default.nix
@@ -1,5 +1,9 @@
 { mkKdeDerivation }:
 mkKdeDerivation {
   pname = "kcharselect";
+  outputs = [
+    "out"
+    "doc"
+  ];
   meta.mainProgram = "kcharselect";
 }

--- a/pkgs/kde/gear/kgraphviewer/default.nix
+++ b/pkgs/kde/gear/kgraphviewer/default.nix
@@ -9,6 +9,11 @@
 mkKdeDerivation {
   pname = "kgraphviewer";
 
+  outputs = [
+    "out"
+    "doc"
+  ];
+
   extraNativeBuildInputs = [ pkg-config ];
   extraBuildInputs = [
     qt5compat

--- a/pkgs/kde/gear/khelpcenter/default.nix
+++ b/pkgs/kde/gear/khelpcenter/default.nix
@@ -10,6 +10,11 @@
 mkKdeDerivation {
   pname = "khelpcenter";
 
+  outputs = [
+    "out"
+    "doc"
+  ];
+
   extraBuildInputs = [
     qtwebengine
     xapian

--- a/pkgs/kde/gear/kio-extras/default.nix
+++ b/pkgs/kde/gear/kio-extras/default.nix
@@ -19,6 +19,11 @@
 mkKdeDerivation {
   pname = "kio-extras";
 
+  outputs = [
+    "out"
+    "doc"
+  ];
+
   extraNativeBuildInputs = [
     pkg-config
     gperf

--- a/pkgs/kde/gear/konsole/default.nix
+++ b/pkgs/kde/gear/konsole/default.nix
@@ -6,6 +6,11 @@
 mkKdeDerivation {
   pname = "konsole";
 
+  outputs = [
+    "out"
+    "doc"
+  ];
+
   extraBuildInputs = [
     qt5compat
     qtmultimedia

--- a/pkgs/kde/gear/korganizer/default.nix
+++ b/pkgs/kde/gear/korganizer/default.nix
@@ -5,6 +5,11 @@
 mkKdeDerivation {
   pname = "korganizer";
 
+  outputs = [
+    "out"
+    "doc"
+  ];
+
   extraBuildInputs = [ qttools ];
   meta.mainProgram = "korganizer";
 }

--- a/pkgs/kde/gear/kwalletmanager/default.nix
+++ b/pkgs/kde/gear/kwalletmanager/default.nix
@@ -1,5 +1,11 @@
 { mkKdeDerivation }:
 mkKdeDerivation {
   pname = "kwalletmanager";
+
+  outputs = [
+    "out"
+    "doc"
+  ];
+
   meta.mainProgram = "kwalletmanager5";
 }

--- a/pkgs/kde/gear/kwave/default.nix
+++ b/pkgs/kde/gear/kwave/default.nix
@@ -19,6 +19,11 @@
 mkKdeDerivation {
   pname = "kwave";
 
+  outputs = [
+    "out"
+    "doc"
+  ];
+
   extraNativeBuildInputs = [ pkg-config ];
   extraBuildInputs = [
     qtmultimedia

--- a/pkgs/kde/gear/okular/default.nix
+++ b/pkgs/kde/gear/okular/default.nix
@@ -10,11 +10,16 @@
   libzip,
   djvulibre,
   ebook_tools,
-  fetchpatch,
   discount,
 }:
 mkKdeDerivation {
   pname = "okular";
+
+  outputs = [
+    "out"
+    "doc"
+    "man"
+  ];
 
   extraNativeBuildInputs = [ pkg-config ];
   extraBuildInputs = [

--- a/pkgs/kde/gear/partitionmanager/default.nix
+++ b/pkgs/kde/gear/partitionmanager/default.nix
@@ -5,6 +5,11 @@
 mkKdeDerivation {
   pname = "partitionmanager";
 
+  outputs = [
+    "out"
+    "doc"
+  ];
+
   propagatedUserEnvPkgs = [ kpmcore ];
 
   passthru = {

--- a/pkgs/kde/misc/kio-extras-kf5/default.nix
+++ b/pkgs/kde/misc/kio-extras-kf5/default.nix
@@ -27,6 +27,11 @@ stdenv.mkDerivation rec {
     hash = "sha256-qar1jzuALINBu6HOuVBU+RUFnqRH9Z/8e5M8ynGxKsk=";
   };
 
+  outputs = [
+    "out"
+    "doc"
+  ];
+
   nativeBuildInputs = [
     cmake
     pkg-config

--- a/pkgs/kde/plasma/bluedevil/default.nix
+++ b/pkgs/kde/plasma/bluedevil/default.nix
@@ -5,5 +5,10 @@
 mkKdeDerivation {
   pname = "bluedevil";
 
+  outptus = [
+    "out"
+    "doc"
+  ];
+
   extraNativeBuildInputs = [ shared-mime-info ];
 }

--- a/pkgs/kde/plasma/kde-cli-tools/default.nix
+++ b/pkgs/kde/plasma/kde-cli-tools/default.nix
@@ -5,5 +5,11 @@
 mkKdeDerivation {
   pname = "kde-cli-tools";
 
+  outputs = [
+    "out"
+    "doc"
+    "man"
+  ];
+
   extraBuildInputs = [ qtsvg ];
 }

--- a/pkgs/kde/plasma/kgamma/default.nix
+++ b/pkgs/kde/plasma/kgamma/default.nix
@@ -5,5 +5,10 @@
 mkKdeDerivation {
   pname = "kgamma";
 
+  outputs = [
+    "out"
+    "doc"
+  ];
+
   extraBuildInputs = [ libxxf86vm ];
 }

--- a/pkgs/kde/plasma/kinfocenter/default.nix
+++ b/pkgs/kde/plasma/kinfocenter/default.nix
@@ -59,6 +59,11 @@ mkKdeDerivation {
       --replace-fail " aha " " ${lib.getExe aha} "
   '';
 
+  outputs = [
+    "out"
+    "doc"
+  ];
+
   extraNativeBuildInputs = [ pkg-config ];
   extraBuildInputs = [ libusb1 ];
 

--- a/pkgs/kde/plasma/kmenuedit/default.nix
+++ b/pkgs/kde/plasma/kmenuedit/default.nix
@@ -1,5 +1,9 @@
 { mkKdeDerivation }:
 mkKdeDerivation {
   pname = "kmenuedit";
+  outptus = [
+    "out"
+    "doc"
+  ];
   meta.mainProgram = "kmenuedit";
 }

--- a/pkgs/kde/plasma/kwin/default.nix
+++ b/pkgs/kde/plasma/kwin/default.nix
@@ -18,7 +18,6 @@
   pipewire,
   krunner,
   python3,
-  fetchpatch,
 }:
 mkKdeDerivation {
   pname = "kwin";
@@ -32,6 +31,11 @@ mkKdeDerivation {
   postPatch = ''
     patchShebangs src/plugins/strip-effect-metadata.py
   '';
+
+  outputs = [
+    "out"
+    "doc"
+  ];
 
   # TZDIR may be unset when running through the kwin_wayland wrapper,
   # but we need it for the lockscreen clock to render

--- a/pkgs/kde/plasma/plasma-desktop/default.nix
+++ b/pkgs/kde/plasma/plasma-desktop/default.nix
@@ -48,6 +48,11 @@ mkKdeDerivation {
     })
   ];
 
+  outputs = [
+    "out"
+    "doc"
+  ];
+
   extraNativeBuildInputs = [ pkg-config ];
   extraBuildInputs = [
     qtsvg

--- a/pkgs/kde/plasma/plasma-pa/default.nix
+++ b/pkgs/kde/plasma/plasma-pa/default.nix
@@ -7,6 +7,11 @@
 mkKdeDerivation {
   pname = "plasma-pa";
 
+  outputs = [
+    "out"
+    "doc"
+  ];
+
   extraNativeBuildInputs = [ pkg-config ];
   extraBuildInputs = [
     libcanberra

--- a/pkgs/kde/plasma/plasma-workspace/default.nix
+++ b/pkgs/kde/plasma/plasma-workspace/default.nix
@@ -47,6 +47,7 @@ mkKdeDerivation {
     "out"
     "dev"
     "devtools"
+    "doc"
     "sessions"
   ];
 

--- a/pkgs/kde/plasma/powerdevil/default.nix
+++ b/pkgs/kde/plasma/powerdevil/default.nix
@@ -7,6 +7,11 @@
 mkKdeDerivation {
   pname = "powerdevil";
 
+  outputs = [
+    "out"
+    "doc"
+  ];
+
   patches = [
     # https://invent.kde.org/plasma/powerdevil/-/merge_requests/601
     ./rb-batterymonitor.patch

--- a/pkgs/kde/plasma/spectacle/default.nix
+++ b/pkgs/kde/plasma/spectacle/default.nix
@@ -20,6 +20,12 @@ mkKdeDerivation {
     })
   ];
 
+  outputs = [
+    "out"
+    "doc"
+    "man"
+  ];
+
   extraNativeBuildInputs = [ pkg-config ];
 
   extraBuildInputs = [

--- a/pkgs/kde/plasma/systemsettings/default.nix
+++ b/pkgs/kde/plasma/systemsettings/default.nix
@@ -3,5 +3,9 @@
 }:
 mkKdeDerivation {
   pname = "systemsettings";
+  outputs = [
+    "out"
+    "doc"
+  ];
   meta.mainProgram = "systemsettings";
 }


### PR DESCRIPTION
Not exhaustive

- cc https://github.com/NixOS/nixpkgs/issues/515268

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
