### PR TITLE
lean4, leanPackages.lean4: fix darwin build

### DIFF
--- a/pkgs/by-name/le/lean4/package.nix
+++ b/pkgs/by-name/le/lean4/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   cmake,
+  cctools,
   fetchFromGitHub,
   git,
   gmp,
@@ -67,7 +68,8 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     makeWrapper
     leangz # Provides leantar
-  ];
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ cctools.libtool ];
 
   buildInputs = [
     gmp

--- a/pkgs/development/lean-modules/lean4/default.nix
+++ b/pkgs/development/lean-modules/lean4/default.nix
@@ -4,6 +4,7 @@
   stdenv,
   symlinkJoin,
   cmake,
+  cctools,
   fetchFromGitHub,
   git,
   gmp,
@@ -75,7 +76,8 @@ let
       cmake
       leangz
       pkg-config
-    ];
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ cctools.libtool ];
 
     buildInputs = [
       gmp


### PR DESCRIPTION
Lake 4.30.0 requires `libtool` on macOS. Fixes Hydra darwin failures since the 4.30.0 bump.