### PR TITLE
android-cli: 1.0.15433482 -> 1.0.15498356

### DIFF
--- a/pkgs/by-name/an/android-cli/package.nix
+++ b/pkgs/by-name/an/android-cli/package.nix
@@ -8,18 +8,19 @@
 }:
 
 let
+  version = "1.0.15498356";
   platformData = {
     x86_64-linux = {
-      url = "https://dl.google.com/android/cli/latest/linux_x86_64/android-cli";
-      hash = "sha256-1F9RVDPqiy60zs2CfWytKSPKeRC9KDTogw4Ml59HaeY=";
+      url = "https://dl.google.com/android/cli/${version}/linux_x86_64/android-cli";
+      hash = "sha256-TmwLwLKqnMCxWwtX8m50KflmisfeG3PjZsBs7z9vccU=";
     };
     x86_64-darwin = {
-      url = "https://dl.google.com/android/cli/latest/darwin_x86_64/android-cli";
-      hash = "sha256-bXP9rRMSqQa3+kfUJnIeDb1LZXh2P2A6ytwunzjyfGs=";
+      url = "https://dl.google.com/android/cli/${version}/darwin_x86_64/android-cli";
+      hash = "sha256-ThBobULyevoKlp/22tdUqnBBccX6FbPDNrSwwuK4wnw=";
     };
     aarch64-darwin = {
-      url = "https://dl.google.com/android/cli/latest/darwin_arm64/android-cli";
-      hash = "sha256-r47LXmilevW0td4N+SRTR7EFnCrPBdG7G/oTUAea90Q=";
+      url = "https://dl.google.com/android/cli/${version}/darwin_arm64/android-cli";
+      hash = "sha256-E3PC0Ivf6MoYRQu56dSD/49LI8DJZhXL27/o6daH0Sg=";
     };
   };
 
@@ -30,7 +31,7 @@ let
 in
 stdenv.mkDerivation {
   pname = "android-cli";
-  version = "1.0.15433482";
+  inherit version;
 
   strictDeps = true;
   __structuredAttrs = true;


### PR DESCRIPTION
## Things done

I was trying to install the android-cli on my pc from nixpkgs unstable but hashes didn't match. Turns out that #523302 used "latest" in fetchurl and the android-cli was updated to a new version.

I found that we can use the version number instead of "latest" do download the specific version, so I updated urls to use that instead of "latest"

Also, android-cli was updated from 1.0.15433482 to 1.0.15498356

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
