### PR TITLE
various: add `doc` & `man` outputs

### DIFF
--- a/pkgs/by-name/bl/bluez/package.nix
+++ b/pkgs/by-name/bl/bluez/package.nix
@@ -71,6 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [
     "out"
     "dev"
+    "man"
   ]
   ++ lib.optional installTests "test";
 

--- a/pkgs/by-name/cp/cpio/package.nix
+++ b/pkgs/by-name/cp/cpio/package.nix
@@ -23,6 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ autoreconfHook ];
 
   separateDebugInfo = true;
+  outputs = [
+    "out"
+    "man"
+  ];
 
   # The code won't compile in c23 mode.
   # https://gcc.gnu.org/gcc-15/porting_to.html#c23-fn-decls-without-parameters

--- a/pkgs/by-name/cu/cups/package.nix
+++ b/pkgs/by-name/cu/cups/package.nix
@@ -14,7 +14,6 @@
   systemdLibs,
   acl,
   gmp,
-  darwin,
   libusb1 ? null,
   gnutls ? null,
   avahi ? null,
@@ -40,6 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     "lib"
     "dev"
     "man"
+    "doc"
   ];
 
   postPatch = ''

--- a/pkgs/by-name/dc/dconf/package.nix
+++ b/pkgs/by-name/dc/dconf/package.nix
@@ -33,6 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
     "out"
     "lib"
     "dev"
+    "man"
   ]
   ++ lib.optional withDocs "devdoc";
 

--- a/pkgs/by-name/ip/iproute2/package.nix
+++ b/pkgs/by-name/ip/iproute2/package.nix
@@ -34,6 +34,8 @@ stdenv.mkDerivation rec {
     "out"
     "dev"
     "scripts"
+    "man"
+    "doc"
   ];
 
   configureFlags = [
@@ -44,7 +46,6 @@ stdenv.mkDerivation rec {
   makeFlags = [
     "PREFIX=$(out)"
     "SBINDIR=$(out)/sbin"
-    "DOCDIR=$(TMPDIR)/share/doc/${pname}" # Don't install docs
     "HDRDIR=$(dev)/include/iproute2"
   ]
   ++ lib.optionals stdenv.hostPlatform.isStatic [

--- a/pkgs/by-name/ma/mandoc/package.nix
+++ b/pkgs/by-name/ma/mandoc/package.nix
@@ -23,6 +23,11 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "8bf0d570f01e70a6e124884088870cbed7537f36328d512909eb10cd53179d9c";
   };
 
+outputs =[
+  "out"
+  "man"
+];
+
   buildInputs = [ zlib ];
 
   configureLocal = ''

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -270,7 +270,10 @@ stdenv.mkDerivation (finalAttrs: {
     "out"
     "dev"
   ]
-  ++ (lib.optional (!buildLibsOnly) "man");
+  ++ (lib.optionals (!buildLibsOnly) [
+    "man"
+    "doc"
+  ]);
   separateDebugInfo = true;
   __structuredAttrs = true;
 


### PR DESCRIPTION
- cc https://github.com/NixOS/nixpkgs/issues/515268
- will probably split into separate PRs

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
