### PR TITLE
betterbird: init at 140.11.0esr-bb23

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -81,6 +81,7 @@ let
       extraPolicies ? { },
       extraPoliciesFiles ? [ ],
       extraAutoConfig ? "",
+      isMail ? false,
       libName ? browser.libName or applicationName, # Important for tor package or the like
       nixExtensions ? null,
       hasMozSystemDirPatch ? (lib.hasPrefix "firefox" pname && !lib.hasSuffix "-bin" pname),
@@ -228,7 +229,7 @@ let
           terminal = false;
         }
         // (
-          if lib.strings.hasPrefix "thunderbird" libName then
+          if isMail then
             {
               genericName = "Email Client";
               comment = "Read and write e-mails or RSS feeds, or manage tasks on calendars.";

--- a/pkgs/applications/networking/mailreaders/thunderbird/wrapper.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/wrapper.nix
@@ -10,6 +10,7 @@ browser: args:
 (wrapFirefox browser (
   {
     libName = "thunderbird";
+    isMail = true;
   }
   // args
 ))

--- a/pkgs/build-support/build-mozilla-mach/default.nix
+++ b/pkgs/build-support/build-mozilla-mach/default.nix
@@ -5,16 +5,19 @@
   meta,
   updateScript ? null,
   binaryName ? "firefox",
+  finalBinaryName ? binaryName,
   application ? "browser",
   applicationName ? "Firefox",
   branding ? null,
   requireSigning ? true,
   allowAddonSideload ? false,
+  withWasiSysroot ? true,
   src,
   unpackPhase ? null,
   extraPatches ? [ ],
   extraPostPatch ? "",
   extraNativeBuildInputs ? [ ],
+  extraPreConfigure ? "",
   extraConfigureFlags ? [ ],
   extraBuildInputs ? [ ],
   extraMakeFlags ? [ ],
@@ -455,7 +458,8 @@ buildStdenv.mkDerivation {
     # linking firefox hits the vm.max_map_count kernel limit with the default musl allocator
     # TODO: Default vm.max_map_count has been increased, retest without this
     export LD_PRELOAD=${mimalloc}/lib/libmimalloc.so
-  '';
+  ''
+  + extraPreConfigure;
 
   # firefox has a different definition of configurePlatforms from nixpkgs, see configureFlags
   configurePlatforms = [ ];
@@ -468,11 +472,11 @@ buildStdenv.mkDerivation {
     "--with-app-name=${binaryName}"
     "--with-distribution-id=org.nixos"
     "--with-libclang-path=${lib.getLib llvmPackagesBuildBuild.libclang}/lib"
-    "--with-wasi-sysroot=${wasiSysRoot}"
     # for firefox, host is buildPlatform, target is hostPlatform
     "--host=${buildStdenv.buildPlatform.config}"
     "--target=${buildStdenv.hostPlatform.config}"
   ]
+  ++ lib.optional withWasiSysroot "--with-wasi-sysroot=${wasiSysRoot}"
   # LTO is done using clang and lld.
   ++ lib.optionals ltoSupport [
     "--enable-lto=cross,full" # Cross-Language LTO
@@ -694,7 +698,7 @@ buildStdenv.mkDerivation {
       bindir=$out/bin
     ''
     + ''
-      "$bindir/${binaryName}" --version
+      "$bindir/${finalBinaryName}" --version
     '';
 
   passthru = {
@@ -703,6 +707,7 @@ buildStdenv.mkDerivation {
     inherit updateScript;
     inherit alsaSupport;
     inherit binaryName;
+    inherit finalBinaryName;
     inherit requireSigning allowAddonSideload;
     inherit jackSupport;
     inherit pipewireSupport;

--- a/pkgs/by-name/be/betterbird-unwrapped/package.nix
+++ b/pkgs/by-name/be/betterbird-unwrapped/package.nix
@@ -1,0 +1,192 @@
+{
+  lib,
+  buildMozillaMach,
+  fetchFromGitHub,
+  git,
+  libdbusmenu-gtk3 ? null,
+  thunderbird-140-unwrapped,
+  stdenv,
+  fetchhg,
+  writers,
+  nix-prefetch-hg,
+  nix,
+}:
+
+let
+  betterbirdVersion = "140.11.0esr-bb23";
+  majVer = lib.versions.major betterbirdVersion;
+
+  thunderbird-unwrapped = thunderbird-140-unwrapped;
+
+  betterbird-patches = fetchFromGitHub {
+    owner = "Betterbird";
+    repo = "thunderbird-patches";
+    rev = betterbirdVersion;
+    hash = "sha256-+hATfjrNLJOqgpVHvhcDs7CohPAsnWr0QJB3j9PLTVI=";
+  };
+
+  # Fetch and extract comm subdirectory
+  comm-source = fetchhg {
+    name = "comm-source";
+    url = "https://hg.mozilla.org/releases/comm-esr${majVer}";
+    rev = "81aede69c16b80937e10ff623edd6ad327239d65";
+    hash = "sha256-ow+jv6eeRecB+hCyNSfL99irZYrEBHq7EqHdOQnFn5k=";
+  };
+
+  updatePackage = writers.writePython3 "update-betterbird" {
+    libraries = (p: [ p.requests ]);
+    flakeIgnore = [ "E501" ];
+    makeWrapperArgs = [
+      "--prefix"
+      "PATH"
+      ":"
+      (lib.makeBinPath [
+        nix
+        nix-prefetch-hg
+      ])
+    ];
+  } ./update.py;
+in
+(
+  (buildMozillaMach {
+    pname = "betterbird";
+    version = betterbirdVersion;
+
+    updateScript = [
+      updatePackage
+      ./.
+    ];
+
+    # Keep binaryName as "thunderbird" so --with-app-name=thunderbird is passed
+    # The betterbird patches change the BINARY variable to "betterbird" while keeping MOZ_APP_NAME=thunderbird
+    applicationName = "Betterbird";
+    binaryName = "thunderbird";
+    finalBinaryName = "betterbird";
+    application = "comm/mail";
+    branding = "comm/mail/branding/betterbird";
+    requireSigning = false;
+    inherit (thunderbird-unwrapped) extraPatches;
+
+    src = fetchhg {
+      name = "mozilla-source";
+      url = "https://hg.mozilla.org/releases/mozilla-esr140";
+      rev = "2e36c464a92f1942683abbed6ceb442308db5eb0";
+      hash = "sha256-J04RUZCYTT5ICFPYDH5Tk+6ZrqQLN9a6uG0+7pQrlBI=";
+    };
+
+    unpackPhase = ''
+      runHook preUnpack
+
+      mozillaDir="$PWD/mozillaDir"
+      # --no-preserve=mode doesn't work because it also removes executable bit
+      cp -r -T "$src" "$mozillaDir"
+      chmod +w "$mozillaDir"
+      cp -r -T ${comm-source} "$mozillaDir/comm"
+      chmod +w -R "$mozillaDir"
+
+      # Change into the source directory
+      cd "$mozillaDir"
+
+      # Set sourceRoot for the build
+      sourceRoot="$mozillaDir"
+
+      runHook postUnpack
+    '';
+
+    extraPostPatch = thunderbird-unwrapped.extraPostPatch or "" + /* bash */ ''
+      echo "extraPostPatch START"
+      declare bb_patches="$(mktemp -d --suffix=_bb_patches)"
+      cp -r -T --no-preserve=mode "${betterbird-patches}/${majVer}" "$bb_patches"
+
+      # fix FHS paths to libdbusmenu (only on non-Darwin when libdbusmenu-gtk3 is available)
+      ${lib.optionalString (!stdenv.hostPlatform.isDarwin && libdbusmenu-gtk3 != null) ''
+        substituteInPlace "$bb_patches/features/12-feature-linux-systray.patch" \
+          --replace-fail "/usr/include/libdbusmenu-glib-0.4/" "${lib.getDev libdbusmenu-gtk3}/include/libdbusmenu-glib-0.4/" \
+          --replace-fail "/usr/include/libdbusmenu-gtk3-0.4/" "${lib.getDev libdbusmenu-gtk3}/include/libdbusmenu-gtk3-0.4/"
+      ''}
+
+      function trim_var() {
+          declare -n var_ref="$1"
+          # remove leading whitespace characters
+          var_ref="''${var_ref#"''${var_ref%%[![:space:]]*}"}"
+          # remove trailing whitespace characters
+          var_ref="''${var_ref%"''${var_ref##*[![:space:]]}"}"
+      }
+
+      function applyPatches() {
+        declare seriesFileName="$1" srcRoot="$2"
+        declare seriesFilePath="${betterbird-patches}/${majVer}/$seriesFileName"
+        declare -a patchLines=()
+        mapfile -t patchLines <"$seriesFilePath"
+        declare patchLine=""
+        for patchLine in "''${patchLines[@]}"; do
+          patchLine="''${patchLine%%#*}"
+          trim_var patchLine
+          if [[ -z $patchLine ]]; then
+            continue
+          fi
+
+          (
+            cd -- "$srcRoot"
+            echo "Applying patch $patchLine in $PWD"
+            ${lib.getExe git} apply -p1 -v --allow-empty < "$bb_patches/$patchLine"
+          )
+        done
+      }
+
+      applyPatches series-moz .
+      applyPatches series comm
+      echo "extraPostPatch END"
+    '';
+
+    extraBuildInputs = lib.optionals (!stdenv.hostPlatform.isDarwin && libdbusmenu-gtk3 != null) [
+      libdbusmenu-gtk3
+    ];
+
+    # Environment variables from official build
+    extraPreConfigure = ''
+      export MOZ_APP_REMOTINGNAME=eu.betterbird.Betterbird
+      export MOZ_REQUIRE_ADDON_SIGNING=0
+    '';
+
+    withWasiSysroot = false;
+
+    # Additional mozconfig options from official Betterbird build
+    extraConfigureFlags = [
+      "--with-unsigned-addon-scopes=app,system"
+      "--allow-addon-sideload"
+    ]
+    ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+      "--enable-default-toolkit=cairo-gtk3-wayland"
+    ]
+    ++ [
+      "--without-wasm-sandboxed-libraries"
+    ];
+
+    extraPassthru = {
+      inherit betterbird-patches comm-source updatePackage;
+    };
+
+    meta = {
+      description = "a fine-tuned version of Mozilla Thunderbird, Thunderbird on steroids, if you will";
+      homepage = "https://www.betterbird.eu/";
+      maintainers = with lib.maintainers; [
+        shelvacu
+        mio
+      ];
+      mainProgram = "betterbird";
+      inherit (thunderbird-unwrapped.meta)
+        platforms
+        broken
+        license
+        ;
+    };
+  }).override
+  {
+    crashreporterSupport = false; # not supported
+    geolocationSupport = false;
+    webrtcSupport = false;
+
+    pgoSupport = false; # console.warn: feeds: "downloadFee d: network connection unavailable"
+  }
+)

--- a/pkgs/by-name/be/betterbird-unwrapped/update.py
+++ b/pkgs/by-name/be/betterbird-unwrapped/update.py
@@ -1,0 +1,119 @@
+import os
+import requests
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+MAJOR_VERSION = 140
+
+
+def get_tags() -> list[str]:
+    token = os.environ.get("GITHUB_TOKEN")
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    response = requests.get(
+        "https://api.github.com/repos/Betterbird/thunderbird-patches/tags",
+        headers=headers,
+    )
+    if response.status_code != 200:
+        raise RuntimeError(f"Failed to fetch release info: {response.status_code} ({response.json().get('message')})")
+    tag_data = response.json()
+    return [x["name"] for x in tag_data]
+
+
+def run(*cmd: str | Path, **kwargs) -> str:
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=None,
+        stdin=subprocess.DEVNULL,
+        text=True,
+        **kwargs,
+    )
+    (stdout_data, _) = proc.communicate()
+    if proc.returncode != 0:
+        raise RuntimeError(f"Failed to run command: {cmd!r} exited with code {proc.returncode}")
+    return stdout_data.strip()
+
+
+def convert_hash_to_sri(base32: str) -> str:
+    return run("nix-hash", "--to-sri", "--type", "sha256", base32)
+
+
+def main() -> int:
+    self_path = Path(sys.argv[1]).absolute()
+    nixpkgs_path = self_path.parent.parent.parent.parent
+
+    print(f"{self_path=} {nixpkgs_path=}", file=sys.stderr)
+
+    def nix_eval(attrpath: str) -> str:
+        return run("nix-instantiate", "--eval", "--raw", "--attr", attrpath, nixpkgs_path)
+
+    tags = get_tags()
+    valid_tags = [tag for tag in tags if re.match(f"^{MAJOR_VERSION}\\..*-bb[0-9]+$", tag)]
+
+    print(f"{tags=} {valid_tags=}", file=sys.stderr)
+
+    old_rev = nix_eval("betterbird-unwrapped.betterbird-patches.rev")
+    if old_rev not in valid_tags:
+        raise RuntimeError(f"Don't know how to update, current rev {old_rev!r} not in {valid_tags!r}")
+
+    new_rev = valid_tags[0]
+
+    if new_rev == old_rev:
+        # nothing to do
+        return 0
+
+    old_url = nix_eval("betterbird-unwrapped.betterbird-patches.url")
+    new_url = old_url.replace(old_rev, new_rev)
+
+    new_hash = run("nix-prefetch-url", "--type", "sha256", "--unpack", new_url)
+    new_sri = convert_hash_to_sri(new_hash)
+
+    old_sri = nix_eval("betterbird-unwrapped.betterbird-patches.hash")
+
+    package_nix = self_path / "package.nix"
+
+    package_nix.write_text(package_nix.read_text().replace(old_rev, new_rev).replace(old_sri, new_sri))
+
+    with tempfile.TemporaryDirectory() as tempdir_str:
+        tempdir = Path(tempdir_str)
+        result = tempdir / "result"
+        run("nix-build", "--expr", "let pkgs = import <nixpkgs> { }; in pkgs.srcOnly { inherit (pkgs.betterbird-unwrapped) name version stdenv; src = pkgs.betterbird-unwrapped.betterbird-patches; }", "--out-link", result, env={**os.environ, "NIX_PATH": f"nixpkgs={nixpkgs_path}"})
+
+        conf_fn = result / f"{MAJOR_VERSION}/{MAJOR_VERSION}.sh"
+        conf = {}
+        for line in conf_fn.read_text().split("\n"):
+            line = line.strip()
+            if line == "" or line[0] == "#":
+                continue
+            name, val = line.split("=", 1)
+            conf[name] = val
+
+        def update_src(conf_name: str, attr_path: str):
+            old_rev = nix_eval(f"{attr_path}.rev")
+            new_rev = conf[f"{conf_name}_REV"]
+            if old_rev == new_rev:
+                return
+            hg_url = nix_eval(f"{attr_path}.url")
+
+            old_sri = nix_eval(f"{attr_path}.hash")
+            new_hash = run("nix-prefetch-hg", hg_url, new_rev)
+            new_sri = convert_hash_to_sri(new_hash)
+            package_nix.write_text(
+                package_nix.read_text()
+                .replace(old_rev, new_rev)
+                .replace(old_sri, new_sri)
+            )
+
+        update_src("MOZILLA", "betterbird-unwrapped.src")
+        update_src("COMM", "betterbird-unwrapped.comm-source")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pkgs/by-name/be/betterbird/package.nix
+++ b/pkgs/by-name/be/betterbird/package.nix
@@ -1,0 +1,8 @@
+{
+  betterbird-unwrapped,
+  wrapThunderbird,
+}:
+wrapThunderbird betterbird-unwrapped {
+  applicationName = "betterbird";
+  libName = "betterbird";
+}


### PR DESCRIPTION
[Betterbird](https://betterbird.eu/) is a fork of thunderbird with various extra features and fixes.

Betterbird was previously in nixpkgs but was [dropped](https://github.com/NixOS/nixpkgs/pull/351205) because of security updates being delayed.

I believe this is much less likely to happen because:
- 2 maintainers, both of whom are not maintaining very many packages. I (shelvacu) am currently marked as maintainer of 5 packages and mio is a maintainer of 2 packages
- This has an auto-update script
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
