### PR TITLE
python3Packages.arxiv2bib: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/arxiv2bib/default.nix
+++ b/pkgs/development/python-modules/arxiv2bib/default.nix
@@ -3,13 +3,14 @@
   lib,
   fetchFromGitHub,
   mock,
+  setuptools,
   unittestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "arxiv2bib";
   version = "1.0.8";
-  format = "setuptools";
+  pyproject = true;
 
   # Missing tests on Pypi
   src = fetchFromGitHub {
@@ -18,6 +19,8 @@ buildPythonPackage rec {
     rev = version;
     sha256 = "1kp2iyx20lpc9dv4qg5fgwf83a1wx6f7hj1ldqyncg0kn9xcrhbg";
   };
+
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [
     unittestCheckHook

--- a/pkgs/development/python-modules/arxiv2bib/default.nix
+++ b/pkgs/development/python-modules/arxiv2bib/default.nix
@@ -7,17 +7,19 @@
   unittestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "arxiv2bib";
   version = "1.0.8";
   pyproject = true;
+
+  __structuredAttrs = true;
 
   # Missing tests on Pypi
   src = fetchFromGitHub {
     owner = "nathangrigg";
     repo = "arxiv2bib";
-    rev = version;
-    sha256 = "1kp2iyx20lpc9dv4qg5fgwf83a1wx6f7hj1ldqyncg0kn9xcrhbg";
+    tag = finalAttrs.version;
+    hash = "sha256-b8HMerITPGY9bjRIeJzpPKiBHH+uPEx2S+xSILqP4s4=";
   };
 
   build-system = [ setuptools ];
@@ -31,6 +33,8 @@ buildPythonPackage rec {
     "tests"
   ];
 
+  pythonImportsCheck = [ "arxiv2bib" ];
+
   meta = {
     description = "Get a BibTeX entry from an arXiv id number, using the arxiv.org API";
     mainProgram = "arxiv2bib";
@@ -38,4 +42,4 @@ buildPythonPackage rec {
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.nico202 ];
   };
-}
+})


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
