### PR TITLE
yashiki: init at 0.14.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1910,6 +1910,11 @@
     githubId = 143312793;
     name = "Annin";
   };
+  anntnzrb = {
+    github = "anntnzrb";
+    githubId = 51257127;
+    name = "anntnzrb";
+  };
   anoa = {
     matrix = "@andrewm:amorgan.xyz";
     email = "andrew@amorgan.xyz";

--- a/pkgs/by-name/ya/yashiki/package.nix
+++ b/pkgs/by-name/ya/yashiki/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+  versionCheckHook,
+  nix-update-script,
+  apple-sdk_15,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "yashiki";
+  version = "0.14.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "typester";
+    repo = "yashiki";
+    tag = "yashiki-v${finalAttrs.version}";
+    hash = "sha256-ePZ8ONdvj3gaQps+5Ua0OLeFdzNdJhoB9yw6pC7qoEQ=";
+  };
+
+  cargoHash = "sha256-JMrftBKyD188SZqEGI4fA/MrfEK8JLKSeEqrQxhSs3U=";
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  buildInputs = [
+    apple-sdk_15
+  ];
+
+  postInstall = ''
+    app="$out/Applications/Yashiki.app"
+
+    mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources/layouts"
+
+    ln -s "$out/bin/yashiki" "$app/Contents/MacOS/yashiki"
+    ln -s "$out/bin/yashiki-layout-tatami" "$app/Contents/Resources/layouts/yashiki-layout-tatami"
+    ln -s "$out/bin/yashiki-layout-byobu" "$app/Contents/Resources/layouts/yashiki-layout-byobu"
+
+    cp resources/icon/Assets.car "$app/Contents/Resources/Assets.car"
+    substitute Info.plist.template "$app/Contents/Info.plist" \
+      --replace-fail VERSION_PLACEHOLDER "${finalAttrs.version}" \
+      --replace-fail "<string>yashiki-launcher</string>" "<string>yashiki</string>"
+
+    installShellCompletion --cmd yashiki --zsh completions/zsh/_yashiki
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "macOS tiling window manager";
+    homepage = "https://github.com/typester/yashiki";
+    changelog = "https://github.com/typester/yashiki/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+    maintainers = with lib.maintainers; [ anntnzrb ];
+    mainProgram = "yashiki";
+    platforms = lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
## Description of changes

Adds `yashiki`, a macOS tiling window manager written in Rust.

The package builds the Rust workspace from source and installs:
- `yashiki`, `yashiki-layout-tatami`, and `yashiki-layout-byobu` binaries
- upstream zsh completion
- a minimal `.app` bundle at `$out/Applications/Yashiki.app`

The `.app` bundle uses upstream `Info.plist.template`, with `CFBundleExecutable` changed from upstream's bash launcher to the actual `yashiki` binary.

Both commits include `Assisted-by: OpenAI ChatGPT` trailers.

## Things done

- Built on platform(s)
  - [x] `aarch64-darwin`
  - [ ] `x86_64-darwin`
  - [ ] `x86_64-linux`
- For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = true`
  - [x] `sandbox = false`
- [x] Tested compilation of all packages that depend on this change using `nixpkgs-review rev HEAD --print-result` and `nixpkgs-review wip --staged -r upstream -b master -p yashiki --print-result`
- [x] Tested basic functionality of all binary files:
  - [x] `result/bin/yashiki version`
  - [x] `result/Applications/Yashiki.app/Contents/MacOS/yashiki version`
- [x] Tested version check hook during package build
- [x] Ran `nix-build lib/tests/maintainers.nix`
- [x] Ran `git diff --check`
- [x] Formatted changed Nix files with `nixfmt`

## nixpkgs-review result

```text
1 package built:
yashiki
```

Platform: `aarch64-darwin`.