### PR TITLE
[Backport release-25.11] scaleway-cli: disable time-dependent test

### DIFF
--- a/pkgs/by-name/sc/scaleway-cli/package.nix
+++ b/pkgs/by-name/sc/scaleway-cli/package.nix
@@ -29,6 +29,16 @@ buildGoModule rec {
 
   doCheck = true;
 
+  checkFlags = [
+    # This subtest hardcodes a go-humanize relative-time string ("35 years ago")
+    # for a fixed 1990 date instead of computing it, so it breaks once enough
+    # wall-clock time passes (now "36 years ago"). go-humanize truncates the
+    # elapsed time by a fixed 360-day year (Year = 12*Month, Month = 30*Day), so
+    # diff/Year rolled 35 -> 36 on 2026-05-12. Upstream keeps bumping the
+    # literal by hand rather than fixing it, so skip the time-dependent subtest.
+    "-skip=^TestMarshal/structWithMapsInSection$"
+  ];
+
   # Some tests require access to scaleway's API, failing when sandboxed
   preCheck = ''
     substituteInPlace core/bootstrap_test.go \


### PR DESCRIPTION
Manual backport of PR https://github.com/NixOS/nixpkgs/pull/527216 (simple conflict).