### PR TITLE
steelix: follow helix for default runtime dir

### DIFF
--- a/pkgs/by-name/st/steelix/package.nix
+++ b/pkgs/by-name/st/steelix/package.nix
@@ -3,10 +3,10 @@
   helix,
   installShellFiles,
   lib,
+  runCommand,
   rustPlatform,
   makeBinaryWrapper,
 }:
-
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "steelix";
   version = "0-unstable-2026-05-21";
@@ -34,7 +34,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   env = {
     HELIX_DISABLE_AUTO_GRAMMAR_BUILD = "1";
-    HELIX_DEFAULT_RUNTIME = helix.runtime;
+    HELIX_DEFAULT_RUNTIME = runCommand "steelix-default-runtime" { } ''
+      cp -r --no-preserve=mode ${finalAttrs.src}/runtime $out
+      rm -rf $out/grammars $out/queries
+    '';
   };
 
   postInstall = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The current Steelix package does not have all the theme in its runtime. This fix that.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
