### PR TITLE
vi-sql: init at 0.1.4

### DIFF
--- a/pkgs/by-name/vi/vi-sql/package.nix
+++ b/pkgs/by-name/vi/vi-sql/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  writableTmpDirAsHomeHook,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "vi-sql";
+  version = "0.1.4";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "kopecmaciej";
+    repo = "vi-sql";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-At3ERFuTyfkhzi12xiLd4XrmyMfgaG5hnvXbEVh6ZKA=";
+  };
+
+  vendorHash = "sha256-sMaX1lfBK6SYxQ79Tz5c++Lfe31uCzksH4sR/4ga5pM=";
+
+  ldflags = [
+    "-s"
+    "-X=github.com/kopecmaciej/vi-sql/internal/build.Version=${finalAttrs.src.tag}"
+  ];
+
+  nativeBuildInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terminal UI for SQL databases";
+    homepage = "https://vi-sql.com/";
+    downloadPage = "https://github.com/kopecmaciej/vi-sql";
+    changelog = "https://github.com/kopecmaciej/vi-sql/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kpbaks ];
+    mainProgram = "vi-sql";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
