### PR TITLE
mlkit: also install barry

### DIFF
--- a/pkgs/by-name/ml/mlkit/package.nix
+++ b/pkgs/by-name/ml/mlkit/package.nix
@@ -27,11 +27,13 @@ stdenv.mkDerivation (finalAttrs: {
     "mlkit_libs"
     "smltojs"
     "smltojs_basislibs"
+    "barry"
   ];
 
   installTargets = [
     "install"
     "install_smltojs"
+    "install_barry"
   ];
 
   doCheck = true;
@@ -46,6 +48,8 @@ stdenv.mkDerivation (finalAttrs: {
     make -C test_dev test
     echo ==== Running MLKit test suite: test_prof ====
     make -C test_dev test_prof
+    echo ==== Running Barry test suite ====
+    make -C test/barry
     runHook postCheck
   '';
 
@@ -54,7 +58,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://elsman.com/mlkit/";
     changelog = "https://github.com/melsman/mlkit/blob/v${finalAttrs.version}/NEWS.md";
     license = lib.licenses.gpl2Plus;
-    platforms = lib.platforms.unix;
+    platforms = [
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
     maintainers = with lib.maintainers; [ athas ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds the `barry` executable to the MLKit build.
[Barry](https://github.com/melsman/mlkit/blob/master/README_BARRY.md) is a Standard ML simplifier, which translates the full Standard ML language (including the module system) into a subset of the Core language.

This PR also properly restricts the available platforms to match that of `mlton`, a build dependency.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
