### PR TITLE
ghdl-llvm-jit: init at 6.0.0

### DIFF
--- a/pkgs/by-name/gh/ghdl/package.nix
+++ b/pkgs/by-name/gh/ghdl/package.nix
@@ -13,11 +13,21 @@
   libmpc,
   gnutar,
   makeWrapper,
-  backend ? "mcode",
+  backend ? if stdenv.hostPlatform.isAarch64 then "llvm-jit" else "mcode",
 }:
 
-assert backend == "mcode" || backend == "llvm" || backend == "gcc";
+assert lib.asserts.assertOneOf "backend" backend [
+  "mcode"
+  "llvm"
+  "llvm-jit"
+  "gcc"
+];
 
+let
+  backendIsLLVM = backend == "llvm";
+  backendIsLLVMJit = backend == "llvm-jit";
+  backendIsGCC = backend == "gcc";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "ghdl-${backend}";
   version = "6.0.0";
@@ -37,17 +47,17 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     gnat
   ]
-  ++ lib.optionals (backend == "llvm" || backend == "gcc") [
+  ++ lib.optionals (backendIsLLVM || backendIsGCC) [
     makeWrapper
   ]
-  ++ lib.optionals (backend == "gcc") [
+  ++ lib.optionals backendIsGCC [
     texinfo
   ];
 
   buildInputs = [
     zlib
   ]
-  ++ lib.optionals (backend == "gcc") [
+  ++ lib.optionals backendIsGCC [
     gmp
     mpfr
     libmpc
@@ -57,7 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
     # If llvm 7.0 works, 7.x releases should work too.
     sed -i 's/check_version  7.0/check_version  7/g' configure
   ''
-  + lib.optionalString (backend == "gcc") ''
+  + lib.optionalString backendIsGCC ''
     ${gnutar}/bin/tar -xf ${gcc13.cc.src}
   '';
 
@@ -66,14 +76,17 @@ stdenv.mkDerivation (finalAttrs: {
     "--disable-werror"
     "--enable-synth"
   ]
-  ++ lib.optionals (backend == "llvm") [
+  ++ lib.optionals (backendIsLLVM || backendIsLLVMJit) [
     "--with-llvm-config=${llvm.dev}/bin/llvm-config"
   ]
-  ++ lib.optionals (backend == "gcc") [
+  ++ lib.optionals backendIsLLVMJit [
+    "--with-llvm-jit"
+  ]
+  ++ lib.optionals backendIsGCC [
     "--with-gcc=gcc-${gcc13.cc.version}"
   ];
 
-  buildPhase = lib.optionalString (backend == "gcc") ''
+  buildPhase = lib.optionalString backendIsGCC ''
     make copy-sources
     mkdir gcc-objs
     cd gcc-objs
@@ -93,14 +106,14 @@ stdenv.mkDerivation (finalAttrs: {
       --with-mpfr-include=${mpfr.dev}/include \
       --with-mpfr-lib=${mpfr.out}/lib \
       --with-mpc=${libmpc} \
-      --enable-default-pie=${if stdenv.targetPlatform.hasSharedLibraries then "yes" else "no"}
+      --enable-default-pie=${lib.boolToYesNo stdenv.targetPlatform.hasSharedLibraries}
     make -j $NIX_BUILD_CORES
     make install
     cd ../
     make -j $NIX_BUILD_CORES ghdllib
   '';
 
-  postFixup = lib.optionalString (backend == "llvm" || backend == "gcc") ''
+  postFixup = lib.optionalString (backendIsLLVM || backendIsGCC) ''
     wrapProgram $out/bin/ghdl \
       --set LIBRARY_PATH ${lib.makeLibraryPath [ zlib ]} \
       --prefix PATH : ${lib.makeBinPath [ stdenv.cc ]}
@@ -108,7 +121,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   hardeningDisable = [
   ]
-  ++ lib.optionals (backend == "gcc") [
+  ++ lib.optionals backendIsGCC [
     # GCC compilation fails with format errors
     "format"
   ];
@@ -135,7 +148,11 @@ stdenv.mkDerivation (finalAttrs: {
       thoughtpolice
       sempiternal-aurora
     ];
-    platforms =
-      lib.platforms.linux ++ lib.optionals (backend == "mcode" || backend == "llvm") [ "x86_64-darwin" ];
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+    ]
+    ++ lib.optionals (backendIsLLVM || backendIsLLVMJit || backendIsGCC) [ "aarch64-linux" ]
+    ++ lib.optionals (backendIsLLVM || backendIsLLVMJit) [ "aarch64-darwin" ];
   };
 })

--- a/pkgs/by-name/gh/ghdl/test-simple.nix
+++ b/pkgs/by-name/gh/ghdl/test-simple.nix
@@ -1,6 +1,7 @@
 {
-  stdenv,
+  stdenvNoCC,
   ghdl-llvm,
+  ghdl-llvm-jit,
   ghdl-mcode,
   ghdl-gcc,
   backend,
@@ -10,12 +11,14 @@ let
   ghdl =
     if backend == "llvm" then
       ghdl-llvm
+    else if backend == "llvm-jit" then
+      ghdl-llvm-jit
     else if backend == "gcc" then
       ghdl-gcc
     else
       ghdl-mcode;
 in
-stdenv.mkDerivation {
+stdenvNoCC.mkDerivation {
   name = "ghdl-test-simple";
   meta.timeout = 300;
   nativeBuildInputs = [ ghdl ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3707,6 +3707,8 @@ with pkgs;
 
   ghdl-llvm = ghdl.override { backend = "llvm"; };
 
+  ghdl-llvm-jit = ghdl.override { backend = "llvm-jit"; };
+
   gcc-arm-embedded = gcc-arm-embedded-15;
 
   # Haskell and GHC


### PR DESCRIPTION
Add the new backend added to ghdl in 5.0.1. Also cleanup various parts of the code, and fix the platforms now that gnat may soon be available on aarch64-linux (`ghdl-mcode` actually doesn't build on it, nor should it).

Also, changed the default backend on aarch64 platforms to be llvm-jit, which should be a drop-in replacement for mcode that actually works on non-x86_64 cpus.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
