### PR TITLE
bacula: fix x86_64-darwin build

### DIFF
--- a/pkgs/by-name/ba/bacula/package.nix
+++ b/pkgs/by-name/ba/bacula/package.nix
@@ -28,9 +28,9 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # libtool.m4 only matches macOS 10.*
-  postPatch = lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) ''
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
     substituteInPlace configure \
-      --replace "10.*)" "*)"
+      --replace-fail "10.*)" "*)"
   '';
 
   buildInputs = [


### PR DESCRIPTION
## Things done

The `postPatch` widens libtool's macOS-version match in the generated `configure` from `10.*` to `*` so it recognises Big Sur and later. It was gated on `(isDarwin && isAarch64)`, which left x86_64-darwin failing at the link step with `ld: symbol(s) not found for architecture x86_64` because the case clause never matches modern macOS versions there either.

The substitution targets the host-OS match in the configure script — arch-agnostic. Gating on `isDarwin` alone fixes the Hydra failure without affecting aarch64-darwin. Switched `--replace` to `--replace-fail` so a future configure-script change that drops the `10.*)` pattern surfaces loudly instead of silently no-op'ing.

Hydra failure being fixed: https://hydra.nixos.org/build/330206792

- Built on platform(s)
  - [x] x86_64-linux (derivation hash unchanged — postPatch is a no-op on isLinux; sanity-built locally and the hash matched cache.nixos.org)
  - [ ] aarch64-linux
  - [x] x86_64-darwin (macOS 15.6.1 Sequoia, Intel Mac — nix-build -A bacula lands /nix/store/.../bacula-15.0.3 cleanly)
  - [ ] aarch64-darwin
- [x] Fits CONTRIBUTING.md

## Backport

Candidate for backport release-26.05 — the failure is on stable Hydra and 26.05 is the last release supporting x86_64-darwin per upstream announcement. Could you apply the label when reviewing?