### PR TITLE
switch-to-configuration-ng: Handle dbus errors

### DIFF
--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
@@ -1073,14 +1073,17 @@ fn login1_proxy(conn: &LocalConnection) -> Proxy<'_, &LocalConnection> {
 fn block_on_jobs(
     conn: &LocalConnection,
     submitted_jobs: &Rc<RefCell<HashMap<dbus::Path<'static>, Job>>>,
-) {
+) -> anyhow::Result<()> {
     while !submitted_jobs.borrow().is_empty() {
         log::debug!(
             "waiting for submitted jobs to finish, still have {} job(s)",
             submitted_jobs.borrow().len()
         );
-        _ = conn.process(DBUS_PROCESS_TIME);
+        _ = conn
+            .process(DBUS_PROCESS_TIME)
+            .context("Failed to process dbus messages while waiting for jobs")?;
     }
+    Ok(())
 }
 
 fn remove_file_if_exists(p: impl AsRef<Path>) -> std::io::Result<()> {
@@ -1521,7 +1524,7 @@ fn do_user_switch(parent_exe: String) -> anyhow::Result<()> {
             submitted_jobs.borrow_mut().insert(job_path, Job::Stop);
         }
     }
-    block_on_jobs(&dbus_conn, &submitted_jobs);
+    block_on_jobs(&dbus_conn, &submitted_jobs)?;
 
     if !units_to_skip.is_empty() {
         print_units("NOT restarting", &units_to_skip);
@@ -1547,7 +1550,7 @@ fn do_user_switch(parent_exe: String) -> anyhow::Result<()> {
             }
         }
     }
-    block_on_jobs(&dbus_conn, &submitted_jobs);
+    block_on_jobs(&dbus_conn, &submitted_jobs)?;
     remove_file_if_exists(&reload_list)
         .with_context(|| format!("Failed to remove {}", reload_list.display()))?;
 
@@ -1563,7 +1566,7 @@ fn do_user_switch(parent_exe: String) -> anyhow::Result<()> {
             }
         }
     }
-    block_on_jobs(&dbus_conn, &submitted_jobs);
+    block_on_jobs(&dbus_conn, &submitted_jobs)?;
     remove_file_if_exists(&restart_list)
         .with_context(|| format!("Failed to remove {}", restart_list.display()))?;
 
@@ -1580,7 +1583,7 @@ fn do_user_switch(parent_exe: String) -> anyhow::Result<()> {
             }
         }
     }
-    block_on_jobs(&dbus_conn, &submitted_jobs);
+    block_on_jobs(&dbus_conn, &submitted_jobs)?;
     remove_file_if_exists(&start_list)
         .with_context(|| format!("Failed to remove {}", start_list.display()))?;
 
@@ -1677,7 +1680,7 @@ fn do_user_switch(parent_exe: String) -> anyhow::Result<()> {
                 }
             }
         }
-        block_on_jobs(&dbus_conn, &submitted_jobs);
+        block_on_jobs(&dbus_conn, &submitted_jobs)?;
 
         print_units("restarting (post-activation)", &to_restart);
         for unit in to_restart.keys() {
@@ -1691,7 +1694,7 @@ fn do_user_switch(parent_exe: String) -> anyhow::Result<()> {
                 }
             }
         }
-        block_on_jobs(&dbus_conn, &submitted_jobs);
+        block_on_jobs(&dbus_conn, &submitted_jobs)?;
 
         let to_start_filtered = filter_units(&units_to_filter, &to_start);
         print_units("starting (post-activation)", &to_start_filtered);
@@ -1706,7 +1709,7 @@ fn do_user_switch(parent_exe: String) -> anyhow::Result<()> {
                 }
             }
         }
-        block_on_jobs(&dbus_conn, &submitted_jobs);
+        block_on_jobs(&dbus_conn, &submitted_jobs)?;
     }
 
     let finished = finished_jobs.borrow();
@@ -2198,7 +2201,7 @@ won't take effect until you reboot the system.
             };
         }
 
-        block_on_jobs(&dbus_conn, &submitted_jobs);
+        block_on_jobs(&dbus_conn, &submitted_jobs)?;
     }
 
     if !units_to_skip.is_empty() {
@@ -2214,7 +2217,7 @@ won't take effect until you reboot the system.
     }
 
     // Wait for all stop jobs to finish
-    block_on_jobs(&dbus_conn, &submitted_jobs);
+    block_on_jobs(&dbus_conn, &submitted_jobs)?;
 
     let mut exit_code = 0;
 
@@ -2437,7 +2440,7 @@ won't take effect until you reboot the system.
     }
 
     // Wait for the restart job of sysinit-reactivation.service to finish
-    block_on_jobs(&dbus_conn, &submitted_jobs);
+    block_on_jobs(&dbus_conn, &submitted_jobs)?;
 
     // Before reloading we need to ensure that the units are still active. They may have been
     // deactivated because one of their requirements got stopped. If they are inactive but should
@@ -2492,7 +2495,7 @@ won't take effect until you reboot the system.
             }
         }
 
-        block_on_jobs(&dbus_conn, &submitted_jobs);
+        block_on_jobs(&dbus_conn, &submitted_jobs)?;
 
         remove_file_if_exists(RELOAD_LIST_FILE)
             .with_context(|| format!("Failed to remove {RELOAD_LIST_FILE}"))?;
@@ -2520,7 +2523,7 @@ won't take effect until you reboot the system.
             }
         }
 
-        block_on_jobs(&dbus_conn, &submitted_jobs);
+        block_on_jobs(&dbus_conn, &submitted_jobs)?;
 
         remove_file_if_exists(RESTART_LIST_FILE)
             .with_context(|| format!("Failed to remove {RESTART_LIST_FILE}"))?;
@@ -2553,7 +2556,7 @@ won't take effect until you reboot the system.
         }
     }
 
-    block_on_jobs(&dbus_conn, &submitted_jobs);
+    block_on_jobs(&dbus_conn, &submitted_jobs)?;
 
     remove_file_if_exists(START_LIST_FILE)
         .with_context(|| format!("Failed to remove {START_LIST_FILE}"))?;


### PR DESCRIPTION
In #527469 I hit a loop that used 100% cpu without stopping. I think the problem was the `block_on_jobs` function not checking for errors when processing the dbus messages. This commit changes that by checking the error.

Fixes #527469

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
