### PR TITLE
lrzip: fix x86_64-darwin build (disable asm)

### DIFF
--- a/pkgs/by-name/lr/lrzip/package.nix
+++ b/pkgs/by-name/lr/lrzip/package.nix
@@ -12,7 +12,13 @@
 }:
 
 let
-  inherit (stdenv.hostPlatform) isx86;
+  inherit (stdenv.hostPlatform) isx86 isDarwin;
+  # nasm emits ELF by default and lrzip's build system doesn't pass
+  # `-f macho64`, so the resulting `7zCrcOpt_asm.o` is rejected at
+  # link time on darwin with "archive member ... is not mach-o".
+  # Falling back to the C path via --disable-asm is the simplest fix;
+  # the perf delta is negligible for this codepath.
+  useAsm = isx86 && !isDarwin;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "lrzip";
@@ -29,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
     autoreconfHook
     perl
   ]
-  ++ lib.optionals isx86 [ nasm ];
+  ++ lib.optionals useAsm [ nasm ];
 
   buildInputs = [
     zlib
@@ -38,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     lz4
   ];
 
-  configureFlags = lib.optionals (!isx86) [
+  configureFlags = lib.optionals (!useAsm) [
     "--disable-asm"
   ];
 


### PR DESCRIPTION
## Things done

The Hydra failure on x86_64-darwin (build 330240771) bails at link time with:

```
ld: ... archive member '7zCrcOpt_asm.o' ... is not mach-o
```

nasm emits ELF object files by default and lrzip's build system doesn't pass `-f macho64`, so the resulting `.o` is unlinkable on darwin.

Falling back to the C implementation via `--disable-asm` is the simplest fix — the perf delta on this codepath is negligible, and it matches what every other non-x86 platform already does (the existing `configureFlags` line had `--disable-asm` gated on `!isx86`). Extending the gate to also exclude darwin lifts nasm out of `nativeBuildInputs` too.

Fixes https://hydra.nixos.org/build/330240771

- Built on platform(s)
  - [x] x86_64-linux (derivation hash unchanged — `useAsm` evaluates identically to `isx86` on linux; fetched from cache)
  - [ ] aarch64-linux
  - [x] x86_64-darwin (macOS 15.6.1 Sequoia, Intel Mac — `nix-build -A lrzip` lands `/nix/store/.../lrzip-0.660`; binary runs)
  - [ ] aarch64-darwin
- [x] Fits CONTRIBUTING.md

## Backport

Candidate for `backport release-26.05` — fixes a Hydra failure on the stable channel + 26.05 is the last release to support x86_64-darwin. Could you apply the label when reviewing?