### PR TITLE
phpExtensions.{shmop,sysvshm}, perlPackages.IPCShareLite: skip doCheck on darwin

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -18041,6 +18041,11 @@ with self;
       url = "mirror://cpan/authors/id/A/AN/ANDYA/IPC-ShareLite-0.17.tar.gz";
       hash = "sha256-FNQGuR2pbWUh0NGoLSKjBidHZSJrhrClbn/93Plq578=";
     };
+    # t/sharelite.t calls IPC::ShareLite->new(...) which creates a SysV
+    # shared-memory segment. The darwin build sandbox denies that; the
+    # test bails with "Failed to create share at t/sharelite.t line 18"
+    # and 13/14 subtests get skipped. The module works at runtime.
+    doCheck = !stdenv.hostPlatform.isDarwin;
     meta = {
       description = "Lightweight interface to shared memory";
       license = with lib.licenses; [

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -665,7 +665,14 @@ lib.makeScope pkgs.newScope (
               name = "session";
               doCheck = false;
             }
-            { name = "shmop"; }
+            {
+              name = "shmop";
+              # Tests try to create a private SysV shared-memory segment
+              # via shmop_open(IPC_PRIVATE, …), which fails in the darwin
+              # build sandbox ("Failed to create share"). The extension
+              # itself works at runtime; skip the tests on darwin.
+              doCheck = !stdenv.hostPlatform.isDarwin;
+            }
             {
               name = "simplexml";
               buildInputs = [
@@ -721,6 +728,9 @@ lib.makeScope pkgs.newScope (
             {
               name = "sysvshm";
               configureFlags = [ "CFLAGS=-std=gnu17" ];
+              # Same as shmop above: the test creates a SysV shm segment
+              # which the darwin build sandbox forbids.
+              doCheck = !stdenv.hostPlatform.isDarwin;
             }
             {
               name = "tidy";


### PR DESCRIPTION
## Things done

Three packages fail on x86_64-darwin Hydra with the same root cause: their tests create a SysV shared-memory segment via `shmop_open(IPC_PRIVATE)` / `IPC::ShareLite->new(...)`, which the darwin build sandbox denies. The extensions themselves work at runtime; only the tests trip the sandbox.

**php-shmop / php-sysvshm** (representative tail):
```
FAIL shmop_open with IPC_PRIVATE creates private SHM [tests/shmop_open_private.phpt]
Tests failed: 3 (60%); Tests passed: 0; FAILED TEST SUMMARY at make: *** [Makefile:135: test] Error 1
```

**perl IPCShareLite**:
```
t/sharelite.t .... 1/14 Failed to create share at t/sharelite.t line 18.
Failed 13/14 subtests; Result: FAIL
```

Following the existing precedent at `perl-packages.nix:3439` and `php-packages.nix:697` (`soap` extension) — `doCheck = !isDarwin` for tests that exercise sandbox-forbidden capabilities. One PR covers all twelve php variant × extension combinations (shmop + sysvshm × 6 php attrs: default + php82/83/84/85 + per-variant aliases) plus the perl module.

Verified on x86_64-darwin (macOS 15.6.1, Intel Mac):
- `php84Extensions.shmop` → `/nix/store/.../php-shmop-8.4.21`
- `php84Extensions.sysvshm` → `/nix/store/.../php-sysvshm-8.4.21`
- `perlPackages.IPCShareLite` → `/nix/store/.../IPC-ShareLite-0.17`

x86_64-linux unchanged — the conditional evaluates to `true` there, matching prior behaviour.

Fixes (representative Hydra failures):
- https://hydra.nixos.org/job/nixpkgs/nixpkgs-26.05-darwin/php84Extensions.shmop.x86_64-darwin
- https://hydra.nixos.org/job/nixpkgs/nixpkgs-26.05-darwin/php84Extensions.sysvshm.x86_64-darwin
- https://hydra.nixos.org/job/nixpkgs/nixpkgs-26.05-darwin/perlPackages.IPCShareLite.x86_64-darwin

- Built on platform(s)
  - [x] x86_64-linux (derivation hash unchanged on linux — conditional is true there)
  - [ ] aarch64-linux
  - [x] x86_64-darwin (macOS 15.6.1 Sequoia, Intel Mac)
  - [ ] aarch64-darwin
- [x] Fits CONTRIBUTING.md

## Backport

Candidate for `backport release-26.05` — same Hydra failure exists on stable + 26.05 is the last release to support x86_64-darwin. Could you apply the label when reviewing?