### PR TITLE
ci/github-script/prepare: qualify recommendation to retarget from nixos-*

### DIFF
--- a/ci/github-script/prepare.js
+++ b/ci/github-script/prepare.js
@@ -41,11 +41,16 @@ module.exports = async ({ github, context, core, dry }) => {
 
     if (baseClassification.type.includes('channel')) {
       const { stable, version } = baseClassification
-      const correctBranch = stable ? `release-${version}` : 'master'
+
+      let releaseStable = `release-*`
+      if (stable) {
+        releaseStable = `release-${version}`
+      }
+
       const body = [
         'The `nixos-*` and `nixpkgs-*` branches are pushed to by the channel release script and should not be merged into directly.',
         '',
-        `Please target \`${correctBranch}\` instead.`,
+        `Make sure you know the [right base branch for your changes](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#branch-conventions), then target \`${releaseStable}\` or \`master\` instead.`,
       ].join('\n')
 
       await postReview({ github, context, core, dry, body, reviewKey })


### PR DESCRIPTION
Currently the script unconditionally recommends that the PR be retargeted against stable if it was originally made against a stable nixos branch, which can be confusing for first-time contributors.

These PRs are always in error, and are usually made by first-time contributors who have not read CONTRIBUTING.md. Accordingly, we shouldn't expect them to know the differences between the stable and unstable branches. A recommendation of retargeting against stable is likely to cause confusion because it is presented as the absolutely correct choice.

Change the message to instead specify they should read the relevant documentation section.

Untested and done from my phone, so double-check everything's right.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
