### PR TITLE
cpufetch: fix x86_64-darwin build (add sysctl.c on darwin too)

### DIFF
--- a/pkgs/by-name/cp/cpufetch/darwin-x86-sysctl.patch
+++ b/pkgs/by-name/cp/cpufetch/darwin-x86-sysctl.patch
@@ -1,0 +1,11 @@
+--- a/Makefile
++++ b/Makefile
+@@ -30,7 +30,7 @@
+ 			HEADERS += $(SRC_DIR)freq/freq.h
+ 			CFLAGS += -pthread
+ 		endif
+-		ifeq ($(os), FreeBSD)
++		ifneq (,$(filter $(os),FreeBSD Darwin))
+ 			SOURCE += $(SRC_COMMON)sysctl.c
+ 			HEADERS += $(SRC_COMMON)sysctl.h
+ 		endif

--- a/pkgs/by-name/cp/cpufetch/package.nix
+++ b/pkgs/by-name/cp/cpufetch/package.nix
@@ -20,6 +20,15 @@ stdenv.mkDerivation (finalAttrs: {
     installShellFiles
   ];
 
+  # Upstream Makefile bug: for x86 builds, sysctl.c is only added to
+  # SOURCE on FreeBSD even though cpuid.c calls get_sys_info_by_name
+  # (defined there) on darwin too. Without this the x86_64-darwin
+  # build fails to link with "Undefined symbols: _get_sys_info_by_name".
+  # Widen the conditional to cover Darwin alongside FreeBSD.
+  patches = lib.optionals stdenv.hostPlatform.isDarwin [
+    ./darwin-x86-sysctl.patch
+  ];
+
   installPhase = ''
     runHook preInstall
 


### PR DESCRIPTION
## Things done

The Hydra failure on x86_64-darwin (build 330211579) bails at link time:

```
Undefined symbols for architecture x86_64:
  "_get_sys_info_by_name", referenced from:
      _get_frequency_info in cpuid-XXX.o
ld: symbol(s) not found for architecture x86_64
```

**Upstream Makefile bug, already fixed on master.** `get_sys_info_by_name` is defined in `src/common/sysctl.c` and called from `src/x86/cpuid.c:979` (CPU-frequency detection via sysctl). The v1.07-tagged Makefile adds `sysctl.c` to `SOURCE` only inside the `ifeq (os, FreeBSD)` block of the x86 arch branch — Darwin x86_64 falls through without the source, so the link breaks.

Upstream master fixed this in [b1f20cf](https://github.com/Dr-Noob/cpufetch/commit/b1f20cf) (post-v1.07, no release tag yet) with semantically the same change:

```diff
-		ifeq ($(os), FreeBSD)
+		ifeq ($(os), $(filter $(os), FreeBSD Darwin))
```

This PR backports the equivalent change to the currently-pinned v1.07 as a small `.patch` file. (Either form works; I'd just bump cpufetch to the unstable post-v1.07 commit but Dr-Noob hasn't cut a release tag for it.)

```diff
-		ifeq ($(os), FreeBSD)
+		ifneq (,$(filter $(os),FreeBSD Darwin))
 			SOURCE += $(SRC_COMMON)sysctl.c
 			HEADERS += $(SRC_COMMON)sysctl.h
 		endif
```

Build now compiles `src/common/sysctl.c` and links cleanly; `cpufetch` runs on macOS 15.6.1 Sequoia and prints the Intel banner.

Fixes https://hydra.nixos.org/build/330211579

- Built on platform(s)
  - [x] x86_64-linux (derivation hash unchanged on linux; cache hit)
  - [ ] aarch64-linux
  - [x] x86_64-darwin (macOS 15.6.1 Sequoia, Intel Mac)
  - [ ] aarch64-darwin
- [x] Fits CONTRIBUTING.md

Candidate for `backport release-26.05`. Could you apply the label when reviewing?