### PR TITLE
libmspub: fix x86_64-darwin link (force ICU_LIBS to include icu-uc)

### DIFF
--- a/pkgs/by-name/li/libmspub/package.nix
+++ b/pkgs/by-name/li/libmspub/package.nix
@@ -31,6 +31,20 @@ stdenv.mkDerivation (finalAttrs: {
 
   configureFlags = [ "--with-docs" ];
 
+  # configure.ac:107 does `PKG_CHECK_MODULES([ICU], [icu-i18n])`. The
+  # pkg-config file `icu-i18n.pc` declares `Requires.private: icu-uc`,
+  # so `pkg-config --libs icu-i18n` returns only `-licui18n` — fine on
+  # linux where the linker auto-pulls libicuuc via NEEDED-entry chain,
+  # but darwin's two-level namespace doesn't follow indirect dylib
+  # deps, so symbols defined in libicuuc (ucnv_open, uloc_getCountry,
+  # …) end up unresolved at link. Force ICU_LIBS to include icu-uc
+  # explicitly. Setting it in the env before configure runs makes
+  # PKG_CHECK_MODULES skip its own detection (per autoconf docs).
+  preConfigure = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    export ICU_LIBS="-licui18n -licuuc -licudata"
+    export ICU_CFLAGS="-I${lib.getDev icu}/include"
+  '';
+
   patches = [
     (fetchpatch {
       url = "https://gitlab.archlinux.org/archlinux/packaging/packages/libmspub/-/raw/8721a52e09e14f905311abd3d5f2ad9bb3fe78a2/buildfix.diff";


### PR DESCRIPTION
## Things done

The Hydra failure on x86_64-darwin (build 330238590) bails at link time with a long list of `_*_76` undefined symbols:

```
Undefined symbols for architecture x86_64:
  "_ucnv_close_76", "_ucnv_open_76",
  "_uloc_getCountry_76", "_uloc_getLanguage_76",
  "_uloc_getLocaleForLCID_76", "_uloc_getScript_76", …
ld: symbol(s) not found for architecture x86_64
```

`configure.ac:107` does `PKG_CHECK_MODULES([ICU], [icu-i18n])`, which sets `ICU_LIBS` to whatever `pkg-config --libs icu-i18n` returns. The shipped `icu-i18n.pc` declares `Requires.private: icu-uc`, so the resolved libs are just `-licui18n` — fine on linux where the linker auto-pulls `libicuuc` via libicui18n's NEEDED-entry chain, but **darwin's two-level namespace doesn't follow indirect dylib deps**. The symbols above all live in `libicuuc`, so the link breaks on x86_64-darwin specifically.

Force `ICU_LIBS` to include `-licuuc -licudata` explicitly via a darwin-only `preConfigure` export. `PKG_CHECK_MODULES` skips its own detection when `ICU_CFLAGS`/`ICU_LIBS` are already in the env (per autoconf docs), so this cleanly overrides the pkg-config result.

aarch64-darwin is already marked `meta.broken` for unrelated reasons, so this doesn't touch that.

Fixes https://hydra.nixos.org/build/330238590

- Built on platform(s)
  - [x] x86_64-linux (derivation hash unchanged — `preConfigure` is darwin-only; cache hit)
  - [ ] aarch64-linux
  - [x] x86_64-darwin (macOS 15.6.1 Sequoia, Intel Mac)
  - [ ] aarch64-darwin (skipped — `meta.broken` upstream for separate reasons)
- [x] Fits CONTRIBUTING.md

Candidate for `backport release-26.05`. Could you apply the label when reviewing?