### PR TITLE
dasm: fix x86_64-darwin build (bump min macOS target 10.5 -> 10.6)

### DIFF
--- a/pkgs/by-name/da/dasm/package.nix
+++ b/pkgs/by-name/da/dasm/package.nix
@@ -25,6 +25,17 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
+  # src/Makefile hardcodes `CFLAGS = -mmacosx-version-min=10.5` on Darwin.
+  # For deployment target < 10.6, clang's link spec wants `libgcc_s.1.dylib`
+  # as the C++ unwinder; that lib isn't present in nixpkgs's apple-sdk
+  # (modern macOS uses libSystem's unwinder, picked up automatically for
+  # target >= 10.6). Bump to 10.6 — still about as backwards-compatible as
+  # 10.5 in practice (10.6 shipped 2009) but avoids the missing libgcc_s.1.
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace src/Makefile \
+      --replace-fail '-mmacosx-version-min=10.5' '-mmacosx-version-min=10.6'
+  '';
+
   configurePhase = false;
   installPhase = ''
     mkdir -p $out/bin


### PR DESCRIPTION
## Things done

The Hydra failure on x86_64-darwin bails at link time:

```
clang -mmacosx-version-min=10.5 main.o ... -o dasm
ld: library not found for -lgcc_s.1
```

dasm's `src/Makefile` hardcodes `CFLAGS = -mmacosx-version-min=10.5` on Darwin. **For deployment target < 10.6, clang's link spec links `libgcc_s.1.dylib` as the C++ unwinder; macOS 10.6+ uses `libSystem`'s unwinder, which is what nixpkgs's apple-sdk provides.** The 10.5 target therefore wants a library that isn't (and can't be) in the sandbox.

Bump the hardcoded min target to 10.6 via `postPatch`. 10.6 shipped in 2009, so the practical compatibility surface is unchanged.

- Built on platform(s)
  - [x] x86_64-linux (derivation hash unchanged on linux — `postPatch` is darwin-only; cache hit)
  - [ ] aarch64-linux
  - [x] x86_64-darwin (macOS 15.6.1 Sequoia, Intel Mac — builds, upstream test suite runs, lands in the store)
  - [ ] aarch64-darwin
- [x] Fits CONTRIBUTING.md

Candidate for `backport release-26.05`. Could you apply the label when reviewing?