### PR TITLE
sambamba: fix x86_64-darwin build (drop -flto=full LDFLAG)

### DIFF
--- a/pkgs/by-name/sa/sambamba/package.nix
+++ b/pkgs/by-name/sa/sambamba/package.nix
@@ -44,6 +44,18 @@ stdenv.mkDerivation (finalAttrs: {
     "CC=${stdenv.cc.targetPrefix}cc"
   ];
 
+  # The Makefile sets `LDFLAGS = -L=-flto=full`, which ldc2 forwards as
+  # `-flto=full` to whatever cc it invokes as the linker. GCC and LLVM
+  # lld accept this; Apple's `ld` does not ("ld: unknown option:
+  # -flto=full") and the link fails. Drop LTO on darwin — slightly
+  # larger binary, but builds. The aarch64-darwin path is already
+  # excluded via meta.platforms = x86_64; this only affects
+  # x86_64-darwin.
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace Makefile \
+      --replace-fail 'LDFLAGS     = -L=-flto=full' 'LDFLAGS     ='
+  '';
+
   # Upstream's install target is broken; copy manually
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
## Things done

The Hydra failure on x86_64-darwin bails at link time:

```
ld: unknown option: -flto=full
clang: error: linker command failed with exit code 1
```

The Makefile sets `LDFLAGS = -L=-flto=full`, which ldc2 forwards as `-flto=full` to whatever cc it invokes as the linker. **GCC and LLVM lld accept that flag (enables link-time optimization); Apple's `ld` does not** — `-flto=full` isn't part of its option set, so the link fails before any LTO actually happens.

The cleanest non-invasive fix is to drop LTO on darwin via `postPatch`. Cost: slightly larger binary, no IPO at link time. Aarch64-darwin is already excluded via `meta.platforms = x86_64`, so this only affects x86_64-darwin.

- Built on platform(s)
  - [x] x86_64-linux (derivation hash unchanged on linux; cache hit)
  - [ ] aarch64-linux
  - [x] x86_64-darwin (macOS 15.6.1 Sequoia, Intel Mac — `nix-build -A sambamba` lands `/nix/store/.../sambamba-1.0.1` cleanly)
  - [ ] aarch64-darwin (`meta.platforms = x86_64`)
- [x] Fits CONTRIBUTING.md

Candidate for `backport release-26.05`. Could you apply the label when reviewing?