### PR TITLE
codex: 0.136.0 -> 0.137.0

### DIFF
--- a/pkgs/by-name/co/codex/package.nix
+++ b/pkgs/by-name/co/codex/package.nix
@@ -25,18 +25,18 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "codex";
-  version = "0.136.0";
+  version = "0.137.0";
 
   src = fetchFromGitHub {
     owner = "openai";
     repo = "codex";
     tag = "rust-v${finalAttrs.version}";
-    hash = "sha256-MI9VrfMFuUOup0e8KECaFA8SbkrPLEG+6K/wqLA8rs8=";
+    hash = "sha256-puszZqi1lZeq8iXWAD9U9+WMnNvzMYKf6wVT9mtjSUU=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/codex-rs";
 
-  cargoHash = "sha256-zHNOUHUnyNxYSWn13H77ZdIuv09kHSlJfQBatTugLUA=";
+  cargoHash = "sha256-SX5LMO+IWismbH61Jd0g1mgykfav8DrqG+wjyNCWyCo=";
 
   __structuredAttrs = true;
 


### PR DESCRIPTION
## Things done

Routine version bump of `codex` from 0.136.0 to 0.137.0.

- Changelog: https://github.com/openai/codex/releases/tag/rust-v0.137.0
- Updated via `nix-update`; `src` hash and `cargoHash` recomputed.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested basic functionality of the built binary (`result/bin/codex --version` → `codex-cli 0.137.0`).
- [ ] Ran `nixpkgs-review` on this PR.

### AI policy disclosure

Per the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy): this version bump was prepared with the assistance of an LLM-based tool (Claude Code). The hashes were generated by `nix-update` and the build + binary were verified locally on aarch64-darwin by a human (@mpscholten), who is the responsible person in the loop and has reviewed this change before submission.