### PR TITLE
opencode: 1.15.13 -> 1.16.0

### DIFF
--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -16,7 +16,7 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opencode";
-  version = "1.15.13";
+  version = "1.16.0";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -25,7 +25,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "anomalyco";
     repo = "opencode";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-+zHwO5ZY8D2s1gZzxoYI7c8yWmQSduPwv4MoFruhhPA=";
+    hash = "sha256-6HLwQmbxyO46+yoHAdQoOlCusReNUJ5Vscjv15k3SK8=";
   };
 
   node_modules = stdenvNoCC.mkDerivation {
@@ -78,7 +78,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     # NOTE: Required else we get errors that our fixed-output derivation references store paths
     dontFixup = true;
 
-    outputHash = "sha256-lDobNmjO+kAqjhYq+vCVa9v+H7DABlxwSJ0ILP4kgrA=";
+    outputHash = "sha256-4yjQlxN+U4CKwA/hE8gACuvA4bBeTrX0ACVBIK4UQCg=";
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
   };


### PR DESCRIPTION
## Things done

Diff: https://github.com/anomalyco/opencode/compare/v1.15.13...v1.16.0

- Built on platform(s)
  - [x] x86_64-linux (`nix-build -A opencode` lands `/nix/store/.../opencode-1.16.0`; `opencode --version` reports 1.16.0)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin (skipped — `meta.platforms = aarch64-darwin, linux-x86_64, aarch64-linux`)
  - [ ] aarch64-darwin
- [x] Tested basic functionality
- [x] Fits CONTRIBUTING.md