### PR TITLE
waydroid-helper: {0.2.7 -> 0.2.9, bump to fuse3}

### DIFF
--- a/pkgs/by-name/wa/waydroid-helper/package.nix
+++ b/pkgs/by-name/wa/waydroid-helper/package.nix
@@ -26,13 +26,13 @@
 }:
 
 let
-  version = "0.2.7";
+  version = "0.2.9";
 
   src = fetchFromGitHub {
     owner = "ayasa520";
     repo = "waydroid-helper";
     tag = "v${version}";
-    hash = "sha256-I8DwaPQQz4eSyuTCwkbidhXACfpdOYcmGjP7d03DIU0=";
+    hash = "sha256-6mVb4GPD2NCsvyaqQAOFox0rNIlyOttiaZKbHBS40Rg=";
   };
 in
 python3Packages.buildPythonApplication {

--- a/pkgs/by-name/wa/waydroid-helper/package.nix
+++ b/pkgs/by-name/wa/waydroid-helper/package.nix
@@ -17,12 +17,12 @@
   android-tools,
   e2fsprogs,
   fakeroot,
-  fuse,
   libadwaita,
   libxml2,
   systemd,
   unzip,
   nix-update-script,
+  fetchpatch,
 }:
 
 let
@@ -39,6 +39,15 @@ python3Packages.buildPythonApplication {
   pname = "waydroid-helper";
   inherit version src;
   pyproject = false; # uses meson
+
+  patches = [
+    # remove for next release
+    (fetchpatch {
+      name = "USE_UMOUNT_NOT_FUSERMOUNT";
+      url = "https://github.com/waydroid-helper/waydroid-helper/commit/eb8ccf7a276f95b31972edbd063245704b2b5b2e.patch";
+      hash = "sha256-z0PWBZTox3RpPCm8/fGYEukU0v41U7/TFcYE0Ec5Zeg=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace dbus/meson.build \
@@ -99,7 +108,6 @@ python3Packages.buildPythonApplication {
         bindfs
         e2fsprogs
         fakeroot
-        fuse
         unzip
       ]
     }"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Trivial bump, program was able to build and launch.
part of:
- NixOS/nixpkgs/pull/521536
- NixOS/nixpkgs/issues/526161

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
