### PR TITLE
open-webui: 0.9.5 -> 0.9.6

### DIFF
--- a/pkgs/by-name/op/open-webui/package.nix
+++ b/pkgs/by-name/op/open-webui/package.nix
@@ -9,13 +9,13 @@
 }:
 let
   pname = "open-webui";
-  version = "0.9.5";
+  version = "0.9.6";
 
   src = fetchFromGitHub {
     owner = "open-webui";
     repo = "open-webui";
     tag = "v${version}";
-    hash = "sha256-RVmFRThK6dNJyqxKepk9WfxzXIwkRoYijZjR1HEhDm8=";
+    hash = "sha256-0d9GfBQY6YtsUbHeO6NTFPFHV6WE51D4fq+NfsM7J5g=";
   };
 
   frontend = buildNpmPackage rec {
@@ -30,7 +30,7 @@ let
       url = "https://github.com/pyodide/pyodide/releases/download/${pyodideVersion}/pyodide-${pyodideVersion}.tar.bz2";
     };
 
-    npmDepsHash = "sha256-kAUbFAFNo5RHMGqO7sPHSxSEZw9Ky6Pxp/vddDyw90E=";
+    npmDepsHash = "sha256-NhDsqfP95RAbSarM07OSII8vbPYWScRMxtWt+gRQ/4c=";
 
     npmFlags = [ "--force" ];
 


### PR DESCRIPTION
## Things done

Diff: https://github.com/open-webui/open-webui/compare/v0.9.5...v0.9.6
Changelog: https://github.com/open-webui/open-webui/blob/v0.9.6/CHANGELOG.md

Refreshed:
- src hash
- frontend npmDepsHash

- Built on platform(s)
  - [x] x86_64-linux (`nix-build -A open-webui` lands `/nix/store/.../open-webui-0.9.6`; pythonImportsCheckPhase green)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits CONTRIBUTING.md