### PR TITLE
songrec: 0.6.7 -> 0.7.3; various miscellaneous improvement

### DIFF
--- a/pkgs/by-name/so/songrec/package.nix
+++ b/pkgs/by-name/so/songrec/package.nix
@@ -57,7 +57,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/marin-m/SongRec";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ tcbravo ];
+    maintainers = with lib.maintainers; [
+      tcbravo
+      tomasrivera
+    ];
     mainProgram = "songrec";
   };
 })

--- a/pkgs/by-name/so/songrec/package.nix
+++ b/pkgs/by-name/so/songrec/package.nix
@@ -12,6 +12,7 @@
   ffmpeg,
   glib,
   libpulseaudio,
+  versionCheckHook,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -51,6 +52,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   postInstall = ''
     mv packaging/rootfs/usr/share $out/share
   '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = {
     description = "Open-source Shazam client for Linux, written in Rust";

--- a/pkgs/by-name/so/songrec/package.nix
+++ b/pkgs/by-name/so/songrec/package.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "marin-m";
     repo = "songrec";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-lCwFMBQ6IimNtXYMfTnFOpwOO2qbwijOEZ+oMsQKAP0=";
   };
 

--- a/pkgs/by-name/so/songrec/package.nix
+++ b/pkgs/by-name/so/songrec/package.nix
@@ -55,6 +55,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Open-source Shazam client for Linux, written in Rust";
     homepage = "https://github.com/marin-m/SongRec";
+    changelog = "https://github.com/marin-m/SongRec/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/so/songrec/package.nix
+++ b/pkgs/by-name/so/songrec/package.nix
@@ -14,24 +14,26 @@
   libpulseaudio,
   versionCheckHook,
   nix-update-script,
+  pipewire,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "songrec";
-  version = "0.6.7";
+  version = "0.7.3";
 
   src = fetchFromGitHub {
     owner = "marin-m";
     repo = "songrec";
     tag = finalAttrs.version;
-    hash = "sha256-lCwFMBQ6IimNtXYMfTnFOpwOO2qbwijOEZ+oMsQKAP0=";
+    hash = "sha256-6DT5KY6Y3CPTFLNG+EostAlMgZ35SLv8r9EXtRadC2U=";
   };
 
-  cargoHash = "sha256-BhDFGkvY6c8XbhJpFX1w8CSXK9IY/HiysNoooytFT9I=";
+  cargoHash = "sha256-9R7HwTwjeCBIxX2xHs++9Zl0SMRmHPHDD1OHNa4q+jI=";
 
   nativeBuildInputs = [
     pkg-config
     wrapGAppsHook4
+    rustPlatform.bindgenHook
   ];
 
   buildInputs = [
@@ -42,6 +44,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     libadwaita
     libpulseaudio
     libsoup_3
+    pipewire
   ];
 
   preFixup = ''

--- a/pkgs/by-name/so/songrec/package.nix
+++ b/pkgs/by-name/so/songrec/package.nix
@@ -13,6 +13,7 @@
   glib,
   libpulseaudio,
   versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -55,6 +56,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Open-source Shazam client for Linux, written in Rust";


### PR DESCRIPTION
Resolves #527593 and https://github.com/marin-m/SongRec/issues/309

I added myself maintainer.

bumps from 0.6.7 to 0.7.3. I added the pipewire dependency (need from 0.6.8) and bindgenHook to resolve some compilation problem per [this wiki page](https://wiki.nixos.org/wiki/Rust#Installating_with_bindgen_support).

I also added changelog, versionCheckHook and nix-update-script as quality of life utilities.

Ping to current maintainer @tcbravo 

No AI/Automation was used for this PR.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
