### PR TITLE
python3Packages.{scancode-toolkit,typecode,extractcode}: fix & add ngi team

### DIFF
--- a/pkgs/development/python-modules/extractcode/default.nix
+++ b/pkgs/development/python-modules/extractcode/default.nix
@@ -18,7 +18,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "extractcode";
   version = "31.1.0";
   pyproject = true;
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "aboutcode-org";
     repo = "extractcode";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-KTLhTvTn5awIJD32lsztm6nh15eoFew1mGJvHIT8H2U=";
   };
 
@@ -83,9 +83,10 @@ buildPythonPackage rec {
   meta = {
     description = "Universal archive extractor using z7zip, libarchive, other libraries and the Python standard library";
     homepage = "https://github.com/aboutcode-org/extractcode";
-    changelog = "https://github.com/aboutcode-org/extractcode/releases/tag/v${version}";
-    license = lib.licenses.asl20;
-    maintainers = [ ];
+    changelog = "https://github.com/aboutcode-org/extractcode/releases/tag/v${finalAttrs.version}";
     mainProgram = "extractcode";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
   };
-}
+})

--- a/pkgs/development/python-modules/extractcode/default.nix
+++ b/pkgs/development/python-modules/extractcode/default.nix
@@ -20,21 +20,15 @@
 
 buildPythonPackage rec {
   pname = "extractcode";
-  version = "31.0.0";
+  version = "31.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "aboutcode-org";
     repo = "extractcode";
     tag = "v${version}";
-    hash = "sha256-mPHGe/pMaOnIykDd4AjGcvh/T4UrbaGxrSVGhchqYFM=";
+    hash = "sha256-KTLhTvTn5awIJD32lsztm6nh15eoFew1mGJvHIT8H2U=";
   };
-
-  postPatch = ''
-    # PEP440 support was removed in newer setuptools, https://github.com/nexB/extractcode/pull/46
-    substituteInPlace setup.cfg \
-      --replace-fail ">=3.6.*" ">=3.6"
-  '';
 
   dontConfigure = true;
 
@@ -76,6 +70,12 @@ buildPythonPackage rec {
     "test_extract_python_testtar_tar_archive_with_special_files"
     # AssertionError: [<function extract at 0x7ffff493dd00>] == [] for archive/rar/basic.rar
     "test_get_extractors_2"
+    # assert [functools.pa...ffff452df80>)] == []
+    "test_windows_media_player_skins_are_zip"
+    # AssertionError: assert Handler(name='Nuget', filetypes=('zip archive', 'mic...
+    "test_get_best_handler_nuget_is_selected_over_zip"
+    "test_get_best_handler_nuget_is_selected_over_zip2"
+    "test_get_best_handler_nuget_is_selected_over_zip3"
   ];
 
   pythonImportsCheck = [ "extractcode" ];

--- a/pkgs/development/python-modules/scancode-toolkit/default.nix
+++ b/pkgs/development/python-modules/scancode-toolkit/default.nix
@@ -59,14 +59,14 @@
   xmltodict,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "scancode-toolkit";
   version = "32.5.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "scancode_toolkit";
-    inherit version;
+    inherit (finalAttrs) version;
     hash = "sha256-WXAZCk0aRmKb1UU1ud95mZFHAMC9U+gDRd9w7TZTVSA=";
   };
 
@@ -146,11 +146,12 @@ buildPythonPackage rec {
   meta = {
     description = "Tool to scan code for license, copyright, package and their documented dependencies and other interesting facts";
     homepage = "https://github.com/nexB/scancode-toolkit";
-    changelog = "https://github.com/nexB/scancode-toolkit/blob/v${version}/CHANGELOG.rst";
+    changelog = "https://github.com/nexB/scancode-toolkit/blob/v${finalAttrs.version}/CHANGELOG.rst";
     license = with lib.licenses; [
       asl20
       cc-by-40
     ];
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
   };
-}
+})

--- a/pkgs/development/python-modules/typecode/default.nix
+++ b/pkgs/development/python-modules/typecode/default.nix
@@ -64,6 +64,7 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/aboutcode-org/typecode";
     changelog = "https://github.com/aboutcode-org/typecode/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
   };
 })

--- a/pkgs/development/python-modules/typecode/default.nix
+++ b/pkgs/development/python-modules/typecode/default.nix
@@ -53,12 +53,8 @@ buildPythonPackage (finalAttrs: {
     # Many of the failures below are reported in:
     # https://github.com/aboutcode-org/typecode/issues/36
 
-    # AssertionError: assert 'application/x-bytecode.python'...
-    "test_package_json"
-
     # fails due to change in file (libmagic) 5.45
-    "test_doc_postscript_eps"
-    "test_package_debian"
+    "test_media_image_img"
   ];
 
   pythonImportsCheck = [ "typecode" ];

--- a/pkgs/development/python-modules/typecode/libmagic.nix
+++ b/pkgs/development/python-modules/typecode/libmagic.nix
@@ -6,7 +6,7 @@
   file,
   zlib,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "typecode-libmagic";
   version = "21.5.31";
   format = "setuptools";
@@ -14,11 +14,11 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "aboutcode-org";
     repo = "scancode-plugins";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-nGgFjp1N1IM/Sm4xLJw5WiZncc369/LqNcwFJBS1EQs=";
   };
 
-  sourceRoot = "${src.name}/builtins/typecode_libmagic-linux";
+  sourceRoot = "${finalAttrs.src.name}/builtins/typecode_libmagic-linux";
 
   propagatedBuildInputs = [ plugincode ];
 
@@ -42,7 +42,8 @@ buildPythonPackage rec {
     description = "ScanCode Toolkit plugin to provide pre-built binary libraries and utilities and their locations";
     homepage = "https://github.com/aboutcode-org/scancode-plugins/tree/main/builtins/typecode_libmagic-linux";
     license = lib.licenses.asl20;
-    maintainers = [ ];
     platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
   };
-}
+})


### PR DESCRIPTION
> [!NOTE]
> Work done as part of [Nix@NGI](https://nixos.org/community/teams/ngi/) packaging effort 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
