### PR TITLE
nixos/fuse: disable by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -58,4 +58,6 @@
 
 - `security.polkit.settings` added for RFC42 style configuration of the polkitd daemon.
 
+- The `programs.fuse` module, which provides the `fusermount3` executable and the `/etc/fuse.conf` config file, is now opt-in. The obligation to enable it has been shifted to its various consumers (e.g. gvfs, flatpak, appimage, sshfs). This can break fuse consumers at runtime, that don't explicitly declare that dependency with a module, e.g the mounting functionality in various backup tools (borg, restic, rclone, ...).
+
 - The `newuidmap` and `newgidmap` security wrappers are now installed with `cap_setuid`/`cap_setgid` file capabilities instead of the setuid-root bit, matching shadow's `--with-fcaps` install mode and other major distributions. Rootless containers (podman, docker-rootless, unprivileged user namespaces) are unaffected. The only behavioural change is that mapping host uid 0 via `/etc/subuid` (which NixOS never configures by default) additionally requires `cap_setfcap`; users who explicitly grant uid 0 in a subuid range can restore the previous behaviour with `security.wrappers.newuidmap.capabilities = lib.mkForce "cap_setuid,cap_setfcap+ep";`.

--- a/nixos/modules/profiles/bashless.nix
+++ b/nixos/modules/profiles/bashless.nix
@@ -15,8 +15,6 @@
   environment.corePackages = lib.mkForce [ ];
   # Contains bash completions
   nix.enable = lib.mkDefault false;
-  # The fuse{,3} package contains a runtime dependency on bash.
-  programs.fuse.enable = lib.mkDefault false;
   documentation.man.man-db.enable = lib.mkDefault false;
   # autovt depends on bash
   console.enable = lib.mkDefault false;

--- a/nixos/modules/programs/appimage.nix
+++ b/nixos/modules/programs/appimage.nix
@@ -43,6 +43,8 @@ in
       }
     );
     environment.systemPackages = [ cfg.package ];
+
+    programs.fuse.enable = true;
   };
 
   meta.maintainers = with lib.maintainers; [

--- a/nixos/modules/programs/fuse.nix
+++ b/nixos/modules/programs/fuse.nix
@@ -12,9 +12,7 @@ in
   meta.maintainers = [ ];
 
   options.programs.fuse = {
-    enable = lib.mkEnableOption "fuse" // {
-      default = true;
-    };
+    enable = lib.mkEnableOption "fuse";
 
     mountMax = lib.mkOption {
       # In the C code it's an "int" (i.e. signed and at least 16 bit), but

--- a/nixos/modules/services/desktop-managers/plasma6.nix
+++ b/nixos/modules/services/desktop-managers/plasma6.nix
@@ -274,6 +274,7 @@ in
 
     services.power-profiles-daemon.enable = mkDefault true;
     services.system-config-printer.enable = mkIf config.services.printing.enable (mkDefault true);
+    programs.fuse.enable = true;
     services.udisks2.enable = true;
     services.upower.enable = config.powerManagement.enable;
     services.libinput.enable = mkDefault true;

--- a/nixos/modules/services/desktops/flatpak.nix
+++ b/nixos/modules/services/desktops/flatpak.nix
@@ -40,6 +40,8 @@ in
       pkgs.fuse3
     ];
 
+    programs.fuse.enable = true;
+
     security.polkit.enable = true;
 
     fonts.fontDir.enable = true;

--- a/nixos/modules/services/desktops/gvfs.nix
+++ b/nixos/modules/services/desktops/gvfs.nix
@@ -40,6 +40,8 @@ in
 
     environment.systemPackages = [ cfg.package ];
 
+    programs.fuse.enable = true;
+
     services.dbus.packages = [ cfg.package ];
 
     systemd.packages = [ cfg.package ];

--- a/nixos/modules/services/network-filesystems/kubo.nix
+++ b/nixos/modules/services/network-filesystems/kubo.nix
@@ -332,8 +332,9 @@ in
     boot.kernel.sysctl."net.core.rmem_max" = lib.mkDefault 7500000;
     boot.kernel.sysctl."net.core.wmem_max" = lib.mkDefault 7500000;
 
-    programs.fuse = lib.mkIf (cfg.autoMount && cfg.settings.Mounts.FuseAllowOther) {
-      userAllowOther = true;
+    programs.fuse = {
+      enable = lib.mkIf cfg.autoMount true;
+      userAllowOther = lib.mkIf cfg.settings.Mounts.fuseAllowOther true;
     };
 
     users.users = lib.mkIf (cfg.user == "ipfs") {

--- a/nixos/modules/tasks/filesystems/sshfs.nix
+++ b/nixos/modules/tasks/filesystems/sshfs.nix
@@ -10,6 +10,8 @@
     lib.mkIf
       (config.boot.supportedFilesystems.sshfs or config.boot.supportedFilesystems."fuse.sshfs" or false)
       {
+        programs.fuse.enable = true;
+
         system.fsPackages = [ pkgs.sshfs ];
       };
 }

--- a/nixos/tests/gocryptfs.nix
+++ b/nixos/tests/gocryptfs.nix
@@ -13,6 +13,8 @@
         pkgs.openssl
       ];
 
+      programs.fuse.enable = true;
+
       specialisation.fstab-test.configuration = {
         # This can't be fileSytems, as the qemu machinery doesn't honor it.
         virtualisation.fileSystems."/plain" = {


### PR DESCRIPTION
This change disables the fuse module by default and shifts the
obligation to enable it to consumers.

### Maintainer feedback wanted
These are apps that I think require fuse, but I'm pinging maintainers to confirm my thinking.

#### Enabled in modules

- gvfs @NixOS/gnome 
- flatpak @getchoo 
- appimage
- kubo @Luflosi 
- sshfs
- plasma6

#### Enabled in tests
- gocryptfs @prusnak @flokli
  - enabled fuse in the test, maybe you'd want `programs.gocryptfs` instead?
  - dependency removed in https://github.com/NixOS/nixpkgs/pull/527732

#### Open questions
What do we want to do with these?

- borgbackup (https://borgbackup.readthedocs.io/en/stable/usage/mount.html) @dotlambda @Scrumplex 
- gcsfs (https://docs.cloud.google.com/storage/docs/cloud-storage-fuse/mount-bucket)
- rclone (https://rclone.org/commands/rclone_mount/) @SuperSandro2000 
- restic (https://restic.readthedocs.io/en/latest/050_restore.html) @mbrgm @djds @dotlambda @ryan4yin 

#### Things I tested:
- [x] nixosTests.kubo
- [x] nixosTests.locate (mentions `fsType = "fuse.sshfs"`)
- [x] nixosTests.os-prober (mentions unionfs-fuse)
- [x] nixosTests.gitlab.runner (mentions `mount_program = "/usr/bin/fuse-overlayfs"`)
- [x] nixosTests.restic
- [x] nixosTests.borgbackup

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
