### PR TITLE
stringzilla: init as standalone library from python package

### DIFF
--- a/pkgs/by-name/fo/forkunion/package.nix
+++ b/pkgs/by-name/fo/forkunion/package.nix
@@ -1,0 +1,39 @@
+{
+  fetchFromGitHub,
+  cmake,
+  lib,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "forkunion";
+  version = "2.3.1";
+
+  outputs = [
+    "out"
+    "lib"
+    "dev"
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "ashvardanian";
+    repo = "ForkUnion";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ikDhf5aDCjUJ94lOC0m1Z43q92vyzEfSNdSO25Irv1o=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  meta = {
+    changelog = "https://github.com/ashvardanian/ForkUnion/releases/tag/${finalAttrs.src.tag}";
+    description = "Lower-latency OpenMP-style minimalistic scoped thread-pool designed for 'Fork-Join' parallelism in Rust and C++, avoiding memory allocations, mutexes, CAS-primitives, and false-sharing on the hot path";
+    homepage = "https://github.com/ashvardanian/ForkUnion";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+  };
+})

--- a/pkgs/by-name/st/stringzilla/package.nix
+++ b/pkgs/by-name/st/stringzilla/package.nix
@@ -1,0 +1,57 @@
+{
+  fetchFromGitHub,
+  cmake,
+  forkunion,
+  lib,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "stringzilla";
+  version = "4.6.1";
+
+  outputs = [
+    "out"
+    "lib"
+    "dev"
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "ashvardanian";
+    repo = "stringzilla";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-yAxHOcxS4YYX0lvKwUExIBFBM5RDyFgeW9QA0WZBthA=";
+  };
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "-Werror;" ""
+  '';
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    forkunion
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "STRINGZILLA_INSTALL" true)
+    (lib.cmakeBool "STRINGZILLA_BUILD_TEST" true)
+  ];
+
+  meta = {
+    changelog = "https://github.com/ashvardanian/StringZilla/releases/tag/${finalAttrs.src.tag}";
+    description = "SIMD-accelerated string search, sort, hashes, fingerprints, & edit distances";
+    homepage = "https://github.com/ashvardanian/stringzilla";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      aciceri
+      dotlambda
+    ];
+  };
+})

--- a/pkgs/development/python-modules/stringzilla/default.nix
+++ b/pkgs/development/python-modules/stringzilla/default.nix
@@ -1,24 +1,15 @@
 {
   buildPythonPackage,
-  fetchFromGitHub,
-  lib,
   numpy,
+  pkgs,
   pytest-repeat,
   pytestCheckHook,
   setuptools,
 }:
 
-buildPythonPackage rec {
-  pname = "stringzilla";
-  version = "4.6.1";
+buildPythonPackage {
+  inherit (pkgs.stringzilla) pname version src;
   pyproject = true;
-
-  src = fetchFromGitHub {
-    owner = "ashvardanian";
-    repo = "stringzilla";
-    tag = "v${version}";
-    hash = "sha256-yAxHOcxS4YYX0lvKwUExIBFBM5RDyFgeW9QA0WZBthA=";
-  };
 
   build-system = [
     setuptools
@@ -35,13 +26,12 @@ buildPythonPackage rec {
   enabledTestPaths = [ "scripts/test_stringzilla.py" ];
 
   meta = {
-    changelog = "https://github.com/ashvardanian/StringZilla/releases/tag/${src.tag}";
-    description = "SIMD-accelerated string search, sort, hashes, fingerprints, & edit distances";
-    homepage = "https://github.com/ashvardanian/stringzilla";
-    license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [
-      aciceri
-      dotlambda
-    ];
+    inherit (pkgs.stringzilla.meta)
+      changelog
+      description
+      homepage
+      license
+      maintainers
+      ;
   };
 }


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
