### PR TITLE
ollama: use tag rev for llama.cpp pin + drop redundant version comment

### DIFF
--- a/pkgs/by-name/ol/ollama/package.nix
+++ b/pkgs/by-name/ol/ollama/package.nix
@@ -109,13 +109,13 @@ let
   cudaPath = lib.removeSuffix "-${cudaMajorVersion}" cudaToolkit;
 
   # Since v0.30, llama.cpp is consumed via CMake FetchContent rather than
-  # vendored in-tree. Pre-stage the pinned commit (read from upstream's
-  # `LLAMA_CPP_VERSION` file — currently `b9509`) so the FetchContent step
-  # uses our copy instead of trying to clone over the network in the sandbox.
+  # vendored in-tree. Pre-stage the pin (tracks upstream's
+  # `LLAMA_CPP_VERSION` file) so the FetchContent step uses our copy
+  # instead of trying to clone over the network in the sandbox.
   llamaCppSrc = fetchFromGitHub {
     owner = "ggml-org";
     repo = "llama.cpp";
-    rev = "6f3a9f3dee3c27545371044a3a38005721ac8a8e"; # tag b9509
+    tag = "b9509";
     hash = "sha256-bO1ucb/+vidj/EYzNCssotjte9NlVLdjC794jToNNeM=";
   };
 


### PR DESCRIPTION
Follow-up to #528150 addressing @SuperSandro2000's review comments:

- **Line 118 (`rev`)** — *"Why are we not using tag if there is a tag?"* — switch from commit SHA + inline `# tag b9509` comment to bare `rev = "b9509"`. `fetchFromGitHub` resolves the tag to the same git object, so the hash is unchanged.
- **Line 113 (prose comment)** — *"We should not repeat the version in this comment and have to update that, too, on every update."* — drop ``currently `b9509` `` from the comment; the remaining text explains the mechanism (tracks upstream's `LLAMA_CPP_VERSION` file, pre-staged because FetchContent can't network in the sandbox) without naming a specific version that would drift on every bump.

Pure source-readability change. `nix-build -A ollama --no-out-link` on x86_64-linux produces the **same store path** as master, confirming the tag resolves to the same object → same tarball → same hash → no rebuild impact.

The same lines exist on `release-26.05` via the backport #528272; happy to mirror this fix there if you apply the `backport release-26.05` label.

###### Things done

- Built on platform(s)
    - [x] x86_64-linux
    - [ ] aarch64-linux
    - [ ] x86_64-darwin
    - [ ] aarch64-darwin
- [x] For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Tested, as applicable:
    - [x] [Tested compilation](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#how-to-build-and-test-your-changes) of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` (n/a — no rebuild, identical store path)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)

###### Add a 👍 [reaction](https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to [pull requests you find important](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#how-to-merge-pull-requests).