### PR TITLE
freerdp: enable support for FIDO2 tokens

### DIFF
--- a/pkgs/by-name/fr/freerdp/package.nix
+++ b/pkgs/by-name/fr/freerdp/package.nix
@@ -39,6 +39,8 @@
   orc,
   cairo,
   cjson,
+  libcbor,
+  libfido2,
   libusb1,
   libpulseaudio,
   cups,
@@ -117,6 +119,8 @@ stdenv.mkDerivation (finalAttrs: {
     ffmpeg
     glib
     icu
+    libcbor
+    libfido2
     libx11
     libxcursor
     libxdamage
@@ -173,6 +177,8 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.mapAttrsToList lib.cmakeBool (
     {
       BUILD_TESTING = false; # false is recommended by upstream
+      CHANNEL_RDPEWA = true;
+      CHANNEL_RDPEWA_CLIENT = true;
       WITH_CAIRO = cairo != null;
       WITH_CUPS = cups != null;
       WITH_FAAC = withUnfree && faac != null;
@@ -230,7 +236,10 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/FreeRDP/FreeRDP/releases/tag/${finalAttrs.src.tag}";
     homepage = "https://www.freerdp.com/";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ deimelias ];
+    maintainers = with lib.maintainers; [
+      cizra
+      deimelias
+    ];
     platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
Enable FIDO2 authentication protocol in freerdp (I think it only works in sdl-freerdp, YMMV with xfreerdp).
Tested, works.
In my testing, sometimes the FIDO2 authentication flow hangs (PIN popup does not appear) - in my case, it was always pcscd's fault. Stopping pcscd helps. This issue is unrelated to FIDO2.

This change was done with the help of a LLM.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
