### PR TITLE
python3Packages.azure-mgmt-nspkg: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/azure-mgmt-nspkg/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-nspkg/default.nix
@@ -6,15 +6,17 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
+  pname = "azure-mgmt-nspkg";
   version = "3.0.2";
   pyproject = true;
-  pname = "azure-mgmt-nspkg";
+
+  __structuredAttrs = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     extension = "zip";
-    sha256 = "8b2287f671529505b296005e6de9150b074344c2c7d1c805b3f053d081d58c52";
+    hash = "sha256-iyKH9nFSlQWylgBebekVCwdDRMLH0cgFs/BT0IHVjFI=";
   };
 
   build-system = [ setuptools ];
@@ -32,4 +34,4 @@ buildPythonPackage rec {
       maxwilson
     ];
   };
-}
+})

--- a/pkgs/development/python-modules/azure-mgmt-nspkg/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-nspkg/default.nix
@@ -3,11 +3,12 @@
   buildPythonPackage,
   fetchPypi,
   azure-nspkg,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   version = "3.0.2";
-  format = "setuptools";
+  pyproject = true;
   pname = "azure-mgmt-nspkg";
 
   src = fetchPypi {
@@ -16,7 +17,9 @@ buildPythonPackage rec {
     sha256 = "8b2287f671529505b296005e6de9150b074344c2c7d1c805b3f053d081d58c52";
   };
 
-  propagatedBuildInputs = [ azure-nspkg ];
+  build-system = [ setuptools ];
+
+  dependencies = [ azure-nspkg ];
 
   doCheck = false;
 


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
