### PR TITLE
Fix python3Packages.django-silk

### DIFF
--- a/pkgs/development/python-modules/django-silk/default.nix
+++ b/pkgs/development/python-modules/django-silk/default.nix
@@ -27,14 +27,14 @@
 
 buildPythonPackage rec {
   pname = "django-silk";
-  version = "5.4.3";
+  version = "5.5.0";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "jazzband";
     repo = "django-silk";
     tag = version;
-    hash = "sha256-VVgH4h2OeOu/NKGMSOHo2tg8Owj1t+HhEN8xWGrj3m8=";
+    hash = "sha256-F9IHxp2dx0hzu9iOaborJjLyzZjs86rccczhc5GPbtY=";
   };
 
   # "test_time_taken" tests aren't suitable for reproducible execution, but Django's

--- a/pkgs/development/python-modules/django-silk/default.nix
+++ b/pkgs/development/python-modules/django-silk/default.nix
@@ -13,6 +13,9 @@
   pillow,
   pydot,
   pygments,
+  pytestCheckHook,
+  pytest-cov-stub,
+  pytest-django,
   python,
   python-dateutil,
   pytz,
@@ -67,18 +70,17 @@ buildPythonPackage rec {
     networkx
     pydot
     factory-boy
+    pytestCheckHook
+    pytest-cov-stub
+    pytest-django
   ];
 
   pythonImportsCheck = [ "silk" ];
 
-  checkPhase = ''
-    runHook preCheck
+  preCheck = ''
+    export DB_ENGINE=sqlite3 DB_NAME=':memory:'
 
-    pushd project
-    DB_ENGINE=sqlite3 DB_NAME=':memory:' ${python.interpreter} manage.py test
-    popd # project
-
-    runHook postCheck
+    cd project
   '';
 
   meta = {


### PR DESCRIPTION
Package does not build because tests fail (they seem to have switched to pytest).

Also upgrade to [latest version](https://github.com/jazzband/django-silk/releases).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
