### PR TITLE
klog-rs: 0.5.1 -> 0.6.0

### DIFF
--- a/pkgs/by-name/kl/klog-rs/package.nix
+++ b/pkgs/by-name/kl/klog-rs/package.nix
@@ -7,26 +7,34 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "klog-rs";
-  version = "0.5.1";
+  version = "0.6.0";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "tobifroe";
     repo = "klog";
-    rev = finalAttrs.version;
-    hash = "sha256-VyUUzhVwJ1tNLICXwy7f85queH+pn4vL5HTL8IHcQ7w=";
+    tag = finalAttrs.version;
+    hash = "sha256-9NYtT4psGaWBVpwprpAdzEaWrmDRRnI1UDVD3Quzj6g=";
   };
 
-  cargoHash = "sha256-KJxssCN9/WoRR1Cv67CK5muVy+cqEEfzSioQtptplQs=";
-  checkFlags = [
+  cargoHash = "sha256-sDjNJAOFW+0wRN9CCDZRj1q0juczugLibst7ys/mERc=";
+
+  checkFlags = map (t: "--skip=${t}") [
     # this integration test depends on a running kubernetes cluster
-    "--skip=k8s::tests::test_get_pod_list"
-    "--skip=k8s::tests::test_get_pod_list_for_resource"
+    "k8s::tests::test_get_pod_list"
+    "k8s::tests::test_get_pod_list_for_resource"
+    "tests::test_active_pods_tracking"
+    "tests::test_pod_manager_clone"
+    "tests::test_pod_manager_creation"
+    "tests::test_refresh_interval_zero_disables_refresh"
+    "tests::test_start_pod_logs_spawns_task"
   ];
 
   meta = {
     description = "Tool to tail logs of multiple Kubernetes pods simultaneously";
     homepage = "https://github.com/tobifroe/klog";
-    changelog = "https://github.com/tobifroe/klog/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/tobifroe/klog/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     mainProgram = "klog";
     maintainers = with lib.maintainers; [ tobifroe ];


### PR DESCRIPTION
diff: https://github.com/tobifroe/klog/compare/0.5.1...0.6.0
changelog: https://github.com/tobifroe/klog/releases/tag/0.6.0

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
