### PR TITLE
julec: 0.2.1 -> 0.2.2

### DIFF
--- a/pkgs/by-name/ju/julec/package.nix
+++ b/pkgs/by-name/ju/julec/package.nix
@@ -22,23 +22,22 @@ let
 in
 clangStdenv.mkDerivation (finalAttrs: {
   pname = "julec";
-  version = "0.2.1";
+  version = "0.2.2";
 
   src = fetchFromGitHub {
     owner = "julelang";
     repo = "jule";
     tag = "jule${finalAttrs.version}";
     name = "jule-${finalAttrs.version}";
-    hash = "sha256-zfFsWP1nFvyzIqtf/nG4itpKxy6ZZjb3gGC3LwLVGPk=";
+    hash = "sha256-m+IJiTNOrOzx/3e67r/yWOjGRRyOy5TWHhjFZXaMOsc=";
   };
 
   irSrc = fetchFromGitHub {
     owner = "julelang";
     repo = "julec-ir";
-    # revision determined by the upstream commit hash
-    rev = "5de197f9041dbc61b1d97ed4e3b84c0f667014f8";
+    tag = "jule${finalAttrs.version}";
     name = "jule-ir-${finalAttrs.version}";
-    hash = "sha256-PMAFXLXa3wS0+TWEU2bjlw5UzOmAx8ittQzuExhrWDM=";
+    hash = "sha256-UclKaxIBW1dqCz2Rk0If7EV3P7XrtUpKuR4ROPWw2Ao=";
   };
 
   dontConfigure = true;

--- a/pkgs/by-name/ju/juledoc/package.nix
+++ b/pkgs/by-name/ju/juledoc/package.nix
@@ -12,8 +12,8 @@ clangStdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "julelang";
     repo = "juledoc";
-    rev = "d6ba549aeb82ea224e2cf07e0f0f3a2448dbd9db";
-    hash = "sha256-3n9VOoXIFEI9V6fzSD75PdwkijXruC7qWClOUlWd52I=";
+    rev = "8504254a30d04a403c1b3ac788b62491233421e5";
+    hash = "sha256-L8Oh2u35hraJYHimxJbBqro7iVh1a7MbVuqtujgb7c8=";
   };
 
   nativeBuildInputs = [ julec.hook ];

--- a/pkgs/by-name/ju/julefmt/package.nix
+++ b/pkgs/by-name/ju/julefmt/package.nix
@@ -12,8 +12,8 @@ clangStdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "julelang";
     repo = "julefmt";
-    rev = "6bd55e31ebba393c973017332502a548ea0f402c";
-    hash = "sha256-j8V5L4j4qaApJixsEo10Qv58IHcU54hnpL8uD+T0C0M=";
+    rev = "7ac9b383013d13a03bc06f90f0b86f4fca11a4a8";
+    hash = "sha256-q90B0rYaUN/gQ3TUNcPS+SqIQefam1Qmzx6jUBe+c0g=";
   };
 
   nativeBuildInputs = [ julec.hook ];


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
