### PR TITLE
mo-viewer: init at 1.6.1

### DIFF
--- a/pkgs/by-name/mo/mo-viewer/package.nix
+++ b/pkgs/by-name/mo/mo-viewer/package.nix
@@ -1,0 +1,103 @@
+{
+  lib,
+  stdenvNoCC,
+  buildGoModule,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  nodejs,
+  pnpm_10,
+  jq,
+  pnpmConfigHook,
+  installShellFiles,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "mo-viewer";
+  version = "1.6.1";
+
+  src = fetchFromGitHub {
+    owner = "k1LoW";
+    repo = "mo";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/PiMYllj0l3XwIkqT/sc7U/vGXdNmTD8RowZWe9ZDR8=";
+  };
+
+  frontend = stdenvNoCC.mkDerivation (finalFrontendAttrs: {
+    pname = "${finalAttrs.pname}-frontend";
+    inherit (finalAttrs) version src;
+
+    pnpmRoot = "internal/frontend";
+
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalFrontendAttrs) pname version src;
+      sourceRoot = "${finalFrontendAttrs.src.name}/internal/frontend";
+      pnpm = pnpm_10;
+      fetcherVersion = 4;
+      hash = "sha256-thlwYvB7y6RFwLknbQt5evF4xQVzllrQqVYDdKSbEUM=";
+    };
+
+    nativeBuildInputs = [
+      nodejs
+      pnpm_10
+      pnpmConfigHook
+      jq
+    ];
+
+    postPatch = ''
+      jq 'del(.pnpm.executionEnv)' internal/frontend/package.json > internal/frontend/package.json.tmp
+      mv internal/frontend/package.json.tmp internal/frontend/package.json
+    '';
+
+    buildPhase = ''
+      runHook preBuild
+      pnpm -C internal/frontend run build
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      cp -r internal/static/dist $out
+      runHook postInstall
+    '';
+  });
+
+  vendorHash = "sha256-rmtJswO3DWWxpb2uk91aIatc7ugNmsqzwlEeKdX7ITE=";
+
+  preBuild = ''
+    cp -r ${finalAttrs.frontend} internal/static/dist
+  '';
+
+  env.CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/k1LoW/mo/version.Revision=v${finalAttrs.version}"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform) ''
+    installShellCompletion --cmd 'mo' \
+      --bash <("$out/bin/mo" completion bash) \
+      --zsh <("$out/bin/mo" completion zsh) \
+      --fish <("$out/bin/mo" completion fish)
+  '';
+
+  doCheck = !stdenvNoCC.hostPlatform.isDarwin;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "--version";
+
+  __structuredAttrs = true;
+
+  meta = {
+    homepage = "https://github.com/k1LoW/mo";
+    description = "Markdown viewer that opens .md files in a browser";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ryota2357 ];
+    mainProgram = "mo";
+  };
+})


### PR DESCRIPTION
`mo` is a Markdown viewer that opens .md files in a browser. 

The upstream repository is named `mo` ([k1LoW/mo](https://github.com/k1LoW/mo)). However, the package attribute name `mo` is already taken ([pkgs/by-name/mo/mo/package.nix](https://github.com/NixOS/nixpkgs/blob/e8a1394ebfa6a0267ac1c26959e5672e755f6f85/pkgs/by-name/mo/mo/package.nix)). So I've packaged this as `mo-viewer`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
