### PR TITLE
s3fs: {bump to fuse3, 1.95 -> 1.97}

### DIFF
--- a/pkgs/by-name/s3/s3fs/package.nix
+++ b/pkgs/by-name/s3/s3fs/package.nix
@@ -7,25 +7,25 @@
   curl,
   openssl,
   libxml2,
-  fuse,
+  fuse3,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "s3fs-fuse";
-  version = "1.95";
+  version = "1.97";
 
   src = fetchFromGitHub {
     owner = "s3fs-fuse";
     repo = "s3fs-fuse";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-wHszw3S+fuZRwTvJy+FkxQTR2BAvr8H924Wd4/C5heE=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-iggSIrmxnhINdzJm60yTWkmDwUWJRNNVqwHGd2Lb7lw=";
   };
 
   buildInputs = [
     curl
     openssl
     libxml2
-    fuse
+    fuse3
   ];
   nativeBuildInputs = [
     autoreconfHook


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/s3fs-fuse/s3fs-fuse/issues/1159

part of:
- NixOS/nixpkgs/pull/521536
- NixOS/nixpkgs/issues/526161


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
