### PR TITLE
aws-lc: 1.69.0 -> 1.73.0

### DIFF
--- a/pkgs/by-name/aw/aws-lc/package.nix
+++ b/pkgs/by-name/aw/aws-lc/package.nix
@@ -4,20 +4,23 @@
   cmakeMinimal,
   fetchFromGitHub,
   ninja,
+  rust-bindgen,
+  rustfmt,
   testers,
   aws-lc,
   nix-update-script,
   useSharedLibraries ? !stdenv.hostPlatform.isStatic,
+  withRustBindings ? true,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "aws-lc";
-  version = "1.69.0";
+  version = "1.73.0";
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = "aws-lc";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-ykpPbMONAJK6rEANOn0O7JfIkXPSoPXs1Zr4Bv+eXqQ=";
+    hash = "sha256-fDDkAN/dIqcvAWCE23zveQB5ZPOAesAxSk9GRJzTDzw=";
   };
 
   outputs = [
@@ -29,10 +32,15 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmakeMinimal
     ninja
+  ]
+  ++ lib.optionals withRustBindings [
+    rust-bindgen
+    rustfmt
   ];
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" useSharedLibraries)
+    (lib.cmakeBool "GENERATE_RUST_BINDINGS" withRustBindings)
     "-GNinja"
     "-DDISABLE_GO=ON"
     "-DDISABLE_PERL=ON"
@@ -53,6 +61,15 @@ stdenv.mkDerivation (finalAttrs: {
       "-Wno-error=stringop-overflow"
     ]
   );
+
+  postInstall = ''
+    # Break output cycle
+    moveToOutput lib/crypto/cmake "$dev"
+    moveToOutput lib/ssl/cmake "$dev"
+  ''
+  + lib.optionalString withRustBindings ''
+    moveToOutput share/rust "$dev"
+  '';
 
   __darwinAllowLocalNetworking = true;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bumped to latest 1.X release.

The versioning approach for `aws-lc` has changed recently, which will need to be taken into account going forward: https://github.com/aws/aws-lc/blob/main/VERSIONING.md - I think we're safe to backport this version at least.

Main benefit here is the new Rust bindings, which will allow dynamic linking in the future for `aws-lc-rs`: https://github.com/aws/aws-lc-rs/blob/main/aws-lc-sys/README.md#using-a-system-installed-aws-lc

Will open a follow up PR hooking it up to `default-crate-overrides`. Only issue I foresee is the Rust crate expects a merged output directory, so may need a `rust-aws-lc-sys` wrapper package.

Given `aws-lc-rs` is the default for `rustls` now, it might be worth doing a sweep of all the old `openssl` configurations across Rust packages too.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
