### PR TITLE
folo: 0.6.3 -> 1.9.0

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -621,7 +621,7 @@ let
       # clang++: error: unknown argument: '-fno-lifetime-dse'
       ./patches/chromium-147-llvm-22.patch
     ]
-    ++ lib.optionals (chromiumVersionAtLeast "148" && lib.versionOlder llvmVersion "23") [
+    ++ lib.optionals (versionRange "148" "149" && lib.versionOlder llvmVersion "23") [
       # clang++: error: unknown argument: '-fsanitize-ignore-for-ubsan-feature=return'
       (fetchpatch {
         name = "chromium-148-revert-build-Add--fsanitizer=return-config.patch";
@@ -651,7 +651,22 @@ let
         hash = "sha256-jR0G9z2R8VGl2tkB3u0368RyWM1J6qYXqNWwKkYd5zU=";
       })
     ]
-    ++ lib.optionals (chromiumVersionAtLeast "148") [
+    ++ lib.optionals (chromiumVersionAtLeast "149" && lib.versionOlder llvmVersion "23") [
+      # clang++: error: unknown argument: '-fdiagnostics-show-inlining-chain'
+      # clang++: error: unknown argument: '-fsanitize-ignore-for-ubsan-feature=array-bounds'
+      # clang++: error: unknown argument: '-fsanitize-ignore-for-ubsan-feature=return'
+      ./patches/chromium-149-llvm-22.patch
+    ]
+    ++ lib.optionals (chromiumVersionAtLeast "149" && stdenv.hostPlatform.isAarch64) [
+      # [43731/56364] CXX obj/media/gpu/sandbox/sandbox/hardware_video_decoding_sandbox_hook_linux.o
+      # FAILED: [code=1] obj/media/gpu/sandbox/sandbox/hardware_video_decoding_sandbox_hook_linux.o
+      # clang++ -MD -MF obj/media/gpu/sandbox/sandbox/hardware_video_decoding_sandbox_hook_linux.o.d [...]
+      # ../../media/gpu/sandbox/hardware_video_decoding_sandbox_hook_linux.cc:123:9: error: use of undeclared identifier 'ERROR'
+      #   123 |     LOG(ERROR) << "dlopen(radeonsi_dri.so) failed with error: " << dlerror();
+      #       |         ^~~~~
+      ./patches/chromium-149-use-of-undeclared-identifier-ERROR.patch
+    ]
+    ++ lib.optionals (versionRange "148" "149") [
       # ninja: error: '../../third_party/rust-toolchain/bin/rustc', needed by 'phony/default_for_rust_host_build_tools_rust_bin_inputs', missing and no known rule to make it
       (fetchpatch {
         name = "chromium-148-revert-Reland-build-use-tool-inputs-instead-of-siso-config-for-rust-actions.patch";
@@ -791,6 +806,12 @@ let
       + lib.optionalString (chromiumVersionAtLeast "148") ''
         mkdir -p third_party/gperf/cipd/bin
         ln -s "${pkgsBuildHost.gperf}/bin/gperf" third_party/gperf/cipd/bin/gperf
+      ''
+      # https://chromium-review.googlesource.com/c/chromium/src/+/7719879
+      # ninja: error: '../../third_party/rust-toolchain/bin/rustc', needed by 'phony/default_for_rust_host_build_tools_rust_bin_inputs', missing and no known rule to make it
+      + lib.optionalString (chromiumVersionAtLeast "149") ''
+        mkdir -p third_party/rust-toolchain/bin
+        ln -s "${buildPackages.rustc}/bin/rustc" third_party/rust-toolchain/bin/rustc
       ''
       +
         lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform && stdenv.hostPlatform.isAarch64)
@@ -973,7 +994,11 @@ let
     # Mute some warnings that are enabled by default. This is useful because
     # our Clang is always older than Chromium's and the build logs have a size
     # of approx. 25 MB without this option (and this saves e.g. 66 %).
-    env.NIX_CFLAGS_COMPILE = "-Wno-unknown-warning-option -Wno-unused-command-line-argument -Wno-shadow";
+    env.NIX_CFLAGS_COMPILE =
+      "-Wno-unknown-warning-option -Wno-unused-command-line-argument -Wno-shadow"
+      # warning: '_LIBCPP_HARDENING_MODE' macro redefined [-Wmacro-redefined]
+      # because of hardeningDisable = [ "strictflexarrays1" ];
+      + lib.optionalString (chromiumVersionAtLeast "149") " -Wno-macro-redefined";
     env.BUILD_CC = "$CC_FOR_BUILD";
     env.BUILD_CXX = "$CXX_FOR_BUILD";
     env.BUILD_AR = "$AR_FOR_BUILD";

--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,44 +1,44 @@
 {
   "chromium": {
-    "version": "148.0.7778.215",
+    "version": "149.0.7827.53",
     "chromedriver": {
-      "version": "148.0.7778.216",
-      "hash_darwin": "sha256-gsK7Q3rwfQQ0iE5e/st/3gGtU+D8dGsTycffpEejmhw=",
-      "hash_darwin_aarch64": "sha256-zHASbRPnYf2q1qq8FsKnYrLwPjzoGk0tzLxB9SdTXFw="
+      "version": "149.0.7827.53",
+      "hash_darwin": "sha256-JzeQy8O9gcoV195sQrfUV1TclUyAI4lzOcE5+BmgKrM=",
+      "hash_darwin_aarch64": "sha256-nEkMVGUVYP0q9UECGT0ibc2vzjVRIO69dFrYOB05lqg="
     },
     "deps": {
       "depot_tools": {
-        "rev": "41c40cfaec7ee3bf0423c59925d8b23982a601f1",
-        "hash": "sha256-s9uvmYHCJKWnNhztmOPb+OHj/HbGo30PupwT4mHWjnM="
+        "rev": "45dedc4c3b87c982fd846b3dc599b233ed3aff90",
+        "hash": "sha256-Ttklyw6IdNeMExlzeiQg/qsCkTmqVhUJ34MFgYmCWD4="
       },
       "gn": {
-        "version": "0-unstable-2026-04-01",
-        "rev": "6e8dcdebbadf4f8aa75e6a4b6e0bdf89dce1513a",
-        "hash": "sha256-BTPD8WM1pVAMkFDlHekMdWFGyf63KdhKkKwsqikqoBQ="
+        "version": "0-unstable-2026-05-01",
+        "rev": "1740f5c25bcac5a650ee3d1c1ec22bfa25fcd756",
+        "hash": "sha256-oFs7fZAZEs/gQ7X1A4uigo9+Y+iEN9sMMQYwAjEuD04="
       },
-      "npmHash": "sha256-JuVcY8iFRDWcPcP4Pg+qm5rnTXkiVfNsqSkXbDWqsE8="
+      "npmHash": "sha256-pF0JtwFpPC4/fodbhSJnQKkczA9WlDg4VqEAy9aDVLg="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "7c855c70efe3f6ade6663c1520913fa7f63a0b2b",
-        "hash": "sha256-uDVYgSjxQ+xw8DHVd5UNkqnUrJ6P5ZWxL2tZToBhgQg=",
+        "rev": "9d2c8156a72129edca4785abb98866fad60ea338",
+        "hash": "sha256-RPFeHTWAeJUzbWU7QyRPmT3sqf3bAEuJ7/IJ3TP40pA=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/clang/tools/clang-format.git",
-        "rev": "c2725e0622e1a86d55f14514f2177a39efea4a0e",
-        "hash": "sha256-f+BbQ6xIubloSzx/MhPSZ8ymCskmS+9+epDGtPjZqXc="
+        "rev": "6eddfb5ec5f92127a531eda66c568d3a11e7ec11",
+        "hash": "sha256-Cm6BOOlEyD0kdYxMSmk6Fj1Dnfs3zCzXsm+BOXgBme0="
       },
       "src/third_party/compiler-rt/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/compiler-rt.git",
-        "rev": "76287b5da8e155135536c8e3a67432d97d74fe3a",
-        "hash": "sha256-q6syHriTR8TCQSqTWbbAkVVK0a/i4wojdEGN7sWGxUY="
+        "rev": "0408cce08083f3d81379ed7d9f5bd26c03e1495b",
+        "hash": "sha256-kR5osTmp2girvNRVHzEKMZDCelgux9RrRuMoXMCRSGM="
       },
       "src/third_party/libc++/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxx.git",
-        "rev": "7ab65651aed6802d2599dcb7a73b1f82d5179d05",
-        "hash": "sha256-7O/X2JW8ghkPTjmFZmT9cgG3Ui5zk3gUb436KlPww34="
+        "rev": "be1c391acca009d8d80535ce924e3d285451cdfa",
+        "hash": "sha256-zKb9PUiiBvhVhWnbQwR8uOFJ9gt3uYmfJ4M9ijpgKRc="
       },
       "src/third_party/libc++abi/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxxabi.git",
@@ -47,13 +47,13 @@
       },
       "src/third_party/libunwind/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libunwind.git",
-        "rev": "6ca46ff28e3578c57cbead6f233969eb3dabc176",
-        "hash": "sha256-JW4kqpVTCFDN4WZE2S5gEkX1O7eDycl+adm3KGlUoTU="
+        "rev": "71192be150bbe04d87bb5298512d464e38d2f654",
+        "hash": "sha256-PxXemxdWZoEavKDOovi67IVWEr2YW8YK2F0LXM3LZPw="
       },
       "src/third_party/llvm-libc/src": {
         "url": "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libc.git",
-        "rev": "2a826f2fda3cf8d75b47cbc3bb1d9b244f13a6ab",
-        "hash": "sha256-OWe2lAT5XbADWuxHgg53lZiU0My/ys86FEXvn4zlVx0="
+        "rev": "deb95b5e48e875920a2eaae799c8dbcd76a6a4db",
+        "hash": "sha256-oAgIT3+vjBrX86jgi/Pb0SCyco0lozjBjXlrKm6i56M="
       },
       "src/chrome/test/data/perf/canvas_bench": {
         "url": "https://chromium.googlesource.com/chromium/canvas_bench.git",
@@ -72,8 +72,8 @@
       },
       "src/docs/website": {
         "url": "https://chromium.googlesource.com/website.git",
-        "rev": "44319eca109f9678595924a90547c1f6650d8664",
-        "hash": "sha256-Trkan7bzRaLFlTkRfNGh7ssoZ3QpMh+mxQacsSM+d2I="
+        "rev": "c9a9ad55e9ec9934244e58a5a8cab9a295526010",
+        "hash": "sha256-2GKWEnlExrTzoIYMxeP4n2klLLT/phB5ZVJ5Nj3/aoY="
       },
       "src/media/cdm/api": {
         "url": "https://chromium.googlesource.com/chromium/cdm.git",
@@ -82,8 +82,8 @@
       },
       "src/net/third_party/quiche/src": {
         "url": "https://quiche.googlesource.com/quiche.git",
-        "rev": "21ffbe4c7b717d00d2d768c259b5b330fd754ac3",
-        "hash": "sha256-yKMmfdSBvbB3T042TJbZ1Mw+y0kyfHP0knQVFWAFPTg="
+        "rev": "fafc2fe9efc9f2e28a0815229fc14ca30c266ba8",
+        "hash": "sha256-4UmjE41MOFCBa3APDMyyJwkeV6LhHl5UsMxZpPRDsRY="
       },
       "src/testing/libfuzzer/fuzzers/wasm_corpus": {
         "url": "https://chromium.googlesource.com/v8/fuzzer_wasm_corpus.git",
@@ -92,8 +92,8 @@
       },
       "src/third_party/angle": {
         "url": "https://chromium.googlesource.com/angle/angle.git",
-        "rev": "a101e2d1db6da927325273566fe8f5404fa3a9bd",
-        "hash": "sha256-uIqodvHxEY9xNse2IHNns2Mz9zLAUZSSIN7pAXB8cPs="
+        "rev": "ded782bca9d5f165d1c4a70124cdc5384043a8b3",
+        "hash": "sha256-7+Hhx/V554hO3zzGuIZswkaRVDElz7ost7vbnf2wyZc="
       },
       "src/third_party/angle/third_party/glmark2/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glmark2/glmark2",
@@ -102,18 +102,18 @@
       },
       "src/third_party/angle/third_party/rapidjson/src": {
         "url": "https://chromium.googlesource.com/external/github.com/Tencent/rapidjson",
-        "rev": "781a4e667d84aeedbeb8184b7b62425ea66ec59f",
-        "hash": "sha256-btUl1a/B0sXwf/+hyvCvVJjWqIkXfVYCpHm3TeBuOxk="
+        "rev": "24b5e7a8b27f42fa16b96fc70aade9106cf7102f",
+        "hash": "sha256-oHHLYRDMb7Y/k0CwsdsxPC5lglr2IChQi0AiOMiFn78="
       },
       "src/third_party/angle/third_party/VK-GL-CTS/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/VK-GL-CTS",
-        "rev": "f52e89f885064b9109501bca16c813bb29389993",
-        "hash": "sha256-3jx4QVR9nB3WggfrORGJGifmJQhAYVSPusa7RlR16qg="
+        "rev": "3fe33a325af90c1c820b1e8109f11ea0f4b60c9b",
+        "hash": "sha256-JgOdlwtjC5HiCWBAaeM+Ffp9KlbI7+erT0ZRZBlWxXI="
       },
       "src/third_party/anonymous_tokens/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/anonymous-tokens.git",
-        "rev": "fdff40da0398d2c229308aed169345f6ff1a150f",
-        "hash": "sha256-eJP45x3vXOG1rWvRl/0H0c2IV7nQ/9dYjAzJGHHszdc="
+        "rev": "208ea23596884f6d86476ea88b64e7931cdec08a",
+        "hash": "sha256-HLUX0mUzA3xcXbw71sIxFBNEkL8x86urcdJH2Yuuy04="
       },
       "src/third_party/readability/src": {
         "url": "https://chromium.googlesource.com/external/github.com/mozilla/readability.git",
@@ -127,28 +127,23 @@
       },
       "src/third_party/dav1d/libdav1d": {
         "url": "https://chromium.googlesource.com/external/github.com/videolan/dav1d.git",
-        "rev": "d69235dd804b24c04ed05639cffcc912cd6cfd75",
-        "hash": "sha256-iKq6TYscIBK4ydv+0msNV3tcs82Ljk5ZNr954Qv2lII="
+        "rev": "5cfc3832687e3229117203905faf5425ac6bc0d7",
+        "hash": "sha256-MWDDrb8P5AIFszY0u5gCrK+kZlbYffIt9Y1b/thXL7I="
       },
       "src/third_party/dawn": {
         "url": "https://dawn.googlesource.com/dawn.git",
-        "rev": "78a9030d63048d832c4b822839bffe38ad4f20e5",
-        "hash": "sha256-ZknkLN64TYAN5j9WsgtKlRBrAc3iCM084zpc8Zui8Ts="
+        "rev": "1815a06195d9c74ac737a96f87c05111926e04f8",
+        "hash": "sha256-71KbW0w60VB67+HM48WpOo18hrVId4/4QBDl+xl5pgo="
       },
       "src/third_party/dawn/third_party/glfw3/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glfw/glfw",
-        "rev": "043378876a67b092f5d0d3d9748660121a336dd3",
-        "hash": "sha256-4QSD1/uxWfYZPMjShB0h639eqAfuBRXAVfOm6BbZCBs="
+        "rev": "b00e6a8a88ad1b60c0a045e696301deb92c9a13e",
+        "hash": "sha256-uVJOf+D3bgS/CyEL1y52gvkml6VUTtNPMTU6X5/XyS4="
       },
-      "src/third_party/dawn/third_party/dxc": {
+      "src/third_party/dawn/third_party/directx-shader-compiler/src": {
         "url": "https://chromium.googlesource.com/external/github.com/microsoft/DirectXShaderCompiler",
-        "rev": "eb67a9085c758516d940e1ce3fed0acfb6518209",
-        "hash": "sha256-z+yIuVweIyLdOiZDRfSppjTRoYq8S93+JNUla4Umot8="
-      },
-      "src/third_party/dawn/third_party/dxheaders": {
-        "url": "https://chromium.googlesource.com/external/github.com/microsoft/DirectX-Headers",
-        "rev": "980971e835876dc0cde415e8f9bc646e64667bf7",
-        "hash": "sha256-0Miw1Cy/jmOo7bLFBOHuTRDV04cSeyvUEyPkpVsX9DA="
+        "rev": "d73829d4e677ef00931e8e57de6d544396ab46cb",
+        "hash": "sha256-BIXNgVeF5x3BZWFWZ1Gz+zpNSOEl+hZWB0GgMEaNS2w="
       },
       "src/third_party/dawn/third_party/directx-headers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/microsoft/DirectX-Headers",
@@ -157,33 +152,33 @@
       },
       "src/third_party/dawn/third_party/OpenGL-Registry/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/OpenGL-Registry",
-        "rev": "5bae8738b23d06968e7c3a41308568120943ae77",
-        "hash": "sha256-K3PcRIiD3AmnbiSm5TwaLs4Gu9hxaN8Y91WMKK8pOXE="
+        "rev": "9cb90ca4902d588bef3c830fbb1da484893bd5fb",
+        "hash": "sha256-mWVORjrbNFINr5WKAIDVnPs2T+96vkxWqZdJwp8oT9I="
       },
       "src/third_party/dawn/third_party/EGL-Registry/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/EGL-Registry",
-        "rev": "7dea2ed79187cd13f76183c4b9100159b9e3e071",
-        "hash": "sha256-Z6DwLfgQ1wsJXz0KKJyVieOatnDmx3cs0qJ6IEgSq1A="
+        "rev": "3d7796b3721d93976b6bfe536aa97bbc4bce8667",
+        "hash": "sha256-csSV8Yp0p0UIrodbX5793uO5iZMjQfy+0D2wPif2+Fw="
       },
       "src/third_party/dawn/third_party/webgpu-cts": {
         "url": "https://chromium.googlesource.com/external/github.com/gpuweb/cts",
-        "rev": "09fdb847d90d0b5bfe57068ce2eb9283cb77fc7f",
-        "hash": "sha256-eTAwnTiAHq8rmbw7u9nAwSuAlS5adStUJKfITlYkcgU="
+        "rev": "5c6b119c4fa0d9059c45f7637df1fe26fc80a6e4",
+        "hash": "sha256-9DAdS2u2YtrCFJu0KTuwRJjTUNexFxdmnn7LkwQ+KiQ="
       },
       "src/third_party/dawn/third_party/webgpu-headers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/webgpu-native/webgpu-headers",
-        "rev": "7d3186c3dd2c708703524027b46b8703534ab3cc",
-        "hash": "sha256-yE3/mfhqc7YtVNg4f/nrUpuRUGRjOzdwl++vPvd+mvc="
+        "rev": "dc16b3e531cf4f31be54236d1a3e988ba5f295a2",
+        "hash": "sha256-tFn3OChLKsYz52Vml7WVgqyrK7SI6WR1Z2C2vvFfakI="
       },
       "src/third_party/highway/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/highway.git",
-        "rev": "84379d1c73de9681b54fbe1c035a23c7bd5d272d",
-        "hash": "sha256-HNrlqtAs1vKCoSJ5TASs34XhzjEbLW+ISco1NQON+BI="
+        "rev": "2607d3b5b0113992fe84d3848859eae13b3b52c1",
+        "hash": "sha256-YUYZO9KLffczjwIz3mBBceD6oM1giLCFLDHgDCevdRA="
       },
       "src/third_party/google_benchmark/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/benchmark.git",
-        "rev": "188e8278990a9069ffc84441cb5a024fd0bede37",
-        "hash": "sha256-GfqY2d+Nd7ovNrXxzTRm/AYWj7GuxIO6FawzUEzwOVA="
+        "rev": "8abf1e701fbd88c8170f48fe0558247e2e5f8e7d",
+        "hash": "sha256-M8QkA8+bckoRjlcVneYXNetmPEWEvmWy/mca5JA40Ho="
       },
       "src/third_party/libpfm4/src": {
         "url": "https://chromium.googlesource.com/external/git.code.sf.net/p/perfmon2/libpfm4.git",
@@ -192,13 +187,13 @@
       },
       "src/third_party/boringssl/src": {
         "url": "https://boringssl.googlesource.com/boringssl.git",
-        "rev": "d8be2b4a71155bf82da092ef543176351eeb59ff",
-        "hash": "sha256-fZc95YrREDbf0YcO6zahIjdX6TcRJANcH9MrkLIIIHw="
+        "rev": "65818adf16411ca394625f5747a1af28faf95d2c",
+        "hash": "sha256-tcTTzQnBp8Od1jdDMrFoCr9bnW0OCjGqUjH3QMnusmo="
       },
       "src/third_party/breakpad/breakpad": {
         "url": "https://chromium.googlesource.com/breakpad/breakpad.git",
-        "rev": "8be0e3114685fcc1589561067282edf75ea1259a",
-        "hash": "sha256-igcX5XwacIwoGbqIcZKwlJYpRWl9Uc32WdpXyHO7UVA="
+        "rev": "afa2870e449ef33ad41545e7670c574cf70926a4",
+        "hash": "sha256-+N6FPtSiLQmNqf5+x5XDSksrRq/YDVSMVx5Rv1PGjfI="
       },
       "src/third_party/cast_core/public/src": {
         "url": "https://chromium.googlesource.com/cast_core/public",
@@ -207,13 +202,13 @@
       },
       "src/third_party/catapult": {
         "url": "https://chromium.googlesource.com/catapult.git",
-        "rev": "4f1d71f6841d210b3a06ab3ef2e2ed679af0ee56",
-        "hash": "sha256-aHlf8gw3KxbKoyyajP4w586iYybx7HSkcKtLcZIgiDE="
+        "rev": "6e4188cabb4f37314ea41e9adfcb2cf9b64e2641",
+        "hash": "sha256-/kleYYllR22KjxHT2gTMGf6LEUZ1Ud7j593fIIAgqAA="
       },
       "src/third_party/catapult/third_party/webpagereplay": {
         "url": "https://chromium.googlesource.com/webpagereplay.git",
-        "rev": "be48b5e3387780790ecc7723434b6ea6733bcc33",
-        "hash": "sha256-KcFUlQMltsMm4WlTVMLzZXfrvu67ffkKjmBcruwZye0="
+        "rev": "b7ac48f52cd298e966a76eb054412915c3e445d4",
+        "hash": "sha256-smtwB6vzLgCAePz0jNfrpm8TxrxBnBkigLxERhxUEvE="
       },
       "src/third_party/ced/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/compact_enc_det.git",
@@ -232,13 +227,13 @@
       },
       "src/third_party/cpu_features/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/cpu_features.git",
-        "rev": "936b9ab5515dead115606559502e3864958f7f6e",
-        "hash": "sha256-E8LoVzhe+TAmARWZTSuINlsVhzpUJMxPPCGe/dHZcyA="
+        "rev": "d3b2440fcfc25fe8e6d0d4a85f06d68e98312f5b",
+        "hash": "sha256-IBJc1sHHh4G3oTzQm1RAHHahsEECC+BDl14DHJ8M1Ys="
       },
       "src/third_party/cpuinfo/src": {
         "url": "https://chromium.googlesource.com/external/github.com/pytorch/cpuinfo.git",
-        "rev": "7607ca500436b37ad23fb8d18614bec7796b68a7",
-        "hash": "sha256-LnLtCMMRg+DwB7MijBdt/tmCKD/zN5y2oTgXlYw3hTg="
+        "rev": "3681f0ce1446167d01dfe125d6db96ba2ac31c3c",
+        "hash": "sha256-PhWbzQgZSUb3eVyx+JTSnxVOAC2WzL2Dw1I9/6LEIsw="
       },
       "src/third_party/crc32c/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/crc32c.git",
@@ -247,28 +242,28 @@
       },
       "src/third_party/cros_system_api": {
         "url": "https://chromium.googlesource.com/chromiumos/platform2/system_api.git",
-        "rev": "c27a09148de373889e5d2bf616c4e85a68050ae2",
-        "hash": "sha256-a/mAa1+if6B1FHe9crO8PDpc3o8M+CeIuXjXT0lwZOY="
+        "rev": "7ecd2b41460516ecd7b7d6e5c298db25e1436b6f",
+        "hash": "sha256-ehbAXv4DZStWDMC3iOjmWkAc4PhAamyI4C9bdXO7FfA="
       },
       "src/third_party/crossbench": {
         "url": "https://chromium.googlesource.com/crossbench.git",
-        "rev": "c179f7919aade97c5cff64d14b9171736e7aaef9",
-        "hash": "sha256-Hxazf58z9imnGO1aj2NRtsQ+BYrfAuIuZscADpr1NVI="
+        "rev": "cecd70a5f49f777f603d38d11ac1f66c03c3e8af",
+        "hash": "sha256-zLwIY8fQVebkfN4KFMbitZODhmiN65JK2s9IG/5Cd+o="
       },
       "src/third_party/crossbench-web-tests": {
         "url": "https://chromium.googlesource.com/chromium/web-tests.git",
-        "rev": "b19e4e52c33fb8a105c3fc99598b0b9b4bc59752",
-        "hash": "sha256-7vCQw91L2c97dnVdrJ53zL8hi0KZffDJJjk7GaG3b/U="
+        "rev": "baf176aadedccc44329231d5dd40346874c2a63e",
+        "hash": "sha256-oY1/uGB6ykePIklWe35rmJWsnpu/wjkER4TJeP4TTdw="
       },
       "src/third_party/depot_tools": {
         "url": "https://chromium.googlesource.com/chromium/tools/depot_tools.git",
-        "rev": "41c40cfaec7ee3bf0423c59925d8b23982a601f1",
-        "hash": "sha256-s9uvmYHCJKWnNhztmOPb+OHj/HbGo30PupwT4mHWjnM="
+        "rev": "45dedc4c3b87c982fd846b3dc599b233ed3aff90",
+        "hash": "sha256-Ttklyw6IdNeMExlzeiQg/qsCkTmqVhUJ34MFgYmCWD4="
       },
       "src/third_party/devtools-frontend/src": {
         "url": "https://chromium.googlesource.com/devtools/devtools-frontend",
-        "rev": "1fb83ff123c44ab59a480056c8c1ba3d33c2caf0",
-        "hash": "sha256-S6agM7HMZ2g2W6e9tYdLSXr0Lc6zeQF9hAYLIeImAYQ="
+        "rev": "33c2f401a9c8ddad2159eb0ab83aa244a5247361",
+        "hash": "sha256-M9aULI+HECgA0ptAG47OPK0QuB+xzmb29iOtJ3whpB0="
       },
       "src/third_party/dom_distiller_js/dist": {
         "url": "https://chromium.googlesource.com/chromium/dom-distiller/dist.git",
@@ -282,8 +277,8 @@
       },
       "src/third_party/eigen3/src": {
         "url": "https://chromium.googlesource.com/external/gitlab.com/libeigen/eigen.git",
-        "rev": "a3074053a614df7a3896cb4edbcba40222a5f549",
-        "hash": "sha256-9AHpSqemqdwXoMiP3hH1YuEd3+nrudeVGTpInw+8BU4="
+        "rev": "2cf9891537250255f50df5109ffe9e700e2a73de",
+        "hash": "sha256-1bu1Y9itHIKcwY5J0sF08DSyfElLHiZ6SRsNZkFjz8o="
       },
       "src/third_party/farmhash/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/farmhash.git",
@@ -292,18 +287,18 @@
       },
       "src/third_party/fast_float/src": {
         "url": "https://chromium.googlesource.com/external/github.com/fastfloat/fast_float.git",
-        "rev": "cb1d42aaa1e14b09e1452cfdef373d051b8c02a4",
-        "hash": "sha256-CG5je117WYyemTe5PTqznDP0bvY5TeXn8Vu1Xh5yUzQ="
+        "rev": "05087a303dad9c98768b33c829d398223a649bc6",
+        "hash": "sha256-ZQm8kDMYdwjKugc2vBG5mwTqXa01u6hODQc/Tai2I9A="
       },
       "src/third_party/federated_compute/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google-parfait/federated-compute.git",
-        "rev": "eb170f645b270c7979edb863fd2cf8edab2b2fd1",
-        "hash": "sha256-Cp0WQBbqWvPdrKCMQhH4Z6zl6YlIPLjafWZEwdkYWlc="
+        "rev": "3112513bf1a80872311e7718c5385f535a819b89",
+        "hash": "sha256-jnG3PCxjaYcClRgzOfIkHbbD3xU9TDLyQR3VZUwHIgU="
       },
       "src/third_party/ffmpeg": {
         "url": "https://chromium.googlesource.com/chromium/third_party/ffmpeg.git",
-        "rev": "b5e18fb9da84e26ceef30d4e4886696bf59337c0",
-        "hash": "sha256-JHAicFKBvtkwmZPRBKYPT6JVqYqF8hyXxU0H7kfgCBs="
+        "rev": "f45bab87ce4c5fafc67fd53fcde777578d01bfa0",
+        "hash": "sha256-fsZSqmG6vFOPJYuBgG6OSWkzRu27B3mv/PqAP8s4ARk="
       },
       "src/third_party/flac": {
         "url": "https://chromium.googlesource.com/chromium/deps/flac.git",
@@ -332,8 +327,8 @@
       },
       "src/third_party/freetype/src": {
         "url": "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git",
-        "rev": "6d9fc45fc4bca8aef0b8f65592520673638c3334",
-        "hash": "sha256-A21ONLz8HxoBkOL/jHfs5YwePmOnFyNdlNYSJa9wers="
+        "rev": "b6bcd2177f72bb4842c7701d7b7f633bb3fc951a",
+        "hash": "sha256-TUz3yUD9HxqUMCOpLk74rEf8J0tMTh4ZCuD94AD4+q4="
       },
       "src/third_party/fxdiv/src": {
         "url": "https://chromium.googlesource.com/external/github.com/Maratyszcza/FXdiv.git",
@@ -342,18 +337,13 @@
       },
       "src/third_party/harfbuzz/src": {
         "url": "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git",
-        "rev": "67bb413f586f36ba44d740319cb7a28b3d283ea6",
-        "hash": "sha256-WCPEkbiiU8dENM+ik0KokW9Uxmz0xlsRFVVPPOEOZXw="
+        "rev": "e6741e2205309752839da60ff075b7fa2e7cddd3",
+        "hash": "sha256-XjUuY17fcZi+dIZFojq+eDsDVrBxtAWRydPdudt56+8="
       },
       "src/third_party/ink/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/ink.git",
-        "rev": "9d5367423281a8fcf5bc1c418e20477a992b270a",
-        "hash": "sha256-uDaK/cDA52Cn+ioPW2bXAJze1eW8TK3xF7+bl/Ylh6Y="
-      },
-      "src/third_party/ink_stroke_modeler/src": {
-        "url": "https://chromium.googlesource.com/external/github.com/google/ink-stroke-modeler.git",
-        "rev": "da42d439389c90ec7574f0381ec53e7f5be0c2eb",
-        "hash": "sha256-W5HgVe0v9O/EuhpKMHp83PLq4p6cuBul3QUGLYdF6rY="
+        "rev": "a988417b6d0b1ea03fb0b40269fbc42313acc6fd",
+        "hash": "sha256-6O+N/ULn8sqsdgFw7VZ7TMjWvCAZbYo398PruPScU/k="
       },
       "src/third_party/instrumented_libs": {
         "url": "https://chromium.googlesource.com/chromium/third_party/instrumented_libraries.git",
@@ -417,8 +407,8 @@
       },
       "src/third_party/fuzztest/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/fuzztest.git",
-        "rev": "800c545cf9d6e9c01328a1974f93a7e6564a74fd",
-        "hash": "sha256-Pvz+CWTBcWE0N0yfNGZhXDgUrGeIaCNfEjP1jYmF6G0="
+        "rev": "e24a91020ab19c3d6f590bd0911b7acb492f81be",
+        "hash": "sha256-wFjuvJzGEaal+pIo5UtkdLHYTpoWxRE6Vf5OGLObGQk="
       },
       "src/third_party/domato/src": {
         "url": "https://chromium.googlesource.com/external/github.com/googleprojectzero/domato.git",
@@ -432,13 +422,13 @@
       },
       "src/third_party/libaom/source/libaom": {
         "url": "https://aomedia.googlesource.com/aom.git",
-        "rev": "343cee0a952f8c7d329e59ff3ac2c8bdbe70ec6a",
-        "hash": "sha256-H8Eu3BiUIiZcyReGDyFq9UvjdMJOX00ERjru8+I0zL8="
+        "rev": "33dba9e12a9f12e737eaa7c2624e8c580950a89a",
+        "hash": "sha256-01DbV0kQFg1yyFpVeo82KBoZHhizA7xnZ1qOuu4HTcs="
       },
       "src/third_party/crabbyavif/src": {
         "url": "https://chromium.googlesource.com/external/github.com/webmproject/CrabbyAvif.git",
-        "rev": "7466a44ac80893803d4a7168b98dc6cd02d1fe2d",
-        "hash": "sha256-x1MRNtGLmwlRNenoQKz2Bgm3J5eHlNiJZtzhT9lttmk="
+        "rev": "c433c9a32320aed983e4106931596fbbae3f77ee",
+        "hash": "sha256-yw1cXB6s6biD2vj2K/3sVbKiaNK7bt+NkbQovbYlJ2Q="
       },
       "src/third_party/nearby/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/nearby-connections.git",
@@ -492,8 +482,8 @@
       },
       "src/third_party/cros-components/src": {
         "url": "https://chromium.googlesource.com/external/google3/cros_components.git",
-        "rev": "fb512780dcc5ba4b5be9e8a3118919002077c760",
-        "hash": "sha256-7wx73HZ6aqXQvLxwX6XnJAPefi/t47gIhvDH3FRT1j4="
+        "rev": "e580888fcc1c108e25c218ccf8b7a4372de18d57",
+        "hash": "sha256-p0Wfvhg/j8v9xL9Pueo7xPVHBKowOLI00AeIZXPQw4k="
       },
       "src/third_party/libdrm/src": {
         "url": "https://chromium.googlesource.com/chromiumos/third_party/libdrm.git",
@@ -520,20 +510,20 @@
         "rev": "9700847afb92cb35969bdfcbbfbbb74b9c7b3376",
         "hash": "sha256-EI/uaHXe0NlqdEw764q0SjerThYEVLRogUlmrsZwXnY="
       },
-      "src/third_party/libphonenumber/dist": {
+      "src/third_party/libphonenumber/src": {
         "url": "https://chromium.googlesource.com/external/libphonenumber.git",
-        "rev": "9d46308f313f2bf8dbce1dfd4f364633ca869ca7",
-        "hash": "sha256-ZbuDrZEUVp/ekjUP8WO/FsjAomRjeDBptT4nQZvTVi4="
+        "rev": "ade546d8856475d0493863ee270eb3be9628106b",
+        "hash": "sha256-cLtsM35Ir3iG3j8+Cy2McL1ysRB0Y1PXealAKl05Twg="
       },
       "src/third_party/libprotobuf-mutator/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/libprotobuf-mutator.git",
-        "rev": "7bf98f78a30b067e22420ff699348f084f802e12",
-        "hash": "sha256-EaEC6R7SzqLw4QjEcWXFXhZc84lNBp6RSa9izjGnWKE="
+        "rev": "c1c950eae0440c3808f2b8bd7c57d0c6a42c1a90",
+        "hash": "sha256-Su1SPr/GEFi7/N8/HrFkVbGfWH0vYdcJ5/on8zLMcyU="
       },
       "src/third_party/libsrtp": {
         "url": "https://chromium.googlesource.com/chromium/deps/libsrtp.git",
-        "rev": "e8383771af8aa4096f5bcfe3743a5ea128f88a9a",
-        "hash": "sha256-xC//VEFrI94nCkyLnRa6uQ+hJQqe41v0Qjm4LJ7K84I="
+        "rev": "cd5d177bf1fde755ddb4c7f0d9ff7693f8b49e5e",
+        "hash": "sha256-6tIbthIcUw58AgaNzvSenZPp/e5vHVTp5K2bpPF+Zg0="
       },
       "src/third_party/libsync/src": {
         "url": "https://chromium.googlesource.com/aosp/platform/system/core/libsync.git",
@@ -547,13 +537,13 @@
       },
       "src/third_party/libvpx/source/libvpx": {
         "url": "https://chromium.googlesource.com/webm/libvpx.git",
-        "rev": "47ac1ec7f3de7d7cb3d070844c427c8f1fa9d6fc",
-        "hash": "sha256-RyYnkLYafiS6kQKeOmzohtxFRXudDzgEmQkG+qKHozc="
+        "rev": "640d4ce27ba918783e28a0da46a8a37abe4a65b6",
+        "hash": "sha256-uCa/MEfw2s05kK91uubi/TqztHulwattzt1vfr0LR4E="
       },
       "src/third_party/libwebm/source": {
         "url": "https://chromium.googlesource.com/webm/libwebm.git",
-        "rev": "b7a1e4767fbb02ad467f45ba378e858e897028da",
-        "hash": "sha256-Lzfs15Us8MDDQYvLRVf6xKg9A76aXPnTukx/A8Mf7rw="
+        "rev": "6184f4484a826724b5293837134ab9492261b941",
+        "hash": "sha256-zXPuisCv2KkGQq23qTNhHeXpyCClUIeyjHra08DHJIw="
       },
       "src/third_party/libwebp/src": {
         "url": "https://chromium.googlesource.com/webm/libwebp.git",
@@ -562,8 +552,8 @@
       },
       "src/third_party/libyuv": {
         "url": "https://chromium.googlesource.com/libyuv/libyuv.git",
-        "rev": "30809ff64a9ca5e45f86439c0d474c2d3eef3d05",
-        "hash": "sha256-DW7PuRqA1x0K8/uJbxBJ4Cn9YEPFhZ9vhuGVVyGKK98="
+        "rev": "a7849e8a5e9c996bef2332efae897e7301055a20",
+        "hash": "sha256-ftOTwWULKNplqjQQ9oM9t+PU3S6/ySDOBoE5E/HWuHg="
       },
       "src/third_party/lss": {
         "url": "https://chromium.googlesource.com/linux-syscall-support.git",
@@ -582,13 +572,13 @@
       },
       "src/third_party/nasm": {
         "url": "https://chromium.googlesource.com/chromium/deps/nasm.git",
-        "rev": "45252858722aad12e545819b2d0f370eb865431b",
-        "hash": "sha256-0KsHYi76IaVNwk0dBhem2AnUXd9PpeS+jUsY+zPmeJ8="
+        "rev": "358842b6b7dd69b2ed635bef17f941e030a05e5f",
+        "hash": "sha256-YwjwubijMZ9OvYeMUVMSunWZ2VCuqUFEOyv/MK/oojc="
       },
       "src/third_party/neon_2_sse/src": {
         "url": "https://chromium.googlesource.com/external/github.com/intel/ARM_NEON_2_x86_SSE.git",
-        "rev": "662a85912e8f86ec808f9b15ce77f8715ba53316",
-        "hash": "sha256-4OzG4wIPwnKbFD9LG+stxHt5O4qB85ZIXVeSrNqDAyM="
+        "rev": "ed59be8546632d5126ff69c87122ae5de20ffe4f",
+        "hash": "sha256-ydHSMPJS+axvW7KIR/9SLWNFq/lP67dpg9Yt7shLCng="
       },
       "src/third_party/openh264/src": {
         "url": "https://chromium.googlesource.com/external/github.com/cisco/openh264",
@@ -597,8 +587,8 @@
       },
       "src/third_party/openscreen/src": {
         "url": "https://chromium.googlesource.com/openscreen",
-        "rev": "448a19d1f24e0f8ce85ad0c1c6a50cf370ae69d7",
-        "hash": "sha256-hRDFnoqAH4HoWZ3oTWlzNge2nwlxpUC/GEq0MQVzBw8="
+        "rev": "684bcd767271a21f3e5d475b17a0fd862f16c65e",
+        "hash": "sha256-Yjz2E1/h+zp7L2x0zE0l+ktQIiSrJ4ZknXOhaVPKQVE="
       },
       "src/third_party/openscreen/src/buildtools": {
         "url": "https://chromium.googlesource.com/chromium/src/buildtools",
@@ -612,13 +602,13 @@
       },
       "src/third_party/pdfium": {
         "url": "https://pdfium.googlesource.com/pdfium.git",
-        "rev": "72ea487e4399c44c3a53a48b104f9612ca772008",
-        "hash": "sha256-0VgmDPyF5k81nBXdo88CcIIbz6XRhaiADnG8gwDGZZk="
+        "rev": "74d747ce1d383caca3ec0e604d77bac35ccd1e58",
+        "hash": "sha256-qMY6L93hlnMgGZ5Blk5ldDnI/LUXYyuk+b7FXCiVV6s="
       },
       "src/third_party/perfetto": {
         "url": "https://chromium.googlesource.com/external/github.com/google/perfetto.git",
-        "rev": "46432bb2a7a60e10fcee516f1692e6846d098a8d",
-        "hash": "sha256-jVih4xWota4SZQi4yEtaIP+4qgD03OsELt2aaulIXik="
+        "rev": "846203c4b3b25f834a0bebc101fa8e1b8f9d0ca9",
+        "hash": "sha256-YOgOau9vNrOOqyUf6WylI/oQ2drCxoW7jnrHt7fAfQM="
       },
       "src/third_party/protobuf-javascript/src": {
         "url": "https://chromium.googlesource.com/external/github.com/protocolbuffers/protobuf-javascript",
@@ -627,8 +617,8 @@
       },
       "src/third_party/pthreadpool/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/pthreadpool.git",
-        "rev": "9003ee6c137cea3b94161bd5c614fb43be523ee1",
-        "hash": "sha256-Es9QNblzo5b+x4K7myQJwIiUKvqyP16QExWPhGqqDO8="
+        "rev": "a56dcd79c699366e7ac6466792c3025883ff7704",
+        "hash": "sha256-WfyuPfII4eSmLskZV0TAcu4K6OyW38TjkDHm+VUx5eY="
       },
       "src/third_party/pyelftools": {
         "url": "https://chromium.googlesource.com/chromiumos/third_party/pyelftools.git",
@@ -657,13 +647,13 @@
       },
       "src/third_party/search_engines_data/resources": {
         "url": "https://chromium.googlesource.com/external/search_engines_data.git",
-        "rev": "2ecec7b3a56bcb5d7a4a1fc9bc71d7e1cda2a8d1",
-        "hash": "sha256-UPP47dgdXxr+LPvTcEc6gi89OxmvdKD3CdwV4wKXvwQ="
+        "rev": "2345fee6ce4ae24d9c365d5c0884ece593c55c67",
+        "hash": "sha256-5qkra6FURaMvEOk+ZKMRH1hc8ixEnk3u4rxNm0G8tuQ="
       },
       "src/third_party/skia": {
         "url": "https://skia.googlesource.com/skia.git",
-        "rev": "03c3234e64f9fbbbcf6a7b9c79e94059df49dbfe",
-        "hash": "sha256-e0MSCbqv4u4995nowzipKorkn6mPpO7tf8+ygj3/nFY="
+        "rev": "53348aa333da02b77c4b5797e2de722f5abde7d0",
+        "hash": "sha256-Qh0ytA45zP67VQE417iUtjPcJmJmDzcu4BAatyh6p0w="
       },
       "src/third_party/smhasher/src": {
         "url": "https://chromium.googlesource.com/external/smhasher.git",
@@ -682,8 +672,8 @@
       },
       "src/third_party/swiftshader": {
         "url": "https://swiftshader.googlesource.com/SwiftShader.git",
-        "rev": "89556131bf9d48af3c5c9fbb9a3322e706da89a3",
-        "hash": "sha256-h0utcwCnzwhFufggkBNeA674x2Kqwu4sz3jQ/9eoQv0="
+        "rev": "f9d5d49a3c599a315e3493dc1e9b5309cffb3305",
+        "hash": "sha256-kBfqgXXJeEPT80mu6CJ2Bwmdv/y8jVzM6TedMXbzo4o="
       },
       "src/third_party/text-fragments-polyfill/src": {
         "url": "https://chromium.googlesource.com/external/github.com/GoogleChromeLabs/text-fragments-polyfill.git",
@@ -692,23 +682,23 @@
       },
       "src/third_party/tflite/src": {
         "url": "https://chromium.googlesource.com/external/github.com/tensorflow/tensorflow.git",
-        "rev": "de8d7f65b6eb670e4dad0225d0d6f99bebaab559",
-        "hash": "sha256-r2b+/VBffxsh1sRM2xcFiBx9K6GD6FsaQXpfFMBFUag="
+        "rev": "2216f531fb72119745382c62f232acf9790f4b6e",
+        "hash": "sha256-zySLNPmug5HS5pwJ/lEMAWjjZSOuxdTgup7Y90k7NZI="
       },
       "src/third_party/litert/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google-ai-edge/LiteRT.git",
-        "rev": "588075c77c6895cce6397d41d2890b1aa0a14372",
-        "hash": "sha256-rcEPZNSV0DiDrmoBCtJ07wFzzpmpM93jG4jYaEdNWvI="
+        "rev": "9b5418dd7a1a318eed20395743dcc868df17d8b0",
+        "hash": "sha256-80amwDPF3RrcoTaTQsunNmlvBGs6KCv369FW3J/Xcts="
       },
       "src/third_party/vulkan-deps": {
         "url": "https://chromium.googlesource.com/vulkan-deps",
-        "rev": "0ced1107c62836f439f684a5696c4bd69e09fce3",
-        "hash": "sha256-VOyN618wzyyO2Wh18gCnw+FCr/NbegX3A/54MClyhwc="
+        "rev": "d234b7b29748c07ef389279dd24f533ebd04cadc",
+        "hash": "sha256-w49HOjPixSI/C5IGlxQMj/Ol9f/Lr2zI2oMhQzzu1zk="
       },
       "src/third_party/glslang/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/glslang",
-        "rev": "715c8500e7cd67f2eba9e60e98852a1ed49d2f15",
-        "hash": "sha256-vSbMdTjlRVvYLi5ZvTVmfe76oAQ4AhqyD+ohvkvIYIs="
+        "rev": "458ff50a67cb69371850068a62b78f1990a1ff9a",
+        "hash": "sha256-2WauVjAEeZn16b4fE4ImKPX3wjDmeN92mqWi3NMiXSw="
       },
       "src/third_party/spirv-cross/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross",
@@ -717,38 +707,38 @@
       },
       "src/third_party/spirv-headers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Headers",
-        "rev": "6dd7ba990830f7c15ac1345ff3b43ef6ffdad216",
-        "hash": "sha256-UKBVs2s05hP+paPq1dZFaUEQQ9Kx9acHxYUyJVx22eY="
+        "rev": "126038020c2bd47efaa942ccc364ca5353ffccde",
+        "hash": "sha256-QBX2M+ZSWgVvCx58NeDIdf6mIkdJbecDktBfUWGPvNc="
       },
       "src/third_party/spirv-tools/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Tools",
-        "rev": "2d14d2e76aa7de72404b17078eda15c20a6a0389",
-        "hash": "sha256-8Xtzq8WOdFEw+uEJqMW39LLHt2m165K9OJsIFZuifoM="
+        "rev": "2ec8457ab33d539b6f1fecc998360c0b8b05ed4f",
+        "hash": "sha256-9TBb/gnDXgZRZXhF27KEQ0XQI5itRHKJQjLrkFDQq7Q="
       },
       "src/third_party/vulkan-headers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers",
-        "rev": "afe9eb980aa928a66d1c9c06f38c55dd59868720",
-        "hash": "sha256-/yolWlC7ruRiJ0gSdCoSlqL9+j2uJAh+o+H0OG37pq4="
+        "rev": "f6a6f7ab165cedbfa2a7d0c93fe27a2d01ce09c8",
+        "hash": "sha256-ZbjmxbRUiVJADNRWziCH0UIM09qKf+lm9PRnWOhZFhQ="
       },
       "src/third_party/vulkan-loader/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Loader",
-        "rev": "df84d2be47457a8dfd7eb66f8c2b031683bd1ba5",
-        "hash": "sha256-8ParcURRRU3eS9Oej/vHTwOwvYy3HsVJsKh2wQLKUgM="
+        "rev": "15a84652b94e465e9a7b25eb507193929863bc2f",
+        "hash": "sha256-pdC3YCM0Nzeabi5TPD+qR5PVdsxmWMnf2L9HsOcbv84="
       },
       "src/third_party/vulkan-tools/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Tools",
-        "rev": "90bf5bc4fd8bea0d300f6564af256a51a34124b8",
-        "hash": "sha256-tmTD/waVX/duaKXvj0FNUS+ncL1agM73kK7pEfHEsSA="
+        "rev": "7c46da2b39036a80ce088576d5794bf39e667f56",
+        "hash": "sha256-nAyNVveeGg9sA0E37YiEPm+UdKsy48nAOjnUYHQnuqw="
       },
       "src/third_party/vulkan-utility-libraries/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Utility-Libraries",
-        "rev": "48b1fd1a65e436bae806cb6180c9338846b9de97",
-        "hash": "sha256-B3GXmwJEvnGcER5DJt0FGrwqNi3t8iV6VgX8uOrExlU="
+        "rev": "2c909c1ab6f9c6caba39a84a4887186b3fafdead",
+        "hash": "sha256-k3xeKHQbd2rTQJsOZKXEMPrYjcHwoCC1N12F6AIP6Ho="
       },
       "src/third_party/vulkan-validation-layers/src": {
         "url": "https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-ValidationLayers",
-        "rev": "ac146eef210b6f52b842111c5d3419ab32a7293f",
-        "hash": "sha256-GqjVHxtda1a47+9G+nqh4qNMJmQaUdZNMUGQ8kAIIkk="
+        "rev": "b105d8ea361af258abed65efb5a1565c031dcf1c",
+        "hash": "sha256-GgznBGYgnCFMNaqAOQ15dlw2dOFfSp3mAV2KokVLzgk="
       },
       "src/third_party/vulkan_memory_allocator": {
         "url": "https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git",
@@ -787,23 +777,23 @@
       },
       "src/third_party/webgpu-cts/src": {
         "url": "https://chromium.googlesource.com/external/github.com/gpuweb/cts.git",
-        "rev": "09fdb847d90d0b5bfe57068ce2eb9283cb77fc7f",
-        "hash": "sha256-eTAwnTiAHq8rmbw7u9nAwSuAlS5adStUJKfITlYkcgU="
+        "rev": "3b327ebc44f11212fd3872972a6dd394634fb9e3",
+        "hash": "sha256-RSZVKv2Z0pg2cGa3Elr2r5VZqdxlRJ+6mzm1Au1qg1I="
       },
       "src/third_party/webpagereplay": {
         "url": "https://chromium.googlesource.com/webpagereplay.git",
-        "rev": "be48b5e3387780790ecc7723434b6ea6733bcc33",
-        "hash": "sha256-KcFUlQMltsMm4WlTVMLzZXfrvu67ffkKjmBcruwZye0="
+        "rev": "b7ac48f52cd298e966a76eb054412915c3e445d4",
+        "hash": "sha256-smtwB6vzLgCAePz0jNfrpm8TxrxBnBkigLxERhxUEvE="
       },
       "src/third_party/webrtc": {
         "url": "https://webrtc.googlesource.com/src.git",
-        "rev": "e3ee86921c57b9f8921045e77f098604803cb66c",
-        "hash": "sha256-n39HENOXmatsZLF6jdYRsb+wl2cM0i6ngT4Zbyu5ayE="
+        "rev": "5a7e0ff57a52e12f834d64c57d040d1105ea17f2",
+        "hash": "sha256-V1accCSU6LV5Ixhd+HBOvqZ7GxT57ALsvaF8ABLIXxM="
       },
       "src/third_party/wuffs/src": {
         "url": "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git",
-        "rev": "e3f919ccfe3ef542cfc983a82146070258fb57f8",
-        "hash": "sha256-373d2F/STcgCHEq+PO+SCHrKVOo6uO1rqqwRN5eeBCw="
+        "rev": "50869df0ea703b4f41b238bfe26aec6ec9c86889",
+        "hash": "sha256-V7inWJqH7Q4Ac/ZB//7XHrpgfAYUPBxWBerBem6Q/Kk="
       },
       "src/third_party/weston/src": {
         "url": "https://chromium.googlesource.com/external/anongit.freedesktop.org/git/wayland/weston.git",
@@ -812,8 +802,13 @@
       },
       "src/third_party/xnnpack/src": {
         "url": "https://chromium.googlesource.com/external/github.com/google/XNNPACK.git",
-        "rev": "1812bbe2928a32f26c5e48466712ba6460cf290c",
-        "hash": "sha256-xal21wjgeql3MjQXw6F1ezcRsnhVKod5jv0nYWroJ1o="
+        "rev": "2ad25fc09167df69c6c02eb8082a0b9658dd5e80",
+        "hash": "sha256-vBMGBXzJPCcsc2kMyGecjti68oZHWUwJKd7tkKub6kg="
+      },
+      "src/third_party/libei/src": {
+        "url": "https://chromium.googlesource.com/external/gitlab.freedesktop.org/libinput/libei.git",
+        "rev": "5d6d8e6590df210b75559a889baa9459c68d9366",
+        "hash": "sha256-lSrIC93Cke90/Xc8dqd3e/TU32tflYHYqc5fE8wglBI="
       },
       "src/third_party/zstd/src": {
         "url": "https://chromium.googlesource.com/external/github.com/facebook/zstd.git",
@@ -822,8 +817,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "5e24a1fd6ffb840b93ee90a800897fcb4d60eeab",
-        "hash": "sha256-JcBGaXhqNRIA4NPPV4eANVM93wsQ9QxSLO/Ecz3wklU="
+        "rev": "5a39b146dd810a52812202fae891281d5dc4db7d",
+        "hash": "sha256-UbX88nE4VyWUm4PvFTOy3mC04MzSdgC006ZpQrEY8cQ="
       }
     }
   },

--- a/pkgs/applications/networking/browsers/chromium/patches/chromium-149-llvm-22.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/chromium-149-llvm-22.patch
@@ -1,0 +1,30 @@
+diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
+index f977c9fed76e6f50c50351ca22128e8c8c8897b1..81460f3591b734f3354a6f9ac7bb0990e5b28889 100644
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -589,7 +589,7 @@ config("compiler") {
+     # Flags for diagnostics.
+     cflags += [ "-fcolor-diagnostics" ]
+     if (!is_win) {
+-      cflags += [ "-fdiagnostics-show-inlining-chain" ]
++      cflags += [ ]
+     } else {
+       # Combine after https://github.com/llvm/llvm-project/pull/192241
+       cflags += [ "/clang:-fdiagnostics-show-inlining-chain" ]
+@@ -1911,7 +1911,7 @@ config("clang_warning_suppression") {
+ # See also: https://crbug.com/40891132#comment10
+ ubsan_hardening("c_array_bounds") {
+   sanitizer = "array-bounds"
+-  condition = !(is_asan && target_cpu == "x86")
++  condition = false
+ 
+   # Because we've enabled array-bounds sanitizing we also want to suppress
+   # the related warning about "unsafe-buffer-usage-in-static-sized-array",
+@@ -1925,6 +1925,7 @@ ubsan_hardening("c_array_bounds") {
+ # `NOTREACHED()` at the end of such functions.
+ ubsan_hardening("return") {
+   sanitizer = "return"
++  condition = false
+ }
+ 
+ config("rustc_revision") {

--- a/pkgs/applications/networking/browsers/chromium/patches/chromium-149-use-of-undeclared-identifier-ERROR.patch
+++ b/pkgs/applications/networking/browsers/chromium/patches/chromium-149-use-of-undeclared-identifier-ERROR.patch
@@ -1,0 +1,12 @@
+diff --git a/media/gpu/sandbox/hardware_video_decoding_sandbox_hook_linux.cc b/media/gpu/sandbox/hardware_video_decoding_sandbox_hook_linux.cc
+index 58ab0db508f73dbac36a84cb71ffdad972b3fc3c..b5b97f6c6b22a79fd5e4e53393859a107cc0f399 100644
+--- a/media/gpu/sandbox/hardware_video_decoding_sandbox_hook_linux.cc
++++ b/media/gpu/sandbox/hardware_video_decoding_sandbox_hook_linux.cc
+@@ -7,6 +7,7 @@
+ #include <dlfcn.h>
+ #include <sys/stat.h>
+ 
++#include "base/logging.h"
+ #include "base/process/process_metrics.h"
+ #include "base/strings/stringprintf.h"
+ #include "build/build_config.h"

--- a/pkgs/by-name/br/brlcad/package.nix
+++ b/pkgs/by-name/br/brlcad/package.nix
@@ -46,8 +46,68 @@ let
     owner = "BRL-CAD";
     repo = "bext";
     rev = "f9074f84c87605f89d912069cee1b1e710ead635"; # must match brlcad_bext_init() in CMakeLists.txt
-    hash = "sha256-jCBw4aDk/bmz2Woe9qIA88mgLRRZSu7zDYM5pi3MbP8=";
+    hash = "sha256-wOzrHiEA+IVUnchSRRUAzIwKkGWtyvnrInnADi3KgiI=";
     fetchSubmodules = true;
+    # remove unneeded subprojects to reduce NAR size
+    postFetch =
+      let
+        subprojectsToRemove = toString [
+          "appleseed"
+          "astyle"
+          "boost"
+          "clipper2"
+          "deflate"
+          "eigen"
+          "embree"
+          "expat"
+          "flexbison"
+          "fmt"
+          "gdal"
+          "geogram"
+          "gte"
+          "icu"
+          "ispc"
+          "jpeg"
+          "lief"
+          "llvm"
+          "lmdb"
+          "lz4"
+          "minizip-ng"
+          "mmesh"
+          "ncurses"
+          "netpbm"
+          "onetbb"
+          "opencolorio"
+          "opencv"
+          "openexr"
+          "openimageio"
+          "openmesh"
+          "osl"
+          "ospray"
+          "patchelf"
+          "plief"
+          "png"
+          "poissonrecon"
+          "proj"
+          "pugixml"
+          "pystring"
+          "qt"
+          "rkcommon"
+          "sqlite3"
+          "stepcode"
+          "tiff"
+          "tinygltf"
+          "xerces-c"
+          "xmltools"
+          "yaml-cpp"
+          "zstd"
+        ];
+      in
+      ''
+        for name in ${subprojectsToRemove}; do
+          rm -r $out/$name
+        done
+      '';
   };
 in
 

--- a/pkgs/by-name/fo/folo/package.nix
+++ b/pkgs/by-name/fo/folo/package.nix
@@ -13,14 +13,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "folo";
-
-  version = "0.6.3";
+  version = "1.9.0";
 
   src = fetchFromGitHub {
     owner = "RSSNext";
     repo = "Folo";
-    tag = "v${version}";
-    hash = "sha256-huVk5KcsepDwtdWMm9pvn31GE1felbH1pR3mGqlSWRs=";
+    tag = "desktop/v${version}";
+    hash = "sha256-VrKWqqXzdEOfl8E069eZCeI5agxWKmRMW6ziGqURuHc=";
   };
 
   nativeBuildInputs = [
@@ -39,29 +38,24 @@ stdenv.mkDerivation rec {
       ;
     pnpm = pnpm_10_29_2;
     fetcherVersion = 3;
-    hash = "sha256-EP7bpbJUcKmHm7KMlKc0Fz2u0niQ3jC7YN/9pp7vucE=";
+    hash = "sha256-uj7xyh+U4OHn6J+jhoPaEOYwOLinRAj5CbWZYPgG6zI=";
   };
 
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
-    # This environment variables inject the production Vite config at build time.
-    # Copy from:
-    # 1. https://github.com/RSSNext/Folo/blob/v0.4.6/.github/workflows/build-desktop.yml#L27
-    # 2. And logs in the corresponding GitHub Actions: https://github.com/RSSNext/Folo/actions/workflows/build-desktop.yml
-    VITE_WEB_URL = "https://app.follow.is";
-    VITE_API_URL = "https://api.follow.is";
-    VITE_SENTRY_DSN = "https://e5bccf7428aa4e881ed5cb713fdff181@o4507542488023040.ingest.us.sentry.io/4507570439979008";
-    VITE_OPENPANEL_CLIENT_ID = "0e477ab4-d92d-4d6e-b889-b09d86ab908e";
-    VITE_OPENPANEL_API_URL = "https://openpanel.follow.is/api";
+    VITE_WEB_URL = "https://app.folo.is";
+    VITE_API_URL = "https://api.folo.is";
+    VITE_OPENPANEL_API_URL = "https://openpanel.folo.is/api";
+
     VITE_FIREBASE_CONFIG = builtins.toJSON {
-      apiKey = "AIzaSyDuM93019tp8VI7wsszJv8ChOs7b1EE5Hk";
-      authDomain = "follow-428106.firebaseapp.com";
-      projectId = "follow-428106";
-      storageBucket = "follow-428106.appspot.com";
-      messagingSenderId = "194977404578";
-      appId = "1:194977404578:web:1920bb0c9ea5e2373669fb";
-      measurementId = "G-SJE57D4F14";
+      apiKey = "AIzaSyBpGB2C2Vz-9ktivqVkW7uTtVopNh3ELvo";
+      authDomain = "diygod-folo.firebaseapp.com";
+      projectId = "diygod-folo";
+      storageBucket = "diygod-folo.firebasestorage.app";
+      messagingSenderId = "992336953943";
+      appId = "1:992336953943:web:998aae576c8bc77dc11912";
+      measurementId = "G-HS4SF4GHWG";
     };
   };
 
@@ -125,7 +119,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/RSSNext/Folo";
     changelog = "https://github.com/RSSNext/Folo/releases/tag/${src.tag}";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ iosmanthus ];
+    maintainers = with lib.maintainers; [ iosmanthus msdone ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "follow";
   };

--- a/pkgs/by-name/ge/geoserver/extensions.nix
+++ b/pkgs/by-name/ge/geoserver/extensions.nix
@@ -42,159 +42,159 @@ in
 {
   app-schema = mkGeoserverExtension {
     name = "app-schema";
-    version = "2.28.3"; # app-schema
-    hash = "sha256-fxMFV5/lvhCcgRfL+2Qf0ePo6EC/bLM1IeL5qNoKVrQ="; # app-schema
+    version = "2.28.4"; # app-schema
+    hash = "sha256-qgzJP8m3CnkZHlM3Wmix9wl8M0G9m8DTJZ8HcBJx/aw="; # app-schema
   };
 
   authkey = mkGeoserverExtension {
     name = "authkey";
-    version = "2.28.3"; # authkey
-    hash = "sha256-pAB8vPn+cZnKQKGLHtXrkLbieTs7wMi6ArGL8fxo31s="; # authkey
+    version = "2.28.4"; # authkey
+    hash = "sha256-UDRVVPGqhCwen/irMz8YUbv01PQ4oRFJgELtzvJ6WGk="; # authkey
   };
 
   cas = mkGeoserverExtension {
     name = "cas";
-    version = "2.28.3"; # cas
-    hash = "sha256-BEDE9dZ4sZBr15Wvbpio9JOIEai53cJLe4QhvYbQwKw="; # cas
+    version = "2.28.4"; # cas
+    hash = "sha256-g0BqPXtRoIYfLps6cFCg/+DBYOZpQX/bolJcwGuCTaI="; # cas
   };
 
   charts = mkGeoserverExtension {
     name = "charts";
-    version = "2.28.3"; # charts
-    hash = "sha256-cFbMdIIQwZudSgDBW8YN81GduG1bSQFLldjtubaclqA="; # charts
+    version = "2.28.4"; # charts
+    hash = "sha256-vhFVGX64M+5NfHYBNj1yMadZ2bKLwemURjwd6jp2HPM="; # charts
   };
 
   control-flow = mkGeoserverExtension {
     name = "control-flow";
-    version = "2.28.3"; # control-flow
-    hash = "sha256-HrS+/QntfSdMHLzA1+wJh7JWA2THLSOBDdIdeG7I4u4="; # control-flow
+    version = "2.28.4"; # control-flow
+    hash = "sha256-FJj8g145s1qOoym+5SQymcSzH8bTzthUg5dWIR7ZGPU="; # control-flow
   };
 
   css = mkGeoserverExtension {
     name = "css";
-    version = "2.28.3"; # css
-    hash = "sha256-7gYg4v8ekThV3k21hrJlu6jULJxdyUFZZh0ToaZSyeI="; # css
+    version = "2.28.4"; # css
+    hash = "sha256-9BYc4j1fk5hTT4jKdHReaoSg7bWjxmyUrOdwMospiiM="; # css
   };
 
   csw = mkGeoserverExtension {
     name = "csw";
-    version = "2.28.3"; # csw
-    hash = "sha256-C/Th+KjiGWCfzMvVpby22BxXnkEtAYg1asYjO/Ge0fA="; # csw
+    version = "2.28.4"; # csw
+    hash = "sha256-/+IQO/X26cMz5+aOtMDJ23ovjnmOOATSgRNs40bzM0I="; # csw
   };
 
   csw-iso = mkGeoserverExtension {
     name = "csw-iso";
-    version = "2.28.3"; # csw-iso
-    hash = "sha256-ctZgjCQDLZKHAmd2Og+Vvu7iYxCU+08pTniImDDjmz0="; # csw-iso
+    version = "2.28.4"; # csw-iso
+    hash = "sha256-kmUH2g18/PXBTl2cUzs2q1fzSn6BllikvatRgNlxRtc="; # csw-iso
   };
 
   db2 = mkGeoserverExtension {
     name = "db2";
-    version = "2.28.3"; # db2
-    hash = "sha256-yVghGPW07USGx4ZYs6F2P5VuGbNaUo3wzOrx1BOvFkE="; # db2
+    version = "2.28.4"; # db2
+    hash = "sha256-4xeE1Y6PXqlt7LCz5s86+Uj6JMV2HqrmJpIAR6pnQhk="; # db2
   };
 
   # Needs wps extension.
   dxf = mkGeoserverExtension {
     name = "dxf";
-    version = "2.28.3"; # dxf
-    hash = "sha256-o40HBSTzAmaUdCHslpBnK8ALHKh36V8PqmGzqdAtl7w="; # dxf
+    version = "2.28.4"; # dxf
+    hash = "sha256-lfvvlennN7Ig0sV2ujAi3KpLmgqFSf1Y5m6pcpSc2wY="; # dxf
   };
 
   excel = mkGeoserverExtension {
     name = "excel";
-    version = "2.28.3"; # excel
-    hash = "sha256-7kOEb3ayiUZs0PV8qSiz+FuniWI1JEfod7wcf4e+1LM="; # excel
+    version = "2.28.4"; # excel
+    hash = "sha256-VSh9rNAnJzbfEYKELY1BRcoHRtifk3J0D08ZnF5+kTc="; # excel
   };
 
   feature-pregeneralized = mkGeoserverExtension {
     name = "feature-pregeneralized";
-    version = "2.28.3"; # feature-pregeneralized
-    hash = "sha256-/6qvxhpg5HG+FlTsUclxxEfAYdhqV/cefDAta1Iw3sg="; # feature-pregeneralized
+    version = "2.28.4"; # feature-pregeneralized
+    hash = "sha256-ZY7Qr3faGZOFg7zX4JFJ+FdSIhXQ1ROulcPRmGRGyAI="; # feature-pregeneralized
   };
 
   # Note: The extension name ("gdal") clashes with pkgs.gdal.
   gdal = mkGeoserverExtension {
     name = "gdal";
-    version = "2.28.3"; # gdal
+    version = "2.28.4"; # gdal
     buildInputs = [ pkgs.gdal ];
-    hash = "sha256-0IFF+x7T6qupakRx0Y+nwlVAC4byiDDCqovdPewdJWY="; # gdal
+    hash = "sha256-7GT6XfpDjCX+TYprg4Y59UshSYa0tACIFQrtPW8vrFM="; # gdal
   };
 
   # Throws "java.io.FileNotFoundException: URL [jar:file:/nix/store/.../WEB-INF/lib/gs-geofence-server-2.24.1.jar!/geofence-default-override.properties] cannot be resolved to absolute file path because it does not reside in the file system: jar:file:/nix/store/.../WEB-INF/lib/gs-geofence-server-2.24.1.jar!/geofence-default-override.properties" but seems to work out of the box.
   #geofence = mkGeoserverExtension {
   #  name = "geofence";
-  #  version = "2.28.3"; # geofence
-  #  hash = "sha256-IQ+s6Q/nEnUAKfCdWQNhVNIEOWyi2VhDxMxWg4lfWKI="; # geofence
+  #  version = "2.28.4"; # geofence
+  #  hash = "sha256-620nYoPkM1GitY221F/uN9Ts8D9h7DBvXf9DAxoUGBY="; # geofence
   #};
 
   #geofence-server-h2 = mkGeoserverExtension {
   #  name = "geofence-server-h2";
-  #  version = "2.28.3"; # geofence-server
-  #  hash = "sha256-WqzBPh0YNMcLbrKdNcYNZSQrVYPYczC/+uIw4I58A14="; # geofence-server-h2
+  #  version = "2.28.4"; # geofence-server
+  #  hash = "sha256-KL4VTHZ3/kfCBkvAKgCmXs+TVa2Z4Zb+UphRyVnZI2I="; # geofence-server-h2
   #};
 
   #geofence-server-postgres = mkGeoserverExtension {
   #  name = "geofence-server-postgres";
-  #  version = "2.28.3"; # geofence-server
-  #  hash = "sha256-ox7EjhVcetJInONerxtLK4MQt4BPIZ9EtPmmK6cnKJY="; # geofence-server-postgres
+  #  version = "2.28.4"; # geofence-server
+  #  hash = "sha256-7EVrhV6vbglGd15K81Ypygu+1tEYtZOy9wsERBu4sNM="; # geofence-server-postgres
   #};
 
   #geofence-wps = mkGeoserverExtension {
   #  name = "geofence-wps";
-  #  version = "2.28.3"; # geofence-wps
-  #  hash = "sha256-txQwmE8mkCttfd57JFYbVuwIpfY+FFzb/hMcGEiEeW4="; # geofence-wps
+  #  version = "2.28.4"; # geofence-wps
+  #  hash = "sha256-7yVXODL1Fx0KM4BSeHCa4Fw/+xE7j9LJtdpVLeWPOI8="; # geofence-wps
   #};
 
   geopkg-output = mkGeoserverExtension {
     name = "geopkg-output";
-    version = "2.28.3"; # geopkg-output
-    hash = "sha256-JlMDDHvieYPTdKzYJxALzVrVZ+Jce447lq99hRQwP6Y="; # geopkg-output
+    version = "2.28.4"; # geopkg-output
+    hash = "sha256-2CbA5opqZwwKBcM87nbY9e/i67vs70SShW08Fpryy8o="; # geopkg-output
   };
 
   grib = mkGeoserverExtension {
     name = "grib";
-    version = "2.28.3"; # grib
-    hash = "sha256-ydDlRbTxxieQkeSHAR4gf1+KrjvjGBQhAEyTc0jTN9E="; # grib
+    version = "2.28.4"; # grib
+    hash = "sha256-apCBtt1SOB8rimpUDny6KOjxzwMjCk+E3vdpv336iJE="; # grib
     buildInputs = [ netcdf ];
   };
 
   gwc-s3 = mkGeoserverExtension {
     name = "gwc-s3";
-    version = "2.28.3"; # gwc-s3
-    hash = "sha256-OsfS7b4w6PsJ6s20wn09FFJzjMv32iZldF9T8qaHH8A="; # gwc-s3
+    version = "2.28.4"; # gwc-s3
+    hash = "sha256-Jy3/EFNJym61st2LAysgRKsS2KBTFhkFSZc6WouO3LA="; # gwc-s3
   };
 
   h2 = mkGeoserverExtension {
     name = "h2";
-    version = "2.28.3"; # h2
-    hash = "sha256-3B0WJrYG7UaHHt2p98zd5mWPJWKz3J/R7iwH4b2PLe4="; # h2
+    version = "2.28.4"; # h2
+    hash = "sha256-tqchE8kkyo35rL9ESs/TD8n9CWAaWiWqe3wxKXt3Ut4="; # h2
   };
 
   iau = mkGeoserverExtension {
     name = "iau";
-    version = "2.28.3"; # iau
-    hash = "sha256-oIgED4jwp5QENorSdWSvj3Pvy92dSF/Pjm6YwdZrbw8="; # iau
+    version = "2.28.4"; # iau
+    hash = "sha256-yorqFxLh9PWoC0j4WXwXs5uK1sy2gV9S1vS36ebKBIc="; # iau
   };
 
   importer = mkGeoserverExtension {
     name = "importer";
-    version = "2.28.3"; # importer
-    hash = "sha256-6ZCmlzu5/sN76ZgVDtU02L9D/aNL+kawcf/EKakdlgU="; # importer
+    version = "2.28.4"; # importer
+    hash = "sha256-XGCVD/CUZjiPCzLyHec7na+fNARkBvnfR1+GbCdogXQ="; # importer
   };
 
   inspire = mkGeoserverExtension {
     name = "inspire";
-    version = "2.28.3"; # inspire
-    hash = "sha256-O/WPgBfyyI/sHZK9xGMjlYf4qyTT7Sx3psYWbjV3z1E="; # inspire
+    version = "2.28.4"; # inspire
+    hash = "sha256-/9juMAOOCycPeJcuB9a3DMIC8xzN1WjrzEi951utodg="; # inspire
   };
 
   # Needs Kakadu plugin from
   # https://github.com/geosolutions-it/imageio-ext
   #jp2k = mkGeoserverExtension {
   #  name = "jp2k";
-  #  version = "2.28.3"; # jp2k
-  #  hash = "sha256-rLwuY5aEIKrjgyAXexFEpsRt+pNZLxI/YFo0yiBCblc="; # jp2k
+  #  version = "2.28.4"; # jp2k
+  #  hash = "sha256-IfGThXCIEkmoTlA3EdIWekFDGBw3K+yqO49RZFDfAeQ="; # jp2k
   #};
 
   # Throws "java.lang.UnsatisfiedLinkError: 'void org.libjpegturbo.turbojpeg.TJDecompressor.init()'"
@@ -202,174 +202,174 @@ in
   # NOTE: When re-enabling this, RE-ENABLE THE CORRESPONDING TEST, TOO! (See tests/geoserver.nix)
   #libjpeg-turbo = mkGeoserverExtension {
   #  name = "libjpeg-turbo";
-  #  version = "2.28.3"; # libjpeg-turbo
-  #  hash = "sha256-cftD9VyJCxkYQBKuyBtnEeBAchYOAJGnl677MQAAdc4="; # libjpeg-turbo
+  #  version = "2.28.4"; # libjpeg-turbo
+  #  hash = "sha256-05aP0WypGM0dz/OXM/1paYgmmwGGcU7j34kYdJIlL0U="; # libjpeg-turbo
   #  buildInputs = [ libjpeg.out ];
   #};
 
   mapml = mkGeoserverExtension {
     name = "mapml";
-    version = "2.28.3"; # mapml
-    hash = "sha256-r7GJbqCAnsxJV8zyHQG8EP3sbiXcfpQHNgMmj7viJac="; # mapml
+    version = "2.28.4"; # mapml
+    hash = "sha256-fZVPUqUlNx2xvh9qEJgIX+rfvT2ZeLjb8SgTEdYC4FI="; # mapml
   };
 
   mbstyle = mkGeoserverExtension {
     name = "mbstyle";
-    version = "2.28.3"; # mbstyle
-    hash = "sha256-RtxnQoWUSHOfizRS1eYR+o+n9HXpCt+bG1UOxFyRy9I="; # mbstyle
+    version = "2.28.4"; # mbstyle
+    hash = "sha256-OHEJ5u1r4KcikluRjah1S137IjbDDtGtVQQbqczjoco="; # mbstyle
   };
 
   metadata = mkGeoserverExtension {
     name = "metadata";
-    version = "2.28.3"; # metadata
-    hash = "sha256-lFnZhs3FdGlQ4J37erOjLVB5QuRo6E0IUvAgONqvP4U="; # metadata
+    version = "2.28.4"; # metadata
+    hash = "sha256-pL1Xti6+TUPN0ujpJjGRt26q3ItEKQa37loNpmQvwVs="; # metadata
   };
 
   mongodb = mkGeoserverExtension {
     name = "mongodb";
-    version = "2.28.3"; # mongodb
-    hash = "sha256-M9l7jdp7oUfo0gMVfMcCVHizi0//YfBqh17tsiDMKno="; # mongodb
+    version = "2.28.4"; # mongodb
+    hash = "sha256-XwQAKp6XZH3W4qsNjhmA73hf6SjINz9/SOPwb2wGdcU="; # mongodb
   };
 
   monitor = mkGeoserverExtension {
     name = "monitor";
-    version = "2.28.3"; # monitor
-    hash = "sha256-HPdoKySCLT3zVdOlNIuJlEu99mJ9J/VjTFEfT63UdUs="; # monitor
+    version = "2.28.4"; # monitor
+    hash = "sha256-JhmsDRoHGbTBCKxKqlxdpmn2WGC/aQnyeuWLs1u0xFE="; # monitor
   };
 
   mysql = mkGeoserverExtension {
     name = "mysql";
-    version = "2.28.3"; # mysql
-    hash = "sha256-w/owOCOXJnw7EoJdPO8NGEw75MEfNMWSCySh0+2x84E="; # mysql
+    version = "2.28.4"; # mysql
+    hash = "sha256-f8xdJ2WVYQV+HG5U2J/1vKBAFo5srFWSPXVAyRUt8kE="; # mysql
   };
 
   netcdf = mkGeoserverExtension {
     name = "netcdf";
-    version = "2.28.3"; # netcdf
-    hash = "sha256-2O7s7SUjAm/V+O2LrdqOLou12WkjxIg0zuIgRMFUp9M="; # netcdf
+    version = "2.28.4"; # netcdf
+    hash = "sha256-wU5MkTYgxxOgBBybbbeHtT2Rj1CoTFBTjGzyLPlPT7A="; # netcdf
     buildInputs = [ netcdf ];
   };
 
   netcdf-out = mkGeoserverExtension {
     name = "netcdf-out";
-    version = "2.28.3"; # netcdf-out
-    hash = "sha256-KgqbHHxBlr0EIPJ1MStCPzV/844C3CUUBuBMe2ljbuA="; # netcdf-out
+    version = "2.28.4"; # netcdf-out
+    hash = "sha256-0RIRTDtTUEj9OUDpAD1LbCY1iGCbXAKbgmH7ZkNHWhM="; # netcdf-out
     buildInputs = [ netcdf ];
   };
 
   ogr-wfs = mkGeoserverExtension {
     name = "ogr-wfs";
-    version = "2.28.3"; # ogr-wfs
+    version = "2.28.4"; # ogr-wfs
     buildInputs = [ pkgs.gdal ];
-    hash = "sha256-+l9U1YoiKn1nxOUP5tRT/9WPRham5Lrk12xt/9rrZuM="; # ogr-wfs
+    hash = "sha256-UAsTKEMVlYTrCpbs8++Kxdn0w6ejzMiPrT7S2NlMNxc="; # ogr-wfs
   };
 
   # Needs ogr-wfs extension.
   ogr-wps = mkGeoserverExtension {
     name = "ogr-wps";
-    version = "2.28.3"; # ogr-wps
+    version = "2.28.4"; # ogr-wps
     # buildInputs = [ pkgs.gdal ];
-    hash = "sha256-PBqObn/gle6A8RVPmKOPhi2YNTqR2MmhbqZT3X7TygI="; # ogr-wps
+    hash = "sha256-sjV0YwR21GQYt4YuDIE2H+5UQ2qRmP7tWVyOXNuLkSM="; # ogr-wps
   };
 
   oracle = mkGeoserverExtension {
     name = "oracle";
-    version = "2.28.3"; # oracle
-    hash = "sha256-fHbgYIz7Kb7lTgDVlKPkMwldXIJn/mqG3oHDUk76rTc="; # oracle
+    version = "2.28.4"; # oracle
+    hash = "sha256-xiIPgpWCDycE6rTW49QnB/7rHbns1GJhWCdIfMEBuXE="; # oracle
   };
 
   params-extractor = mkGeoserverExtension {
     name = "params-extractor";
-    version = "2.28.3"; # params-extractor
-    hash = "sha256-nseCXkh4V13FfbWtva79ydxg7sFMTeGrK3HygaVNPR8="; # params-extractor
+    version = "2.28.4"; # params-extractor
+    hash = "sha256-/AOjfsA58btiOBv4zvF4jdLt2lE5GPDKUKzNZyX8fI0="; # params-extractor
   };
 
   printing = mkGeoserverExtension {
     name = "printing";
-    version = "2.28.3"; # printing
-    hash = "sha256-zGqDnmrO82cgCQgaorHa+O/Z5L42um/7CttZ2wC7Az4="; # printing
+    version = "2.28.4"; # printing
+    hash = "sha256-smytiUVPKq31YyWE/xLwiGPLQ6DxScj2gHjMbgKCjMc="; # printing
   };
 
   pyramid = mkGeoserverExtension {
     name = "pyramid";
-    version = "2.28.3"; # pyramid
-    hash = "sha256-BCvGhp9WmdqutPu09kIExJzuFGdOWQ8Eyin95iIhdw8="; # pyramid
+    version = "2.28.4"; # pyramid
+    hash = "sha256-xfOzBm5eTbzfRRiMQ63i29GW91IxWKIotrSUa6BgD5M="; # pyramid
   };
 
   querylayer = mkGeoserverExtension {
     name = "querylayer";
-    version = "2.28.3"; # querylayer
-    hash = "sha256-oA8F3J9i5sQTmUGLysddXF+GU6hR1yOHbNqiUAyPDTE="; # querylayer
+    version = "2.28.4"; # querylayer
+    hash = "sha256-WyLyUoLfv8JIKBqjphcXgWBbtkJEB3ig4cyY158lRQk="; # querylayer
   };
 
   sldservice = mkGeoserverExtension {
     name = "sldservice";
-    version = "2.28.3"; # sldservice
-    hash = "sha256-AehHS+ELScFdeZi5kyqqJ9nldKla06r8Yq1PB43cYA0="; # sldservice
+    version = "2.28.4"; # sldservice
+    hash = "sha256-DsN9tKZshcsz6/IsPA0l757YtmsakBi/NbgEUwnfafs="; # sldservice
   };
 
   sqlserver = mkGeoserverExtension {
     name = "sqlserver";
-    version = "2.28.3"; # sqlserver
-    hash = "sha256-ZS5ThHv/TEiH4BWcox68GKbqueFq7qhWDtDMgcUBINo="; # sqlserver
+    version = "2.28.4"; # sqlserver
+    hash = "sha256-MBMU4pJKgS3qra9pli8SAnOtIiDU2zD0sXJaKXlr0+A="; # sqlserver
   };
 
   vectortiles = mkGeoserverExtension {
     name = "vectortiles";
-    version = "2.28.3"; # vectortiles
-    hash = "sha256-vvZSFfKgAFFtzLKv+RVh99frUyG2RkWrCwfR7scF+xw="; # vectortiles
+    version = "2.28.4"; # vectortiles
+    hash = "sha256-6E3lwH573lTSMYtQ00b3fVtJYSsIFETwT7JAZHI6ubQ="; # vectortiles
   };
 
   wcs2_0-eo = mkGeoserverExtension {
     name = "wcs2_0-eo";
-    version = "2.28.3"; # wcs2_0-eo
-    hash = "sha256-x876KCXUbr1kGkAoHtDhoNqFGFVWw3te0tBt+03+ywU="; # wcs2_0-eo
+    version = "2.28.4"; # wcs2_0-eo
+    hash = "sha256-w30lrzli6++7NDu59QsRFxyIQBMSV7M5BeTqGSJmw18="; # wcs2_0-eo
   };
 
   web-resource = mkGeoserverExtension {
     name = "web-resource";
-    version = "2.28.3"; # web-resource
-    hash = "sha256-gjeqIP0qGCjogDgxug3k+1daVCxKQeHAsEJJWmPbe/8="; # web-resource
+    version = "2.28.4"; # web-resource
+    hash = "sha256-GH0foPjbBcKOXahqgPv+02Jex3ZE5XKmeWNDew0DKF4="; # web-resource
   };
 
   wmts-multi-dimensional = mkGeoserverExtension {
     name = "wmts-multi-dimensional";
-    version = "2.28.3"; # wmts-multi-dimensional
-    hash = "sha256-LbdMCDHjCiWpEUxL43RZY19a5DfJ9RKxmcq213NbAY8="; # wmts-multi-dimensional
+    version = "2.28.4"; # wmts-multi-dimensional
+    hash = "sha256-gi8qwwKG9K1l4AJ05vDGykxCmd42oSFSZtwhDwDI8m0="; # wmts-multi-dimensional
   };
 
   wps = mkGeoserverExtension {
     name = "wps";
-    version = "2.28.3"; # wps
-    hash = "sha256-QgDpKbRGwGnAVrx/PW87N22D2yhrmzfg6qNmevXWI44="; # wps
+    version = "2.28.4"; # wps
+    hash = "sha256-2qh7fDeJAswTb+P60zNQeH1nc0886Dfh7pWpUWCaEKc="; # wps
   };
 
   # Needs hazelcast (https://github.com/hazelcast/hazelcast (?)) which is not
   # available in nixpgs as of 2024/01.
   #wps-cluster-hazelcast = mkGeoserverExtension {
   #  name = "wps-cluster-hazelcast";
-  #  version = "2.28.3"; # wps-cluster-hazelcast
-  #  hash = "sha256-beSIkj3btLokQsS800vD0q2hiagLnnX+VTH8DMQy8NI="; # wps-cluster-hazelcast
+  #  version = "2.28.4"; # wps-cluster-hazelcast
+  #  hash = "sha256-r9BpjvFL00lgTrbhIxY7c16sGu6ujKJ6D4oDz61KekA="; # wps-cluster-hazelcast
   #};
 
   wps-download = mkGeoserverExtension {
     name = "wps-download";
-    version = "2.28.3"; # wps-download
-    hash = "sha256-2dIjMPA8Y3sPzJLtPxX0HFuq+dYxmz65dJzxugkSyS0="; # wps-download
+    version = "2.28.4"; # wps-download
+    hash = "sha256-MAL71aYRKOFSKnhj+3dxZhCDQL/6GAeAtB11Zs6C5tI="; # wps-download
   };
 
   # Needs Postrgres configuration or similar.
   # See https://docs.geoserver.org/main/en/user/extensions/wps-jdbc/index.html
   wps-jdbc = mkGeoserverExtension {
     name = "wps-jdbc";
-    version = "2.28.3"; # wps-jdbc
-    hash = "sha256-yL5xw1g2FcWCSgfw28gbYmrvIiHD0coE9AAH601Bqbg="; # wps-jdbc
+    version = "2.28.4"; # wps-jdbc
+    hash = "sha256-QBydO6EKLe22W+3pCP4p9TqMyp1KeKReyeidL5yxndo="; # wps-jdbc
   };
 
   ysld = mkGeoserverExtension {
     name = "ysld";
-    version = "2.28.3"; # ysld
-    hash = "sha256-oe/eT/IdqnlrQ58HBpuQA6ZRw8oCPAWPQ2Tles71V8M="; # ysld
+    version = "2.28.4"; # ysld
+    hash = "sha256-Qg+wzMzRebqqOAK4Y7hsfcTyKcz/E5Fw/fHLcUr3KwY="; # ysld
   };
 
 }

--- a/pkgs/by-name/ge/geoserver/package.nix
+++ b/pkgs/by-name/ge/geoserver/package.nix
@@ -10,11 +10,11 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "geoserver";
-  version = "2.28.3";
+  version = "2.28.4";
 
   src = fetchurl {
     url = "mirror://sourceforge/geoserver/GeoServer/${finalAttrs.version}/geoserver-${finalAttrs.version}-bin.zip";
-    hash = "sha256-jXvuIQvpOYGnRTcdHwa+p8lbMaaqiFDMLRRzpxs6wLg=";
+    hash = "sha256-bQECI2MEk8OcALk21bbv/V/yNbOrHKlhcpoVy37U1i0=";
   };
 
   sourceRoot = ".";

--- a/pkgs/by-name/ir/irpf/package.nix
+++ b/pkgs/by-name/ir/irpf/package.nix
@@ -17,7 +17,7 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "irpf";
-  version = "2026-1.2";
+  version = "2026-1.3";
 
   # https://www.gov.br/receitafederal/pt-br/centrais-de-conteudo/download/pgd/dirpf
   # Para outros sistemas operacionais -> Multi
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     in
     fetchzip {
       url = "https://downloadirpf.receita.fazenda.gov.br/irpf/${year}/irpf/arquivos/IRPF${finalAttrs.version}.zip";
-      hash = "sha256-Zw/QtmbINCV1VPz52KCxam+WFgkh8Kjz1v0e7oVeZCs=";
+      hash = "sha256-5CX+HaIfQRoeWQHvXTGBhqRAaCM7UH2Duq8+6+3Ai7o=";
     };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ir/irpf/package.nix
+++ b/pkgs/by-name/ir/irpf/package.nix
@@ -17,7 +17,7 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "irpf";
-  version = "2026-1.3";
+  version = "2026-1.4";
 
   # https://www.gov.br/receitafederal/pt-br/centrais-de-conteudo/download/pgd/dirpf
   # Para outros sistemas operacionais -> Multi
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     in
     fetchzip {
       url = "https://downloadirpf.receita.fazenda.gov.br/irpf/${year}/irpf/arquivos/IRPF${finalAttrs.version}.zip";
-      hash = "sha256-5CX+HaIfQRoeWQHvXTGBhqRAaCM7UH2Duq8+6+3Ai7o=";
+      hash = "sha256-tPIu1nt1FtGyjM1vnzAHenjlKeAKJfqPus+XsP2CH5g=";
     };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ma/mapserver/package.nix
+++ b/pkgs/by-name/ma/mapserver/package.nix
@@ -30,13 +30,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mapserver";
-  version = "8.6.3";
+  version = "8.6.4";
 
   src = fetchFromGitHub {
     owner = "MapServer";
     repo = "MapServer";
     rev = "rel-${lib.replaceStrings [ "." ] [ "-" ] finalAttrs.version}";
-    hash = "sha256-PVuoljsDXxDFSB+VVCEmOsSQw8fGR0RaFcaom+W5B2E=";
+    hash = "sha256-kqCP0QZ8gNqS54B8nL8M9Wr9WyMQnORCs42O1eiMtRw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ma/mattermost/mattermost-remove-free-banner.patch
+++ b/pkgs/by-name/ma/mattermost/mattermost-remove-free-banner.patch
@@ -1,7 +1,7 @@
-diff --git a/webapp/channels/src/components/global_header/left_controls/product_menu/product_branding_team_edition/product_branding_free_edition.tsx b/webapp/channels/src/components/global_header/left_controls/product_menu/product_branding_team_edition/product_branding_free_edition.tsx
+diff --git a/channels/src/components/global_header/left_controls/product_menu/product_branding_team_edition/product_branding_free_edition.tsx b/channels/src/components/global_header/left_controls/product_menu/product_branding_team_edition/product_branding_free_edition.tsx
 index 93cb8ab263..3d12cd5e54 100644
---- a/webapp/channels/src/components/global_header/left_controls/product_menu/product_branding_team_edition/product_branding_free_edition.tsx
-+++ b/webapp/channels/src/components/global_header/left_controls/product_menu/product_branding_team_edition/product_branding_free_edition.tsx
+--- a/channels/src/components/global_header/left_controls/product_menu/product_branding_team_edition/product_branding_free_edition.tsx
++++ b/channels/src/components/global_header/left_controls/product_menu/product_branding_team_edition/product_branding_free_edition.tsx
 @@ -57,7 +57,6 @@ const ProductBrandingFreeEdition = (): JSX.Element => {
                  width={116}
                  height={20}
@@ -10,10 +10,10 @@ index 93cb8ab263..3d12cd5e54 100644
          </ProductBrandingFreeEditionContainer>
      );
  };
-diff --git a/webapp/channels/src/components/header_footer_route/header.scss b/webapp/channels/src/components/header_footer_route/header.scss
-index c2e6fbd187..bc1cedcff1 100644
---- a/webapp/channels/src/components/header_footer_route/header.scss
-+++ b/webapp/channels/src/components/header_footer_route/header.scss
+diff --git a/channels/src/components/header_footer_route/header.scss b/channels/src/components/header_footer_route/header.scss
+index c2e6fbd187..828955cc79 100644
+--- a/channels/src/components/header_footer_route/header.scss
++++ b/channels/src/components/header_footer_route/header.scss
 @@ -47,20 +47,7 @@
              }
  
@@ -36,23 +36,10 @@ index c2e6fbd187..bc1cedcff1 100644
              }
          }
      }
-@@ -83,12 +70,6 @@
-             margin-top: 12px;
-         }
-     }
--
--    &.has-free-banner.has-custom-site-name {
--        .header-back-button {
--            bottom: -20px;
--        }
--    }
- }
- 
- @media screen and (max-width: 699px) {
-diff --git a/webapp/channels/src/components/widgets/menu/menu_items/menu_item.scss b/webapp/channels/src/components/widgets/menu/menu_items/menu_item.scss
+diff --git a/channels/src/components/widgets/menu/menu_items/menu_item.scss b/channels/src/components/widgets/menu/menu_items/menu_item.scss
 index dee9b57f8c..8ef4aa073a 100644
---- a/webapp/channels/src/components/widgets/menu/menu_items/menu_item.scss
-+++ b/webapp/channels/src/components/widgets/menu/menu_items/menu_item.scss
+--- a/channels/src/components/widgets/menu/menu_items/menu_item.scss
++++ b/channels/src/components/widgets/menu/menu_items/menu_item.scss
 @@ -316,14 +316,7 @@
      }
  
@@ -69,11 +56,11 @@ index dee9b57f8c..8ef4aa073a 100644
  
          button {
              padding: 3px 0;
-diff --git a/webapp/channels/webpack.config.js b/webapp/channels/webpack.config.js
-index f29f19f9ab..ab85fc3b86 100644
---- a/webapp/channels/webpack.config.js
-+++ b/webapp/channels/webpack.config.js
-@@ -469,6 +469,9 @@ if (targetIsDevServer) {
+diff --git a/channels/webpack.config.js b/channels/webpack.config.js
+index 852046de70..cf28fdcbd6 100644
+--- a/channels/webpack.config.js
++++ b/channels/webpack.config.js
+@@ -470,6 +470,9 @@ if (targetIsDevServer) {
              historyApiFallback: {
                  index: '/static/root.html',
              },

--- a/pkgs/by-name/ma/mattermost/mattermost-remove-user-limit.patch
+++ b/pkgs/by-name/ma/mattermost/mattermost-remove-user-limit.patch
@@ -1,16 +1,46 @@
 diff --git a/server/channels/app/limits.go b/server/channels/app/limits.go
-index 4c88c1f049..3c1af8d02f 100644
+index 4c88c1f049..fb7d84ef05 100644
 --- a/server/channels/app/limits.go
 +++ b/server/channels/app/limits.go
-@@ -10,8 +10,8 @@ import (
- )
+@@ -18,23 +18,8 @@ func (a *App) GetServerLimits() (*model.ServerLimits, *model.AppError) {
+ 	limits := &model.ServerLimits{}
+ 	license := a.License()
  
- const (
--	maxUsersLimit     = 200
--	maxUsersHardLimit = 250
-+	maxUsersLimit     = 10000000
-+	maxUsersHardLimit = 10000000
- )
+-	if license == nil && maxUsersLimit > 0 {
+-		// Enforce hard-coded limits for unlicensed servers (no grace period).
+-		limits.MaxUsersLimit = maxUsersLimit
+-		limits.MaxUsersHardLimit = maxUsersHardLimit
+-	} else if license != nil && license.IsSeatCountEnforced && license.Features != nil && license.Features.Users != nil {
+-		// Enforce license limits as required by the license with configurable extra users.
+-		licenseUserLimit := int64(*license.Features.Users)
+-		limits.MaxUsersLimit = licenseUserLimit
+-
+-		// Use ExtraUsers if configured, otherwise default to 0 (no extra users)
+-		extraUsers := 0
+-		if license.ExtraUsers != nil {
+-			extraUsers = *license.ExtraUsers
+-		}
+-
+-		limits.MaxUsersHardLimit = licenseUserLimit + int64(extraUsers)
+-	}
++	limits.MaxUsersLimit = 0
++	limits.MaxUsersHardLimit = 0
  
- func (a *App) GetServerLimits() (*model.ServerLimits, *model.AppError) {
-    
+ 	// Check if license has post history limits and get the calculated timestamp
+ 	if license != nil && license.Limits != nil && license.Limits.PostHistory > 0 {
+@@ -99,14 +84,5 @@ func (a *App) GetPostHistoryLimit() int64 {
+ }
+ 
+ func (a *App) isAtUserLimit() (bool, *model.AppError) {
+-	userLimits, appErr := a.GetServerLimits()
+-	if appErr != nil {
+-		return false, appErr
+-	}
+-
+-	if userLimits.MaxUsersHardLimit == 0 {
+-		return false, nil
+-	}
+-
+-	return userLimits.ActiveUserCount >= userLimits.MaxUsersHardLimit, appErr
++	return false, nil
+ }

--- a/pkgs/by-name/ma/mattermost/package.nix
+++ b/pkgs/by-name/ma/mattermost/package.nix
@@ -138,13 +138,9 @@ buildMattermost rec {
     '';
   };
 
-  patches =
-    lib.optionals removeFreeBadge [
-      ./mattermost-remove-free-banner.patch
-    ]
-    ++ lib.optionals removeUserLimit [
-      ./mattermost-remove-user-limit.patch
-    ];
+  patches = lib.optionals removeUserLimit [
+    ./mattermost-remove-user-limit.patch
+  ];
 
   # Needed because buildGoModule does not support go workspaces yet.
   # We use go 1.22's workspace vendor command, which is not yet available
@@ -247,6 +243,10 @@ buildMattermost rec {
       inherit version src;
 
       sourceRoot = "${src.name}/webapp";
+
+      patches = lib.optionals removeFreeBadge [
+        ./mattermost-remove-free-banner.patch
+      ];
 
       # Remove deprecated image-webpack-loader causing build failures
       # See: https://github.com/tcoopman/image-webpack-loader#deprecated

--- a/pkgs/development/compilers/go/1.25.nix
+++ b/pkgs/development/compilers/go/1.25.nix
@@ -25,11 +25,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "go";
-  version = "1.25.10";
+  version = "1.25.11";
 
   src = fetchurl {
     url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
-    hash = "sha256-IM8EqS5a+ZdI40G8iZb6KAkMmsmHZfoRXsXd9B169B0=";
+    hash = "sha256-e05bB5s8m8QgNzymhiGilrTRPBBzXUrKxBcZKNcPVIA=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
## Description
Update folo (formerly Follow) from 0.6.3 to 1.9.0.

This major version bump includes:
- Upgraded AI summaries to Kimi model
- Enhanced Obsidian plugin support
- Improved mark-read functionality with batched updates
- Multiple bug fixes for context menus, timeline pagination, and unread badges
- Infrastructure: OTA-backed download delivery

Full changelog: https://github.com/RSSNext/Folo/releases/tag/desktop/v1.9.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests in nixos/tests.
  - [ ] Package tests at `passthru.tests`.
  - [ ] Tests in lib/tests or pkgs/test for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.
- [ ] Follows the automation/AI policy.
