### PR TITLE
folo: 0.6.3 -> 1.9.0

### DIFF
--- a/pkgs/by-name/fo/folo/package.nix
+++ b/pkgs/by-name/fo/folo/package.nix
@@ -13,14 +13,13 @@
 }:
 stdenv.mkDerivation rec {
   pname = "folo";
-
-  version = "0.6.3";
+  version = "1.9.0";
 
   src = fetchFromGitHub {
     owner = "RSSNext";
     repo = "Folo";
-    tag = "v${version}";
-    hash = "sha256-huVk5KcsepDwtdWMm9pvn31GE1felbH1pR3mGqlSWRs=";
+    tag = "desktop/v${version}";
+    hash = "sha256-VrKWqqXzdEOfl8E069eZCeI5agxWKmRMW6ziGqURuHc=";
   };
 
   nativeBuildInputs = [
@@ -39,29 +38,24 @@ stdenv.mkDerivation rec {
       ;
     pnpm = pnpm_10_29_2;
     fetcherVersion = 3;
-    hash = "sha256-EP7bpbJUcKmHm7KMlKc0Fz2u0niQ3jC7YN/9pp7vucE=";
+    hash = "sha256-uj7xyh+U4OHn6J+jhoPaEOYwOLinRAj5CbWZYPgG6zI=";
   };
 
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
-    # This environment variables inject the production Vite config at build time.
-    # Copy from:
-    # 1. https://github.com/RSSNext/Folo/blob/v0.4.6/.github/workflows/build-desktop.yml#L27
-    # 2. And logs in the corresponding GitHub Actions: https://github.com/RSSNext/Folo/actions/workflows/build-desktop.yml
-    VITE_WEB_URL = "https://app.follow.is";
-    VITE_API_URL = "https://api.follow.is";
-    VITE_SENTRY_DSN = "https://e5bccf7428aa4e881ed5cb713fdff181@o4507542488023040.ingest.us.sentry.io/4507570439979008";
-    VITE_OPENPANEL_CLIENT_ID = "0e477ab4-d92d-4d6e-b889-b09d86ab908e";
-    VITE_OPENPANEL_API_URL = "https://openpanel.follow.is/api";
+    VITE_WEB_URL = "https://app.folo.is";
+    VITE_API_URL = "https://api.folo.is";
+    VITE_OPENPANEL_API_URL = "https://openpanel.folo.is/api";
+
     VITE_FIREBASE_CONFIG = builtins.toJSON {
-      apiKey = "AIzaSyDuM93019tp8VI7wsszJv8ChOs7b1EE5Hk";
-      authDomain = "follow-428106.firebaseapp.com";
-      projectId = "follow-428106";
-      storageBucket = "follow-428106.appspot.com";
-      messagingSenderId = "194977404578";
-      appId = "1:194977404578:web:1920bb0c9ea5e2373669fb";
-      measurementId = "G-SJE57D4F14";
+      apiKey = "AIzaSyBpGB2C2Vz-9ktivqVkW7uTtVopNh3ELvo";
+      authDomain = "diygod-folo.firebaseapp.com";
+      projectId = "diygod-folo";
+      storageBucket = "diygod-folo.firebasestorage.app";
+      messagingSenderId = "992336953943";
+      appId = "1:992336953943:web:998aae576c8bc77dc11912";
+      measurementId = "G-HS4SF4GHWG";
     };
   };
 
@@ -125,7 +119,7 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/RSSNext/Folo";
     changelog = "https://github.com/RSSNext/Folo/releases/tag/${src.tag}";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ iosmanthus ];
+    maintainers = with lib.maintainers; [ iosmanthus msdone ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "follow";
   };


### PR DESCRIPTION
- Version number: 0.6.3 -> 1.9.0
- Git tag formatting change: `v${version}` -> `desktop/v${version}`
- Source hash update
- pnpmDeps hash update
- Environment variable updates (API URLs and Firebase configuration)


## Description
Update folo (formerly Follow) from 0.6.3 to 1.9.0.

This major version bump includes:
- Upgraded AI summaries to Kimi model
- Enhanced Obsidian plugin support
- Improved mark-read functionality with batched updates
- Multiple bug fixes for context menus, timeline pagination, and unread badges
- Infrastructure: OTA-backed download delivery

Full changelog: https://github.com/RSSNext/Folo/releases/tag/desktop/v1.9.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests in nixos/tests.
  - [ ] Package tests at `passthru.tests`.
  - [ ] Tests in lib/tests or pkgs/test for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.
- [ ] Follows the automation/AI policy.
