### PR TITLE
emacs31: init

### DIFF
--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -17,6 +17,20 @@ lib.makeScope pkgs.newScope (
         ;
     };
 
+    emacs31 = callPackage (self.sources.emacs31) inheritedArgs;
+
+    emacs31-gtk3 = self.emacs31.override {
+      withGTK3 = true;
+    };
+
+    emacs31-nox = self.emacs31.override {
+      noGui = true;
+    };
+
+    emacs31-pgtk = self.emacs31.override {
+      withPgtk = true;
+    };
+
     emacs30 = callPackage (self.sources.emacs30) inheritedArgs;
 
     emacs30-gtk3 = self.emacs30.override {

--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -13,7 +13,7 @@ lib.makeScope pkgs.newScope (
       inherit lib;
       inherit (pkgs)
         fetchFromGitHub
-        fetchzip
+        fetchgit
         ;
     };
 
@@ -31,11 +31,6 @@ lib.makeScope pkgs.newScope (
       withPgtk = true;
     };
 
-    emacs30-macport = callPackage (self.sources.emacs30-macport) (
-      inheritedArgs
-      // {
-        srcRepo = true;
-      }
-    );
+    emacs30-macport = callPackage (self.sources.emacs30-macport) inheritedArgs;
   }
 )

--- a/pkgs/applications/editors/emacs/make-emacs.nix
+++ b/pkgs/applications/editors/emacs/make-emacs.nix
@@ -29,7 +29,6 @@
   gtk3-x11,
   harfbuzz,
   imagemagick,
-  jansson,
   libxaw,
   libxcursor,
   libxft,
@@ -80,8 +79,6 @@
   withGpm ? stdenv.hostPlatform.isLinux,
   # https://github.com/emacs-mirror/emacs/blob/emacs-27.2/etc/NEWS#L118-L120
   withImageMagick ? false,
-  # Emacs 30+ has native JSON support
-  withJansson ? lib.versionOlder version "30",
   withMailutils ? true,
   withMotif ? false,
   withNS ? stdenv.hostPlatform.isDarwin && !(variant == "macport" || noGui),
@@ -255,9 +252,6 @@ stdenv.mkDerivation (finalAttrs: {
     gettext
     gnutls
     (lib.getDev harfbuzz)
-  ]
-  ++ lib.optionals withJansson [
-    jansson
   ]
   ++ [
     libxml2

--- a/pkgs/applications/editors/emacs/make-emacs.nix
+++ b/pkgs/applications/editors/emacs/make-emacs.nix
@@ -66,7 +66,7 @@
   # Boolean flags
   withNativeCompilation ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
   noGui ? false,
-  srcRepo ? false,
+  srcRepo ? true,
   withAcl ? false,
   withAlsaLib ? false,
   withAthena ? false,

--- a/pkgs/applications/editors/emacs/sources.nix
+++ b/pkgs/applications/editors/emacs/sources.nix
@@ -74,7 +74,7 @@ let
         '';
         changelog =
           {
-            "mainline" = "https://www.gnu.org/savannah-checkouts/gnu/emacs/news/NEWS.${version}";
+            "mainline" = "https://cgit.git.savannah.gnu.org/cgit/emacs.git/plain/etc/NEWS?h=${rev}";
             "macport" = "https://github.com/jdtsmith/emacs-mac/blob/${rev}/NEWS-mac";
           }
           .${variant};

--- a/pkgs/applications/editors/emacs/sources.nix
+++ b/pkgs/applications/editors/emacs/sources.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromGitHub,
-  fetchzip,
+  fetchgit,
 }:
 
 let
@@ -26,9 +26,9 @@ let
       src =
         {
           "mainline" = (
-            fetchzip {
-              url = "mirror://gnu/emacs/${rev}.tar.xz";
-              inherit hash;
+            fetchgit {
+              url = "https://https.git.savannah.gnu.org/git/emacs.git";
+              inherit rev hash;
             }
           );
           "macport" = (

--- a/pkgs/applications/editors/emacs/sources.nix
+++ b/pkgs/applications/editors/emacs/sources.nix
@@ -105,6 +105,14 @@ let
     };
 in
 {
+  emacs31 = import ./make-emacs.nix (mkArgs {
+    pname = "emacs";
+    version = "31.0.90";
+    variant = "mainline";
+    rev = "emacs-31.0.90";
+    hash = "sha256-Rzlnn+NKQ+jICXLNop27RnVInq79myn4hueJieDO2Ck=";
+  });
+
   emacs30 = import ./make-emacs.nix (mkArgs {
     pname = "emacs";
     version = "30.2";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8928,6 +8928,11 @@ with pkgs;
   electrum-ltc = libsForQt5.callPackage ../applications/misc/electrum/ltc.nix { };
 
   inherit (recurseIntoAttrs (callPackage ../applications/editors/emacs { }))
+    emacs31
+    emacs31-gtk3
+    emacs31-nox
+    emacs31-pgtk
+
     emacs30
     emacs30-gtk3
     emacs30-nox


### PR DESCRIPTION
Emacs 31.0.90 is out, yay!

See the announcement here:

https://lists.gnu.org/archive/html/emacs-devel/2026-06/msg00118.html

This is still WIP, but I wanted to put this out here ASAP to have something to show and gather feedback.

TODO:
- [x] Review each patch applied (which I copied from current emacs-30 build) and either drop (if applied upstream) ~~or refresh them (if necessary)~~ Thanks, @jian-lin!
- [x] ~~The tar.xz has not yet propagated to the mirrors~~, so fetching is not working right now. EDIT: @jian-lin identified the issue: prereleases are not propagated to the mirrors, but rather served through https://alpha.gnu.org/emacs/pretest/
- [x] ~~The hash of the source tar.xz as processed by the derivation does not match the one I obtain by downloading and adding it to the store manually:~~
EDIT: @jian-lin noticed that the hash was reproduced correctly by using nix-prefetch-file + nix hash \o/
EDIT2: PEBCAK.  Thanks to @jian-lin for clarifying the correct usage:
```
nix store prefetch-file --unpack https://alpha.gnu.org/gnu/emacs/pretest/emacs-31.0.90.tar.xz
```
- [x] update `with*` flags in `make-emacs.nix` if needed
- [ ] nixpkgs-vet complains:
<details>
<pre>
building '/nix/store/acf2xj7y4nfh3pk9zdrj4v83zbx5mr27-nixpkgs-vet.drv'...
- Attribute `pkgs.emacs31` is a new package with `strictDeps` unset or set to `false`.
  Please enable `strictDeps = true;` in pkgs/top-level/all-packages.nix.
 (NPV-164)
- Attribute `pkgs.emacs31` is a new package with `__structuredAttrs` unset or set to `false`.
  Please enable `__structuredAttrs = true;` in pkgs/top-level/all-packages.nix.
 (NPV-166)
- Attribute `pkgs.emacs31-gtk3` is a new package with `strictDeps` unset or set to `false`.
  Please enable `strictDeps = true;` in pkgs/top-level/all-packages.nix.
 (NPV-164)
- Attribute `pkgs.emacs31-gtk3` is a new package with `__structuredAttrs` unset or set to `false`.
  Please enable `__structuredAttrs = true;` in pkgs/top-level/all-packages.nix.
 (NPV-166)
- Attribute `pkgs.emacs31-nox` is a new package with `strictDeps` unset or set to `false`.
  Please enable `strictDeps = true;` in pkgs/top-level/all-packages.nix.
 (NPV-164)
- Attribute `pkgs.emacs31-nox` is a new package with `__structuredAttrs` unset or set to `false`.
  Please enable `__structuredAttrs = true;` in pkgs/top-level/all-packages.nix.
 (NPV-166)
- Attribute `pkgs.emacs31-pgtk` is a new package with `strictDeps` unset or set to `false`.
  Please enable `strictDeps = true;` in pkgs/top-level/all-packages.nix.
 (NPV-164)
- Attribute `pkgs.emacs31-pgtk` is a new package with `__structuredAttrs` unset or set to `false`.
  Please enable `__structuredAttrs = true;` in pkgs/top-level/all-packages.nix.
 (NPV-166)
This PR introduces additional instances of discouraged patterns as listed above. Please fix them before merging.
error: Cannot build '/nix/store/acf2xj7y4nfh3pk9zdrj4v83zbx5mr27-nixpkgs-vet.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/243vy86rc65d5fqhvkf8b06b5xm20awl-nixpkgs-vet
       Last 25 log lines:
       > - Attribute `pkgs.emacs31` is a new package with `strictDeps` unset or set to `false`.
       >   Please enable `strictDeps = true;` in pkgs/top-level/all-packages.nix.
       >  (NPV-164)
       > - Attribute `pkgs.emacs31` is a new package with `__structuredAttrs` unset or set to `false`.
       >   Please enable `__structuredAttrs = true;` in pkgs/top-level/all-packages.nix.
       >  (NPV-166)
       > - Attribute `pkgs.emacs31-gtk3` is a new package with `strictDeps` unset or set to `false`.
       >   Please enable `strictDeps = true;` in pkgs/top-level/all-packages.nix.
       >  (NPV-164)
       > - Attribute `pkgs.emacs31-gtk3` is a new package with `__structuredAttrs` unset or set to `false`.
       >   Please enable `__structuredAttrs = true;` in pkgs/top-level/all-packages.nix.
       >  (NPV-166)
       > - Attribute `pkgs.emacs31-nox` is a new package with `strictDeps` unset or set to `false`.
       >   Please enable `strictDeps = true;` in pkgs/top-level/all-packages.nix.
       >  (NPV-164)
       > - Attribute `pkgs.emacs31-nox` is a new package with `__structuredAttrs` unset or set to `false`.
       >   Please enable `__structuredAttrs = true;` in pkgs/top-level/all-packages.nix.
       >  (NPV-166)
       > - Attribute `pkgs.emacs31-pgtk` is a new package with `strictDeps` unset or set to `false`.
       >   Please enable `strictDeps = true;` in pkgs/top-level/all-packages.nix.
       >  (NPV-164)
       > - Attribute `pkgs.emacs31-pgtk` is a new package with `__structuredAttrs` unset or set to `false`.
       >   Please enable `__structuredAttrs = true;` in pkgs/top-level/all-packages.nix.
       >  (NPV-166)
       > This PR introduces additional instances of discouraged patterns as listed above. Please fix them before merging.
       For full logs, run:
         nix log /nix/store/acf2xj7y4nfh3pk9zdrj4v83zbx5mr27-nixpkgs-vet.drv
To run locally: ./ci/nixpkgs-vet.sh master https://github.com/NixOS/nixpkgs.git
If you're having trouble, ping @NixOS/nixpkgs-vet
Error: Process completed with exit code 1.
</pre>
</details>


Ref: #342408 (previous introduction of an Emacs pretest)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
