### PR TITLE
aws-lc: 1.69.0 -> 5.0.0

### DIFF
--- a/pkgs/by-name/aw/aws-lc/package.nix
+++ b/pkgs/by-name/aw/aws-lc/package.nix
@@ -11,13 +11,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "aws-lc";
-  version = "1.69.0";
+  version = "5.0.0";
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = "aws-lc";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-ykpPbMONAJK6rEANOn0O7JfIkXPSoPXs1Zr4Bv+eXqQ=";
+    hash = "sha256-Dvy6mzEfKgimxCGp7q2fPk9urBMJMU6gZmaZXwdZfWw=";
   };
 
   outputs = [
@@ -45,6 +45,11 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preCheck
     ninja run_minimal_tests
     runHook postCheck
+  '';
+
+  postInstall = ''
+    moveToOutput lib/crypto/cmake "$dev"
+    moveToOutput lib/ssl/cmake "$dev"
   '';
 
   env.NIX_CFLAGS_COMPILE = toString (


### PR DESCRIPTION
https://github.com/aws/aws-lc/releases/tag/v5.0.0
https://github.com/aws/aws-lc/releases/tag/v1.73.0
https://github.com/aws/aws-lc/releases/tag/v1.72.1
https://github.com/aws/aws-lc/releases/tag/v1.72.0
https://github.com/aws/aws-lc/releases/tag/v1.71.0
https://github.com/aws/aws-lc/releases/tag/v1.70.0

with recent releases, aws-lc has completely redone its versioning. see https://github.com/aws/aws-lc/blob/main/VERSIONING.md.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
