### PR TITLE
windows.npiperelay: update 0.1.0 (jstarks) -> 1.11.2 (albertony), use maintained fork

### DIFF
--- a/pkgs/os-specific/windows/npiperelay/default.nix
+++ b/pkgs/os-specific/windows/npiperelay/default.nix
@@ -1,27 +1,73 @@
 {
   lib,
-  buildGoModule,
+  buildGo125Module,
   fetchFromGitHub,
+  nix-update-script,
+  stdenv,
+  testers,
+  testWithWine ? true,
+  wine64,
 }:
 
-buildGoModule rec {
+buildGo125Module (finalAttrs: {
   pname = "npiperelay";
-  version = "0.1.0";
+  version = "1.11.2";
 
   src = fetchFromGitHub {
-    owner = "jstarks";
+    owner = "albertony";
     repo = "npiperelay";
-    rev = "v${version}";
-    sha256 = "sha256-cg4aZmpTysc8m1euxIO2XPv8OMnBk1DwhFcuIFHF/1o=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-kH2QXhzEfkR4EBHTBsTFxresRtvDpPVRf4ad+jRyAHg=";
+    # populate values that require us to use git. By doing this in postFetch we
+    # can delete .git afterwards and maintain better reproducibility of the src.
+    leaveDotGit = true;
+    postFetch = ''
+      git -C $out rev-parse HEAD > $out/COMMIT
+      # in format of 0000-00-00T00:00:00Z (RFC3339)
+      date -u -d "@$(git -C $out log -1 --pretty=%ct)" "+%Y-%m-%dT%H:%M:%SZ" > $out/SOURCE_DATE_EPOCH
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
   };
 
   vendorHash = null;
 
+  # INFO: no explicit ldflags are set in the https://github.com/albertony/npiperelay/blob/v1.11.2/.goreleaser.yml
+  # using default https://goreleaser.com/resources/cookbooks/using-main.version/
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+    "-X main.builtBy=nixpkgs"
+    # "-X main.commit=${finalAttrs.src.rev}"
+    # "-X main.date=1970-01-01T00:00:00Z"
+  ];
+
+  # ldflags based on metadata from git and source
+  preBuild = ''
+    ldflags+=" -X main.commit=$(cat COMMIT)"
+    ldflags+=" -X main.date=$(cat SOURCE_DATE_EPOCH)"
+  '';
+
+  doCheck = !stdenv.hostPlatform.isDarwin;
+  passthru.updateScript = nix-update-script { };
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command =
+      (if (testWithWine && stdenv.hostPlatform.isLinux) then "${lib.getExe wine64} " else "")
+      + "${finalAttrs.meta.mainProgram}";
+    version = "${finalAttrs.pname} ${finalAttrs.src.tag}";
+  };
+
   meta = {
     description = "Access Windows named pipes from WSL";
-    homepage = "https://github.com/jstarks/npiperelay";
+    homepage = "https://github.com/albertony/npiperelay";
+    changelog = "https://github.com/albertony/npiperelay/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.shlevy ];
-    platforms = lib.platforms.windows;
+    # INFO: use pkgs.pkgsCross.mingwW64.windows.npiperelay in WSL
+    # Linux is added here to allow building and running npiperelay.exe from WSL,
+    # but it is not the primary target platform
+    platforms = lib.platforms.windows ++ lib.platforms.linux;
+    mainProgram = "${finalAttrs.pname}.exe";
   };
-}
+})


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
