### PR TITLE
{,python3Packages.}usearch: init at 2.25.3

### DIFF
--- a/pkgs/by-name/nu/numkong/package.nix
+++ b/pkgs/by-name/nu/numkong/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  cmake,
+  fetchFromGitHub,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "numkong";
+  version = "7.7.0";
+
+  outputs = [
+    "out"
+    "lib"
+    "dev"
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "ashvardanian";
+    repo = "NumKong";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JZafqqq3jDX+iim2DvyuavuvZ0wrPLIU+hcrOiT1L84=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = "Portable mixed-precision math, linear-algebra, & retrieval library with 2000+ SIMD kernels for x86, Arm, RISC-V, LoongArch, Power, & WebAssembly";
+    homepage = "https://github.com/ashvardanian/NumKong/";
+    changelog = "https://github.com/ashvardanian/NumKong/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+  };
+})

--- a/pkgs/by-name/us/usearch/package.nix
+++ b/pkgs/by-name/us/usearch/package.nix
@@ -1,0 +1,102 @@
+{
+  lib,
+  cmake,
+  fetchFromGitHub,
+  fetchzip,
+  jemalloc,
+  llvmPackages,
+  numkong,
+  stdenv,
+}:
+let
+  sqliteSrc = fetchzip {
+    url = "https://sqlite.org/2024/sqlite-amalgamation-3450200.zip";
+    hash = "sha256-nkDMIiTHjeiopPbGcviQekgSOYifuNM/kr07IHgQvoI=";
+  };
+
+  inherit (stdenv.hostPlatform.extensions) sharedLibrary;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "usearch";
+  version = "2.25.3";
+
+  outputs = [
+    "out"
+    "lib"
+    "dev"
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "unum-cloud";
+    repo = "USearch";
+    tag = "v${finalAttrs.version}";
+    # we need to use the pinned stringzilla because the now removed (or partially by levenshtein replaced) hamming_distance is being used.
+    fetchSubmodules = true;
+    hash = "sha256-lk6cBUwu3+ud/43HSmDWVP2RhXtH8+KmWSuREPoKQ4s=";
+  };
+
+  postPatch = ''
+    rm -r numkong
+    # TODO: change numkong to provide a CMakeLists.txt file or pc config file, so that headers can be auto discovered
+    ln -s ${numkong.src} numkong
+  '';
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    jemalloc
+  ]
+  ++ lib.optional stdenv.hostPlatform.isDarwin llvmPackages.openmp;
+
+  postInstall = ''
+    install {libusearch*,sqlite/libsqlite3}${sharedLibrary} -t $lib/lib/
+  '';
+
+  preFixup =
+    lib.optionalString stdenv.hostPlatform.isLinux ''
+      patchelf \
+        --replace-needed libnumkong${sharedLibrary} $lib/lib/libnumkong${sharedLibrary} \
+        --replace-needed libsqlite3${sharedLibrary} $lib/lib/libsqlite3${sharedLibrary} \
+        --shrink-rpath $lib/lib/libusearch*
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      install_name_tool -id $lib/lib/libnumkong${sharedLibrary} $lib/lib/libnumkong${sharedLibrary}
+      for f in $lib/lib/libusearch*${sharedLibrary}; do
+        install_name_tool \
+          -change @rpath/libnumkong${sharedLibrary} $lib/lib/libnumkong${sharedLibrary} \
+          "$f"
+      done
+    '';
+
+  cmakeFlags = [
+    # dependencies
+    (lib.cmakeBool "USEARCH_USE_JEMALLOC" true)
+    (lib.cmakeBool "USEARCH_USE_NUMKONG" true)
+    (lib.cmakeBool "USEARCH_USE_OPENMP" true)
+
+    # libraries
+    (lib.cmakeBool "USEARCH_BUILD_LIB_C" true)
+    (lib.cmakeBool "USEARCH_BUILD_SQLITE" true)
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_SQLITE3" sqliteSrc.outPath)
+
+    # checks
+    (lib.cmakeBool "USEARCH_BUILD_TEST_C" true)
+    (lib.cmakeBool "USEARCH_BUILD_TEST_CPP" true)
+
+    # benchmarking not only wastes CPU, but also requires the clipp repo to be cloned
+    (lib.cmakeBool "USEARCH_BUILD_BENCH_CPP" false)
+  ];
+
+  meta = {
+    description = "Smaller & Faster Single-File Vector Search Engine from Unum";
+    homepage = "https://github.com/unum-cloud/USearch/";
+    changelog = "https://github.com/unum-cloud/USearch/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+  };
+})

--- a/pkgs/development/python-modules/numkong/default.nix
+++ b/pkgs/development/python-modules/numkong/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  llvmPackages,
+  ml-dtypes,
+  numpy,
+  pkgs,
+  pytest-repeat,
+  pytest-xdist,
+  pytestCheckHook,
+  scipy,
+  setuptools,
+  stdenv,
+}:
+
+buildPythonPackage {
+  inherit (pkgs.numkong) pname version src;
+  pyproject = true;
+
+  build-system = [
+    setuptools
+  ];
+
+  buildInputs = lib.optional stdenv.hostPlatform.isDarwin llvmPackages.openmp;
+
+  pythonImportsCheck = [ "numkong" ];
+
+  nativeCheckInputs = [
+    numpy
+    scipy
+    ml-dtypes
+    pytest-repeat
+    pytest-xdist
+    pytestCheckHook
+    # there are more tests for big libraries, but we avoid them to not explode the closure size
+  ];
+
+  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
+    # slight floating point error
+    "test/test_similarities.py::test_cdist_float_accuracy"
+    "test/test_similarities.py::test_cdist_jaccard"
+  ];
+
+  meta = {
+    inherit (pkgs.numkong.meta)
+      description
+      homepage
+      changelog
+      license
+      maintainers
+      ;
+  };
+}

--- a/pkgs/development/python-modules/usearch/default.nix
+++ b/pkgs/development/python-modules/usearch/default.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  buildPythonPackage,
+  cmake,
+  numba,
+  numpy,
+  numkong,
+  py-cpuinfo,
+  pybind11,
+  pytestCheckHook,
+  setuptools,
+  tqdm,
+  pkgs,
+  stdenv,
+  which,
+  writableTmpDirAsHomeHook,
+}:
+
+buildPythonPackage {
+  inherit (pkgs.usearch) pname version src;
+  pyproject = true;
+
+  postPatch = ''
+    substituteInPlace python/usearch/__init__.py \
+      --replace-fail 'manager = BinaryManager(version=version)' \
+        'return "${lib.getLib pkgs.usearch}/lib/libusearch_sqlite${
+          if stdenv.hostPlatform.isDarwin then "" else stdenv.hostPlatform.extensions.sharedLibrary
+        }"'
+  '';
+
+  nativeBuildInputs = [
+    which
+  ];
+
+  buildInputs = [
+    pkgs.numkong
+  ];
+
+  build-system = [
+    cmake
+    pybind11
+    setuptools
+  ];
+
+  dependencies = [
+    numkong
+    numpy
+    tqdm
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  pythonImportsCheck = [ "usearch" ];
+
+  nativeCheckInputs = [
+    numba
+    py-cpuinfo
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  meta = {
+    inherit (pkgs.usearch.meta)
+      description
+      homepage
+      changelog
+      license
+      maintainers
+      ;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11458,6 +11458,8 @@ self: super: with self; {
 
   numexpr = callPackage ../development/python-modules/numexpr { };
 
+  numkong = callPackage ../development/python-modules/numkong { };
+
   numpy = numpy_2;
 
   numpy-financial = callPackage ../development/python-modules/numpy-financial { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21036,6 +21036,8 @@ self: super: with self; {
 
   usbtmc = callPackage ../development/python-modules/usbtmc { };
 
+  usearch = callPackage ../development/python-modules/usearch { };
+
   useful-types = callPackage ../development/python-modules/useful-types { };
 
   user-agents = callPackage ../development/python-modules/user-agents { };


### PR DESCRIPTION
Extracted from #523179

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
