### PR TITLE
lib.types.submoduleWith: add `apply` option

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1412,6 +1412,7 @@ rec {
       modules,
       specialArgs ? { },
       shorthandOnlyDefinesConfig ? false,
+      apply ? lib.id,
       description ? null,
       class ? null,
     }@attrs:
@@ -1500,7 +1501,7 @@ rec {
           in
           {
             headError = checkDefsForError check loc defs;
-            value = configuration.config;
+            value = apply configuration.config;
             valueMeta = { inherit configuration; };
           };
       };

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -282,7 +282,7 @@ Submodules are detailed in [Submodule](#section-option-types-submodule).
     options. This is equivalent to
     `types.submoduleWith { modules = toList o; shorthandOnlyDefinesConfig = true; }`.
 
-`types.submoduleWith` { *`modules`*, *`specialArgs`* ? {}, *`shorthandOnlyDefinesConfig`* ? false }
+`types.submoduleWith` { *`modules`*, *`specialArgs`* ? {}, *`shorthandOnlyDefinesConfig`* ? false, *`apply`* ? `lib.id` }
 
 :   Like `types.submodule`, but more flexible and with better defaults.
     It has parameters
@@ -321,6 +321,17 @@ Submodules are detailed in [Submodule](#section-option-types-submodule).
         With this option enabled, defining a non-`config` section
         requires using a function:
         `the-submodule = { ... }: { options = { ... }; }`.
+
+    -   *`apply`* A function applied to the merged value.
+        Allows applying final transformations to the merge result.
+
+        For example, one could remove internal sub-options from the final value:
+        ```nix
+        value: removeAttrs value [
+          "warnings"
+          "assertions"
+        ]
+        ```
 
 `types.deferredModule`
 


### PR DESCRIPTION
Allows applying final transformations to the merge result.

For example, one could remove internal sub-options from the final value:

```nix
value: removeAttrs value [
  "warnings"
  "assertions"
]
```

Which is much simpler than the current approach needed:
```nix
submoduleWithoutAssertions =
  module:
  let
    type = types.submodule module;
  in
  type
  // {
    # Ensure the functor preserves custom merge
    functor = type.functor // {
      type = submoduleWithoutAssertions;
    };

    # Ensure substSubModules preserves custom merge
    substSubModules = submoduleWithoutAssertions;

    # Discard internal options when merging
    merge = type.merge // {
      v2 =
        args:
        let
          result = type.merge.v2 args;
        in
        {
          inherit (result) headError valueMeta;
          value = removeAttrs result.value [
            "warnings"
            "assertions"
          ];
        };
    };
  };
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
