### PR TITLE
jasterix: init at 0.1.4

### DIFF
--- a/pkgs/by-name/ja/jasterix/package.nix
+++ b/pkgs/by-name/ja/jasterix/package.nix
@@ -1,0 +1,70 @@
+{
+  applyPatches,
+  boost,
+  catch2_3,
+  cmake,
+  fetchFromGitHub,
+  lib,
+  libarchive,
+  libpcap,
+  log4cpp,
+  onetbb,
+  openssl,
+  stdenv,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "jasterix";
+  version = "0.1.4";
+
+  src = fetchFromGitHub {
+    owner = "OpenATSGmbH";
+    repo = "jASTERIX";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-df5tByZwtQLdV0UlSo1WkgyoF3hReU/mN74V2WL6zoI=";
+  };
+
+  # Disable boost-stacktrace_backtrace, which is an optional dependency and not yet available in Nix.
+  postPatch = ''
+    sed -i 's/\(find_package .*\) stacktrace_backtrace/\1/' CMakeLists.txt
+    sed -i 's/BOOST_STACKTRACE_USE_BACKTRACE/#BOOST_STACKTRACE_USE_BACKTRACE/' CMakeLists.txt
+    sed -i 's/BOOST_STACKTRACE_LINK/#BOOST_STACKTRACE_LINK/' CMakeLists.txt
+  '';
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED" (!stdenv.hostPlatform.isStatic))
+    (lib.cmakeBool "BUILD_STATIC" stdenv.hostPlatform.isStatic)
+    (lib.cmakeBool "WITH_UNIT_TESTS" finalAttrs.doCheck)
+  ];
+
+  buildInputs = [
+    boost.dev
+    catch2_3
+    libarchive.dev
+    libpcap
+    log4cpp
+    onetbb.dev
+    openssl.dev
+  ];
+
+  doCheck = false; # The tests require ASTERIX files that are not publicly provided
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "C++ Library for EUROCONTROL's ASTERIX to JSON conversion";
+    homepage = "https://github.com/OpenATSGmbH/jASTERIX";
+    changelog = "https://github.com/OpenATSGmbH/jASTERIX/releases/tag/v${finalAttrs.src.tag}";
+    maintainers = [ lib.maintainers.vog ];
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


jASTERIX is a C++ Library for EUROCONTROL's [ASTERIX](https://www.eurocontrol.int/services/asterix) to [JSON](https://www.json.org/) conversion. It is part of the [OpenATS COMPASS project](https://github.com/hpuhr/COMPASS/), but released as a separate library to allow easy usage in other projects.

* https://github.com/OpenATSGmbH/jASTERIX

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
