### PR TITLE
python314Packages.pyacoustid: 1.3.0 -> 1.3.1, cleanup, modernise

### DIFF
--- a/pkgs/development/python-modules/pyacoustid/default.nix
+++ b/pkgs/development/python-modules/pyacoustid/default.nix
@@ -1,42 +1,51 @@
 {
   lib,
-  buildPythonPackage,
-  fetchPypi,
-  requests,
   audioread,
+  buildPythonPackage,
+  fetchFromGitHub,
   pkgs,
+  poetry-core,
+  pytestCheckHook,
+  requests,
+  stdenv,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pyacoustid";
-  version = "1.3.0";
-  format = "setuptools";
+  version = "1.3.1";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-X09IcZHBnruQgnCxt7UpfxMtozKxVouWqRRXTAee0Xc=";
+  src = fetchFromGitHub {
+    owner = "beetbox";
+    repo = "pyacoustid";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7bL1g7Zvzc+Re0zSjsEqFsNzgkgwh+onoS4sQk0t55o=";
   };
 
-  propagatedBuildInputs = [
-    requests
-    audioread
-  ];
-
   postPatch = ''
-    sed -i \
-        -e '/^FPCALC_COMMAND *=/s|=.*|= "${pkgs.chromaprint}/bin/fpcalc"|' \
-        acoustid.py
+    substituteInPlace chromaprint.py \
+      --replace "ctypes.CDLL(name" 'ctypes.CDLL("${lib.getLib pkgs.chromaprint}/lib/libchromaprint${stdenv.hostPlatform.extensions.sharedLibrary}"'
   '';
 
-  # package has no tests
-  doCheck = false;
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    audioread
+    requests
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
 
   pythonImportsCheck = [ "acoustid" ];
 
   meta = {
-    description = "Bindings for Chromaprint acoustic fingerprinting";
-    homepage = "https://github.com/sampsyo/pyacoustid";
+    description = "Bindings for Chromaprint acoustic fingerprinting and the Acoustid Web service";
+    homepage = "https://github.com/beetbox/pyacoustid";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
Extracted from #523179

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
