### PR TITLE
hamlib: update hamlib to version 4.7.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9417,6 +9417,13 @@
     githubId = 2881922;
     name = "Francis St-Amour";
   };
+  fstracke = {
+    email = "fritz.stracke@rwth-aachen.de";
+    github = "fstracke";
+    githubId = 31512703;
+    name = "Fritz Stracke";
+    keys = [ { fingerprint = "7A9D 6DB2 0C5A AA55 7838  EEE6 B8CA 2D9A D8F0 506F"; } ];
+  };
   ftrvxmtrx = {
     email = "ftrvxmtrx@gmail.com";
     github = "ftrvxmtrx";

--- a/pkgs/by-name/ha/hamlib_4/package.nix
+++ b/pkgs/by-name/ha/hamlib_4/package.nix
@@ -1,9 +1,10 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   perl,
   swig,
+  autoreconfHook,
   gd,
   ncurses,
   python311,
@@ -23,11 +24,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "hamlib";
-  version = "4.6.2";
+  version = "4.7.1";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/hamlib/hamlib-${finalAttrs.version}.tar.gz";
-    hash = "sha256-sqxz9E3RFh6V/e5slSdhRHV2R7+S1/2zae4v5B7Ueug=";
+  src = fetchFromGitHub {
+    owner = "Hamlib";
+    repo = "Hamlib";
+    tag = finalAttrs.version;
+    hash = "sha256-nI8gDACxlci2Q9V2W4D1DYDUL74JwlCs+qyyNkXOPu4=";
   };
 
   strictDeps = true;
@@ -36,6 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     swig
     pkg-config
     libtool
+    autoreconfHook
   ]
   ++ lib.optionals pythonBindings [ python3 ]
   ++ lib.optionals tclBindings [ tcl ]
@@ -78,7 +82,10 @@ stdenv.mkDerivation (finalAttrs: {
       lgpl2Plus
     ];
     homepage = "https://hamlib.sourceforge.net";
-    maintainers = with lib.maintainers; [ relrod ];
+    maintainers = with lib.maintainers; [
+      relrod
+      fstracke
+    ];
     platforms = with lib.platforms; unix;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarize the changes you have made and explain why they are necessary here ^

For package updates, please link to a changelog or describe changes; this helps your fellow maintainers discover breaking updates.
For new packages, please briefly describe the package or provide a link to its homepage.
-->

This PR updates the hamlib package to version 4.7.1.
The repository has changed their primary host to GitHub, which is reflected in the PR.
I added myself as maintainer for the package, as I now need to use it regularly and can add updates when released.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
