### PR TITLE
jemalloc: enable heap profiling by default

### DIFF
--- a/pkgs/by-name/je/jemalloc/package.nix
+++ b/pkgs/by-name/je/jemalloc/package.nix
@@ -60,6 +60,8 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags = [
     "--with-version=${finalAttrs.version}-0-g0000000000000000000000000000000000000000"
     "--with-lg-vaddr=${with stdenv.hostPlatform; toString (if isILP32 then 32 else parsed.cpu.bits)}"
+    # Profiling is inert unless enabled at runtime
+    "--enable-prof"
   ]
   # see the comment on stripPrefix
   ++ lib.optional stripPrefix "--with-jemalloc-prefix="


### PR DESCRIPTION
Enables `--enable-prof` by default.

This doesn't do anything at runtime unless `MALLOC_CONF` is set: https://github.com/jemalloc/jemalloc/wiki/Use-Case%3A-Heap-Profiling

So the cost is negligible (in theory, at least).

Did a survey across some other package managers:
- Arch enables it: https://gitlab.archlinux.org/archlinux/packaging/packages/jemalloc/-/blob/main/PKGBUILD#L23
- Debian enables it on `i386` / `amd64` only: https://sources.debian.org/src/jemalloc/5.3.1-2/debian/rules#L25-L30
- Fedora enables it: https://src.fedoraproject.org/rpms/jemalloc/blob/rawhide/f/jemalloc.spec#_74
- Homebrew doesn't enable it, but looks like it should work on Darwin as of v5.3.1: https://github.com/jemalloc/jemalloc/pull/2610

This doesn't hurt reproducibility on `aarch64-linux` / `x86_64-linux`, tested with `--check`.

Unsure whether this should be enabled on the more exotic platforms or not by default.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
