### PR TITLE
rerun: 0.32.2 -> 0.33.0

### DIFF
--- a/pkgs/by-name/re/rerun/package.nix
+++ b/pkgs/by-name/re/rerun/package.nix
@@ -35,7 +35,7 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rerun";
-  version = "0.32.2";
+  version = "0.33.0";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -49,7 +49,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "rerun-io";
     repo = "rerun";
     tag = finalAttrs.version;
-    hash = "sha256-VVMogg0mWBoev9oE4CSbv2caTTpcfkReTWA1tJ2n7RI=";
+    hash = "sha256-1jlZ+8jx1dNsWWrkQSyFAIK/VQNSotcyTknz0WhIaIc=";
   };
 
   # The path in `build.rs` is wrong for some reason, so we patch it to make the passthru tests work
@@ -58,7 +58,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail '"rerun_sdk/rerun_cli/rerun"' '"rerun_sdk/rerun"'
   '';
 
-  cargoHash = "sha256-6cL7pocqcMiw+D7R6LIcegP4tO9fUTgXQFG51n6rsU4=";
+  cargoHash = "sha256-3erI/kWTJ5Exl9QpGidsIizi0UWbudzMSzoscoSTmP8=";
 
   cargoBuildFlags = [
     "--package"

--- a/pkgs/development/python-modules/rerun-notebook/default.nix
+++ b/pkgs/development/python-modules/rerun-notebook/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage (finalAttrs: {
     inherit (finalAttrs) version;
     format = "wheel";
     python = "py2.py3";
-    hash = "sha256-4kSDPW8ATfNcajb4Ebz6llwqfsX8lNYlYDZbekdcmMk=";
+    hash = "sha256-GDgqFShq40hcptQPie9pwyZFed/9kBmvke5/OwfHl6M=";
   };
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/rerun-sdk/default.nix
+++ b/pkgs/development/python-modules/rerun-sdk/default.nix
@@ -106,13 +106,18 @@ buildPythonPackage {
 
   disabledTests = [
     # ConnectionError: Connection: connecting to server: transport error
+    "test_decode_matrix"
+    "test_fixed_rate_sampling_duplicates_decode_correctly"
     "test_isolated_streams"
+    "test_off_grid_capture_rate_decodes_correctly"
+    "test_save_screenshot"
     "test_send_dataframe_roundtrip"
     "test_server_failed_table_creation_does_not_leak_entry"
     "test_server_version_info"
     "test_server_with_dataset_files"
     "test_server_with_dataset_prefix"
     "test_server_with_multiple_datasets"
+    "test_viewer_dies_on_client_close"
 
     # TypeError: 'Snapshot' object is not callable
     "test_chunk_record_batch"
@@ -127,7 +132,9 @@ buildPythonPackage {
 
     # av.InvalidDataError: the mp4 asset is a Git LFS pointer, not the real
     # video (rerun.src is fetched without fetchLFS).
+    "test_anchor_path_decodes_mid_gop_target"
     "test_collect_optimize_video_stream_summary"
+    "test_heuristic_fallback_when_is_keyframe_column_absent"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/rerun-io/rerun/compare/0.32.2...0.33.0
Changelog: https://github.com/rerun-io/rerun/blob/0.33.0/CHANGELOG.md

cc @SomeoneSerge

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test