### PR TITLE
python3Packages.babelgladeextractor: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/babelgladeextractor/default.nix
+++ b/pkgs/development/python-modules/babelgladeextractor/default.nix
@@ -7,17 +7,20 @@
   babel,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "babelgladeextractor";
   version = "0.7.0";
   pyproject = true;
+
+  __structuredAttrs = true;
+
   disabled = (!isPy3k); # uses python3 specific file io in setup.py
 
   src = fetchPypi {
     pname = "BabelGladeExtractor";
-    inherit version;
+    inherit (finalAttrs) version;
     extension = "tar.bz2";
-    sha256 = "160p4wi2ss69g141c2z59azvrhn7ymy5m9h9d65qrcabigi0by5w";
+    hash = "sha256-vPgF4otLsYyLaQmmWnz1x8K8v0rlCxZIeMloLSInF5g=";
   };
 
   build-system = [ setuptools ];
@@ -27,10 +30,12 @@ buildPythonPackage rec {
   # SyntaxError: Non-ASCII character '\xc3' in file /build/BabelGladeExtractor-0.6.3/babelglade/tests/test_translate.py on line 20, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
   doCheck = isPy3k;
 
+  pythonImportsCheck = [ "babelglade" ];
+
   meta = {
     homepage = "https://github.com/gnome-keysign/babel-glade";
     description = "Babel Glade XML files translatable strings extractor";
     license = lib.licenses.bsd3;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/babelgladeextractor/default.nix
+++ b/pkgs/development/python-modules/babelgladeextractor/default.nix
@@ -3,13 +3,14 @@
   isPy3k,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   babel,
 }:
 
 buildPythonPackage rec {
   pname = "babelgladeextractor";
   version = "0.7.0";
-  format = "setuptools";
+  pyproject = true;
   disabled = (!isPy3k); # uses python3 specific file io in setup.py
 
   src = fetchPypi {
@@ -19,7 +20,9 @@ buildPythonPackage rec {
     sha256 = "160p4wi2ss69g141c2z59azvrhn7ymy5m9h9d65qrcabigi0by5w";
   };
 
-  propagatedBuildInputs = [ babel ];
+  build-system = [ setuptools ];
+
+  dependencies = [ babel ];
 
   # SyntaxError: Non-ASCII character '\xc3' in file /build/BabelGladeExtractor-0.6.3/babelglade/tests/test_translate.py on line 20, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
   doCheck = isPy3k;


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
