### PR TITLE
nixos/niri: pin defaultSession so GDM 50 stops bouncing to gnome-session

### DIFF
--- a/nixos/modules/programs/wayland/niri.nix
+++ b/nixos/modules/programs/wayland/niri.nix
@@ -33,6 +33,14 @@ in
         services = {
           displayManager.sessionPackages = [ cfg.package ];
 
+          # GDM 50 falls back to launching "gnome-session" as the user
+          # session command when neither AccountsService nor displayManager
+          # .defaultSession pins one. On Niri-only setups that produces a
+          # login loop because gnome-session isn't installed. Pin Niri as
+          # the default so it works out of the box; users with multiple
+          # sessions can still override.
+          displayManager.defaultSession = lib.mkDefault "niri";
+
           # Recommended by upstream
           # https://github.com/YaLTeR/niri/wiki/Important-Software#portals
           gnome.gnome-keyring.enable = lib.mkDefault true;


### PR DESCRIPTION
## Description of changes

GDM 50 falls back to launching `gnome-session` as the user session command when both:

- the user's AccountsService record at `/var/lib/AccountsService/users/$USER` has `Session=` empty, and
- `services.displayManager.defaultSession` is unset.

On a Niri-only machine `gnome-session` isn't installed, so the spawn fails with ENOENT:

```
gdm-wayland-session[…]: Gdm: could not start session: Failed to execute child process "gnome-session" (No such file or directory)
gdm-wayland-session[…]: Unable to run session
```

and the user gets bounced straight back to the greeter, creating a login loop, easy to hit on a fresh install or whenever the AccountsService record gets reset.

GDM 49 hit the same fallback path, but the gnome-session binary happened to be reachable so the greeter survived, and the user's first session pick from the picker got stashed in AccountsService. Subsequent logins read that field and worked. The tighter environment in GDM 50 broke that accidental save.

This patch sets `services.displayManager.defaultSession = lib.mkDefault "niri"` inside the niri module. A Niri-only install now boots straight into the compositor; users running multiple session packages can still override.

Related: #523332

## Things done

- Built locally on `release-26.05` with this change applied to the equivalent place in the release-branch module — boots cleanly into Niri from GDM 50 without any AccountsService manipulation.
- [x] Built on platform(s)
  - [x] x86_64-linux
- [ ] For non-Linux: built on platform(s)
- [ ] Tested, as applicable:
  - [ ] NixOS test(s)
  - [x] manual: GDM 50 + niri only, fresh AccountsService record (`Session=`)
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] 26.05 Release Notes (or backporting 25.05 and 25.11 Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking (n/a — this is a default that users can override)
  - [x] (Module updates) Added a release notes entry if the change is significant (n/a — the option already exists, this just sets a sensible default)
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module (n/a)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## Backport considerations

Worth backporting to release-26.05 — the regression hits users on the current release.