### PR TITLE
python3Packages.unstructured: bundle NLTK data to fix import-time download

### DIFF
--- a/pkgs/development/python-modules/unstructured/default.nix
+++ b/pkgs/development/python-modules/unstructured/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  symlinkJoin,
 
   # build-system
   setuptools,
@@ -30,6 +31,7 @@
   joblib,
   # jsonpath-python,
   nltk,
+  nltk-data,
   olefile,
   orderly-set,
   python-dateutil,
@@ -118,6 +120,18 @@
 }:
 let
   version = "0.18.31";
+
+  # unstructured downloads these NLTK corpora at import time unless they are already on
+  # nltk.data.path, which fails in offline or read-only builds. Bundle them and register
+  # the directory in postPatch. It must be named "nltk_data": unstructured's resolver
+  # uses paths ending in "nltk_data" as-is and appends "/nltk_data" to any others.
+  nltkData = symlinkJoin {
+    name = "nltk_data";
+    paths = with nltk-data; [
+      averaged-perceptron-tagger-eng
+      punkt-tab
+    ];
+  };
 in
 buildPythonPackage rec {
   pname = "unstructured";
@@ -132,6 +146,11 @@ buildPythonPackage rec {
   };
 
   build-system = [ setuptools ];
+
+  postPatch = ''
+    substituteInPlace unstructured/nlp/tokenize.py \
+      --replace-fail 'import nltk' 'import nltk; nltk.data.path.append("${nltkData}")'
+  '';
 
   dependencies = [
     # Base dependencies
@@ -257,10 +276,14 @@ buildPythonPackage rec {
     ];
   };
 
-  pythonImportsCheck = [ "unstructured" ];
+  pythonImportsCheck = [
+    "unstructured"
+    # exercises the bundled NLTK corpora lookup, so the build catches an attempted download
+    "unstructured.nlp.tokenize"
+  ];
 
-  # test try to download punkt from nltk
-  # figure out how to make it available to enable the tests
+  # the import-time NLTK download is handled via nltkData above, but the test suite has
+  # further offline/data requirements that are not yet verified, so keep it disabled.
   doCheck = false;
 
   nativeCheckInputs = [


### PR DESCRIPTION
unstructured/nlp/tokenize.py downloads the `averaged_perceptron_tagger_eng` and `punkt_tab` NLTK corpora at import time unless they are already present on `nltk.data.path`. In offline or read-only/sandboxed environments (such as a systemd service with a read-only filesystem) this fails with `OSError: [Errno 30] Read-only file system: '/nltk_data'` as soon as a consumer imports a partition module (e.g. `unstructured.partition.epub` via open-webui).

Bundle the two required corpora through `nltk-data` and register the directory on `nltk.data.path` with a small postPatch, so importing unstructured works without network access or a writable home. The directory is named `nltk_data` because unstructured's resolver only uses such paths verbatim.

Also import `unstructured.nlp.tokenize` in pythonImportsCheck so the build itself exercises the corpora lookup and guards against regressions.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The problem can be reproduced by a snippet like this in your configuration.nix:

```nix
  services.open-webui = {
    enable = true;
    # Enable open-webui's optional 'unstructured' dependency so it can process document (and other) files.
    package = pkgs.open-webui.overridePythonAttrs (old: {
      dependencies = old.dependencies ++ pkgs.open-webui.optional-dependencies.unstructured;
    });
  };
```

which will cause the following error: https://gist.github.com/grische/4ac1f431df6bc6f1d946c04199690ae3
```
open-webui[36241]: 2026-06-05 11:45:34.920 | ERROR    | open_webui.routers.retrieval:process_file:1741 - [Errno 30] Read-only file system: '/nltk_data'
```

This probably also fixes #361566

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
