### PR TITLE
gokapi-cli: init at 2.2.4

### DIFF
--- a/pkgs/by-name/go/gokapi-cli/package.nix
+++ b/pkgs/by-name/go/gokapi-cli/package.nix
@@ -1,0 +1,32 @@
+{ gokapi }:
+
+gokapi.overrideAttrs (old: {
+  __structuredAttrs = true;
+
+  pname = "gokapi-cli";
+
+  preBuild = "";
+
+  subPackages = [
+    "cmd/cli-uploader"
+  ];
+
+  postInstall = ''
+    mv "$out/bin/cli-uploader" "$out/bin/gokapi-cli"
+  '';
+
+  nativeInstallCheckInputs = [ ];
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    "$out/bin/gokapi-cli" help | grep -q "Gokapi CLI"
+
+    runHook postInstallCheck
+  '';
+
+  meta = old.meta // {
+    description = "CLI uploader and downloader for Gokapi";
+    mainProgram = "gokapi-cli";
+  };
+})


### PR DESCRIPTION
Adds the official Gokapi CLI binary from the existing Gokapi source package.

  Upstream ships and documents the CLI under `cmd/cli-uploader`, while the existing nixpkgs `gokapi` package only exposes the server binary from `cmd/gokapi`.

  Homepage: https://github.com/Forceu/Gokapi

  ## Things done

  - Built on platform:
    - [x] x86_64-linux
    - [ ] aarch64-linux
    - [ ] x86_64-darwin
    - [ ] aarch64-darwin
  - Tested, as applicable:
    - [ ] [NixOS tests] in [nixos/tests].
    - [ ] [Package tests] at `passthru.tests`.
    - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Nixpkgs Release Notes
    - [ ] Package update: when the change is major or breaking.
  - NixOS Release Notes
    - [ ] Module addition: when adding a new NixOS module.
    - [ ] Module update: when the change is significant.
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
  - [x] Follows the [automation/AI policy].

  Tested:
  - `nixfmt --check pkgs/by-name/go/gokapi-cli/package.nix`
  - `nix-build -A gokapi-cli --no-out-link`
  - `gokapi-cli help`