### PR TITLE
plex-desktop: disabling bundled gmmlib

### DIFF
--- a/pkgs/by-name/pl/plex-desktop/package.nix
+++ b/pkgs/by-name/pl/plex-desktop/package.nix
@@ -6,6 +6,7 @@
   extraEnv ? { },
   fetchurl,
   ffmpeg_6-headless,
+  intel-gmmlib,
   lib,
   libdrm,
   libedit,
@@ -130,6 +131,9 @@ let
       rm $out/lib/libdrm.so*
       rm $out/lib/libdrm*
 
+      # remove bundled gmmlib
+      rm $out/lib/libigdgmm.so*
+
       # Keep dependencies where the version from nixpkgs is higher.
       cp usr/lib/x86_64-linux-gnu/libasound.so.2 $out/lib/libasound.so.2
       cp usr/lib/x86_64-linux-gnu/libjbig.so.0 $out/lib/libjbig.so.0
@@ -150,6 +154,7 @@ buildFHSEnv {
   inherit pname version meta;
   targetPkgs = pkgs: [
     alsa-lib
+    intel-gmmlib
     libdrm
     xkeyboard_config
   ];


### PR DESCRIPTION
Removes bundled gmmlib and includes intel-gmmlib from nixpkgs in env.

This was necessary because hardware decoding was failing (cpu usage spiking, intel_gpu_top showing no video usage, etc.)


This output from strace  indicated plex-desktop was using it's own copy of gmmlib
```
80514 openat(AT_FDCWD, "/run/opengl-driver/lib/dri/iHD_drv_video.so", O_RDONLY|O_CLOEXEC) = 160
80514 openat(AT_FDCWD, "/nix/store/8wnpd538r1l62s1j8jych5hmxdx46v81-plex-desktop-1.112.0/lib/libigdgmm.so.12", O_RDONLY|O_CLOEXEC) = 160
80514 access("/run/opengl-driver/lib/dri/iHD_drv_video.so", F_OK) = 0
```

After the changes made, intel_gpu_top shows video hardware acceleration, playback is smoother, and cpu usage lower. 

Interesting parallels to #381335

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
