### PR TITLE
python3Packages.curl-cffi: 0.14.0 -> 0.15.0

### DIFF
--- a/pkgs/development/python-modules/curl-cffi/default.nix
+++ b/pkgs/development/python-modules/curl-cffi/default.nix
@@ -11,6 +11,7 @@
   cryptography,
   fastapi,
   httpx,
+  litestar,
   proxy-py,
   pytest-asyncio,
   pytest-trio,
@@ -23,14 +24,14 @@
 }:
 buildPythonPackage rec {
   pname = "curl-cffi";
-  version = "0.14.0";
+  version = "0.15.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "lexiforest";
     repo = "curl_cffi";
     tag = "v${version}";
-    hash = "sha256-5Q9oHAOjefihxj6xU1UGVTl6Ib31XqhrxLtOgI5VABs=";
+    hash = "sha256-I8rQj28IvLD7HWuog46E0dLFgnWSA6oE4Jyn9Flr7mQ=";
   };
 
   patches = [ ./use-system-libs.patch ];
@@ -55,6 +56,7 @@ buildPythonPackage rec {
     cryptography
     fastapi
     httpx
+    litestar
     proxy-py
     pytest-asyncio
     pytest-trio

--- a/pkgs/development/python-modules/curl-cffi/use-system-libs.patch
+++ b/pkgs/development/python-modules/curl-cffi/use-system-libs.patch
@@ -1,21 +1,38 @@
 --- a/scripts/build.py
 +++ b/scripts/build.py
-@@ -141,7 +141,6 @@ def get_curl_libraries():
+@@ -122,27 +122,8 @@ def get_curl_libraries():
  ffibuilder = FFI()
  system = platform.system()
  root_dir = Path(__file__).parent.parent
 -download_libcurl()
- 
+-
+-# With mega archive, we only have one to link
+-static_libs = get_curl_archives()
+ extra_link_args = []
+-if is_static:
+-    if system == "Darwin":
+-        extra_link_args = [
+-            f"-Wl,-force_load,{static_libs[0]}",
+-            "-lc++",
+-        ]
+-    elif system in ("Linux", "Android"):
+-        cxx_lib = "-lc++" if is_android else "-lstdc++"
+-        extra_link_args = [
+-            "-Wl,--whole-archive",
+-            static_libs[0],
+-            "-Wl,--no-whole-archive",
+-            cxx_lib,
+-        ]
+-
+-libraries = get_curl_libraries()
++libraries = ["curl-impersonate"]
  
  ffibuilder.set_source(
-@@ -150,9 +149,7 @@ ffibuilder.set_source(
-         #include "shim.h"
+     "curl_cffi._wrapper",
+@@ -160,7 +132,7 @@ ffibuilder.set_source(
      """,
-     # FIXME from `curl-impersonate`
+     library_dirs=[str(libdir)],
 -    libraries=get_curl_libraries(),
--    extra_objects=get_curl_archives(),
--    library_dirs=[arch["libdir"]],
-+    libraries=["curl-impersonate"],
++    libraries=libraries,
+     extra_objects=[],  # linked via extra_link_args
      source_extension=".c",
-     include_dirs=[
-         str(root_dir / "include"),


### PR DESCRIPTION
## curl-cffi

Version bump. System libraries patch updated via Devin using GPT-5.5. Verified by a self-review. Tested via nix-build and nixpkgs-review.

## yt-dlp

Updated to unstable build that supports new curl-cffi. https://github.com/yt-dlp/yt-dlp/commit/0f45ecc920f31c3c5704c62bad8da2e2844ff9bc 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
