### PR TITLE
apko: 1.2.14 -> 1.2.15

### DIFF
--- a/pkgs/by-name/ap/apko/package.nix
+++ b/pkgs/by-name/ap/apko/package.nix
@@ -11,13 +11,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "apko";
-  version = "1.2.14";
+  version = "1.2.15";
 
   src = fetchFromGitHub {
     owner = "chainguard-dev";
     repo = "apko";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-+yvQK6mrDT9MOeJsEJp4maycz6jpyAnGkc4QddaCbDo=";
+    hash = "sha256-/Y5JqCCqbP+5Of4K6+Bdag9lLKiY/SJiz6x3W6gQnDE=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -29,7 +29,7 @@ buildGoModule (finalAttrs: {
       find "$out" -name .git -print0 | xargs -0 rm -rf
     '';
   };
-  vendorHash = "sha256-ITxeRtPJmLEqD8BundfWdQO10XGHaElL2vpYFSM24pQ=";
+  vendorHash = "sha256-cp29oB3YcqQljeLq4ySOMhV+CXYnQ+ZnDljHn0UzmWs=";
 
   excludedPackages = [
     "internal/gen-jsonschema"


### PR DESCRIPTION
<!--
ZHF PR template — fill in:
  1. The optional "Borrowed the patch from..." line, or delete it.
  2. <ZHF_ISSUE>            e.g. 516381
  3. <HYDRA_BUILD_ID>       e.g. 327143320 (the #number under the X)
  4. <HYDRA_JOB_NAME>       e.g. python314Packages.irc.x86_64-linux
       (used as the alt text; appears if the banner image fails to load)
  Then tick the boxes that actually apply before submitting.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
