### PR TITLE
lib.modules.mkRemovedOptionModule: show full path of submodule options

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -1710,26 +1710,25 @@ let
   mkRemovedOptionModule =
     optionName: replacementInstructions:
     { options, ... }:
+    let
+      opt = getAttrFromPath optionName options;
+    in
     {
       options = setAttrByPath optionName (mkOption {
         visible = false;
         apply =
           x:
-          throw "The option `${showOption optionName}' can no longer be used since it's been removed. ${replacementInstructions}";
+          throw "The option `${opt}' can no longer be used since it's been removed. ${replacementInstructions}";
       });
-      config.assertions =
-        let
-          opt = getAttrFromPath optionName options;
-        in
-        [
-          {
-            assertion = !opt.isDefined;
-            message = ''
-              The option definition `${showOption optionName}' in ${showFiles opt.files} no longer has any effect; please remove it.
-              ${replacementInstructions}
-            '';
-          }
-        ];
+      config.assertions = [
+        {
+          assertion = !opt.isDefined;
+          message = ''
+            The option definition `${opt}' in ${showFiles opt.files} no longer has any effect; please remove it.
+            ${replacementInstructions}
+          '';
+        }
+      ];
     };
 
   /**

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -773,6 +773,12 @@ checkConfigOutput "^true$" config.result ./doRename-condition.nix ./doRename-con
 checkConfigOutput "^true$" config.result ./doRename-condition.nix ./doRename-condition-no-enable.nix
 checkConfigOutput "^true$" config.result ./doRename-condition.nix ./doRename-condition-migrated.nix
 
+# mkRemoveOptionModule
+checkConfigError 'error: The option `a\.b. can no longer be used since it'\''s been removed\. instructions\s*$' config.a.b ./mkRemoveOptionModule.nix
+checkConfigError 'error: The option `c\.d\.e. can no longer be used since it'\''s been removed\.\s*$' config.c.d.e ./mkRemoveOptionModule.nix
+checkConfigError 'error: list index . in .* is out of range\s*$' config.errors.1 ./mkRemoveOptionModule.nix
+checkConfigOutput '^"The option definition `a\.b. in `example-file. no longer has any effect; please remove it\.\\ninstructions\\n"$' config.errors.0 ./mkRemoveOptionModule.nix
+
 # Anonymous modules get deduplicated by key
 checkConfigOutput '^"pear"$' config.once.raw ./merge-module-with-key.nix
 checkConfigOutput '^"pear\\npear"$' config.twice.raw ./merge-module-with-key.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -776,8 +776,12 @@ checkConfigOutput "^true$" config.result ./doRename-condition.nix ./doRename-con
 # mkRemoveOptionModule
 checkConfigError 'error: The option `a\.b. can no longer be used since it'\''s been removed\. instructions\s*$' config.a.b ./mkRemoveOptionModule.nix
 checkConfigError 'error: The option `c\.d\.e. can no longer be used since it'\''s been removed\.\s*$' config.c.d.e ./mkRemoveOptionModule.nix
-checkConfigError 'error: list index . in .* is out of range\s*$' config.errors.1 ./mkRemoveOptionModule.nix
+checkConfigError 'error: list index . in .* is out of range\s*$' config.errors.3 ./mkRemoveOptionModule.nix
 checkConfigOutput '^"The option definition `a\.b. in `example-file. no longer has any effect; please remove it\.\\ninstructions\\n"$' config.errors.0 ./mkRemoveOptionModule.nix
+# mkRemoveOptionModule in submodule
+checkConfigError 'error: The option `submodules\.x\.sub\.opt. can no longer be used since it'\''s been removed\. suboption\s*$' config.submodules.x.sub.opt ./mkRemoveOptionModule.nix
+checkConfigOutput '^"The option definition `submodules\.y\.sub\.opt. in `another-file. no longer has any effect; please remove it\.\\nsuboption\\n"$' config.errors.1 ./mkRemoveOptionModule.nix
+checkConfigOutput '^"The option definition `submodules\.z\.sub\.opt. in `another-file. no longer has any effect; please remove it\.\\nsuboption\\n"$' config.errors.2 ./mkRemoveOptionModule.nix
 
 # Anonymous modules get deduplicated by key
 checkConfigOutput '^"pear"$' config.once.raw ./merge-module-with-key.nix

--- a/lib/tests/modules/assertions.nix
+++ b/lib/tests/modules/assertions.nix
@@ -1,0 +1,16 @@
+{ lib, ... }:
+# Based on <nixpkgs/nixos/modules/misc/assertions.nix>
+{
+  options = {
+    assertions = lib.mkOption {
+      type = lib.types.listOf lib.types.unspecified;
+      default = [ ];
+      internal = true;
+    };
+    warnings = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      internal = true;
+    };
+  };
+}

--- a/lib/tests/modules/mkRemoveOptionModule.nix
+++ b/lib/tests/modules/mkRemoveOptionModule.nix
@@ -11,6 +11,14 @@
       type = lib.types.listOf lib.types.str;
       default = map (x: x.message) (lib.filter (x: !x.assertion) config.assertions);
     };
+    submodules = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.submodule [
+          ./assertions.nix
+          (lib.mkRemovedOptionModule [ "sub" "opt" ] "suboption")
+        ]
+      );
+    };
   };
 
   config = {
@@ -18,5 +26,19 @@
       file = "example-file";
       value = 1234;
     };
+
+    submodules = lib.mkDefinition {
+      file = "another-file";
+      value = {
+        x = {
+          # empty
+        };
+        y.sub.opt = "err1";
+        z.sub.opt = "err2";
+      };
+    };
+
+    # Propagate submodule assertions
+    assertions = lib.concatMap (x: x.assertions) (lib.attrValues config.submodules);
   };
 }

--- a/lib/tests/modules/mkRemoveOptionModule.nix
+++ b/lib/tests/modules/mkRemoveOptionModule.nix
@@ -1,0 +1,22 @@
+{ lib, config, ... }:
+{
+  imports = [
+    ./assertions.nix
+    (lib.mkRemovedOptionModule [ "a" "b" ] "instructions")
+    (lib.mkRemovedOptionModule [ "c" "d" "e" ] "")
+  ];
+
+  options = {
+    errors = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = map (x: x.message) (lib.filter (x: !x.assertion) config.assertions);
+    };
+  };
+
+  config = {
+    a.b = lib.mkDefinition {
+      file = "example-file";
+      value = 1234;
+    };
+  };
+}


### PR DESCRIPTION

Adds test coverage for `mkRemovedOptionModule`, then fix option-path rendering for options with prefixes (i.e. sub-options).

Discovered in https://github.com/nix-community/nixvim/pull/4376#discussion_r3364044627


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
