### PR TITLE
pragtical: 3.9.0 -> 3.11.2

### DIFF
--- a/pkgs/by-name/pr/pragtical/package.nix
+++ b/pkgs/by-name/pr/pragtical/package.nix
@@ -7,6 +7,7 @@
   ninja,
   pkg-config,
   freetype,
+  harfbuzz,
   libgit2,
   libkqueue,
   libuchardet,
@@ -17,14 +18,15 @@
   pcre2,
   sdl3,
   sdl3-image,
+  sdl3-net,
   xz,
   zlib,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pragtical";
-  version = "3.9.0";
-  pluginManagerRev = "ae9bd107783b1b8cbe7f0dec53b1b0b401f6ac91";
+  version = "3.11.2";
+  pluginManagerRev = "v1.5.1";
   linenoiseRev = "e78e236c8d85c078fdd9fc4e1f08716058aa1a42";
 
   src = fetchFromGitHub {
@@ -45,12 +47,14 @@ stdenv.mkDerivation (finalAttrs: {
         --replace-fail 'revision = master' 'revision = ${finalAttrs.linenoiseRev}'
 
       ${lib.getExe meson} subprojects download \
-          colors linenoise plugins ppm widget
+        colors linenoise plugins ppm widget mbedtls
+      # TODO: remove mbedtls from list once ppm supports mbedtls_4
+      # See https://github.com/pragtical/plugin-manager/issues/11
 
       find subprojects -type d -name .git -prune -execdir rm -r {} +
     '';
 
-    hash = "sha256-hs4WFBqR9G+YsHw9/qaO0BCeIMqPEWOvFaeuN2W9hSQ=";
+    hash = "sha256-6S4hnmSsejLr7IiZ4mtHT5ImBsVlyKFtLx9PBgv6b90=";
   };
 
   strictDeps = true;
@@ -64,6 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     freetype
+    harfbuzz
     libgit2
     libkqueue # optional
     libuchardet
@@ -74,6 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
     pcre2
     sdl3
     sdl3-image
+    sdl3-net
     xz
     zlib
   ];


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/528439

Related: https://github.com/pragtical/plugin-manager/issues/11

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
