### PR TITLE
nixos/kernel: use inherit instead of broad with

### DIFF
--- a/nixos/modules/system/boot/initrd-openvpn.nix
+++ b/nixos/modules/system/boot/initrd-openvpn.nix
@@ -4,11 +4,13 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
-
+  inherit (lib)
+    literalExpression
+    mkIf
+    mkOption
+    types
+    ;
   cfg = config.boot.initrd.network.openvpn;
 
 in

--- a/nixos/modules/system/boot/initrd-ssh.nix
+++ b/nixos/modules/system/boot/initrd-ssh.nix
@@ -4,11 +4,25 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
-
+  inherit (lib)
+    concatMapStrings
+    concatStrings
+    concatStringsSep
+    escapeShellArg
+    flip
+    isString
+    listToAttrs
+    literalExpression
+    mkIf
+    mkOption
+    mkRemovedOptionModule
+    nameValuePair
+    optionalString
+    stringLength
+    substring
+    types
+    ;
   cfg = config.boot.initrd.network.ssh;
   shell = if cfg.shell == null then "/bin/ash" else cfg.shell;
   inherit (config.programs.ssh) package;

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -4,10 +4,20 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
+  inherit (lib)
+    concatStringsSep
+    literalExpression
+    mkDefault
+    mkEnableOption
+    mkIf
+    mkMerge
+    mkOption
+    mkRemovedOptionModule
+    optionals
+    optionalString
+    types
+    ;
 
   inherit (config.boot) kernelPatches;
   inherit (config.boot.kernel) features randstructSeed;

--- a/nixos/modules/system/boot/kernel_config.nix
+++ b/nixos/modules/system/boot/kernel_config.nix
@@ -1,7 +1,18 @@
 { lib, config, ... }:
-
-with lib;
 let
+  inherit (lib)
+    all
+    concatStrings
+    elem
+    getValues
+    literalExpression
+    mapAttrsToList
+    mkOption
+    optionalString
+    stringToCharacters
+    substring
+    types
+    ;
   mergeFalseByDefault =
     locs: defs:
     if defs == [ ] then
@@ -51,7 +62,6 @@ let
   };
 
   mkValue =
-    with lib;
     val:
     let
       isNumber =
@@ -130,11 +140,12 @@ in
     settings = mkOption {
       type = types.attrsOf kernelItem;
       example = literalExpression ''
-        with lib.kernel; {
-               "9P_NET" = yes;
-               USB = option yes;
-               MMC_BLOCK_MINORS = freeform "32";
-             }'';
+        {
+          "9P_NET" = yes;
+          USB = option yes;
+          MMC_BLOCK_MINORS = lib.kernel.freeform "32";
+        }
+      '';
       description = ''
         Structured kernel configuration.
       '';

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -21,6 +21,7 @@ let
     concatStringsSep
     filter
     filterAttrs
+    forEach
     getBin
     hasPrefix
     hasSuffix

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -11,11 +11,28 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
-
+  inherit (lib)
+    all
+    any
+    attrValues
+    concatMap
+    concatMapStringsSep
+    concatStringsSep
+    filter
+    filterAttrs
+    getBin
+    hasPrefix
+    hasSuffix
+    literalExpression
+    literalMD
+    mapAttrsToList
+    mkIf
+    mkMerge
+    mkOption
+    optionalString
+    types
+    ;
   udev = config.systemd.package;
 
   kernel-name = config.boot.kernelPackages.kernel.name or "kernel";

--- a/nixos/modules/system/boot/stage-2.nix
+++ b/nixos/modules/system/boot/stage-2.nix
@@ -4,11 +4,8 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
-
+  inherit (lib) types mkOption literalExpression;
   useHostResolvConf = config.networking.resolvconf.enable && config.networking.useHostResolvConf;
 
   bootStage2 = pkgs.replaceVarsWith {


### PR DESCRIPTION
with lib; at the top of the file brings in the full lexical scope of lib. which has small performance implications on eval time.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
