### PR TITLE
necesse-server: 1.2.0-22728942 -> 1.2.0-23522718

### DIFF
--- a/pkgs/by-name/ne/necesse-server/package.nix
+++ b/pkgs/by-name/ne/necesse-server/package.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  version = "1.2.0-22728942";
+  version = "1.2.0-23522718";
   urlVersion = lib.replaceStrings [ "." ] [ "-" ] version;
 
 in
@@ -15,8 +15,8 @@ stdenvNoCC.mkDerivation {
   inherit version;
 
   src = fetchzip {
-    url = "https://necessegame.com/content/server/${urlVersion}/necesse-server-linux64-${urlVersion}.zip";
-    hash = "sha256-kSBql3oHG368DczSM7FkWeAZcfTrNP1x31LX7HRrgTE=";
+    url = "https://necesse.pwn.sh/server/necesse-server-linux64-${urlVersion}.zip";
+    hash = "sha256-PIguTYULddLKj6PpoSvX3gNSvqrS7oRTOPuwoA0/XOc=";
   };
 
   # removing packaged jre since we use our own

--- a/pkgs/by-name/ne/necesse-server/update.sh
+++ b/pkgs/by-name/ne/necesse-server/update.sh
@@ -3,13 +3,30 @@
 
 set -eu -o pipefail
 
+website=$(curl -sL https://necessegame.com/server)
+
 version=$(
-    curl -s http://www.necessegame.com/server \
+    echo "$website" \
         | pup 'a[href*="linux64"] text{}' \
         | awk -F'[v ]' '/Linux64/ {print $4"-"$6}' \
         | sort -Vu \
         | tail -n1
 )
 
-[[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+\-[0-9]+$ ]] \
-    && update-source-version necesse-server "$version"
+if [[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+\-[0-9]+$ ]]; then
+    version_url=${version//./-}
+
+    # extract the expiring presigned S3 URL for the new zip
+    url=$(
+        echo "$website" \
+            | pup "a[href*=\"linux64-${version_url}\"] attr{href}" \
+            | sed 's/\&amp;/\&/g'
+    )
+
+    # call API to remote-fetch the zip immediately and keep it cached,
+    # then fetch the zip locally to get the SRI hash, then update.
+    # fails early if the zip cannot be remote-fetched / cached.
+    curl -s --fail-with-body "https://necesse.pwn.sh/cache.php?version=${version_url}" \
+        && sri=$(nix-prefetch-url --unpack "$url" | xargs nix hash convert --hash-algo sha256 --to sri) \
+        && update-source-version necesse-server "$version" "$sri"
+fi


### PR DESCRIPTION
This PR updates necesse-server to v1.2.0-23522718.

---

Unfortunately, the vendor changed how Necesse server files can be fetched and now uses S3 presigned URLs that expire after one hour instead of static links. This means we need a caching server to keep the files until the package build completes.

To address his, I've reworked the update script to do the following:

  1. Checks vendor website for latest server version and extracts the expiring URL
  2. Sends the new version string to my caching server → the caching server immediately fetches the new server zipfile if it is not cached yet
  4. Downloads the latest server zipfile from vendor to calculate the SRI hash
  5. Updates version and hash of the package

The caching server URL is static and can now be used with `fetchzip` like the previous vendor URL.
The SRI hash comes from the vendor zipfile and ensures that the cached zipfiles are identical.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
