### PR TITLE
cudaPackages.tensorrt: Init 10.16.1

### DIFF
--- a/pkgs/development/cuda-modules/_cuda/manifests/tensorrt/redistrib_10.16.1.json
+++ b/pkgs/development/cuda-modules/_cuda/manifests/tensorrt/redistrib_10.16.1.json
@@ -1,0 +1,37 @@
+
+{
+    "release_date": "2026-04-07",
+    "release_label": "10.16.1",
+    "release_product": "tensorrt",
+    "tensorrt": {
+        "name": "NVIDIA TensorRT",
+        "license": "TensorRT",
+        "version": "10.16.1.11",
+        "cuda_variant": [
+            "12",
+            "13"
+        ],
+        "linux-sbsa": {
+          "cuda13": {
+            "md5": "141f8346668152f5ae31b13d1280066d",
+            "relative_path": "tensorrt/10.16.1/tars/TensorRT-10.16.1.11.Linux.aarch64-gnu.cuda-13.2.tar.gz",
+            "sha256": "63ecfb16d2df932cc5c3f2a362ae6281919f565c5ca3a5e1299c95780e165c91",
+            "size": "5617960358"
+          }
+        },
+        "linux-x86_64": {
+          "cuda12": {
+            "md5": "df43a636866bc933c4794383ae9fd7bd",
+            "relative_path": "tensorrt/10.16.1/tars/TensorRT-10.16.1.11.Linux.x86_64-gnu.cuda-12.9.tar.gz",
+            "sha256": "48e64fc9231fe3aeaa18be13385b486ea7c7131dd64f09b54e5fcb051386f014",
+            "size": "8546982998"
+          },
+          "cuda13": {
+            "md5": "523a08f532cb88cad8384793df555221",
+            "relative_path": "tensorrt/10.16.1/tars/TensorRT-10.16.1.11.Linux.x86_64-gnu.cuda-13.2.tar.gz",
+            "sha256": "08334948c57c3bcf2de171ef4bd53d15f48a61a942b048abea12e32f892284e8",
+            "size": "7568035730"
+          }
+        }
+    }
+}

--- a/pkgs/development/cuda-modules/packages/tensorrt-samples/package.nix
+++ b/pkgs/development/cuda-modules/packages/tensorrt-samples/package.nix
@@ -117,6 +117,10 @@ backendStdenv.mkDerivation (finalAttrs: {
         tag = "v10.14";
         hash = "sha256-pWvXpXiUriLDYHqro3HWAmO/9wbGznyUrc9qxq/t0/U=";
       };
+      "10.16.1" = {
+        tag = "v10.16";
+        hash = "sha256-Wm5oOXxAIpIlwiJKhH0WjgUAuTB9H2xFEVpM/sO36qk=";
+      };
     }
   );
 

--- a/pkgs/development/cuda-modules/packages/tensorrt-samples/passthru.nix
+++ b/pkgs/development/cuda-modules/packages/tensorrt-samples/passthru.nix
@@ -27,6 +27,7 @@ in
       else
         lib.getAttr finalAttrs.version {
           "10.14.1" = sample-data_10_14_1;
+          "10.16.1" = sample-data_10_14_1; # Release 10.16 is missing sample data
         }
     );
 


### PR DESCRIPTION
Adds 10.16.1 manifest for TensorRT

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
