### PR TITLE
yt-dlp: pin `python3Packages.curl-cffi` at v0.14.0

### DIFF
--- a/pkgs/by-name/yt/yt-dlp/package.nix
+++ b/pkgs/by-name/yt/yt-dlp/package.nix
@@ -35,6 +35,8 @@ let
     pname = "curl-cffi";
     version = "0.14.0";
     pyproject = true;
+    __structuredAttrs = true;
+    strictDeps = true;
 
     src = fetchFromGitHub {
       owner = "lexiforest";
@@ -61,18 +63,20 @@ let
     doCheck = false;
   });
 in
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "yt-dlp";
   # The websites yt-dlp deals with are a very moving target. That means that
   # downloads break constantly. Because of that, updates should always be backported
   # to the latest stable release.
   version = "2026.03.17";
   pyproject = true;
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "yt-dlp";
     repo = "yt-dlp";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-A4LUCuKCjpVAOJ8jNoYaC3mRCiKH0/wtcsle0YfZyTA=";
   };
 
@@ -97,9 +101,9 @@ python3Packages.buildPythonApplication rec {
 
   # expose optional-dependencies, but provide all features
   dependencies =
-    optional-dependencies.default
-    ++ optional-dependencies.curl-cffi
-    ++ lib.optionals withSecretStorage optional-dependencies.secretstorage;
+    finalAttrs.passthru.optional-dependencies.default
+    ++ finalAttrs.passthru.optional-dependencies.curl-cffi
+    ++ lib.optionals withSecretStorage finalAttrs.passthru.optional-dependencies.secretstorage;
 
   optional-dependencies = {
     default = with python3Packages; [
@@ -191,7 +195,7 @@ python3Packages.buildPythonApplication rec {
   };
 
   meta = {
-    changelog = "https://github.com/yt-dlp/yt-dlp/blob/${version}/Changelog.md";
+    changelog = "https://github.com/yt-dlp/yt-dlp/blob/${finalAttrs.src.tag}/Changelog.md";
     description = "Feature-rich command-line audio/video downloader";
     homepage = "https://github.com/yt-dlp/yt-dlp/";
     license = lib.licenses.unlicense;
@@ -209,4 +213,4 @@ python3Packages.buildPythonApplication rec {
       FlameFlag
     ];
   };
-}
+})

--- a/pkgs/by-name/yt/yt-dlp/package.nix
+++ b/pkgs/by-name/yt/yt-dlp/package.nix
@@ -25,8 +25,42 @@
   bun,
   quickjs,
   quickjs-ng,
+
+  # for pinned curl-cffi
+  curl-impersonate,
 }:
 
+let
+  curl-cffi_14 = python3Packages.buildPythonPackage (finalAttrs: {
+    pname = "curl-cffi";
+    version = "0.14.0";
+    pyproject = true;
+
+    src = fetchFromGitHub {
+      owner = "lexiforest";
+      repo = "curl_cffi";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-5Q9oHAOjefihxj6xU1UGVTl6Ib31XqhrxLtOgI5VABs=";
+    };
+
+    patches = [ ./use-system-libs.patch ];
+
+    buildInputs = [ curl-impersonate ];
+
+    build-system = [
+      python3Packages.cffi
+      python3Packages.setuptools
+    ];
+
+    dependencies = [
+      python3Packages.cffi
+      python3Packages.certifi
+    ];
+
+    pythonImportsCheck = [ "curl_cffi" ];
+    doCheck = false;
+  });
+in
 python3Packages.buildPythonApplication rec {
   pname = "yt-dlp";
   # The websites yt-dlp deals with are a very moving target. That means that
@@ -78,7 +112,7 @@ python3Packages.buildPythonApplication rec {
       websockets
       yt-dlp-ejs # keep pinned version in sync!
     ];
-    curl-cffi = [ python3Packages.curl-cffi ];
+    curl-cffi = [ curl-cffi_14 ];
     secretstorage = with python3Packages; [
       cffi
       secretstorage

--- a/pkgs/by-name/yt/yt-dlp/use-system-libs.patch
+++ b/pkgs/by-name/yt/yt-dlp/use-system-libs.patch
@@ -1,0 +1,21 @@
+--- a/scripts/build.py
++++ b/scripts/build.py
+@@ -141,7 +141,6 @@ def get_curl_libraries():
+ ffibuilder = FFI()
+ system = platform.system()
+ root_dir = Path(__file__).parent.parent
+-download_libcurl()
+ 
+ 
+ ffibuilder.set_source(
+@@ -150,9 +149,7 @@ ffibuilder.set_source(
+         #include "shim.h"
+     """,
+     # FIXME from `curl-impersonate`
+-    libraries=get_curl_libraries(),
+-    extra_objects=get_curl_archives(),
+-    library_dirs=[arch["libdir"]],
++    libraries=["curl-impersonate"],
+     source_extension=".c",
+     include_dirs=[
+         str(root_dir / "include"),


### PR DESCRIPTION
`yt-dlp` doesn't support `python3Packages.curl-cffi` 0.15.0 yet, so pin the latter at 0.14.0.
Alsp replaces `rec` with `finalAttrs` and applies `__structuredAttrs = true` and `strictDeps = true` per the latest guidance.

Unblocks #528539
  
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
