### PR TITLE
zlequalizer: 1.1.1 -> 1.2.1

### DIFF
--- a/pkgs/by-name/zl/zlequalizer/package.nix
+++ b/pkgs/by-name/zl/zlequalizer/package.nix
@@ -2,6 +2,7 @@
   lib,
   clangStdenv,
   fetchFromGitHub,
+  nix-update-script,
 
   # nativeBuildInputs
   cmake,
@@ -26,17 +27,33 @@
   libjack2,
   libxkbcommon,
   lv2,
+  # Highway is built static-dispatch only upstream (HWY_COMPILE_ONLY_STATIC is
+  # forced ON), so exactly one ISA is baked in -- there is no runtime dispatch.
+  # Default to the portable baseline so the cached binary runs everywhere nixpkgs
+  # targets. Override for a faster *local* build, e.g.
+  #   zlequalizer.override { simdTarget = "AVX2"; }
+  # SSE4/AVX2 map to -march=x86-64-v2/v3 and will SIGILL on CPUs lacking that ISA,
+  # which is why this must not be raised for the binary cache.
+  simdTarget ? (if clangStdenv.hostPlatform.isAarch64 then "NEON" else "SSE2"),
 }:
-
+assert lib.assertOneOf "simdTarget" simdTarget [
+  "SSE2"
+  "SSE4"
+  "AVX2"
+  "NEON"
+];
 clangStdenv.mkDerivation (finalAttrs: {
   pname = "zlequalizer";
-  version = "1.1.1";
+  version = "1.2.1";
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "ZL-Audio";
     repo = "ZLEqualizer";
     tag = finalAttrs.version;
-    hash = "sha256-H6j4e9V0Nf3kkm1ds9zSjLsHeDXU5PIHreJVRpjf/Ts=";
+    hash = "sha256-IFfJTd0jfTDbXqyqr34BQoflj3nyB4k/0BqeC6V2j4E=";
     fetchSubmodules = true;
   };
 
@@ -91,12 +108,9 @@ clangStdenv.mkDerivation (finalAttrs: {
   };
 
   cmakeFlags = [
-    # see: https://github.com/ZL-Audio/ZLEqualizer#clone-and-build
-    (lib.cmakeFeature "KFR_ARCHS" (
-      if clangStdenv.hostPlatform.isAarch64 then "neon64" else "sse2;avx;avx2"
-    ))
+    (lib.cmakeFeature "ZL_HWY_STATIC_TARGET" simdTarget)
     (lib.cmakeBool "ZL_JUCE_COPY_PLUGIN" false)
-    # set the version for in the settings screen.
+    # set the version for the settings screen.
     (lib.cmakeFeature "FOOBAR_VERSION" "${finalAttrs.version}")
   ];
 
@@ -119,9 +133,13 @@ clangStdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     homepage = "https://zl-audio.github.io/plugins/zlequalizer2/";
+    changelog = "https://github.com/ZL-Audio/ZLEqualizer/releases/tag/${finalAttrs.version}";
     description = "Versatile equalizer plugin for VST3, LV2 and standalone";
+    mainProgram = "ZL Equalizer 2";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [
       magnetophon


### PR DESCRIPTION
modernize
add simdTarget


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
