### PR TITLE
crocoddyl: enable multithread, mim-solvers: enable multithread

### DIFF
--- a/pkgs/by-name/cr/crocoddyl/package.nix
+++ b/pkgs/by-name/cr/crocoddyl/package.nix
@@ -7,10 +7,13 @@
   ffmpeg,
   ipopt,
   lapack,
+  llvmPackages,
   lib,
   pinocchio,
   pkg-config,
   stdenv,
+
+  withMultithread ? true,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -45,6 +48,10 @@ stdenv.mkDerivation (finalAttrs: {
     pinocchio
   ];
 
+  buildInputs = lib.optionals (stdenv.hostPlatform.isDarwin && withMultithread) [
+    llvmPackages.openmp
+  ];
+
   checkInputs = [
     ffmpeg
   ];
@@ -53,7 +60,10 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "INSTALL_DOCUMENTATION" true)
     (lib.cmakeBool "BUILD_EXAMPLES" false)
     (lib.cmakeBool "BUILD_PYTHON_INTERFACE" false)
+    (lib.cmakeBool "BUILD_WITH_MULTITHREADS" withMultithread)
   ];
+
+  passthru = { inherit withMultithread; };
 
   prePatch = ''
     substituteInPlace \

--- a/pkgs/by-name/mi/mim-solvers/package.nix
+++ b/pkgs/by-name/mi/mim-solvers/package.nix
@@ -28,7 +28,9 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
 
-  buildInputs = lib.optional stdenv.hostPlatform.isDarwin llvmPackages.openmp;
+  buildInputs = lib.optional (
+    stdenv.hostPlatform.isDarwin && crocoddyl.withMultithread
+  ) llvmPackages.openmp;
 
   propagatedBuildInputs = [
     crocoddyl
@@ -38,6 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeBool "BUILD_PYTHON_INTERFACE" false)
     (lib.cmakeBool "BUILD_WITH_PROXSUITE" true)
+    (lib.cmakeBool "BUILD_WITH_MULTITHREADS" crocoddyl.withMultithread)
   ];
 
   nativeCheckInputs = [


### PR DESCRIPTION
Got some logs saying "Warning: the number of threads won't affect the computational performance as multithreading support is not enabled.", and, yes, this was forgotten.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
