### PR TITLE
[Backport staging-26.05] rustPlatform.fetchCargoVendor: de-duplicate git sources by selector

### DIFF
--- a/pkgs/build-support/rust/fetch-cargo-vendor-util.py
+++ b/pkgs/build-support/rust/fetch-cargo-vendor-util.py
@@ -292,6 +292,7 @@ def create_vendor(vendor_staging_dir: Path, out_dir: Path) -> None:
     lockfile_version = get_lockfile_version(cargo_lock_toml)
 
     source_to_ind: dict[str, str] = {}
+    selector_to_ind: dict[tuple, str] = {}
     source_config = {}
     next_registry_ind = 0
     next_git_ind = 0
@@ -327,24 +328,35 @@ def create_vendor(vendor_staging_dir: Path, out_dir: Path) -> None:
             continue
 
         if source.startswith("git+"):
-            ind = f"git-{next_git_ind}"
-            next_git_ind += 1
             source_info = parse_git_source(source, lockfile_version)
             selector = make_git_source_selector(source_info)
+            selector_key = (source_info["url"], source_info["type"], source_info["value"])
+            if selector_key in selector_to_ind:
+                ind = selector_to_ind[selector_key]
+            else:
+                ind = f"git-{next_git_ind}"
+                next_git_ind += 1
+                selector_to_ind[selector_key] = ind
+                add_source_replacement(
+                    orig_key=f"original-source-{ind}",
+                    orig_selector=selector,
+                    vendored_key=f"vendored-source-{ind}",
+                    vendored_dir=f"@vendor@/source-{ind}"
+                )
         elif source.startswith("registry+") or source.startswith("sparse+"):
             ind = f"registry-{next_registry_ind}"
             next_registry_ind += 1
             selector = make_registry_source_selector(source)
+            add_source_replacement(
+                orig_key=f"original-source-{ind}",
+                orig_selector=selector,
+                vendored_key=f"vendored-source-{ind}",
+                vendored_dir=f"@vendor@/source-{ind}"
+            )
         else:
             raise Exception(f"Can't process source: {source}.")
 
         source_to_ind[source] = ind
-        add_source_replacement(
-            orig_key=f"original-source-{ind}",
-            orig_selector=selector,
-            vendored_key=f"vendored-source-{ind}",
-            vendored_dir=f"@vendor@/source-{ind}"
-        )
 
     config_path = out_dir / ".cargo" / "config.toml"
     config_path.parent.mkdir()


### PR DESCRIPTION
(cherry picked from commit 100e23324c871a3b9210bd50c59d4f22e6cc452c)


Manual backport of https://github.com/NixOS/nixpkgs/pull/501979

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
