### PR TITLE
python3Packages.torch-geometric: 2.7.0 -> 2.8.0

### DIFF
--- a/pkgs/development/python-modules/torch-geometric/default.nix
+++ b/pkgs/development/python-modules/torch-geometric/default.nix
@@ -54,11 +54,17 @@
   # modelhub
   huggingface-hub,
   # rag
+  faiss,
+  json-repair,
+  langgraph,
+  openai,
   # pcst-fast,
+  pyyaml,
   datasets,
   transformers,
   sentencepiece,
   accelerate,
+  peft,
   # test
   onnx,
   onnxruntime,
@@ -73,14 +79,15 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "torch-geometric";
-  version = "2.7.0";
+  version = "2.8.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "pyg-team";
     repo = "pytorch_geometric";
     tag = finalAttrs.version;
-    hash = "sha256-xlOzpoYRoEfIRWSQoZbEPvUW43AMr3rCgIYnxwG/z3A=";
+    hash = "sha256-O2W/68DtVimDR4wQb5UVJcqzuZv7GG+CxCj7rqNu9iE=";
   };
 
   build-system = [
@@ -148,13 +155,19 @@ buildPythonPackage (finalAttrs: {
       huggingface-hub
     ];
     rag = [
+      faiss
+      json-repair
+      langgraph
+      openai
       # pcst-fast (unpackaged)
+      pyyaml
       datasets
       transformers
       pandas
       sentencepiece
       accelerate
       torchmetrics
+      peft
     ];
     test = [
       onnx


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/pyg-team/pytorch_geometric/compare/2.7.0...2.8.0
Changelog: https://github.com/pyg-team/pytorch_geometric/blob/2.8.0/CHANGELOG.md

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test