### PR TITLE
angle: fix .pc and darwin dylib

### DIFF
--- a/pkgs/by-name/an/angle/package.nix
+++ b/pkgs/by-name/an/angle/package.nix
@@ -146,7 +146,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     mkdir -p $out/lib/pkgconfig
 
-    cat > $out/lib/pkgconfig/angle.pc <<EOF
+    cat > $out/lib/pkgconfig/angle.pc <<'EOF'
     prefix=${placeholder "out"}
     exec_prefix=''${prefix}
     libdir=''${prefix}/lib

--- a/pkgs/by-name/an/angle/package.nix
+++ b/pkgs/by-name/an/angle/package.nix
@@ -17,6 +17,7 @@
   pciutils,
   libGL,
   apple-sdk_15,
+  fixDarwinDylibNames,
   xcbuild,
 }:
 let
@@ -68,6 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     llvmPackages.bintools
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    fixDarwinDylibNames
     xcbuild
   ];
 
@@ -99,6 +101,8 @@ stdenv.mkDerivation (finalAttrs: {
     # clang++: error: argument unused during compilation: '-stdlib=libc++'
     "treat_warnings_as_errors=false"
   ];
+
+  env.NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-headerpad_max_install_names";
 
   patches = [
     # https://issues.chromium.org/issues/432275627
@@ -173,6 +177,13 @@ stdenv.mkDerivation (finalAttrs: {
     EOF
 
     runHook postInstall
+  '';
+
+  postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    install_name_tool \
+        -change ./libGLESv2.dylib \
+        $out/lib/libGLESv2.dylib \
+        $out/lib/libGLESv1_CM.dylib
   '';
 
   meta = {


### PR DESCRIPTION
Two issues were fixed:

1. The `pkg-config` file for ANGLE was broken with empty `-I` and `-L` values for the cflags and ldflags.
2. The Darwin dylib reference paths were local, both for the dylib name and for the references to each other.

The fixes for these two things are relatively simple.
1. Regarding the `pkg-config` file being incorrect, this is attributable to the heredoc for instantiating `pkg-config` file using variables that are not adequately escaped. While this is solved by #522385 by replacing that whole portion with something another derivation used, I instead opted here to simply escape the heredoc so no shell interpolation is used; this is cleaner IMO and I expect that is what the original author intended.
2. Regarding the dylib issue, what we were seeing was dylib names and dependencies being filesystem-relative, like `./libEGL.dylib`. This is obviously incorrect, so this patch makes sure to patch most of the cases simply by adding `fixDarwinDylibNames` to the `nativeBuildInputs` and then patches up the remaining internal dependency with `install_name_tool`. To be able to do this I had to make the linking step not optimize the header name section. As all of these changes are only relevant on Darwin platforms I made sure to gate these behind platform checks. After rebuilding with these patches, the names of the dylibs and the internal dependencies now all use absolute store paths.

I will note, AI was used in the debugging / research process to learn which tools are the correct tools for the job, but the actual changes were made and tested by me. I am going through this process in an attempt to fix the Ladybird Browser build on Darwin, and I will note it does not build without this patchset, but with it (and a few more patches to Ladybird itself) the project does build correctly in its entirety, and the changes themselves look to be correct after scanning `nixpkgs` for similar snippets, so I am confident in the quality of this PR. At no point was the AI used to generate any of this PRs description (unless you are counting the template generation by GitHub lol).
 
## Things done

(I also ran nix fmt, ~and nixpkgs-review is ongoing but I expect it could take a while~ but nixpkgs-review filled up my disk, although I only had like 10-20GB left to be fair)

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
