### PR TITLE
librewolf: only do LTO on linux

### DIFF
--- a/pkgs/by-name/li/librewolf-unwrapped/librewolf.nix
+++ b/pkgs/by-name/li/librewolf-unwrapped/librewolf.nix
@@ -1,4 +1,9 @@
-{ callPackage, runCommand }:
+{
+  callPackage,
+  runCommand,
+  lib,
+  stdenv,
+}:
 let
   src = callPackage ./src.nix { };
 in
@@ -14,6 +19,8 @@ rec {
     # Flags based on discussion in https://github.com/NixOS/nixpkgs/issues/482250
     "--disable-debug"
     "--disable-debug-symbols"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     "--enable-lto=thin,cross"
   ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Darwin builds of librewolf have been failing, both locally and on [hydra](https://hydra.nixos.org/job/nixpkgs/nixpkgs-25.11-darwin/librewolf-unwrapped.aarch64-darwin), since this change: https://github.com/NixOS/nixpkgs/commit/0379eb58b548780c9816b431f3a8c154d0e57adc (https://github.com/NixOS/nixpkgs/issues/482250)

The issue seems to be that LTO-enabled builds do not work on darwin. Only enabling LTO for linux hosts fixes the issue and lets me compile the package on my M2 Mac. Hopefully it does the same for the cloud builds.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].

I do not know which of these are applicable for my PR.
I tried running `nix-build --attr pkgs.librewolf-unwrapped.passthru.tests` but got the following error:
<details><summary>Details</summary>
<p>

```shell
warning: Nix search path entry '/nix/var/nix/profiles/per-user/root/channels' does not exist, ignoring
evaluation warning: Do not use the `pkgs` module argument in tests you want to run on darwin. It is ambiguous, and many tests are broken because of it. If you need to use a package on the VM host, use `hostPkgs`. Otherwise, use `config.node.pkgs`, or `config.nodes.<name>.nixpkgs.pkgs`.
error:
       … while evaluating the attribute 'drvPath'
         at /Users/user/projects/nixpkgs/lib/customisation.nix:415:11:
          414|         // {
          415|           drvPath =
             |           ^
          416|             assert condition;

       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating the option `driverConfiguration.test_script':

       … while evaluating definitions from `/Users/user/projects/nixpkgs/nixos/lib/testing/driver-configuration.nix':

       … while evaluating the option `testScriptString':

       … while evaluating definitions from `/Users/user/projects/nixpkgs/nixos/lib/testing/testScript.nix':

       … while evaluating the option `testScript':

       … while evaluating definitions from `/Users/user/projects/nixpkgs/nixos/tests/firefox.nix':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: Refusing to evaluate package 'valgrind-3.26.0' in /Users/user/projects/nixpkgs/pkgs/by-name/va/valgrind/package.nix:103 because it has problems:
       - broken: This package is broken.

       See also https://nixos.org/manual/nixpkgs/unstable#sec-problems
       To allow evaluation regardless, use:
       - Nixpkgs import: import nixpkgs { config = <below code>; }
       - NixOS: nixpkgs.config = <below code>;
       - nix-* commands: Put below code in ~/.config/nixpkgs/config.nix

         {
           problems.handlers = {
             valgrind.broken = "warn"; # or "ignore"
           };
         }
``` 

</p>
</details> 

- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
