### PR TITLE
libudev-garden,gardendevd: init

### DIFF
--- a/pkgs/by-name/ga/gardendevd/package.nix
+++ b/pkgs/by-name/ga/gardendevd/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  fetchFromCodeberg,
+  nix-update-script,
+  acl,
+  elogind,
+  meson,
+  ninja,
+  pkg-config,
+  util-linux,
+  kmod,
+  uaccessSupport ? true,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gardendevd";
+  version = "0.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "Gardenhouse";
+    repo = "gardendevd";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-aEG2QIRFH3F5tXBD1U+6SNmOpUMHgdhH7AXwyGGrilI=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = lib.optionals uaccessSupport [
+    acl
+    elogind
+  ];
+
+  mesonFlags = [
+    "-Dopenrc=disabled"
+    (lib.mesonEnable "uaccess" uaccessSupport)
+  ];
+
+  postPatch = ''
+    substituteInPlace src/rules-builtin.c \
+      --replace-fail "/sbin/blkid" "${util-linux}/bin/blkid" \
+      --replace-fail "/sbin/modprobe" "${kmod}/bin/modprobe"
+    substituteInPlace src/rules-parse.c \
+      --replace-fail "/usr/lib/udev/rules.d" "$out/lib/udev/rules.d"
+    substituteInPlace src/spawn.c \
+      --replace-fail "/usr/lib/udev/" "$out/lib/udev/"
+
+    patchShebangs scripts/
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://codeberg.org/Gardenhouse/gardendevd";
+    description = "Udev daemon running on top of mdevd to replace systemd-udev";
+    longDescription = ''
+      Gardendevd is a udev-compatible daemon that processes device
+      events from the Linux kernel. It is designed to be a lightweight
+      and flexible alternative to systemd-udevd, leveraging mdevd for
+      device node creation and firmware loading.
+    '';
+    maintainers = with lib.maintainers; [
+      aanderse
+      choco98
+    ];
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/li/libudev-garden/package.nix
+++ b/pkgs/by-name/li/libudev-garden/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchFromCodeberg,
+  nix-update-script,
+  meson,
+  ninja,
+  pkg-config,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libudev-garden";
+  version = "0.2.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "Gardenhouse";
+    repo = "libudev-garden";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+95+3Hb6lkIhpNZF0pQdM9y5GxZCplp/o2nemZJb5Wc=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://codeberg.org/Gardenhouse/libudev-garden";
+    description = "Daemonless replacement for libudev for use with gardendevd";
+    maintainers = with lib.maintainers; [
+      aanderse
+      choco98
+    ];
+    license = lib.licenses.isc;
+    pkgConfigModules = [ "libudev" ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds `gardendevd` and `libudev-garden`, tools for replacing udev. I decided to add them in the same pr as they are intertwined and only really work when used together.

All testing has been done on `finix` and they're working great!

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
