### PR TITLE
pyubx2: init at 1.3.1

### DIFF
--- a/pkgs/development/python-modules/pyrtcm/default.nix
+++ b/pkgs/development/python-modules/pyrtcm/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pynmeagps,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pyrtcm";
+  version = "1.1.12";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "semuconsulting";
+    repo = "pyrtcm";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hRfz+S4e+qhMP2YvfFDD9MKrTq2QxaNZFxoX0k2divk=";
+  };
+
+  build-system = [ setuptools ];
+
+  buildInputs = [
+    pynmeagps
+  ];
+
+  pythonImportsCheck = [
+    "pyrtcm"
+  ];
+
+  meta = {
+    description = "Python library for parsing RTCM 3 protocol messages";
+    homepage = "https://github.com/semuconsulting/pyrtcm";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ luz ];
+  };
+})

--- a/pkgs/development/python-modules/pyubx2/default.nix
+++ b/pkgs/development/python-modules/pyubx2/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pynmeagps,
+  pyrtcm,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pyubx2";
+  version = "1.3.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "semuconsulting";
+    repo = "pyubx2";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-bb/RLpVP2yd3ybKiiTEzogiYRpi3H9zbxs9lYylaaXI=";
+  };
+
+  build-system = [ setuptools ];
+
+  buildInputs = [
+    pynmeagps
+    pyrtcm
+  ];
+
+  pythonImportsCheck = [
+    "pyubx2"
+  ];
+
+  meta = {
+    description = "Python library for parsing and generating UBX GPS/GNSS protocol messages";
+    homepage = "https://github.com/semuconsulting/pyubx2";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ luz ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15190,6 +15190,8 @@ self: super: with self; {
 
   pyrss2gen = callPackage ../development/python-modules/pyrss2gen { };
 
+  pyrtcm = callPackage ../development/python-modules/pyrtcm { };
+
   pyrtlsdr = callPackage ../development/python-modules/pyrtlsdr { };
 
   pyrympro = callPackage ../development/python-modules/pyrympro { };
@@ -16511,6 +16513,8 @@ self: super: with self; {
   pytz-deprecation-shim = callPackage ../development/python-modules/pytz-deprecation-shim { };
 
   pyu2f = callPackage ../development/python-modules/pyu2f { };
+
+  pyubx2 = callPackage ../development/python-modules/pyubx2 { };
 
   pyuca = callPackage ../development/python-modules/pyuca { };
 


### PR DESCRIPTION
The python module for ublox devices.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
