### PR TITLE
chhoto-url: 7.1.5 -> 7.2.1

### DIFF
--- a/nixos/tests/chhoto-url.nix
+++ b/nixos/tests/chhoto-url.nix
@@ -38,7 +38,7 @@
 
     resp = json.loads(machine.succeed("curl localhost:8000/api/getconfig"))
     assert resp["success"] is False
-    assert resp["reason"] == "No valid authentication was found"
+    assert resp["reason"] == "No valid authentication."
 
     resp = json.loads(machine.succeed("curl -H 'X-API-Key: api_key' localhost:8000/api/getconfig"))
     expected_version = "${config.nodes.machine.services.chhoto-url.package.version}"

--- a/pkgs/by-name/ch/chhoto-url/package.nix
+++ b/pkgs/by-name/ch/chhoto-url/package.nix
@@ -8,23 +8,23 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "chhoto-url";
-  version = "7.1.5";
+  version = "7.2.1";
 
   src = fetchFromGitHub {
     owner = "SinTan1729";
     repo = "chhoto-url";
     tag = finalAttrs.version;
-    hash = "sha256-TREBriuK7k3ZBDkdQ5gGdptWCG/5UOdhoWcOj1Ppd/8=";
+    hash = "sha256-B6bMuy/EEveYtQtGBO5CNeEUlPK8eQ412k+SwlRPm2M=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/actix";
 
   postPatch = ''
-    substituteInPlace src/{main.rs,services.rs} \
+    substituteInPlace src/{main.rs,services/get.rs,services/utils.rs} \
       --replace-fail "./resources/" "${placeholder "out"}/share/chhoto-url/resources/"
   '';
 
-  cargoHash = "sha256-S+fWxhPRB+JZPjWQkww9VYtYfc9vnXCZgUZTu+ND1So=";
+  cargoHash = "sha256-9EVGsOipx9ObygpM37iZYLnhYjSMHFhHTDvjHkLWLz8=";
 
   postInstall = ''
     mkdir -p $out/share/chhoto-url


### PR DESCRIPTION
Changelog: https://github.com/SinTan1729/chhoto-url/releases/tag/7.2.1
Diff: https://github.com/SinTan1729/chhoto-url/compare/7.1.5...7.2.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
