### PR TITLE
python3Packages.exa-py: 2.12.0-unstable-2026-04-15 -> 2.13.1-unstable-2026-06-03

### DIFF
--- a/pkgs/development/python-modules/exa-py/default.nix
+++ b/pkgs/development/python-modules/exa-py/default.nix
@@ -27,7 +27,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "exa-py";
-  version = "2.12.0-unstable-2026-04-15";
+  version = "2.13.1-unstable-2026-06-03";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -35,17 +35,9 @@ buildPythonPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "exa-labs";
     repo = "exa-py";
-    rev = "af7f88999763f1cb7e3c4a67f4aa24cef5f6eb11";
-    hash = "sha256-7rLEvjngSRObFdT1DcrZfqWBCsvWVxdNIgxBNhNNk+4=";
+    rev = "42fde906ecd069c15ad4888e1585b395a0db7edf";
+    hash = "sha256-6o4SKAeP5q+57LCbbw5vP7r/dEA1HiQNa9CkopbTlxg=";
   };
-
-  # https://github.com/pytest-dev/pytest-asyncio/issues/658
-  # default behaviour changes with new python version.
-  # planning on trying to vendor upstream
-  postPatch = ''
-    substituteInPlace tests/unit/test_search_monitors.py --replace-fail \
-      'get_event_loop().run_until_complete' 'run'
-  '';
 
   build-system = [
     poetry-core


### PR DESCRIPTION



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
