### PR TITLE
clipse: 1.1.0 -> 1.2.1, add maintainer magicquark, modernise

### DIFF
--- a/pkgs/by-name/cl/clipse/package.nix
+++ b/pkgs/by-name/cl/clipse/package.nix
@@ -33,6 +33,9 @@ buildGoModule (finalAttrs: {
     hash = "sha256-iDMHEhYuxspBYG54WivnVj2GfMxAc5dcrjNxtAMhsck=";
   };
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   vendorHash = "sha256-LxwST4Zjxq6Fwc47VeOdv19J3g/DHZ7Fywp2ZvVR06I=";
 
   tags =

--- a/pkgs/by-name/cl/clipse/package.nix
+++ b/pkgs/by-name/cl/clipse/package.nix
@@ -73,6 +73,9 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/savedra1/clipse";
     license = lib.licenses.mit;
     mainProgram = "clipse";
-    maintainers = [ lib.maintainers.savedra1 ];
+    maintainers = with lib.maintainers; [
+      magicquark
+      savedra1
+    ];
   };
 })

--- a/pkgs/by-name/cl/clipse/package.nix
+++ b/pkgs/by-name/cl/clipse/package.nix
@@ -2,20 +2,71 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  stdenv,
+  enableWayland ? stdenv.hostPlatform.isLinux,
+  enableX11 ? false,
+  libpng,
+  libx11,
+  libxi,
+  libxkbcommon,
+  libxtst,
+  pkg-config,
+  xclip,
+  xinput,
+  xkbcomp,
+  xkbutils,
+  xsel,
 }:
 
+assert lib.assertMsg (
+  stdenv.hostPlatform.isLinux -> (lib.xor enableX11 enableWayland)
+) "Exactly one of enableWayland, enableX11 must be true";
+
 buildGoModule (finalAttrs: {
-  pname = "clipse";
-  version = "1.1.0";
+  pname = "clipse${lib.optionalString enableX11 "-x11"}";
+  version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "savedra1";
     repo = "clipse";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-yUkHT7SZT7Eudvk1n43V+WGWqUKtXaV+p4ySMK/XzQw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-iDMHEhYuxspBYG54WivnVj2GfMxAc5dcrjNxtAMhsck=";
   };
 
-  vendorHash = "sha256-+9uoB/1g4qucdM8RJRs+fSc5hpcgaCK0GrUOFgHWeKo=";
+  vendorHash = "sha256-LxwST4Zjxq6Fwc47VeOdv19J3g/DHZ7Fywp2ZvVR06I=";
+
+  tags =
+    if stdenv.hostPlatform.isDarwin then
+      [ "darwin" ]
+    else if enableWayland then
+      [ "wayland" ]
+    else if enableX11 then
+      [ "linux" ]
+    else
+      [ ];
+
+  env = {
+    CGO_ENABLED = if enableX11 || stdenv.hostPlatform.isDarwin then "1" else "0";
+  };
+
+  nativeBuildInputs = lib.optionals enableX11 [
+    pkg-config
+  ];
+
+  buildInputs = lib.optionals enableX11 [
+    libpng
+    libx11
+    libxi
+    libxkbcommon
+    libxtst
+    xclip
+    xinput
+    xkbcomp
+    xkbutils
+    xsel
+  ];
+
+  proxyVendor = true;
 
   meta = {
     description = "Useful clipboard manager TUI for Unix";

--- a/pkgs/by-name/cl/clipse/package.nix
+++ b/pkgs/by-name/cl/clipse/package.nix
@@ -69,6 +69,7 @@ buildGoModule (finalAttrs: {
   proxyVendor = true;
 
   meta = {
+    changelog = "https://github.com/savedra1/clipse/blob/main/CHANGELOG.md";
     description = "Useful clipboard manager TUI for Unix";
     homepage = "https://github.com/savedra1/clipse";
     license = lib.licenses.mit;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11629,4 +11629,9 @@ with pkgs;
   gpac-unstable = callPackage ../by-name/gp/gpac/package.nix {
     releaseChannel = "unstable";
   };
+
+  clipse-x11 = callPackage ../by-name/cl/clipse/package.nix {
+    enableWayland = false;
+    enableX11 = true;
+  };
 }


### PR DESCRIPTION
### clipse: 1.1.0 -> 1.2.1, add maintainer magicquark, modernise

Supersedes https://github.com/NixOS/nixpkgs/pull/484504.

> In this new version of clipse, the Go build now requires different tags and CGO availability depending on the display server used by the host OS.
> 
> E.g.
> 
>     Wayland: CGO_ENABLED=0 go build -tags wayland -o clipse
>     X11: go build -tags linux -o clipse
>     Darwin: go build -tags darwin -o clipse
> 
> The package has been updated to handle this, using the stdenv library to check for a Darwin host, and defaulting to Wayland unless clipse-x11 is used for the package name (overriding as X11).

I have tested this on Wayland, both `clipse` and `clipse-x11` work, but I have not had a chance to test `clipse-x11` with a native x11 display server.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test