### PR TITLE
octavePackages.instrument-control: Build from source and 0.10.0 -> 0.10.1

### DIFF
--- a/pkgs/development/octave-modules/instrument-control/default.nix
+++ b/pkgs/development/octave-modules/instrument-control/default.nix
@@ -7,13 +7,13 @@
 
 buildOctavePackage rec {
   pname = "instrument-control";
-  version = "0.10.0";
+  version = "0.10.1";
 
   src = fetchFromGitHub {
     owner = "gnu-octave";
     repo = "instrument-control";
     tag = "release-${version}";
-    sha256 = "sha256-eXlH7BFRh4Vq/2LiBsmTvZNhXm4IbeCHK+OsKMQI0tY=";
+    sha256 = "sha256-oasZryYK/KgrIMZWU6j8g24MJMr5R6LwPvuqojAXbm4=";
   };
 
   passthru.updateScript = nix-update-script {

--- a/pkgs/development/octave-modules/instrument-control/default.nix
+++ b/pkgs/development/octave-modules/instrument-control/default.nix
@@ -3,6 +3,8 @@
   lib,
   fetchFromGitHub,
   nix-update-script,
+  pkg-config,
+  autoreconfHook,
 }:
 
 buildOctavePackage rec {
@@ -15,6 +17,26 @@ buildOctavePackage rec {
     tag = "release-${version}";
     sha256 = "sha256-oasZryYK/KgrIMZWU6j8g24MJMr5R6LwPvuqojAXbm4=";
   };
+
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+  ];
+
+  # autoreconfHook provides an autoreconfPhase that is run as a
+  # preconfigurePhase, which means it runs AFTER the source is un-tarred, and
+  # before buildOctavePackage's buildPhase re-tars it up into a format for later
+  # consumption by Octave's "pkg build" command.
+  preAutoreconf = ''
+    pushd src
+    # Upstream's bootstrap script uses wget to fetch config.guess & config.sub
+    # and has them committed to the repository. We must remove them so autoreconf
+    # actually fires for our environment.
+    rm config.*
+  '';
+  postAutoreconf = ''
+    popd
+  '';
 
   passthru.updateScript = nix-update-script {
     extraArgs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Same 0.10.0 -> 0.10.1 update from #525845. Now we build from source so more tests can pass in CI.

It is not easy to run the unit tests, because those open both UDP and TCP connections to remote servers to determine if all features are functioning. This may have to remain a package that requires manual supervision, unless someone comes along and figures out the nice way to handle this in Nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
