### PR TITLE
stdenv: do not pass crossOverlays redundantly

### DIFF
--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -4,7 +4,7 @@
   crossSystem,
   config,
   overlays,
-  crossOverlays ? [ ],
+  crossOverlays,
 }:
 
 let

--- a/pkgs/stdenv/custom/default.nix
+++ b/pkgs/stdenv/custom/default.nix
@@ -4,7 +4,6 @@
   crossSystem,
   config,
   overlays,
-  crossOverlays ? [ ],
 }:
 
 assert crossSystem == localSystem;

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -13,7 +13,6 @@
   crossSystem,
   config,
   overlays,
-  crossOverlays ? [ ],
   # Allow passing in bootstrap files directly so we can test the stdenv bootstrap process when changing the bootstrap tools
   bootstrapFiles ? (config.replaceBootstrapFiles or lib.id) (
     if localSystem.isAarch64 then

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -13,31 +13,40 @@
   config,
   overlays,
   crossOverlays ? [ ],
-}@args:
+}:
 
 let
+  commonArgs = {
+    inherit
+      lib
+      localSystem
+      crossSystem
+      config
+      overlays
+      ;
+  };
   # The native (i.e., impure) build environment.  This one uses the
   # tools installed on the system outside of the Nix environment,
   # i.e., the stuff in /bin, /usr/bin, etc.  This environment should
   # be used with care, since many Nix packages will not build properly
   # with it (e.g., because they require GNU Make).
-  stagesNative = import ./native args;
+  stagesNative = import ./native commonArgs;
 
   # The Nix build environment.
-  stagesNix = import ./nix (args // { bootStages = stagesNative; });
+  stagesNix = import ./nix (commonArgs // { bootStages = stagesNative; });
 
-  stagesFreeBSD = import ./freebsd args;
+  stagesFreeBSD = import ./freebsd commonArgs;
 
   # On Linux systems, the standard build environment consists of Nix-built
   # instances glibc and the `standard' Unix tools, i.e., the Posix utilities,
   # the GNU C compiler, and so on.
-  stagesLinux = import ./linux args;
+  stagesLinux = import ./linux commonArgs;
 
-  stagesDarwin = import ./darwin args;
+  stagesDarwin = import ./darwin commonArgs;
 
-  stagesCross = import ./cross args;
+  stagesCross = import ./cross (commonArgs // { inherit crossOverlays; });
 
-  stagesCustom = import ./custom args;
+  stagesCustom = import ./custom commonArgs;
 
 in
 # Select the appropriate stages for the platform `system'.

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -12,7 +12,7 @@
   crossSystem,
   config,
   overlays,
-  crossOverlays ? [ ],
+  crossOverlays,
 }:
 
 let

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -6,7 +6,6 @@
   crossSystem,
   config,
   overlays,
-  crossOverlays ? [ ],
   bootstrapFiles ?
     let
       table = {

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -59,8 +59,6 @@
   crossSystem,
   config,
   overlays,
-  crossOverlays ? [ ],
-
   bootstrapFiles ?
     let
       table = {

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -4,7 +4,6 @@
   crossSystem,
   config,
   overlays,
-  crossOverlays ? [ ],
 }:
 
 assert crossSystem == localSystem;

--- a/pkgs/stdenv/nix/default.nix
+++ b/pkgs/stdenv/nix/default.nix
@@ -1,11 +1,10 @@
 {
   lib,
-  crossSystem,
   localSystem,
+  crossSystem,
   config,
   overlays,
   bootStages,
-  ...
 }:
 
 assert crossSystem == localSystem;

--- a/pkgs/top-level/impure.nix
+++ b/pkgs/top-level/impure.nix
@@ -44,8 +44,6 @@ in
   # fix-point made by Nixpkgs.
   overlays ? import ./impure-overlays.nix,
 
-  crossOverlays ? [ ],
-
   ...
 }@args:
 


### PR DESCRIPTION
Two small, non-functional cleanups to how crossOverlays is threaded through stdenv bootstrapping. No change in evaluated output — purely tightens the internal interface. Also avoids `@args` pattern

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
