### PR TITLE
isl{,_0_2{0,3,7}}, libffi{,Real,_3_3}, darwin.libffi: using `nixpkgs.hostPlatform.gcc.arch` as the value of config `--with-gcc-arch`

### DIFF
--- a/pkgs/by-name/li/libffiReal/package.nix
+++ b/pkgs/by-name/li/libffiReal/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   configureFlags = [
-    "--with-gcc-arch=generic" # no detection of -march= or -mtune=
+    "--with-gcc-arch=${stdenv.hostPlatform.gcc.arch or "unknown"}" # https://github.com/libffi/libffi/blob/30c03c63aca3d1f5d7e9ce43de5b2edce930b0e5/m4/ax_gcc_archflag.m4
     "--enable-pax_emutramp"
   ];
 

--- a/pkgs/by-name/li/libffi_3_3/package.nix
+++ b/pkgs/by-name/li/libffi_3_3/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   configureFlags = [
-    "--with-gcc-arch=generic" # no detection of -march= or -mtune=
+    "--with-gcc-arch=${stdenv.hostPlatform.gcc.arch or "unknown"}" # https://github.com/libffi/libffi/blob/30c03c63aca3d1f5d7e9ce43de5b2edce930b0e5/m4/ax_gcc_archflag.m4
     "--enable-pax_emutramp"
 
     # Causes issues in downstream packages which misuse ffi_closure_alloc

--- a/pkgs/development/libraries/isl/0.20.0.nix
+++ b/pkgs/development/libraries/isl/0.20.0.nix
@@ -5,7 +5,4 @@ import ./generic.nix rec {
     "https://libisl.sourceforge.io/isl-${version}.tar.xz"
   ];
   sha256 = "1akpgq0rbqbah5517blg2zlnfvjxfcl9cjrfc75nbcx5p2gnlnd5";
-  configureFlags = [
-    "--with-gcc-arch=generic" # don't guess -march=/mtune=
-  ];
 }

--- a/pkgs/development/libraries/isl/0.23.0.nix
+++ b/pkgs/development/libraries/isl/0.23.0.nix
@@ -5,7 +5,4 @@ import ./generic.nix rec {
     "https://libisl.sourceforge.io/isl-${version}.tar.xz"
   ];
   sha256 = "sha256-XvxT767xUTAfTn3eOFa2aBLYFT3t4k+rF2c/gByGmPI=";
-  configureFlags = [
-    "--with-gcc-arch=generic" # don't guess -march=/mtune=
-  ];
 }

--- a/pkgs/development/libraries/isl/0.27.0.nix
+++ b/pkgs/development/libraries/isl/0.27.0.nix
@@ -5,7 +5,4 @@ import ./generic.nix rec {
     "https://libisl.sourceforge.io/isl-${version}.tar.xz"
   ];
   sha256 = "sha256-bYurtZ57Zy6Mt4cOh08/e4E7bgDmrz+LBPdXmWVkPVw=";
-  configureFlags = [
-    "--with-gcc-arch=generic" # don't guess -march=/mtune=
-  ];
 }

--- a/pkgs/development/libraries/isl/generic.nix
+++ b/pkgs/development/libraries/isl/generic.nix
@@ -2,7 +2,6 @@
   version,
   urls,
   sha256,
-  configureFlags ? [ ],
   patches ? [ ],
 }:
 
@@ -38,7 +37,9 @@ stdenv.mkDerivation {
     ];
   buildInputs = [ gmp ];
 
-  inherit configureFlags;
+  configureFlags = [
+    "--with-gcc-arch=${stdenv.hostPlatform.gcc.arch or "unknown"}" # https://repo.or.cz/isl.git/blob/24244001b17ffaebf3df5a668e8f6ca8697e99da:/m4/ax_gcc_archflag.m4
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/os-specific/darwin/by-name/li/libffi/package.nix
+++ b/pkgs/os-specific/darwin/by-name/li/libffi/package.nix
@@ -47,7 +47,7 @@ mkAppleDerivation (finalAttrs: {
   ];
 
   configureFlags = [
-    "--with-gcc-arch=generic" # no detection of -march= or -mtune=
+    "--with-gcc-arch=${stdenv.hostPlatform.gcc.arch or "unknown"}" # https://github.com/libffi/libffi/blob/30c03c63aca3d1f5d7e9ce43de5b2edce930b0e5/m4/ax_gcc_archflag.m4
     "--enable-builddir=build"
   ];
 


### PR DESCRIPTION
using `nixpkgs.hostPlatform.gcc.arch` as the value of config `--with-gcc-arch` from https://www.gnu.org/software/autoconf-archive/ax_gcc_archflag.html and defaults this config to `x86-64` instead of `generic` as it's not an valid value of `-march` but `-mtune`: https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html#index-mtune-16

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
