### PR TITLE
freetype: add patches for four vulnerabilities from project zero

### DIFF
--- a/pkgs/by-name/fr/freetype/package.nix
+++ b/pkgs/by-name/fr/freetype/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   buildPackages,
   pkgsHostHost,
   pkg-config,
@@ -69,6 +70,53 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./enable-table-validation.patch
+
+    # https://project-zero.issues.chromium.org/issues/505355061
+    # https://gitlab.freedesktop.org/freetype/freetype/-/work_items/1419
+    # https://gitlab.freedesktop.org/freetype/freetype/-/work_items/1420
+    (fetchpatch {
+      name = "truetype-shz-limit-heap-buffer-overflow-part1.patch";
+      url = "https://gitlab.freedesktop.org/freetype/freetype/-/commit/1803559c4ee407d0bcbf2a67dbe96690cee869d2.patch";
+      hash = "sha256-zxtJ2pJz8pNofgYrJ6c8/eZqRvxTotanF2IdU9ckpM4=";
+    })
+    (fetchpatch {
+      name = "truetype-shz-limit-heap-buffer-overflow-part2.patch";
+      url = "https://gitlab.freedesktop.org/freetype/freetype/-/commit/7d600a022e1d813e85a8c94ffd395f6135872267.patch";
+      hash = "sha256-aHE11C9Cr23D2lqNmTVUDA5E07xxUm+AcYdWJG9zLFs=";
+    })
+
+    # https://project-zero.issues.chromium.org/issues/505357209
+    # https://gitlab.freedesktop.org/freetype/freetype/-/work_items/1421
+    (fetchpatch {
+      name = "truetype-iup-integer-overflow.patch";
+      url = "https://gitlab.freedesktop.org/freetype/freetype/-/commit/7974be74d8b5a2fbf99aa88f0461d1f80af51cee.patch";
+      hash = "sha256-b5Px0ALsnC5K1+601YioAjCLkLVXNnvTIZ1aQtCeNoQ=";
+    })
+
+    # https://project-zero.issues.chromium.org/issues/506902245
+    # https://gitlab.freedesktop.org/freetype/freetype/-/work_items/1423
+    # https://gitlab.freedesktop.org/freetype/freetype/-/merge_requests/428
+    (fetchpatch {
+      name = "truetype-variation-handling-signednes-mismatch.patch";
+      url = "https://gitlab.freedesktop.org/freetype/freetype/-/commit/0d45c7f1911bc6db0bf072eea0c8cdccd77bc6b3.patch";
+      hash = "sha256-bw/9O86sZQa+vwdgx2MTqxWi6vjMcRTyC42ba9CaZ3I=";
+    })
+
+    # prerequisite for the below to apply, since this changes formatting of
+    # affected code.
+    (fetchpatch {
+      name = "ftobjs-formatting.patch";
+      url = "https://gitlab.freedesktop.org/freetype/freetype/-/commit/590b77014bd920d0bdf64c039fddbce89a288b83.patch";
+      hash = "sha256-govOzLBzQMAjSKABVFryDnSn2by2f/W9BgGG3o+qSuE=";
+    })
+
+    # https://project-zero.issues.chromium.org/issues/507321912
+    # https://gitlab.freedesktop.org/freetype/freetype/-/work_items/1425
+    (fetchpatch {
+      name = "sub-byte-bitmaps-heap-buffer-over-read.patch";
+      url = "https://gitlab.freedesktop.org/freetype/freetype/-/commit/cbe12767ea73d1006edc75fcd61c0b0d2a88f34e.patch";
+      hash = "sha256-jMeqY9uX7Ryfdd8icGDT4kEKl6aGRWafSN8GzOhGW7g=";
+    })
   ]
   ++ lib.optional useEncumberedCode ./enable-subpixel-rendering.patch;
 


### PR DESCRIPTION
see https://seclists.org/oss-sec/2026/q2/822.

issues:
- https://gitlab.freedesktop.org/freetype/freetype/-/work_items/1419 / https://gitlab.freedesktop.org/freetype/freetype/-/work_items/1420
- https://gitlab.freedesktop.org/freetype/freetype/-/work_items/1421
- https://gitlab.freedesktop.org/freetype/freetype/-/work_items/1423
- https://gitlab.freedesktop.org/freetype/freetype/-/work_items/1425

we believe this is all of the relevant commits, from looking through the issues and commit history. however, it is somewhat hard to tell in the absence of a release or patches from another distro (especially for the first, which mentions "and several follow-up commits").

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`. (working on it, but that's a lot of builds with the stdenv rebuilds that were merged this morning. will leave running overnight)
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
