### PR TITLE
python3: include ABI debug suffix `d` in `executable` (fixes FT+debug)

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -202,6 +202,7 @@ let
         in
         python;
       pythonVersion = with sourceVersion; "${major}.${minor}";
+      abiFlags = lib.optionalString (!enableGIL) "t" + lib.optionalString enableDebug "d";
       libPrefix = "python${pythonVersion}${lib.optionalString (!enableGIL) "t"}";
     in
     passthruFun {
@@ -213,7 +214,7 @@ let
         pythonVersion
         ;
       implementation = "cpython";
-      executable = libPrefix;
+      executable = "python${pythonVersion}${abiFlags}";
       sitePackages = "lib/${libPrefix}/site-packages";
       inherit hasDistutilsCxxPatch pythonAttr;
       inherit (splices)
@@ -227,7 +228,7 @@ let
       pythonABITags = [
         "abi3"
         "none"
-        "cp${sourceVersion.major}${sourceVersion.minor}${lib.optionalString (!enableGIL) "t"}"
+        "cp${sourceVersion.major}${sourceVersion.minor}${abiFlags}"
       ];
     };
 


### PR DESCRIPTION
When instantiating an environment with the Python interpreter built with both free threading (aka. without GIL) and `pydebug`, the value of `passthru.executable` doesn't match any installed file. This was noticed when building CI pipelines that require the Python interpreter built with both debug features and free threading.

The cause is that `executable` was built from `libPrefix`, which only tracks the `t` suffix from `--without-gil` and not the `d` suffix from `--with-pydebug`. `libPrefix` doubles as the stdlib install directory, and cpython deliberately shares that directory between debug and non-debug builds of a given version, so the `d` is intentionally absent there.

This slipped through because cpython only ever installs a `python$VERSION -> python$LDVERSION` symlink (e.g. `python3.13 -> python3.13d`). For debug-only builds the old code happened to ask for `python3.13`, which is that symlink, so it worked by accident. For FT+debug, `libPrefix` is `python3.13t`, but cpython installs no such file; only `python3.13` (symlink) and `python3.13td` (binary).

Fix: append `d` to `executable` (and to the `cp<ver>` wheel ABI tag in `pythonABITags`) when `enableDebug` is true.

Reproducer for the problem as a bash script:

```bash
set -euo pipefail

nixpkgs="${1:-<nixpkgs>}" # Either custom path if provided, or just <nixpkgs>

read -r -d '' expr <<EOF || true
let
  pkgs = import ${nixpkgs} { };
  py = pkgs.python313FreeThreading.override {
    enableDebug = true;
    self = py;
    pythonAttr = "python313FreeThreading";
  };
in py
EOF

executable=$(nix-instantiate --eval --json --expr "($expr).executable" | tr -d '"')
echo "passthru.executable = ${executable}"

out=$(nix-build --no-out-link --expr "$expr")
echo "store path:           ${out}"

if [[ -e "${out}/bin/${executable}" ]]; then
  echo "result:               OK (binary exists)"
  exit 0
fi

echo "result:               FAIL (${out}/bin/${executable} not found)"
echo "actually installed:"
ls "${out}/bin/" | grep '^python3\.' | sed 's/^/  /'
exit 1
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
