### PR TITLE
lib.attrsets.mergeAttrsList: small arithmetic performance improvements

### DIFF
--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -1612,13 +1612,15 @@ rec {
       binaryMerge =
         start: end:
         # assert start < end; # Invariant
-        if end - start >= 2 then
-          # If there's at least 2 elements, split the range in two, recurse on each part and merge the result
-          # The invariant is satisfied because each half will have at least 1 element
-          binaryMerge start ((start + end) / 2) // binaryMerge ((start + end) / 2) end
+        if end - start == 1 then
+          # Base case - there will be exactly 1 element due to the invariant, in
+          # which case we just return it directly
+          elemAt list start
         else
-          # Otherwise there will be exactly 1 element due to the invariant, in which case we just return it directly
-          elemAt list start;
+          # If there's at least 2 elements, split the range in two, recurse on each part and merge the result
+          # Relies on floor for odd results
+          # The invariant is satisfied because each half will have at least 1 element
+          binaryMerge start ((start + end) / 2) // binaryMerge ((start + end) / 2) end;
     in
     if list == [ ] then
       # Calling binaryMerge as below would not satisfy its invariant

--- a/lib/attrsets.nix
+++ b/lib/attrsets.nix
@@ -1615,7 +1615,7 @@ rec {
         if end - start >= 2 then
           # If there's at least 2 elements, split the range in two, recurse on each part and merge the result
           # The invariant is satisfied because each half will have at least 1 element
-          binaryMerge start (start + (end - start) / 2) // binaryMerge (start + (end - start) / 2) end
+          binaryMerge start ((start + end) / 2) // binaryMerge ((start + end) / 2) end
         else
           # Otherwise there will be exactly 1 element due to the invariant, in which case we just return it directly
           elemAt list start;


### PR DESCRIPTION
I was testing out `mergeAttrsList` for https://github.com/NixOS/nixpkgs/issues/528515#issuecomment-4636248192, to see if it won out for long lists. While looking at it, I realized that we could clean up the arithmetic - calculating the midpoint and checking for the base case faster. I wasn't sure if this would actually make a real-time difference, but on my 250k element bench, it brought me from:
```sh
Benchmark 1: nix-instantiate --eval --strict ./benchmark.nix -A output2a > /dev/null
  Time (mean ± σ):     886.3 ms ±  10.8 ms    [User: 689.9 ms, System: 190.0 ms]
  Range (min … max):   868.7 ms … 906.2 ms    20 runs
```
to:
```sh
Benchmark 1: nix-instantiate --eval --strict ./benchmark.nix -A output2b > /dev/null
  Time (mean ± σ):     846.4 ms ±   9.4 ms    [User: 651.4 ms, System: 187.7 ms]
  Range (min … max):   833.3 ms … 869.5 ms    20 runs
```
I was hoping to see a similar win for by-name, but the difference there was relatively miniscule.
```sh
# before
Benchmark 1: nix eval --expr 'import ./pkgs/top-level/by-name-overlay.nix ./pkgs/by-name' --impure
  Time (mean ± σ):      74.7 ms ±   1.7 ms    [User: 45.4 ms, System: 29.0 ms]
  Range (min … max):    71.7 ms …  84.8 ms    200 runs
# after
Benchmark 1: nix eval --expr 'import ./pkgs/top-level/by-name-overlay.nix ./pkgs/by-name' --impure
  Time (mean ± σ):      74.9 ms ±   1.3 ms    [User: 45.4 ms, System: 29.2 ms]
  Range (min … max):    71.9 ms …  79.7 ms    200 runs
```
But the stats for by-name are happy!
```json
{
  "attrset": {
    "lookups": null,
    "merges": null,
    "mergeCopies": null
  },
  "list": {
    "concats": false
  },
  "parser": {
    "expressions": "-0.28%"
  },
  "memory": {
    "envs": null,
    "list": null,
    "sets": null,
    "symbols": null,
    "values": "-2.96%",
    "total": "-0.43%"
  },
  "speed": {
    "primops": "-36.32%",
    "functionCalls": null,
    "thunksMade": "-20.18%",
    "thunksAvoided": "-37.42%"
  }
}
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
