### PR TITLE
tests.overriding: attach fetchgit tests

### DIFF
--- a/pkgs/test/overriding.nix
+++ b/pkgs/test/overriding.nix
@@ -226,9 +226,11 @@ let
 
   tests-fetchurl =
     let
+      fakeSha256-1 = genNonzeroFakeHash lib.fakeSha256 "1";
+      fakeHash-2 = genNonzeroFakeHash lib.fakeHash "B";
       src-with-sha256 = pkgs.fetchurl {
         url = "https://example.com/source.tar.gz";
-        sha256 = lib.fakeSha256;
+        sha256 = fakeSha256-1;
       };
     in
     {
@@ -240,19 +242,19 @@ let
             ;
         };
         expected = {
-          outputHash = lib.fakeSha256;
+          outputHash = fakeSha256-1;
           outputHashAlgo = "sha256";
         };
       };
       test-fetchurl-overrideAttrs-hash = {
         expr = {
-          inherit (src-with-sha256.overrideAttrs { hash = pkgs.hello.src.hash; })
+          inherit (src-with-sha256.overrideAttrs { hash = fakeHash-2; })
             outputHash
             outputHashAlgo
             ;
         };
         expected = {
-          outputHash = pkgs.hello.src.hash;
+          outputHash = fakeHash-2;
           outputHashAlgo = null;
         };
       };

--- a/pkgs/test/overriding.nix
+++ b/pkgs/test/overriding.nix
@@ -148,11 +148,41 @@ let
       };
     };
 
+  /**
+    Take two positional arguments `fakeHash` and `partialHash`,
+    and return a modified version of fakeHash whose hash body is partially substituted by `partialHash` from the beginning,
+    used to assert a specific fake hash variant is used by an overridden FOD.
+
+    # Inputs
+
+    `fakeHash`
+
+    : The specified zero fake hash
+
+    `partialHash`
+
+    : A trimmed non-zero hash body, to substitute the beginning of the zero hash body.
+  */
+  genNonzeroFakeHash =
+    fakeHash:
+    let
+      isSRIHash = lib.hasInfix "-" fakeHash;
+      defaultHashAlgo = lib.optionalString isSRIHash lib.head (lib.splitString "-" lib.fakeHash);
+      defaultHashPrefix = lib.optionalString isSRIHash (defaultHashAlgo + "-");
+      defaultHashBody = lib.removePrefix defaultHashPrefix fakeHash;
+    in
+    partialHash:
+    defaultHashPrefix
+    + partialHash
+    + (lib.substring (lib.stringLength partialHash) (lib.stringLength defaultHashBody) defaultHashBody);
+
   tests-fetchgit =
     let
+      fakeSha256-1 = genNonzeroFakeHash lib.fakeSha256 "1";
+      fakeHash-2 = genNonzeroFakeHash lib.fakeHash "B";
       src-with-sha256 = pkgs.fetchgit {
         url = "https://example.com/source.git";
-        sha256 = lib.fakeSha256;
+        sha256 = fakeSha256-1;
       };
     in
     {
@@ -164,19 +194,19 @@ let
             ;
         };
         expected = {
-          outputHash = lib.fakeSha256;
+          outputHash = fakeSha256-1;
           outputHashAlgo = "sha256";
         };
       };
       test-fetchgit-overrideAttrs-hash = {
         expr = {
-          inherit (src-with-sha256.overrideAttrs { hash = pkgs.nix.src.hash; })
+          inherit (src-with-sha256.overrideAttrs { hash = fakeHash-2; })
             outputHash
             outputHashAlgo
             ;
         };
         expected = {
-          outputHash = pkgs.nix.src.hash;
+          outputHash = fakeHash-2;
           outputHashAlgo = null;
         };
       };

--- a/pkgs/test/overriding.nix
+++ b/pkgs/test/overriding.nix
@@ -8,6 +8,7 @@ let
   tests =
     tests-stdenv
     // test-extendMkDerivation
+    // tests-fetchgit
     // tests-fetchhg
     // tests-fetchurl
     // tests-go


### PR DESCRIPTION
`tests-fetchgit` was implemented in PR #463871 but not attach to `tests.overriding`, hence this fix.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
