### PR TITLE
nixos/nspawn-container: add `virtualisation.writableStore`

### DIFF
--- a/nixos/doc/manual/development/writing-nixos-tests.section.md
+++ b/nixos/doc/manual/development/writing-nixos-tests.section.md
@@ -165,6 +165,14 @@ machines in a NixOS test, whether they are virtual machines or containers:
     [`nat.nix`](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests/nat.nix)
     for an example.
 
+`virtualisation.writableStore`
+
+:   By default, the Nix store in the test is not writable. If you enable
+    this option, a writable union file system is mounted on top of the
+    Nix store to make it appear writable. This is necessary for tests
+    that run Nix operations that modify the store. The QEMU test driver
+    uses `overlayfs` for this; the nspawn test driver uses bind mounts.
+
 #### Configuring `systemd-nspawn` containers {#ssec-nixos-test-nspawn-containers}
 
 Some options are specific to `systemd-nspawn` containers:
@@ -192,14 +200,6 @@ Some options are specific to QEMU virtual machines:
 `virtualisation.memorySize`
 
 :   The memory of the VM in MiB (1024×1024 bytes).
-
-
-`virtualisation.writableStore`
-
-:   By default, the Nix store in the VM is not writable. If you enable
-    this option, a writable union file system is mounted on top of the
-    Nix store to make it appear writable. This is necessary for tests
-    that run Nix operations that modify the store.
 
 For more options, see the module
 [`qemu-vm.nix`](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/virtualisation/qemu-vm.nix).

--- a/nixos/modules/virtualisation/nspawn-container/default.nix
+++ b/nixos/modules/virtualisation/nspawn-container/default.nix
@@ -63,6 +63,18 @@ in
       };
 
     };
+
+    virtualisation.writableStore = lib.mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Makes the container's `/nix/store` writable so new paths can be pushed
+        into the running container, e.g. by `nix-copy-closure --to`. Less
+        efficient than the read-only default. Unlike the overlay-based VM store
+        (`qemu-vm.nix`), store paths already in the container's closure cannot
+        be modified; only new paths can be added.
+      '';
+    };
   };
 
   config = {
@@ -113,8 +125,11 @@ in
     virtualisation.systemd-nspawn.options = [
       "--private-network"
       "--machine=${config.system.name}"
-      "--bind-ro=/nix/store:/nix/store"
-
+    ]
+    # With a writable store the wrapper below binds a per-container store
+    # clone over `/nix/store`, so drop the read-only host-store bind here.
+    ++ lib.optional (!cfg.writableStore) "--bind-ro=/nix/store:/nix/store"
+    ++ [
       # systemd-nspawn does some cleverness to mount a procfs and sysfs in an
       # unprivileged container, see
       # <https://github.com/systemd/systemd/blob/v258.2/src/nspawn/nspawn.c#L4341-L4349>.
@@ -146,9 +161,27 @@ in
           init = "${config.system.build.toplevel}/init";
           cmdline-json = builtins.toJSON cfg.cmdline;
         };
+
+        # store paths to bind into the writable store
+        closure = pkgs.closureInfo {
+          rootPaths = [ config.system.build.toplevel ];
+        };
+
+        # binds: writable store + read-only `closure` paths (only known at run-time)
+        stageWritableStore = ''
+          : "''${RUN_NSPAWN_STORE_DIR:=$PWD/${config.system.name}-store}"
+          ${pkgs.coreutils}/bin/mkdir -p "$RUN_NSPAWN_STORE_DIR"
+          while IFS= read -r entry; do
+            set -- "--bind=$entry:/nix/store/''${entry##*/}" "$@"
+          done < ${closure}/store-paths
+          set -- "--bind=$RUN_NSPAWN_STORE_DIR:/nix/store" "$@"
+        '';
       in
       pkgs.writers.writeDashBin "run-${config.system.name}-nspawn" ''
-        exec ${lib.getExe run-nspawn} ${commandLineOptions} ${lib.escapeShellArgs config.virtualisation.systemd-nspawn.options} "$@"
+        set -eu
+        ${lib.optionalString cfg.writableStore stageWritableStore}
+        exec ${lib.getExe run-nspawn} ${commandLineOptions} \
+          ${lib.escapeShellArgs config.virtualisation.systemd-nspawn.options} "$@"
       '';
   };
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -152,6 +152,7 @@ in
     ssh-backdoor = runTestOn [ "x86_64-linux" ] ./nixos-test-driver/ssh-backdoor.nix;
     console-log = runTest ./nixos-test-driver/console-log.nix;
     containers = runTest ./nixos-test-driver/containers.nix;
+    nspawn-writable-store = runTest ./nixos-test-driver/nspawn-writable-store.nix;
     skip-typecheck = runTest ./nixos-test-driver/skip-typecheck.nix;
     driver-timeout =
       pkgs.runCommand "ensure-timeout-induced-failure"

--- a/nixos/tests/nixos-test-driver/nspawn-writable-store.nix
+++ b/nixos/tests/nixos-test-driver/nspawn-writable-store.nix
@@ -1,0 +1,37 @@
+{ lib, ... }:
+{
+  name = "nspawn-writable-store";
+
+  meta.maintainers = with lib.maintainers; [ kiara ];
+
+  containers = {
+    writable = {
+      virtualisation.writableStore = true;
+    };
+
+    readonly = {
+      virtualisation.writableStore = false;
+    };
+  };
+
+  testScript = ''
+    build_derivation = """
+      nix-build --option substitute false -E 'derivation {
+        name = "t";
+        builder = "/bin/sh";
+        args = ["-c" "echo something > $out"];
+        system = builtins.currentSystem;
+        preferLocalBuild = true;
+      }'
+    """
+
+    writable.start()
+    readonly.start()
+
+    with subtest("Nix store is writable"):
+      writable.succeed(build_derivation)
+
+    with subtest("Nix store is read only"):
+      readonly.fail(build_derivation)
+  '';
+}


### PR DESCRIPTION
Add an option `virtualisation.writableStore` to the nspawn test driver mirroring the QEMU driver's [existing option](https://search.nixos.org/options?query=virtualisation.writableStore#show=option%253Avirtualisation.writableStore).

By default the container shares the host `/nix/store` read-only, which is efficient but prevents pushing new paths into a running container (e.g. via `nix-copy-closure --to` during a deployment). Add an opt-in `virtualisation.writableStore` that, when enabled, stages a per-container writable store: the launcher bind-mounts each top-level host store entry into a writable backing directory as a real path, then binds that over `/nix/store`. New paths land alongside the bind-mounts in the writable backing.

A writable overlayfs (as `qemu-vm.nix` uses) is not viable here: the kernel rejects an overlay upper inside the nested user namespaces of the Nix build sandbox where these containers run. Real bind-mounts are used rather than `cp -al` (cross-device against the sandbox's separate store bind mount) or a symlink farm (`nix-daemon` rejects symlinked top-level store entries).

The option defaults to `false`, preserving the existing read-only bind.

Disclaimer: I used a coding agent in the creation of this patch.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
      - `nix-build -A nixosTests.nixos-test-driver.nspawn-writable-store`
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
