### PR TITLE
maintainers: drop cameronfyfe

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4426,12 +4426,6 @@
     githubId = 54632731;
     name = "Cameron Dugan";
   };
-  cameronfyfe = {
-    email = "cameron.j.fyfe@gmail.com";
-    github = "cameronfyfe";
-    githubId = 21013281;
-    name = "Cameron Fyfe";
-  };
   cameronnemo = {
     email = "cnemo@tutanota.com";
     github = "CameronNemo";

--- a/pkgs/by-name/ca/cargo-risczero/package.nix
+++ b/pkgs/by-name/ca/cargo-risczero/package.nix
@@ -49,6 +49,6 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "cargo-risczero";
     homepage = "https://risczero.com";
     license = with lib.licenses; [ asl20 ];
-    maintainers = with lib.maintainers; [ cameronfyfe ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/du/dumbpipe/package.nix
+++ b/pkgs/by-name/du/dumbpipe/package.nix
@@ -46,7 +46,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       asl20
       mit
     ];
-    maintainers = with lib.maintainers; [ cameronfyfe ];
+    maintainers = [ ];
     mainProgram = "dumbpipe";
   };
 })

--- a/pkgs/by-name/et/ets/package.nix
+++ b/pkgs/by-name/et/ets/package.nix
@@ -40,7 +40,7 @@ buildGoModule (finalAttrs: {
     description = "Command output timestamper";
     homepage = "https://github.com/gdubicki/ets/";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ cameronfyfe ];
+    maintainers = [ ];
     mainProgram = "ets";
   };
 })

--- a/pkgs/by-name/pr/present-cli/package.nix
+++ b/pkgs/by-name/pr/present-cli/package.nix
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage {
     description = "Script interpolation engine for markdown documents";
     homepage = "https://github.com/terror/present/";
     license = lib.licenses.cc0;
-    maintainers = with lib.maintainers; [ cameronfyfe ];
+    maintainers = [ ];
     mainProgram = "present";
   };
 }

--- a/pkgs/by-name/se/sendme/package.nix
+++ b/pkgs/by-name/se/sendme/package.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       asl20
       mit
     ];
-    maintainers = with lib.maintainers; [ cameronfyfe ];
+    maintainers = [ ];
     mainProgram = "sendme";
   };
 })

--- a/pkgs/tools/networking/iroh/default.nix
+++ b/pkgs/tools/networking/iroh/default.nix
@@ -45,7 +45,6 @@ let
         ];
         maintainers = with lib.maintainers; [
           andreashgk
-          cameronfyfe
         ];
         mainProgram = name;
       };


### PR DESCRIPTION
No [comments](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Acameronfyfe) since October 2025 despite 15 [review requests](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+created%3A%3E%3D2025-11-01+user-review-requested%3Acameronfyfe). Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/33954594ec46166510795930ba8ebf0856249d4e/maintainers/README.md#losing-maintainer-status).

@cameronfyfe if you object to being dropped please respond saying so within a week. Even if you don't make it, you are of course welcome back whenever you would like!



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
