### PR TITLE
python3Packages.basemap-data: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/basemap-data/default.nix
+++ b/pkgs/development/python-modules/basemap-data/default.nix
@@ -1,13 +1,16 @@
 {
   lib,
   buildPythonPackage,
+  setuptools,
   basemap,
 }:
 
 buildPythonPackage rec {
   pname = "basemap-data";
-  format = "setuptools";
+  pyproject = true;
   inherit (basemap) version src;
+
+  build-system = [ setuptools ];
 
   sourceRoot = "${src.name}/data/basemap_data";
 

--- a/pkgs/development/python-modules/basemap-data/default.nix
+++ b/pkgs/development/python-modules/basemap-data/default.nix
@@ -5,14 +5,14 @@
   basemap,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "basemap-data";
   pyproject = true;
   inherit (basemap) version src;
 
   build-system = [ setuptools ];
 
-  sourceRoot = "${src.name}/data/basemap_data";
+  sourceRoot = "${finalAttrs.src.name}/data/basemap_data";
 
   # no tests
   doCheck = false;
@@ -28,4 +28,4 @@ buildPythonPackage rec {
     ];
     teams = [ lib.teams.geospatial ];
   };
-}
+})


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
