### PR TITLE
python3Packages.bashlex: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/bashlex/default.nix
+++ b/pkgs/development/python-modules/bashlex/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   python,
+  setuptools,
   pytestCheckHook,
 }:
 
@@ -10,7 +11,7 @@ buildPythonPackage rec {
   pname = "bashlex";
   version = "0.18";
 
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "idank";
@@ -18,6 +19,8 @@ buildPythonPackage rec {
     rev = version;
     hash = "sha256-ddZN91H95RiTLXx4lpES1Dmz7nNsSVUeuFuOEpJ7LQI=";
   };
+
+  build-system = [ setuptools ];
 
   # workaround https://github.com/idank/bashlex/issues/51
   preBuild = ''

--- a/pkgs/development/python-modules/bashlex/default.nix
+++ b/pkgs/development/python-modules/bashlex/default.nix
@@ -7,16 +7,18 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "bashlex";
   version = "0.18";
 
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "idank";
     repo = "bashlex";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-ddZN91H95RiTLXx4lpES1Dmz7nNsSVUeuFuOEpJ7LQI=";
   };
 
@@ -37,4 +39,4 @@ buildPythonPackage rec {
     homepage = "https://github.com/idank/bashlex";
     maintainers = with lib.maintainers; [ multun ];
   };
-}
+})


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
