### PR TITLE
python3Packages.basiciw: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/basiciw/default.nix
+++ b/pkgs/development/python-modules/basiciw/default.nix
@@ -8,16 +8,18 @@
   isPyPy,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "basiciw";
   version = "0.2.2";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   disabled = isPyPy;
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "1ajmflvvlkflrcmqmkrx0zaira84z8kv4ssb2jprfwvjh8vfkysb";
+    inherit (finalAttrs) pname version;
+    hash = "sha256-S/vpNoJyc5evFEtrsif6BKkc1Qc9z4ory9RNujd1Vao=";
   };
 
   build-system = [ setuptools ];
@@ -25,10 +27,12 @@ buildPythonPackage rec {
   buildInputs = [ gcc ];
   dependencies = [ wirelesstools ];
 
+  pythonImportsCheck = [ "basiciw" ];
+
   meta = {
     description = "Get info about wireless interfaces using libiw";
     homepage = "https://github.com/enkore/basiciw";
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl2;
   };
-}
+})

--- a/pkgs/development/python-modules/basiciw/default.nix
+++ b/pkgs/development/python-modules/basiciw/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   gcc,
   wirelesstools,
   isPyPy,
@@ -10,7 +11,7 @@
 buildPythonPackage rec {
   pname = "basiciw";
   version = "0.2.2";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = isPyPy;
 
@@ -19,8 +20,10 @@ buildPythonPackage rec {
     sha256 = "1ajmflvvlkflrcmqmkrx0zaira84z8kv4ssb2jprfwvjh8vfkysb";
   };
 
+  build-system = [ setuptools ];
+
   buildInputs = [ gcc ];
-  propagatedBuildInputs = [ wirelesstools ];
+  dependencies = [ wirelesstools ];
 
   meta = {
     description = "Get info about wireless interfaces using libiw";


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
