### PR TITLE
python3Packages.bcdoc: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/bcdoc/default.nix
+++ b/pkgs/development/python-modules/bcdoc/default.nix
@@ -7,14 +7,16 @@
   six,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "bcdoc";
   version = "0.16.0";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "f568c182e06883becf7196f227052435cffd45604700c82362ca77d3427b6202";
+    inherit (finalAttrs) pname version;
+    hash = "sha256-9WjBguBog77PcZbyJwUkNc/9RWBHAMgjYsp300J7YgI=";
   };
 
   build-system = [ setuptools ];
@@ -27,9 +29,11 @@ buildPythonPackage rec {
   # Tests fail due to nix file timestamp normalization.
   doCheck = false;
 
+  pythonImportsCheck = [ "bcdoc" ];
+
   meta = {
     homepage = "https://github.com/boto/bcdoc";
     license = lib.licenses.asl20;
     description = "ReST document generation tools for botocore";
   };
-}
+})

--- a/pkgs/development/python-modules/bcdoc/default.nix
+++ b/pkgs/development/python-modules/bcdoc/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   docutils,
   six,
 }:
@@ -9,12 +10,14 @@
 buildPythonPackage rec {
   pname = "bcdoc";
   version = "0.16.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "f568c182e06883becf7196f227052435cffd45604700c82362ca77d3427b6202";
   };
+
+  build-system = [ setuptools ];
 
   buildInputs = [
     docutils


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
