### PR TITLE
python3Packages.bcf: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/bcf/default.nix
+++ b/pkgs/development/python-modules/bcf/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   appdirs,
   click,
   colorama,
@@ -16,7 +17,7 @@
 buildPythonPackage rec {
   pname = "bcf";
   version = "1.9.1";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "hardwario";
@@ -25,12 +26,14 @@ buildPythonPackage rec {
     sha256 = "sha256-xKggVEN3O0umDEt358xc+79/SEVm2peMjfFHGTppTEo=";
   };
 
+  build-system = [ setuptools ];
+
   postPatch = ''
     sed -ri 's/@@VERSION@@/${version}/g' \
       bcf/__init__.py setup.py
   '';
 
-  propagatedBuildInputs = [
+  dependencies = [
     appdirs
     click
     colorama

--- a/pkgs/development/python-modules/bcf/default.nix
+++ b/pkgs/development/python-modules/bcf/default.nix
@@ -14,22 +14,24 @@
   requests,
   schema,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "bcf";
   version = "1.9.1";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "hardwario";
     repo = "bch-firmware-tool";
-    rev = "v${version}";
-    sha256 = "sha256-xKggVEN3O0umDEt358xc+79/SEVm2peMjfFHGTppTEo=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-xKggVEN3O0umDEt358xc+79/SEVm2peMjfFHGTppTEo=";
   };
 
   build-system = [ setuptools ];
 
   postPatch = ''
-    sed -ri 's/@@VERSION@@/${version}/g' \
+    sed -ri 's/@@VERSION@@/${finalAttrs.version}/g' \
       bcf/__init__.py setup.py
   '';
 
@@ -57,4 +59,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ cynerd ];
   };
-}
+})


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
