### PR TITLE
python3Packages.bcg: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/bcg/default.nix
+++ b/pkgs/development/python-modules/bcg/default.nix
@@ -14,16 +14,18 @@
   schema,
   simplejson,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "bcg";
   version = "1.17.0";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "hardwario";
     repo = "bch-gateway";
-    rev = "v${version}";
-    sha256 = "2Yh5MeIv+BIxjoO9GOPqq7xTAFhyBvnxPy7DeO2FrkI=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2Yh5MeIv+BIxjoO9GOPqq7xTAFhyBvnxPy7DeO2FrkI=";
   };
 
   patches = [
@@ -35,7 +37,7 @@ buildPythonPackage rec {
     })
   ];
   postPatch = ''
-    sed -ri 's/@@VERSION@@/${version}/g' \
+    sed -ri 's/@@VERSION@@/${finalAttrs.version}/g' \
       bcg/__init__.py setup.py
   '';
 
@@ -63,4 +65,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ cynerd ];
   };
-}
+})

--- a/pkgs/development/python-modules/bcg/default.nix
+++ b/pkgs/development/python-modules/bcg/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   fetchpatch,
+  setuptools,
   appdirs,
   click,
   click-log,
@@ -16,7 +17,7 @@
 buildPythonPackage rec {
   pname = "bcg";
   version = "1.17.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "hardwario";
@@ -38,7 +39,9 @@ buildPythonPackage rec {
       bcg/__init__.py setup.py
   '';
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     appdirs
     click
     click-log


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
