### PR TITLE
python3Packages.beanstalkc: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/beanstalkc/default.nix
+++ b/pkgs/development/python-modules/beanstalkc/default.nix
@@ -29,6 +29,6 @@ buildPythonPackage (finalAttrs: {
     description = "Simple beanstalkd client library for Python";
     maintainers = with lib.maintainers; [ aanderse ];
     license = lib.licenses.asl20;
-    homepage = "https://github.com/earl/beanstalkc";
+    homepage = "https://github.com/bosondata/beanstalkc";
   };
 })

--- a/pkgs/development/python-modules/beanstalkc/default.nix
+++ b/pkgs/development/python-modules/beanstalkc/default.nix
@@ -5,21 +5,25 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "beanstalkc";
   version = "0.5.2";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "bosondata";
     repo = "beanstalkc";
-    rev = "v${version}";
-    sha256 = "1dpb1yimp2pfnikmgsb2fr9x6h8riixlsx3xfqphnfvrid49vw5s";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-uvCdSIt5Owsvdn10TXuMGUHTU3Zi6VdntO6KW6MP67Y=";
   };
 
   build-system = [ setuptools ];
 
   doCheck = false;
+
+  pythonImportsCheck = [ "beanstalkc" ];
 
   meta = {
     description = "Simple beanstalkd client library for Python";
@@ -27,4 +31,4 @@ buildPythonPackage rec {
     license = lib.licenses.asl20;
     homepage = "https://github.com/earl/beanstalkc";
   };
-}
+})

--- a/pkgs/development/python-modules/beanstalkc/default.nix
+++ b/pkgs/development/python-modules/beanstalkc/default.nix
@@ -2,12 +2,13 @@
   lib,
   fetchFromGitHub,
   buildPythonPackage,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "beanstalkc";
   version = "0.5.2";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "bosondata";
@@ -15,6 +16,8 @@ buildPythonPackage rec {
     rev = "v${version}";
     sha256 = "1dpb1yimp2pfnikmgsb2fr9x6h8riixlsx3xfqphnfvrid49vw5s";
   };
+
+  build-system = [ setuptools ];
 
   doCheck = false;
 


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
