### PR TITLE
python3Packages.bech32: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/bech32/default.nix
+++ b/pkgs/development/python-modules/bech32/default.nix
@@ -21,7 +21,7 @@ buildPythonPackage (finalAttrs: {
   pythonImportsCheck = [ "bech32" ];
 
   meta = {
-    homepage = "https://pypi.org/project/bech32/";
+    homepage = "https://github.com/fiatjaf/bech32";
     license = with lib.licenses; [ mit ];
   };
 })

--- a/pkgs/development/python-modules/bech32/default.nix
+++ b/pkgs/development/python-modules/bech32/default.nix
@@ -4,20 +4,24 @@
   fetchPypi,
   setuptools,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "bech32";
   version = "1.2.0";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-fW24IUYDvXhx/PpsCCbvaLhbCr2Q+iHChanF4h0r2Jk=";
   };
 
   build-system = [ setuptools ];
 
+  pythonImportsCheck = [ "bech32" ];
+
   meta = {
     homepage = "https://pypi.org/project/bech32/";
     license = with lib.licenses; [ mit ];
   };
-}
+})

--- a/pkgs/development/python-modules/bech32/default.nix
+++ b/pkgs/development/python-modules/bech32/default.nix
@@ -2,16 +2,19 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
 }:
 buildPythonPackage rec {
   pname = "bech32";
   version = "1.2.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-fW24IUYDvXhx/PpsCCbvaLhbCr2Q+iHChanF4h0r2Jk=";
   };
+
+  build-system = [ setuptools ];
 
   meta = {
     homepage = "https://pypi.org/project/bech32/";


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
