### PR TITLE
htgettoken: migrate to pyproject and fix secondary programs

### DIFF
--- a/pkgs/by-name/ht/htgettoken/package.nix
+++ b/pkgs/by-name/ht/htgettoken/package.nix
@@ -2,13 +2,12 @@
   lib,
   fetchFromGitHub,
   python3,
-  makeWrapper,
 }:
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "htgettoken";
   version = "2.6";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "fermitools";
@@ -17,21 +16,15 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     hash = "sha256-jHKKTnFZ+6LHaB61wi5+Ht6ZHrE4dDqADIMfGWI47oM=";
   };
 
-  nativeBuildInputs = with python3.pkgs; [
+  build-system = with python3.pkgs; [
     setuptools
-    makeWrapper
   ];
 
-  postInstall = with python3.pkgs; ''
-    wrapProgram $out/bin/htgettoken \
-      --prefix PYTHONPATH : "${
-        makePythonPath [
-          gssapi
-          paramiko
-          urllib3
-        ]
-      }"
-  '';
+  dependencies = with python3.pkgs; [
+    gssapi
+    paramiko
+    urllib3
+  ];
 
   meta = {
     description = "Gets OIDC authentication tokens for High Throughput Computing via a Hashicorp vault server ";

--- a/pkgs/by-name/ht/htgettoken/package.nix
+++ b/pkgs/by-name/ht/htgettoken/package.nix
@@ -1,7 +1,14 @@
 {
   lib,
   fetchFromGitHub,
+  makeBinaryWrapper,
   python3,
+  bash,
+  curl,
+  coreutils,
+  gnused,
+  jq,
+  scitokens-cpp,
 }:
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
@@ -20,11 +27,49 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     setuptools
   ];
 
+  nativeBuildInputs = [
+    makeBinaryWrapper
+  ];
+
+  buildInputs = [
+    bash
+    curl
+    coreutils
+    jq
+    scitokens-cpp
+  ];
+
   dependencies = with python3.pkgs; [
     gssapi
     paramiko
     urllib3
   ];
+
+  postInstall = ''
+    wrapProgram $out/bin/htdecodetoken \
+        --prefix PATH : ${
+          lib.makeBinPath [
+            coreutils
+            jq
+            scitokens-cpp
+          ]
+        }
+    wrapProgram $out/bin/htdestroytoken \
+        --prefix PATH : $out/bin:${
+          lib.makeBinPath [
+            coreutils
+            curl
+          ]
+        }
+    wrapProgram $out/bin/httokensh \
+        --prefix PATH : $out/bin:${
+          lib.makeBinPath [
+            coreutils
+            gnused
+            jq
+          ]
+        }
+  '';
 
   meta = {
     description = "Gets OIDC authentication tokens for High Throughput Computing via a Hashicorp vault server ";


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974
- The secondary programs `htdecodetoken`, `htdestroytoken` and `httokensh` are bash scripts which didn't work until now, because they have a `#!/bin/bash` shebang which wasn't patched. I also wrapped them to give them access to the programs they call.
- @veprbl, was there a specific reason the python dependencies where added to `htgettoken` via custom wrapping instead of simply adding them to `dependencies`? I changed that to pass the dependency check done with `pyproject = true` and it seems to work fine at a first glance. It can be executed without immediately failing with an `ImportError`. However, I don't have a vault server to actually test the main functionality.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
