### PR TITLE
python3Packages.binaryornot: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/binaryornot/default.nix
+++ b/pkgs/development/python-modules/binaryornot/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   chardet,
   hypothesis,
 }:
@@ -9,12 +10,14 @@
 buildPythonPackage rec {
   pname = "binaryornot";
   version = "0.4.4";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "359501dfc9d40632edc9fac890e19542db1a287bbcfa58175b66658392018061";
   };
+
+  build-system = [ setuptools ];
 
   prePatch = ''
     # TypeError: binary() got an unexpected keyword argument 'average_size'
@@ -22,7 +25,7 @@ buildPythonPackage rec {
       --replace "average_size=512" ""
   '';
 
-  propagatedBuildInputs = [ chardet ];
+  dependencies = [ chardet ];
 
   nativeCheckInputs = [ hypothesis ];
 

--- a/pkgs/development/python-modules/binaryornot/default.nix
+++ b/pkgs/development/python-modules/binaryornot/default.nix
@@ -7,14 +7,16 @@
   hypothesis,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "binaryornot";
   version = "0.4.4";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "359501dfc9d40632edc9fac890e19542db1a287bbcfa58175b66658392018061";
+    inherit (finalAttrs) pname version;
+    hash = "sha256-NZUB38nUBjLtyfrIkOGVQtsaKHu8+lgXW2Zlg5IBgGE=";
   };
 
   build-system = [ setuptools ];
@@ -22,16 +24,18 @@ buildPythonPackage rec {
   prePatch = ''
     # TypeError: binary() got an unexpected keyword argument 'average_size'
     substituteInPlace tests/test_check.py \
-      --replace "average_size=512" ""
+      --replace-fail "average_size=512" ""
   '';
 
   dependencies = [ chardet ];
 
   nativeCheckInputs = [ hypothesis ];
 
+  pythonImportsCheck = [ "binaryornot" ];
+
   meta = {
     homepage = "https://github.com/audreyr/binaryornot";
     description = "Ultra-lightweight pure Python package to check if a file is binary or text";
     license = lib.licenses.bsd3;
   };
-}
+})


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
