### PR TITLE
tradicted-trading-journal: init at 1.0.0

### DIFF
--- a/pkgs/by-name/tr/tradicted-trading-journal/package.nix
+++ b/pkgs/by-name/tr/tradicted-trading-journal/package.nix
@@ -1,0 +1,23 @@
+{ lib
+, appimageTools
+, fetchurl
+}:
+
+appimageTools.wrapType2 {
+  pname = "tradicted-trading-journal";
+  version = "1.0.0";
+
+  src = fetchurl {
+    url = "https://github.com/tradicted/tradicted-journal/releases/download/v1.0.0/tradicted-trading-journal-1.0.0.AppImage";
+    hash = "sha256-OzGwDiFrC4vdX+b1BBg5RQXyNW9ejlPFpODnoYEkt0g=";
+  };
+
+  meta = {
+    description = "Free open-source desktop trading journal by Tradicted";
+    homepage = "https://www.tradicted.com";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/tr/tradicted-trading-journal/package.nix
+++ b/pkgs/by-name/tr/tradicted-trading-journal/package.nix
@@ -1,6 +1,7 @@
-{ lib
-, appimageTools
-, fetchurl
+{
+  lib,
+  appimageTools,
+  fetchurl,
 }:
 
 appimageTools.wrapType2 {
@@ -12,11 +13,14 @@ appimageTools.wrapType2 {
     hash = "sha256-OzGwDiFrC4vdX+b1BBg5RQXyNW9ejlPFpODnoYEkt0g=";
   };
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   meta = {
     description = "Free open-source desktop trading journal by Tradicted";
     homepage = "https://www.tradicted.com";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = [ ];
     platforms = [ "x86_64-linux" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
## Summary:
New package: tradicted-trading-journal — a free open-source desktop trading journal by Tradicted. Homepage: https://www.tradicted.com/
## Things done
Built on: x86_64-linux ✓
Packages the official AppImage release using appimageTools.wrapType2
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
