### PR TITLE
git-worktree-runner: init at 2.7.3

### DIFF
--- a/pkgs/by-name/gi/git-worktree-runner/package.nix
+++ b/pkgs/by-name/gi/git-worktree-runner/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  installShellFiles,
+  makeWrapper,
+  bash,
+  coreutils,
+  findutils,
+  gawk,
+  git,
+  gnugrep,
+  gnused,
+  versionCheckHook,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  pname = "git-worktree-runner";
+  version = "2.7.3";
+
+  src = fetchFromGitHub {
+    owner = "coderabbitai";
+    repo = "git-worktree-runner";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-tksTABDbNlXcC8vRi5q3u5MjeCRapeL2pgS8PLhduz8=";
+  };
+
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+  ];
+
+  buildInputs = [ bash ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/git-worktree-runner $out/bin
+    cp -r bin lib adapters templates $out/share/git-worktree-runner/
+
+    patchShebangs $out/share/git-worktree-runner/bin
+
+    for prog in git-gtr gtr; do
+      makeWrapper $out/share/git-worktree-runner/bin/$prog $out/bin/$prog \
+        --prefix PATH : ${
+          lib.makeBinPath [
+            coreutils
+            findutils
+            gawk
+            git
+            gnugrep
+            gnused
+          ]
+        }
+    done
+
+    installShellCompletion \
+      --cmd git-gtr \
+        --bash completions/gtr.bash \
+        --zsh  completions/_git-gtr \
+        --fish completions/git-gtr.fish
+    installShellCompletion --cmd gtr --bash completions/gtr.bash
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+
+  meta = {
+    description = "Bash-based Git worktree manager with editor and AI tool integration";
+    homepage = "https://github.com/coderabbitai/git-worktree-runner";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ macalinao ];
+    mainProgram = "git-gtr";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description

Add [git-worktree-runner](https://github.com/coderabbitai/git-worktree-runner), a Bash-based Git worktree manager with editor and AI tool integration.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
