### PR TITLE
domain-check: init at 1.0.2

### DIFF
--- a/pkgs/by-name/do/domain-check/package.nix
+++ b/pkgs/by-name/do/domain-check/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "domain-check";
+  version = "1.0.2";
+
+  src = fetchFromGitHub {
+    owner = "saidutt46";
+    repo = "domain-check";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+gNuwJ0ohpAqpKygwIjBLpOIrW9QFFdyRo3mAFDbGJs=";
+  };
+
+  __structuredAttrs = true;
+
+  cargoHash = "sha256-txgOQvoQ6ADD5VqxUrJ1yr4ycje6b6FCOxIMg3he8Gw=";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  checkFlags = [
+    # CLI tests
+    "--skip=test_all_with_bootstrap_returns_more_than_32_tlds"
+    "--skip=test_backward_compat_no_generation_flags"
+    "--skip=test_config_detailed_info_respected_without_flag"
+    "--skip=test_custom_preset_from_config"
+    "--skip=test_env_detailed_info_respected_without_flag"
+    # Tests require network access
+    "--skip=test_known_taken_domain_google_com"
+  ];
+
+  doInstallCheck = true;
+
+  meta = {
+    description = "Tool to check domain availability";
+    homepage = "https://github.com/saidutt46/domain-check";
+    changelog = "https://github.com/saidutt46/domain-check/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "domain-check";
+  };
+})


### PR DESCRIPTION
Tool to check domain availability

https://github.com/saidutt46/domain-check

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
