### PR TITLE
emacs: enable __structuredAttrs

### DIFF
--- a/pkgs/applications/editors/emacs/make-emacs.nix
+++ b/pkgs/applications/editors/emacs/make-emacs.nix
@@ -408,6 +408,8 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.withFeature withSelinux "selinux")
   ];
 
+  __structuredAttrs = true;
+
   env =
     lib.optionalAttrs withNativeCompilation {
       NATIVE_FULL_AOT = "1";


### PR DESCRIPTION
Follow-up of #528448.

The recent addition to emacs31 packages revealed, via `nixpkgs-vet`, that we are lacking some strictures in the emacs derivation:
<details>
<pre>
building '/nix/store/acf2xj7y4nfh3pk9zdrj4v83zbx5mr27-nixpkgs-vet.drv'...
- Attribute `pkgs.emacs31` is a new package with `strictDeps` unset or set to `false`.
  Please enable `strictDeps = true;` in pkgs/top-level/all-packages.nix.
 (NPV-164)
- Attribute `pkgs.emacs31` is a new package with `__structuredAttrs` unset or set to `false`.
  Please enable `__structuredAttrs = true;` in pkgs/top-level/all-packages.nix.
 (NPV-166)
- Attribute `pkgs.emacs31-gtk3` is a new package with `strictDeps` unset or set to `false`.
  Please enable `strictDeps = true;` in pkgs/top-level/all-packages.nix.
 (NPV-164)
- Attribute `pkgs.emacs31-gtk3` is a new package with `__structuredAttrs` unset or set to `false`.
  Please enable `__structuredAttrs = true;` in pkgs/top-level/all-packages.nix.
 (NPV-166)
- Attribute `pkgs.emacs31-nox` is a new package with `strictDeps` unset or set to `false`.
  Please enable `strictDeps = true;` in pkgs/top-level/all-packages.nix.
 (NPV-164)
- Attribute `pkgs.emacs31-nox` is a new package with `__structuredAttrs` unset or set to `false`.
  Please enable `__structuredAttrs = true;` in pkgs/top-level/all-packages.nix.
 (NPV-166)
- Attribute `pkgs.emacs31-pgtk` is a new package with `strictDeps` unset or set to `false`.
  Please enable `strictDeps = true;` in pkgs/top-level/all-packages.nix.
 (NPV-164)
- Attribute `pkgs.emacs31-pgtk` is a new package with `__structuredAttrs` unset or set to `false`.
  Please enable `__structuredAttrs = true;` in pkgs/top-level/all-packages.nix.
 (NPV-166)
This PR introduces additional instances of discouraged patterns as listed above. Please fix them before merging.
error: Cannot build '/nix/store/acf2xj7y4nfh3pk9zdrj4v83zbx5mr27-nixpkgs-vet.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/243vy86rc65d5fqhvkf8b06b5xm20awl-nixpkgs-vet
       Last 25 log lines:
       > - Attribute `pkgs.emacs31` is a new package with `strictDeps` unset or set to `false`.
       >   Please enable `strictDeps = true;` in pkgs/top-level/all-packages.nix.
       >  (NPV-164)
       > - Attribute `pkgs.emacs31` is a new package with `__structuredAttrs` unset or set to `false`.
       >   Please enable `__structuredAttrs = true;` in pkgs/top-level/all-packages.nix.
       >  (NPV-166)
       > - Attribute `pkgs.emacs31-gtk3` is a new package with `strictDeps` unset or set to `false`.
       >   Please enable `strictDeps = true;` in pkgs/top-level/all-packages.nix.
       >  (NPV-164)
       > - Attribute `pkgs.emacs31-gtk3` is a new package with `__structuredAttrs` unset or set to `false`.
       >   Please enable `__structuredAttrs = true;` in pkgs/top-level/all-packages.nix.
       >  (NPV-166)
       > - Attribute `pkgs.emacs31-nox` is a new package with `strictDeps` unset or set to `false`.
       >   Please enable `strictDeps = true;` in pkgs/top-level/all-packages.nix.
       >  (NPV-164)
       > - Attribute `pkgs.emacs31-nox` is a new package with `__structuredAttrs` unset or set to `false`.
       >   Please enable `__structuredAttrs = true;` in pkgs/top-level/all-packages.nix.
       >  (NPV-166)
       > - Attribute `pkgs.emacs31-pgtk` is a new package with `strictDeps` unset or set to `false`.
       >   Please enable `strictDeps = true;` in pkgs/top-level/all-packages.nix.
       >  (NPV-164)
       > - Attribute `pkgs.emacs31-pgtk` is a new package with `__structuredAttrs` unset or set to `false`.
       >   Please enable `__structuredAttrs = true;` in pkgs/top-level/all-packages.nix.
       >  (NPV-166)
       > This PR introduces additional instances of discouraged patterns as listed above. Please fix them before merging.
       For full logs, run:
         nix log /nix/store/acf2xj7y4nfh3pk9zdrj4v83zbx5mr27-nixpkgs-vet.drv
To run locally: ./ci/nixpkgs-vet.sh master https://github.com/NixOS/nixpkgs.git
If you're having trouble, ping @NixOS/nixpkgs-vet
Error: Process completed with exit code 1.
</pre>
</details>

As clarified by @jian-lin in his [comment](https://github.com/NixOS/nixpkgs/pull/528448#discussion_r3364594089), we need to enable `strictDeps` and `__structuredAttrs` on the Emacs derivation.

UPDATE: `strictDeps` has been dealt with on #529355.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
