### PR TITLE
emacs: test and work around upstream bug#81105

### DIFF
--- a/pkgs/applications/editors/emacs/build-support/wrapper-test.nix
+++ b/pkgs/applications/editors/emacs/build-support/wrapper-test.nix
@@ -15,6 +15,10 @@ runCommand "test-emacs-withPackages-wrapper"
       ))
       git # needed by magit
     ];
+    env = {
+      # emulate a default NixOS env where INFOPATH is set like this (not ending with a ":")
+      INFOPATH = "/fake-info-dir1:/fake-info-dir2";
+    };
   }
   ''
     emacs --batch --eval="(require 'magit)"
@@ -23,5 +27,9 @@ runCommand "test-emacs-withPackages-wrapper"
     # transitive dependencies should be made available
     # https://github.com/NixOS/nixpkgs/issues/388829
     emacs --batch --eval="(require 'flx)"
+
+    # test that https://debbugs.gnu.org/cgi/bugreport.cgi?bug=81105 is fixed or worked around
+    emacs --batch --eval='(progn (package-activate-all) (info "(magit)Top"))'
+
     touch $out
   ''

--- a/pkgs/applications/editors/emacs/site-start.el
+++ b/pkgs/applications/editors/emacs/site-start.el
@@ -72,6 +72,14 @@ least specific (the system profile)"
                          (nix--profile-paths))
                  woman-manpath)))
 
+;;; Make info manuals of installed elisp pkgs available (work around Emacs bug#81105)
+(when-let* ((path (getenv "INFOPATH")))
+  ;; Normally, Emacs 31 extends `Info-default-directory-list' when activating elisp pkgs.
+  ;; We add a trailing path-separator ":" to INFOPATH when needed
+  ;; to ensure `Info-default-directory-list' is used to initialize `Info-directory-list'.
+  (unless (string-suffix-p path-separator path)
+    (setenv "INFOPATH" (concat path path-separator))))
+
 ;;; Make tramp work for remote NixOS machines
 (defvar tramp-remote-path)
 (eval-after-load 'tramp


### PR DESCRIPTION
See commit messages for details.

https://debbugs.gnu.org/cgi/bugreport.cgi?bug=81105

---

bug#81105 was discovered by @Vonfry and then investigated by @Vonfry and me.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
