### PR TITLE
eggnog-mapper: 2.1.13 -> 2.1.14, fix for python 3.12+ and migrate to pyproject

### DIFF
--- a/pkgs/by-name/eg/eggnog-mapper/package.nix
+++ b/pkgs/by-name/eg/eggnog-mapper/package.nix
@@ -11,7 +11,7 @@
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "eggnog-mapper";
   version = "2.1.14";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "eggnogdb";
@@ -29,14 +29,12 @@ python3Packages.buildPythonApplication (finalAttrs: {
     })
   ];
 
-  postPatch = ''
-    # Not a great solution...
-    substituteInPlace setup.cfg \
-      --replace "==" ">="
-  '';
-
   nativeBuildInputs = [
     autoPatchelfHook
+  ];
+
+  build-system = with python3Packages; [
+    setuptools
   ];
 
   buildInputs = [
@@ -45,12 +43,20 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   propagatedBuildInputs = [
     wget
-  ]
-  ++ (with python3Packages; [
+  ];
+
+  dependencies = with python3Packages; [
     biopython
     psutil
     xlsxwriter
-  ]);
+  ];
+
+  # Upstream already relaxed these dependencies, but that is not yet included in 2.1.14
+  pythonRelaxDeps = [
+    "biopython"
+    "psutil"
+    "xlsxwriter"
+  ];
 
   # Tests rely on some of the databases being available, which is not bundled
   # with this package as (1) in total, they represent >100GB of data, and (2)

--- a/pkgs/by-name/eg/eggnog-mapper/package.nix
+++ b/pkgs/by-name/eg/eggnog-mapper/package.nix
@@ -2,6 +2,7 @@
   lib,
   autoPatchelfHook,
   fetchFromGitHub,
+  fetchpatch2,
   python3Packages,
   wget,
   zlib,
@@ -18,6 +19,15 @@ python3Packages.buildPythonApplication (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-rjQojz6JA7T03s4PojjXJuDZhdAx9VhPQrlRTGZaYZg=";
   };
+
+  patches = [
+    # From https://github.com/eggnogdb/eggnog-mapper/pull/599
+    (fetchpatch2 {
+      name = "replace-distutils.patch";
+      url = "https://github.com/eggnogdb/eggnog-mapper/commit/998129d3766e060ff450e8f950b5361c6318b0a2.patch?full_index=1";
+      hash = "sha256-xYNd9p5BhGpvFXCWXRSEkZf+Lt4hCRGYeV9Oe4mDz3I=";
+    })
+  ];
 
   postPatch = ''
     # Not a great solution...

--- a/pkgs/by-name/eg/eggnog-mapper/package.nix
+++ b/pkgs/by-name/eg/eggnog-mapper/package.nix
@@ -9,14 +9,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "eggnog-mapper";
-  version = "2.1.13";
+  version = "2.1.14";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "eggnogdb";
     repo = "eggnog-mapper";
-    tag = finalAttrs.version;
-    hash = "sha256-Gu4D8DBvgCPlO+2MjeNZy6+lNqsIlksegWmmYvEZmUU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rjQojz6JA7T03s4PojjXJuDZhdAx9VhPQrlRTGZaYZg=";
   };
 
   postPatch = ''


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974
- Updates to 2.1.14. There already is a 2.1.15 tag upstream, but that does not include a fix necessary to actually download the databases. I created an upstream issue about this: https://github.com/eggnogdb/eggnog-mapper/issues/605
- 2.1.14 instead has the issue of wrongfully reporting it's own version as 2.1.13, but I deemed that to be the smaller problem in comparison.
- A patch to replace `distutils` is needed to run on python 3.12+. This has already been merged upstream but is not included in the release.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
