### PR TITLE
cudaPackages_13_3.cccl: init at 13.3.3.3.1; cudaPackages_13_3.cuda_cccl: alias to cccl

### DIFF
--- a/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
@@ -110,7 +110,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals enableMpi [ mpi ]
   ++ lib.optionals enableCuda [
-    cudaPackages.cuda_cccl
+    cudaPackages.cccl
     cudaPackages.cuda_cudart
     cudaPackages.libcufft
     cudaPackages.cuda_profiler_api

--- a/pkgs/by-name/ca/catboost/package.nix
+++ b/pkgs/by-name/ca/catboost/package.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals cudaSupport [
     cudaPackages.cuda_cudart
-    cudaPackages.cuda_cccl
+    cudaPackages.cccl
     cudaPackages.libcublas
   ];
 

--- a/pkgs/by-name/ct/ctranslate2/package.nix
+++ b/pkgs/by-name/ct/ctranslate2/package.nix
@@ -84,7 +84,7 @@ stdenv'.mkDerivation (finalAttrs: {
       mkl
     ]
     ++ lib.optionals withCUDA [
-      cudaPackages.cuda_cccl # <nv/target> required by the fp16 headers in cudart
+      cudaPackages.cccl # <nv/target> required by the fp16 headers in cudart
       cudaPackages.cuda_cudart
       cudaPackages.libcublas
       cudaPackages.libcurand

--- a/pkgs/by-name/dc/dcgm/package.nix
+++ b/pkgs/by-name/dc/dcgm/package.nix
@@ -37,7 +37,7 @@ let
   # C.f. https://github.com/NVIDIA/DCGM/blob/7e1012302679e4bb7496483b32dcffb56e528c92/dcgmbuild/scripts/0080_cuda.sh#L24-L39
   getCudaPackages =
     p: with p; [
-      cuda_cccl
+      cccl
       cuda_cudart
       cuda_nvcc
       cuda_nvml_dev

--- a/pkgs/by-name/dl/dlib/package.nix
+++ b/pkgs/by-name/dl/dlib/package.nix
@@ -76,7 +76,7 @@
       libcurand
       libcusolver
       cudnn
-      cuda_cccl
+      cccl
     ]
   );
 

--- a/pkgs/by-name/fa/faiss/package.nix
+++ b/pkgs/by-name/fa/faiss/package.nix
@@ -31,10 +31,10 @@ let
   stdenv = if cudaSupport then backendStdenv else inputs.stdenv;
 
   cudaComponents = with cudaPackages; [
+    cccl
     cuda_cudart # cuda_runtime.h
     libcublas
     libcurand
-    cuda_cccl
 
     # cuda_profiler_api.h
     (cudaPackages.cuda_profiler_api or cudaPackages.cuda_nvprof)

--- a/pkgs/by-name/gp/gpt4all/package.nix
+++ b/pkgs/by-name/gp/gpt4all/package.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals cudaSupport (
     with cudaPackages;
     [
-      cuda_cccl
+      cccl
       cuda_cudart
       libcublas
     ]

--- a/pkgs/by-name/gp/gpu-burn/package.nix
+++ b/pkgs/by-name/gp/gpu-burn/package.nix
@@ -12,7 +12,7 @@ let
   inherit (config) cudaSupport;
   inherit (cudaPackages)
     backendStdenv
-    cuda_cccl
+    cccl
     cuda_cudart
     cuda_nvcc
     libcublas
@@ -49,7 +49,7 @@ backendStdenv.mkDerivation {
   ];
 
   buildInputs = [
-    cuda_cccl # <nv/target>
+    cccl # <nv/target>
     cuda_cudart # driver_types.h
     cuda_nvcc # crt/host_defines.h
     libcublas # cublas_v2.h

--- a/pkgs/by-name/ka/katago/package.nix
+++ b/pkgs/by-name/ka/katago/package.nix
@@ -78,7 +78,7 @@ stdenv'.mkDerivation rec {
   ++ lib.optionals (backend == "cuda") (
     with cudaPackages;
     [
-      cuda_cccl
+      cccl
       cuda_cudart
       cuda_nvcc
       cudnn

--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -74,7 +74,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     cudaPackages.libcublas
     cudaPackages.cuda_nvcc
     cudaPackages.cuda_cudart
-    cudaPackages.cuda_cccl
+    cudaPackages.cccl
   ]
   ++ lib.optionals clblastSupport [
     clblast

--- a/pkgs/by-name/ll/llama-cpp/package.nix
+++ b/pkgs/by-name/ll/llama-cpp/package.nix
@@ -59,7 +59,7 @@ let
     ;
 
   cudaBuildInputs = with cudaPackages; [
-    cuda_cccl # <nv/target>
+    cccl # <nv/target>
 
     # A temporary hack for reducing the closure size, remove once cudaPackages
     # have stopped using lndir: https://github.com/NixOS/nixpkgs/issues/271792

--- a/pkgs/by-name/ll/llrCUDA/package.nix
+++ b/pkgs/by-name/ll/llrCUDA/package.nix
@@ -39,7 +39,7 @@ backendStdenv.mkDerivation (finalAttrs: {
     gmp
     cudaPackages.cuda_cudart
     cudaPackages.libcufft
-    cudaPackages.cuda_cccl
+    cudaPackages.cccl
   ];
 
   env = {

--- a/pkgs/by-name/lo/local-ai/package.nix
+++ b/pkgs/by-name/lo/local-ai/package.nix
@@ -77,7 +77,7 @@ let
   inherit (cudaPackages)
     libcublas
     cuda_nvcc
-    cuda_cccl
+    cccl
     cuda_cudart
     libcufft
     ;
@@ -255,7 +255,7 @@ let
     buildInputs =
       [ ]
       ++ lib.optionals with_cublas [
-        cuda_cccl
+        cccl
         cuda_cudart
         libcublas
         libcufft

--- a/pkgs/by-name/ma/maa-assistant-arknights/fastdeploy-ppocr.nix
+++ b/pkgs/by-name/ma/maa-assistant-arknights/fastdeploy-ppocr.nix
@@ -44,7 +44,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals cudaSupport (
     with cudaPackages;
     [
-      cuda_cccl # cub/cub.cuh
+      cccl # cub/cub.cuh
       libcublas # cublas_v2.h
       libcurand # curand.h
       libcusparse # cusparse.h

--- a/pkgs/by-name/ma/maa-assistant-arknights/package.nix
+++ b/pkgs/by-name/ma/maa-assistant-arknights/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals cudaSupport (
     with cudaPackages;
     [
-      cuda_cccl # cub/cub.cuh
+      cccl # cub/cub.cuh
       libcublas # cublas_v2.h
       libcurand # curand.h
       libcusparse # cusparse.h

--- a/pkgs/by-name/ma/magma/package.nix
+++ b/pkgs/by-name/ma/magma/package.nix
@@ -207,7 +207,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lists.optionals cudaSupport (
     with cudaPackages;
     [
-      cuda_cccl # <nv/target> and <cuda/std/type_traits>
+      cccl # <nv/target> and <cuda/std/type_traits>
       cuda_cudart # cuda_runtime.h
       libcublas # cublas_v2.h
       libcusparse # cusparse.h

--- a/pkgs/by-name/mi/mistral-rs/package.nix
+++ b/pkgs/by-name/mi/mistral-rs/package.nix
@@ -129,7 +129,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     openssl
   ]
   ++ lib.optionals cudaSupport [
-    cudaPackages.cuda_cccl
+    cudaPackages.cccl
     cudaPackages.cuda_cudart
     cudaPackages.cuda_nvrtc
     cudaPackages.libcublas

--- a/pkgs/by-name/mm/mmseqs2/package.nix
+++ b/pkgs/by-name/mm/mmseqs2/package.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional enableMpi mpi
   ++ lib.optionals cudaSupport [
     cudaPackages.cuda_cudart
-    cudaPackages.cuda_cccl
+    cudaPackages.cccl
   ];
 
   postInstall = ''

--- a/pkgs/by-name/mo/moshi/package.nix
+++ b/pkgs/by-name/mo/moshi/package.nix
@@ -83,7 +83,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     alsa-lib
   ]
   ++ lib.optionals config.cudaSupport [
-    cudaPackages.cuda_cccl
+    cudaPackages.cccl
     cudaPackages.cuda_cudart
     cudaPackages.cuda_nvrtc
     cudaPackages.libcublas

--- a/pkgs/by-name/ol/ollama/package.nix
+++ b/pkgs/by-name/ol/ollama/package.nix
@@ -82,7 +82,7 @@ let
   cudaLibs = [
     cudaPackages.cuda_cudart
     cudaPackages.libcublas
-    cudaPackages.cuda_cccl
+    cudaPackages.cccl
   ];
 
   vulkanLibs = [
@@ -102,7 +102,7 @@ let
       (lib.getBin (cudaPackages.cuda_nvcc.__spliced.buildHost or cudaPackages.cuda_nvcc))
     ];
 
-    # cuda_cccl and cuda_cudart both have a LICENSE file in their output
+    # cccl and cuda_cudart both have a LICENSE file in their output
     ignoreCollisions = true;
   };
 

--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -205,7 +205,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals cudaSupport (
     with cudaPackages;
     [
-      cuda_cccl # cub/cub.cuh
+      cccl # cub/cub.cuh
       libcublas # cublas_v2.h
       libcurand # curand.h
       libcusparse # cusparse.h

--- a/pkgs/by-name/op/openimagedenoise/package.nix
+++ b/pkgs/by-name/op/openimagedenoise/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   ++ lib.optionals cudaSupport [
     cudaPackages.cuda_cudart
-    cudaPackages.cuda_cccl
+    cudaPackages.cccl
   ];
 
   cmakeFlags = [

--- a/pkgs/by-name/st/stable-diffusion-cpp/package.nix
+++ b/pkgs/by-name/st/stable-diffusion-cpp/package.nix
@@ -71,7 +71,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     (optionals cudaSupport (
       with cudaPackages;
       [
-        cuda_cccl
+        cccl
         cuda_cudart
         libcublas
       ]

--- a/pkgs/by-name/su/suitesparse/package.nix
+++ b/pkgs/by-name/su/suitesparse/package.nix
@@ -60,7 +60,7 @@ effectiveStdenv.mkDerivation rec {
     ]
     ++ lib.optionals enableCuda [
       cudaPackages.cuda_cudart
-      cudaPackages.cuda_cccl
+      cudaPackages.cccl
       cudaPackages.libcublas
     ];
 

--- a/pkgs/by-name/ti/tiny-cuda-nn/package.nix
+++ b/pkgs/by-name/ti/tiny-cuda-nn/package.nix
@@ -18,7 +18,7 @@ let
   cuda-common-redist = with cudaPackages; [
     (lib.getDev cuda_cudart) # cuda_runtime.h
     (lib.getLib cuda_cudart)
-    (lib.getDev cuda_cccl) # <nv/target>
+    (lib.getDev cccl) # <nv/target>
     (lib.getInclude cuda_nvrtc) # nvrtc.h
     (lib.getLib cuda_nvrtc)
     (lib.getInclude libcublas) # cublas_v2.h

--- a/pkgs/by-name/uc/ucc/package.nix
+++ b/pkgs/by-name/uc/ucc/package.nix
@@ -20,7 +20,7 @@ let
   inherit (lib.strings) concatStringsSep;
 
   inherit (cudaPackages)
-    cuda_cccl
+    cccl
     cuda_cudart
     cuda_nvcc
     cuda_nvml_dev
@@ -77,7 +77,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     ucx
   ]
   ++ optionals enableCuda [
-    cuda_cccl
+    cccl
     cuda_cudart
     cuda_nvml_dev
     nccl

--- a/pkgs/by-name/wh/whisper-cpp/package.nix
+++ b/pkgs/by-name/wh/whisper-cpp/package.nix
@@ -58,7 +58,7 @@ let
     ;
 
   cudaBuildInputs = with cudaPackages; [
-    cuda_cccl # <nv/target>
+    cccl # <nv/target>
 
     # A temporary hack for reducing the closure size, remove once cudaPackages
     # have stopped using lndir: https://github.com/NixOS/nixpkgs/issues/271792

--- a/pkgs/development/cuda-modules/aliases.nix
+++ b/pkgs/development/cuda-modules/aliases.nix
@@ -9,4 +9,11 @@ in
 final: _:
 builtins.mapAttrs mkRenamed {
   # A comment to prevent empty { } from collapsing into a single line
+
+  # NVIDIA renamed cuda_cccl to cccl in CUDA 13.3.
+  # For the sake of simplicity, we updated the attrname tree-wide, accross all cudaPackages version.
+  cuda_cccl = {
+    path = "cccl";
+    package = final.cccl;
+  };
 }

--- a/pkgs/development/cuda-modules/packages/cccl.nix
+++ b/pkgs/development/cuda-modules/packages/cccl.nix
@@ -7,7 +7,7 @@
 }:
 buildRedist {
   redistName = "cuda";
-  pname = "cuda_cccl";
+  pname = if cudaAtLeast "13.3" then "cccl" else "cuda_cccl";
 
   # Restrict header-only packages to a single output.
   # Also, when using multiple outputs (i.e., `out`, `dev`, and `include`), something isn't being patched correctly,

--- a/pkgs/development/cuda-modules/packages/cuda-samples.nix
+++ b/pkgs/development/cuda-modules/packages/cuda-samples.nix
@@ -3,7 +3,7 @@
   backendStdenv,
   _cuda,
   cmake,
-  cuda_cccl,
+  cccl,
   cuda_culibos,
   cuda_cudart,
   cuda_nvcc,
@@ -71,10 +71,10 @@ backendStdenv.mkDerivation (finalAttrs: {
           "${lib.getOutput "include" cuda_cudart}/include/cooperative_groups" \
         --replace-fail \
           "\''${CUDAToolkit_BIN_DIR}/../include/nv" \
-          "${lib.getOutput "include" cuda_cccl}/include/nv" \
+          "${lib.getOutput "include" cccl}/include/nv" \
         --replace-fail \
           "\''${CUDAToolkit_BIN_DIR}/../include/cuda" \
-          "${lib.getOutput "include" cuda_cccl}/include/cuda"
+          "${lib.getOutput "include" cccl}/include/cuda"
     ''
     + lib.optionalString (samplesAtLeast "13") ''
       nixLog "patching sample 0_Introduction/matrixMul_nvrtc"
@@ -85,10 +85,10 @@ backendStdenv.mkDerivation (finalAttrs: {
           "${lib.getOutput "include" cuda_cudart}/include/cooperative_groups" \
         --replace-fail \
           "\''${CUDA_INCLUDE_DIR}/cccl/nv" \
-          "${lib.getOutput "include" cuda_cccl}/include/nv" \
+          "${lib.getOutput "include" cccl}/include/nv" \
         --replace-fail \
           "\''${CUDA_INCLUDE_DIR}/cccl/cuda" \
-          "${lib.getOutput "include" cuda_cccl}/include/cuda"
+          "${lib.getOutput "include" cccl}/include/cuda"
     ''
     # These three samples give undefined references, like
     # nvlink error   : Undefined reference to '__cudaCDP2Free' in 'CMakeFiles/cdpBezierTessellation.dir/BezierLineCDP.cu.o'
@@ -184,7 +184,7 @@ backendStdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    cuda_cccl
+    cccl
     cuda_cudart
     cuda_nvrtc
     cuda_nvtx

--- a/pkgs/development/cuda-modules/packages/cuda_cudart.nix
+++ b/pkgs/development/cuda-modules/packages/cuda_cudart.nix
@@ -4,7 +4,7 @@
   _cuda,
   addDriverRunpath,
   buildRedist,
-  cuda_cccl,
+  cccl,
   cuda_compat,
   cuda_crt,
   cuda_nvcc,
@@ -47,7 +47,7 @@ buildRedist (finalAttrs: {
     # Add the dependency on CCCL's include directory.
     # - nv/target
     # TODO(@connorbaker): Check that the dependency offset for this is correct.
-    ++ [ (lib.getOutput "include" cuda_cccl) ]
+    ++ [ (lib.getOutput "include" cccl) ]
     # NOTE: cuda_compat may be null or unavailable
     ++ lib.optionals (cuda_compat.meta.available or false) [ cuda_compat ];
 

--- a/pkgs/development/cuda-modules/packages/cuda_nvcc.nix
+++ b/pkgs/development/cuda-modules/packages/cuda_nvcc.nix
@@ -5,7 +5,7 @@
   setupCudaHook,
   cudaAtLeast,
   cudaOlder,
-  cuda_cccl,
+  cccl,
   glibc,
   lib,
   libnvvm,
@@ -120,7 +120,7 @@ buildRedist (finalAttrs: {
         substituteInPlace "''${!outputBin:?}/bin/nvcc.profile" \
           --replace-fail \
             '$(TOP)/$(_TARGET_DIR_)/include/cccl' \
-            "${lib.getOutput "include" cuda_cccl}/include"
+            "${lib.getOutput "include" cccl}/include"
       ''
       # Unconditional patching to switch to the correct include paths.
       # NOTE: _TARGET_DIR_ appears to be used for the target architecture, which is relevant for cross-compilation.

--- a/pkgs/development/cuda-modules/packages/cudatoolkit.nix
+++ b/pkgs/development/cuda-modules/packages/cudatoolkit.nix
@@ -4,7 +4,7 @@
   backendStdenv,
   cudaAtLeast,
   cudaMajorMinorVersion,
-  cuda_cccl ? null,
+  cccl ? null,
   cuda_crt ? null,
   cuda_cudart ? null,
   cuda_cuobjdump ? null,
@@ -40,7 +40,7 @@ let
     cuda_nvprune
   ];
   targetPackages = [
-    cuda_cccl
+    cccl
     cuda_cudart
     cuda_cupti
     cuda_cuxxfilt

--- a/pkgs/development/cuda-modules/packages/libnvshmem.nix
+++ b/pkgs/development/cuda-modules/packages/libnvshmem.nix
@@ -3,7 +3,7 @@
   backendStdenv,
   buildPackages,
   cmake,
-  cuda_cccl,
+  cccl,
   cuda_cudart,
   cuda_nvcc,
   cuda_nvml_dev,
@@ -104,7 +104,7 @@ backendStdenv.mkDerivation (finalAttrs: {
   enableParallelBuilding = true;
 
   buildInputs = [
-    cuda_cccl
+    cccl
     cuda_cudart
     cuda_nvml_dev
     cuda_nvrtc

--- a/pkgs/development/cuda-modules/packages/nccl-tests.nix
+++ b/pkgs/development/cuda-modules/packages/nccl-tests.nix
@@ -4,7 +4,7 @@
 {
   backendStdenv,
   _cuda,
-  cuda_cccl,
+  cccl,
   cuda_cudart,
   cuda_nvcc,
   cudaNamePrefix,
@@ -53,7 +53,7 @@ backendStdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    cuda_cccl # <nv/target>
+    cccl # <nv/target>
     cuda_cudart
     nccl
   ]

--- a/pkgs/development/cuda-modules/packages/nccl.nix
+++ b/pkgs/development/cuda-modules/packages/nccl.nix
@@ -1,7 +1,7 @@
 {
   _cuda,
   backendStdenv,
-  cuda_cccl,
+  cccl,
   cuda_cudart,
   cuda_nvcc,
   cudaAtLeast,
@@ -82,7 +82,7 @@ backendStdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     (getInclude cuda_nvcc)
-    cuda_cccl
+    cccl
     cuda_cudart
   ];
 

--- a/pkgs/development/cuda-modules/packages/saxpy/package.nix
+++ b/pkgs/development/cuda-modules/packages/saxpy/package.nix
@@ -1,7 +1,7 @@
 {
   backendStdenv,
   cmake,
-  cuda_cccl,
+  cccl,
   cuda_cudart,
   cuda_nvcc,
   cudaNamePrefix,
@@ -26,7 +26,7 @@ backendStdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    cuda_cccl
+    cccl
     cuda_cudart
     libcublas
   ];

--- a/pkgs/development/cuda-modules/packages/tests/cuda-library-samples.nix
+++ b/pkgs/development/cuda-modules/packages/tests/cuda-library-samples.nix
@@ -4,7 +4,7 @@
   autoPatchelfHook,
   backendStdenv,
   cmake,
-  cuda_cccl,
+  cccl,
   cuda_cudart,
   cuda_nvcc,
   cudatoolkit,
@@ -99,7 +99,7 @@ in
         (lib.getDev libcusparse)
         cuda_nvcc
         (lib.getDev cuda_cudart) # <cuda_runtime_api.h>
-        cuda_cccl # <nv/target>
+        cccl # <nv/target>
       ];
 
       postPatch = prevAttrs.postPatch or "" + ''

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -434,7 +434,7 @@ effectiveStdenv.mkDerivation {
   ]
   ++ optionals enableCuda [
     cudaPackages.cuda_cudart
-    cudaPackages.cuda_cccl # <thrust/*>
+    cudaPackages.cccl # <thrust/*>
     cudaPackages.libnpp # npp.h
     nvidia-optical-flow-sdk
   ]

--- a/pkgs/development/python-modules/bitsandbytes/default.nix
+++ b/pkgs/development/python-modules/bitsandbytes/default.nix
@@ -41,7 +41,7 @@ let
   # NOTE: torchvision doesn't use cudnn; torch does!
   #   For this reason it is not included.
   cuda-common-redist = with cudaPackages; [
-    (lib.getDev cuda_cccl) # <thrust/*>
+    (lib.getDev cccl) # <thrust/*>
     (lib.getDev libcublas) # cublas_v2.h
     (lib.getLib libcublas)
     (lib.getInclude libcublas) # cublasLt.h

--- a/pkgs/development/python-modules/causal-conv1d/default.nix
+++ b/pkgs/development/python-modules/causal-conv1d/default.nix
@@ -39,7 +39,7 @@ buildPythonPackage rec {
       with cudaPackages;
       [
         cuda_cudart # cuda_runtime.h, -lcudart
-        cuda_cccl
+        cccl
         libcusparse # cusparse.h
         libcusolver # cusolverDn.h
         cuda_nvcc

--- a/pkgs/development/python-modules/cupy/default.nix
+++ b/pkgs/development/python-modules/cupy/default.nix
@@ -32,7 +32,7 @@ let
   outpaths = lib.filter (outpath: outpath != null) (
     with cudaPackages;
     [
-      cuda_cccl # <nv/target>
+      cccl # <nv/target>
       cuda_cudart
       cuda_nvcc # <crt/host_defines.h>
       cuda_nvprof

--- a/pkgs/development/python-modules/deep-ep/default.nix
+++ b/pkgs/development/python-modules/deep-ep/default.nix
@@ -79,7 +79,7 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
   ++ lib.optionals cudaSupport (
     with cudaPackages;
     [
-      cuda_cccl # <nv/target>
+      cccl # <nv/target>
       cuda_cudart # cuda_runtime.h
       libcublas # cublas_v2.h
       libcusolver # cusolverDn.h

--- a/pkgs/development/python-modules/deep-gemm/default.nix
+++ b/pkgs/development/python-modules/deep-gemm/default.nix
@@ -60,7 +60,7 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
         paths = with cudaPackages; [
           (lib.getBin cuda_nvcc) # bin/nvcc, bin/ptxas, nvvm/, nvcc.profile
           (lib.getBin cutlass) # include/cute, include/cutlass
-          (lib.getInclude cuda_cccl) # include/cuda/std/* (libcu++)
+          (lib.getInclude cccl) # include/cuda/std/* (libcu++)
           (lib.getInclude cuda_cudart) # include/cuda_runtime.h, cuda_bf16.h, cuda_fp8.h
           (lib.getInclude cuda_cuobjdump) # bin/cuobjdump
         ];

--- a/pkgs/development/python-modules/flash-attn/default.nix
+++ b/pkgs/development/python-modules/flash-attn/default.nix
@@ -68,7 +68,7 @@ let
     ];
 
     buildInputs = [
-      cudaPackages.cuda_cccl # <thrust/*>
+      cudaPackages.cccl # <thrust/*>
       cudaPackages.libcublas # cublas_v2.h
       cudaPackages.libcurand # curand.h
       cudaPackages.libcusolver # cusolverDn.h

--- a/pkgs/development/python-modules/flashinfer/default.nix
+++ b/pkgs/development/python-modules/flashinfer/default.nix
@@ -56,7 +56,7 @@ buildPythonPackage (finalAttrs: {
   dontUseCmakeConfigure = true;
 
   buildInputs = with cudaPackages; [
-    cuda_cccl
+    cccl
     cuda_cudart
     libcublas
     libcurand

--- a/pkgs/development/python-modules/gpu-rir/default.nix
+++ b/pkgs/development/python-modules/gpu-rir/default.nix
@@ -54,7 +54,7 @@ buildPythonPackage {
   ];
 
   buildInputs = with cudaPackages; [
-    cuda_cccl # <nv/target>
+    cccl # <nv/target>
     cuda_cudart # cuda_runtime.h
     libcufft
     libcurand

--- a/pkgs/development/python-modules/jaxlib/default.nix
+++ b/pkgs/development/python-modules/jaxlib/default.nix
@@ -116,7 +116,7 @@ let
       (lib.getOutput "static" cuda_cudart) # libcudart_static.a
 
       # Headers
-      (lib.getDev cuda_cccl) # block_load.cuh
+      (lib.getDev cccl) # block_load.cuh
       (lib.getDev cuda_cudart) # cuda.h
       (lib.getDev cuda_cupti) # cupti.h
       (lib.getDev cuda_nvcc) # See https://github.com/google/jax/issues/19811

--- a/pkgs/development/python-modules/libmobility/default.nix
+++ b/pkgs/development/python-modules/libmobility/default.nix
@@ -115,7 +115,7 @@ buildPythonPackage.override { stdenv = cudaPackages.backendStdenv; } (finalAttrs
     lapack
   ]
   ++ (with cudaPackages; [
-    cuda_cccl # <nv/target>
+    cccl # <nv/target>
     cuda_cudart # CUDA::cuda_driver (driver stub)
     libcublas
     libcufft

--- a/pkgs/development/python-modules/llama-cpp-python/default.nix
+++ b/pkgs/development/python-modules/llama-cpp-python/default.nix
@@ -89,7 +89,7 @@ buildPythonPackage.override { stdenv = stdenvTarget; } rec {
     with cudaPackages;
     [
       cuda_cudart # cuda_runtime.h
-      cuda_cccl # <thrust/*>
+      cccl # <thrust/*>
       libcublas # cublas_v2.h
     ]
   );

--- a/pkgs/development/python-modules/mamba-ssm/default.nix
+++ b/pkgs/development/python-modules/mamba-ssm/default.nix
@@ -10,7 +10,6 @@
   transformers,
   triton,
   cudaPackages,
-  rocmPackages,
   config,
   cudaSupport ? config.cudaSupport,
   which,
@@ -41,7 +40,7 @@ buildPythonPackage rec {
       with cudaPackages;
       [
         cuda_cudart # cuda_runtime.h, -lcudart
-        cuda_cccl
+        cccl
         libcusparse # cusparse.h
         libcusolver # cusolverDn.h
         cuda_nvcc

--- a/pkgs/development/python-modules/mmcv/default.nix
+++ b/pkgs/development/python-modules/mmcv/default.nix
@@ -72,8 +72,8 @@ buildPythonPackage (finalAttrs: {
   ++ lib.optionals cudaSupport (
     with cudaPackages;
     [
+      cccl # <thrust/*>
       cuda_cudart # cuda_runtime.h
-      cuda_cccl # <thrust/*>
       libcublas # cublas_v2.h
       libcusolver # cusolverDn.h
       libcusparse # cusparse.h

--- a/pkgs/development/python-modules/tensorflow/default.nix
+++ b/pkgs/development/python-modules/tensorflow/default.nix
@@ -136,7 +136,7 @@ let
   cudaComponents = with cudaPackages; [
     (cuda_nvcc.__spliced.buildHost or cuda_nvcc)
     (cuda_nvprune.__spliced.buildHost or cuda_nvprune)
-    cuda_cccl # block_load.cuh
+    cccl # block_load.cuh
     cuda_cudart # cuda.h
     cuda_cupti # cupti.h
     cuda_nvcc # See https://github.com/google/jax/issues/19811

--- a/pkgs/development/python-modules/torch/source/default.nix
+++ b/pkgs/development/python-modules/torch/source/default.nix
@@ -550,7 +550,7 @@ buildPythonPackage.override { inherit stdenv; } (finalAttrs: {
   ++ lib.optionals cudaSupport (
     with cudaPackages;
     [
-      cuda_cccl # <thrust/*>
+      cccl # <thrust/*>
       cuda_cudart # cuda_runtime.h and libraries
       cuda_cupti # For kineto
       cuda_nvcc # crt/host_config.h; even though we include this in nativeBuildInputs, it's needed here too

--- a/pkgs/development/python-modules/vllm/default.nix
+++ b/pkgs/development/python-modules/vllm/default.nix
@@ -305,7 +305,7 @@ let
 
   mergedCudaLibraries = with cudaPackages; [
     cuda_cudart # cuda_runtime.h, -lcudart
-    cuda_cccl
+    cccl
     libcurand # curand_kernel.h
     libcusparse # cusparse.h
     libcusolver # cusolverDn.h

--- a/pkgs/development/python-modules/warp-lang/default.nix
+++ b/pkgs/development/python-modules/warp-lang/default.nix
@@ -166,7 +166,7 @@ buildPythonPackage.override { stdenv = effectiveStdenv; } (finalAttrs: {
     ]
     ++ lib.optionals cudaSupport [
       (lib.getStatic cudaPackages.cuda_nvcc) # dependency on nvptxcompiler_static; no dynamic version available
-      cudaPackages.cuda_cccl
+      cudaPackages.cccl
       cudaPackages.cuda_cudart
       cudaPackages.cuda_nvcc
       cudaPackages.cuda_nvrtc

--- a/pkgs/development/python-modules/xformers/default.nix
+++ b/pkgs/development/python-modules/xformers/default.nix
@@ -82,7 +82,7 @@ buildPythonPackage.override { stdenv = effectiveStdenv; } (finalAttrs: {
       [
         cuda_cudart # cuda_runtime_api.h
         libcusparse # cusparse.h
-        cuda_cccl # nv/target
+        cccl # nv/target
         libcublas # cublas_v2.h
         libcusolver # cusolverDn.h
         libcurand # curand_kernel.h


### PR DESCRIPTION
## Things done

Starting from CUDA 13.3, NVIDIA's [cccl](https://github.com/nvidia/cccl) package is referenced as `cccl` instead of `cuda_cccl` in the manifest.

This PR initializes the corresponding `cudaPackages_13_3.cccl` package, which didn't exist until now, and creates an alias from `cudaPackages_13_3.cuda_cccl` to fix downstream consumers (`cuda_nvcc`, `cuda_cudart`, ...).

- **cudaPackages_13_3.cccl: init at 13.3.3.3.1**
- **cudaPackages_13_3.cuda_cccl: alias to cccl**

cc @NixOS/cuda-maintainers
cc @bryanhonof @kmittman

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
