### PR TITLE
python3Packages.pingouin: init at 0.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10191,6 +10191,11 @@
     githubId = 13297896;
     name = "David Isaksson";
   };
+  grandjeanlab = {
+    github = "grandjeanlab";
+    githubId = 22633767;
+    name = "grandjeanlab";
+  };
   gravndal = {
     email = "gaute.ravndal+nixos@gmail.com";
     github = "gravndal";

--- a/pkgs/development/python-modules/pandas-flavor/default.nix
+++ b/pkgs/development/python-modules/pandas-flavor/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools-scm,
+
+  # test framework
+  pytestCheckHook,
+  pytest-cov-stub,
+
+  # dependencies
+  pandas,
+  xarray,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pandas-flavor";
+  version = "0.8.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "pyjanitor-devs";
+    repo = "pandas_flavor";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-c1pHH8vQOl1qicJJCVGuQoPbJp9uK03KDVr+rJWByhY=";
+  };
+
+  build-system = [
+    setuptools-scm
+  ];
+
+  dependencies = [
+    pandas
+    xarray
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-cov-stub
+  ];
+
+  pythonImportsCheck = [
+    "pandas_flavor"
+  ];
+
+  meta = {
+    description = "The easy way to write your own flavor of Pandas";
+    homepage = "https://github.com/pyjanitor-devs/pandas_flavor";
+    changelog = "https://github.com/pyjanitor-devs/pandas_flavor/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ grandjeanlab ];
+  };
+})

--- a/pkgs/development/python-modules/pingouin/default.nix
+++ b/pkgs/development/python-modules/pingouin/default.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # test framework
+  pytestCheckHook,
+
+  # dependencies
+  matplotlib,
+  numpy,
+  pandas,
+  pandas-flavor,
+  scikit-learn,
+  scipy,
+  seaborn,
+  statsmodels,
+  tabulate,
+
+  # optional dependencies
+  mpmath,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pingouin";
+  version = "0.6.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "raphaelvallat";
+    repo = "pingouin";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-22nVAw6qbYwumwVJr/ZZD2HSpgD+9onnMe/hULjQHZI=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    matplotlib
+    numpy
+    pandas
+    pandas-flavor
+    scikit-learn
+    scipy
+    seaborn
+    statsmodels
+    tabulate
+  ];
+
+  passthru.optional-dependencies = {
+    extras = [
+      mpmath
+    ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ]
+  ++ finalAttrs.passthru.optional-dependencies.extras;
+
+  pythonImportsCheck = [
+    "pingouin"
+  ];
+
+  meta = {
+    description = "Statistical package in Python based on Pandas";
+    homepage = "https://github.com/raphaelvallat/pingouin";
+    changelog = "https://github.com/raphaelvallat/pingouin/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ grandjeanlab ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12712,6 +12712,8 @@ self: super: with self; {
 
   ping3 = callPackage ../development/python-modules/ping3 { };
 
+  pingouin = callPackage ../development/python-modules/pingouin { };
+
   pinocchio = callPackage ../development/python-modules/pinocchio { inherit (pkgs) pinocchio; };
 
   pins = callPackage ../development/python-modules/pins { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12257,6 +12257,8 @@ self: super: with self; {
 
   pandas-datareader = callPackage ../development/python-modules/pandas-datareader { };
 
+  pandas-flavor = callPackage ../development/python-modules/pandas-flavor { };
+
   pandas-stubs = callPackage ../development/python-modules/pandas-stubs { };
 
   pandas-ta = callPackage ../development/python-modules/pandas-ta { };


### PR DESCRIPTION
Add python3Packages.pingouin, a module to carry out effect size statistics, along with its dependency python3Packages.pandas-flavor, and adding myself to the maintainer list.  

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].