### PR TITLE
pnpm-fixup-state-db: make it depend on nodejs-slim

### DIFF
--- a/pkgs/build-support/node/fetch-pnpm-deps/default.nix
+++ b/pkgs/build-support/node/fetch-pnpm-deps/default.nix
@@ -52,19 +52,7 @@ in
       pnpm-fixup-state-db' =
         if pnpm.nodejs-slim or null != null then
           pnpm-fixup-state-db.override {
-            # FIXME: make npm-config-hook accept nodejs-slim
-            nodejs =
-              let
-                inherit (pnpm) nodejs-slim;
-              in
-              if nodejs-slim ? paths && builtins.isList nodejs-slim.paths then
-                # If nodejs-slim has a list `paths` attribute, it's likely a simlinkJoin
-                nodejs-slim
-              else
-                # Otherwise we need to recreate one by overriding the default one
-                pnpm-fixup-state-db.nodejs.override {
-                  inherit nodejs-slim;
-                };
+            inherit (pnpm) nodejs-slim;
           }
         else
           pnpm-fixup-state-db;

--- a/pkgs/build-support/src-only/default.nix
+++ b/pkgs/build-support/src-only/default.nix
@@ -37,37 +37,44 @@
 
 attrs:
 let
-  argsToOverride = args: {
-    name = "${args.name or "${args.pname}-${args.version}"}-source";
+  argsToOverride =
+    args:
+    {
+      name = "${args.name or "${args.pname}-${args.version}"}-source";
 
-    outputs = [ "out" ];
+      outputs = [ "out" ];
 
-    phases = [
-      "unpackPhase"
-      "patchPhase"
-      "installPhase"
-    ];
-    separateDebugInfo = false;
+      phases = [
+        "unpackPhase"
+        "patchPhase"
+        "installPhase"
+      ];
+      separateDebugInfo = false;
 
-    dontUnpack = lib.warnIf (args.dontUnpack or false
-    ) "srcOnly: derivation has dontUnpack set, overriding" false;
+      dontUnpack = lib.warnIf (args.dontUnpack or false
+      ) "srcOnly: derivation has dontUnpack set, overriding" false;
 
-    dontInstall = false;
-    installPhase = "cp -pr --reflink=auto -- . $out";
+      dontInstall = false;
+      installPhase = "cp -pr --reflink=auto -- . $out";
 
-    # the original derivation might've set something like outputDev = "lib", but "lib" isn't an output anymore
-    # some things get confused and error if one of these is set to an output that doesn't exist
-    # ex: pkgs/build-support/setup-hooks/multiple-outputs.sh
-    outputDev = "out";
-    outputBin = "out";
-    outputInclude = "out";
-    outputLib = "out";
-    outputDoc = "out";
-    outputDevdoc = "out";
-    outputMan = "out";
-    outputDevman = "out";
-    outputInfo = "out";
-  };
+      # the original derivation might've set something like outputDev = "lib", but "lib" isn't an output anymore
+      # some things get confused and error if one of these is set to an output that doesn't exist
+      # ex: pkgs/build-support/setup-hooks/multiple-outputs.sh
+      outputDev = "out";
+      outputBin = "out";
+      outputInclude = "out";
+      outputLib = "out";
+      outputDoc = "out";
+      outputDevdoc = "out";
+      outputMan = "out";
+      outputDevman = "out";
+      outputInfo = "out";
+
+    }
+    // lib.optionalAttrs (lib.isAttrs args.outputChecks or null) {
+      # If the original derivation includes outputChecks for output we are removing, we need to reset it to an empty check.
+      outputChecks = { };
+    };
 in
 
 # If we are passed a derivation (based on stdenv*), we can use overrideAttrs to

--- a/pkgs/by-name/pn/pnpm-fixup-state-db/package.nix
+++ b/pkgs/by-name/pn/pnpm-fixup-state-db/package.nix
@@ -1,7 +1,7 @@
 {
   buildNpmPackage,
   lib,
-  nodejs,
+  nodejs-slim,
   pnpm,
   tests,
 }:
@@ -11,12 +11,13 @@ buildNpmPackage {
 
   src = ./src;
 
-  inherit nodejs;
+  nodejs = nodejs-slim;
+  nativeBuildInputs = lib.optional (builtins.hasAttr "npm" nodejs-slim) nodejs-slim.npm;
 
   npmDepsHash = "sha256-um6a4pEtPtdxHBRq9g5ZW20wIQAMjWJ3qF96XuxJg8o=";
 
   postInstall = ''
-    makeWrapper ${lib.getExe nodejs} $out/bin/pnpm-fixup-state-db \
+    makeWrapper ${lib.getExe nodejs-slim} $out/bin/pnpm-fixup-state-db \
       --add-flags "$out/lib/node_modules/pnpm-fixup-state-db"
   '';
 

--- a/pkgs/development/web/nodejs/symlink.nix
+++ b/pkgs/development/web/nodejs/symlink.nix
@@ -44,6 +44,10 @@
                 "man"
                 "out"
                 "static"
+
+                # Filter out outputs that didn't exist on 25.11
+                "npm"
+                "corepack"
               ])
               && !(builtins.hasAttr name nodejs)
             ) (builtins.attrNames nodejs-slim)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes: https://github.com/NixOS/nixpkgs/pull/514575#discussion_r3347372681

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
