### PR TITLE
python3Packages.blinkstick: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/blinkstick/default.nix
+++ b/pkgs/development/python-modules/blinkstick/default.nix
@@ -11,6 +11,8 @@ buildPythonPackage {
   version = "unstable-2023-05-04";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "arvydas";
     repo = "blinkstick-python";

--- a/pkgs/development/python-modules/blinkstick/default.nix
+++ b/pkgs/development/python-modules/blinkstick/default.nix
@@ -8,7 +8,7 @@
 
 buildPythonPackage {
   pname = "blinkstick";
-  version = "unstable-2023-05-04";
+  version = "1.2.0-unstable-2023-05-04";
   pyproject = true;
 
   __structuredAttrs = true;

--- a/pkgs/development/python-modules/blinkstick/default.nix
+++ b/pkgs/development/python-modules/blinkstick/default.nix
@@ -2,13 +2,14 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   pyusb,
 }:
 
 buildPythonPackage {
   pname = "blinkstick";
   version = "unstable-2023-05-04";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "arvydas";
@@ -17,7 +18,9 @@ buildPythonPackage {
     hash = "sha256-9bc7TD/Ilc952ywLauFd0+3Lh64lQlYuDC1KG9eWDgs=";
   };
 
-  propagatedBuildInputs = [ pyusb ];
+  build-system = [ setuptools ];
+
+  dependencies = [ pyusb ];
 
   # Project has no tests
   doCheck = false;


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
