### PR TITLE
python3Packages.cuda-bindings: init at 13.3.1 for CUDA 13.3

### DIFF
--- a/pkgs/development/python-modules/cuda-bindings/13_3.nix
+++ b/pkgs/development/python-modules/cuda-bindings/13_3.nix
@@ -1,0 +1,58 @@
+{
+  replaceVars,
+  cudaLibPaths,
+}:
+{
+  version = "13.3.1";
+  sourceHash = "sha256-k8ZNWw2ZpNepcWzv8TJfoxSGVn6HUCYfamEDESIcUQY=";
+
+  nvidiaLibsPatch = replaceVars ./patch-nvidia-libs-paths_13_3.patch {
+    inherit (cudaLibPaths)
+      libcudart
+      libcufile
+      libnvfatbin
+      libnvjitlink
+      libnvml
+      libnvrtc
+      libnvvm
+      ;
+  };
+
+  # Remove cuda-pathfinder from build-system requirements
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail \
+        '"cuda-pathfinder>=1.5",' \
+        ""
+  '';
+
+  pythonImportsCheck = [
+    "cuda.bindings.nvfatbin"
+    "cuda.bindings.nvml"
+  ];
+
+  disabledTests = [
+    # Requires GPU discovery support not available in the test environment
+    "test_discover_gpus"
+
+    # sysfs cpu topology is not available in the sandbox, causing:
+    #   cuda.bindings.nvml.UnknownError: Unknown Error
+    #   hwloc/linux: failed to find sysfs cpu topology directory, aborting linux discovery.
+    "test_device_get_cpu_affinity_within_scope"
+    "test_device_get_memory_affinity"
+
+    # Requires the nvidia_fs kernel module (GPUDirect Storage), causing:
+    #   cuda.bindings.cufile.cuFileError: NVFS_SETUP_ERROR (5033): NVFS driver initialization error
+    "test_buf_register_already_registered"
+    "test_buf_register_host_memory"
+    "test_buf_register_invalid_flags"
+    "test_buf_register_large_buffer"
+    "test_buf_register_multiple_buffers"
+    "test_buf_register_simple"
+    "test_get_bar_size_in_kb"
+    "test_get_parameter_min_max_value"
+    "test_set_parameter_posix_pool_slab_array"
+    "test_set_stats_level"
+    "test_stats_start_stop"
+  ];
+}

--- a/pkgs/development/python-modules/cuda-bindings/default.nix
+++ b/pkgs/development/python-modules/cuda-bindings/default.nix
@@ -11,6 +11,7 @@
   pyclibrary,
   setuptools,
   setuptools-scm,
+  cuda-pathfinder,
 
   # env
   symlinkJoin,
@@ -19,7 +20,6 @@
   numpy,
 
   # tests
-  cuda-pathfinder,
   pytest-benchmark,
   pytestCheckHook,
   util-linux,
@@ -54,6 +54,7 @@ let
       "13.0" = import ./13_0.nix args;
       "13.1" = import ./13_1.nix args;
       "13.2" = import ./13_2.nix args;
+      "13.3" = import ./13_3.nix args;
     }
     .${cudaVersion} or (throw "Unsupported cuda-bindings version: ${cudaVersion}");
 
@@ -114,6 +115,9 @@ buildPythonPackage (finalAttrs: {
     pyclibrary
     setuptools
     setuptools-scm
+  ]
+  ++ lib.optionals (cudaAtLeast "13.3") [
+    cuda-pathfinder
   ];
 
   env = {

--- a/pkgs/development/python-modules/cuda-bindings/patch-nvidia-libs-paths_13_3.patch
+++ b/pkgs/development/python-modules/cuda-bindings/patch-nvidia-libs-paths_13_3.patch
@@ -1,0 +1,160 @@
+diff --git a/cuda_bindings/cuda/bindings/_internal/cufile_linux.pyx b/cuda_bindings/cuda/bindings/_internal/cufile_linux.pyx
+index a49ba1890f..b32fb24208 100644
+--- a/cuda_bindings/cuda/bindings/_internal/cufile_linux.pyx
++++ b/cuda_bindings/cuda/bindings/_internal/cufile_linux.pyx
+@@ -9,7 +9,7 @@ import threading
+ 
+ from .utils import FunctionNotFoundError, NotSupportedError
+ 
+-from cuda.pathfinder import load_nvidia_dynamic_lib
++from ctypes import CDLL
+ 
+ import cython
+ 
+@@ -107,7 +107,7 @@ cdef void* __cuFileGetParameterPosixPoolSlabArray = NULL
+ 
+ 
+ cdef void* load_library() except* with gil:
+-    cdef uintptr_t handle = load_nvidia_dynamic_lib("cufile")._handle_uint
++    cdef uintptr_t handle = CDLL("@libcufile@/lib/libcufile.so")._handle
+     return <void*>handle
+ 
+ 
+diff --git a/cuda_bindings/cuda/bindings/_internal/nvfatbin_linux.pyx b/cuda_bindings/cuda/bindings/_internal/nvfatbin_linux.pyx
+index 448e51240e..6de894800b 100644
+--- a/cuda_bindings/cuda/bindings/_internal/nvfatbin_linux.pyx
++++ b/cuda_bindings/cuda/bindings/_internal/nvfatbin_linux.pyx
+@@ -9,7 +9,7 @@ from libc.stdint cimport intptr_t, uintptr_t
+ import threading
+ from .utils import FunctionNotFoundError, NotSupportedError
+ 
+-from cuda.pathfinder import load_nvidia_dynamic_lib
++from ctypes import CDLL
+ 
+ 
+ ###############################################################################
+@@ -74,7 +74,7 @@ cdef void* __nvFatbinAddTileIR = NULL
+ 
+ 
+ cdef void* load_library() except* with gil:
+-    cdef uintptr_t handle = load_nvidia_dynamic_lib("nvfatbin")._handle_uint
++    cdef uintptr_t handle = CDLL("@libnvfatbin@/lib/libnvfatbin.so")._handle
+     return <void*>handle
+ 
+ 
+diff --git a/cuda_bindings/cuda/bindings/_internal/nvjitlink_linux.pyx b/cuda_bindings/cuda/bindings/_internal/nvjitlink_linux.pyx
+index 34ad6b5f0c..dc20de43a7 100644
+--- a/cuda_bindings/cuda/bindings/_internal/nvjitlink_linux.pyx
++++ b/cuda_bindings/cuda/bindings/_internal/nvjitlink_linux.pyx
+@@ -9,7 +9,7 @@ from libc.stdint cimport intptr_t, uintptr_t
+ import threading
+ from .utils import FunctionNotFoundError, NotSupportedError
+ 
+-from cuda.pathfinder import load_nvidia_dynamic_lib
++from ctypes import CDLL
+ 
+ 
+ ###############################################################################
+@@ -78,7 +78,7 @@ cdef void* __nvJitLinkGetLinkedLTOIR = NULL
+ 
+ 
+ cdef void* load_library() except* with gil:
+-    cdef uintptr_t handle = load_nvidia_dynamic_lib("nvJitLink")._handle_uint
++    cdef uintptr_t handle = CDLL("@libnvjitlink@/lib/libnvJitLink.so")._handle
+     return <void*>handle
+ 
+ 
+diff --git a/cuda_bindings/cuda/bindings/_internal/nvml_linux.pyx b/cuda_bindings/cuda/bindings/_internal/nvml_linux.pyx
+index 825931d756..77004f360c 100644
+--- a/cuda_bindings/cuda/bindings/_internal/nvml_linux.pyx
++++ b/cuda_bindings/cuda/bindings/_internal/nvml_linux.pyx
+@@ -10,7 +10,7 @@ import threading
+ 
+ from .utils import FunctionNotFoundError, NotSupportedError
+ 
+-from cuda.pathfinder import load_nvidia_dynamic_lib
++from ctypes import CDLL
+ 
+ 
+ ###############################################################################
+@@ -414,7 +414,7 @@ cdef void* __nvmlGpuInstanceSetVgpuSchedulerState_v2 = NULL
+ 
+ 
+ cdef void* load_library() except* with gil:
+-    cdef uintptr_t handle = load_nvidia_dynamic_lib("nvml")._handle_uint
++    cdef uintptr_t handle = CDLL("@libnvml@/lib/libnvidia-ml.so")._handle
+     return <void*>handle
+ 
+ 
+diff --git a/cuda_bindings/cuda/bindings/_internal/nvrtc_linux.pyx b/cuda_bindings/cuda/bindings/_internal/nvrtc_linux.pyx
+index ac9cbca550..68644df6be 100644
+--- a/cuda_bindings/cuda/bindings/_internal/nvrtc_linux.pyx
++++ b/cuda_bindings/cuda/bindings/_internal/nvrtc_linux.pyx
+@@ -9,7 +9,7 @@ from libc.stdint cimport intptr_t, uintptr_t
+ import threading
+ from .utils import FunctionNotFoundError, NotSupportedError
+ 
+-from cuda.pathfinder import load_nvidia_dynamic_lib
++from ctypes import CDLL
+ 
+ ###############################################################################
+ # Extern
+@@ -87,7 +87,7 @@ cdef void* __nvrtcGetBundledHeadersInfo = NULL
+ cdef void* __nvrtcRemoveBundledHeaders = NULL
+ 
+ cdef void* load_library() except* with gil:
+-    cdef uintptr_t handle = load_nvidia_dynamic_lib("nvrtc")._handle_uint
++    cdef uintptr_t handle = CDLL("@libnvrtc@/lib/libnvrtc.so")._handle
+     return <void*>handle
+ 
+ cdef int _init_nvrtc() except -1 nogil:
+diff --git a/cuda_bindings/cuda/bindings/_internal/nvvm_linux.pyx b/cuda_bindings/cuda/bindings/_internal/nvvm_linux.pyx
+index 2a1d155862..94aa05421a 100644
+--- a/cuda_bindings/cuda/bindings/_internal/nvvm_linux.pyx
++++ b/cuda_bindings/cuda/bindings/_internal/nvvm_linux.pyx
+@@ -9,7 +9,7 @@ from libc.stdint cimport intptr_t, uintptr_t
+ import threading
+ from .utils import FunctionNotFoundError, NotSupportedError
+ 
+-from cuda.pathfinder import load_nvidia_dynamic_lib
++from ctypes import CDLL
+ 
+ 
+ ###############################################################################
+@@ -76,7 +76,7 @@ cdef void* __nvvmLLVMVersion = NULL
+ 
+ 
+ cdef void* load_library() except* with gil:
+-    cdef uintptr_t handle = load_nvidia_dynamic_lib("nvvm")._handle_uint
++    cdef uintptr_t handle = CDLL("@libnvvm@/lib/libnvvm.so")._handle
+     return <void*>handle
+ 
+ 
+diff --git a/cuda_bindings/cuda/bindings/cyruntime.pyx.in b/cuda_bindings/cuda/bindings/cyruntime.pyx.in
+index 230b5d8f84..c88872e5f1 100644
+--- a/cuda_bindings/cuda/bindings/cyruntime.pyx.in
++++ b/cuda_bindings/cuda/bindings/cyruntime.pyx.in
+@@ -2048,7 +2048,7 @@ cdef cudaError_t cudaGraphicsVDPAURegisterOutputSurface(cudaGraphicsResource** r
+ {{if True}}
+ 
+ from libc.stdint cimport uintptr_t
+-from cuda.pathfinder import load_nvidia_dynamic_lib
++from ctypes import CDLL
+ {{if 'Windows' == platform.system()}}
+ cimport cuda.bindings._lib.windll as windll
+ {{else}}
+@@ -2058,11 +2058,11 @@ cimport cuda.bindings._lib.dlfcn as dlfcn
+ cdef cudaError_t getLocalRuntimeVersion(int* runtimeVersion) except ?cudaErrorCallRequiresNewerDriver nogil:
+     # Load
+     with gil:
+-        loaded_dl = load_nvidia_dynamic_lib("cudart")
++        loaded_dl = CDLL("@libcudart@/lib/libcudart.so")
+         {{if 'Windows' == platform.system()}}
+-        handle = <uintptr_t>loaded_dl._handle_uint
++        handle = <uintptr_t>loaded_dl._handle
+         {{else}}
+-        handle = <void *><uintptr_t>loaded_dl._handle_uint
++        handle = <void *><uintptr_t>loaded_dl._handle
+         {{endif}}
+ 
+     {{if 'Windows' == platform.system()}}


### PR DESCRIPTION
## Things done

Initialize `python3Packages.cuda-bindings` 13.3.1 for `cudaPackages_13_3`.

Depends on #528773.

cc @NixOS/cuda-maintainers

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
