### PR TITLE
vsketch: init at 1.2.0, vpype: init at 1.15.0, pnoise: init at 0.2.0

### DIFF
--- a/pkgs/by-name/vs/vsketch/package.nix
+++ b/pkgs/by-name/vs/vsketch/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  python3Packages,
+  fetchPypi,
+}:
+
+python3Packages.buildPythonPackage (finalAttrs: {
+  pname = "vsketch";
+  version = "1.2.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-hRYcJsmSF5+4p4q/akO3PiLgwekw4uZi0JuHebd7S+Q=";
+  };
+
+  dependencies = with python3Packages; [
+    cookiecutter
+    matplotlib
+    multiprocess
+    numpy
+    pnoise
+    pyside6
+    shapely
+    vpype
+    watchfiles
+  ];
+
+  build-system = with python3Packages; [
+    poetry-core
+  ];
+
+  meta = {
+    changelog = "https://github.com/abey79/vsketch/blob/${finalAttrs.version}/CHANGELOG.md";
+    description = "Generative plotter art environment for Python";
+    homepage = "https://github.com/abey79/vsketch";
+    license = lib.licenses.mit;
+    mainProgram = "vsk";
+    maintainers = with lib.maintainers; [ kybe236 ];
+  };
+})

--- a/pkgs/development/python-modules/pnoise/default.nix
+++ b/pkgs/development/python-modules/pnoise/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+
+  # dependencies
+  numpy,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pnoise";
+  version = "0.2.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-djgzENYCvMftI1XNM0+OvFuI5x1b/f7jLRuT05gZcs8=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    numpy
+  ];
+
+  meta = {
+    changelog = "https://github.com/plottertools/pnoise/blob/${finalAttrs.version}/CHANGELOG.md";
+    description = "Vectorized port of Processing noise() function";
+    homepage = "https://github.com/plottertools/pnoise";
+    license = lib.licenses.lgpl21;
+    maintainers = with lib.maintainers; [ kybe236 ];
+  };
+})

--- a/pkgs/development/python-modules/vpype/default.nix
+++ b/pkgs/development/python-modules/vpype/default.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+
+  # build-system
+  poetry-core,
+
+  # dependencies
+  asteval,
+  cachetools,
+  click,
+  moderngl,
+  multiprocess,
+  numpy,
+  pnoise,
+  pyphen,
+  scipy,
+  shapely,
+  svgelements,
+  svgwrite,
+  tomli,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "vpype";
+  version = "1.15.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-CQofiMiII43wdE3gF5udnzgpzYi6xguISQ4+OXqErtM=";
+  };
+
+  pythonRelaxDeps = [ "pyphen" ];
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    asteval
+    cachetools
+    click
+    moderngl
+    multiprocess
+    numpy
+    pnoise
+    pyphen
+    scipy
+    shapely
+    svgelements
+    svgwrite
+    tomli
+  ];
+
+  meta = {
+    changelog = "https://github.com/abey79/vpype/blob/${finalAttrs.version}/CHANGELOG.md";
+    description = "Swiss-Army-knife command-line/libary tool for plotter vector graphics";
+    homepage = "https://github.com/abey79/vpype";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kybe236 ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12925,6 +12925,8 @@ self: super: with self; {
 
   pnglatex = callPackage ../development/python-modules/pnglatex { };
 
+  pnoise = callPackage ../development/python-modules/pnoise { };
+
   pocket = callPackage ../development/python-modules/pocket { };
 
   pocket-tts = callPackage ../development/python-modules/pocket-tts { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21252,6 +21252,8 @@ self: super: with self; {
 
   vprof = callPackage ../development/python-modules/vprof { };
 
+  vpype = callPackage ../development/python-modules/vpype { };
+
   vqgan-jax = callPackage ../development/python-modules/vqgan-jax { };
 
   vsts = callPackage ../development/python-modules/vsts { };


### PR DESCRIPTION
## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
