### PR TITLE
minimal-bootstrap.gnumake-musl: fix build

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -184,6 +184,9 @@ lib.makeScope
           tinycc = tinycc-musl;
           gawk = gawk-mes;
           gnumakeBoot = gnumake;
+          # GNU Make's release tarball relies on preserved mtimes for
+          # pregenerated Autotools files.
+          gnutar = gnutar-musl;
         };
 
         gnumake-static = callPackage ./gnumake/static.nix {


### PR DESCRIPTION
Fixes `minimal-bootstrap.gnumake-musl` failing during the minimal bootstrap build.

GNU Make's release tarball contains pregenerated Autotools files such as
`aclocal.m4` and `Makefile.in`. Those files are expected to remain newer than
their inputs, so the build does not try to regenerate them.

`gnumake-musl` was unpacking the tarball with the earlier Mes-built `gnutar`,
which does not preserve archive mtimes. That can make `configure.ac` and `m4/*`
appear newer than the pregenerated files, causing serial `make` to invoke
missing bootstrap-time tools such as `aclocal-1.16` or `automake-1.16`.

Wire `gnutar-musl` into `gnumake-musl` explicitly. `gnutar-musl` is already
documented in this bootstrap set as preserving mtimes for pregenerated files.

Disclosure: this PR description and the commit message were prepared with
assistance from OpenAI Codex (GPT-5.5), and the change was manually reviewed.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc @alejandrosame @Gskartwii @Artturin @emilytrau @Ericson2314 @06kellyjac @pyrox0 @siraben