### PR TITLE
python3Packages.qemu,qemu-python-utils: fix build

### DIFF
--- a/pkgs/development/python-modules/qemu/default.nix
+++ b/pkgs/development/python-modules/qemu/default.nix
@@ -5,10 +5,7 @@
   setuptools,
   fuseSupport ? false,
   fusepy,
-  tuiSupport ? false,
-  urwid,
-  urwid-readline,
-  pygments,
+  qemu-qmp,
 }:
 
 buildPythonPackage {
@@ -31,18 +28,12 @@ buildPythonPackage {
     fi
   '';
 
-  buildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs =
-    [ ]
-    ++ lib.optionals fuseSupport [ fusepy ]
-    ++ lib.optionals tuiSupport [
-      urwid
-      urwid-readline
-      pygments
-    ];
+  dependencies = [ qemu-qmp ] ++ lib.optionals fuseSupport [ fusepy ];
 
-  # Project requires avocado-framework for testing, therefore replacing check phase
+  # Project now uses pytest instead of avocado-framework for testing but does not perform functional testing.
+  # let's keep it this way.
   checkPhase = ''
     for bin in $out/bin/*; do
       $bin --help
@@ -51,13 +42,11 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "qemu" ];
 
-  preFixup =
-    (lib.optionalString (!tuiSupport) ''
-      rm $out/bin/qmp-tui
-    '')
-    + (lib.optionalString (!fuseSupport) ''
+  preFixup = (
+    lib.optionalString (!fuseSupport) ''
       rm $out/bin/qom-fuse
-    '');
+    ''
+  );
 
   meta = {
     homepage = "https://www.qemu.org/";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9656,7 +9656,6 @@ with pkgs;
   qemu-python-utils = python3Packages.toPythonApplication (
     python3Packages.qemu.override {
       fuseSupport = true;
-      tuiSupport = true;
     }
   );
 


### PR DESCRIPTION
tuiSupport for qemu is dropped
https://github.com/qemu/qemu/commit/e1e49b35b3c3cf6b7c68b6b1df18a477ac3183e5


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
