### PR TITLE
kulala-core: 0.13.0 -> 0.14.1, kulala-fmt: 1.4.0 -> 3.1.0

### DIFF
--- a/pkgs/by-name/ku/kulala-core/package.nix
+++ b/pkgs/by-name/ku/kulala-core/package.nix
@@ -10,7 +10,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "kulala-core";
-  version = "0.13.0";
+  version = "0.14.1";
 
   strictDeps = true;
   __structuredAttrs = true;
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "mistweaverco";
     repo = "kulala-core";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-pUBG8tlybpd/YPArIssCEy5Op47MVPLJsOOolVItZpU=";
+    hash = "sha256-1EtYAKulMQbtYWHZ8MkUA1fMcL3V07/Sz1sjl5PnaI4=";
   };
 
   node_modules = stdenv.mkDerivation {
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     dontFixup = true;
 
-    outputHash = "sha256-NjHm6KU6Cd0ZyL1c+bmNbEHb5E83/xjQ5UGRjY1hzgQ=";
+    outputHash = "sha256-XQlBawD3vt8pVc7Gy9XeiGie89HWbljNJt7kUEDaDKk=";
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
   };

--- a/pkgs/by-name/ku/kulala-fmt/package.nix
+++ b/pkgs/by-name/ku/kulala-fmt/package.nix
@@ -1,29 +1,109 @@
 {
   lib,
-  buildGoModule,
+  stdenv,
+  bun,
   fetchFromGitHub,
+  kulala-core,
+  makeBinaryWrapper,
+  nodejs,
+  writableTmpDirAsHomeHook,
 }:
 
-buildGoModule (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "kulala-fmt";
-  version = "1.4.0";
+  version = "3.1.0";
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "mistweaverco";
     repo = "kulala-fmt";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-yq7DMrt+g5wM/tynI7Cf6MBJs/d+fP3IppndKnTJMTw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-4rVsw3dyoKrC6lj8m2R42iZmBk5G2LIVtV6Ro9pHSBo=";
   };
 
-  vendorHash = "sha256-GazDEm/qv0nh8vYT+Tf0n4QDGHlcYtbMIj5rlZBvpKo=";
+  node_modules = stdenv.mkDerivation {
+    pname = "${finalAttrs.pname}-node_modules";
+    inherit (finalAttrs) version src;
 
-  env.CGO_ENABLED = 0;
+    strictDeps = true;
+    __structuredAttrs = true;
 
-  ldflags = [
-    "-s"
-    "-w"
-    "-X github.com/mistweaverco/kulala-fmt/cmd/kulalafmt.VERSION=${finalAttrs.version}"
+    nativeBuildInputs = [
+      bun
+      writableTmpDirAsHomeHook
+    ];
+
+    dontConfigure = true;
+
+    buildPhase = ''
+      runHook preBuild
+
+      bun install \
+        --cpu="*" \
+        --frozen-lockfile \
+        --ignore-scripts \
+        --no-progress \
+        --os="*"
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp -R node_modules $out/
+
+      runHook postInstall
+    '';
+
+    dontFixup = true;
+
+    outputHash = "sha256-z+jQC2RCav3VG/agWizcWFat8KgkGdBzaGQriviEbyo=";
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+  };
+
+  nativeBuildInputs = [
+    bun
+    makeBinaryWrapper
+    nodejs
   ];
+
+  dontConfigure = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    cp -R ${finalAttrs.node_modules}/node_modules .
+    patchShebangs node_modules
+    bun run build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 dist/cli.cjs $out/lib/kulala-fmt/cli.cjs
+    makeBinaryWrapper ${lib.getExe nodejs} $out/bin/kulala-fmt \
+      --add-flags $out/lib/kulala-fmt/cli.cjs \
+      --set KULALA_CORE_PATH ${lib.getExe kulala-core}
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    $out/bin/kulala-fmt --version | grep -x ${lib.escapeShellArg finalAttrs.version}
+    printf '%s\n' 'GET https://example.com' | $out/bin/kulala-fmt format --stdin | grep 'GET https://example.com'
+
+    runHook postInstallCheck
+  '';
 
   meta = {
     description = "Opinionated .http and .rest files linter and formatter";
@@ -31,6 +111,6 @@ buildGoModule (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ CnTeng ];
     mainProgram = "kulala-fmt";
-    platforms = lib.platforms.all;
+    platforms = nodejs.meta.platforms;
   };
 })


### PR DESCRIPTION
Updates:
- kulala-core to v0.14.1.
- kulala-fmt to v3.1.0, replacing the old Go derivation with the current Bun/Rollup-built CLI and wiring it to packaged kulala-core via KULALA_CORE_PATH.

Changelogs:
- kulala-core: https://github.com/mistweaverco/kulala-core/compare/v0.13.0...v0.14.1
- kulala-fmt: https://github.com/mistweaverco/kulala-fmt/compare/v1.4.0...v3.1.0

Supersedes:
- #391575
- #523348

Related https://github.com/nix-community/nixvim/issues/4180

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Verification performed:
- `kulala-fmt --version`
- `kulala-fmt format --stdin`
- `kulala-fmt check --stdin`

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

