### PR TITLE
python3Packages.boa-api: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/boa-api/default.nix
+++ b/pkgs/development/python-modules/boa-api/default.nix
@@ -2,12 +2,13 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "boa-api";
   version = "0.1.14";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "boalang";
@@ -15,6 +16,8 @@ buildPythonPackage rec {
     tag = "v${version}";
     sha256 = "sha256-8tt68NLi5ewSKiHdu3gDawTBPylbDmB4zlUUqa7EQuY=";
   };
+
+  build-system = [ setuptools ];
 
   # upstream has no tests
   doCheck = false;

--- a/pkgs/development/python-modules/boa-api/default.nix
+++ b/pkgs/development/python-modules/boa-api/default.nix
@@ -5,16 +5,18 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "boa-api";
   version = "0.1.14";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "boalang";
     repo = "api-python";
-    tag = "v${version}";
-    sha256 = "sha256-8tt68NLi5ewSKiHdu3gDawTBPylbDmB4zlUUqa7EQuY=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8tt68NLi5ewSKiHdu3gDawTBPylbDmB4zlUUqa7EQuY=";
   };
 
   build-system = [ setuptools ];
@@ -27,8 +29,8 @@ buildPythonPackage rec {
   meta = {
     homepage = "https://github.com/boalang/api-python";
     description = "Python client API for communicating with Boa's (https://boa.cs.iastate.edu/) XML-RPC based services";
-    changelog = "https://github.com/boalang/api-python/blob/${src.rev}/Changes.txt";
+    changelog = "https://github.com/boalang/api-python/blob/${finalAttrs.src.rev}/Changes.txt";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ swflint ];
   };
-}
+})


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
