### PR TITLE
gobject-introspection: don't pollute LD_LIBRARY_PATH of emulator

### DIFF
--- a/pkgs/development/libraries/gobject-introspection/wrappers/g-ir-scanner.sh
+++ b/pkgs/development/libraries/gobject-introspection/wrappers/g-ir-scanner.sh
@@ -4,4 +4,5 @@
 exec @dev@/bin/.g-ir-scanner-wrapped \
     --use-binary-wrapper=@emulatorwrapper@ \
     --use-ldd-wrapper=@dev@/bin/g-ir-scanner-lddwrapper \
+    --lib-dirs-envvar=GIR_EXTRA_LIBS_PATH \
     "$@"


### PR DESCRIPTION
fixes cross compilation on non-gnu systems, e.g.
```
nix-build -A pkgsMusl.pkgsCross.aarch64-multiplatform-musl.gobject-introspection
```

the behavior was already iffy on gnu -> gnu cross; musl ld is just more strict.

g-ir-scanner invokes host binaries, and by default populates LD_LIBRARY_PATH with other host libraries that binary may need to load. when cross compiling, we don't invoke host binaries directly, but use a qemu wrapper (g-ir-scanner-qemuwrapper.sh). the default wiring for this causes g-ir-scanner to populate LD_LIBRARY_PATH with host libraries before invoking qemu; musl ld doesn't handle that well and fails to load qemu.

to solve this, instruct g-ir-scanner to keep LD_LIBRARY_PATH unchanged and write the host library list to `GIR_EXTRA_LIBS_PATH` instead; our qemu wrapper appends that onto `LD_LIBRARY_PATH` only for the emulated binary, and not for qemu itself.

this patch only touches `g-ir-scanner.sh`; the other side of that interface was already implemented via `./g-ir-scanner-qemuwrapper.sh`

> exec @emulator@ ${GIR_EXTRA_OPTIONS:-} \
>     ${GIR_EXTRA_LIBS_PATH:+-E LD_LIBRARY_PATH="${GIR_EXTRA_LIBS_PATH}"} \
>     "$@"

that file references OpenEmbedded, where we can see them using this `--lib-dirs-envvar` flag in the same manner:

<https://github.com/openembedded/openembedded-core/blob/c5a14f39a6717a99b510cb97aa2fb403d4b98d99/meta/recipes-gnome/gobject-introspection/gobject-introspection_1.72.0.bb#L90>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
