### PR TITLE
inspircd: apply patches for missing escaping in LDAP modules

### DIFF
--- a/pkgs/by-name/in/inspircd/package.nix
+++ b/pkgs/by-name/in/inspircd/package.nix
@@ -67,6 +67,7 @@ in
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   nixosTests,
   perl,
   pkg-config,
@@ -156,6 +157,22 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "sha256-fMfsNbkp9M8KiuhwOEFmPjowZ4JLP4IpX6LRO9aLHzY=";
   };
+
+  patches = [
+    # Additions to LDAP code for the benefit of the next patch
+    (fetchpatch {
+      name = "inspircd-ldap-api.patch";
+      url = "https://github.com/inspircd/inspircd/commit/b7e5357b144c2e20c72431e22f0f2b13e5be82ce.patch";
+      hash = "sha256-nrgjmSBEIXdhlu/3WbMspIgSTHR29D4TfvKZ26JcYHs=";
+    })
+    # Resolves missing escaping in LDAP search filters which can be used to bypass auth
+    # https://docs.inspircd.org/security/2026-01/
+    (fetchpatch {
+      name = "inspircd-ldap-filter-escape.patch";
+      url = "https://github.com/inspircd/inspircd/commit/6319ae4fb8c10dabc9464ad49faec532096fbcb5.patch";
+      hash = "sha256-RtwNZA3PZDtQ5wW0TfCrvD+zfQHTFLg4mQRP5/qrAzg=";
+    })
+  ];
 
   outputs = [
     "bin"


### PR DESCRIPTION
This can be used to bypass auth or gain privileges for certain configurations.
https://docs.inspircd.org/security/2026-01/

Backport of relevant patches of #528852.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
