### PR TITLE
python3Packages.silero-vad: init at 6.2.1

### DIFF
--- a/pkgs/development/python-modules/silero-vad/default.nix
+++ b/pkgs/development/python-modules/silero-vad/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  packaging,
+  torch,
+  torchaudio,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "silero-vad";
+  version = "6.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "snakers4";
+    repo = "silero-vad";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-peGaJkSqjeobgx479OKt8ErorFviTIA7naFPewgab4U=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    packaging
+    torch
+    torchaudio
+  ];
+
+  # tests use torchcodec which refuses to decode tests/data/test.mp3
+  # this causes all tests to fail. See https://github.com/snakers4/silero-vad/issues/777
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "silero_vad"
+  ];
+
+  meta = {
+    description = "Silero VAD: pre-trained enterprise-grade Voice Activity Detector";
+    changelog = "https://github.com/snakers4/silero-vad/releases/tag/${finalAttrs.src.tag}";
+    homepage = "https://github.com/snakers4/silero-vad";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ seudonym ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18037,6 +18037,8 @@ self: super: with self; {
 
   sigtools = callPackage ../development/python-modules/sigtools { };
 
+  silero-vad = callPackage ../development/python-modules/silero-vad { };
+
   silver-platter = callPackage ../development/python-modules/silver-platter { };
 
   simanneal = callPackage ../development/python-modules/simanneal { };


### PR DESCRIPTION
This package is distinct from the existing `python3Packages.pysilero-vad`, which is a separate third-party wrapper. 

Homepage: https://github.com/snakers4/silero-vad
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
