### PR TITLE
matrix-tuwunel: run tests in debug profile

### DIFF
--- a/pkgs/by-name/ma/matrix-tuwunel/package.nix
+++ b/pkgs/by-name/ma/matrix-tuwunel/package.nix
@@ -150,6 +150,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     libredirect.hook
   ];
 
+  # Make sure tuwunel doesn't try to write to arbitrary
+  # directories or have DNS timeouts during `cargo test`.
   preCheck =
     let
       fakeResolvConf = writeTextFile {
@@ -163,7 +165,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
       export NIX_REDIRECTS="/etc/resolv.conf=${fakeResolvConf}"
       export TUWUNEL_DATABASE_PATH="$(mktemp -d)/smoketest.db"
     '';
+
   doCheck = true;
+
+  # 2026-06-24: Tuwunel has 16 integration tests. Cargo turns each of these
+  # into a separate binary that links in all 110 MB worth of tuwunel.  Linking
+  # 16 big binaries like this takes a really long time and was causing Hydra
+  # to time out the build during `checkPhase`.  So, we run the checks in the
+  # "debug" profile.  This reduces the build+test time on my machine from
+  # 44min to 12min.
+  checkType = "debug";
 
   passthru = {
     rocksdb = rocksdb'; # make used rocksdb version available (e.g., for backup scripts)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The tuwunel build is timing out intermittently on both [aarch64](https://hydra.nixos.org/job/nixos/release-26.05/nixpkgs.matrix-tuwunel.aarch64-linux) and [x86-64](https://hydra.nixos.org/job/nixos/unstable/nixpkgs.matrix-tuwunel.x86_64-linux#tabs-status).

The specific step that causes the timeout is the `Compiling tuwunel v1.7.1 (/build/source/src/main)` step during `checkPhase`.  So, we're timing out **building** the tests and not **running** them.

This is caused by tuwunel having 16 integration tests.  Cargo compiles each of them as a separate binary which statically links 110 MB worth of tuwunel.  Linking 16 big binaries like this takes a really long time in "release" profile.

Building the tests in debug profile reduces the package build from 44min to 12min on my machine.  So, let's do that.

The previous version of this PR just disabled the tests, hence the first few comments below.  We don't need to do that anymore.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
