### PR TITLE
python3Packages.whichcraft: use finalAttrs, cleanup, migrate to pyproject, add changelog

### DIFF
--- a/pkgs/development/python-modules/whichcraft/default.nix
+++ b/pkgs/development/python-modules/whichcraft/default.nix
@@ -2,18 +2,21 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   pytest,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "whichcraft";
   version = "0.6.1";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
     sha256 = "11yfkzyplizdgndy34vyd5qlmr1n5mxis3a3svxmx8fnccdvknxc";
   };
+
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [ pytest ];
 

--- a/pkgs/development/python-modules/whichcraft/default.nix
+++ b/pkgs/development/python-modules/whichcraft/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   fetchPypi,
   pytest,
-  glibcLocales,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -15,9 +14,6 @@ buildPythonPackage (finalAttrs: {
     inherit (finalAttrs) pname version;
     sha256 = "11yfkzyplizdgndy34vyd5qlmr1n5mxis3a3svxmx8fnccdvknxc";
   };
-
-  env.LC_ALL = "en_US.utf-8";
-  buildInputs = [ glibcLocales ];
 
   nativeCheckInputs = [ pytest ];
 

--- a/pkgs/development/python-modules/whichcraft/default.nix
+++ b/pkgs/development/python-modules/whichcraft/default.nix
@@ -6,13 +6,13 @@
   glibcLocales,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "whichcraft";
   version = "0.6.1";
   format = "setuptools";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     sha256 = "11yfkzyplizdgndy34vyd5qlmr1n5mxis3a3svxmx8fnccdvknxc";
   };
 
@@ -30,4 +30,4 @@ buildPythonPackage rec {
     description = "Cross-platform cross-python shutil.which functionality";
     license = lib.licenses.bsd3;
   };
-}
+})

--- a/pkgs/development/python-modules/whichcraft/default.nix
+++ b/pkgs/development/python-modules/whichcraft/default.nix
@@ -27,6 +27,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     homepage = "https://github.com/pydanny/whichcraft";
     description = "Cross-platform cross-python shutil.which functionality";
+    changelog = "https://github.com/cookiecutter/whichcraft/blob/${finalAttrs.version}/HISTORY.rst";
     license = lib.licenses.bsd3;
   };
 })


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974
- cleanup `glibcLocales` as doesn't seem to be needed anymore, removing it causes no changes apart from the store path
- use finalAttrs
- add a changelog
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
