### PR TITLE
vimPlugins.*: ensure `passthru.vimPlugin = true`

### DIFF
--- a/pkgs/applications/editors/vim/plugins/non-generated/notmuch-vim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/notmuch-vim/default.nix
@@ -1,1 +1,17 @@
-{ notmuch }: notmuch.vim
+{
+  vimUtils,
+  notmuch,
+}:
+vimUtils.buildVimPlugin {
+  inherit (notmuch) pname version;
+  src = notmuch.vim;
+  meta = {
+    inherit (notmuch.meta)
+      changelog
+      description
+      homepage
+      license
+      platforms
+      ;
+  };
+}

--- a/pkgs/applications/editors/vim/plugins/non-generated/parinfer-rust/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/parinfer-rust/default.nix
@@ -1,1 +1,8 @@
-{ parinfer-rust }: parinfer-rust
+{
+  vimUtils,
+  parinfer-rust,
+}:
+vimUtils.buildVimPlugin {
+  inherit (parinfer-rust) pname version meta;
+  src = parinfer-rust;
+}

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -478,21 +478,23 @@ assertNoAdditions {
     nvimSkipModules = [ "ccc.kit.Thread.Server._bootstrap" ];
   };
 
-  chadtree = super.chadtree.overrideAttrs {
+  chadtree = super.chadtree.overrideAttrs (old: {
     # > E5108: Error executing lua ...implugin-chadtree-0-unstable-2026-01-18/lua/chadtree.lua:162: Vim:Failed to start server: address already in use
     doCheck = stdenv.hostPlatform.isLinux;
     buildInputs = [
       python3
     ];
-    passthru.python3Dependencies =
-      ps: with ps; [
-        pynvim-pp
-        pyyaml
-        std2
-      ];
+    passthru = old.passthru // {
+      python3Dependencies =
+        ps: with ps; [
+          pynvim-pp
+          pyyaml
+          std2
+        ];
+    };
     # We need some patches so it stops complaining about not being in a venv
     patches = [ ./patches/chadtree/emulate-venv.patch ];
-  };
+  });
 
   ChatGPT-nvim = super.ChatGPT-nvim.overrideAttrs {
     dependencies = with self; [
@@ -1053,13 +1055,15 @@ assertNoAdditions {
     };
   });
 
-  coq_nvim = super.coq_nvim.overrideAttrs {
-    passthru.python3Dependencies =
-      ps: with ps; [
-        pynvim-pp
-        pyyaml
-        std2
-      ];
+  coq_nvim = super.coq_nvim.overrideAttrs (old: {
+    passthru = old.passthru // {
+      python3Dependencies =
+        ps: with ps; [
+          pynvim-pp
+          pyyaml
+          std2
+        ];
+    };
 
     # We need some patches so it stops complaining about not being in a venv
     patches = [ ./patches/coq_nvim/emulate-venv.patch ];
@@ -1068,7 +1072,7 @@ assertNoAdditions {
       # Other modules require global variables
       "coq"
     ];
-  };
+  });
 
   cornelis = super.cornelis.overrideAttrs {
     dependencies = [ self.vim-textobj-user ];
@@ -1265,7 +1269,9 @@ assertNoAdditions {
 
   deoplete-khard = super.deoplete-khard.overrideAttrs (old: {
     dependencies = [ self.deoplete-nvim ];
-    passthru.python3Dependencies = ps: [ (ps.toPythonModule khard) ];
+    passthru = old.passthru // {
+      python3Dependencies = ps: [ (ps.toPythonModule khard) ];
+    };
     meta = old.meta // {
       description = "Address-completion for khard via deoplete";
       homepage = "https://github.com/nicoe/deoplete-khard";
@@ -1446,7 +1452,9 @@ assertNoAdditions {
   };
 
   fcitx-vim = super.fcitx-vim.overrideAttrs (old: {
-    passthru.python3Dependencies = ps: with ps; [ dbus-python ];
+    passthru = old.passthru // {
+      python3Dependencies = ps: with ps; [ dbus-python ];
+    };
     meta = old.meta // {
       description = "Keep and restore fcitx state when leaving/re-entering insert mode or search mode";
       license = lib.licenses.mit;
@@ -1969,9 +1977,11 @@ assertNoAdditions {
     };
   });
 
-  jupytext-nvim = super.jupytext-nvim.overrideAttrs {
-    passthru.python3Dependencies = ps: [ ps.jupytext ];
-  };
+  jupytext-nvim = super.jupytext-nvim.overrideAttrs (old: {
+    passthru = old.passthru // {
+      python3Dependencies = ps: [ ps.jupytext ];
+    };
+  });
 
   just-nvim = super.just-nvim.overrideAttrs {
     checkInputs = with self; [
@@ -2366,20 +2376,22 @@ assertNoAdditions {
     runtimeDeps = [ luau-lsp ];
   };
 
-  magma-nvim = super.magma-nvim.overrideAttrs {
-    passthru.python3Dependencies =
-      ps: with ps; [
-        pynvim
-        jupyter-client
-        ueberzug
-        pillow
-        cairosvg
-        plotly
-        ipykernel
-        pyperclip
-        pnglatex
-      ];
-  };
+  magma-nvim = super.magma-nvim.overrideAttrs (old: {
+    passthru = old.passthru // {
+      python3Dependencies =
+        ps: with ps; [
+          pynvim
+          jupyter-client
+          ueberzug
+          pillow
+          cairosvg
+          plotly
+          ipykernel
+          pyperclip
+          pnglatex
+        ];
+    };
+  });
 
   maple-nvim = super.maple-nvim.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
@@ -2597,13 +2609,15 @@ assertNoAdditions {
     };
   });
 
-  ncm2-jedi = super.ncm2-jedi.overrideAttrs {
+  ncm2-jedi = super.ncm2-jedi.overrideAttrs (old: {
     dependencies = with self; [
       nvim-yarp
       ncm2
     ];
-    passthru.python3Dependencies = ps: with ps; [ jedi ];
-  };
+    passthru = old.passthru // {
+      python3Dependencies = ps: with ps; [ jedi ];
+    };
+  });
 
   ncm2-neoinclude = super.ncm2-neoinclude.overrideAttrs {
     dependencies = [ self.neoinclude-vim ];
@@ -4817,7 +4831,9 @@ assertNoAdditions {
   });
 
   vim-beancount = super.vim-beancount.overrideAttrs (old: {
-    passthru.python3Dependencies = ps: with ps; [ beancount ];
+    passthru = old.passthru // {
+      python3Dependencies = ps: with ps; [ beancount ];
+    };
     meta = old.meta // {
       license = lib.licenses.vim;
     };
@@ -5300,9 +5316,11 @@ assertNoAdditions {
     };
   });
 
-  vim-mediawiki-editor = super.vim-mediawiki-editor.overrideAttrs {
-    passthru.python3Dependencies = [ python3.pkgs.mwclient ];
-  };
+  vim-mediawiki-editor = super.vim-mediawiki-editor.overrideAttrs (old: {
+    passthru = old.passthru // {
+      python3Dependencies = [ python3.pkgs.mwclient ];
+    };
+  });
 
   vim-merginal = super.vim-merginal.overrideAttrs (old: {
     meta = old.meta // {

--- a/pkgs/test/vim/default.nix
+++ b/pkgs/test/vim/default.nix
@@ -3,13 +3,9 @@
   vimUtils,
   vim-full,
   vimPlugins,
+
+  pkgs,
 }:
-let
-  inherit (vimUtils) buildVimPlugin;
-
-  packages.myVimPackage.start = with vimPlugins; [ vim-nix ];
-
-in
 lib.recurseIntoAttrs {
   vim_empty_config = vimUtils.vimrcFile {
     beforePlugins = "";
@@ -28,4 +24,33 @@ lib.recurseIntoAttrs {
     name = "vim-with-vim-addon-nix";
     vimrcConfig.packages.myVimPackage.start = with vimPlugins; [ vim-nix ];
   };
+
+  # test that all vimPlugins have `passthru.vimPlugin = true`
+  test-all-plugins-have-vimPlugin-true =
+    let
+      # we remove aliases as they are irrelevant here and cause warning when evaling this test
+      pkgsNoAliases = (
+        pkgs.extend (
+          self: prev: {
+            config = prev.config // {
+              allowAliases = false;
+            };
+          }
+        )
+      );
+      vimPluginsNoAliases = pkgsNoAliases.vimPlugins;
+    in
+    assert
+      lib.attrNames (
+        lib.filterAttrs (
+          name: elem:
+          # exclude non-plugins
+          lib.isDerivation elem
+          && name != "corePlugins"
+          # only plugins that don't have `vimPlugin = true`
+          && elem.passthru.vimPlugin or false != true
+        ) vimPluginsNoAliases
+      ) == [ ];
+    # testing is done during evaluation above so this derivation is irrelevant
+    vim-full;
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I was writing a function to separate vim plugins from other packages and realised that the `jupytext-nvim` plugin was missing the `passthru.vimPlugin` that other vim plugins had.
As it turns out there are more than a few plugins like this, as the nix expression below shows.

This PR fixes all the cases I identified (mostly due to overwriting `passthru` or bypassing `buildVimPlugin`).
It also adds a test although I'm not sure it's really needed so lmk and I'll remove it.

```nix
# test.nix
let
  pkgs = import ./. { };
  lib = pkgs.lib;
in
lib.attrNames (
  lib.filterAttrs (
    name: elem:
    # exclude non-evaling plugins
    (lib.tryEval elem).success
    # exclude non-plugins
    && lib.isDerivation elem
    && name != "corePlugins"
    # show only plugins that don't have `vimPlugin = true`
    && elem.passthru.vimPlugin or false != true
  ) pkgs.vimPlugins
)
```
```bash
$ nix eval --file test.nix
[ "chad" "chadtree" "coq_nvim" "deoplete-khard" "fcitx-vim" "jupytext-nvim" "magma-nvim" "magma-nvim-goose" "ncm2-jedi" "notmuch-vim" "parinfer-rust" "vim-beancount" "vim-mediawiki-editor" ]
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
