### PR TITLE
ci/github-script/merge: ignore case when checking for merge bot comment

### DIFF
--- a/ci/github-script/merge.js
+++ b/ci/github-script/merge.js
@@ -97,7 +97,7 @@ function hasMergeCommand(body) {
   return (body ?? '')
     .replace(/<!--.*?-->/gms, '')
     .replace(/(^`{3,})[^`].*?\1/gms, '')
-    .match(/^@NixOS\/nixpkgs-merge-bot merge\s*$/m)
+    .match(/^@NixOS\/nixpkgs-merge-bot merge\s*$/im)
 }
 
 async function handleMergeComment({ github, body, node_id, reaction }) {


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/pull/528059#issuecomment-4639903600 (despite the displayed value, as can be seen by editing/copying markdown, the command was all-lowercase).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
