### PR TITLE
cert-x-gen: init at 1.1.1

### DIFF
--- a/pkgs/by-name/ce/cert-x-gen/package.nix
+++ b/pkgs/by-name/ce/cert-x-gen/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  fetchFromGitHub,
+  libgit2,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+  zlib,
+  zstd,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cert-x-gen";
+  version = "1.1.1";
+
+  src = fetchFromGitHub {
+    owner = "Bugb-Technologies";
+    repo = "cert-x-gen";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-J3VPPOvBKitgtCi5h8LcXkcfFNciMKX0q8cQ/ytXncg=";
+  };
+
+  __structuredAttrs = true;
+
+  cargoHash = "sha256-ze5wLwwp2XdWQNEY+n+M6ZTYfw+QQZUR6V9/mgb32RI=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libgit2
+    openssl
+    zlib
+    zstd
+  ];
+
+  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  env = {
+    OPENSSL_NO_VENDOR = true;
+    ZSTD_SYS_USE_PKG_CONFIG = true;
+  };
+
+  meta = {
+    description = "Polyglot execution engine and CLI for vulnerability detection using real code";
+    homepage = "https://github.com/Bugb-Technologies/cert-x-gen";
+    changelog = "https://github.com/Bugb-Technologies/cert-x-gen/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "cxg";
+  };
+})


### PR DESCRIPTION
Polyglot execution engine and CLI for vulnerability detection using real code

https://github.com/Bugb-Technologies/cert-x-gen

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
