### PR TITLE
discord: don't strip upstream binaries on darwin

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/darwin.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/darwin.nix
@@ -107,6 +107,7 @@ stdenv.mkDerivation {
   sourceRoot = ".";
 
   dontUnpack = true;
+  dontStrip = true;
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
On aarch64-darwin, `fixupPhase` strips files under `Applications`, and the wrapped `strip` (`llvm-strip`) corrupts Discord's bundled `*.ico` files. Each icon is inflated from ~15 KB to ~808 MB, making the app bundle nearly 9 GB.

```shell
echo "Before:"
for f in /nix/store/zr140yzl42h9ypqd8b17g62d3qrjp8np-discord-0.0.390/Applications/Discord.app/Contents/Resources/modules/discord_desktop_core/app/images/badges/*.ico; do
  printf '%-12s %12s\n' "$(basename "$f")" "$(stat -f '%z' "$f")"
done | sort -V

echo "After:"
for f in /nix/store/7frfisx55s52vqk4gbdq3zdrscxv1hpv-discord-0.0.390/Applications/Discord.app/Contents/Resources/modules/discord_desktop_core/app/images/badges/*.ico; do
  printf '%-12s %12s\n' "$(basename "$f")" "$(stat -f '%z' "$f")"
done | sort -V
```

```
Before:
badge-1.ico     808452160
badge-2.ico     808452160
badge-3.ico     808452160
badge-4.ico     808452160
badge-5.ico     808452160
badge-6.ico     808452160
badge-7.ico     808452160
badge-8.ico     808452160
badge-9.ico     808452160
badge-10.ico    808452160
badge-11.ico    808452160
After:
badge-1.ico         15086
badge-2.ico         15086
badge-3.ico         15086
badge-4.ico         15086
badge-5.ico         15086
badge-6.ico         15086
badge-7.ico         15086
badge-8.ico         15086
badge-9.ico         15086
badge-10.ico        15086
badge-11.ico        15086
```

This is similar to #376353.

## Things done

Added `dontStrip = true;` to the Darwin package.

Open question: should this also apply to the Linux package, since Discord is also an upstream pre-built binary there as well, or is it better to keep this Darwin-only since the corruption was only reproduced with Darwin’s `llvm-strip`?

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
