### PR TITLE
nixos/wireless: add support for setting wireless regdom

### DIFF
--- a/nixos/modules/hardware/wireless.nix
+++ b/nixos/modules/hardware/wireless.nix
@@ -1,0 +1,39 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib;
+let
+  cfg = config.hardware.wireless;
+
+  setWirelessRegdom = pkgs.writeScript "set-wireless-regdom" ''
+    #!/bin/sh
+    ${lib.getExe pkgs.iw} reg set ${cfg.regulatoryDomain}
+  '';
+
+  udevRule = pkgs.writeTextFile {
+    name = "regdom-udev-rule";
+    text = ''
+      # Set wireless regulatory domain at device creation
+
+      ACTION=="add", SUBSYSTEM=="module", DEVPATH=="/module/cfg80211", RUN+="${setWirelessRegdom}"
+    '';
+    destination = "/lib/udev/rules.d/85-regulatory.rules";
+  };
+in
+{
+  options.hardware.wireless = {
+    regulatoryDomain = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "DE";
+      description = "Set the wireless regulatory domain";
+    };
+  };
+  config = mkIf (cfg.regulatoryDomain != null) {
+    services.udev.packages = [ udevRule ];
+    hardware.wirelessRegulatoryDatabase = true;
+  };
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -129,6 +129,7 @@
   ./hardware/video/virtualbox.nix
   ./hardware/video/webcam/facetimehd.nix
   ./hardware/video/webcam/ipu6.nix
+  ./hardware/wireless.nix
   ./hardware/wooting.nix
   ./hardware/xone.nix
   ./hardware/xpad-noone.nix


### PR DESCRIPTION
Fixes #25378


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
