### PR TITLE
Add docstring to public function 'ninja'

### DIFF
--- a/pkgs/development/python-modules/ninja/stub/ninja/__init__.py
+++ b/pkgs/development/python-modules/ninja/stub/ninja/__init__.py
@@ -10,4 +10,5 @@ def _program(name, args):
     return subprocess.call([os.path.join(BIN_DIR, name)] + args, close_fds=False)
 
 def ninja():
+    """Run the ninja build system with command-line arguments."""
     raise SystemExit(_program('ninja', sys.argv[1:]))


### PR DESCRIPTION
## Problem Background
The public function `ninja` in the stub module was missing a docstring, which could lead to reduced code readability and incomplete documentation. This makes it harder for users and developers to understand the function's purpose at a glance.

## Changes Made
Added a docstring to the `ninja` function to clearly describe its functionality as running the ninja build system with command-line arguments. This improves code clarity and aligns with Python best practices for documenting public APIs.

## Verification
The change is purely documentary and does not affect the code's external behavior or API. Verified by reviewing the added docstring for accuracy and ensuring it matches the function's implementation. No functional tests are required as this is a non-functional update.