### PR TITLE
proton-vpn (darwin): 6.4.0 -> 6.5.0

### DIFF
--- a/pkgs/by-name/pr/proton-vpn/darwin.nix
+++ b/pkgs/by-name/pr/proton-vpn/darwin.nix
@@ -8,12 +8,15 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "proton-vpn";
-  version = "6.4.0";
+  version = "6.5.0";
 
   src = fetchurl {
     url = "https://github.com/ProtonVPN/ios-mac-app/releases/download/mac%2F${finalAttrs.version}/ProtonVPN_mac_v${finalAttrs.version}.dmg";
-    hash = "sha256-F5NS7NNqxNJcl7gFaqWtWxBxBbV6Btp7cyyDpegEGLQ=";
+    hash = "sha256-lB44pIA5AxdcYQ/iccWcqJDOrQkVLRVl0vy1HuPPl8o=";
   };
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   sourceRoot = ".";
 


### PR DESCRIPTION
https://protonvpn.com/support/release-notes-macos:

>Version 6.5.0: April 24, 2026
>* Improved connection options. You can now choose your preferred supported city or state. Expand any country to see all available locations and select the one you want
>* Fixed some network interface issues when using split tunneling
>* Made some bug fixes and stability improvements


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
