### PR TITLE
libstemmer, pystemmer, snowballstemmer: version bumps and cleanup/modernization

### DIFF
--- a/pkgs/by-name/li/libstemmer/package.nix
+++ b/pkgs/by-name/li/libstemmer/package.nix
@@ -44,6 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Snowball Stemming Algorithms";
     homepage = "https://snowballstem.org/";
+    changelog = "https://github.com/snowballstem/snowball/blob/v${finalAttrs.version}/NEWS";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ fpletz ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/li/libstemmer/package.nix
+++ b/pkgs/by-name/li/libstemmer/package.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libstemmer";
-  version = "2.2.0";
+  version = "3.1.1";
 
   src = fetchFromGitHub {
     owner = "snowballstem";
     repo = "snowball";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qXrypwv/I+5npvGHGsHveijoui0ZnoGYhskCfLkewVE=";
+    hash = "sha256-FpvV2brpjl0/l/EmrHN9tWFrXUUz9BDUH548MAjiTa8=";
   };
 
   nativeBuildInputs = [ perl ];

--- a/pkgs/development/python-modules/pystemmer/default.nix
+++ b/pkgs/development/python-modules/pystemmer/default.nix
@@ -47,8 +47,7 @@ buildPythonPackage rec {
 
   meta = {
     description = "Snowball stemming algorithms, for information retrieval";
-    downloadPage = "https://github.com/snowballstem/pystemmer";
-    homepage = "http://snowball.tartarus.org/";
+    homepage = "https://github.com/snowballstem/pystemmer";
     license = with lib.licenses; [
       bsd3
       mit

--- a/pkgs/development/python-modules/pystemmer/default.nix
+++ b/pkgs/development/python-modules/pystemmer/default.nix
@@ -8,7 +8,7 @@
   libstemmer,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pystemmer";
   version = "3.0.0";
   pyproject = true;
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "snowballstem";
     repo = "pystemmer";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-c3ucbneUo5UBfdrd5Ktl4HriVusvWBEA1brrgahEQ9A=";
   };
 
@@ -53,4 +53,4 @@ buildPythonPackage rec {
     ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/development/python-modules/pystemmer/default.nix
+++ b/pkgs/development/python-modules/pystemmer/default.nix
@@ -11,8 +11,7 @@
 buildPythonPackage rec {
   pname = "pystemmer";
   version = "3.0.0";
-  format = "setuptools";
-  pyproejct = true;
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "snowballstem";

--- a/pkgs/development/python-modules/pystemmer/default.nix
+++ b/pkgs/development/python-modules/pystemmer/default.nix
@@ -2,6 +2,7 @@
   lib,
   python,
   fetchFromGitHub,
+  fetchpatch2,
   buildPythonPackage,
   cython,
   setuptools,
@@ -10,15 +11,29 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pystemmer";
-  version = "3.0.0";
+  version = "3.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "snowballstem";
     repo = "pystemmer";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-c3ucbneUo5UBfdrd5Ktl4HriVusvWBEA1brrgahEQ9A=";
+    hash = "sha256-GPPl6ioB9sB2y8G2hYfu2ksR+D9xNJjK6glMADLnr7M=";
   };
+
+  patches = [
+    # These 2 patches should be removed on the next version bump after 3.1.0
+    (fetchpatch2 {
+      name = "libstemmer-3.1-algorithms.patch";
+      url = "https://github.com/snowballstem/pystemmer/commit/301c074791708ab2c479808b410480c34183cd9a.patch?full_index=1";
+      hash = "sha256-830nep2gjlVuVaepsHIkzL/U4fejwK0jH+WujLrOfUs=";
+    })
+    (fetchpatch2 {
+      name = "dont-hard-code-algorithms-doctest.patch";
+      url = "https://github.com/snowballstem/pystemmer/commit/77ee7b34fdcd61c78146ae4c6e536a63755db0e6.patch?full_index=1";
+      hash = "sha256-eEfNFpD6T+prokVnpAOx4rABCPS5YXdbG3xKdJzb48M=";
+    })
+  ];
 
   build-system = [
     cython

--- a/pkgs/development/python-modules/snowballstemmer/default.nix
+++ b/pkgs/development/python-modules/snowballstemmer/default.nix
@@ -23,6 +23,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "16 stemmer algorithms (15 + Poerter English stemmer) generated from Snowball algorithms";
     homepage = "https://snowballstem.org/";
+    changelog = "https://github.com/snowballstem/snowball/blob/v${finalAttrs.version}/NEWS";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/development/python-modules/snowballstemmer/default.nix
+++ b/pkgs/development/python-modules/snowballstemmer/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "16 stemmer algorithms (15 + Poerter English stemmer) generated from Snowball algorithms";
-    homepage = "http://sigal.saimon.org/en/latest/index.html";
+    homepage = "https://snowballstem.org/";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
   };

--- a/pkgs/development/python-modules/snowballstemmer/default.nix
+++ b/pkgs/development/python-modules/snowballstemmer/default.nix
@@ -11,6 +11,8 @@ buildPythonPackage (finalAttrs: {
   version = "3.1.1";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
     inherit (finalAttrs) pname version;
     sha256 = "sha256-4Hu8VKDXmP5gEKEjmEIuYqi/u6lcOU/QlW71jLTT4mA=";

--- a/pkgs/development/python-modules/snowballstemmer/default.nix
+++ b/pkgs/development/python-modules/snowballstemmer/default.nix
@@ -1,24 +1,27 @@
 {
   lib,
   buildPythonPackage,
-  pystemmer,
   fetchPypi,
+  setuptools,
+  pystemmer,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "snowballstemmer";
   version = "3.1.1";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
     sha256 = "sha256-4Hu8VKDXmP5gEKEjmEIuYqi/u6lcOU/QlW71jLTT4mA=";
   };
 
+  build-system = [ setuptools ];
+
+  dependencies = [ pystemmer ];
+
   # No tests included
   doCheck = false;
-
-  propagatedBuildInputs = [ pystemmer ];
 
   meta = {
     description = "16 stemmer algorithms (15 + Poerter English stemmer) generated from Snowball algorithms";


### PR DESCRIPTION
This does changes to 3 packages:
- `libstemmer`
- `python3Packages.pystemmer`
- `python3Packages.snowballstemmer`

In paticular:
- `pystemmer`, `snowballstemmer`: update homepage
- `pystemmer`, `snowballstemmer`: migrate to `pyproject` (#515974)
- `pystemmer`: use `finalAttrs`
- ~~`libstemmer`~~, `snowballstemmer`: enable `structuredAttrs`
- `libstemmer`, `snowballstemmer`: add changelog
- `libstemmer`, `pystemmer`: version bumps

About the specific versions:
- `pystemmer`: 3.1.0 is the newest available version
- `libstemmer`: 3.1.1 is the newest available version, ~~I bumped to 3.0.1 because `pystemmer` contains a test that fails with newer version as it compared the exact list of available stemmers. This has also been blocking a separate PR to bump `libstemmer` (#405568). It has already been updated upstream but is not yet included in a release.~~ `pystemmer` gets the upstream patch applied to stop complaining.
- `snowballstemmer`: ~~This comes from the same repository as `libstemmer`. It's newest version is therefore also 3.1.1. I decided to keep it on 3.0.1 for the time being, to keep it in sync with `libstemmer`.~~ Updated to 3.1.1 in #541370

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
