### PR TITLE
wakapi: fix empty warning

### DIFF
--- a/nixos/modules/services/web-apps/wakapi.nix
+++ b/nixos/modules/services/web-apps/wakapi.nix
@@ -196,14 +196,12 @@ in
       }
     ];
 
-    warnings = [
-      (lib.optionalString (cfg.database.createLocally && cfg.settings.db.dialect != "postgres") ''
-        You have enabled automatic database configuration, but the database dialect is not set to "posgres".
+    warnings = lib.optional (cfg.database.createLocally && cfg.settings.db.dialect != "postgres") ''
+      You have enabled automatic database configuration, but the database dialect is not set to "postgres".
 
-        The Wakapi module only supports PostgreSQL. Please set `services.wakapi.database.createLocally`
-        to `false`, or switch to "postgres" as your database dialect.
-      '')
-    ];
+      The Wakapi module only supports PostgreSQL. Please set `services.wakapi.database.createLocally`
+      to `false`, or switch to "postgres" as your database dialect.
+    '';
 
     users = {
       users.wakapi = {


### PR DESCRIPTION
`lib.optionalString` returns and empty string when the condition is `false`, so with the defaults (`createLocally = false`), you get `warnings = [ "" ]`. The fix is to use `lib.optional` instead, which returns `[]` when `false`:

The current output is:
```
nix flake check
warning: Git tree '/home/alvr/Projects/dotfiles' is dirty
trace: evaluation warning:
```

---

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test