### PR TITLE
nixos/docker-image: conflicting with container runtime's resolv.conf

### DIFF
--- a/nixos/modules/virtualisation/docker-image.nix
+++ b/nixos/modules/virtualisation/docker-image.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ lib, ... }:
 
 {
   imports = [
@@ -10,11 +10,14 @@
     echo "docker" > /run/systemd/container
   '';
 
-  # Prevent resolvconf from overriding Docker managed resolv.conf
-  environment.etc."resolv.conf".enable = false;
-
-  # Let Docker manage /etc/resolv.conf
-  networking.resolvconf.enable = false;
+  # Prevent resolvconf from overriding Docker-managed resolv.conf.
+  # Docker bind-mounts /etc/resolv.conf at container runtime and uses
+  # its own embedded DNS server (127.0.0.11) for resolution. The
+  # resolvconf service must not manage the file or it will conflict
+  # with Docker's DNS handling. mkForce is needed because other
+  # modules or user configuration may set these options.
+  environment.etc."resolv.conf".enable = lib.mkForce false;
+  networking.resolvconf.enable = lib.mkForce false;
 
   # Iptables do not work in Docker.
   networking.firewall.enable = false;

--- a/nixos/modules/virtualisation/docker-image.nix
+++ b/nixos/modules/virtualisation/docker-image.nix
@@ -10,6 +10,12 @@
     echo "docker" > /run/systemd/container
   '';
 
+  # Prevent resolvconf from overriding Docker managed resolv.conf
+  environment.etc."resolv.conf".enable = false;
+
+  # Let Docker manage /etc/resolv.conf
+  networking.resolvconf.enable = false;
+
   # Iptables do not work in Docker.
   networking.firewall.enable = false;
 


### PR DESCRIPTION
Change-Id: I2f8dc2275343c125927253359a3867c76a6a6964


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
