### PR TITLE
traceway-cli: init at 1.8.14

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9400,6 +9400,13 @@
     github = "frectonz";
     githubId = 53809656;
   };
+  fred-drake = {
+    name = "Fred Drake";
+    email = "fred.drake@gmail.com";
+    github = "fred-drake";
+    githubId = 1041653;
+    keys = [ { fingerprint = "09F4 6F1B 2CE0 2DDC 3DB9  F2B0 88D2 0443 CB00 F7D4"; } ];
+  };
   fred441a = {
     email = "frederik@altofte.dk";
     github = "fred441a";

--- a/pkgs/by-name/tr/traceway-cli/package.nix
+++ b/pkgs/by-name/tr/traceway-cli/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "traceway-cli";
+  version = "1.8.14";
+
+  src = fetchFromGitHub {
+    owner = "tracewayapp";
+    repo = "traceway";
+    tag = "cli/v${finalAttrs.version}";
+    hash = "sha256-WKcHDDCz89pTeQHIXDdLYieYEwjl/SQKpg//LosVcwk=";
+  };
+
+  # The Go module and main package live in cli/ of a monorepo that also contains
+  # sibling Go directories (backend/, frontend/). Confine the build to cli/ and
+  # disable workspace mode so the toolchain never discovers the siblings.
+  sourceRoot = "${finalAttrs.src.name}/cli";
+  env.GOWORK = "off";
+
+  # Upstream CI builds pure Go with CGO disabled.
+  env.CGO_ENABLED = 0;
+
+  vendorHash = "sha256-T+LtdUo8Cog+lECRVaRS/+ARqU6zHNXfIAc6P7n/OfE=";
+
+  subPackages = [ "cmd/traceway" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd traceway \
+      --bash <($out/bin/traceway completion bash) \
+      --zsh <($out/bin/traceway completion zsh) \
+      --fish <($out/bin/traceway completion fish)
+  '';
+
+  # The checkPhase tests use httptest.NewServer, which binds a loopback socket;
+  # the Darwin sandbox blocks local networking by default, so allow it.
+  __darwinAllowLocalNetworking = true;
+
+  doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script {
+    # Repo also publishes backend/v* tags; keep updates on the cli/ train.
+    extraArgs = [ "--version-regex=cli/v([0-9.]+)" ];
+  };
+
+  meta = {
+    description = "Command-line client for the Traceway observability platform";
+    homepage = "https://github.com/tracewayapp/traceway";
+    changelog = "https://github.com/tracewayapp/traceway/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    mainProgram = "traceway";
+    maintainers = with lib.maintainers; [ fred-drake ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
Adds `traceway`, the command-line client for the [Traceway](https://github.com/tracewayapp/traceway) observability platform (querying logs, metrics, HTTP endpoint performance, and exception groups against a Traceway instance).

Notes for reviewers:

- Pure-Go CLI (`CGO_ENABLED = 0`), built from source via `buildGoModule`. License: MIT.
- Upstream is a monorepo: the CLI lives in `cli/` and is released under slash-prefixed tags (`cli/vX.Y.Z`). `sourceRoot = "${finalAttrs.src.name}/cli"` together with `env.GOWORK = "off"` confine the build to `cli/` so the sibling Go modules (`backend/`, `frontend/`) are never discovered.
- The repo also publishes mirrored `backend/v*` tags, so `passthru.updateScript` pins `nix-update` to the `cli/` train with `--version-regex=cli/v([0-9.]+)` to avoid cross-train bumps.
- Version is injected through `ldflags` (`-X main.version`); `versionCheckHook` confirms `traceway --version` reports `1.7.33`. Shell completions for bash/zsh/fish are installed.

Built from source and ran `--version` on `x86_64-linux`, `x86_64-darwin`, and `aarch64-darwin`. `ci/nixpkgs-vet.sh` validates. `aarch64-linux` was not built locally (no builder available) and should be covered by ofborg.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

