### PR TITLE
labelife-label-printer: 2.2.0.002 -> 2.3.1.001

### DIFF
--- a/pkgs/by-name/la/labelife-label-printer/package.nix
+++ b/pkgs/by-name/la/labelife-label-printer/package.nix
@@ -18,15 +18,15 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "labelife-label-printer";
-  version = "2.2.0.002";
+  version = "2.3.1.001";
 
   arch =
     archAttrset.${stdenv.hostPlatform.system}
       or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
 
   src = fetchurl {
-    url = "https://oss.qu-in.ltd/Labelife/Label_Printer_Driver_Linux.zip";
-    hash = "sha256-yUrEV3pdTqiATZ1V9Ze0zTjsyA3b9i+Bbh1v0FzGeas=";
+    url = "https://web.archive.org/web/20260607010653/https://oss.qu-in.ltd/Labelife/Label_Printer_Driver_Linux.zip";
+    hash = "sha256-qpsyOuTrOTcXEQeCNNRV0QeV0s0RD2eqy/tGTA7qMWA=";
   };
 
   nativeBuildInputs = [
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     unzip -q ${finalAttrs.src}
 
     # Extract inner tar.gz with --strip-components=1 to remove the `LabelPrinter-${finalAttrs.version}/` prefix
-    tar -xzf Label_Printer_Driver_Linux.tar.gz --strip-components=1
+    tar -xzf LabelPrinter-${finalAttrs.version}.tar.gz --strip-components=1
 
     runHook postUnpack
   '';
@@ -66,9 +66,14 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://labelife.net";
     license = lib.licenses.unfree;
     longDescription = ''
-      Supported printer models include:
-      - D520 & D520BT
-      - PM-241 & PM-241-BT
+      CUPS driver for Labelife-compatible thermal label printers.
+      Supported printer families include D-series (D420D, D520, D530,
+      D550), PM-series (PM-241, PM-246S, PM-249, PM-344), T-series
+      (T200, T300, T410, T460, T800), CT-series (CT200, CT310, CT510),
+      AM-series (AM-242, AM-243), and others (A646, PL70, DS-50P, 6XL).
+
+      Many models are available in multiple connectivity variants
+      (BT, WF, WIFI).
 
       Brands using Labelife drivers include:
       - Phomemo


### PR DESCRIPTION
Switch to web.archive.org mirror. Expanded printer model support (D, PM, T, CT, AM series).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
