### PR TITLE
flutter: fix aapt errors in flake environments

### DIFF
--- a/pkgs/development/compilers/flutter/flutter.nix
+++ b/pkgs/development/compilers/flutter/flutter.nix
@@ -18,6 +18,7 @@
   writableTmpDirAsHomeHook,
   installShellFiles,
   flutterTools ? null,
+  aapt,
 }@args:
 
 let
@@ -130,6 +131,7 @@ let
       makeShellWrapper "$out/bin/dart" "$out/bin/flutter" \
         --set-default FLUTTER_ROOT "$out" \
         --set FLUTTER_ALREADY_LOCKED true \
+        --set NIX_AAPT2_BINARY_PATH "${lib.getExe aapt}" \
         --add-flags "--disable-dart-dev --packages='${flutterTools.pubcache}/package_config.json' \$NIX_FLUTTER_TOOLS_VM_OPTIONS $out/bin/cache/flutter_tools.snapshot"
 
       runHook postInstall

--- a/pkgs/development/compilers/flutter/patches/gradle-wrapper-force-provided-binary.patch
+++ b/pkgs/development/compilers/flutter/patches/gradle-wrapper-force-provided-binary.patch
@@ -1,0 +1,21 @@
+diff --git a/packages/flutter_tools/lib/src/android/gradle.dart b/packages/flutter_tools/lib/src/android/gradle.dart
+index 13a0be4ca25..fd7b0980579 100644
+--- a/packages/flutter_tools/lib/src/android/gradle.dart
++++ b/packages/flutter_tools/lib/src/android/gradle.dart
+@@ -477,6 +477,16 @@ class AndroidGradleBuilder implements AndroidBuilder {
+       return;
+     }
+ 
++    assert(
++      globals.platform.environment['NIX_AAPT2_BINARY_PATH']!.isNotEmpty,
++      'The environment variable NIX_AAPT2_BINARY_PATH is unset!',
++    );
++
++    // Force Gradle to use a custom `aapt2` binary, instead of letting it build its own.
++    options.add(
++      '-Pandroid.aapt2FromMavenOverride=${globals.platform.environment['NIX_AAPT2_BINARY_PATH']}',
++    );
++
+     // Assembly work starts here.
+     final BuildInfo buildInfo = androidBuildInfo.buildInfo;
+     final String assembleTask = isBuildingBundle


### PR DESCRIPTION
Hello,

This pull request fixes build errors caused by Gradle trying to run a dynamically linked `aapt2` binary. I'm not sure whether this is an issue on systems with Android Studio installed, but it does come up within my development Flakes.

To see an example of this, simply clone my [example Flutter app](https://github.com/username-generic/nix-flutter-test-app) (generated via `flutter create`), and run the following commands inside its root directory:

```sh
nix develop
flutter build apk # Fails
exit
nix develop --override-input nixpkgs "github:username-generic/nixpkgs?ref=fix-flutter-aapt"
flutter build apk # Successful
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
