### PR TITLE
python3Packages.reflex: 0.9.2 -> 0.9.4

### DIFF
--- a/pkgs/development/python-modules/reflex/default.nix
+++ b/pkgs/development/python-modules/reflex/default.nix
@@ -98,14 +98,14 @@ in
 
 buildPythonPackage (finalAttrs: {
   pname = "reflex";
-  version = "0.9.2";
+  version = "0.9.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "reflex-dev";
     repo = "reflex";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-HY8FaOUU2kp/39OqO+7Xpepiu/6obxTMir11jGtRAkE=";
+    hash = "sha256-CTW8p8cPSZnTMgXk9F6oHvbfIiTtgKZVvRygUZbccJw=";
   };
 
   build-system = [
@@ -193,6 +193,10 @@ buildPythonPackage (finalAttrs: {
 
     # AssertionError (mocked_open.call_count == 2)
     "test_delete_token_from_config"
+
+    # circular imports (reflex-docgen)
+    "test_compiling_docs_does_not_evaluate_upload"
+    "test_enterprise_parent_breadcrumb_uses_overview_route"
   ];
 
   disabledTestPaths = [
@@ -205,6 +209,7 @@ buildPythonPackage (finalAttrs: {
     # circular imports (reflex-docgen)
     "tests/units/docgen/test_class_and_component.py"
     "tests/units/docgen/test_markdown.py"
+    "tests/units/docgen/test_reflex_transformer.py"
     "docs/app/tests/test_doc_links.py"
     "docs/app/tests/test_docgen_double_eval.py"
 
@@ -369,7 +374,6 @@ buildPythonPackage (finalAttrs: {
           mistletoe
           pyyaml
           finalAttrs.finalPackage # reflex
-          typing-extensions
           typing-inspection
         ];
         reflex-hosting-cli.dependencies = [


### PR DESCRIPTION
Changelog: https://github.com/reflex-dev/reflex/releases/tag/v0.9.4


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
