### PR TITLE
python3Packages.cachier: 4.1.0 -> 4.2.0

### DIFF
--- a/pkgs/development/python-modules/cachier/default.nix
+++ b/pkgs/development/python-modules/cachier/default.nix
@@ -6,9 +6,12 @@
   setuptools,
   click,
   watchdog,
+  pympler,
   portalocker,
   pytestCheckHook,
   pytest-cov-stub,
+  pytest-asyncio,
+  aiosqlite,
   sqlalchemy,
   pymongo,
   dnspython,
@@ -19,14 +22,14 @@
 
 buildPythonPackage rec {
   pname = "cachier";
-  version = "4.1.0";
+  version = "4.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "python-cachier";
     repo = "cachier";
     tag = "v${version}";
-    hash = "sha256-FmrwH5Ksmgt0HA5eUN5LU36P5sY4PymRKsUWVkQlvBo=";
+    hash = "sha256-hiyevLMtKV8M8znB2mznHLRM+pVN6uCxZZVf3H0gjTI=";
   };
 
   pythonRemoveDeps = [ "setuptools" ];
@@ -37,6 +40,7 @@ buildPythonPackage rec {
 
   dependencies = [
     watchdog
+    pympler
     portalocker
     # not listed as dep, but needed to run main script entrypoint
     click
@@ -45,6 +49,8 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pytest-cov-stub
+    pytest-asyncio
+    aiosqlite
     sqlalchemy
     pymongo
     dnspython
@@ -83,7 +89,7 @@ buildPythonPackage rec {
 
   disabledTestPaths = [
     # Keeps breaking due to concurrent access or failing to close the db between tests.
-    "tests/test_sql_core.py"
+    "tests/sql_tests/test_sql_core.py"
   ];
 
   preBuild = ''


### PR DESCRIPTION
Changelog: https://github.com/python-cachier/cachier/releases/tag/v4.2.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
