### PR TITLE
iceshrimp-net: init at 2026.1.1-beta

### DIFF
--- a/pkgs/by-name/ic/iceshrimp-net/deps.json
+++ b/pkgs/by-name/ic/iceshrimp-net/deps.json
@@ -1,0 +1,1140 @@
+[
+  {
+    "pname": "microsoft.net.runtime.monotargets.sdk",
+    "version": "10.0.8",
+    "hash": "sha256-3ID3irAXZ6dzo6aZ1fAYmAPXhMacP5QQ1Gf9KK+/LNQ=",
+    "installable": "true"
+  },
+  {
+    "pname": "microsoft.net.runtime.emscripten.3.1.56.node.linux-x64",
+    "version": "10.0.8",
+    "hash": "sha256-Gur/kDyJ/aBI1T/lDDoSYQvFPrYgegAAa6MwA7UVhoc=",
+    "installable": "true"
+  },
+  {
+    "pname": "microsoft.net.runtime.emscripten.3.1.56.node.linux-arm64",
+    "version": "10.0.8",
+    "hash": "sha256-TJMXC+3YvUj+7dwTY3VjJTA6atPrXQh63nKGoP5qSWk=",
+    "installable": "true"
+  },
+  {
+    "pname": "microsoft.net.runtime.webassembly.sdk",
+    "version": "10.0.8",
+    "hash": "sha256-OL308g7OEuSlGnztl9BiSIXtwboNtWZoI36T1pF3ITs=",
+    "installable": "true"
+  },
+  {
+    "pname": "microsoft.netcore.app.runtime.aot.linux-x64.cross.browser-wasm",
+    "version": "10.0.8",
+    "hash": "sha256-NgNsu9FeYkq+IDGneuIEOUjFjFg5fNgOq6J1XoMRtuA=",
+    "installable": "true"
+  },
+  {
+    "pname": "microsoft.netcore.app.runtime.aot.linux-arm64.cross.browser-wasm",
+    "version": "10.0.8",
+    "hash": "sha256-UJakSoC/JUOYlm5HSrfze/vwkVl5MkPpH+CYXDEYDtE=",
+    "installable": "true"
+  },
+  {
+    "pname": "microsoft.net.runtime.monoaotcompiler.task",
+    "version": "10.0.8",
+    "hash": "sha256-PmJlLFQIJ5Jk7tzj4JL6N6ILkwzI798rBekrGY8gElo=",
+    "installable": "true"
+  },
+  {
+    "pname": "microsoft.net.runtime.emscripten.3.1.56.cache.linux-x64",
+    "version": "10.0.8",
+    "hash": "sha256-00r4SMkY6Ku8rDhFduStkqzZlcdl+AcXH4Exx7DAgaU=",
+    "installable": "true"
+  },
+  {
+    "pname": "microsoft.net.runtime.emscripten.3.1.56.cache.linux-arm64",
+    "version": "10.0.8",
+    "hash": "sha256-AhWv08j005W2OsJrbf0D+rxwhoDnMJKlfCwaByloJN4=",
+    "installable": "true"
+  },
+  {
+    "pname": "microsoft.net.runtime.emscripten.3.1.56.sdk.linux-x64",
+    "version": "10.0.8",
+    "hash": "sha256-hSnuBmqj1HxqxISLbxCDUhouDHp4lMgW3KBUSLYU4ss=",
+    "installable": "true"
+  },
+  {
+    "pname": "microsoft.net.runtime.emscripten.3.1.56.sdk.linux-arm64",
+    "version": "10.0.8",
+    "hash": "sha256-P85xojymYNKp95qS2mmPod8NkHnRY4PD9Ugg6QhYeY0=",
+    "installable": "true"
+  },
+  {
+    "pname": "AngleSharp",
+    "version": "1.4.0",
+    "hash": "sha256-xHpoMkhYSj7ejeMmI2e7ygef84QGZhttPjYOnLjITd0="
+  },
+  {
+    "pname": "AsyncKeyedLock",
+    "version": "8.0.2",
+    "hash": "sha256-0NKdC+oxdYxS3Uz1lak5RpdTWyKYT7C3hkCdm5T0D84="
+  },
+  {
+    "pname": "Blazored.LocalStorage",
+    "version": "4.5.0",
+    "hash": "sha256-0vklTFHEGgNG8V6ivQictuooyiXS2nMn/qLpfYhEBlE="
+  },
+  {
+    "pname": "BlazorIntersectionObserver",
+    "version": "3.1.0",
+    "hash": "sha256-IXOYn3vY7JAO1QSqlamozCyv50zd7HtvFOMI5xaZMJY="
+  },
+  {
+    "pname": "Carbon.Storage",
+    "version": "3.15.0",
+    "hash": "sha256-Hy8Zxllf8SRCJ9bekDpHTgfsqqPLo/P8BnIq1xgv7k4="
+  },
+  {
+    "pname": "CommunityToolkit.HighPerformance",
+    "version": "8.4.0",
+    "hash": "sha256-q9RZZvLlvk1sXuIr5wdBxyTf9o0G2mk23xtNGDf6vGs="
+  },
+  {
+    "pname": "CommunityToolkit.HighPerformance",
+    "version": "8.4.2",
+    "hash": "sha256-IgDfOixA81NSrmXaFwx9jAb4jCOQ3s+hsC8qulV/AB0="
+  },
+  {
+    "pname": "DbExceptionClassifier.Common",
+    "version": "1.0.0",
+    "hash": "sha256-5MEYt3dNZcCjxyPw4zXQuBpyYWRm9+mbNXrxMYWKIxE="
+  },
+  {
+    "pname": "DbExceptionClassifier.PostgreSQL",
+    "version": "1.0.0",
+    "hash": "sha256-zwF1c8oiBJXyrCvk/SxrkyEuYHZZgL3i6nNShyundN0="
+  },
+  {
+    "pname": "dotNetRdf.Core",
+    "version": "3.5.3-iceshrimp",
+    "hash": "sha256-FwUj9hrsrb1KQmQYZjCSo1l1zDCStv+Plim7YopaqAM=",
+    "url": "https://iceshrimp.dev/api/packages/iceshrimp/nuget/package/dotnetrdf.core/3.5.3-iceshrimp/dotnetrdf.core.3.5.3-iceshrimp.nupkg"
+  },
+  {
+    "pname": "EntityFrameworkCore.Exceptions.Common",
+    "version": "10.0.0",
+    "hash": "sha256-3eKuhDeu9Wq3ckdCJ0zqJ+hAy5qXmMRPuLzXiu1epOc="
+  },
+  {
+    "pname": "EntityFrameworkCore.Exceptions.PostgreSQL",
+    "version": "10.0.0",
+    "hash": "sha256-SSiax044lboZsyUfxD1QoHpp2Dak0LrOYAadIIKRFmM="
+  },
+  {
+    "pname": "EntityFrameworkCore.Projectables",
+    "version": "5.0.2",
+    "hash": "sha256-l46coPU3GRn4Rwycmo+carzshtjDB01JzwKNkjtoDwY="
+  },
+  {
+    "pname": "EntityFrameworkCore.Projectables.Abstractions",
+    "version": "5.0.2",
+    "hash": "sha256-TMgYZXe7N28KTxk3bXyU3qx1yTZT73fd86WeTgO1Uxg="
+  },
+  {
+    "pname": "FlexLabs.EntityFrameworkCore.Upsert",
+    "version": "10.0.0",
+    "hash": "sha256-JYOfZqSa66EdkPVDKscaRXs/WC+QKKntt7Eb8PBxJX0="
+  },
+  {
+    "pname": "HtmlAgilityPack",
+    "version": "1.12.4",
+    "hash": "sha256-58ohjvtRXFwfY46Hny9GWL2r6KwZzkJWHFXwIWjkaHU="
+  },
+  {
+    "pname": "Humanizer.Core",
+    "version": "2.14.1",
+    "hash": "sha256-EXvojddPu+9JKgOG9NSQgUTfWq1RpOYw7adxDPKDJ6o="
+  },
+  {
+    "pname": "Iceshrimp.AssemblyUtils",
+    "version": "1.1.0",
+    "hash": "sha256-wFx47siuOPlCZpIiN4+IdCvGdPqeHge4+IM40LbMje0=",
+    "url": "https://iceshrimp.dev/api/packages/iceshrimp/nuget/package/iceshrimp.assemblyutils/1.1.0/iceshrimp.assemblyutils.1.1.0.nupkg"
+  },
+  {
+    "pname": "Iceshrimp.Assertions",
+    "version": "10.0.0",
+    "hash": "sha256-Y3qJtSxK+D4p8HZHFyfudI7lWriFodIoskZExM+Oagg=",
+    "url": "https://iceshrimp.dev/api/packages/iceshrimp/nuget/package/iceshrimp.assertions/10.0.0/iceshrimp.assertions.10.0.0.nupkg"
+  },
+  {
+    "pname": "Iceshrimp.Assets.Branding",
+    "version": "1.1.0",
+    "hash": "sha256-P5P9fxgj7/eaHR8OTRZeMb+0U2YZNhZmkUg4oSe4jFU=",
+    "url": "https://iceshrimp.dev/api/packages/iceshrimp/nuget/package/iceshrimp.assets.branding/1.1.0/iceshrimp.assets.branding.1.1.0.nupkg"
+  },
+  {
+    "pname": "Iceshrimp.Assets.Emoji",
+    "version": "1.3.0",
+    "hash": "sha256-os5/vwcWHjjsdf/5fQpF5fLM+vJbutdldC+bM8QTRy0=",
+    "url": "https://iceshrimp.dev/api/packages/iceshrimp/nuget/package/iceshrimp.assets.emoji/1.3.0/iceshrimp.assets.emoji.1.3.0.nupkg"
+  },
+  {
+    "pname": "Iceshrimp.Assets.Fonts",
+    "version": "1.2.0",
+    "hash": "sha256-5e+OpZRoZElfll93VkjHQalj1u2YX0z/sEH4PRqLjxg=",
+    "url": "https://iceshrimp.dev/api/packages/iceshrimp/nuget/package/iceshrimp.assets.fonts/1.2.0/iceshrimp.assets.fonts.1.2.0.nupkg"
+  },
+  {
+    "pname": "Iceshrimp.Assets.PhosphorIcons",
+    "version": "2.3.0",
+    "hash": "sha256-n06eVIBXgi38pZNITON6mjxyuxs5fAuXFx4+l+/Ef40=",
+    "url": "https://iceshrimp.dev/api/packages/iceshrimp/nuget/package/iceshrimp.assets.phosphoricons/2.3.0/iceshrimp.assets.phosphoricons.2.3.0.nupkg"
+  },
+  {
+    "pname": "Iceshrimp.EntityFrameworkCore.Extensions",
+    "version": "1.1.0",
+    "hash": "sha256-pw2Kpp/90+QUxXTb6q9T+73r4mYWCk28TqC9hfejE30=",
+    "url": "https://iceshrimp.dev/api/packages/iceshrimp/nuget/package/iceshrimp.entityframeworkcore.extensions/1.1.0/iceshrimp.entityframeworkcore.extensions.1.1.0.nupkg"
+  },
+  {
+    "pname": "Iceshrimp.MfmSharp",
+    "version": "1.3.1",
+    "hash": "sha256-qRo82JECyPB8T3tNbFuJ4tmvGiIRVzTxUmBjKCn8q+c="
+  },
+  {
+    "pname": "Iceshrimp.MimeTypes",
+    "version": "1.0.1",
+    "hash": "sha256-S4JxL7Azowa80+Mjuv/6OzFHPgTQLrXatJm2j7JdNbo=",
+    "url": "https://iceshrimp.dev/api/packages/iceshrimp/nuget/package/iceshrimp.mimetypes/1.0.1/iceshrimp.mimetypes.1.0.1.nupkg"
+  },
+  {
+    "pname": "Iceshrimp.ObjectStorage.Core",
+    "version": "0.34.0",
+    "hash": "sha256-XoDvb3AdXDzlJEex4LQ4og0Ul4b6XhnuQLSh0q3vqtc=",
+    "url": "https://iceshrimp.dev/api/packages/iceshrimp/nuget/package/iceshrimp.objectstorage.core/0.34.0/iceshrimp.objectstorage.core.0.34.0.nupkg"
+  },
+  {
+    "pname": "Iceshrimp.ObjectStorage.S3",
+    "version": "0.35.0",
+    "hash": "sha256-WmI/qr9a/yuKWjXXM98F1JKsjTgGQW8ctMzXYTMeq8c=",
+    "url": "https://iceshrimp.dev/api/packages/iceshrimp/nuget/package/iceshrimp.objectstorage.s3/0.35.0/iceshrimp.objectstorage.s3.0.35.0.nupkg"
+  },
+  {
+    "pname": "Iceshrimp.Utils.Common",
+    "version": "1.3.2",
+    "hash": "sha256-iS4EvojJBpdBzbzIi63HiTEhMu3U5KIOwoUNoSddMLU=",
+    "url": "https://iceshrimp.dev/api/packages/iceshrimp/nuget/package/iceshrimp.utils.common/1.3.2/iceshrimp.utils.common.1.3.2.nupkg"
+  },
+  {
+    "pname": "Iceshrimp.Utils.DependencyInjection",
+    "version": "1.0.4",
+    "hash": "sha256-sLPdPjRFyJf8eG5eFtEB7iOVpftO8RNEn1EPWUHUFGY=",
+    "url": "https://iceshrimp.dev/api/packages/iceshrimp/nuget/package/iceshrimp.utils.dependencyinjection/1.0.4/iceshrimp.utils.dependencyinjection.1.0.4.nupkg"
+  },
+  {
+    "pname": "Iceshrimp.WebPush",
+    "version": "2.2.0",
+    "hash": "sha256-7dIVBXXkykwWjfdGGrJlBWUXW0WjHtWRvWimt7fu0O0=",
+    "url": "https://iceshrimp.dev/api/packages/iceshrimp/nuget/package/iceshrimp.webpush/2.2.0/iceshrimp.webpush.2.2.0.nupkg"
+  },
+  {
+    "pname": "Isopoh.Cryptography.Argon2",
+    "version": "2.0.0",
+    "hash": "sha256-gVjUBCEaW6CnHBKHJWvtlxc2gos+Y7XRdQdTmWnnots="
+  },
+  {
+    "pname": "Isopoh.Cryptography.Blake2b",
+    "version": "2.0.0",
+    "hash": "sha256-QeBB8D40IGLFJBpxT9THbp5xMv50RwxumyVzJZ3l1nI="
+  },
+  {
+    "pname": "Isopoh.Cryptography.SecureArray",
+    "version": "2.0.0",
+    "hash": "sha256-WI/QzocCAVeNJXnvHcj44aSYXjerH50ARbrL5XYm0OM="
+  },
+  {
+    "pname": "JetBrains.Annotations",
+    "version": "2025.2.2",
+    "hash": "sha256-Bf7m0P3DQB47GrMbnNlXd3i9/GMS5Bg6gILWpdsjVvY="
+  },
+  {
+    "pname": "JetBrains.Annotations",
+    "version": "2025.2.4",
+    "hash": "sha256-YJpS77UH9tTETCKHr5M+bQOax1BLPFqIr/i+KLN9tEI="
+  },
+  {
+    "pname": "MessagePack",
+    "version": "2.5.187",
+    "hash": "sha256-3sBINhdkGdKPKTKxE4YuLGFHg6stAEHUIboR1g7eXgA="
+  },
+  {
+    "pname": "MessagePack.Annotations",
+    "version": "2.5.187",
+    "hash": "sha256-SQCJa6u8coWMptbR9iQJLjoi/YkT9t0kJNbojh9vUPw="
+  },
+  {
+    "pname": "Microsoft.ApplicationInsights",
+    "version": "2.23.0",
+    "hash": "sha256-5sf3bg7CZZjHseK+F3foOchEhmVeioePxMZVvS6Rjb0="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Authorization",
+    "version": "10.0.7",
+    "hash": "sha256-p/5PblQjWNTHvjbjw9mUCnDUqpCTUD2y5YW5xQnWeEo="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Components",
+    "version": "10.0.7",
+    "hash": "sha256-0xzpegKVge1q9+XrY5C0UGCKB1dpIUAmU/WRmy2CNWk="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Components",
+    "version": "8.0.0",
+    "hash": "sha256-hdRzDkVUSnxZFxxS4MeNafOXYGxcZ8fhLiyPvdeK4lA="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Components.Analyzers",
+    "version": "10.0.7",
+    "hash": "sha256-EGltwvkVGz7XWsCZw7FYMMWc4FYPjGW11MbYUSpv4uk="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Components.Authorization",
+    "version": "10.0.7",
+    "hash": "sha256-5UWQT7aJj8lmP6lU0nltOrwQz8UOQBCklAJEZ5rUZJ4="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Components.Forms",
+    "version": "10.0.7",
+    "hash": "sha256-SPZrnVIQYSMfeFMvSntk3kM2a8X2ED1/f7V9LMfwhDY="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Components.Forms",
+    "version": "8.0.0",
+    "hash": "sha256-rggamq5n3Nb5GXfpArcc+r8y3XeaDmbYJtD9uv3LsZ8="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Components.Web",
+    "version": "10.0.7",
+    "hash": "sha256-Z90kEL1T3+9k2B+j3yyKciMRo6fQB5NBK398q2yocT0="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Components.Web",
+    "version": "5.0.0",
+    "hash": "sha256-HhZrs32G4DtopInGgZYZ57uxHABlCL+QMEylQZvUmsk="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Components.Web",
+    "version": "8.0.0",
+    "hash": "sha256-dsCb4B6r5iHPbEp8+uFzAfD1txGI5dEIWgwtT9+GgU8="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Components.Web",
+    "version": "8.0.1",
+    "hash": "sha256-Znds4DZSc7G4mCQLaiO6EEWKzt7oI2+pp1ilqUW75Hs="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Components.WebAssembly",
+    "version": "10.0.7",
+    "hash": "sha256-vf0KR1//U2WSmqcMWEVm0wLlO3Qoy4Br9in8lgApldM="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Components.WebAssembly.Server",
+    "version": "10.0.7",
+    "hash": "sha256-4LtuWKaE/qxbi3GeoQ8HJGiQAvJmQu2uz5GwK3vw6xw="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Connections.Abstractions",
+    "version": "10.0.6",
+    "hash": "sha256-wNOi3KgOEBt1QBwpy1CM5lMO2NkaXpV7Gm9toIICrGI="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Connections.Abstractions",
+    "version": "10.0.7",
+    "hash": "sha256-fK1fKqrh8O6AeZMX0mz1o0rMR7tcaAjuFdEmJ351oWU="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Cryptography.Internal",
+    "version": "10.0.7",
+    "hash": "sha256-0Qoweg4yPoZ91js2jA7BKILw5A5fZceRaWHiCmAnAlY="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.DataProtection",
+    "version": "10.0.7",
+    "hash": "sha256-IMYLaQvSvX4cPzbL+d5RjVVAkom0Y+ZWQRhS02OmVIo="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.DataProtection.Abstractions",
+    "version": "10.0.7",
+    "hash": "sha256-Z5uVT/KAWxCUH4/35ZcCLiPKdu6Ha+cNtV0p0017ekA="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.DataProtection.EntityFrameworkCore",
+    "version": "10.0.7",
+    "hash": "sha256-YC9o4nKQF5TeUX8gNjX7L01o3bFhk9tHaCKGImMlMtY="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Http.Connections.Client",
+    "version": "10.0.7",
+    "hash": "sha256-sIppPS+9nK80g4Zl/lw42UeHSzZvhUT3Awuyl5y5mdA="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Http.Connections.Common",
+    "version": "10.0.7",
+    "hash": "sha256-aHlV5pLzf056/yw9q4oCQn0dCC7AISG21JddYxKq7RY="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.JsonPatch",
+    "version": "10.0.7",
+    "hash": "sha256-sbF5N0U+OXZKRUXXPppPrvJXevmUGnvDl6LqPtpEsBY="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Metadata",
+    "version": "10.0.7",
+    "hash": "sha256-ibWWlDdyqyX8utgFGJuMSJZeKjhdkbrQ63AHEMoQRfI="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Mvc.NewtonsoftJson",
+    "version": "10.0.7",
+    "hash": "sha256-nVAGFNglXbdJtuk099NVyC+qN/lgL3T0UdZ0GtJ1d1M="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.SignalR.Client",
+    "version": "10.0.7",
+    "hash": "sha256-1EL90+2ldYKhRJuRxIBpuMo0jqidqFk7rid3zZv8jHk="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.SignalR.Client.Core",
+    "version": "10.0.7",
+    "hash": "sha256-oxmj1Nlr9JObfvJU5kFNTtZOWaGZobDWG0lvu+Fnfsc="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.SignalR.Common",
+    "version": "10.0.6",
+    "hash": "sha256-dHA0OTbu/4gU7EHpm4pQuwn4WQUC1WM4rFySbRO3pZA="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.SignalR.Common",
+    "version": "10.0.7",
+    "hash": "sha256-/PqSI8b29uf5OL2cqcUN8q/8yzYV+Gd+IEMLrbu7asU="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.SignalR.Protocols.Json",
+    "version": "10.0.7",
+    "hash": "sha256-JzMgKZz1oM4B/Jthg8cE5MNfBJ4XDg48TBSBtZsGZEo="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.SignalR.Protocols.MessagePack",
+    "version": "10.0.6",
+    "hash": "sha256-hP/v3bWoEZWH4KcS/gNo3VvcbRcyekcpypS8O9KccnY="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.SignalR.Protocols.MessagePack",
+    "version": "10.0.7",
+    "hash": "sha256-/4ie2qVBrgzPcYa65KEcDg0c2uPDp6KDlIMyEi22H08="
+  },
+  {
+    "pname": "Microsoft.Build.Framework",
+    "version": "17.11.31",
+    "hash": "sha256-YS4oASrmC5dmZrx5JPS7SfKmUpIJErlUpVDsU3VrfFE="
+  },
+  {
+    "pname": "Microsoft.Build.Framework",
+    "version": "18.0.2",
+    "hash": "sha256-fO31KAdDs2J0RUYD1ov9UB3ucsbALan7K0YdWW+yg7A="
+  },
+  {
+    "pname": "Microsoft.Build.Framework",
+    "version": "18.4.0",
+    "hash": "sha256-k7n57+b16WJZ+C+TCBZT+8OklpSGdCjIAHeBwmP+X/k="
+  },
+  {
+    "pname": "Microsoft.Build.Utilities.Core",
+    "version": "18.4.0",
+    "hash": "sha256-IThcoj7uvCHEbHVIoLqBXCXTv9HWwaXVIFSFiohL3SI="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.Analyzers",
+    "version": "3.11.0",
+    "hash": "sha256-hQ2l6E6PO4m7i+ZsfFlEx+93UsLPo4IY3wDkNG11/Sw="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.Common",
+    "version": "5.0.0",
+    "hash": "sha256-g4ALvBSNyHEmSb1l5TFtWW7zEkiRmhqLx4XWZu9sr2U="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.CSharp",
+    "version": "5.0.0",
+    "hash": "sha256-ctBCkQGFpH/xT5rRE3xibu9YxPD108RuC4a4Z25koG8="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.CSharp.Workspaces",
+    "version": "5.0.0",
+    "hash": "sha256-yWVcLt/f2CouOfFy966glGdtSFy+RcgrU1dd9UtlL/Q="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.Workspaces.Common",
+    "version": "5.0.0",
+    "hash": "sha256-Bir5e1gEhgQQ6upQmVKQHAKLRfenAu60DAzNupNnZsQ="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.Workspaces.MSBuild",
+    "version": "5.0.0",
+    "hash": "sha256-+58+iqTayTiE0pDaog1U8mjaDA8bNNDLA8gjCQZZudo="
+  },
+  {
+    "pname": "Microsoft.DiaSymReader",
+    "version": "2.2.3",
+    "hash": "sha256-Wf2Hy/9o3xSKB9ZRXj3oUgr2CcUwu+BFn2BP2cX7KJQ="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore",
+    "version": "10.0.0",
+    "hash": "sha256-xfgrlxhtOkQwF5Q7j8gSm41URJiH8IuJ/T/Dh88++hE="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore",
+    "version": "10.0.4",
+    "hash": "sha256-V3Vwl1MtVMRTPo7a9lAgs6UaeMnFV3eEsKnLyPaPMHA="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore",
+    "version": "10.0.7",
+    "hash": "sha256-ujx4e1rgGtGdsGxKKO4K0JUHHQ15Jg4jSFVsMjdbXKA="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Abstractions",
+    "version": "10.0.7",
+    "hash": "sha256-hvMqfhPhGzM0RG5UmW1aLcRpUYwdprAd0lbLxRC5GR8="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Analyzers",
+    "version": "10.0.7",
+    "hash": "sha256-/o6FXF0ReWHe66VkhjgGepMruul3DGYXAe9L3fSxVBc="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Design",
+    "version": "10.0.7",
+    "hash": "sha256-r9k8A/yyYq18ABiqMyZXw23y2u4o0glQrqiOufvDjh0="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Relational",
+    "version": "10.0.0",
+    "hash": "sha256-vOP2CE5YA551BlpbOuIy6RuAiAEPEpCVS1cEE33/zN4="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Relational",
+    "version": "10.0.4",
+    "hash": "sha256-WwGoCwNxDXyqfBvUX9fGa/6X+yiDBuE7hf3csU78+Os="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Relational",
+    "version": "10.0.5",
+    "hash": "sha256-5jfkvUKSexKCbCsYZYkBAWd4BIN48dlF5pP6htfDMMQ="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Relational",
+    "version": "10.0.7",
+    "hash": "sha256-PwUDxiyT3pLZlLO8/5Wq1ypHjuv15g+3IZPn9NdFC9g="
+  },
+  {
+    "pname": "Microsoft.Extensions.ApiDescription.Server",
+    "version": "10.0.0",
+    "hash": "sha256-fgJ4g1gRX2W+TmNWxboxATYnZQxAGIpvl0EZD3BMVM0="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Abstractions",
+    "version": "10.0.7",
+    "hash": "sha256-u3pHlFaDPeY2v89jNYLiHUQ2aGMKpe5wpXZUt8hkgdE="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Memory",
+    "version": "10.0.7",
+    "hash": "sha256-8qXL1F5gE9OZUEp/9pNVT33hjRMVAPt4eovT1NesKoQ="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration",
+    "version": "10.0.0",
+    "hash": "sha256-MsLskVPpkCvov5+DWIaALCt1qfRRX4u228eHxvpE0dg="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration",
+    "version": "10.0.2",
+    "hash": "sha256-dBJAKDyp/sm+ZSMQfH0+4OH8Jnv1s20aHlWS6HNnH+c="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration",
+    "version": "10.0.7",
+    "hash": "sha256-2RqDs7+dXtGY78E5jSd1qyKu+dMQkbzv+oMY09SEJm0="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "10.0.0",
+    "hash": "sha256-GcgrnTAieCV7AVT13zyOjfwwL86e99iiO/MiMOxPGG0="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "10.0.2",
+    "hash": "sha256-P+0kaDGO+xB9KxF9eWHDJ4hzi05sUGM/uMNEX5NdBTE="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "10.0.7",
+    "hash": "sha256-MnUJzZYnl089xuVi6kpt9kymBIvYun9U+Itd12dM5Co="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Binder",
+    "version": "10.0.7",
+    "hash": "sha256-lU4G801+Cy3ua+S2slY5UVHOPXdF0I7r3lYX38mQSPw="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.FileExtensions",
+    "version": "10.0.7",
+    "hash": "sha256-LjHOWNzZ1I2ODEFRfIFIWTNw1gpTtJakepdulIOILDA="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Json",
+    "version": "10.0.7",
+    "hash": "sha256-A6YQgo8pjza/gP+85FXubm4xYYhURQvAsj3US0mwTTE="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "10.0.7",
+    "hash": "sha256-dICogdaqa5mHqyvFA0lTomFa39Dqm4nn7Pit6qi6eQY="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "8.0.0",
+    "hash": "sha256-+qIDR8hRzreCHNEDtUcPfVHQdurzWPo/mqviCH78+EQ="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "10.0.0",
+    "hash": "sha256-9iodXP39YqgxomnOPOxd/mzbG0JfOSXzFoNU3omT2Ps="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "10.0.7",
+    "hash": "sha256-uQmTQarMn0fuZV03MyCb78Ex+96cuqFHNO5SyFOPkJk="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyModel",
+    "version": "10.0.7",
+    "hash": "sha256-ZPL20hmZmttPGjiF3zAVyB/0o9VBOSBwi6sF0/084KA="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyModel",
+    "version": "8.0.2",
+    "hash": "sha256-PyuO/MyCR9JtYqpA1l/nXGh+WLKCq34QuAXN9qNza9Q="
+  },
+  {
+    "pname": "Microsoft.Extensions.Diagnostics",
+    "version": "10.0.7",
+    "hash": "sha256-Sd0ZsXgO7w/35vOKN1B0CZdcIcMJnf/Z/8POSikTyRk="
+  },
+  {
+    "pname": "Microsoft.Extensions.Diagnostics.Abstractions",
+    "version": "10.0.0",
+    "hash": "sha256-cix7QxQ/g3sj6reXu3jn0cRv2RijzceaLLkchEGTt5E="
+  },
+  {
+    "pname": "Microsoft.Extensions.Diagnostics.Abstractions",
+    "version": "10.0.7",
+    "hash": "sha256-ocntk68Qa3ccHGEnzmZuKdBWdQEnp4PgwJk63bSRjDA="
+  },
+  {
+    "pname": "Microsoft.Extensions.Features",
+    "version": "10.0.7",
+    "hash": "sha256-k7dtn75urRu5ofYIU6vHN9yhBA5sHbJZYtUHM+trR0o="
+  },
+  {
+    "pname": "Microsoft.Extensions.FileProviders.Abstractions",
+    "version": "10.0.0",
+    "hash": "sha256-CHDs2HCN8QcfuYQpgNVszZ5dfXFe4yS9K2GoQXecc20="
+  },
+  {
+    "pname": "Microsoft.Extensions.FileProviders.Abstractions",
+    "version": "10.0.7",
+    "hash": "sha256-ibxSdxibq1UKOo4Mz+zthbZd0UUFipnJNb0hPwvEXCA="
+  },
+  {
+    "pname": "Microsoft.Extensions.FileProviders.Physical",
+    "version": "10.0.7",
+    "hash": "sha256-B1jF2XZ6z5TavZVAD0GzW2Q0ILyskeUdTaWF3OgS9mY="
+  },
+  {
+    "pname": "Microsoft.Extensions.FileSystemGlobbing",
+    "version": "10.0.7",
+    "hash": "sha256-KdLAYPizG4yCLK7oF5yd3lPXzMYKI+uZJhRXKD9VlHg="
+  },
+  {
+    "pname": "Microsoft.Extensions.Hosting.Abstractions",
+    "version": "10.0.0",
+    "hash": "sha256-Sub3Thay/+eR84cEODk/nPh1oYIYtawvDX6r0duReqo="
+  },
+  {
+    "pname": "Microsoft.Extensions.Hosting.Abstractions",
+    "version": "10.0.7",
+    "hash": "sha256-S1WAgBHPi7H71uQUGyl2aG/IITgYfVNznyXsFrRe/kE="
+  },
+  {
+    "pname": "Microsoft.Extensions.Localization",
+    "version": "10.0.7",
+    "hash": "sha256-nsiUMEvLwo8an+x6fAAzNMowoz2CSZx9RY54yYrHVUo="
+  },
+  {
+    "pname": "Microsoft.Extensions.Localization.Abstractions",
+    "version": "10.0.7",
+    "hash": "sha256-Rr43ZnvcIxRW6Mvmtleezyg39Eq8lIkWjbO6YuUXWOw="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging",
+    "version": "10.0.7",
+    "hash": "sha256-AUOet0nWZHB132XCPuyUp5xTFNnWjHhoOtzooFcXHk4="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "10.0.0",
+    "hash": "sha256-BnhgGZc01HwTSxogavq7Ueq4V7iMA3wPnbfRwQ4RhGk="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "10.0.7",
+    "hash": "sha256-/ITLUXgcs5tRDdeileNlmNB92V25CRd1FGBocChJj0g="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Configuration",
+    "version": "10.0.0",
+    "hash": "sha256-7/TWO1aq8hdgbcTEKDBWIjgSC9KpFN3kRnMX+12bOkU="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Configuration",
+    "version": "10.0.7",
+    "hash": "sha256-bgfSy30lXJhN9T+CWdwodnpZJDLJoElM4HKOOCijjfo="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "10.0.0",
+    "hash": "sha256-j5MOqZSKeUtxxzmZjzZMGy0vELHdvPraqwTQQQNVsYA="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "10.0.6",
+    "hash": "sha256-GJCULaUcN2FxCA9fKOLe5EDEtkKLrEuP2Kw0jRqospA="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "10.0.7",
+    "hash": "sha256-XtyfdZ26kjnuCF/YHbdGdsIeR/nxSW7yyQZ04sOa9RU="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options.ConfigurationExtensions",
+    "version": "10.0.7",
+    "hash": "sha256-6UBnB1ouWwRkVEGt5xLfXZvpYsCQQJijKvBlBCJOmmM="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "10.0.0",
+    "hash": "sha256-Dup08KcptLjlnpN5t5//+p4n8FUTgRAq4n/w1s6us+I="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "10.0.2",
+    "hash": "sha256-8Ccrjjv9cFVf9RyCc7GS/Byt8+DXdSNea0UX3A5BEdA="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "10.0.7",
+    "hash": "sha256-cQBhL1IkRl1lxaZImAZBVS39CfWkB+J6+hJVEVBE35I="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "8.0.0",
+    "hash": "sha256-FU8qj3DR8bDdc1c+WeGZx/PCZeqqndweZM9epcpXjSo="
+  },
+  {
+    "pname": "Microsoft.Extensions.Validation",
+    "version": "10.0.7",
+    "hash": "sha256-P27Y1bIoLBSKXKFszjvvPHS7gI1DgrcOy2Ad3nFc66M="
+  },
+  {
+    "pname": "Microsoft.JSInterop",
+    "version": "10.0.7",
+    "hash": "sha256-WvzNtb8RA6sKziII8BfBmFQdwpycru6LoBCq/XxS1Tw="
+  },
+  {
+    "pname": "Microsoft.JSInterop",
+    "version": "5.0.0",
+    "hash": "sha256-jnIGEY7GYmODOCdElMbB0t1s4UiCLjB+kVjTx/milM8="
+  },
+  {
+    "pname": "Microsoft.JSInterop",
+    "version": "8.0.0",
+    "hash": "sha256-k4omTJJODnwUMFtgUrUFh/HK+ly8SWlZJVsH64p96LQ="
+  },
+  {
+    "pname": "Microsoft.JSInterop.WebAssembly",
+    "version": "10.0.7",
+    "hash": "sha256-ULfDfcxmhToWV9/W/uweyvBDW+3uKsC0Szaag2XmrNY="
+  },
+  {
+    "pname": "Microsoft.NET.Sdk.WebAssembly.Pack",
+    "version": "10.0.8",
+    "hash": "sha256-c6eCATnJUqnIwiGX2DqHVA8a841K5BHD7JehkIuHzSM="
+  },
+  {
+    "pname": "Microsoft.NET.StringTools",
+    "version": "17.6.3",
+    "hash": "sha256-H2Qw8x47WyFOd/VmgRmGMc+uXySgUv68UISgK8Frsjw="
+  },
+  {
+    "pname": "Microsoft.NET.StringTools",
+    "version": "18.4.0",
+    "hash": "sha256-uyHzUxlqdLe1QnDp4LNeANJcrSm/9zuxQyVcjUZNyAM="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Runtime.Mono.browser-wasm",
+    "version": "10.0.8",
+    "hash": "sha256-JIr8wsgLQVBqXjJlOc43cd3iO21s7u+qZQK391JnfZk=",
+    "installable": "true"
+  },
+  {
+    "pname": "Microsoft.OpenApi",
+    "version": "2.4.1",
+    "hash": "sha256-DXdbXq5Gpg3MJVBM0C8uF6mcLczVJAUFp6LAdFojgPs="
+  },
+  {
+    "pname": "Microsoft.Testing.Extensions.CodeCoverage",
+    "version": "18.5.2",
+    "hash": "sha256-PkIEXfbyEwlxOIG4h420/TpWbbzAy7eV8RUy7iXHVtk="
+  },
+  {
+    "pname": "Microsoft.Testing.Extensions.Telemetry",
+    "version": "2.2.2",
+    "hash": "sha256-4rXpgfroh8MnLWjYxUtYo/VcErYe9gpCaz80np3r1CI="
+  },
+  {
+    "pname": "Microsoft.Testing.Extensions.TrxReport",
+    "version": "2.2.2",
+    "hash": "sha256-IOgroCb3Wvwas4z2Xxy4ils5AswZpKT/wvjQM5e95ig="
+  },
+  {
+    "pname": "Microsoft.Testing.Extensions.TrxReport.Abstractions",
+    "version": "2.2.2",
+    "hash": "sha256-aP+mw/Q5U6lfNmMJCzLqVMpZ+TnBMTqXH0VGhR2FvbI="
+  },
+  {
+    "pname": "Microsoft.Testing.Extensions.VSTestBridge",
+    "version": "2.2.2",
+    "hash": "sha256-rtyA0w70swCKfz+ly6ev/BlNXH8WUHurfxsaWoo1LbA="
+  },
+  {
+    "pname": "Microsoft.Testing.Platform",
+    "version": "2.1.0",
+    "hash": "sha256-CbR0j0Dh65cMccO7L6ppx4b5iiXjqxjjfC9A85HeLuM="
+  },
+  {
+    "pname": "Microsoft.Testing.Platform",
+    "version": "2.2.2",
+    "hash": "sha256-azYgL1c9oVE1JDYs0HUWTClaIumw1xvxgmNz4Mx0q30="
+  },
+  {
+    "pname": "Microsoft.Testing.Platform.MSBuild",
+    "version": "2.2.2",
+    "hash": "sha256-uuhiI0aGFpM+I2ASh99rsfsRhKf8b/JUNx4Hcd2Ac6Q="
+  },
+  {
+    "pname": "Microsoft.TestPlatform.ObjectModel",
+    "version": "18.3.0",
+    "hash": "sha256-3Y3OxAQsXl6sunQlSjfq31aLWykHQTj2o/TOVI/uy88="
+  },
+  {
+    "pname": "Microsoft.VisualStudio.SolutionPersistence",
+    "version": "1.0.52",
+    "hash": "sha256-KZGPtOXe6Hv8RrkcsgoLKTRyaCScIpQEa2NhNB3iOXw="
+  },
+  {
+    "pname": "Microsoft.Win32.SystemEvents",
+    "version": "6.0.0",
+    "hash": "sha256-N9EVZbl5w1VnMywGXyaVWzT9lh84iaJ3aD48hIBk1zA="
+  },
+  {
+    "pname": "Mono.TextTemplating",
+    "version": "3.0.0",
+    "hash": "sha256-VlgGDvgNZb7MeBbIZ4DE2Nn/j2aD9k6XqNHnASUSDr0="
+  },
+  {
+    "pname": "MSTest.Analyzers",
+    "version": "4.2.2",
+    "hash": "sha256-m6FRWUdYM9tuNnm7ehY+j1wIr2i12+0LeK5JcpJdp5M="
+  },
+  {
+    "pname": "MSTest.TestAdapter",
+    "version": "4.2.2",
+    "hash": "sha256-QFjHNHVyijmuq29MuhUNMnaWEcJWPWGVp21BQj0Hb7M="
+  },
+  {
+    "pname": "MSTest.TestFramework",
+    "version": "4.2.2",
+    "hash": "sha256-+yrzh3fmkvOMnqk+eYKQTC1267uKeUDcS3TV1+3Gnck="
+  },
+  {
+    "pname": "NetVips",
+    "version": "3.2.0",
+    "hash": "sha256-170GHh2PS7rYu4kdfsdjG4QdPitfOy4JhaqIfBpseGY="
+  },
+  {
+    "pname": "NetVips.Native",
+    "version": "8.18.0-iceshrimp",
+    "hash": "sha256-Ch1ko4qN1M4hDXPQnGBdX33S54QQaHKbAIm7wBhdN4s=",
+    "url": "https://iceshrimp.dev/api/packages/iceshrimp/nuget/package/netvips.native/8.18.0-iceshrimp/netvips.native.8.18.0-iceshrimp.nupkg"
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "12.0.1",
+    "hash": "sha256-4Xf3RZrJomAh3jaZrEAJX3oPmOowGV8yDB9Y3h0Dw4U="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "13.0.3",
+    "hash": "sha256-hy/BieY4qxBWVVsDqqOPaLy1QobiIapkbrESm6v2PHc="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "13.0.4",
+    "hash": "sha256-8JCB1FdAW681qXP6DFDWvycu1oPyVoxaYgpJ2pUvZSk="
+  },
+  {
+    "pname": "Newtonsoft.Json.Bson",
+    "version": "1.0.2",
+    "hash": "sha256-ZUj6YFSMZp5CZtXiamw49eZmbp1iYBuNsIKNnjxcRzA="
+  },
+  {
+    "pname": "Npgsql",
+    "version": "10.0.2",
+    "hash": "sha256-hW03ZWoW7y16vvScwsjZNyqFybGy+s6hQYQXebo78yQ="
+  },
+  {
+    "pname": "Npgsql.EntityFrameworkCore.PostgreSQL",
+    "version": "10.0.1",
+    "hash": "sha256-G5WmWoc02gHTsdBLXESFQ5eMV+liwiO8YjzFKg4NDEk="
+  },
+  {
+    "pname": "Npgsql.OpenTelemetry",
+    "version": "10.0.2",
+    "hash": "sha256-8RDpth3qEXoOzqldbNLg4ef7aMYuLPTPmPXkkho80uw="
+  },
+  {
+    "pname": "OpenTelemetry",
+    "version": "1.15.3",
+    "hash": "sha256-zOrEPW8noHfUINJtIWQYMTls2JLRUYm7aoyffjrMBLU="
+  },
+  {
+    "pname": "OpenTelemetry.Api",
+    "version": "1.14.0",
+    "hash": "sha256-Dn8gWzYyFQuNjP1m6YJzSrPetF+G+R+zVFEJevFSv+c="
+  },
+  {
+    "pname": "OpenTelemetry.Api",
+    "version": "1.15.3",
+    "hash": "sha256-vriWJD2xvBt6ir9u5o/aVPBqBJJA7S6IJhkjKDkeLfc="
+  },
+  {
+    "pname": "OpenTelemetry.Api.ProviderBuilderExtensions",
+    "version": "1.15.3",
+    "hash": "sha256-Z4x0eA1dkCOJS5xYZ6ogMOk6H+ivvXuVj1mORyWMOSo="
+  },
+  {
+    "pname": "OpenTelemetry.Exporter.OpenTelemetryProtocol",
+    "version": "1.15.3",
+    "hash": "sha256-TEFjBSkkYYCIkSjXg8ymBOxRIrG1QvW3wb6FZF+2Mrk="
+  },
+  {
+    "pname": "OpenTelemetry.Extensions.Hosting",
+    "version": "1.15.3",
+    "hash": "sha256-5Z5/80xNttniodCF71s9cGXvDCkIc8Qdvpr969K5G0c="
+  },
+  {
+    "pname": "OpenTelemetry.Instrumentation.AspNetCore",
+    "version": "1.15.2",
+    "hash": "sha256-rfStn++qynwoTOa5H5IFwbAPn7sOgW/vebcfKvOusio="
+  },
+  {
+    "pname": "OpenTelemetry.Instrumentation.Http",
+    "version": "1.15.1",
+    "hash": "sha256-VG3zmUmFcN+mk7BkIcss1RjkcrVWrQMn8AUDTM4wpus="
+  },
+  {
+    "pname": "OpenTelemetry.Instrumentation.Runtime",
+    "version": "1.15.1",
+    "hash": "sha256-wE0909zdzuGUB/KD/yEfLV9F5EvZGMmwjL2tpO4bOh4="
+  },
+  {
+    "pname": "Otp.NET",
+    "version": "1.4.1",
+    "hash": "sha256-M4BJnj0H2t9UlGXM693WePZuNMMSfrZ3kir95lDLfMQ="
+  },
+  {
+    "pname": "QRCoder",
+    "version": "1.8.0",
+    "hash": "sha256-UvOeFFxUZ/bddmDs6IamiYGDIfgxybE/CSpPyy5DMxI="
+  },
+  {
+    "pname": "Scalar.AspNetCore",
+    "version": "2.14.0",
+    "hash": "sha256-793pYxXkDSZqCgA2+OtrIzFI6cWlMNPDZzhMMWQPC6o="
+  },
+  {
+    "pname": "SixLabors.Fonts",
+    "version": "2.1.3",
+    "hash": "sha256-lUTFK7OBtiXU1gyROax4GXDRvNj3aqgGlZZvicc37VQ="
+  },
+  {
+    "pname": "SixLabors.ImageSharp",
+    "version": "3.1.13-iceshrimp",
+    "hash": "sha256-jn1MWm4EZp/86WzNpTAXMl8BpMM1rYM0Azh/A8X5V9k=",
+    "url": "https://iceshrimp.dev/api/packages/iceshrimp/nuget/package/sixlabors.imagesharp/3.1.13-iceshrimp/sixlabors.imagesharp.3.1.13-iceshrimp.nupkg"
+  },
+  {
+    "pname": "SixLabors.ImageSharp.Drawing",
+    "version": "2.1.7",
+    "hash": "sha256-LkStbMTvIPIXvkda4Xn1simHaH0mJHHuCI0+AaAS4/4="
+  },
+  {
+    "pname": "Swashbuckle.AspNetCore",
+    "version": "10.1.7",
+    "hash": "sha256-6NUOoTHcPdJAtrlMVkmgKs/sxuwV1Q78QzG+tt4j4wo="
+  },
+  {
+    "pname": "Swashbuckle.AspNetCore.Swagger",
+    "version": "10.1.7",
+    "hash": "sha256-jRCchEG4ESpuYtbzMDGtKkR9BkLO4Ac3PQwSmu8B6m8="
+  },
+  {
+    "pname": "Swashbuckle.AspNetCore.SwaggerGen",
+    "version": "10.1.7",
+    "hash": "sha256-+6xUOc4EJS7KXQySb2wH2FF9yGM5rgzvlJz45QQyXBw="
+  },
+  {
+    "pname": "Swashbuckle.AspNetCore.SwaggerUI",
+    "version": "10.1.7",
+    "hash": "sha256-5JYW0MKQ0ePdMHHZrDDaWuj7BX0pvA7NT/K6M49TFm4="
+  },
+  {
+    "pname": "System.CodeDom",
+    "version": "6.0.0",
+    "hash": "sha256-uPetUFZyHfxjScu5x4agjk9pIhbCkt5rG4Axj25npcQ="
+  },
+  {
+    "pname": "System.Composition",
+    "version": "9.0.0",
+    "hash": "sha256-FehOkQ2u1p8mQ0/wn3cZ+24HjhTLdck8VZYWA1CcgbM="
+  },
+  {
+    "pname": "System.Composition.AttributedModel",
+    "version": "9.0.0",
+    "hash": "sha256-a7y7H6zj+kmYkllNHA402DoVfY9IaqC3Ooys8Vzl24M="
+  },
+  {
+    "pname": "System.Composition.Convention",
+    "version": "9.0.0",
+    "hash": "sha256-tw4vE5JRQ60ubTZBbxoMPhtjOQCC3XoDFUH7NHO7o8U="
+  },
+  {
+    "pname": "System.Composition.Hosting",
+    "version": "9.0.0",
+    "hash": "sha256-oOxU+DPEEfMCuNLgW6wSkZp0JY5gYt44FJNnWt+967s="
+  },
+  {
+    "pname": "System.Composition.Runtime",
+    "version": "9.0.0",
+    "hash": "sha256-AyIe+di1TqwUBbSJ/sJ8Q8tzsnTN+VBdJw4K8xZz43s="
+  },
+  {
+    "pname": "System.Composition.TypedParts",
+    "version": "9.0.0",
+    "hash": "sha256-F5fpTUs3Rr7yP/NyIzr+Xn5NdTXXp8rrjBnF9UBBUog="
+  },
+  {
+    "pname": "System.Configuration.ConfigurationManager",
+    "version": "10.0.1",
+    "hash": "sha256-XmXL//tniOp4RYiXs9HzNbwODjyGYW/bsWO0OuWXAxE="
+  },
+  {
+    "pname": "System.Configuration.ConfigurationManager",
+    "version": "10.0.2",
+    "hash": "sha256-KlwLNJ4RfuLOHevPvcW4BeiNioGVos7G2NaWBaTkLt8="
+  },
+  {
+    "pname": "System.Configuration.ConfigurationManager",
+    "version": "9.0.0",
+    "hash": "sha256-+pLnTC0YDP6Kjw5DVBiFrV/Q3x5is/+6N6vAtjvhVWk="
+  },
+  {
+    "pname": "System.Diagnostics.EventLog",
+    "version": "10.0.1",
+    "hash": "sha256-Yn8jT9uKNnknLsSvtV9hyqfz/5x/aKnZt6XtfQOIdVM="
+  },
+  {
+    "pname": "System.Diagnostics.EventLog",
+    "version": "10.0.2",
+    "hash": "sha256-rezZk0M4+MWRxwGSFzXfvekrhL8qLTp7Pc8YsSy/4nE="
+  },
+  {
+    "pname": "System.Diagnostics.EventLog",
+    "version": "9.0.0",
+    "hash": "sha256-tPvt6yoAp56sK/fe+/ei8M65eavY2UUhRnbrREj/Ems="
+  },
+  {
+    "pname": "System.Drawing.Common",
+    "version": "6.0.0",
+    "hash": "sha256-/9EaAbEeOjELRSMZaImS1O8FmUe8j4WuFUw1VOrPyAo="
+  },
+  {
+    "pname": "System.IO.Hashing",
+    "version": "10.0.7",
+    "hash": "sha256-rC66xfhV06/Ya6FGEGm/D4hyaKUj9PH+60ElwROtv58="
+  },
+  {
+    "pname": "System.Reflection.TypeExtensions",
+    "version": "4.7.0",
+    "hash": "sha256-GEtCGXwtOnkYejSV+Tfl+DqyGq5jTUaVyL9eMupMHBM="
+  },
+  {
+    "pname": "System.Security.Cryptography.Pkcs",
+    "version": "10.0.7",
+    "hash": "sha256-+3RdvoSme0k3FoutPdJLkbWPWsmqPVo80hMgpuH3FP0="
+  },
+  {
+    "pname": "System.Security.Cryptography.ProtectedData",
+    "version": "10.0.1",
+    "hash": "sha256-B2sQ5rfu4fROzUDbi0A2rHPq27QDmQa3k56MfpE1adA="
+  },
+  {
+    "pname": "System.Security.Cryptography.ProtectedData",
+    "version": "10.0.2",
+    "hash": "sha256-FnpxhnVrLdn3y35NmYRgxh7dw0odYYwco4RotlTuwsI="
+  },
+  {
+    "pname": "System.Security.Cryptography.ProtectedData",
+    "version": "9.0.0",
+    "hash": "sha256-gPgPU7k/InTqmXoRzQfUMEKL3QuTnOKowFqmXTnWaBQ="
+  },
+  {
+    "pname": "System.Security.Cryptography.Xml",
+    "version": "10.0.7",
+    "hash": "sha256-gfXCF/CXaXkt9E9BTOZZfKFQsMKBN4lrHUw45eQLeic="
+  },
+  {
+    "pname": "TypedSignalR.Client",
+    "version": "3.6.0",
+    "hash": "sha256-tNlLv+rdrZY76KPAOdaYb2iQo2QN6nfnB0059LaWqso="
+  },
+  {
+    "pname": "Ulid",
+    "version": "1.4.1",
+    "hash": "sha256-Fv+UmMBEFqnmdh+Nde0x1hS7WiY5c33LHAEC3cAkbIA="
+  },
+  {
+    "pname": "VDS.Common",
+    "version": "3.0.0",
+    "hash": "sha256-B2O+cIVE+fMpK2jXovFt9vpuuBGIMXD0bKORrvRH9/w="
+  }
+]

--- a/pkgs/by-name/ic/iceshrimp-net/package.nix
+++ b/pkgs/by-name/ic/iceshrimp-net/package.nix
@@ -1,0 +1,109 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchgit,
+  buildDotnetModule,
+  dotnetCorePackages,
+  vips,
+  openjpeg,
+  python315,
+  enableVIPS ? true,
+  enableAOT ? false,
+}:
+let
+  inherit (dotnetCorePackages) fetchNupkg;
+
+  targetRID =
+    {
+      aarch64-linux = "linux-arm64";
+      x86_64-linux = "linux-x64";
+    }
+    .${stdenvNoCC.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
+in
+buildDotnetModule rec {
+  pname = "iceshrimp-net";
+  version = "2026.1.1-beta";
+
+  src = fetchgit {
+    url = "https://iceshrimp.dev/iceshrimp/Iceshrimp.NET";
+    rev = "v${version}";
+    hash = "sha256-HeLP9OprznxYks63pfmChs7TH+aad39Cm8DvrCIoQ8s=";
+  };
+
+  projectFile = "Iceshrimp.Backend/Iceshrimp.Backend.csproj";
+
+  dotnet-sdk = dotnetCorePackages.sdk_10_0;
+  dotnet-runtime = dotnetCorePackages.aspnetcore_10_0;
+
+  nugetDeps = ./deps.json;
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  buildInputs = lib.optionals enableVIPS [
+    vips
+    openjpeg
+  ];
+
+  nativeBuildInputs = lib.optional enableAOT python315;
+
+  dotnetFlags =
+    lib.optionals enableVIPS [
+      "-p:EnableLibVips=true"
+      "-p:BundleNativeDeps=true"
+    ]
+    ++ lib.optionals enableAOT [
+      "-p:EnableAOT=true"
+    ];
+
+  preConfigure = lib.optionalString enableAOT ''
+    dotnet workload install wasm-tools
+  '';
+
+  configurePhase = ''
+    runHook preConfigure
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    dotnet build ${projectFile} \
+      -p:ContinuousIntegrationBuild=true \
+      -p:Deterministic=true \
+      -p:DeterministicSourcePaths=true \
+      -p:OverwriteReadOnlyFiles=true \
+      --configuration Release \
+      --runtime ${targetRID} \
+      ${lib.join " " dotnetFlags} \
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    dotnet publish ${projectFile} \
+      -p:ContinuousIntegrationBuild=true \
+      -p:Deterministic=true \
+      -p:DeterministicSourcePaths=true \
+      -p:OverwriteReadOnlyFiles=true \
+      --no-build \
+      --configuration Release \
+      --runtime ${targetRID} \
+      --output $out/lib/$pname \
+      ${lib.join " " dotnetFlags}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A decentralized and federated social networking service, implementing the ActivityPub standard.";
+    homepage = "https://iceshrimp.dev";
+    changelog = "https://iceshrimp.dev/iceshrimp/iceshrimp.NET/releases/tag/v${version}";
+    license = lib.licenses.eupl12;
+    platforms = lib.platforms.linux;
+    mainProgram = "Iceshrimp.Backend";
+    maintainers = [ lib.maintainers.twoneis ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Packaging for [Iceshrimp.NET](https://iceshrimp.dev), a rewrite using the .NET framework of the iceshrimp-js federated ActivityPub service. While I welcome every review of course there are some things I want to draw special attention to that I am unsure about:
- **Package naming** I think following the naming guidelines iceshrimp-net is a sensible name but I am not entirely sure this is correct
- **NativeAOT** The project supports native AOT, however I have been unable to package it with nix because of the required .NET workload `wasm-tools`. While it works perfectly fine without it, it would be a nice-to-have. Maybe someone from @NixOS/dotnet can help here. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
