### PR TITLE
python3Packages.cielo-connect-api: init at 1.0.6

### DIFF
--- a/pkgs/development/python-modules/cielo-connect-api/default.nix
+++ b/pkgs/development/python-modules/cielo-connect-api/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  aiohttp,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "cielo-connect-api";
+  version = "1.0.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "cielo-connect";
+    repo = "cielo-connect-api";
+    tag = finalAttrs.version;
+    hash = "sha256-rFI3oNv8TYLwSu5Mofg2SjNcfq0WoVoN0KReigLj5ZU=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ aiohttp ];
+
+  pythonImportsCheck = [ "cieloconnectapi" ];
+
+  meta = {
+    description = "Async Python API client for Cielo Home devices";
+    homepage = "https://github.com/cielo-connect/cielo-connect-api";
+    changelog = "https://github.com/cielo-connect/cielo-connect-api/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -1009,7 +1009,8 @@
       ];
     "cielo_home" =
       ps: with ps; [
-      ]; # missing inputs: cielo-connect-api
+        cielo-connect-api
+      ];
     "cisco_ios" =
       ps: with ps; [
         pexpect
@@ -7850,6 +7851,7 @@
     "cert_expiry"
     "chacon_dio"
     "chess_com"
+    "cielo_home"
     "citybikes"
     "clicksend_tts"
     "climate"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2757,6 +2757,8 @@ self: super: with self; {
 
   ci-py = callPackage ../development/python-modules/ci-py { };
 
+  cielo-connect-api = callPackage ../development/python-modules/cielo-connect-api { };
+
   cinemagoer = callPackage ../development/python-modules/cinemagoer { };
 
   circuit-webhook = callPackage ../development/python-modules/circuit-webhook { };


### PR DESCRIPTION
- https://pypi.org/project/cielo-connect-api/
- https://github.com/cielo-connect/cielo-connect-api
- https://www.home-assistant.io/integrations/cielo_home/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
