### PR TITLE
python3Packages.lg-rs232-tv: init at 1.2.0

### DIFF
--- a/pkgs/development/python-modules/lg-rs232-tv/default.nix
+++ b/pkgs/development/python-modules/lg-rs232-tv/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  uv-build,
+  serialx,
+  aiowebostv,
+  pytest-asyncio,
+  pytest-timeout,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "lg-rs232-tv";
+  version = "1.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "home-assistant-libs";
+    repo = "lg-rs232-tv";
+    tag = finalAttrs.version;
+    hash = "sha256-gMjRyZ/gUMAsS0v465ISD38YAlrOB8N/5VAFZkXtyAE=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.8.4,<0.9.0" "uv_build"
+  '';
+
+  build-system = [ uv-build ];
+
+  dependencies = [ serialx ];
+
+  optional-dependencies = {
+    esphome = serialx.optional-dependencies.esphome;
+    remote = [ aiowebostv ];
+  };
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-timeout
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "lg_rs232_tv" ];
+
+  meta = {
+    description = "Async library to control LG TVs over RS232";
+    homepage = "https://github.com/home-assistant-libs/lg-rs232-tv";
+    changelog = "https://github.com/home-assistant-libs/lg-rs232-tv/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -3610,8 +3610,9 @@
     "lg_tv_rs232" =
       ps: with ps; [
         aiousbwatcher
+        lg-rs232-tv
         serialx
-      ]; # missing inputs: lg-rs232-tv
+      ];
     "libre_hardware_monitor" =
       ps: with ps; [
         librehardwaremonitor-api
@@ -8228,6 +8229,7 @@
     "lg_netcast"
     "lg_soundbar"
     "lg_thinq"
+    "lg_tv_rs232"
     "libre_hardware_monitor"
     "lichess"
     "lidarr"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8789,6 +8789,8 @@ self: super: with self; {
 
   lexilang = callPackage ../development/python-modules/lexilang { };
 
+  lg-rs232-tv = callPackage ../development/python-modules/lg-rs232-tv { };
+
   lgpio = toPythonModule (
     pkgs.lgpio.override {
       inherit buildPythonPackage;


### PR DESCRIPTION
- https://pypi.org/project/lg-rs232-tv/
- https://github.com/home-assistant-libs/lg-rs232-tv
- https://www.home-assistant.io/integrations/lg_tv_rs232

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
