### PR TITLE
python3Packages.scalar-fastapi: 1.6.1 -> 1.8.2

### DIFF
--- a/pkgs/development/python-modules/scalar-fastapi/default.nix
+++ b/pkgs/development/python-modules/scalar-fastapi/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
 
   # build-system
   setuptools,
@@ -23,14 +23,18 @@
 
 buildPythonPackage rec {
   pname = "scalar-fastapi";
-  version = "1.6.1";
+  version = "1.8.2";
   pyproject = true;
 
-  src = fetchPypi {
+  src = fetchFromGitHub {
+    owner = "scalar";
+    repo = "scalar";
     pname = "scalar_fastapi";
-    inherit version;
-    hash = "sha256-XTzJbw84TTiLWKuldqkDuQfjyY2sqxM5ByIQ6UbE8DM=";
+    # The commit changed integrations/fastapi/package.json which defines version number
+    rev = "0f4bd9da2706be09a8afba017465f55a62dc0975";
+    hash = "sha256-FvbRsLEfdG2fqg14xXG0K1nn8+qX/Co9Sy2EOM0DTlg=";
   };
+  sourceRoot = "${src.name}/integrations/fastapi";
 
   build-system = [
     setuptools


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Since https://github.com/scalar/scalar/commit/186b1ea32451e4c43d69c3f83755ad2291478abd, pypi wheel no longer contains tests, so fetch from GitHub instead.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
