### PR TITLE
python3Packages.zigpy-zboss: 1.2.0 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/zigpy-zboss/default.nix
+++ b/pkgs/development/python-modules/zigpy-zboss/default.nix
@@ -2,12 +2,12 @@
   buildPythonPackage,
   coloredlogs,
   fetchFromGitHub,
-  fetchpatch,
   jsonschema,
   lib,
-  pytest-asyncio_0,
+  pytest-asyncio,
   pytest-mock,
   pytestCheckHook,
+  serialx,
   setuptools,
   voluptuous,
   zigpy,
@@ -15,39 +15,22 @@
 
 buildPythonPackage rec {
   pname = "zigpy-zboss";
-  version = "1.2.0";
+  version = "2.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "kardia-as";
     repo = "zigpy-zboss";
     tag = "v${version}";
-    hash = "sha256-T2R291GeFIsnDRI1tAydTlLamA3LF5tKxKFhPtcEUus=";
+    hash = "sha256-mVOuBy/uf4NsWqSfpL/ETLMnUDF5H8x1n8XoNjH5DNY=";
   };
-
-  patches = [
-    # https://github.com/kardia-as/zigpy-zboss/pull/66
-    (fetchpatch {
-      name = "replace-async-timeout-with-asyncio-timeout.patch";
-      url = "https://github.com/kardia-as/zigpy-zboss/commit/91688873ddbcd0c2196f0da69a857b2e2bec75a6.patch";
-      excludes = [ "setup.cfg" ];
-      hash = "sha256-aC0+FbbtuHDW3ApJDnTG3TUeNWhzecEYVuiSOik03uU=";
-    })
-    (fetchpatch {
-      # https://github.com/kardia-as/zigpy-zboss/pull/67
-      name = "replace-pyserial-asyncio-with-pyserial-asyncio-fast.patch";
-      url = "https://github.com/kardia-as/zigpy-zboss/commit/d44ceb537dc16ce020f8c60a0ff35e88672f3455.patch";
-      hash = "sha256-aXWRtBLDr9NLIMNK/xtsYuy/hEB2zHU3YYcRKbguTTo=";
-    })
-  ];
-
-  pythonRemoveDeps = [ "async_timeout" ];
 
   build-system = [ setuptools ];
 
   dependencies = [
     coloredlogs
     jsonschema
+    serialx
     voluptuous
     zigpy
   ];
@@ -55,26 +38,9 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "zigpy_zboss" ];
 
   nativeCheckInputs = [
-    pytest-asyncio_0
+    pytest-asyncio
     pytest-mock
     pytestCheckHook
-  ];
-
-  disabledTestPaths = [
-    # AttributeError: 'Ledvance' object has no attribute 'get'
-    "tests/application/test_connect.py"
-    "tests/application/test_join.py"
-    "tests/application/test_requests.py"
-    "tests/application/test_startup.py"
-    "tests/application/test_zdo_requests.py"
-    "tests/application/test_zigpy_callbacks.py"
-    # This hasn't been updated in 2 years, and we're getting new failing tests. Best I can do for now is disable them.
-    # If this recieves an update, please give reenabling these tests a try.
-    "tests/api/test_listeners.py"
-    "tests/api/test_request.py"
-    "tests/api/test_response.py"
-    "tests/api/test_connect.py"
-    "tests/test_uart.py"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/zigpy-zboss/default.nix
+++ b/pkgs/development/python-modules/zigpy-zboss/default.nix
@@ -13,7 +13,7 @@
   zigpy,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "zigpy-zboss";
   version = "2.0.0";
   pyproject = true;
@@ -21,7 +21,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "kardia-as";
     repo = "zigpy-zboss";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-mVOuBy/uf4NsWqSfpL/ETLMnUDF5H8x1n8XoNjH5DNY=";
   };
 
@@ -44,10 +44,10 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/kardia-as/zigpy-zboss/releases/tag/v${version}";
+    changelog = "https://github.com/kardia-as/zigpy-zboss/releases/tag/${finalAttrs.src.tag}";
     description = "Library for zigpy which communicates with Nordic nRF52 radios";
     homepage = "https://github.com/kardia-as/zigpy-zboss";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ dotlambda ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/kardia-as/zigpy-zboss/compare/v1.2.0...v2.0.0

Changelog: https://github.com/kardia-as/zigpy-zboss/releases/tag/v2.0.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
