### PR TITLE
python3Packages.pajgps-api: init at 0.3.1

### DIFF
--- a/pkgs/development/python-modules/pajgps-api/default.nix
+++ b/pkgs/development/python-modules/pajgps-api/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  aiohttp,
+  pytestCheckHook,
+  python-dotenv,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pajgps-api";
+  version = "0.3.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "skipperro";
+    repo = "pajgps-api";
+    tag = finalAttrs.version;
+    hash = "sha256-OJbWF5KcqyRud0Sfx7rME+mXIjiZQD9UxD3vpeV6RWY=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [ aiohttp ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    python-dotenv
+  ];
+
+  pythonImportsCheck = [ "pajgps_api" ];
+
+  meta = {
+    description = "Python library to interact with the PAJ GPS API";
+    homepage = "https://github.com/skipperro/pajgps-api";
+    changelog = "https://github.com/skipperro/pajgps-api/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -4972,7 +4972,8 @@
       ];
     "paj_gps" =
       ps: with ps; [
-      ]; # missing inputs: pajgps-api
+        pajgps-api
+      ];
     "palazzetti" =
       ps: with ps; [
         pypalazzetti
@@ -8429,6 +8430,7 @@
     "ovo_energy"
     "owntracks"
     "p1_monitor"
+    "paj_gps"
     "palazzetti"
     "panasonic_viera"
     "panel_custom"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12235,6 +12235,8 @@ self: super: with self; {
 
   paintcompiler = callPackage ../development/python-modules/paintcompiler { };
 
+  pajgps-api = callPackage ../development/python-modules/pajgps-api { };
+
   palace = callPackage ../development/python-modules/palace { };
 
   palettable = callPackage ../development/python-modules/palettable { };


### PR DESCRIPTION
- https://pypi.org/project/pajgps-api/
- https://github.com/skipperro/pajgps-api
- https://www.home-assistant.io/integrations/paj_gps/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
