### PR TITLE
python3Packages.aioptdevices: init at 2026.7.1

### DIFF
--- a/pkgs/development/python-modules/aioptdevices/default.nix
+++ b/pkgs/development/python-modules/aioptdevices/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  aiohttp,
+  orjson,
+  pytest-aiohttp,
+  pytest-asyncio,
+  pytest-cov-stub,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "aioptdevices";
+  version = "2026.7.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ParemTech-Inc";
+    repo = "aioptdevices";
+    tag = "v2026.07.1";
+    hash = "sha256-6vF64lmPSU95YpkrqNh5jAWnoUHZqXn7WK9xtc4sKs8=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail ", 'versioningit'" "" \
+      --replace-fail 'dynamic = ["version"]' 'version = "${finalAttrs.version}"'
+
+    # test_connection.py imports secret.py at module level. It holds live API
+    # credentials and is gitignored upstream, so create a stub to allow collection
+    echo 'TOKEN = "token"' > tests/secret.py
+    echo 'DEVICE_ID = "device-id"' >> tests/secret.py
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiohttp
+    orjson
+  ];
+
+  nativeCheckInputs = [
+    pytest-aiohttp
+    pytest-asyncio
+    pytest-cov-stub
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "aioptdevices" ];
+
+  disabledTests = [
+    # require network access and live API credentials
+    "test_real_server"
+    "test_real_server_multi"
+  ];
+
+  meta = {
+    description = "Fetch PTDevices information from the PTDevices servers";
+    homepage = "https://github.com/ParemTech-Inc/aioptdevices";
+    changelog = "https://github.com/ParemTech-Inc/aioptdevices/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -5318,7 +5318,8 @@
       ];
     "ptdevices" =
       ps: with ps; [
-      ]; # missing inputs: aioptdevices
+        aioptdevices
+      ];
     "pterodactyl" =
       ps: with ps; [
         py-dactyl
@@ -8558,6 +8559,7 @@
     "proxmoxve"
     "prusalink"
     "ps4"
+    "ptdevices"
     "pterodactyl"
     "pure_energie"
     "purpleair"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -474,6 +474,8 @@ self: super: with self; {
 
   aioprometheus = callPackage ../development/python-modules/aioprometheus { };
 
+  aioptdevices = callPackage ../development/python-modules/aioptdevices { };
+
   aiopulse = callPackage ../development/python-modules/aiopulse { };
 
   aiopulsegrow = callPackage ../development/python-modules/aiopulsegrow { };


### PR DESCRIPTION
- https://pypi.org/project/aioptdevices/
- https://github.com/ParemTech-Inc/aioptdevices
- https://www.home-assistant.io/integrations/ptdevices

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
