### PR TITLE
python3Packages.esios-api: init at 4.4.0

### DIFF
--- a/pkgs/development/python-modules/esios-api/default.nix
+++ b/pkgs/development/python-modules/esios-api/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  aiohttp,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  pytest-asyncio,
+  pytest-cov-stub,
+  pytest-timeout,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "esios-api";
+  version = "4.4.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "chiro79";
+    repo = "esios-api";
+    tag = finalAttrs.version;
+    hash = "sha256-ZmU1D+W3ah4LUwgHwaS6NJpfKPLSRgIC8psUXTy/muM=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "poetry_core>=2.4.0" "poetry_core"
+  '';
+
+  build-system = [ poetry-core ];
+
+  dependencies = [ aiohttp ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-cov-stub
+    pytest-timeout
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "esios_api" ];
+
+  meta = {
+    description = "Retrieval of Spanish Electricity hourly prices (PVPC)";
+    homepage = "https://github.com/chiro79/esios-api";
+    changelog = "https://github.com/chiro79/esios-api/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -5312,7 +5312,8 @@
       ];
     "pvpc_hourly_pricing" =
       ps: with ps; [
-      ]; # missing inputs: esios_api
+        esios-api
+      ];
     "pyload" =
       ps: with ps; [
         pyloadapi
@@ -8479,6 +8480,7 @@
     "pushbullet"
     "pushover"
     "pvoutput"
+    "pvpc_hourly_pricing"
     "pyload"
     "python_script"
     "qbittorrent"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5166,6 +5166,8 @@ self: super: with self; {
 
   eseries = callPackage ../development/python-modules/eseries { };
 
+  esios-api = callPackage ../development/python-modules/esios-api { };
+
   esp-idf-size = callPackage ../development/python-modules/esp-idf-size { };
 
   espeak-phonemizer = callPackage ../development/python-modules/espeak-phonemizer { };


### PR DESCRIPTION
- https://pypi.org/project/esios-api/
- https://github.com/chiro79/esios-api
- https://www.home-assistant.io/integrations/pvpc_hourly_pricing/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
