### PR TITLE
python3Packages.ha-xthings-cloud: init at 1.0.5

### DIFF
--- a/pkgs/development/python-modules/ha-xthings-cloud/default.nix
+++ b/pkgs/development/python-modules/ha-xthings-cloud/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  aiohttp,
+  pyjwt,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "ha-xthings-cloud";
+  version = "1.0.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "XthingsJacobs";
+    repo = "ha-xthings-cloud";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Qz/JOvOcT7GicqduNOi4r9F2xqtQLX9d8D1zQb5oAUo=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiohttp
+    pyjwt
+  ];
+
+  pythonImportsCheck = [ "ha_xthings_cloud" ];
+
+  meta = {
+    description = "Async Python client for Xthings Cloud API";
+    homepage = "https://github.com/XthingsJacobs/ha-xthings-cloud";
+    changelog = "https://github.com/XthingsJacobs/ha-xthings-cloud/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -7526,7 +7526,8 @@
       ];
     "xthings_cloud" =
       ps: with ps; [
-      ]; # missing inputs: ha-xthings-cloud
+        ha-xthings-cloud
+      ];
     "yale" =
       ps: with ps; [
         aiohasupervisor
@@ -8816,6 +8817,7 @@
     "xiaomi_aqara"
     "xiaomi_ble"
     "xiaomi_miio"
+    "xthings_cloud"
     "yale"
     "yale_smart_alarm"
     "yalexs_ble"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6974,6 +6974,8 @@ self: super: with self; {
 
   ha-silabs-firmware-client = callPackage ../development/python-modules/ha-silabs-firmware-client { };
 
+  ha-xthings-cloud = callPackage ../development/python-modules/ha-xthings-cloud { };
+
   habanero = callPackage ../development/python-modules/habanero { };
 
   habiticalib = callPackage ../development/python-modules/habiticalib { };


### PR DESCRIPTION
- https://pypi.org/project/ha-xthings-cloud/
- https://github.com/XthingsJacobs/ha-xthings-cloud
- https://www.home-assistant.io/integrations/xthings_cloud/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
