### PR TITLE
nixos/tailscale: order tailscaled after network-online.target

### DIFF
--- a/nixos/modules/services/networking/tailscale.nix
+++ b/nixos/modules/services/networking/tailscale.nix
@@ -144,7 +144,12 @@ in
     environment.systemPackages = [ cfg.package ]; # for the CLI
     systemd.packages = [ cfg.package ];
     systemd.services.tailscaled = {
-      after = lib.mkIf (config.networking.networkmanager.enable) [ "NetworkManager-wait-online.service" ];
+      after =
+        # nm-online hang must not kill nixos-rebuild on NM restart (#180175)
+        lib.optional config.networking.networkmanager.enable "NetworkManager-wait-online.service"
+        # `wants` pulls the barrier in so this `after` isn't inert (#527403)
+        ++ [ "network-online.target" ];
+      wants = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
       path = [
         (dirOf config.security.wrapperDir) # for `su` to use taildrive with correct access rights


### PR DESCRIPTION
This PR is almost entirely AI generated (opus 4.8), but I have thoroughly reviewed the entirety of it with my own eyes and I vouch for it.

---

## Description of changes

Resolves #527403

`tailscaled` previously had only an `after` edge on `NetworkManager-wait-online.service`, gated to NetworkManager setups. **That edge is kept** — it exists to stop an `nm-online` hang from killing `nixos-rebuild` when NetworkManager is restarted during activation (#180175, PR #344678).

The problem this PR fixes is separate: a systemd `After=` edge is inert at boot unless the named unit is pulled into the same transaction, which it wasn't here, so `tailscaled` could start before connectivity was established. With MagicDNS enabled, `tailscaled` then claims DNS — pointing resolution at `100.100.100.100` — while it can't yet reach the control plane or forward upstream queries, breaking public DNS until it happens to reconnect (which doesn't reliably self-heal, see [tailscale/tailscale#4254](https://github.com/tailscale/tailscale/issues/4254)).

This **additionally** orders `tailscaled` against `network-online.target` with both `wants` and `after`:
- `wants` pulls the barrier into `tailscaled`'s transaction so the ordering actually takes effect.
- `network-online.target` is backend-agnostic (NetworkManager, networkd, dhcpcd), which also fixes the previously unguarded non-NetworkManager case.

The existing NetworkManager-wait-online edge is left intact so the #180175 activation fix is preserved; this PR is purely additive. See #527403 for the full root-cause analysis.

Resulting `after` lists (verified by evaluating the module):
- NetworkManager: `[ "NetworkManager-wait-online.service" "network-online.target" ]`
- other backends: `[ "network-online.target" ]`

### Note on the boot-delay tradeoff

This now pulls `network-online.target` into the boot transaction whenever `services.tailscale.enable` is set (previously the `after`-only edge pulled it in for no one). That means `*-wait-online.service` runs at boot and can add delay on slow/flaky links. This is opt-in behind the tailscale module and justified for a VPN daemon that needs the network, but flagging it for reviewer awareness.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
- [ ] (NixOS) Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Module evaluates correctly for both NetworkManager and non-NetworkManager configurations.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)