### PR TITLE
nixos/home-assistant: open firewall ports for homekit component

### DIFF
--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -864,11 +864,18 @@ in
 
     networking.firewall.allowedTCPPorts = mkMerge [
       (mkIf cfg.openFirewall [ cfg.config.http.server_port ])
-      (mkIf cfg.openFirewallForComponents
+      (mkIf cfg.openFirewallForComponents (
+        # https://www.home-assistant.io/integrations/homekit/#firewall
+        optionals (useComponent "homekit") [ 21063 ]
         # https://www.home-assistant.io/integrations/sonos/#network-requirements
-        (optionals (useComponent "sonos") [ 1400 ])
-      )
+        ++ optionals (useComponent "sonos") [ 1400 ]
+      ))
     ];
+
+    networking.firewall.allowedUDPPorts = mkIf cfg.openFirewallForComponents (
+      # https://www.home-assistant.io/integrations/homekit/#firewall
+      optionals (useComponent "homekit") [ 5353 ]
+    );
 
     # symlink the configuration to /etc/home-assistant
     environment.etc = mkMerge [


### PR DESCRIPTION
Open the firewall ports HomeKit needs when `openFirewallForComponents` is enabled: TCP 21063 for the HomeKit bridge and UDP 5353 for mDNS, per the [integration's firewall docs](https://www.home-assistant.io/integrations/homekit/#firewall).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
