### PR TITLE
python3Packages.cheetah3: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/cheetah3/default.nix
+++ b/pkgs/development/python-modules/cheetah3/default.nix
@@ -2,12 +2,13 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "cheetah3";
   version = "3.4.0.post5";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "CheetahTemplate3";
@@ -15,6 +16,8 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-qWV6ncSe4JbGZD7sLc/kEXY1pUM1II24UgsS/zX872Y=";
   };
+
+  build-system = [ setuptools ];
 
   doCheck = false; # Circular dependency
 

--- a/pkgs/development/python-modules/cheetah3/default.nix
+++ b/pkgs/development/python-modules/cheetah3/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "Template engine and code generation tool";
-    homepage = "http://www.cheetahtemplate.org/";
+    homepage = "https://www.cheetahtemplate.org/";
     changelog = "https://github.com/CheetahTemplate3/cheetah3/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ pjjw ];

--- a/pkgs/development/python-modules/cheetah3/default.nix
+++ b/pkgs/development/python-modules/cheetah3/default.nix
@@ -5,15 +5,17 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "cheetah3";
   version = "3.4.0.post5";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "CheetahTemplate3";
     repo = "cheetah3";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-qWV6ncSe4JbGZD7sLc/kEXY1pUM1II24UgsS/zX872Y=";
   };
 
@@ -26,8 +28,8 @@ buildPythonPackage rec {
   meta = {
     description = "Template engine and code generation tool";
     homepage = "http://www.cheetahtemplate.org/";
-    changelog = "https://github.com/CheetahTemplate3/cheetah3/releases/tag/${version}";
+    changelog = "https://github.com/CheetahTemplate3/cheetah3/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ pjjw ];
   };
-}
+})

--- a/pkgs/development/python-modules/cheetah3/default.nix
+++ b/pkgs/development/python-modules/cheetah3/default.nix
@@ -21,8 +21,6 @@ buildPythonPackage (finalAttrs: {
 
   build-system = [ setuptools ];
 
-  doCheck = false; # Circular dependency
-
   pythonImportsCheck = [ "Cheetah" ];
 
   meta = {


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
