### PR TITLE
mfcl2690dwlpr: init at 4.0.0-1

### DIFF
--- a/pkgs/by-name/mf/mfcl2690dwlpr/package.nix
+++ b/pkgs/by-name/mf/mfcl2690dwlpr/package.nix
@@ -1,0 +1,90 @@
+{
+  coreutils,
+  dpkg,
+  fetchurl,
+  file,
+  ghostscript,
+  gnugrep,
+  gnused,
+  lib,
+  makeWrapper,
+  patchelf,
+  perl,
+  pkgs,
+  stdenv,
+  which,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mfcl2690dwlpr";
+  version = "4.0.0-1";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf105065/mfcl2690dwpdrv-${finalAttrs.version}.i386.deb";
+    hash = "sha256-dl2knx8NaO02ulU+bmCqUDDoeEW3Sv4NfUbrqyirUlY=";
+  };
+
+  unpackPhase = ''
+    dpkg-deb -x $src $out
+  '';
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+    patchelf
+  ];
+
+  dontPatchELF = true;
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  installPhase = ''
+    dir=$out/opt/brother/Printers/MFCL2690DW
+    filter=$dir/lpd/lpdfilter
+
+    substituteInPlace $filter \
+      --replace-fail '/usr/bin/perl' '${lib.getExe perl}' \
+      --replace-fail '$basedir =~ s/\/lpd\/.*$//g;' '$basedir = "'"$dir"'";' \
+      --replace-fail '$PRINTER =~ s/^\/opt\/.*\/Printers\///g;' '$PRINTER = "MFCL2690DW";'
+
+    ln -s $dir/lpd/x86_64/rawtobr3 $dir/lpd/rawtobr3
+
+    wrapProgram $filter \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          file
+          ghostscript
+          gnugrep
+          gnused
+          which
+        ]
+      }
+
+    for f in $dir/lpd/x86_64/brprintconflsr3 $dir/lpd/x86_64/rawtobr3; do
+      patchelf --set-interpreter \
+        ${pkgs.glibc}/lib/ld-linux-x86-64.so.2 \
+        $f
+    done
+
+    for f in $dir/lpd/i686/brprintconflsr3 $dir/lpd/i686/rawtobr3; do
+      patchelf --set-interpreter \
+        ${pkgs.pkgsi686Linux.glibc}/lib/ld-linux.so.2 \
+        $f
+    done
+  '';
+
+  meta = {
+    description = "Brother MFC-L2690DW LPR printer driver";
+    homepage = "https://www.brother.com/";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [
+      nick-linux
+    ];
+    platforms = [
+      "x86_64-linux"
+      "i686-linux"
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This packages the official LPR driver for the Brother MFC-L2690DW from Brother's Linux release.

The driver ships both 32-bit and 64-bit binaries, both get patched with the correct glibc interpreter. The filter script figures out its own location using regex against /opt/ which obviously breaks in the nix store, so $basedir and $PRINTER are patched to build into nix store path.

One thing to note just to make it easier for review Brother drivers are of course unfree.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
