### PR TITLE
python3Packages.clean-fid: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/clean-fid/default.nix
+++ b/pkgs/development/python-modules/clean-fid/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
 
   # dependencies
   numpy,
@@ -16,7 +17,7 @@
 buildPythonPackage {
   pname = "clean-fid";
   version = "0.1.35";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "GaParmar";
@@ -25,7 +26,9 @@ buildPythonPackage {
     hash = "sha256-fqBU/TmCXDTPU3KTP0+VYQoP+HsT2UMcZeLzQHKD9hw=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     numpy
     pillow
     requests

--- a/pkgs/development/python-modules/clean-fid/default.nix
+++ b/pkgs/development/python-modules/clean-fid/default.nix
@@ -47,7 +47,8 @@ buildPythonPackage {
 
   meta = {
     description = "PyTorch - FID calculation with proper image resizing and quantization steps [CVPR 2022]";
-    homepage = "https://github.com/GaParmar/clean-fid";
+    homepage = "https://www.cs.cmu.edu/~clean-fid/";
+    downloadPage = "https://github.com/GaParmar/clean-fid";
     license = lib.licenses.mit;
     teams = [ lib.teams.tts ];
   };

--- a/pkgs/development/python-modules/clean-fid/default.nix
+++ b/pkgs/development/python-modules/clean-fid/default.nix
@@ -19,6 +19,8 @@ buildPythonPackage {
   version = "0.1.35";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "GaParmar";
     repo = "clean-fid";


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
