### PR TITLE
python3Packages.audio-offset-finder: init at 0.5.5

### DIFF
--- a/pkgs/by-name/au/audio-offset-finder/package.nix
+++ b/pkgs/by-name/au/audio-offset-finder/package.nix
@@ -1,0 +1,38 @@
+{ lib
+, python3Packages
+, fetchFromGitHub
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "audio-offset-finder";
+  version = "0.5.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "bbc";
+    repo = "audio-offset-finder";
+    tag = "v${version}";
+    hash = "sha256-XIjRqm6EvQ9qp1xdMHk+6jtN5b8VwkcjoXDtXs7JvOY";
+  };
+
+  pythonRelaxDeps = [ "numpy" ];
+
+  dependencies = with python3Packages; [
+    librosa
+    matplotlib
+    numpy
+    scipy
+  ];
+
+  build-system = [
+    python3Packages.setuptools
+  ];
+
+  meta = with lib; {
+    description = "Find the offset of an audio file within another audio file";
+    license = licenses.apsl20;
+    homepage = "https://github.com/bbc/audio-offset-finder";
+    maintainers = with maintainers; [ john-rodewald ];
+    mainProgram = "audio-offset-finder";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1084,6 +1084,8 @@ self: super: with self; {
 
   audio-metadata = callPackage ../development/python-modules/audio-metadata { };
 
+  audio-offset-finder = callPackage ../by-name/au/audio-offset-finder { };
+
   audioop-lts =
     if pythonAtLeast "3.13" then callPackage ../development/python-modules/audioop-lts { } else null;
 


### PR DESCRIPTION

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
