### PR TITLE
lx-music-desktop: force X11 backend by default

### DIFF
--- a/pkgs/by-name/lx/lx-music-desktop/package.nix
+++ b/pkgs/by-name/lx/lx-music-desktop/package.nix
@@ -11,7 +11,11 @@
   makeDesktopItem,
 
   electron_40,
-  commandLineArgs ? "",
+  # Electron renders incorrectly under Wayland: the window stays hidden and
+  # dragging, window positioning, the tray icon and the desktop lyrics window
+  # all break. Force the X11 backend by default, as recommended upstream.
+  # https://github.com/lyswhut/lx-music-desktop/pull/2846#issuecomment-4641318543
+  commandLineArgs ? "--ozone-platform=x11",
 }:
 
 let


### PR DESCRIPTION
## Description of changes

Recent Electron versions render incorrectly under Wayland for lx-music-desktop: the main window stays hidden, and dragging, window positioning, the tray icon and the desktop lyrics window all break. Upstream recommends launching with `--ozone-platform=x11` to work around this.

This defaults `commandLineArgs` to `--ozone-platform=x11` so the app works out of the box. Users who want to try Wayland can still override `commandLineArgs` (e.g. to `""`) and set `NIXOS_OZONE_WL=1`.

Upstream reference: https://github.com/lyswhut/lx-music-desktop/pull/2846#issuecomment-4641318543

## Things done

- Built on x86_64-linux; verified the resulting wrapper passes `--ozone-platform=x11`
- Formatted with `nixfmt-rfc-style`