### PR TITLE
python3Packages.scalib: make portable and add nix-update-script

### DIFF
--- a/pkgs/development/python-modules/scalib/default.nix
+++ b/pkgs/development/python-modules/scalib/default.nix
@@ -17,6 +17,8 @@
   pytest-cov-stub,
   scikit-learn,
   scipy,
+
+  nix-update-script,
 }:
 buildPythonPackage (finalAttrs: {
   pname = "scalib";
@@ -73,6 +75,8 @@ buildPythonPackage (finalAttrs: {
     scipy
     numpy
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Side-Channel Analysis Library";

--- a/pkgs/development/python-modules/scalib/default.nix
+++ b/pkgs/development/python-modules/scalib/default.nix
@@ -29,6 +29,10 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-DVXb93W0TmOcyGyMN5GmIJNAdbLeeFnNm+3QfTw2j5s=";
   };
 
+  env = {
+    SCALIB_PORTABLE = "1";
+  };
+
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail '"setuptools-scm-git-archive",' ""


### PR DESCRIPTION
By default, the `" -C target-cpu=native"` flag is set, making the package not portable.
Setting the `SCALIB_PORTABLE` env variable avoids that.

From `setup.py`:

```python
portable = not noflags and env_true(os.environ.get("SCALIB_PORTABLE"))
```
```python
if noflags or portable:
    pass
elif x86_64_v3:
    rustflags += " -C target-cpu=x86-64-v3"
else:
    rustflags += " -C target-cpu=native"
```

Also, added `nix-update-script`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
