### PR TITLE
elmPackages.elm-format: jailbreak

### DIFF
--- a/pkgs/development/compilers/elm/packages/ghc9_8/default.nix
+++ b/pkgs/development/compilers/elm/packages/ghc9_8/default.nix
@@ -12,6 +12,11 @@ pkgs.haskell.packages.ghc98.override {
         # https://github.com/avh4/elm-format/blob/e7e5da37716acbfb4954a88128b5cc72b2c911d9/package/nix/generate_derivation.sh
         elm-format = justStaticExecutables (
           overrideCabal (drv: {
+            # jailbreak required due to optparse-applicative bounds
+            # optparse-applicative >=0.17.0.0 && <0.19
+            # upstream PR https://github.com/avh4/elm-format/pull/841
+            jailbreak = true;
+
             postPatch = ''
               mkdir -p ./generated
               cat <<EOHS > ./generated/Build_elm_format.hs
@@ -35,8 +40,14 @@ pkgs.haskell.packages.ghc98.override {
       inherit elmPkgs;
 
       # Needed for elm-format
+
       avh4-lib = self.callPackage ./elm-format/avh4-lib.nix { };
-      elm-format-lib = self.callPackage ./elm-format/elm-format-lib.nix { };
+      # jailbreak required due to optparse-applicative bounds
+      # optparse-applicative >=0.17.0.0 && <0.19
+      # upstream PR https://github.com/avh4/elm-format/pull/841
+      elm-format-lib = pkgs.haskell.lib.doJailbreak (
+        self.callPackage ./elm-format/elm-format-lib.nix { }
+      );
       elm-format-test-lib = self.callPackage ./elm-format/elm-format-test-lib.nix { };
       elm-format-markdown = self.callPackage ./elm-format/elm-format-markdown.nix { };
     };


### PR DESCRIPTION
Jailbreak elm-format to avoid build failure on optparse-applicative bounds in haskell-updates. see https://github.com/NixOS/nixpkgs/pull/521260

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
