### PR TITLE
wordwarvi: init at 1.0.4-unstable-2025-09-25

### DIFF
--- a/pkgs/by-name/wo/wordwarvi/package.nix
+++ b/pkgs/by-name/wo/wordwarvi/package.nix
@@ -1,0 +1,64 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  pkg-config,
+  portaudio,
+  libvorbis,
+  gtk2,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "wordwarvi";
+  version = "1.0.4-unstable-2025-09-25";
+
+  src = fetchFromGitHub {
+    owner = "smcameron";
+    repo = "wordwarvi";
+    rev = "3611fca0158b20610daa0e5ce9ed86e197660c37";
+    hash = "sha256-6mwB54FHcneCf9CmwRMRrORwhhCrkxZTfQ97/c49uMo=";
+  };
+
+  postPatch = ''
+    substituteInPlace Makefile --replace-fail '/bin/rm' 'rm'
+  '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    portaudio
+    libvorbis
+    gtk2
+  ];
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+    "BINDIR=$(PREFIX)/bin"
+  ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "Retro-styled side scrolling shoot'em up arcade game";
+    homepage = "https://smcameron.github.io/wordwarvi/";
+    maintainers = with lib.maintainers; [ marcin-serwin ];
+    license =
+      with lib.licenses;
+      AND [
+        gpl2Plus
+
+        # Sounds
+        cc-by-30
+        cc-by-sa-30
+      ];
+  };
+  platforms = lib.platforms.linux;
+  mainProgram = "wordwarvi";
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Part of: #380688

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
