### PR TITLE
sone: 0.17.0 -> 0.19.0

### DIFF
--- a/pkgs/by-name/so/sone/package.nix
+++ b/pkgs/by-name/so/sone/package.nix
@@ -1,8 +1,8 @@
 {
   lib,
   fetchFromGitHub,
-  fetchNpmDeps,
-  npmHooks,
+  fetchPnpmDeps,
+  pnpmConfigHook,
   rustPlatform,
   wrapGAppsHook3,
   alsa-lib,
@@ -17,33 +17,39 @@
   nodejs,
   openssl,
   pkg-config,
+  pnpm_11,
   webkitgtk_4_1,
 }:
 
+let
+  pnpm = pnpm_11;
+in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sone";
-  version = "0.17.0";
+  version = "0.19.0";
 
   src = fetchFromGitHub {
     owner = "lullabyX";
     repo = "sone";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-5SeB8PrTZQpXnp3WfSTJjEX5uxQr8vEfyzWinTsPvsA=";
+    hash = "sha256-DDUMbKhcVzUGiButQivMQdY8+j6LXBVICMMRI55yTnM=";
   };
 
-  cargoHash = "sha256-6nXwuVKOuHE1SQCkytArs0a2qr7fIEpRndgDX1omYQg=";
+  cargoHash = "sha256-OJLC0daanMoIhsRGOxUgmFdG0vzeMbLCDesgrVxCwOA=";
 
-  npmDeps = fetchNpmDeps {
-    name = "${finalAttrs.pname}-npm-deps-${finalAttrs.version}";
-    inherit (finalAttrs) src;
-    hash = "sha256-qOapQI+r84aj5aE/wQ4fCFEljeW8UbRHEXhaorBkIzk=";
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-mstEHVONYW4NOYUxG+6pwMdobwuY0ZBMHC49skh/pEQ=";
   };
 
   nativeBuildInputs = [
     cargo-tauri.hook
     nodejs
-    npmHooks.npmConfigHook
     pkg-config
+    pnpm
+    pnpmConfigHook
     wrapGAppsHook3
   ];
 


### PR DESCRIPTION
<!-- updated the package to use pnpm in order to update beyond 0.17.0.
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
--> Gapless Playback

    Seamless, silence-free transitions between tracks in normal output mode — on by default. Requires GStreamer 1.24+ and falls back automatically when unavailable.

 Home

    Home page is now organized into tabs, with magazine-style cards and quick deep-link shortcuts.
    Remembers your last-used tab, with skeleton placeholders and a fade-in while loading.

Now Playing

    Album cover gently tilts toward your cursor with a true-perspective 3D effect.
    Tap the time display to switch between total duration and time remaining.
    Adjust volume by scrolling the mouse wheel over the volume control.

Keep Awake

    Your screen no longer sleeps or blanks while music is playing — across X11, Wayland, and D-Bus/portal desktops.

 Scrobbling

    Sends the primary artist, plus MusicBrainz artist IDs when available, to Last.fm, Libre.fm, and ListenBrainz for more accurate matching.

Updates

    A gentle toast lets you know when a new version of SONE is available.

Logging

    Disk logs now capture more detail by default and keep more history (~50MB), making bug reports and troubleshooting easier.

Fixes

    Support for DACs with a fixed channel count, via automatic channel negotiation and a stereo mix matrix.
    Exclusive and bit-perfect output now correctly resolve ALSA plugin devices (front:, hdmi:) to the right sound card.
    Signal Path now classifies bit-depth widening as lossless instead of lossy.
    Player overlays close properly on navigation and browser back/forward.
    Miniplayer: clicking the album art focuses the main window, and clicking the track title opens the album.
    "Go to track radio" works even when a track has no associated mix.
    Smoother loading on long "View all" lists with incremental pagination.

nstall via repository (new — auto-updates with your system)

Add the SONE repository once and apt upgrade / dnf upgrade / zypper up will keep it current. The setup script auto-detects your distro and imports the signing key.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
