### PR TITLE
ollama: fix darwin build by disabling MLX backends

### DIFF
--- a/pkgs/by-name/ol/ollama/package.nix
+++ b/pkgs/by-name/ol/ollama/package.nix
@@ -301,6 +301,7 @@ goBuild (finalAttrs: {
         -DCMAKE_SKIP_BUILD_RPATH=ON \
         -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
         -DFETCHCONTENT_SOURCE_DIR_LLAMA_CPP="$TMPDIR/llama-cpp-src" \
+        -DOLLAMA_MLX_BACKENDS="" \
         ${cmakeFlagsCudaArchitectures} \
         ${cmakeFlagsRocmTargets} \
         ${cmakeFlagsBackend}


### PR DESCRIPTION
MLX backends require xcrun metal/metalib which are unavailable in the Nix sandbox. Pass -DOLLAMA_MLX_BACKENDS="" to cmake to skip the Metal toolchain check. Core Metal/llama.cpp backend is unaffected.