### PR TITLE
rmux: init at 0.5.0

### DIFF
--- a/pkgs/by-name/rm/rmux/package.nix
+++ b/pkgs/by-name/rm/rmux/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rmux";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "Helvesec";
+    repo = "rmux";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-W4Jw2r+4x90+x5WkrRwxrlqytRlU4wEY98MWJZbcblY=";
+  };
+
+  __structuredAttrs = true;
+
+  cargoHash = "sha256-fu96A2v5VH01HxNGpdLpBTH3o9DHrocSyvuK14nE1fk=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  passthru.updateScript = nix-update-script { };
+
+  # Tests require network access
+  doCheck = false;
+
+  meta = {
+    description = "Universal multiplexer with a typed SDK";
+    homepage = "https://github.com/Helvesec/rmux";
+    changelog = "https://github.com/Helvesec/rmux/releases/tag/${finalAttrs.src.tag}";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "rmux";
+  };
+})


### PR DESCRIPTION
Universal multiplexer with a typed SDK

https://github.com/Helvesec/rmux


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
