### PR TITLE
grpc: 1.80.0 -> 1.81.0

### DIFF
--- a/pkgs/by-name/gr/grpc/package.nix
+++ b/pkgs/by-name/gr/grpc/package.nix
@@ -25,7 +25,7 @@
 # nixpkgs-update: no auto update
 stdenv.mkDerivation (finalAttrs: {
   pname = "grpc";
-  version = "1.80.0"; # N.B: if you change this, please update:
+  version = "1.81.0"; # N.B: if you change this, please update:
   # pythonPackages.grpcio
   # pythonPackages.grpcio-channelz
   # pythonPackages.grpcio-health-checking
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "grpc";
     repo = "grpc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/dpTRG5JcZY2VAsqOYNIpFW7ouSy/eC2STulP7qdSYg=";
+    hash = "sha256-o1wfHrgD2VE6HcPPEWQPQZXrMh+8+GNoUjbCQoRlIWg=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/python-modules/grpcio-channelz/default.nix
+++ b/pkgs/development/python-modules/grpcio-channelz/default.nix
@@ -12,13 +12,13 @@
 # nixpkgs-update: no auto update
 buildPythonPackage rec {
   pname = "grpcio-channelz";
-  version = "1.80.0";
+  version = "1.81.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "grpcio_channelz";
     inherit version;
-    hash = "sha256-fs6As480ti6Q5uHFqghYXwwPE8GpyI6vdNioZxw6n6E=";
+    hash = "sha256-V6Gr5QURNJv9iafEJtHbaRmOLJzUcbr2wNVgbDTbmt8=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/grpcio-health-checking/default.nix
+++ b/pkgs/development/python-modules/grpcio-health-checking/default.nix
@@ -11,13 +11,13 @@
 # nixpkgs-update: no auto update
 buildPythonPackage rec {
   pname = "grpcio-health-checking";
-  version = "1.80.0";
+  version = "1.81.0";
   format = "setuptools";
 
   src = fetchPypi {
     pname = "grpcio_health_checking";
     inherit version;
-    hash = "sha256-LMXwi8i4FrhlWrb1nHFFAGO6IHZtMeIaST6RLjVgyLE=";
+    hash = "sha256-CfMWdPGs3PIUvE5kDru77xZbB3of1kg0eVGW1Sv9zjk=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/grpcio-reflection/default.nix
+++ b/pkgs/development/python-modules/grpcio-reflection/default.nix
@@ -12,13 +12,13 @@
 # nixpkgs-update: no auto update
 buildPythonPackage rec {
   pname = "grpcio-reflection";
-  version = "1.80.0";
+  version = "1.81.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "grpcio_reflection";
     inherit version;
-    hash = "sha256-6cdqq8QyQnmUW3C8dqPUG8T5OWv/zxz8EBGlccLFYiE=";
+    hash = "sha256-UZHbeqbKsbaYGwh5+kT9zdQ7pkTwMBxAuXb4E+tO/wY=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/grpcio-status/default.nix
+++ b/pkgs/development/python-modules/grpcio-status/default.nix
@@ -12,13 +12,13 @@
 # nixpkgs-update: no auto update
 buildPythonPackage rec {
   pname = "grpcio-status";
-  version = "1.80.0";
+  version = "1.81.0";
   format = "setuptools";
 
   src = fetchPypi {
     pname = "grpcio_status";
     inherit version;
-    hash = "sha256-33OAKkyJo+qIqir/lx6Ib8zOFivC5lEUCLPWehRDgc0=";
+    hash = "sha256-tv6XiM/dHw9jwFKKHgv9tB6P8Fg+kg0tjoiIWYwBu2k=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/grpcio-testing/default.nix
+++ b/pkgs/development/python-modules/grpcio-testing/default.nix
@@ -12,13 +12,13 @@
 # nixpkgs-update: no auto update
 buildPythonPackage rec {
   pname = "grpcio-testing";
-  version = "1.80.0";
+  version = "1.81.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "grpcio_testing";
     inherit version;
-    hash = "sha256-+1rVfED/36l3MEPfo46MN3Oa+ONHHxZwoh54BRzRmv0=";
+    hash = "sha256-MjcL3/wM0Jq63pKP2ID5Gb8HCv5dASot4UEkJ7LcGSE=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/grpcio-tools/default.nix
+++ b/pkgs/development/python-modules/grpcio-tools/default.nix
@@ -13,13 +13,13 @@
 # nixpkgs-update: no auto update
 buildPythonPackage rec {
   pname = "grpcio-tools";
-  version = "1.80.0";
+  version = "1.81.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "grpcio_tools";
     inherit version;
-    hash = "sha256-JgUrGcbODc9S0QJElq6j4r36hkFZ8G3HuXsi0EGpSyY=";
+    hash = "sha256-BzPXc+yoy0YfTyobecZMEj25ZhvkGwgYS4FJeyuZHMs=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/grpcio/default.nix
+++ b/pkgs/development/python-modules/grpcio/default.nix
@@ -18,12 +18,12 @@
 # nixpkgs-update: no auto update
 buildPythonPackage rec {
   pname = "grpcio";
-  version = "1.80.0";
+  version = "1.81.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-KayhXt0GiMIroB18wBywANcrIDP0o8cqgaGbVv0UMlc=";
+    hash = "sha256-pazX79Ox/ptOsLyqoVB+7WigrQZ4tlTD97Rk35up3KU=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Updates grpc and its corresponding python packages.
Changelog: https://github.com/grpc/grpc/releases/tag/v1.81.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
