### PR TITLE
python3Packages.streamlit: 1.55.0 -> 1.58.0

### DIFF
--- a/pkgs/development/python-modules/streamlit/default.nix
+++ b/pkgs/development/python-modules/streamlit/default.nix
@@ -2,12 +2,15 @@
   lib,
   stdenv,
   altair,
+  anyio,
   blinker,
   buildPythonPackage,
   cachetools,
   click,
   fetchPypi,
   gitpython,
+  httptools,
+  itsdangerous,
   numpy,
   packaging,
   pandas,
@@ -15,24 +18,28 @@
   protobuf,
   pyarrow,
   pydeck,
-  setuptools,
+  python-multipart,
   requests,
   rich,
+  setuptools,
+  starlette,
   tenacity,
   toml,
   tornado,
   typing-extensions,
+  uvicorn,
   watchdog,
+  websockets,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "streamlit";
-  version = "1.55.0";
+  version = "1.58.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-AV5RK70C0AD0BH5REY3AhrcOfZxGtKEaM8JQlzE3liY=";
+    hash = "sha256-eKIucIWwU6985UREK/S2cHceaMUJuhvaoFa6Bwj0nD0=";
   };
 
   build-system = [ setuptools ];
@@ -44,23 +51,30 @@ buildPythonPackage (finalAttrs: {
 
   dependencies = [
     altair
+    anyio
     blinker
     cachetools
     click
+    gitpython
+    httptools
+    itsdangerous
     numpy
     packaging
     pandas
     pillow
     protobuf
     pyarrow
+    pydeck
+    python-multipart
     requests
     rich
+    starlette
     tenacity
     toml
-    typing-extensions
-    gitpython
-    pydeck
     tornado
+    typing-extensions
+    uvicorn
+    websockets
   ]
   ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [ watchdog ];
 


### PR DESCRIPTION
Changelog: https://github.com/streamlit/streamlit/releases/tag/1.58.0

Closes #528279 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
