### PR TITLE
peirates: init at 1.29a

### DIFF
--- a/pkgs/by-name/pe/peirates/package.nix
+++ b/pkgs/by-name/pe/peirates/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "peirates";
+  version = "1.29a";
+
+  src = fetchFromGitHub {
+    owner = "inguardians";
+    repo = "peirates";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-VSb0l1yLFl5dZQn0Pb0HWLbeFiTUhZQBsJcjmrt4C7g=";
+  };
+
+  __structuredAttrs = true;
+
+  vendorHash = "sha256-QwESK8ZTlb0boI+PCvoXYbVG6a47Ws1k8nrc7yQWPtE=";
+
+  proxyVendor = true;
+
+  preBuild = ''
+    export GOFLAGS="$GOFLAGS -mod=mod"
+  '';
+
+  ldflags = [ "-s" ];
+
+  meta = {
+    description = "Kubernetes Penetration Testing tool";
+    homepage = "https://github.com/inguardians/peirates";
+    changelog = "https://github.com/inguardians/peirates/blob/${finalAttrs.src.rev}/changelog.md";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "peirates";
+  };
+})


### PR DESCRIPTION
Kubernetes Penetration Testing tool

https://github.com/inguardians/peirates

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
