### PR TITLE
yscan: init at 0.1.0

### DIFF
--- a/pkgs/by-name/ys/yscan/package.nix
+++ b/pkgs/by-name/ys/yscan/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  fetchpatch2,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "yscan";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "yetidevworks";
+    repo = "yscan";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dIRtqn6vismwgQUwfK5KzApBDBlAmOt+mfdBY8sr47g=";
+  };
+
+  __structuredAttrs = true;
+
+  cargoPatches = [
+    # https://github.com/yetidevworks/yscan/pull/2
+    (fetchpatch2 {
+      name = "cargo-lock.patch";
+      url = "https://github.com/yetidevworks/yscan/commit/54c0d9f008e0a9205ff639db8223c0a89fe72f34.patch?full_index=1";
+      hash = "sha256-n1JthKGLAS+Rx4BiLNwtRNZ4NHpS0Azv6uThjQgWqJg=";
+    })
+  ];
+
+  cargoHash = "sha256-nQV0vtx2hwKxysSHNB6j9d6JSuFlFFqtZr2hPciyo40=";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  doInstallCheck = true;
+
+  meta = {
+    description = "TUI IP and Port Scanner";
+    homepage = "https://github.com/yetidevworks/yscan";
+    changelog = "https://github.com/yetidevworks/yscan/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "yscan";
+  };
+})


### PR DESCRIPTION
TUI IP and Port Scanner

https://github.com/yetidevworks/yscan

Related to https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
