### PR TITLE
nixos/plasma6: allow excluding more packages

### DIFF
--- a/nixos/modules/services/desktop-managers/plasma6.nix
+++ b/nixos/modules/services/desktop-managers/plasma6.nix
@@ -45,7 +45,7 @@ in
     };
 
     environment.plasma6.excludePackages = mkOption {
-      description = "List of default packages to exclude from the configuration";
+      description = "List of packages to exclude from the configuration. You can use this to remove some optional parts of Plasma, and also to remove packages automatically added to support other enabled options.";
       type = types.listOf types.package;
       default = [ ];
       example = literalExpression "[ pkgs.kdePackages.elisa ]";
@@ -179,7 +179,25 @@ in
           # Since PackageKit Nix support is not there yet,
           # only install discover if flatpak or fwupd is enabled.
           discover
-        ];
+        ]
+        # Optional and hardware support features
+        ++ lib.optionals config.hardware.bluetooth.enable [
+          bluedevil
+          bluez-qt
+          pkgs.openobex
+          pkgs.obexftp
+        ]
+        ++ lib.optional config.networking.networkmanager.enable plasma-nm
+        ++ lib.optional config.services.pulseaudio.enable plasma-pa
+        ++ lib.optional config.services.pipewire.pulse.enable plasma-pa
+        ++ lib.optional config.powerManagement.enable powerdevil
+        ++ lib.optional config.services.printing.enable print-manager
+        ++ lib.optional config.hardware.sane.enable skanpage
+        ++ lib.optional config.services.colord.enable colord-kde
+        ++ lib.optional config.services.hardware.bolt.enable plasma-thunderbolt
+        ++ lib.optional config.services.samba.enable kdenetwork-filesharing
+        ++ lib.optional config.services.xserver.wacom.enable wacomtablet
+        ++ lib.optional config.services.flatpak.enable flatpak-kcm;
       in
       requiredPackages
       ++ utils.removePackagesByName optionalPackages config.environment.plasma6.excludePackages
@@ -200,25 +218,7 @@ in
           ''
         )
         kio-extras-kf5
-      ]
-      # Optional and hardware support features
-      ++ lib.optionals config.hardware.bluetooth.enable [
-        bluedevil
-        bluez-qt
-        pkgs.openobex
-        pkgs.obexftp
-      ]
-      ++ lib.optional config.networking.networkmanager.enable plasma-nm
-      ++ lib.optional config.services.pulseaudio.enable plasma-pa
-      ++ lib.optional config.services.pipewire.pulse.enable plasma-pa
-      ++ lib.optional config.powerManagement.enable powerdevil
-      ++ lib.optional config.services.printing.enable print-manager
-      ++ lib.optional config.hardware.sane.enable skanpage
-      ++ lib.optional config.services.colord.enable colord-kde
-      ++ lib.optional config.services.hardware.bolt.enable plasma-thunderbolt
-      ++ lib.optional config.services.samba.enable kdenetwork-filesharing
-      ++ lib.optional config.services.xserver.wacom.enable wacomtablet
-      ++ lib.optional config.services.flatpak.enable flatpak-kcm;
+      ];
 
     environment.pathsToLink = [
       # FIXME: modules should link subdirs of `/share` rather than relying on this


### PR DESCRIPTION
This change allows `environment.plasma6.excludePackages` to remove packages that are added by the plasma6 module to support other enabled options.

I've also updated the option description to better reflect what it does. Feel free to make suggestions if it could be phrased better.

For existing installations, the only issue this could introduce, is that if somebody had packages in `excludePackages` that couldn't be excluded previously, they would now be excluded and not installed, which could cause confusion. I guess that should be considered before backporting this to stable. (@NixOS/qt-kde ?)

Resolves #527116
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
