### PR TITLE
navidrome: Use tinygo + wasm & zip shrinking to reduce output size

### DIFF
--- a/pkgs/by-name/na/navidrome/plugins/apple-music/package.nix
+++ b/pkgs/by-name/na/navidrome/plugins/apple-music/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
   pkgs,
-  buildNavidromePlugin,
+  buildNavidromeGoPlugin,
 }:
 
-buildNavidromePlugin rec {
+buildNavidromeGoPlugin rec {
   pname = "apple-music-plugin";
   version = "0.2.0";
 

--- a/pkgs/by-name/na/navidrome/plugins/build-plugin.nix
+++ b/pkgs/by-name/na/navidrome/plugins/build-plugin.nix
@@ -3,6 +3,10 @@
   lib,
   navidrome,
   zip,
+  tinygo,
+  binaryen,
+  jq,
+  advancecomp,
 }:
 
 {
@@ -29,25 +33,58 @@ buildGoModule (
     }
     // (args.env or { });
 
-    postBuild = ''
-      GOOS=wasip1 \
-      GOARCH=wasm \
-      go build \
+    nativeBuildInputs = [
+      tinygo
+      zip
+      binaryen
+      jq
+      advancecomp
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      export HOME=$(mktemp -d)
+
+      tinygo build \
+        -target=wasip1 \
         -buildmode=c-shared \
-        -o $GOPATH/bin/plugin.wasm .
+        -opt=z \
+        -no-debug \
+        -panic=trap \
+        -gc=leaking \
+        -o plugin.wasm .
+
+      # Optimize the output
+      wasm-opt -Oz \
+        --strip-debug \
+        --strip-producers \
+        --strip-target-features \
+        --vacuum \
+        --dce \
+        --remove-unused-module-elements \
+        --converge \
+        plugin.wasm -o plugin.wasm
+
+      # JSON can be safely minified to save some bytes
+      jq -c . manifest.json > manifest.json
+
+      runHook postBuild
     '';
 
-    postInstall = ''
-      mkdir $out/share
-      pushd $(mktemp -d)
-      cp $GOPATH/bin/plugin.wasm .
-      cp ${finalAttrs.src}/manifest.json .
-      ${lib.getExe zip} \
-        $out/share/${finalAttrs.pname}.ndp \
-        plugin.wasm \
-        manifest.json
-      popd
-      rm -r $out/bin
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/share
+      # timestamps not required
+      touch -t 202001010000.00 manifest.json plugin.wasm
+      TZ=UTC zip -X -D out.zip manifest.json plugin.wasm
+      # shrink to absolute smallest possible zip file
+      advzip -z -4 out.zip
+
+      cp out.zip $out/share/${finalAttrs.pname}.ndp
+
+      runHook postInstall
     '';
 
     passthru = {

--- a/pkgs/by-name/na/navidrome/plugins/discord-rich-presence/package.nix
+++ b/pkgs/by-name/na/navidrome/plugins/discord-rich-presence/package.nix
@@ -1,9 +1,9 @@
 {
   lib,
   pkgs,
-  buildNavidromePlugin,
+  buildNavidromeGoPlugin,
 }:
-buildNavidromePlugin rec {
+buildNavidromeGoPlugin rec {
   pname = "discord-rich-presence-plugin";
   version = "1.0.0";
 

--- a/pkgs/by-name/na/navidrome/plugins/listenbrainz-daily-playlist/package.nix
+++ b/pkgs/by-name/na/navidrome/plugins/listenbrainz-daily-playlist/package.nix
@@ -1,9 +1,9 @@
 {
   lib,
   pkgs,
-  buildNavidromePlugin,
+  buildNavidromeGoPlugin,
 }:
-buildNavidromePlugin rec {
+buildNavidromeGoPlugin rec {
   pname = "listenbrainz-daily-playlist";
   version = "5.0.2";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2547,7 +2547,7 @@ with pkgs;
 
   nanoemoji = with python3Packages; toPythonApplication nanoemoji;
 
-  buildNavidromePlugin = callPackage ../by-name/na/navidrome/plugins/build-plugin.nix { };
+  buildNavidromeGoPlugin = callPackage ../by-name/na/navidrome/plugins/build-plugin.nix { };
   navidromePlugins = recurseIntoAttrs (
     lib.makeExtensible (
       self:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

The current `buildNavidromePlugin` can be improved. The function uses the official go compiler to compile to wasm. However, [the official Navidrome documentation suggests using `tinygo`](https://github.com/navidrome/navidrome/blob/master/plugins/README.md#2-build-with-tinygo-and-package-as-ndp). I updated the function to use `tinygo` and added some other minimization techniques. Using `jq` we can compress the JSON to shave off some bytes. Using `wasm-opt` we can optimize the output wasm, and using `advzip` we can get the absolute smallest zip.

I tested this by compiling all current Navidrome plugins (only 3 currently exist) and compared their sizes. `tinygo` seems to bring the size down the most:

```text
Original implementation:
-r--r--r-- 2 root root 1178497 Jan  1  1970 apple-music-plugin.ndp
-r--r--r-- 2 root root 1028163 Jan  1  1970 discord-rich-presence-plugin.ndp
-r--r--r-- 2 root root 1103376 Jan  1  1970 listenbrainz-daily-playlist.ndp

Using tinygo:
-r--r--r-- 2 root root 174271 Jan  1  1970 apple-music-plugin.ndp
-r--r--r-- 2 root root 121580 Jan  1  1970 discord-rich-presence-plugin.ndp
-r--r--r-- 2 root root 148339 Jan  1  1970 listenbrainz-daily-playlist.ndp

Using all optimizations:
-r--r--r-- 3 root root 156360 Jan  1  1970 apple-music-plugin.ndp
-r--r--r-- 2 root root 108299 Jan  1  1970 discord-rich-presence-plugin.ndp
-r--r--r-- 2 root root 132157 Jan  1  1970 listenbrainz-daily-playlist.ndp
```

`apple-music-plugin` for example can be shrunk down from ~1.1 MiB -> ~171 KiB (tinygo) -> ~153 KiB (all optimizations)

I also renamed the plugin to `buildNavidromeGoPlugin`, as the other name could suggest it supports building _any_ Navidrome plugin, although it can only build Go based Navidrome plugins.