### PR TITLE
lxmf-rs: init at 0.2.0

### DIFF
--- a/pkgs/by-name/lx/lxmf-rs/package.nix
+++ b/pkgs/by-name/lx/lxmf-rs/package.nix
@@ -1,0 +1,67 @@
+{
+  stdenv,
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  bzip2,
+  dbus,
+  sqlite,
+  nix-update-script,
+  writableTmpDirAsHomeHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "lxmf-rs";
+  version = "0.2.0";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "FreeTAKTeam";
+    repo = "LXMF-rs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2bxSBw4ISb7xOQiazrSVytvW9cW4i7azB7U8sos7+yA=";
+  };
+
+  cargoHash = "sha256-EqRL1JoAdyh46Ev8S/Ta6RsbhhaNH6dlisudpO2D1Rw=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    bzip2
+    dbus
+    sqlite
+  ];
+
+  env = {
+    LIBSQLITE3_SYS_USE_PKG_CONFIG = true;
+  };
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  checkFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+    # assertion failed: matches
+    "--skip=transport::announce_limits::tests::held_announces_evict_worst_entry_when_capacity_is_reached"
+    "--skip=transport::announce_limits::tests::held_announces_release_lowest_hops_first"
+    "--skip=transport::announce_limits::tests::ingress_limiting_is_scoped_per_interface"
+    # multicast listener expected to see the Broadcast tx within 500ms
+    "--skip=broadcast_tx_reaches_multicast_listeners"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Full port of Reticulum and LXMF to Rust with added SDK";
+    homepage = "https://github.com/FreeTAKTeam/LXMF-rs";
+    changelog = "https://github.com/FreeTAKTeam/LXMF-rs/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.epl20;
+    maintainers = with lib.maintainers; [ drupol ];
+    mainProgram = "lxmf-rs";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
