### PR TITLE
redo-apenwarr: fix tests in sandboxed darwin

### DIFF
--- a/pkgs/by-name/re/redo-apenwarr/package.nix
+++ b/pkgs/by-name/re/redo-apenwarr/package.nix
@@ -48,6 +48,11 @@ stdenv.mkDerivation (finalAttrs: {
     # See https://github.com/apenwarr/redo/pull/47
     substituteInPlace minimal/do \
       --replace-fail 'cd "$dodir"' 'cd "''${dodir:-.}"'
+
+    # the tests refer to /etc/passwd (as an arbitrarily-chosen absolute-path file that won't change),
+    # but that fails under sandboxing. Replace it with another arbrarily-chosen file that won't change:
+    substituteInPlace t/105-sympath/all.do \
+      --replace-fail "/etc/passwd" "${coreutils}/bin/pwd"
   '';
 
   inherit doCheck;


### PR DESCRIPTION
From https://github.com/apenwarr/redo/blob/7f00abc36be15f398fa3ecf9f4e5283509c34a00/t/105-sympath/all.do#L16-L17 - redo's testsuite uses /etc/passwd as a sample absolute-path dependency that won't change. Under darwin, this gets caught by sandboxing:

```
> do      t/105-sympath/all
> do        ../../../../../../private/etc/passwd
> do: ../../../../../../private/etc/passwd: no .do file (/nix/var/nix/builds/nix-15278-2435295101/source)
```

Fix tests by replacing /etc/passwd with another arbitrarily-chosen absolute path which we know we can read

Hopefully this'll fix hydra builds which have been broken for a while - https://hydra.nixos.org/job/nixpkgs/unstable/redo-apenwarr.aarch64-darwin/all. I'm not entirely sure why they worked before, maybe a change in sandboxing behaviour?


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
