### PR TITLE
nixosTests.systemd-initrd-luks-{fido2,unl0kr}: fix failing LUKS tests

### DIFF
--- a/nixos/tests/systemd-initrd-luks-fido2.nix
+++ b/nixos/tests/systemd-initrd-luks-fido2.nix
@@ -38,7 +38,6 @@
           };
         };
         virtualisation.rootDevice = "/dev/mapper/cryptroot";
-        virtualisation.fileSystems."/".autoFormat = true;
       };
     };
 
@@ -52,6 +51,8 @@
       # Create encrypted volume
       machine.wait_for_unit("multi-user.target")
       machine.succeed("echo -n supersecret | cryptsetup luksFormat -q --iter-time=1 /dev/vdb -")
+      machine.succeed("echo -n supersecret | cryptsetup luksOpen   -q               /dev/vdb cryptroot")
+      machine.succeed("mkfs.ext4 /dev/mapper/cryptroot")
       machine.succeed("PASSWORD=supersecret SYSTEMD_LOG_LEVEL=debug systemd-cryptenroll --fido2-device=auto /dev/vdb |& systemd-cat")
 
       # Boot from the encrypted disk

--- a/nixos/tests/systemd-initrd-luks-unl0kr.nix
+++ b/nixos/tests/systemd-initrd-luks-unl0kr.nix
@@ -73,7 +73,6 @@ in
           cryptroot2.device = "/dev/vdc";
         };
         virtualisation.rootDevice = "/dev/mapper/cryptroot";
-        virtualisation.fileSystems."/".autoFormat = true;
         # test mounting device unlocked in initrd after switching root
         virtualisation.fileSystems."/cryptroot2" = {
           device = "/dev/mapper/cryptroot2";
@@ -100,7 +99,7 @@ in
       machine.succeed("mkfs.ext4 /dev/mapper/cryptroot2")
 
       # Boot from the encrypted disk
-        machine.succeed("${boot-luks}/bin/switch-to-configuration boot")
+      machine.succeed("${boot-luks}/bin/switch-to-configuration boot")
       machine.succeed("sync")
       machine.crash()
 

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -791,7 +791,7 @@ stdenv.mkDerivation (finalAttrs: {
           systemd-credentials-tpm2
           systemd-escaping
           systemd-initrd-btrfs-raid
-          # systemd-initrd-luks-fido2 # broken on master
+          systemd-initrd-luks-fido2
           systemd-initrd-luks-keyfile
           systemd-initrd-luks-empty-passphrase
           systemd-initrd-luks-password


### PR DESCRIPTION
The fido2 test was missed in b13891782fdec1b72e1e9ab4f86fce1638f20203 (it was disabled at the time because canokey-qemu was broken) and started hanging once b5611f96b6e1be1bf94165b3acd3bf49970a4c56 dropped the systemd patch that made `autoFormat` work on empty LUKS volumes.

The unl0kr test had a stray indent from b7e08105608ebfff482d85c99226b0620429150c that broke the test driver type check.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

