### PR TITLE
python3Packages.geopy: migrate to pyproject, use finalAttrs, enable structuredAttrs

### DIFF
--- a/pkgs/development/python-modules/geopy/default.nix
+++ b/pkgs/development/python-modules/geopy/default.nix
@@ -9,7 +9,7 @@
   pytz,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "geopy";
   version = "2.4.1";
   format = "setuptools";
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "geopy";
     repo = "geopy";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-mlOXDEtYry1IUAZWrP2FuY/CGliUnCPYLULnLNN0n4Y=";
   };
 
@@ -45,8 +45,8 @@ buildPythonPackage rec {
   meta = {
     homepage = "https://github.com/geopy/geopy";
     description = "Python Geocoding Toolbox";
-    changelog = "https://github.com/geopy/geopy/releases/tag/${version}";
+    changelog = "https://github.com/geopy/geopy/releases/tag/${finalAttrs.version}";
     license = with lib.licenses; [ mit ];
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/geopy/default.nix
+++ b/pkgs/development/python-modules/geopy/default.nix
@@ -14,6 +14,8 @@ buildPythonPackage (finalAttrs: {
   version = "2.4.1";
   format = "setuptools";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "geopy";
     repo = "geopy";

--- a/pkgs/development/python-modules/geopy/default.nix
+++ b/pkgs/development/python-modules/geopy/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   docutils,
   fetchFromGitHub,
+  setuptools,
   geographiclib,
   pytest7CheckHook,
   pythonAtLeast,
@@ -12,7 +13,7 @@
 buildPythonPackage (finalAttrs: {
   pname = "geopy";
   version = "2.4.1";
-  format = "setuptools";
+  pyproject = true;
 
   __structuredAttrs = true;
 
@@ -23,7 +24,9 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-mlOXDEtYry1IUAZWrP2FuY/CGliUnCPYLULnLNN0n4Y=";
   };
 
-  propagatedBuildInputs = [ geographiclib ];
+  build-system = [ setuptools ];
+
+  dependencies = [ geographiclib ];
 
   nativeCheckInputs = [
     docutils


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974
- use finalAttrs
- enable structuredAttrs
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
