### PR TITLE
pkgs.formats: performance cleanups

### DIFF
--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -469,7 +469,7 @@ optionalAttrs allowAliases aliases
       generate =
         name: value:
         pkgs.callPackage (
-          { runCommand, remarshal }:
+          { runCommand }:
           runCommand name
             {
               nativeBuildInputs = [ json2x ];

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -617,12 +617,14 @@ optionalAttrs allowAliases aliases
       tuple = values: "{${listContent values}}";
 
       toConf =
-        values:
         let
           keyConfig =
             rootKey: key: value:
             "config ${rootKey}, ${key}, ${toElixir value}";
           keyConfigs = rootKey: values: mapAttrsToList (keyConfig rootKey) values;
+        in
+        values:
+        let
           rootConfigs = flatten (mapAttrsToList keyConfigs values);
         in
         ''

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -837,7 +837,7 @@ optionalAttrs allowAliases aliases
             float
             str
             path
-            package
+            types.package
           ]);
         in
         attrsOf atomType;

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -551,9 +551,6 @@ optionalAttrs allowAliases aliases
     [Tuple]: <https://hexdocs.pm/elixir/Tuple.html>
   */
   elixirConf =
-    {
-      elixir ? pkgs.elixir,
-    }:
     let
       toElixir =
         value:
@@ -634,6 +631,9 @@ optionalAttrs allowAliases aliases
           ${concatStringsSep "\n" rootConfigs}
         '';
     in
+    {
+      elixir ? pkgs.elixir,
+    }:
     {
       type =
         let

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -495,8 +495,7 @@ optionalAttrs allowAliases aliases
   */
   cdn =
     { }:
-    json { }
-    // {
+    {
       type = serializableValueWith { typeName = "CDN"; };
 
       generate =

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -1063,7 +1063,6 @@ optionalAttrs allowAliases aliases
     };
 
   hcl1 =
-    args:
     let
       # Helper function to recursively transform values for HCL1 canonicalization
       # Rule: If an attribute value is an attribute set, wrap it in a list
@@ -1079,6 +1078,7 @@ optionalAttrs allowAliases aliases
           value;
       jsonFormat = json { };
     in
+    args:
     jsonFormat
     // {
       generate = name: value: jsonFormat.generate name (mapAttrs (_: transform) value);

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -841,9 +841,7 @@ optionalAttrs allowAliases aliases
         in
         attrsOf atomType;
       generate =
-        name: value:
         let
-
           # note that list type has been omitted here as the separator varies, see `nix.settings.*`
           mkValueString =
             v:
@@ -871,8 +869,8 @@ optionalAttrs allowAliases aliases
           mkKeyValuePairs = attrs: concatStringsSep "\n" (mapAttrsToList mkKeyValue attrs);
 
           isExtra = key: hasPrefix "extra-" key;
-
         in
+        name: value:
         pkgs.writeTextFile {
           inherit name;
           # workaround for https://github.com/NixOS/nix/issues/9487

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -23,6 +23,7 @@ let
     pipe
     singleton
     strings
+    toJSON
     toPretty
     types
     versionAtLeast
@@ -143,7 +144,7 @@ optionalAttrs allowAliases aliases
           runCommand name
             {
               nativeBuildInputs = [ jq ];
-              value = builtins.toJSON value;
+              value = toJSON value;
               preferLocalBuild = true;
               __structuredAttrs = true;
             }
@@ -168,7 +169,7 @@ optionalAttrs allowAliases aliases
           runCommand name
             {
               nativeBuildInputs = [ remarshal_0_17 ];
-              value = builtins.toJSON value;
+              value = toJSON value;
               preferLocalBuild = true;
               __structuredAttrs = true;
             }
@@ -193,7 +194,7 @@ optionalAttrs allowAliases aliases
           runCommand name
             {
               nativeBuildInputs = [ remarshal ];
-              value = builtins.toJSON value;
+              value = toJSON value;
               preferLocalBuild = true;
               __structuredAttrs = true;
             }
@@ -506,7 +507,7 @@ optionalAttrs allowAliases aliases
           runCommand name
             {
               nativeBuildInputs = [ json2cdn ];
-              value = builtins.toJSON value;
+              value = toJSON value;
               preferLocalBuild = true;
               __structuredAttrs = true;
             }
@@ -939,8 +940,8 @@ optionalAttrs allowAliases aliases
                 python3
                 black
               ];
-              imports = builtins.toJSON (value._imports or [ ]);
-              value = builtins.toJSON (removeAttrs value [ "_imports" ]);
+              imports = toJSON (value._imports or [ ]);
+              value = toJSON (removeAttrs value [ "_imports" ]);
               pythonGen = pkgs.writeText "pythonGen" ''
                 import json
                 import os
@@ -1012,7 +1013,7 @@ optionalAttrs allowAliases aliases
                   python3Packages.xmltodict
                   libxml2Python
                 ];
-                value = builtins.toJSON value;
+                value = toJSON value;
                 pythonGen = pkgs.writeText "pythonGen" ''
                   import json
                   import os

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -256,6 +256,11 @@ optionalAttrs allowAliases aliases
             mapAttrs (key: val: if isList val then listToValue val else val)
           else
             id;
+
+        ignoredArgs = [
+          "listToValue"
+          "atomsCoercedToLists"
+        ];
       in
       {
         ini =
@@ -287,12 +292,7 @@ optionalAttrs allowAliases aliases
               name: value:
               pipe value [
                 (mapAttrs (_: maybeToList listToValue))
-                (toINI (
-                  removeAttrs args [
-                    "listToValue"
-                    "atomsCoercedToLists"
-                  ]
-                ))
+                (toINI (removeAttrs args ignoredArgs))
                 (pkgs.writeText name)
               ];
           };
@@ -341,15 +341,10 @@ optionalAttrs allowAliases aliases
                 ...
               }:
               pkgs.writeText name (
-                toINIWithGlobalSection
-                  (removeAttrs args [
-                    "listToValue"
-                    "atomsCoercedToLists"
-                  ])
-                  {
-                    globalSection = maybeToList listToValue globalSection;
-                    sections = mapAttrs (_: maybeToList listToValue) sections;
-                  }
+                toINIWithGlobalSection (removeAttrs args ignoredArgs) {
+                  globalSection = maybeToList listToValue globalSection;
+                  sections = mapAttrs (_: maybeToList listToValue) sections;
+                }
               );
           };
 

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -37,6 +37,7 @@ let
     toKeyValue
     toLua
     mkLuaInline
+    toPlist
     ;
 
   inherit (lib.types)
@@ -397,7 +398,7 @@ optionalAttrs allowAliases aliases
     // {
       generate =
         name: value:
-        lib.warn
+        warn
           "Direct use of `pkgs.formats.systemd` has been deprecated, please use `pkgs.formats.systemd { }` instead."
           rawFormat.generate
           name
@@ -812,7 +813,7 @@ optionalAttrs allowAliases aliases
             ''
         ) { };
       # Alias for mkLuaInline
-      lib.mkRaw = lib.mkLuaInline;
+      lib.mkRaw = mkLuaInline;
     };
 
   nixConf =
@@ -883,7 +884,7 @@ optionalAttrs allowAliases aliases
             ${mkKeyValuePairs (filterAttrs (key: _: isExtra key) value)}
             ${extraOptions}
           '';
-          checkPhase = lib.optionalString checkConfig (
+          checkPhase = optionalString checkConfig (
             if pkgs.stdenv.hostPlatform != pkgs.stdenv.buildPlatform then
               ''
                 echo "Ignoring validation for cross-compilation"
@@ -1059,7 +1060,7 @@ optionalAttrs allowAliases aliases
         in
         valueType;
 
-      generate = name: value: pkgs.writeText name (lib.generators.toPlist { inherit escape; } value);
+      generate = name: value: pkgs.writeText name (toPlist { inherit escape; } value);
     };
 
   hcl1 =

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -358,7 +358,7 @@ optionalAttrs allowAliases aliases
           {
             listsAsDuplicateKeys ? false,
             ...
-          }@args:
+          }:
           let
             atom = iniAtom {
               inherit listsAsDuplicateKeys;

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -256,6 +256,12 @@ optionalAttrs allowAliases aliases
             mapAttrs (key: val: if isList val then listToValue val else val)
           else
             id;
+        maybeCoerceAllLists =
+          listToValue:
+          if listToValue != null then
+            mapAttrs (_: mapAttrs (key: val: if isList val then listToValue val else val))
+          else
+            id;
 
         ignoredArgs = [
           "listToValue"
@@ -291,7 +297,7 @@ optionalAttrs allowAliases aliases
             generate =
               name: value:
               pipe value [
-                (mapAttrs (_: maybeCoerceList listToValue))
+                (maybeCoerceAllLists listToValue)
                 (toINI (removeAttrs args ignoredArgs))
                 (pkgs.writeText name)
               ];
@@ -343,7 +349,7 @@ optionalAttrs allowAliases aliases
               pkgs.writeText name (
                 toINIWithGlobalSection (removeAttrs args ignoredArgs) {
                   globalSection = maybeCoerceList listToValue globalSection;
-                  sections = mapAttrs (_: maybeCoerceList listToValue) sections;
+                  sections = maybeCoerceAllLists listToValue sections;
                 }
               );
           };

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -250,7 +250,7 @@ optionalAttrs allowAliases aliases
             description = "section of an INI file (attrs of " + atom.description + ")";
           };
 
-        maybeToList =
+        maybeCoerceList =
           listToValue:
           if listToValue != null then
             mapAttrs (key: val: if isList val then listToValue val else val)
@@ -291,7 +291,7 @@ optionalAttrs allowAliases aliases
             generate =
               name: value:
               pipe value [
-                (mapAttrs (_: maybeToList listToValue))
+                (mapAttrs (_: maybeCoerceList listToValue))
                 (toINI (removeAttrs args ignoredArgs))
                 (pkgs.writeText name)
               ];
@@ -342,8 +342,8 @@ optionalAttrs allowAliases aliases
               }:
               pkgs.writeText name (
                 toINIWithGlobalSection (removeAttrs args ignoredArgs) {
-                  globalSection = maybeToList listToValue globalSection;
-                  sections = mapAttrs (_: maybeToList listToValue) sections;
+                  globalSection = maybeCoerceList listToValue globalSection;
+                  sections = mapAttrs (_: maybeCoerceList listToValue) sections;
                 }
               );
           };

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -449,15 +449,15 @@ optionalAttrs allowAliases aliases
         attrsOf atom;
 
       generate =
-        name: value:
         let
-          transformedValue =
+          transformValue =
             if listToValue != null then
-              mapAttrs (key: val: if isList val then listToValue val else val) value
+              mapAttrs (key: val: if isList val then listToValue val else val)
             else
-              value;
+              id;
+          finalArgs = removeAttrs args [ "listToValue" ];
         in
-        pkgs.writeText name (toKeyValue (removeAttrs args [ "listToValue" ]) transformedValue);
+        name: value: pkgs.writeText name (toKeyValue finalArgs (transformValue value));
 
     };
 


### PR DESCRIPTION
Just a look-through of the file for some cleanups. I'm fairly certain the `callPackage` usage in `pkgs.formats.json` and other formats is just a shitty form of inheriting variables, that isn't being used for overrides at all - but I'm not confident in that, so I'm leaving that out of this PR.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
