### PR TITLE
nixos/gunicorn: add module and test

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -10,6 +10,8 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- [gunicorn](https://gunicorn.org/) WSGI HTTP Python applications can now be configured through a module. Available as [services.gunicorn.instances](#opt-services.gunicorn.instances).
+
 - [tranquil](https://tangled.org/tranquil.farm/tranquil-pds) is an ATProto PDS (personal data server) implementation in Rust. A featureful, spec conscious and community driven alternative to the Bluesky reference implementation PDS. Available as [services.tranquil-pds](#opt-services.tranquil-pds.enable).
 
 - [FlapAlerted](https://github.com/Kioubit/FlapAlerted), detects BGP flapping events and provides statistics based on BGP update messages. Available as [services.flap-alerted](#opt-services.flap-alerted.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1821,6 +1821,7 @@
   ./services/web-servers/darkhttpd.nix
   ./services/web-servers/fcgiwrap.nix
   ./services/web-servers/garage.nix
+  ./services/web-servers/gunicorn
   ./services/web-servers/h2o/default.nix
   ./services/web-servers/hitch/default.nix
   ./services/web-servers/jboss/default.nix

--- a/nixos/modules/services/web-servers/gunicorn/default.nix
+++ b/nixos/modules/services/web-servers/gunicorn/default.nix
@@ -1,0 +1,115 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  instanceOptions = import ./instance-options.nix;
+  cfg = config.services.gunicorn;
+
+  mapToUnits = f: lib.mapAttrs' (_: inst: lib.nameValuePair inst.process.unit (f inst));
+
+  gunicornArgs =
+    inst:
+    lib.cli.toCommandLineShellGNU { } (
+      {
+        bind = if inst.socket.type == "unix" then "unix:${inst.socket.address}" else inst.socket.address;
+      }
+      // inst.process.extraArgs
+    );
+
+  mkPythonEnv =
+    app:
+    app.python.buildEnv.override {
+      extraLibs = with app.python.pkgs; [
+        (toPythonModule app.package)
+        gunicorn
+      ];
+    };
+
+in
+{
+  options.services.gunicorn.instances = lib.mkOption {
+    type = lib.types.attrsOf (lib.types.submodule instanceOptions);
+    default = { };
+    description = ''
+      Configuration for instances of gunicorn.
+      Each instance is isolated in its own systemd service.
+      Corresponding sockets are exposed and managed by systemd.
+    '';
+  };
+
+  config = {
+    assertions = lib.concatLists (
+      lib.mapAttrsToList (name: inst: [
+        {
+          assertion = inst.socket.type == "unix" -> inst.socket.user != null;
+          message = "Socket owner is required for the UNIX socket type.";
+        }
+        {
+          assertion = inst.socket.type == "unix" -> inst.socket.group != null;
+          message = "Socket owner is required for the UNIX socket type.";
+        }
+        {
+          assertion = inst.socket.user != null -> inst.socket.type == "unix";
+          message = "Socket owner can only be set for the UNIX socket type.";
+        }
+        {
+          assertion = inst.socket.group != null -> inst.socket.type == "unix";
+          message = "Socket owner can only be set for the UNIX socket type.";
+        }
+        {
+          assertion = inst.socket.mode != null -> inst.socket.type == "unix";
+          message = "Socket mode can only be set for the UNIX socket type.";
+        }
+      ]) cfg.instances
+    );
+
+    systemd.services = mapToUnits (inst: {
+      after = [ "network.target" ];
+      wantedBy = lib.optional (inst.socket.type != "unix") "multi-user.target";
+
+      # from https://docs.gunicorn.org/en/latest/deploy.html#systemd
+      serviceConfig = {
+        User = inst.process.user;
+        Group = inst.process.group;
+        DynamicUser = true;
+
+        Type = "notify";
+        NotifyAccess = "main";
+        KillMode = "mixed";
+        TimeoutStopSec = 5;
+        PrivateTmp = true;
+
+        ExecReload = ''
+          ${lib.getExe' pkgs.coreutils "kill"} -s HUP $MAINPID
+        '';
+
+        ExecStart = ''
+          ${lib.getExe' (mkPythonEnv inst.app) "gunicorn"} \
+            ${gunicornArgs inst} \
+            ${lib.escapeShellArg inst.app.module}
+        '';
+      };
+    }) cfg.instances;
+
+    systemd.sockets = mapToUnits (
+      inst:
+      lib.mkIf (inst.socket.type == "unix") {
+        wantedBy = [ "sockets.target" ];
+        socketConfig = {
+          ListenStream = inst.socket.address;
+          SocketUser = inst.socket.user;
+          SocketGroup = inst.socket.group;
+          SocketMode = inst.socket.mode;
+        };
+      }
+    ) cfg.instances;
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ euxane ];
+  };
+}

--- a/nixos/modules/services/web-servers/gunicorn/instance-options.nix
+++ b/nixos/modules/services/web-servers/gunicorn/instance-options.nix
@@ -1,0 +1,119 @@
+{
+  config,
+  lib,
+  ...
+}:
+
+{
+  options = {
+    app.package = lib.mkOption {
+      type = lib.types.package;
+      description = "Package of the WSGI Python application.";
+    };
+
+    app.python = lib.mkOption {
+      type = lib.types.package;
+      default = config.app.package.python;
+      defaultText = lib.literalExpression "config.services.gunicorn.instances.<name>.app.package.python";
+      description = ''
+        Python interpreter package to use.
+        Defaults to the one exposed by the WSGI application package
+        through its `passthru.python` attribute, if it is defined.
+      '';
+    };
+
+    app.module = lib.mkOption {
+      type = lib.types.str;
+      default = config.app.package.wsgiModule;
+      defaultText = lib.literalExpression "config.services.gunicorn.instances.<name>.app.package.wsgiModule";
+      description = ''
+        Module entry-point of the WSGI app.
+        Defaults to the one exposed by the WSGI application package
+        through its `passthru.wsgiModule` attribute, if it is defined.
+      '';
+    };
+
+    process.extraArgs = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      description = "Extra command line arguments to pass to gunicorn.";
+    };
+
+    process.unit = lib.mkOption {
+      type = lib.types.str;
+      default = "gunicorn-${config._module.args.name}";
+      defaultText = lib.literalExpression "gunicorn-\${config.services.gunicorn.instances.<name>.name}";
+      description = "Name for the systemd unit of this instance.";
+    };
+
+    process.user = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        User as which this instance of gunicorn will be run.
+
+        It will be dynamically allocated if unspecified or if the name does not match a static user.
+      '';
+    };
+
+    process.group = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        Group as which this instance of gunicorn will be run.
+
+        It will be dynamically allocated if unspecified or if the name does not match a static group.
+      '';
+    };
+
+    socket.type = lib.mkOption {
+      type = lib.types.enum [
+        "unix"
+        "tcp"
+      ];
+      default = "unix";
+      description = "Socket type: 'unix' or 'tcp'.";
+    };
+
+    socket.address = lib.mkOption {
+      type = lib.types.str;
+      default = "/run/${config.process.unit}.sock";
+      defaultText = lib.literalExpression ''
+        /run/''${config.services.gunicorn.instances.<name>.process.unit}.sock
+      '';
+      example = "1.2.3.4:5678";
+      description = ''
+        Socket address.
+        In case of a UNIX socket, this should be its filesystem path.
+      '';
+    };
+
+    socket.user = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        User to be set as owner of the UNIX socket.
+      '';
+    };
+
+    socket.group = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        Group to be set as owner of the UNIX socket.
+      '';
+    };
+
+    socket.mode = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = if config.socket.type == "unix" then "0600" else null;
+      defaultText = lib.literalExpression ''
+        if config.services.gunicorn.instances.<name>.socket.type == "unix" then "0600" else null
+      '';
+      description = ''
+        Mode to be set on the UNIX socket.
+        Defaults to private to the socket's owner.
+      '';
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -697,6 +697,7 @@ in
   grub = runTest ./grub.nix;
   guacamole-server = runTest ./guacamole-server.nix;
   guix = handleTest ./guix { };
+  gunicorn = runTest ./gunicorn.nix;
   gvisor = runTest ./gvisor.nix;
   h2o = import ./web-servers/h2o {
     inherit runTest;

--- a/nixos/tests/gunicorn.nix
+++ b/nixos/tests/gunicorn.nix
@@ -1,0 +1,86 @@
+{ lib, pkgs, ... }:
+
+let
+  writeSimplePythonApp =
+    pname: text:
+    pkgs.python3.pkgs.buildPythonApplication {
+      inherit pname;
+      version = "0.0";
+      pyproject = false;
+      src = pkgs.writeText "${pname}.py" text;
+      unpackPhase = "true";
+      installPhase = ''
+        OUTDIR=$out/${pkgs.python3.sitePackages}
+        mkdir -p $OUTDIR
+        cp $src $OUTDIR/${pname}.py
+      '';
+    };
+
+  dummyApp = {
+    python = pkgs.python3;
+    module = "dummy-wsgi:app";
+    package =
+      writeSimplePythonApp "dummy-wsgi" # python
+        ''
+          def app(environ, start_response):
+              data = b'Up and running!\n'
+              status = '200 OK'
+              response_headers = [
+                  ('Content-type', 'text/plain'),
+                  ('Content-Length', str(len(data)))
+              ]
+              start_response(status, response_headers)
+              return iter([data])
+        '';
+  };
+
+in
+{
+  name = "gunicorn";
+
+  meta = {
+    maintainers = with lib.maintainers; [ euxane ];
+  };
+
+  nodes.machine =
+    { config, ... }:
+    {
+      services.gunicorn.instances."standalone" = {
+        app = dummyApp;
+        socket = {
+          type = "tcp";
+          address = "127.0.0.1:8080";
+        };
+      };
+
+      services.gunicorn.instances."unix-socket" = {
+        app = dummyApp;
+        socket = {
+          inherit (config.services.nginx) user group;
+        };
+      };
+
+      services.nginx = {
+        enable = true;
+        recommendedProxySettings = true;
+        virtualHosts."localhost".locations."/" = {
+          proxyPass = "http://unix:${config.services.gunicorn.instances."unix-socket".socket.address}";
+        };
+      };
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+
+    machine.wait_for_unit("gunicorn-standalone.service")
+    machine.wait_for_open_port(8080)
+    machine.succeed("curl -sSf localhost:8080 | grep -q 'Up and running!'")
+
+    machine.wait_for_unit("nginx.service")
+    machine.wait_for_open_port(80)
+    machine.succeed("curl -sSf localhost | grep -q 'Up and running!'")
+
+    machine.shutdown()
+  '';
+}

--- a/pkgs/development/python-modules/gunicorn/default.nix
+++ b/pkgs/development/python-modules/gunicorn/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  nixosTests,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -50,6 +51,10 @@ buildPythonPackage rec {
     pytest-cov-stub
   ]
   ++ lib.concatAttrValues optional-dependencies;
+
+  passthru = {
+    tests.simple = nixosTests.gunicorn;
+  };
 
   meta = {
     description = "WSGI HTTP Server for UNIX, fast clients and sleepy applications";


### PR DESCRIPTION
## Things done

This introduces a new module for configuring gunicorn WSGI HTTP Python applications.
Example of usage for otterwiki: #440513

---

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
