### PR TITLE
dovecot_2_3: fix building of `withMySQL = true`

### DIFF
--- a/pkgs/by-name/do/dovecot/generic.nix
+++ b/pkgs/by-name/do/dovecot/generic.nix
@@ -66,7 +66,8 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ]
   ++ lib.optionals (stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isDarwin) [ rpcsvc-proto ]
-  ++ lib.optionals (stdenv.hostPlatform.isDarwin) [ autoreconfHook ];
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin) [ autoreconfHook ]
+  ++ lib.optionals (withMySQL && lib.strings.versionOlder version "2.4") [ libmysqlclient ];
 
   buildInputs = [
     openssl
@@ -98,7 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional withLDAP openldap
   ++ lib.optional withPCRE2 pcre2
   ++ lib.optional withUnwind libunwind
-  ++ lib.optional withMySQL libmysqlclient
+  ++ lib.optional (withMySQL && lib.strings.versionAtLeast version "2.4") libmysqlclient
   ++ lib.optional withPgSQL libpq
   ++ lib.optional withSQLite sqlite
   ++ lib.optional withLua lua5_3;


### PR DESCRIPTION
```
$ nix repl
:b pkgs.dovecot_2_3.override { withMySQL = true; }
[...]
checking for mysql_config... NO
checking for mysql_init in -lmysqlclient... no
configure: error: Can't build with MySQL support: libmysqlclient not found
```
It can be built on the `nixos-25.11` branch with `pkgs.dovecot`, so might be an regression on `nixos-26.05`.
Flags are taken from #462806


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
