### PR TITLE
various: MiniHarinn adopting orphan packages he cares about

### DIFF
--- a/pkgs/by-name/ac/acme-sh/package.nix
+++ b/pkgs/by-name/ac/acme-sh/package.nix
@@ -76,5 +76,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Only;
     inherit (coreutils.meta) platforms;
     mainProgram = "acme.sh";
+    maintainers = with lib.maintainers; [ miniharinn ];
   };
 })

--- a/pkgs/by-name/ai/air/package.nix
+++ b/pkgs/by-name/ai/air/package.nix
@@ -30,6 +30,6 @@ buildGoModule (finalAttrs: {
     mainProgram = "air";
     homepage = "https://github.com/air-verse/air";
     license = lib.licenses.gpl3Only;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ miniharinn ];
   };
 })

--- a/pkgs/by-name/do/dolt/package.nix
+++ b/pkgs/by-name/do/dolt/package.nix
@@ -29,6 +29,6 @@ buildGoModule (finalAttrs: {
     mainProgram = "dolt";
     homepage = "https://github.com/dolthub/dolt";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ miniharinn ];
   };
 })

--- a/pkgs/by-name/ht/http-server/package.nix
+++ b/pkgs/by-name/ht/http-server/package.nix
@@ -34,6 +34,6 @@ buildNpmPackage rec {
     homepage = "https://github.com/http-party/http-server";
     license = lib.licenses.mit;
     mainProgram = "http-server";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ miniharinn ];
   };
 }

--- a/pkgs/by-name/li/libuv/package.nix
+++ b/pkgs/by-name/li/libuv/package.nix
@@ -210,7 +210,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://libuv.org/";
     changelog = "https://github.com/libuv/libuv/blob/v${finalAttrs.version}/ChangeLog";
     pkgConfigModules = [ "libuv" ];
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ miniharinn ];
     platforms = lib.platforms.all;
     license = with lib.licenses; [
       mit

--- a/pkgs/by-name/lu/lux/package.nix
+++ b/pkgs/by-name/lu/lux/package.nix
@@ -40,5 +40,6 @@ buildGoModule (finalAttrs: {
     changelog = "https://github.com/iawia002/lux/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     mainProgram = "lux";
+    maintainers = with lib.maintainers; [ miniharinn ];
   };
 })

--- a/pkgs/by-name/nl/nlohmann_json/package.nix
+++ b/pkgs/by-name/nl/nlohmann_json/package.nix
@@ -67,5 +67,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/nlohmann/json/blob/develop/ChangeLog.md";
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ miniharinn ];
   };
 })

--- a/pkgs/by-name/qm/qmk-udev-rules/package.nix
+++ b/pkgs/by-name/qm/qmk-udev-rules/package.nix
@@ -40,5 +40,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Official QMK udev rules list";
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ miniharinn ];
   };
 })

--- a/pkgs/development/python-modules/seaborn/default.nix
+++ b/pkgs/development/python-modules/seaborn/default.nix
@@ -86,5 +86,6 @@ buildPythonPackage rec {
     homepage = "https://seaborn.pydata.org/";
     changelog = "https://github.com/mwaskom/seaborn/blob/v${version}/doc/whatsnew/v${version}.rst";
     license = with lib.licenses; [ bsd3 ];
+    maintainers = with lib.maintainers; [ miniharinn ];
   };
 }

--- a/pkgs/development/python-modules/tqdm/default.nix
+++ b/pkgs/development/python-modules/tqdm/default.nix
@@ -60,5 +60,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/tqdm/tqdm";
     changelog = "https://tqdm.github.io/releases/";
     license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ miniharinn ];
   };
 }


### PR DESCRIPTION
I feel like I have more capacity to maintain additional packages that I care about, so I picked up these orphaned packages. 

This should not cause any rebuilds as it only touches `meta.*`. After this gets merged, I will probably open a follow-up PR to clean up, modernize, and bump these packages later. Thanks!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
