### PR TITLE
haguichi: Changelog URL fix and post install cleanup

### DIFF
--- a/pkgs/by-name/ha/haguichi/package.nix
+++ b/pkgs/by-name/ha/haguichi/package.nix
@@ -11,7 +11,6 @@
   meson,
   ninja,
   pkg-config,
-  python3,
   vala,
   wrapGAppsHook4,
 }:
@@ -27,17 +26,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-BKpHAlhxd8Zy/ZpPkLhXqlgZsil9JEZmVmHis1gte4Q=";
   };
 
-  postPatch = ''
-    patchShebangs meson_post_install.py
-  '';
-
   strictDeps = true;
 
   nativeBuildInputs = [
     meson
     ninja
     pkg-config
-    python3
     vala
     wrapGAppsHook4
     desktop-file-utils # for update-desktop-database

--- a/pkgs/by-name/ha/haguichi/package.nix
+++ b/pkgs/by-name/ha/haguichi/package.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://haguichi.net/";
     changelog = "https://haguichi.net/news/release${
       lib.strings.replaceStrings [ "." ] [ "" ] finalAttrs.version
-    }";
+    }/";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ OPNA2608 ];


### PR DESCRIPTION
This contains two fixes:
- Removed obsolete `meson_post_install.py` script call and `python3` package dependency:
The `meson_post_install.py` script was dropped in version 1.5.0 in favor of the builtin Meson [`gnome.post_install`](https://mesonbuild.com/Gnome-module.html#gnomepost_install) module.
Therefore the latest [build log](https://hydra.nixos.org/build/328948702/nixlog/1) reports `find: 'meson_post_install.py': No such file or directory`.
- Added missing trailing forward slash to changelog URL to prevent 301 redirect response.

Disclaimer: I'm the upstream developer, not a NixOS user or maintainer. So I have not tested these patches. Feel free to modify if I done something stupid.

cc maintainer: @OPNA2608 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
