### PR TITLE
ntsc-rs: init at 0.9.4

### DIFF
--- a/pkgs/by-name/nt/ntsc-rs/package.nix
+++ b/pkgs/by-name/nt/ntsc-rs/package.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  pkg-config,
+  glib,
+  gst_all_1,
+  openssl,
+  libclang,
+  wayland,
+  libxkbcommon,
+  libGL,
+  libx11,
+  libxcursor,
+  libxi,
+  makeWrapper,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ntsc-rs";
+  version = "0.9.4";
+
+  src = fetchFromGitHub {
+    owner = "ntsc-rs";
+    repo = "ntsc-rs";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-t65pE7Nk1It4Irhh8JXM+/+ewOGjok5HkmJPUg8tBEg=";
+  };
+
+  cargoHash = "sha256-MAaUrEbRNHZ5IMKUxr22HLacJG3YNvhuVfXyOoa+HEE=";
+
+  nativeBuildInputs = [
+    pkg-config
+    libclang
+    makeWrapper
+  ];
+
+  buildInputs = [
+    glib
+    openssl
+    # I tried to include all related packages here like open-scq30 has done.
+    wayland
+    libxkbcommon
+    libGL
+    libx11
+    libxcursor
+    libxi
+  ]
+  ++ (with gst_all_1; [
+    gstreamer
+    gst-plugins-base
+  ]);
+
+  __structuredAttrs = true;
+
+  env = {
+    LIBCLANG_PATH = "${lib.getLib libclang}/lib";
+  };
+
+  # It seems that wrapGAppsHook4 doesn't work for this package.
+  postFixup = ''
+    for prog in \
+      $out/bin/ntsc-rs-launcher \
+      $out/bin/ntsc-rs-standalone
+    do
+      wrapProgram "$prog" \
+        --prefix LD_LIBRARY_PATH : ${
+          lib.makeLibraryPath [
+            wayland
+            libxkbcommon
+            libGL
+            libx11
+            libxcursor
+            libxi
+          ]
+        }
+    done
+  '';
+
+  updateScript = nix-update-script { };
+
+  meta = {
+    description = "Free, open-source VHS effect which emulates NTSC and VHS video artifacts";
+    homepage = "https://ntsc.rs/";
+    downloadPage = "https://github.com/ntsc-rs/ntsc-rs/releases";
+    changelog = "https://github.com/ntsc-rs/ntsc-rs/releases/tag/${finalAttrs.src.tag}";
+    # See https://github.com/ntsc-rs/ntsc-rs/commit/621d2cc53e4f834a21005ec030a3b24fb5cbde38
+    # for more info about licenses.
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ VZstless ];
+    mainProgram = "ntsc-rs";
+  };
+})


### PR DESCRIPTION
Please check wayland/X11 related wrap more carefully as this is the first time for me to pack related package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
