### PR TITLE
wooting-bg-service: init at 0.4.8

### DIFF
--- a/nixos/modules/hardware/wooting.nix
+++ b/nixos/modules/hardware/wooting.nix
@@ -4,11 +4,27 @@
   pkgs,
   ...
 }:
+let
+  cfg = config.hardware.wooting;
+in
 {
-  options.hardware.wooting.enable = lib.mkEnableOption "support for Wooting keyboards";
+  options.hardware.wooting = {
+    enable = lib.mkEnableOption "support for Wooting keyboards";
+    background-service.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Support for Wootility background service.
+        Don't forget to enable it in the Wootility app.
+      '';
+    };
+  };
 
-  config = lib.mkIf config.hardware.wooting.enable {
-    environment.systemPackages = [ pkgs.wootility ];
-    services.udev.packages = [ pkgs.wooting-udev-rules ];
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      pkgs.wootility
+    ]
+    ++ lib.optional cfg.background-service.enable pkgs.wooting-bg-service;
+    services.udev.packages = lib.optional pkgs.stdenv.isLinux pkgs.wooting-udev-rules;
   };
 }

--- a/pkgs/by-name/wo/wootility/package.nix
+++ b/pkgs/by-name/wo/wootility/package.nix
@@ -3,14 +3,29 @@
   fetchurl,
   lib,
   makeWrapper,
+  stdenv,
 }:
 
 let
   pname = "wootility";
+  selectSystem =
+    attrs:
+    attrs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  sys = lib.splitString "-" stdenv.hostPlatform.system;
   version = "5.3.2";
+
+  platform = if (builtins.elemAt sys 0) == "aarch64" then "arm64" else "x64";
+  os = if (builtins.elemAt sys 1) == "darwin" then "mac" else "linux";
+
+  # In case more Linux platforms are supported in the future.
+  availablePlatforms = {
+    x86_64-linux = "sha256-XCQTVFUv5SkqQamC8uJqJ2sHqU2ap2jvkzDGjTUuWug=";
+  };
+
   src = fetchurl {
-    url = "https://wootility-updates.ams3.cdn.digitaloceanspaces.com/wootility-linux/Wootility-${version}.AppImage";
-    sha256 = "sha256-XCQTVFUv5SkqQamC8uJqJ2sHqU2ap2jvkzDGjTUuWug=";
+    url = "https://api.wooting.io/public/wootility/download?os=${os}&version=${version}&platform=${platform}";
+    hash = selectSystem availablePlatforms;
   };
 in
 
@@ -37,6 +52,9 @@ appimageTools.wrapType2 {
     export LC_ALL=C.UTF-8
   '';
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   extraPkgs =
     pkgs: with pkgs; [
       libxkbfile
@@ -45,12 +63,12 @@ appimageTools.wrapType2 {
   meta = {
     homepage = "https://wooting.io/wootility";
     description = "Customization and management software for Wooting keyboards";
-    platforms = lib.platforms.linux;
+    platforms = builtins.attrNames availablePlatforms;
     license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [
       sodiboo
       returntoreality
     ];
-    mainProgram = "wootility";
+    mainProgram = pname;
   };
 }

--- a/pkgs/by-name/wo/wooting-bg-service/package.nix
+++ b/pkgs/by-name/wo/wooting-bg-service/package.nix
@@ -1,0 +1,70 @@
+{
+  appimageTools,
+  fetchurl,
+  lib,
+  makeWrapper,
+  wootility,
+  stdenv,
+}:
+
+let
+  pname = "wooting-bg-service";
+
+  selectSystem =
+    attrs:
+    attrs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  platform = lib.splitString "-" stdenv.hostPlatform.system;
+  version = "0.4.8";
+
+  # In case more Linux platforms are supported in the future.
+  availablePlatforms = {
+    x86_64-linux = "sha256-syezhx3ME5wFxLba3W6+UdrPF0DfbxCd1u+6yXCr6zI=";
+  };
+
+  src = fetchurl {
+    url = "https://api.wooting.io/public/bg-service/download-installer?target=${builtins.elemAt platform 1}&arch=${builtins.elemAt platform 0}&version=v${version}";
+    hash = selectSystem availablePlatforms;
+  };
+in
+
+appimageTools.wrapType2 {
+  inherit version pname src;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  extraInstallCommands =
+    let
+      contents = appimageTools.extract { inherit pname version src; };
+    in
+    ''
+      install -Dm444 '${contents}/Wooting Background Service.desktop' -t $out/share/applications
+      install -Dm444 '${contents}/Wooting Background Service.png' -t $out/share/icons
+      install -Dm444 ${contents}/${pname}.png -t $out/share/icons
+    '';
+
+  profile = ''
+    export LC_ALL=C.UTF-8
+  '';
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  extraPkgs =
+    pkgs: with pkgs; [
+      libxkbfile
+      xdg-utils
+    ];
+
+  meta = {
+    homepage = "https://wooting.io/wootility";
+    description = "Wooting's background service. Provides applinking and allows access to CPU usage, battery level, Discord mute status, etc.";
+    platforms = builtins.attrNames availablePlatforms;
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [
+      sodiboo
+      returntoreality
+    ];
+    mainProgram = pname;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
Adds wooting-bg-service. Also adds darwin support for wootiltiy.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
