### PR TITLE
nixos/dovecot: improve eval warn of removed options for using Dovecot 2.3

### DIFF
--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -200,21 +200,30 @@ in
       ]
       ''Use `services.dovecot2.settings.protocols = "lmtp"` for Dovecot 2.3, `services.dovecot2.settings.protocols.lmtp` for Dovecot 2.4.''
     )
-    (mkRemovedOptionModule [
-      "services"
-      "dovecot2"
-      "sslServerCert"
-    ] "Use `settings.ssl_cert` for Dovecot 2.3, `settings.ssl_server_cert_file` for 2.4.")
-    (mkRemovedOptionModule [
-      "services"
-      "dovecot2"
-      "sslServerKey"
-    ] "Use `settings.ssl_key` for Dovecot 2.3, `settings.ssl_server_key_file` for 2.4.")
-    (mkRemovedOptionModule [
-      "services"
-      "dovecot2"
-      "sslCACert"
-    ] "Use `settings.ssl_ca` for Dovecot 2.3, `settings.ssl_server_ca_file` for 2.4.")
+    (mkRemovedOptionModule
+      [
+        "services"
+        "dovecot2"
+        "sslServerCert"
+      ]
+      ''Use `settings.ssl_cert = "</path"` for Dovecot 2.3, `settings.ssl_server_cert_file = "/path"` for 2.4.''
+    )
+    (mkRemovedOptionModule
+      [
+        "services"
+        "dovecot2"
+        "sslServerKey"
+      ]
+      ''Use `settings.ssl_key = "</path"` for Dovecot 2.3, `settings.ssl_server_key_file = "/path"` for 2.4.''
+    )
+    (mkRemovedOptionModule
+      [
+        "services"
+        "dovecot2"
+        "sslCACert"
+      ]
+      ''Use `settings.ssl_ca = "</path"` for Dovecot 2.3, `settings.ssl_server_ca_file = "/path"` for 2.4.''
+    )
     (mkRemovedOptionModule [
       "services"
       "dovecot2"

--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -176,21 +176,30 @@ in
       "dovecot2"
       "modules"
     ] "Now need to use `environment.systemPackages` to load additional Dovecot modules")
-    (mkRemovedOptionModule [
-      "services"
-      "dovecot2"
-      "enablePop3"
-    ] "Set 'services.dovecot2.settings.protocols.pop3 = true/false;' instead.")
-    (mkRemovedOptionModule [
-      "services"
-      "dovecot2"
-      "enableImap"
-    ] "Set 'services.dovecot2.settings.protocols.imap = true/false;' instead.")
-    (mkRemovedOptionModule [
-      "services"
-      "dovecot2"
-      "enableLmtp"
-    ] "Set 'services.dovecot2.settings.protocols.lmtp = true/false;' instead.")
+    (mkRemovedOptionModule
+      [
+        "services"
+        "dovecot2"
+        "enablePop3"
+      ]
+      ''Use `services.dovecot2.settings.protocols = "pop3"` for Dovecot 2.3, `services.dovecot2.settings.protocols.pop3` for Dovecot 2.4.''
+    )
+    (mkRemovedOptionModule
+      [
+        "services"
+        "dovecot2"
+        "enableImap"
+      ]
+      ''Use `services.dovecot2.settings.protocols = "imap"` for Dovecot 2.3, `services.dovecot2.settings.protocols.imap` for Dovecot 2.4.''
+    )
+    (mkRemovedOptionModule
+      [
+        "services"
+        "dovecot2"
+        "enableLmtp"
+      ]
+      ''Use `services.dovecot2.settings.protocols = "lmtp"` for Dovecot 2.3, `services.dovecot2.settings.protocols.lmtp` for Dovecot 2.4.''
+    )
     (mkRemovedOptionModule [
       "services"
       "dovecot2"

--- a/nixos/modules/services/mail/dovecot.nix
+++ b/nixos/modules/services/mail/dovecot.nix
@@ -222,7 +222,7 @@ in
         "dovecot2"
         "sslCACert"
       ]
-      ''Use `settings.ssl_ca = "</path"` for Dovecot 2.3, `settings.ssl_server_ca_file = "/path"` for 2.4.''
+      ''Use `settings.ssl_ca = "</path"` for Dovecot 2.3, `settings.ssl_server_ca_file = "/path"` for incoming connections in 2.4, `settings.ssl_client_ca_file = "/path"` for outgoing connections in 2.4.''
     )
     (mkRemovedOptionModule [
       "services"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
