### PR TITLE
nixos/users-groups: drop the weak-hash activation warning

### DIFF
--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -950,32 +950,8 @@ in
         };
       };
 
-      # Warn about user accounts with deprecated password hashing schemes
-      # This does not work when the users and groups are created by
-      # systemd-sysusers because the users are created too late then.
-      system.activationScripts.hashes =
-        if !config.systemd.sysusers.enable && !config.services.userborn.enable then
-          {
-            deps = [ "users" ];
-            text = ''
-              users=()
-              while IFS=: read -r user hash _; do
-                if [[ "$hash" = "$"* && ! "$hash" =~ ^\''$${cryptSchemeIdPatternGroup}\$ ]]; then
-                  users+=("$user")
-                fi
-              done </etc/shadow
-
-              if (( "''${#users[@]}" )); then
-                echo "
-              WARNING: The following user accounts rely on password hashing algorithms
-              that have been removed. They need to be renewed as soon as possible, as
-              they do prevent their users from logging in."
-                printf ' - %s\n' "''${users[@]}"
-              fi
-            '';
-          }
-        else
-          ""; # keep around for backwards compatibility
+      # for backwards compatibility
+      system.activationScripts.hashes = stringAfter [ "users" ] "";
 
       # for backwards compatibility
       system.activationScripts.groups = stringAfter [ "users" ] "";


### PR DESCRIPTION
The libxcrypt transition was in 23.05, so I think we've given people sufficient time to fix hashes of mutable users.


Part of #475305.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
