### PR TITLE
python313Packages.greatfet: 2025.0.0 -> 2026.0.0

### DIFF
--- a/pkgs/development/python-modules/greatfet/default.nix
+++ b/pkgs/development/python-modules/greatfet/default.nix
@@ -2,6 +2,7 @@
   buildPythonPackage,
   cmsis-svd,
   fetchFromGitHub,
+  fetchPypi,
   ipython,
   lib,
   prompt-toolkit,
@@ -11,6 +12,7 @@
   setuptools,
   tabulate,
   tqdm,
+  unzip,
 }:
 
 buildPythonPackage rec {
@@ -25,12 +27,36 @@ buildPythonPackage rec {
     hash = "sha256-qXPNatakMVtvl26FG1bx+ngCeqRpg1So6qFamKK8WWk=";
   };
 
+  # The prebuilt LPC firmware image (greatfet_usb.bin) and the DFU recovery
+  # stub (flash_stub.bin) are release artifacts cross-compiled from firmware/.
+  # They are absent from the git checkout (their build inputs are now-empty
+  # submodules) but are shipped in the upstream wheel. Without them
+  # `greatfet_firmware --autoflash` and DFU-mode firmware recovery are
+  # unavailable, so vendor them from the wheel to match `pip install greatfet`.
+  firmwareAssets = fetchPypi {
+    inherit pname version;
+    format = "wheel";
+    dist = "py3";
+    python = "py3";
+    hash = "sha256-sH1FAkfdC0HxRLZjfx7b2AYWMh4rtSijFgsU/YnVKq0=";
+  };
+
   sourceRoot = "${src.name}/host";
+
+  nativeBuildInputs = [ unzip ];
 
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail ', "setuptools-git-versioning<2"' "" \
       --replace-fail 'dynamic = ["version"]' 'version = "${version}"'
+
+    # Restore the prebuilt firmware images shipped in the upstream wheel; the
+    # existing MANIFEST.in (recursive-include greatfet/assets *) then packages
+    # them into greatfet/assets/ where find_greatfet_asset() looks at runtime.
+    unzip -j -o ${firmwareAssets} \
+      'greatfet/assets/greatfet_usb.bin' \
+      'greatfet/assets/flash_stub.bin' \
+      -d greatfet/assets/
   '';
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/greatfet/default.nix
+++ b/pkgs/development/python-modules/greatfet/default.nix
@@ -2,7 +2,6 @@
   buildPythonPackage,
   cmsis-svd,
   fetchFromGitHub,
-  future,
   ipython,
   lib,
   prompt-toolkit,
@@ -16,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "greatfet";
-  version = "2025.0.0";
+  version = "2026.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "greatscottgadgets";
     repo = "greatfet";
     tag = "v${version}";
-    hash = "sha256-tY1ZUtjCeb0+EmmbzKbIcPQrjHc3JzgA/6yDuFwwHu4=";
+    hash = "sha256-qXPNatakMVtvl26FG1bx+ngCeqRpg1So6qFamKK8WWk=";
   };
 
   sourceRoot = "${src.name}/host";
@@ -40,7 +39,6 @@ buildPythonPackage rec {
 
   dependencies = [
     cmsis-svd
-    future
     ipython
     prompt-toolkit
     pyfwup


### PR DESCRIPTION
Upstream dropped the `future` dependency in this release as part of removing the remaining Python 2-3 migration imports.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
