### PR TITLE
gui-for-singbox: 1.23.2 -> 1.25.4

### DIFF
--- a/pkgs/by-name/gu/gui-for-singbox/frontend-runtime-path.patch
+++ b/pkgs/by-name/gu/gui-for-singbox/frontend-runtime-path.patch
@@ -27,31 +27,33 @@ diff -ruN a/src/stores/env.ts b/src/stores/env.ts
 diff -ruN a/src/stores/kernelApi.ts b/src/stores/kernelApi.ts
 --- a/src/stores/kernelApi.ts
 +++ b/src/stores/kernelApi.ts
-@@ -248,8 +248,12 @@
-   const runCoreProcess = (isAlpha: boolean) => {
-     return new Promise<number | void>((resolve, reject) => {
-       let output: string
-+      const coreWorkingDirectory =
-+        envStore.env.os === 'linux' && envStore.env.configPath
-+          ? `${envStore.env.configPath}/${CoreWorkingDirectory}`
-+          : CoreWorkingDirectory
-       const pid = ExecBackground(
--        CoreWorkingDirectory + '/' + getKernelFileName(isAlpha),
-+        coreWorkingDirectory + '/' + getKernelFileName(isAlpha),
-         getKernelRuntimeArgs(isAlpha),
-         (out) => {
-           output = out
-@@ -263,8 +267,9 @@
-           reject(output)
-         },
-         {
--          PidFile: CorePidFilePath,
-+          PidFile: coreWorkingDirectory + '/pid.txt',
-           StopOutputKeyword: CoreStopOutputKeyword,
-+          WorkingDirectory: envStore.env.configPath || envStore.env.basePath,
-           Env: getKernelRuntimeEnv(isAlpha),
-         },
-       ).catch((e) => reject(e))
+@@ -271,19 +271,24 @@
+   const runCoreProcess = async (isAlpha: boolean) => {
+     let stopped = false
++    const coreWorkingDirectory =
++      envStore.env.os === 'linux' && envStore.env.configPath
++        ? `${envStore.env.configPath}/${CoreWorkingDirectory}`
++        : CoreWorkingDirectory
+     const pid = await ExecBackground(
+-      CoreWorkingDirectory + '/' + getKernelFileName(isAlpha),
++      coreWorkingDirectory + '/' + getKernelFileName(isAlpha),
+       getKernelRuntimeArgs(isAlpha),
+       undefined,
+       async (end) => {
+         stopped = true
+         const logs = await ReadFile(CoreLogFilePath, { Range: '-4096' }).catch((err) => String(err))
+         logs.split('\n').forEach((line) => line && logsStore.recordKernelLog(line))
+         end && logsStore.recordKernelLog(end)
+         onCoreStopped()
+       },
+       {
+-        PidFile: CorePidFilePath,
+         LogFile: CoreLogFilePath,
++        PidFile: coreWorkingDirectory + '/pid.txt',
++        WorkingDirectory: envStore.env.configPath || envStore.env.basePath,
+         Env: getKernelRuntimeEnv(isAlpha),
+       },
+     )
 diff -ruN a/src/types/app.d.ts b/src/types/app.d.ts
 --- a/src/types/app.d.ts
 +++ b/src/types/app.d.ts
@@ -63,6 +65,30 @@ diff -ruN a/src/types/app.d.ts b/src/types/app.d.ts
    appPath: string
    os: OS
    arch: string
+diff -ruN a/src/views/PluginsView/index.vue b/src/views/PluginsView/index.vue
+--- a/src/views/PluginsView/index.vue
++++ b/src/views/PluginsView/index.vue
+@@ -37,7 +37,7 @@
+     label: 'common.openFile',
+     handler: async (id: string) => {
+       const plugin = pluginsStore.getPluginById(id)
+-      await OpenURI(envStore.env.basePath + '/' + plugin!.path)
++      await OpenURI(`${envStore.env.configPath || envStore.env.basePath}/${plugin!.path}`)
+     },
+   },
+ ]
+diff -ruN a/src/views/RulesetsView/index.vue b/src/views/RulesetsView/index.vue
+--- a/src/views/RulesetsView/index.vue
++++ b/src/views/RulesetsView/index.vue
+@@ -27,7 +27,7 @@
+     label: 'common.openFile',
+     handler: async (id: string) => {
+       const ruleset = rulesetsStore.getRulesetById(id)
+-      await OpenURI(envStore.env.basePath + '/' + ruleset!.path)
++      await OpenURI(`${envStore.env.configPath || envStore.env.basePath}/${ruleset!.path}`)
+     },
+   },
+   {
 diff -ruN a/src/utils/helper.ts b/src/utils/helper.ts
 --- a/src/utils/helper.ts
 +++ b/src/utils/helper.ts

--- a/pkgs/by-name/gu/gui-for-singbox/package.nix
+++ b/pkgs/by-name/gu/gui-for-singbox/package.nix
@@ -20,13 +20,13 @@
 
 let
   pname = "gui-for-singbox";
-  version = "1.23.2";
+  version = "1.25.4";
 
   src = fetchFromGitHub {
     owner = "GUI-for-Cores";
     repo = "GUI.for.SingBox";
     tag = "v${version}";
-    hash = "sha256-CEJ0yzF2smBlLgZ4EH5UWV4Pc4vA2ZH80TjoudUKWZM=";
+    hash = "sha256-+2MdFF1iufbPJvf5XGrM9t9vaY7BNdIu/vSWgAKcbvQ=";
   };
 
   metaCommon = {
@@ -58,7 +58,7 @@ let
         ;
       pnpm = pnpm_10;
       fetcherVersion = 3;
-      hash = "sha256-m9Rmc9Ww4jb2aQ+RXOwF71daZ6puspdMM/xidnk/YHs=";
+      hash = "sha256-BrDO9xdMuMnhXPAd9QvtU4R1W1WacnsVcGde+WFjvGA=";
     };
 
     buildPhase = ''
@@ -89,7 +89,7 @@ buildGo126Module {
 
   patches = [ ./xdg-path-and-restart-patch.patch ];
 
-  vendorHash = "sha256-9uWrctbQ+vujb1Q8zT7Bv7rVyNY1rCM577c9caOKRNo=";
+  vendorHash = "sha256-Xi/EgMLex25p2tmRHEldCv6hgUKIpLJTmrMpHPGLY5M=";
 
   nativeBuildInputs = [
     autoPatchelfHook

--- a/pkgs/by-name/gu/gui-for-singbox/xdg-path-and-restart-patch.patch
+++ b/pkgs/by-name/gu/gui-for-singbox/xdg-path-and-restart-patch.patch
@@ -1,7 +1,7 @@
 diff -ruN a/bridge/bridge.go b/bridge/bridge.go
 --- a/bridge/bridge.go
 +++ b/bridge/bridge.go
-@@ -50,6 +50,7 @@
+@@ -51,6 +51,7 @@
  
  	Env.BasePath = filepath.ToSlash(filepath.Dir(exePath))
  	Env.AppName = filepath.Base(exePath)
@@ -13,7 +13,7 @@ diff -ruN a/bridge/bridge.go b/bridge/bridge.go
  
  func (a *App) RestartApp() FlagResult {
  	log.Printf("RestartApp")
--	exePath := Env.BasePath + "/" + Env.AppName
+-	exePath := resolvePath(Env.AppName)
 +	exePath, err := os.Executable()
 +	if err != nil {
 +		exePath = filepath.Join(Env.BasePath, Env.AppName)
@@ -29,15 +29,6 @@ diff -ruN a/bridge/bridge.go b/bridge/bridge.go
  		OS:           Env.OS,
  		ARCH:         Env.ARCH,
  		IsPrivileged: Env.IsPrivileged,
-@@ -258,7 +263,7 @@
- }
- 
- func loadConfig() {
--	b, err := os.ReadFile(Env.BasePath + "/data/user.yaml")
-+	b, err := os.ReadFile(GetPath("data/user.yaml"))
- 	if err == nil {
- 		yaml.Unmarshal(b, &Config)
- 	}
 diff -ruN a/bridge/types.go b/bridge/types.go
 --- a/bridge/types.go
 +++ b/bridge/types.go
@@ -52,9 +43,8 @@ diff -ruN a/bridge/types.go b/bridge/types.go
 diff -ruN a/bridge/utils.go b/bridge/utils.go
 --- a/bridge/utils.go
 +++ b/bridge/utils.go
-@@ -13,7 +13,29 @@
- 	"golang.org/x/text/encoding/simplifiedchinese"
- )
+@@ -23,7 +23,29 @@
+ var requestTransportCache sync.Map
  
 +func GetConfigPath() string {
 +	if Env.OS == "linux" {
@@ -69,7 +59,7 @@ diff -ruN a/bridge/utils.go b/bridge/utils.go
 +	return Env.BasePath
 +}
 +
- func GetPath(path string) string {
+ func resolvePath(path string) string {
 +	if Env.OS == "linux" && !filepath.IsAbs(path) {
 +		cleanPath := filepath.ToSlash(filepath.Clean(path))
 +		if cleanPath == "data" {
@@ -82,3 +72,4 @@ diff -ruN a/bridge/utils.go b/bridge/utils.go
  	if !filepath.IsAbs(path) {
  		path = filepath.Join(Env.BasePath, path)
  	}
+ 	return filepath.ToSlash(filepath.Clean(path))


### PR DESCRIPTION
Upstream changelog: https://github.com/GUI-for-Cores/GUI.for.SingBox/releases/tag/v1.25.4

Changes:
- Update gui-for-singbox 1.23.2 -> 1.25.4
- Refresh runtime/XDG path patches for the new upstream version
- Patch OpenURI path handling so plugin/ruleset files are opened from the config path
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
