### PR TITLE
maintainers: remove maintainers with deleted GitHub accounts

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -329,12 +329,6 @@
     githubId = 381298;
     name = "9R";
   };
-  _9yokuro = {
-    email = "xzstd099@protonmail.com";
-    github = "9yokuro";
-    githubId = 119095935;
-    name = "9yokuro";
-  };
   a-camarillo = {
     name = "Anthony Camarillo";
     email = "anthony.camarillo.96@gmail.com";
@@ -8356,11 +8350,6 @@
     githubId = 16175276;
     keys = [ { fingerprint = "E4CE B0F0 B2EC 09A3 9678  F294 CC7A 7E3C 6CF3 1343"; } ];
   };
-  EstebanMacanek = {
-    name = "Esteban Macanek";
-    github = "EstebanMacanek";
-    githubId = 75503218;
-  };
   esteve = {
     name = "Esteve Fernandez";
     email = "nixpkgs@nara.ac";
@@ -13421,12 +13410,6 @@
     name = "Joshua Park";
     github = "joshprk";
     githubId = 123624726;
-  };
-  joshuafern = {
-    name = "Joshua Fern";
-    email = "joshuafern@protonmail.com";
-    github = "JoshuaFern";
-    githubId = 4300747;
   };
   joshvanl = {
     email = " me@joshvanl.dev ";
@@ -19208,12 +19191,6 @@
     name = "Nasir Hussain";
     keys = [ { fingerprint = "7A10 AB8E 0BEC 566B 090C  9BE3 D812 6E55 9CE7 C35D"; } ];
   };
-  nasrally = {
-    email = "suffer.ring@ya.ru";
-    github = "nasrally";
-    githubId = 50599445;
-    name = "Nikita Grishko";
-  };
   nat-418 = {
     github = "nat-418";
     githubId = 93013864;
@@ -22282,12 +22259,6 @@
     githubId = 6314611;
     keys = [ { fingerprint = "EEC7 53FC EAAA FD9E 4DC0  9BB5 CAEB 4185 C226 D76B"; } ];
   };
-  prominentretail = {
-    email = "me@jakepark.me";
-    github = "ProminentRetail";
-    githubId = 94048404;
-    name = "Jake Park";
-  };
   proofconstruction = {
     email = "source@proof.construction";
     github = "proofconstruction";
@@ -22735,11 +22706,6 @@
     githubId = 1542224;
     matrix = "@qyriad:katesiria.org";
     name = "Qyriad";
-  };
-  qzylinra = {
-    github = "qzylinra";
-    githubId = 225773816;
-    name = "qzylinra";
   };
   r-aizawa = {
     github = "Xantibody";

--- a/pkgs/applications/misc/xppen/generic.nix
+++ b/pkgs/applications/misc/xppen/generic.nix
@@ -63,7 +63,6 @@ stdenv.mkDerivation {
     mainProgram = "PenTablet";
     maintainers = with lib.maintainers; [
       gepbird
-      nasrally
     ];
     platforms = [ "x86_64-linux" ];
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];

--- a/pkgs/by-name/do/dosbox-staging/package.nix
+++ b/pkgs/by-name/do/dosbox-staging/package.nix
@@ -125,7 +125,6 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
-      joshuafern
       Zaechus
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/sy/syncrclone/package.nix
+++ b/pkgs/by-name/sy/syncrclone/package.nix
@@ -28,7 +28,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     changelog = "https://github.com/Jwink3101/syncrclone/blob/${finalAttrs.src.rev}/docs/changelog.md";
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ prominentretail ];
+    maintainers = [ ];
     mainProgram = "syncrclone";
   };
 })

--- a/pkgs/by-name/tr/tradingview/package.nix
+++ b/pkgs/by-name/tr/tradingview/package.nix
@@ -98,7 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://www.tradingview.com/support/solutions/43000673888/";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ prominentretail ];
+    maintainers = [ ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "tradingview";
   };

--- a/pkgs/by-name/vi/vim-startuptime/package.nix
+++ b/pkgs/by-name/vi/vim-startuptime/package.nix
@@ -31,7 +31,7 @@ buildGoModule (finalAttrs: {
   meta = {
     homepage = "https://github.com/rhysd/vim-startuptime";
     description = "Small Go program for better `vim --startuptime` alternative";
-    maintainers = with lib.maintainers; [ _9yokuro ];
+    maintainers = [ ];
     license = lib.licenses.mit;
     mainProgram = "vim-startuptime";
   };

--- a/pkgs/by-name/wh/whatsapp-chat-exporter/package.nix
+++ b/pkgs/by-name/wh/whatsapp-chat-exporter/package.nix
@@ -42,7 +42,6 @@ python3Packages.buildPythonApplication {
     mainProgram = "wtsexporter";
     maintainers = with lib.maintainers; [
       bbenno
-      EstebanMacanek
     ];
   };
 }

--- a/pkgs/by-name/xe/xephem/package.nix
+++ b/pkgs/by-name/xe/xephem/package.nix
@@ -106,7 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "xephem";
     homepage = "https://xephem.github.io/XEphem/Site/xephem.html";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ EstebanMacanek ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/development/python-modules/vpk/default.nix
+++ b/pkgs/development/python-modules/vpk/default.nix
@@ -24,6 +24,6 @@ buildPythonPackage rec {
     mainProgram = "vpk";
     homepage = "https://github.com/ValvePython/vpk";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ joshuafern ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
It's not possible to ping these maintainers or request them for review. Could be worth emailing, though?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
