### PR TITLE
mmterm: init at 0.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -353,6 +353,11 @@
     githubId = 65275785;
     name = "Alexander Kenji Berthold";
   };
+  a-maccormack = {
+    github = "a-maccormack";
+    githubId = 78695941;
+    name = "Alister MacCormack";
+  };
   a-peirogon = {
     email = "ainfanthe@gmail.com";
     github = "a-peirogon";

--- a/pkgs/by-name/mm/mmterm/package.nix
+++ b/pkgs/by-name/mm/mmterm/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  fontconfig,
+  freetype,
+  libGL,
+  libx11,
+  libxcursor,
+  libxi,
+  libxkbcommon,
+  libxrandr,
+  wayland,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "mmterm";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "roramirez";
+    repo = "mmterm";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-EKrEKaIA9uAarPJECdR9aqWDBJ2c2l/K+vEZuIVT89o=";
+  };
+
+  cargoHash = "sha256-tkQLxgVjcCX/NfJdyb1XLkzHbNgc3km0YxqiWiB0jkQ=";
+
+  doCheck = false;
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    fontconfig
+    freetype
+    libGL
+    libx11
+    libxcursor
+    libxi
+    libxkbcommon
+    libxrandr
+    wayland
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Cross-platform terminal emulator with modal input (vim-style), PTY backend, and split-pane support";
+    homepage = "https://github.com/roramirez/mmterm";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ a-maccormack ];
+    mainProgram = "mmterm";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION

Add mmterm, a cross-platform terminal emulator with vim-style modal input, PTY backend, and split-pane support. It renders entirely via a CPU pixel buffer (no GPU/OpenGL/Vulkan dependencies).

Homepage: https://github.com/roramirez/mmterm

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test