### PR TITLE
libressl: properly override TLS_DEFAULT_CA_FILE

### DIFF
--- a/pkgs/by-name/li/libressl/default.nix
+++ b/pkgs/by-name/li/libressl/default.nix
@@ -133,6 +133,8 @@ in
       } include/arch/loongarch64/opensslconf.h
     '';
     patches = [
+      # https://github.com/libressl/portable/issues/1295
+      ./tls_default_ca_file.patch
       common-cmake-install-full-dirs-patch
     ];
   };
@@ -141,6 +143,8 @@ in
     version = "4.2.1";
     hash = "sha256-bVwvWFg1iOp5H0yGRQBAcdAN+lVKW/eIoAbKHrWr1ws=";
     patches = [
+      # https://github.com/libressl/portable/issues/1295
+      ./tls_default_ca_file.patch
       common-cmake-install-full-dirs-patch
     ];
   };

--- a/pkgs/by-name/li/libressl/tls_default_ca_file.patch
+++ b/pkgs/by-name/li/libressl/tls_default_ca_file.patch
@@ -1,0 +1,13 @@
+diff --git a/tls/CMakeLists.txt.bak b/tls/CMakeLists.txt
+index a1b244a..8c28465 100644
+--- a/tls/CMakeLists.txt.bak
++++ b/tls/CMakeLists.txt
+@@ -41,8 +41,6 @@ if(WIN32)
+        set(TLS_COMPAT_SRC ${TLS_COMPAT_SRC} compat/pwrite.c)
+ endif()
+ 
+-add_definitions(-DTLS_DEFAULT_CA_FILE=\"${OPENSSLDIR}/cert.pem\")
+-
+ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/tls.sym DESTINATION
+        ${CMAKE_CURRENT_BINARY_DIR})
+ 


### PR DESCRIPTION
The override of the `TLS_DEFAULT_CA_FILE` preprocessor constant does not work due to a bug in LibreSSL's CMakeLists.txt, which attempts to always override the definition.

**Without this patch, CMake will override this to `etc/ssl/cert.pem` which is not desired**

This commit adds a patch that simply removes the definition.  It is okay because we explicitly set it ourselves anyways.

See Also: https://github.com/libressl/portable/issues/1295, #529192

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
