### PR TITLE
rpki-client: init at 9.8

### DIFF
--- a/pkgs/by-name/rp/rpki-client/package.nix
+++ b/pkgs/by-name/rp/rpki-client/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  clangStdenv,
+  fetchurl,
+  makeWrapper,
+
+  expat,
+  libressl,
+  cacert,
+  openrsync,
+  zlib,
+}:
+clangStdenv.mkDerivation (finalAttrs: {
+  pname = "rpki-client";
+  version = "9.8";
+
+  src = fetchurl {
+    url = "mirror://openbsd/rpki-client/rpki-client-${finalAttrs.version}.tar.gz";
+    hash = "sha256-QpIKrFr9CZYXP7n3hIaRosSd0jTk8QR4gIwapHViCGE=";
+  };
+
+  nativeBuildInputs = [
+    # We need the openrsync binary as a native build input so we can make the
+    # ./configure script happy.
+    openrsync
+
+    makeWrapper
+  ];
+
+  buildInputs = [
+    # We need OpenSSL and libtls, both provided by LibreSSL.
+    libressl
+
+    expat
+    zlib
+  ];
+
+  # Override the prefix during the build because the binary would otherwise
+  # contain hard-coded paths to the nix store for mutable resources, such as
+  # sockets or cache.
+  buildFlags = [ "prefix=" ];
+
+  # Create a wrapper that includes openrsync in the path, as rpki-client invokes
+  # openrsync for syncing purposes.
+  postFixup = ''
+    wrapProgram $out/bin/rpki-client  \
+      --prefix PATH : ${lib.makeBinPath [ openrsync ]}
+  '';
+
+  strictDeps = true;
+  __structuredAttrs = true;
+  meta = {
+    description = "Free implementation of the Resource Public Key Infrastructure (RPKI) for Relying Parties (RP) to facilitate validation of BGP announcements.";
+    license = lib.licenses.isc;
+    homepage = "http://www.rpki-client.org/";
+    maintainers = with lib.maintainers; [ cvengler ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
**For now, this is effectively blocked on #529202. In order to not cause a mass rebuilt, this branch IS NOT based on #529202. Instead, we have to rebase once it got merged. For now, I recommend reviewers to review this in a temporary branch with fixes from this PR and #529202 applied**

This commit initializes [rpki-client](https://rpki-client) at version 9.8.

rpki-client is OpenBSDs implementation of RPKI and tightly integrated into OpenBGPD, for which we already have a package too.

The portable version also supports output formats supported by other routing daemons, such as BIRD.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
