### PR TITLE
nunicode: 1.11 -> 1.11.1

### DIFF
--- a/pkgs/by-name/nu/nunicode/package.nix
+++ b/pkgs/by-name/nu/nunicode/package.nix
@@ -9,7 +9,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nunicode";
-  version = "1.11";
+  version = "1.11.1";
 
   outputs = [
     "out"
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "alekseyt";
     repo = "nunicode";
     tag = finalAttrs.version;
-    hash = "sha256-6255YdX7eYSAj0EAE4RgX1m4XDNIF/Nc4ZCvXzTxpag=";
+    hash = "sha256-73jkbWbQGSya4hf+/5c2bpJsRmncgjA2m+6bud2UN0A=";
   };
 
   postPatch = ''
@@ -73,7 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Fast, small and portable Unicode library with SQLite extension";
     homepage = "https://bitbucket.org/alekseyt/nunicode";
-    changelog = "https://bitbucket.org/alekseyt/nunicode/src/${finalAttrs.version}/CHANGELOG";
+    changelog = "https://bitbucket.org/alekseyt/nunicode/src/${finalAttrs.src.tag}/CHANGELOG";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.mjoerg ];
     platforms = lib.platforms.unix;


### PR DESCRIPTION
https://bitbucket.org/alekseyt/nunicode/src/1.11.1/CHANGELOG
https://bitbucket.org/alekseyt/nunicode/branches/compare/refs/tags/1.11.1%0Drefs/tags/1.11

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 529209 --additional-package nixosTests.audiobookshelf`
Commit: `8fa3c7daef333d90e4c094791cd1113724c7d482`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 test built:</summary>
  <ul>
    <li>nixosTests.audiobookshelf</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>audiobookshelf</li>
    <li>nunicode</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test