### PR TITLE
scanservjs: add NixOS test

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1489,6 +1489,7 @@ in
   sane = runTest ./sane.nix;
   sanoid = runTest ./sanoid.nix;
   saunafs = runTest ./saunafs.nix;
+  scanservjs = runTest ./scanservjs.nix;
   scaphandre = runTest ./scaphandre.nix;
   schleuder = runTest ./schleuder.nix;
   scion-freestanding-deployment = runTest ./scion/freestanding-deployment;

--- a/nixos/tests/scanservjs.nix
+++ b/nixos/tests/scanservjs.nix
@@ -1,0 +1,22 @@
+let
+  port = 1234;
+in
+{
+  name = "scanservjs";
+
+  nodes.machine =
+    { ... }:
+    {
+      services.scanservjs = {
+        enable = true;
+        settings.port = port;
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("scanservjs.service")
+    machine.wait_until_succeeds(
+        "curl --silent --fail --show-error --location http://localhost:${toString port}"
+    )
+  '';
+}

--- a/pkgs/by-name/sc/scanservjs/package.nix
+++ b/pkgs/by-name/sc/scanservjs/package.nix
@@ -3,6 +3,7 @@
   fetchFromGitHub,
   buildNpmPackage,
   nodejs,
+  nixosTests,
 }:
 
 buildNpmPackage (finalAttrs: {
@@ -24,6 +25,10 @@ buildNpmPackage (finalAttrs: {
       --set NODE_ENV production \
       --add-flags "'$out/lib/node_modules/scanservjs/app-server/src/server.js'"
   '';
+
+  passthru = {
+    tests.smoke-test = nixosTests.scanservjs;
+  };
 
   meta = {
     description = "SANE scanner nodejs web ui";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **nixosTests.scanservjs: init**
- **scanservjs: link nixosTests**

The test currently fails, due to the regression noted here:
https://github.com/NixOS/nixpkgs/issues/475043

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
