### PR TITLE
solvespace: migrate to pcre2

### DIFF
--- a/pkgs/by-name/so/solvespace/package.nix
+++ b/pkgs/by-name/so/solvespace/package.nix
@@ -24,7 +24,7 @@
   libthai,
   libxkbcommon,
   pangomm,
-  pcre,
+  pcre2,
   util-linuxMinimal, # provides libmount
   libxtst,
   libxdmcp,
@@ -36,6 +36,8 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "solvespace";
   version = "3.2";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "solvespace";
     repo = "solvespace";
@@ -43,6 +45,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-+ZSAC7wDOaN51RjbSAqaQOp10JzxSME3g0ln4VdkwcA=";
     fetchSubmodules = true;
   };
+
+  strictDeps = true;
 
   nativeBuildInputs = [
     cmake
@@ -70,7 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
     libthai
     libxkbcommon
     pangomm
-    pcre
+    pcre2
     util-linuxMinimal
     libpthread-stubs
     libxdmcp


### PR DESCRIPTION
Part of: #356387

Migrates `solvespace` to PCRE2. Builds fine for me and I tested it out by drawing a few shapes, seems to work :D

Also added some usual 'get stuff up to date' things

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
