### PR TITLE
lib.debug.runTests: exclude tests.tests from test cases

### DIFF
--- a/lib/debug.nix
+++ b/lib/debug.nix
@@ -533,7 +533,7 @@ rec {
             ]
           else
             [ ]
-        ) tests
+        ) (removeAttrs tests [ "tests" ])
       )
     );
 

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -158,6 +158,54 @@ in
 
 runTests {
 
+  # DEBUG
+
+  testRunTest =
+    let
+      test-cases = {
+        foo-false = {
+          expr = 2;
+          expected = 3;
+        };
+        foo-true = {
+          expr = 1;
+          expected = 1;
+        };
+        test-bar-false = {
+          expr = 2;
+          expected = 3;
+        };
+        test-bar-true = {
+          expr = 1;
+          expected = 1;
+        };
+      };
+      test-cases-without-prefixed = lib.filterAttrs (n: v: lib.hasPrefix "foo-" n) test-cases;
+      toResult =
+        testCases:
+        lib.attrValues (
+          lib.mapAttrs (testName: testCase: {
+            name = testName;
+            inherit (testCase) expected;
+            result = testCase.expr;
+          }) testCases
+        );
+    in
+    {
+      expr = {
+        empty = runTests { };
+        testlist-unspecified-without-prefixed = runTests test-cases-without-prefixed;
+        testlist-unspecified-with-prefixed = runTests test-cases;
+        testlist-nonempty = runTests (test-cases // { tests = lib.attrNames test-cases-without-prefixed; });
+      };
+      expected = {
+        empty = [ ];
+        testlist-unspecified-without-prefixed = [ ];
+        testlist-unspecified-with-prefixed = toResult { inherit (test-cases) test-bar-false; };
+        testlist-nonempty = toResult { inherit (test-cases) foo-false; };
+      };
+    };
+
   # CUSTOMIZATION
 
   testFunctionArgsMakeOverridable = {

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -196,12 +196,16 @@ runTests {
         empty = runTests { };
         testlist-unspecified-without-prefixed = runTests test-cases-without-prefixed;
         testlist-unspecified-with-prefixed = runTests test-cases;
+        testlist-empty-without-prefixed = runTests (test-cases-without-prefixed // { tests = [ ]; });
+        testlist-empty-with-prefixed = runTests (test-cases // { tests = [ ]; });
         testlist-nonempty = runTests (test-cases // { tests = lib.attrNames test-cases-without-prefixed; });
       };
       expected = {
         empty = [ ];
         testlist-unspecified-without-prefixed = [ ];
         testlist-unspecified-with-prefixed = toResult { inherit (test-cases) test-bar-false; };
+        testlist-empty-without-prefixed = [ ];
+        testlist-empty-with-prefixed = toResult { inherit (test-cases) test-bar-false; };
         testlist-nonempty = toResult { inherit (test-cases) foo-false; };
       };
     };


### PR DESCRIPTION
This PR fixes `lib.runTests`'s evaluation failure when `tests.tests` is specified as an empty list.

By the implementation of the test selection logic in `lib.debug.runTests`, it is meant to work when `tests.tests` is specified empty, but such situation currently results in an evaluation failure.

By `lib.debug.runTests`'s documentation, `tests.tests` specifies the subset of tests to run as a list, which itself is not a test case. It should be excluded from the test case mapping logic, hence this PR.

If applied, this PR will fix the behaviour of `lib.runTests` when `tests.tests == [ ]` and other potential complication caused by the falsely-processed `tests.tests`.

All rebuilds results from `lib/debug.nix` being modified. `lib.runTests` itself should cause no rebuilds.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
