### PR TITLE
onedriver: bump to fuse3

### DIFF
--- a/pkgs/by-name/on/onedriver/package.nix
+++ b/pkgs/by-name/on/onedriver/package.nix
@@ -5,7 +5,7 @@
   pkg-config,
   webkitgtk_4_1,
   glib,
-  fuse,
+  fuse3,
   installShellFiles,
   wrapGAppsHook3,
   glib-networking,
@@ -34,7 +34,7 @@ buildGoModule {
   buildInputs = [
     webkitgtk_4_1
     glib
-    fuse
+    fuse3
     glib-networking
   ];
 
@@ -63,7 +63,7 @@ buildGoModule {
 
     substituteInPlace $out/lib/systemd/user/onedriver@.service \
       --replace-fail "/usr/bin/onedriver" "$out/bin/onedriver" \
-      --replace-fail "/usr/bin/fusermount" "${wrapperDir}/fusermount"
+      --replace-fail "/usr/bin/fusermount3" "${wrapperDir}/fusermount3"
   '';
 
   meta = {


### PR DESCRIPTION
Updated `onedriver` to use `fuse3` as requested in #526161

# Report

Checked `fuse3` is now used somewhere:
```bash
$ grep ExecStopPost ./result/share/systemd/user/onedriver@.service
ExecStopPost=/run/wrappers/bin/fusermount3 -uz /%I
```

Stopped my running instance and started the new binary
```bash
$ systemctl stop --user onedriver-onedrive.service
$ pgrep onedriver -a
# NOTHING
$ ./result/bin/onedriver --log error ~/mydrive
11:33:03 WRN Configuration file not found, using defaults. error="open /home/user/.config/onedriver/config.yml: no such file or directory" path=/home/user/.config/onedriver/config.yml
2026/06/06 11:33:04 Unimplemented opcode OPCODE-52
^Z
[1]+  Stopped                    ./result/bin/onedriver ~/mydrive
```
<details>
<summary>
NOTE: the OPCODE-52 is unimplemented from go-fuse but I didn't find any issues about it
</summary>

```
$ parallel gh search {1} --repo {2} OPCODE-52 ::: issues prs ::: jstaf/onedriver hanwen/go-fuse
hanwen/go-fuse	188	closed	If total length of data is less than off read entire data slice		2017-10-06T23:00:05Z
hanwen/go-fuse	289	closed	nodefs: add TestReadDirStress		2019-04-08T07:05:28Z
jstaf/onedriver	424	open	SIGSEGV at onedriver/fs.(*Filesystem).Open(0xc0002540e0, 0x590798?, 0xc0005123d8, 0x7eb0e0?)		2025-08-13T11:40:19Z
hanwen/go-fuse	593	open	asynchronous IO processing at FUSE layer		2026-01-10T19:53:18Z
hanwen/go-fuse	351	open	fs: Tests are flaky		2024-10-29T10:04:27Z
hanwen/go-fuse	546	closed	Panic in init on macOS 15.1.1 build 24B91 with v2.7.0		2024-11-22T06:33:58Z
hanwen/go-fuse	16	closed	MAC issues, fixes		2016-07-29T17:07:58Z
hanwen/go-fuse	14	closed	Handling INTERRUPT requests		2019-04-12T06:51:01Z
hanwen/go-fuse	96	closed	unionfs self tests fail 20% of the time on Linux 4.4		2019-01-26T13:31:36Z
hanwen/go-fuse	179	closed	First Write operation works, but none thereafter		2017-08-11T11:52:29Z
hanwen/go-fuse	281	closed	regression: 05a3771 "fuse: Enable parallel lookup and readdir by default" causes hangs		2020-03-23T16:02:13Z
hanwen/go-fuse	261	closed	Tests get stuck.		2021-01-25T16:29:13Z
```
</details>

While it was still running I accessed the drive
```bash
$ pgrep -a onedriver && ls ~/mydrive
30301 ./result/bin/onedriver /home/user/mydrive
...
# WORKED: FILES REDACTED
```

Now I stopped the binary
```bash
$ fg
./result/bin/onedriver ~/mydrive
^C11:37:32 INF Signal received, unmounting filesystem. signal=INTERRUPT
```
As it said it unmounted cleanly:
```bash
$ fusermount3 -uz ~/mydrive
/nix/store/m47d8x8m4zdk5l9sb26rxmfc2gkvb6h4-fuse-3.17.4-bin/bin/fusermount3: entry for /home/user/mydrive not found in /etc/mtab
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
