### PR TITLE
phredsort: init at 1.4.0

### DIFF
--- a/pkgs/by-name/ph/phredsort/package.nix
+++ b/pkgs/by-name/ph/phredsort/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+}:
+buildGoModule (finalAttrs: {
+  pname = "phredsort";
+  version = "1.4.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "vmikk";
+    repo = "phredsort";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-kZzEfX+1fBZS5vLV4qfAF5mJh9/ev+I6lRTR2B1dCMc=";
+  };
+
+  vendorHash = "sha256-ntOZAr78luezOJftbveq4X4GOr+6DUe3oxE610C5ORs=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = {
+    description = "CLI tool for sorting sequences in a FASTQ file by their quality scores";
+    homepage = "https://github.com/vmikk/phredsort";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ artur-sannikov ];
+  };
+})


### PR DESCRIPTION
`phredsort` is a cli tool for sorting sequences in a FASTQ file by their quality scores,

Repo: https://github.com/vmikk/phredsort

## Things done

Tested basic functions with https://zenodo.org/records/3736457/files/1_control_psbA3_2019_minq7.fastq.

```
phredsort -i 1_control_psbA3_2019_minq7.fastq -o output.fastq  --metric maxee --minqual 20 --maxqual 40
```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
