### PR TITLE
ueransim: 3.2.8 -> 3.3.0

### DIFF
--- a/pkgs/by-name/ue/ueransim/package.nix
+++ b/pkgs/by-name/ue/ueransim/package.nix
@@ -4,7 +4,6 @@
   cmake,
   pkg-config,
   fetchFromGitHub,
-  fetchpatch,
   lksctp-tools,
   iproute2,
   nix-update-script,
@@ -12,13 +11,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "ueransim";
-  version = "3.2.8";
+  version = "3.3.0";
 
   src = fetchFromGitHub {
     owner = "aligungr";
     repo = "ueransim";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-dnFGPEgnmbx+ehfeas1Imv8G7s8snd7P2h70E3PtmuY=";
+    hash = "sha256-lTo/XYkRddyNdOpNO7MIAwq5mKMHDarCVzXjDomeXec=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/aligungr/UERANSIM/compare/v3.2.8...v3.3.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
