### PR TITLE
asymptote: 3.11 -> 3.12

### DIFF
--- a/pkgs/by-name/as/asymptote/package.nix
+++ b/pkgs/by-name/as/asymptote/package.nix
@@ -30,10 +30,12 @@
   curl,
   texinfo,
   texliveSmall,
+  vulkan-headers,
+  glfw,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "3.11";
+  version = "3.12";
   pname = "asymptote";
 
   outputs = [
@@ -46,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://sourceforge/asymptote/${finalAttrs.version}/asymptote-${finalAttrs.version}.src.tgz";
-    hash = "sha256-U36fImIb+E8J7g1E3EVcTqkboZODDx12JKB9RxDX59E=";
+    hash = "sha256-6uwel0Y+8hOjk8OI1GanNHiwgY+UA8liuRJAZZybjxs=";
   };
 
   # override with TeX Live containers to avoid building sty, docs from source
@@ -111,6 +113,8 @@ stdenv.mkDerivation (finalAttrs: {
         pyqt5
       ]
     ))
+    vulkan-headers
+    glfw
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [ libtirpc ];
 


### PR DESCRIPTION
Update to version 3.12

- Added `vulkan-headers` and `glfw` to `buildInputs` to support the new
  Vulkan renderer introduced in this release.

- **Release notes:** https://asymptote.sourceforge.io/ReleaseNotes

_- **Note on `nixpkgs-review`:** The Asymptote derivation builds perfectly,
  but `nixpkgs-review` caught several downstream reverse-dependencies
  failing (like `haskellPackages.reanimate` and `qmk`), likely because they
  are incompatible with the new 3.12 Vulkan renderer._
 
**UPDATE:** nix-review succeeded. Follow for more in the comments down below.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
