### PR TITLE
python3Packages.update-copyright: migrate to pyproject, enable __structuredAttrs, use finalAttrs

### DIFF
--- a/pkgs/development/python-modules/update-copyright/default.nix
+++ b/pkgs/development/python-modules/update-copyright/default.nix
@@ -10,6 +10,8 @@ buildPythonPackage (finalAttrs: {
   version = "0.6.2";
   format = "setuptools";
 
+  __structuredAttrs = true;
+
   disabled = !isPy3k;
 
   # Has no tests

--- a/pkgs/development/python-modules/update-copyright/default.nix
+++ b/pkgs/development/python-modules/update-copyright/default.nix
@@ -5,7 +5,7 @@
   isPy3k,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "update-copyright";
   version = "0.6.2";
   format = "setuptools";
@@ -16,7 +16,8 @@ buildPythonPackage rec {
   doCheck = false;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) version;
+    pname = "update-copyright";
     sha256 = "17ybdgbdc62yqhda4kfy1vcs1yzp78d91qfhj5zbvz1afvmvdk7z";
   };
 
@@ -26,4 +27,4 @@ buildPythonPackage rec {
     homepage = "http://blog.tremily.us/posts/update-copyright";
     license = lib.licenses.gpl3;
   };
-}
+})

--- a/pkgs/development/python-modules/update-copyright/default.nix
+++ b/pkgs/development/python-modules/update-copyright/default.nix
@@ -22,6 +22,8 @@ buildPythonPackage (finalAttrs: {
     setuptools
   ];
 
+  pythonImportsCheck = [ "update_copyright" ];
+
   # Has no tests
   doCheck = false;
 

--- a/pkgs/development/python-modules/update-copyright/default.nix
+++ b/pkgs/development/python-modules/update-copyright/default.nix
@@ -32,6 +32,6 @@ buildPythonPackage (finalAttrs: {
     description = "Automatic copyright update tool";
     mainProgram = "update-copyright.py";
     homepage = "http://blog.tremily.us/posts/update-copyright";
-    license = lib.licenses.gpl3;
+    license = lib.licenses.gpl3Plus;
   };
 })

--- a/pkgs/development/python-modules/update-copyright/default.nix
+++ b/pkgs/development/python-modules/update-copyright/default.nix
@@ -3,25 +3,30 @@
   buildPythonPackage,
   fetchPypi,
   isPy3k,
+  setuptools,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "update-copyright";
   version = "0.6.2";
-  format = "setuptools";
+  pyproject = true;
 
   __structuredAttrs = true;
 
   disabled = !isPy3k;
-
-  # Has no tests
-  doCheck = false;
 
   src = fetchPypi {
     inherit (finalAttrs) version;
     pname = "update-copyright";
     sha256 = "17ybdgbdc62yqhda4kfy1vcs1yzp78d91qfhj5zbvz1afvmvdk7z";
   };
+
+  build-system = [
+    setuptools
+  ];
+
+  # Has no tests
+  doCheck = false;
 
   meta = {
     description = "Automatic copyright update tool";

--- a/pkgs/development/python-modules/update-copyright/default.nix
+++ b/pkgs/development/python-modules/update-copyright/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  isPy3k,
   setuptools,
 }:
 
@@ -12,8 +11,6 @@ buildPythonPackage (finalAttrs: {
   pyproject = true;
 
   __structuredAttrs = true;
-
-  disabled = !isPy3k;
 
   src = fetchPypi {
     inherit (finalAttrs) version;

--- a/pkgs/development/python-modules/update-copyright/default.nix
+++ b/pkgs/development/python-modules/update-copyright/default.nix
@@ -15,7 +15,7 @@ buildPythonPackage (finalAttrs: {
   src = fetchPypi {
     inherit (finalAttrs) version;
     pname = "update-copyright";
-    sha256 = "17ybdgbdc62yqhda4kfy1vcs1yzp78d91qfhj5zbvz1afvmvdk7z";
+    hash = "sha256-/8y263Yq/L1+kdDhkBo69/ug2Q7eTaIaxF4Y1tZry58=";
   };
 
   build-system = [


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974
- use finalAttrs
- enable structuredAttrs
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
