### PR TITLE
libpaper: 1.1.29 -> 2.2.8

### DIFF
--- a/pkgs/by-name/li/libpaper/package.nix
+++ b/pkgs/by-name/li/libpaper/package.nix
@@ -6,12 +6,12 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "1.1.29";
+  version = "2.2.8";
   pname = "libpaper";
 
   src = fetchurl {
-    url = "mirror://debian/pool/main/libp/libpaper/libpaper_${finalAttrs.version}.tar.gz";
-    hash = "sha256-JjMOIemjEkZY1RX9hQsM3lRv9C2JsllqUmTF8Wd/BUc=";
+    url = "https://github.com/rrthomas/libpaper/releases/download/v${finalAttrs.version}/libpaper-${finalAttrs.version}.tar.gz";
+    hash = "sha256-HjMFcWkBkYdOykFex2iJ3RG6uYh6IwLWo2Zc0IHE13s=";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
@@ -36,9 +36,15 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
+    changelog = "https://github.com/rrthomas/libpaper/releases/tag/v${finalAttrs.version}";
     description = "Library for handling paper characteristics";
-    homepage = "http://packages.debian.org/unstable/source/libpaper";
-    license = lib.licenses.gpl2;
+    homepage = "https://github.com/rrthomas/libpaper";
+    license = with lib.licenses; [
+      gpl2Only
+      gpl3Plus
+      mit
+      publicDomain
+    ];
     platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
Diff: https://github.com/rrthomas/libpaper/compare/v1.1.29...v2.2.8


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
