### PR TITLE
python3Packages.pickleshare: migrate to pyproject, enable __structuredAttrs, use finalAttrs

### DIFF
--- a/pkgs/development/python-modules/pickleshare/default.nix
+++ b/pkgs/development/python-modules/pickleshare/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "Tiny 'shelve'-like database with concurrency support";
-    homepage = "https://github.com/vivainio/pickleshare";
+    homepage = "https://github.com/ipython/pickleshare";
     license = lib.licenses.mit;
   };
 })

--- a/pkgs/development/python-modules/pickleshare/default.nix
+++ b/pkgs/development/python-modules/pickleshare/default.nix
@@ -5,13 +5,13 @@
   path,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   version = "0.7.5";
   format = "setuptools";
   pname = "pickleshare";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     sha256 = "87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca";
   };
 
@@ -25,4 +25,4 @@ buildPythonPackage rec {
     homepage = "https://github.com/vivainio/pickleshare";
     license = lib.licenses.mit;
   };
-}
+})

--- a/pkgs/development/python-modules/pickleshare/default.nix
+++ b/pkgs/development/python-modules/pickleshare/default.nix
@@ -10,6 +10,8 @@ buildPythonPackage (finalAttrs: {
   format = "setuptools";
   pname = "pickleshare";
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
     inherit (finalAttrs) pname version;
     sha256 = "87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca";

--- a/pkgs/development/python-modules/pickleshare/default.nix
+++ b/pkgs/development/python-modules/pickleshare/default.nix
@@ -2,13 +2,14 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   path,
 }:
 
 buildPythonPackage (finalAttrs: {
-  version = "0.7.5";
-  format = "setuptools";
   pname = "pickleshare";
+  version = "0.7.5";
+  pyproject = true;
 
   __structuredAttrs = true;
 
@@ -17,7 +18,9 @@ buildPythonPackage (finalAttrs: {
     sha256 = "87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca";
   };
 
-  propagatedBuildInputs = [ path ];
+  build-system = [ setuptools ];
+
+  dependencies = [ path ];
 
   # No proper test suite
   doCheck = false;


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974
- use `finalAttrs`
- enable `__structuredAttrs`
- update homepage
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
