### PR TITLE
flatpak: fix fontconfig path remap

### DIFF
--- a/pkgs/by-name/fl/flatpak/fix-fonts-icons.patch
+++ b/pkgs/by-name/fl/flatpak/fix-fonts-icons.patch
@@ -66,7 +66,7 @@ index 94ad013..5c9f55e 100644
 +                              NULL);
 +      g_string_append_printf (xml_snippet,
 +                              "\t<remap-dir as-path=\"%s\">/run/host/fonts</remap-dir>\n",
-+                              "/run/current-system/sw/share/X11/fonts");
++                              "/usr/share/fonts");
 +    }
  
    if (g_file_test ("/usr/local/share/fonts", G_FILE_TEST_EXISTS))


### PR DESCRIPTION
This PR aims to fix fonts in flatpaks. The previous path in the patch (/run/current-system/sw/share/X11/fonts) is wrong because flatpak never looks at that dir. Fixed by updating the dir in the remap to /usr/share/fonts. This way, flatpaks should look at /run/host/fonts where fonts are bind mounted inside the flatpak container. More details in the issue #528859.

fixes #345517. fixes #528859.

AI was used for investigation and to review the changes. The actual changes where made by hand.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
