### PR TITLE
libpqxx: 7.10.7 -> 8.0.1

### DIFF
--- a/pkgs/by-name/li/libpqxx/package.nix
+++ b/pkgs/by-name/li/libpqxx/package.nix
@@ -1,26 +1,23 @@
 {
   lib,
   stdenv,
-  gcc14Stdenv,
+  cmake,
   fetchFromGitHub,
   libpq,
   python3,
   postgresql,
   postgresqlTestHook,
-  autoreconfHook,
 }:
 
-# Work around issue reported in https://github.com/NixOS/nixpkgs/issues/476278.
-# Should be solved when libpqxx 8.x is released.
-gcc14Stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libpqxx";
-  version = "7.10.7";
+  version = "8.0.1";
 
   src = fetchFromGitHub {
     owner = "jtv";
     repo = "libpqxx";
-    rev = finalAttrs.version;
-    hash = "sha256-A33Z6xSIReYHHS3KerBSDTuo59tixduxXVEMfa/2I7A=";
+    tag = finalAttrs.version;
+    hash = "sha256-b7NgMzqu0VkAFZPmaeE0eOmsedL76MvFtWKlmD8UfAo=";
   };
 
   outputs = [
@@ -29,8 +26,7 @@ gcc14Stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeBuildInputs = [
-    # Needed because Makefile.am is patched to disable the tools/lint test.
-    autoreconfHook
+    cmake
     python3
   ];
 
@@ -44,21 +40,25 @@ gcc14Stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
-    # Disable linting step for tests, it tries to install packages with pip.
-    substituteInPlace Makefile.am \
-      --replace-fail "TESTS = tools/lint" ""
-
-    patchShebangs ./tools/splitconfig.py
-    # Needed for autoreconfHook
-    patchShebangs tools/*.py
+    substituteInPlace src/CMakeLists.txt \
+      --replace-fail '"\''${prefix}/''${CMAKE_INSTALL_INCLUDEDIR}' '"''${CMAKE_INSTALL_FULL_INCLUDEDIR}' \
+      --replace-fail '"\''${prefix}/''${CMAKE_INSTALL_LIBDIR}' '"''${CMAKE_INSTALL_FULL_LIBDIR}'
   '';
 
-  configureFlags = [
-    "--disable-documentation"
-    "--enable-shared"
+  cmakeFlags = [
+    "-DBUILD_DOC=OFF"
+    "-DBUILD_SHARED_LIBS=ON"
   ];
 
   doCheck = lib.meta.availableOn stdenv.hostPlatform postgresqlTestHook;
+
+  checkPhase = ''
+    runHook preCheck
+
+    test/runner
+
+    runHook postCheck
+  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
Diff: https://github.com/jtv/libpqxx/compare/7.10.7...8.0.1

Changelog:
https://github.com/jtv/libpqxx/releases/tag/8.0.0
https://github.com/jtv/libpqxx/releases/tag/8.0.1

This breaks hydra.
cc @Conni2461 @dasJ @helsinki-Jo @Mindavi 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
