### PR TITLE
python3Packages.cuda-bindings: 12.9.6 -> 12.9.7

### DIFF
--- a/pkgs/development/python-modules/cuda-bindings/12_9.nix
+++ b/pkgs/development/python-modules/cuda-bindings/12_9.nix
@@ -3,8 +3,8 @@
   cudaLibPaths,
 }:
 {
-  version = "12.9.6";
-  sourceHash = "sha256-uRv27h2b6wXC8oOf5k2KxZ0bUFNvNu6XO05FBbJcU1k=";
+  version = "12.9.7";
+  sourceHash = "sha256-782NIynBe3YiBozwt6c/K60wOXwEJlRllLXyC9+XQLc=";
 
   nvidiaLibsPatch = replaceVars ./patch-nvidia-libs-paths_12_9.patch {
     inherit (cudaLibPaths)

--- a/pkgs/development/python-modules/cuda-bindings/patch-nvidia-libs-paths_12_9.patch
+++ b/pkgs/development/python-modules/cuda-bindings/patch-nvidia-libs-paths_12_9.patch
@@ -1,34 +1,3 @@
-diff --git a/cuda_bindings/cuda/bindings/_bindings/cynvrtc.pyx.in b/cuda_bindings/cuda/bindings/_bindings/cynvrtc.pyx.in
-index f684be6870..9437de642b 100644
---- a/cuda_bindings/cuda/bindings/_bindings/cynvrtc.pyx.in
-+++ b/cuda_bindings/cuda/bindings/_bindings/cynvrtc.pyx.in
-@@ -8,7 +8,7 @@ cimport cuda.bindings._lib.windll as windll
- {{else}}
- cimport cuda.bindings._lib.dlfcn as dlfcn
- {{endif}}
--from cuda.pathfinder import load_nvidia_dynamic_lib
-+from ctypes import CDLL
- from libc.stdint cimport intptr_t, uintptr_t
- import threading
- 
-@@ -47,7 +47,7 @@ cdef int _cuPythonInit() except -1 nogil:
-     # Load library
-     with gil, __symbol_lock:
-         {{if 'Windows' == platform.system()}}
--        handle = load_nvidia_dynamic_lib("nvrtc")._handle_uint
-+        handle = CDLL("@libnvrtc@/lib/libnvrtc.so")._handle
- 
-         # Load function
-         {{if 'nvrtcGetErrorString' in found_functions}}
-@@ -156,7 +156,7 @@ cdef int _cuPythonInit() except -1 nogil:
-         {{endif}}
- 
-         {{else}}
--        handle = <void*><uintptr_t>(load_nvidia_dynamic_lib("nvrtc")._handle_uint)
-+        handle = <void*><uintptr_t>(CDLL("@libnvrtc@/lib/libnvrtc.so")._handle)
- 
-         # Load function
-         {{if 'nvrtcGetErrorString' in found_functions}}
 diff --git a/cuda_bindings/cuda/bindings/_internal/cufile_linux.pyx b/cuda_bindings/cuda/bindings/_internal/cufile_linux.pyx
 index 78ea77b283..0b875a6cd3 100644
 --- a/cuda_bindings/cuda/bindings/_internal/cufile_linux.pyx
@@ -96,7 +65,7 @@ index d676aac372..ed3c000566 100644
  
  
 diff --git a/cuda_bindings/cuda/bindings/_internal/nvml_linux.pyx b/cuda_bindings/cuda/bindings/_internal/nvml_linux.pyx
-index 28f0919423..852f75e46d 100644
+index 51f6e8205b..233160cc24 100644
 --- a/cuda_bindings/cuda/bindings/_internal/nvml_linux.pyx
 +++ b/cuda_bindings/cuda/bindings/_internal/nvml_linux.pyx
 @@ -10,7 +10,7 @@ import threading
@@ -108,7 +77,7 @@ index 28f0919423..852f75e46d 100644
  
  
  ###############################################################################
-@@ -406,7 +406,7 @@ cdef void* __nvmlDeviceSetRusdSettings_v1 = NULL
+@@ -414,7 +414,7 @@ cdef void* __nvmlGpuInstanceSetVgpuSchedulerState_v2 = NULL
  
  
  cdef void* load_library() except* with gil:
@@ -117,8 +86,30 @@ index 28f0919423..852f75e46d 100644
      return <void*>handle
  
  
+diff --git a/cuda_bindings/cuda/bindings/_internal/nvrtc_linux.pyx b/cuda_bindings/cuda/bindings/_internal/nvrtc_linux.pyx
+index d3eb62be13..6d5d093c1b 100644
+--- a/cuda_bindings/cuda/bindings/_internal/nvrtc_linux.pyx
++++ b/cuda_bindings/cuda/bindings/_internal/nvrtc_linux.pyx
+@@ -9,7 +9,7 @@ from libc.stdint cimport intptr_t, uintptr_t
+ import threading
+ from .utils import FunctionNotFoundError, NotSupportedError
+ 
+-from cuda.pathfinder import load_nvidia_dynamic_lib
++from ctypes import CDLL
+ 
+ ###############################################################################
+ # Extern
+@@ -82,7 +82,7 @@ cdef void* __nvrtcGetPCHHeapSizeRequired = NULL
+ cdef void* __nvrtcSetFlowCallback = NULL
+ 
+ cdef void* load_library() except* with gil:
+-    cdef uintptr_t handle = load_nvidia_dynamic_lib("nvrtc")._handle_uint
++    cdef uintptr_t handle = CDLL("@libnvrtc@/lib/libnvrtc.so")._handle
+     return <void*>handle
+ 
+ cdef int _init_nvrtc() except -1 nogil:
 diff --git a/cuda_bindings/cuda/bindings/_internal/nvvm_linux.pyx b/cuda_bindings/cuda/bindings/_internal/nvvm_linux.pyx
-index 8a84834a9a..a3ced66807 100644
+index 03ade4f939..0385da3087 100644
 --- a/cuda_bindings/cuda/bindings/_internal/nvvm_linux.pyx
 +++ b/cuda_bindings/cuda/bindings/_internal/nvvm_linux.pyx
 @@ -9,7 +9,7 @@ from libc.stdint cimport intptr_t, uintptr_t
@@ -130,7 +121,7 @@ index 8a84834a9a..a3ced66807 100644
  
  
  ###############################################################################
-@@ -75,7 +75,7 @@ cdef void* __nvvmGetProgramLog = NULL
+@@ -76,7 +76,7 @@ cdef void* __nvvmLLVMVersion = NULL
  
  
  cdef void* load_library() except* with gil:
@@ -167,12 +158,3 @@ index 5cd65fbd96..fbbcffbbb7 100644
          {{endif}}
  
      {{if 'Windows' == platform.system()}}
-diff --git a/cuda_bindings/cuda/bindings/nvml.pyx b/cuda_bindings/cuda/bindings/nvml.pyx
-index 42c9fdcc87..0661379a68 100644
---- a/cuda_bindings/cuda/bindings/nvml.pyx
-+++ b/cuda_bindings/cuda/bindings/nvml.pyx
-@@ -27471,4 +27471,3 @@ cpdef str vgpu_type_get_name(unsigned int vgpu_type_id):
-         __status__ = nvmlVgpuTypeGetName(<nvmlVgpuTypeId_t>vgpu_type_id, vgpu_type_name, <unsigned int*>size)
-     check_status(__status__)
-     return cpython.PyUnicode_FromStringAndSize(vgpu_type_name, size[0])
--


### PR DESCRIPTION
## Things done

Diff: https://github.com/NVIDIA/cuda-python/compare/v12.9.6...v12.9.7
Changelog: https://github.com/NVIDIA/cuda-python/releases/tag/v12.9.7

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
