### PR TITLE
libretro.potator: init at 0-unstable-2026-06-04

### DIFF
--- a/pkgs/applications/emulators/libretro/cores/potator.nix
+++ b/pkgs/applications/emulators/libretro/cores/potator.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkLibretroCore,
+}:
+mkLibretroCore {
+  core = "potator";
+  version = "0-unstable-2026-06-04";
+
+  src = fetchFromGitHub {
+    owner = "libretro";
+    repo = "potator";
+    rev = "227c5f6f3ce74d32e9002ce24c1420288559a860";
+    hash = "sha256-XJMwvzWfgKn594ILO5RHyGA8nxegz+qBI8DHOMSHRWw=";
+  };
+
+  makefile = "Makefile";
+  preBuild = "cd platform/libretro";
+
+  meta = {
+    description = "A Watara Supervision Emulator based on Normmatt version";
+    homepage = "https://github.com/libretro/potator";
+    license = lib.licenses.unlicense;
+  };
+}

--- a/pkgs/applications/emulators/libretro/default.nix
+++ b/pkgs/applications/emulators/libretro/default.nix
@@ -145,6 +145,8 @@ lib.makeScope newScope (self: {
 
   play = self.callPackage ./cores/play.nix { };
 
+  potator = self.callPackage ./cores/potator.nix { };
+
   ppsspp = self.callPackage ./cores/ppsspp.nix { };
 
   prboom = self.callPackage ./cores/prboom.nix { };


### PR DESCRIPTION
Added new potator libretro core for adding Watara Supervision support to Retroarch.

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [X] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].