### PR TITLE
emacs: fix build for Emacs 30 withNS on darwin

### DIFF
--- a/pkgs/applications/editors/emacs/default.nix
+++ b/pkgs/applications/editors/emacs/default.nix
@@ -1,4 +1,8 @@
-{ lib, pkgs }:
+{
+  lib,
+  pkgs,
+  stdenv,
+}:
 
 lib.makeScope pkgs.newScope (
   self:
@@ -10,7 +14,7 @@ lib.makeScope pkgs.newScope (
   in
   {
     sources = import ./sources.nix {
-      inherit lib;
+      inherit lib stdenv;
       inherit (pkgs)
         fetchFromGitHub
         fetchgit

--- a/pkgs/applications/editors/emacs/sources.nix
+++ b/pkgs/applications/editors/emacs/sources.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitHub,
   fetchgit,
+  stdenv,
 }:
 
 let
@@ -119,27 +120,36 @@ in
     variant = "mainline";
     rev = "emacs-30.2";
     hash = "sha256-3Lfb3HqdlXqSnwJfxe7npa4GGR9djldy8bKRpkQCdSA=";
-    patches = fetchpatch: [
-      (fetchpatch {
-        name = "fix-off-by-one-mistake-80851-CVE-2026-6861.patch";
-        url = "https://cgit.git.savannah.gnu.org/cgit/emacs.git/patch/?id=8f535370b9efbc91673b20c6987a5cae4f6dc562";
-        hash = "sha256-ny44eIi8DUa9pQhVGzhGz4H6FXU4+ki86SITLXhkwpw=";
-      })
-      (builtins.path {
-        name = "inhibit-lexical-cookie-warning-67916.patch";
-        path = ./inhibit-lexical-cookie-warning-67916-30.patch;
-      })
-      (fetchpatch {
-        # tree-sitter 0.26 compatibility fix, see https://bugs.gentoo.org/970856
-        url = "https://gitweb.gentoo.org/proj/emacs-patches.git/plain/emacs/30.2/01_all_treesit-0.26.patch?id=d0f47979806d9be5a190fdb4ffa1bde439b2d616";
-        hash = "sha256-3pWeRxjAhr3ntBR3xDhoDUZDjU6xICU23NUpb/Vl6R4=";
-      })
-      (fetchpatch {
-        # tree-sitter 0.26 compatibility fix, see https://bugs.gentoo.org/971731
-        url = "https://gitweb.gentoo.org/proj/emacs-patches.git/plain/emacs/30.2/02_all_ts-query-pred.patch?id=86190bf195b3e17108372d8ad89eb57037180dd2";
-        hash = "sha256-0GPyfKLSaB09a8hamrSf6lx4Qk8Big4AKMOivkN1wEM=";
-      })
-    ];
+    patches =
+      fetchpatch:
+      [
+        (fetchpatch {
+          name = "fix-off-by-one-mistake-80851-CVE-2026-6861.patch";
+          url = "https://cgit.git.savannah.gnu.org/cgit/emacs.git/patch/?id=8f535370b9efbc91673b20c6987a5cae4f6dc562";
+          hash = "sha256-ny44eIi8DUa9pQhVGzhGz4H6FXU4+ki86SITLXhkwpw=";
+        })
+        (builtins.path {
+          name = "inhibit-lexical-cookie-warning-67916.patch";
+          path = ./inhibit-lexical-cookie-warning-67916-30.patch;
+        })
+        (fetchpatch {
+          # tree-sitter 0.26 compatibility fix, see https://bugs.gentoo.org/970856
+          url = "https://gitweb.gentoo.org/proj/emacs-patches.git/plain/emacs/30.2/01_all_treesit-0.26.patch?id=d0f47979806d9be5a190fdb4ffa1bde439b2d616";
+          hash = "sha256-3pWeRxjAhr3ntBR3xDhoDUZDjU6xICU23NUpb/Vl6R4=";
+        })
+        (fetchpatch {
+          # tree-sitter 0.26 compatibility fix, see https://bugs.gentoo.org/971731
+          url = "https://gitweb.gentoo.org/proj/emacs-patches.git/plain/emacs/30.2/02_all_ts-query-pred.patch?id=86190bf195b3e17108372d8ad89eb57037180dd2";
+          hash = "sha256-0GPyfKLSaB09a8hamrSf6lx4Qk8Big4AKMOivkN1wEM=";
+        })
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [
+        (fetchpatch {
+          # backport fix of bug#79879 to build Emacs 30 withNS on darwin
+          url = "https://cgit.git.savannah.gnu.org/cgit/emacs.git/patch/?id=85f2bf2bc7ba0a6557e992601658530f562e00d2";
+          hash = "sha256-Iu/9BOLe6nb9DhlsyjWeCx/qfHM9N3hOq+6g0PnZ1NY=";
+        })
+      ];
   });
 
   emacs30-macport = import ./make-emacs.nix (mkArgs {


### PR DESCRIPTION
#529355 has a better fix, this PR is more for context

---

In 04b2b5057bc33fa78cfc19a7fb414d84a622384d (#528448), we changed emacs.src from release tarballs to git source, which made Emacs 30 withNS on darwin fail to build due to an upstream Emacs bug#79879[1]. This patch backports upstream fix[2] (actually, I think it is more of a workaround) to Emacs 30 on darwin to make it build again.

Some details about the bug:

Emacs 30 configure.ac adds "--std=c99" to compile Objective-C files if the compiler by default does not support C99.  New autoconf, such as 2.73, defaults[3] to C23.  As a result, Objective-C files are compiled with flags like this "clang --std=gnu23 ... --std=c99 nsfns.m", which can be seen by passing "V=1" to `make`.  So the build fails.

I think the upstream fix[2] is more of a workaround because when they check if the compiler by default supports C99, they are checking against `gcc` instead of `clang` which is actually used to build Objective-C files.  I have verified that `clang` by default supports C99 so if they are checking correctly against `clang`, Emacs 30 withNS can be built on darwin without any patch.  I created #529355 to fix the mischeck.

[1]: https://debbugs.gnu.org/cgi/bugreport.cgi?bug=79879
[2]: https://cgit.git.savannah.gnu.org/cgit/emacs.git/commit/?id=85f2bf2bc7ba0a6557e992601658530f562e00d2
[3]: https://lists.gnu.org/archive/html/autoconf/2026-03/msg00060.html

---

The build failure was investigated by @marienz, @panchoh and me.  @marienz has many interesting findings, such as autoconf-2.73 defaulting to C23 and the link to upstream fix[2].

Review tip: hide whitespace https://github.com/NixOS/nixpkgs/pull/529324/changes?w=1

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
