### PR TITLE
libretro.px68k: init at 0-unstable-2026-04-20

### DIFF
--- a/pkgs/applications/emulators/libretro/cores/px68k.nix
+++ b/pkgs/applications/emulators/libretro/cores/px68k.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkLibretroCore,
+}:
+mkLibretroCore {
+  core = "px68k";
+  version = "0-unstable-2026-04-20";
+
+  src = fetchFromGitHub {
+    owner = "libretro";
+    repo = "px68k-libretro";
+    rev = "45dfd4005434d1199b01fb74a5371ec9bc513164";
+    hash = "sha256-LA+m+BROJ1bm2v9YgLkEmfLYW0gF9/jOu/Sr7kze8gY=";
+  };
+
+  makefile = "Makefile";
+
+  meta = {
+    description = "Portable SHARP X68000 Emulator for Libretro";
+    homepage = "https://github.com/libretro/px68k-libretro";
+    license = lib.licenses.gpl2Only;
+  };
+}

--- a/pkgs/applications/emulators/libretro/default.nix
+++ b/pkgs/applications/emulators/libretro/default.nix
@@ -155,6 +155,8 @@ lib.makeScope newScope (self: {
 
   puae2021 = self.callPackage ./cores/puae2021.nix { };
 
+  px68k = self.callPackage ./cores/px68k.nix { };
+
   quicknes = self.callPackage ./cores/quicknes.nix { };
 
   same_cdi = self.callPackage ./cores/same_cdi.nix { }; # the name is not a typo


### PR DESCRIPTION
Addition of px86k core for libretro to support for emulating Sharp X68000 to RetroArch.
 
- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [X] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].