### PR TITLE
simulide: 1.1.0-SR1 -> 1.1.0-SR2

### DIFF
--- a/pkgs/by-name/si/simulide/package.nix
+++ b/pkgs/by-name/si/simulide/package.nix
@@ -29,19 +29,20 @@ let
       };
     };
     "1.1.0" = rec {
-      release = "SR1";
-      rev = "2005";
-      src = fetchbzr {
-        url = "https://code.launchpad.net/~arcachofo/simulide/1.1.0";
-        sha256 = "sha256-YVQduUjPQF5KxMlm730FZTShHP/7JEcAMIFn+mQITrQ=";
+      release = "SR2";
+      rev = "28965e3bd6dd118598db1f5639ce1cf2e3c56e36";
+      src = fetchFromGitHub {
+        owner = "Arcachofo";
+        repo = "SimuliDE_110";
         inherit rev;
+        hash = "sha256-Ec72OE4xBlanFFzrrGu0lTY2BEVu7slc1+ZDFr8lUT8=";
       };
     };
     "1.2.0" = rec {
       release = "RC1";
       rev = "da3a925491fab9fa2a8633d18e45f8e1b576c9d2";
       src = fetchFromGitHub {
-        owner = "eeTools";
+        owner = "Arcachofo";
         repo = "SimulIDE-dev";
         hash = "sha256-6Gh0efBizDK1rUNkyU+/ysj7QwkAs3kTA1mQZYFb/pI=";
         inherit rev;

--- a/pkgs/by-name/si/simulide/package.nix
+++ b/pkgs/by-name/si/simulide/package.nix
@@ -168,7 +168,8 @@ stdenv.mkDerivation {
       It supports PIC, AVR, Arduino and other MCUs and MPUs.
     '';
     homepage = "https://simulide.com/";
-    license = lib.licenses.gpl3Only;
+    license =
+      if lib.versionAtLeast versionNum "1.1.0" then lib.licenses.agpl3Only else lib.licenses.gpl3Only;
     mainProgram = "simulide";
     maintainers = with lib.maintainers; [
       carloscraveiro


### PR DESCRIPTION
Development is happening on GitHub now, so I guess the dev created a separate repo for the earlier, `bzr`-only release.

The dev moved the project back to their own GitHub profile from `eeTools`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
