### PR TITLE
dtrx: cleanup

### DIFF
--- a/pkgs/by-name/dt/dtrx/package.nix
+++ b/pkgs/by-name/dt/dtrx/package.nix
@@ -64,8 +64,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
     ''--prefix PATH : "${lib.makeBinPath archivers}"''
   ];
 
-  build-system = with python3Packages; [
-    setuptools
+  build-system = [
+    python3Packages.setuptools
   ];
 
   nativeCheckInputs = archivers ++ [

--- a/pkgs/by-name/dt/dtrx/package.nix
+++ b/pkgs/by-name/dt/dtrx/package.nix
@@ -1,24 +1,24 @@
 {
-  lib,
+  binutils,
+  bzip2,
+  cabextract,
+  cpio,
   fetchFromGitHub,
   gitUpdater,
-  python3Packages,
   gnutar,
-  unzip,
-  lhasa,
-  rpm,
-  binutils,
-  cpio,
   gzip,
+  lhasa,
+  lib,
+  lzip,
   p7zip,
-  cabextract,
+  python3Packages,
+  rpm,
   unrar,
   unshield,
-  bzip2,
+  unzip,
   xz,
-  lzip,
-  unzipSupport ? false,
   unrarSupport ? false,
+  unzipSupport ? false,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
@@ -37,21 +37,21 @@ python3Packages.buildPythonApplication (finalAttrs: {
     let
       archivers = lib.makeBinPath (
         [
-          gnutar
-          lhasa
-          rpm
           binutils
-          cpio
-          gzip
-          p7zip
-          cabextract
-          unshield
           bzip2
-          xz
+          cabextract
+          cpio
+          gnutar
+          gzip
+          lhasa
           lzip
+          p7zip
+          rpm
+          unshield
+          xz
         ]
-        ++ lib.optional unzipSupport unzip
         ++ lib.optional unrarSupport unrar
+        ++ lib.optional unzipSupport unzip
       );
     in
     [

--- a/pkgs/by-name/dt/dtrx/package.nix
+++ b/pkgs/by-name/dt/dtrx/package.nix
@@ -20,7 +20,24 @@
   unrarSupport ? false,
   unzipSupport ? false,
 }:
-
+let
+  archivers = [
+    binutils
+    bzip2
+    cabextract
+    cpio
+    gnutar
+    gzip
+    lhasa
+    lzip
+    p7zip
+    rpm
+    unshield
+    xz
+  ]
+  ++ lib.optional unrarSupport unrar
+  ++ lib.optional unzipSupport unzip;
+in
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "dtrx";
   version = "8.7.1";
@@ -33,30 +50,9 @@ python3Packages.buildPythonApplication (finalAttrs: {
     sha256 = "sha256-FNSFEGIK0vDNlvqc8BKDCB/0hoxrITfeh59JcyzX3jY=";
   };
 
-  makeWrapperArgs =
-    let
-      archivers = lib.makeBinPath (
-        [
-          binutils
-          bzip2
-          cabextract
-          cpio
-          gnutar
-          gzip
-          lhasa
-          lzip
-          p7zip
-          rpm
-          unshield
-          xz
-        ]
-        ++ lib.optional unrarSupport unrar
-        ++ lib.optional unzipSupport unzip
-      );
-    in
-    [
-      ''--prefix PATH : "${archivers}"''
-    ];
+  makeWrapperArgs = [
+    ''--prefix PATH : "${lib.makeBinPath archivers}"''
+  ];
 
   build-system = with python3Packages; [
     setuptools

--- a/pkgs/by-name/dt/dtrx/package.nix
+++ b/pkgs/by-name/dt/dtrx/package.nix
@@ -1,14 +1,18 @@
 {
+  arj,
   binutils,
+  brotli,
   bzip2,
   cabextract,
   cpio,
+  dtrx,
   fetchFromGitHub,
   gitUpdater,
   gnutar,
   gzip,
   lhasa,
   lib,
+  lrzip,
   lzip,
   p7zip,
   python3Packages,
@@ -17,24 +21,30 @@
   unshield,
   unzip,
   xz,
+  zstd,
+  arjSupport ? false,
   unrarSupport ? false,
   unzipSupport ? false,
 }:
 let
   archivers = [
     binutils
+    brotli
     bzip2
     cabextract
     cpio
     gnutar
     gzip
     lhasa
+    lrzip
     lzip
     p7zip
     rpm
     unshield
     xz
+    zstd
   ]
+  ++ lib.optional arjSupport arj
   ++ lib.optional unrarSupport unrar
   ++ lib.optional unzipSupport unzip;
 in
@@ -58,7 +68,28 @@ python3Packages.buildPythonApplication (finalAttrs: {
     setuptools
   ];
 
+  nativeCheckInputs = archivers ++ [
+    python3Packages.pyaml
+  ];
+
+  postPatch = ''
+    patchShebangs --build tests/compare.py
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+    tests/compare.py '^(?!download and extract$)(?!password zip noninteractive$).*'
+    runHook postCheck
+  '';
+
+  doCheck = arjSupport && unrarSupport && unzipSupport;
+
   passthru.updateScript = gitUpdater { };
+  passthru.tests.dtrx-full = dtrx.override {
+    arjSupport = true;
+    unrarSupport = true;
+    unzipSupport = true;
+  };
 
   meta = {
     description = "Do The Right Extraction: A tool for taking the hassle out of extracting archives";

--- a/pkgs/by-name/dt/dtrx/package.nix
+++ b/pkgs/by-name/dt/dtrx/package.nix
@@ -1,6 +1,6 @@
 {
   arj,
-  binutils,
+  binutils-unwrapped,
   brotli,
   bzip2,
   cabextract,
@@ -28,7 +28,7 @@
 }:
 let
   archivers = [
-    binutils
+    binutils-unwrapped
     brotli
     bzip2
     cabextract


### PR DESCRIPTION
- formatting/style improvements
- enable checkPhase
- enable arj, brotli, lrzip, zstd extractors
- switch binutils -> binutils-unwrapped (dtrx is primarily interested in tools like 'ar' -- it doesn't need any of the nix wrappers that adjust flags/etc).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
