### PR TITLE
kmp-lsp: init at 0.20.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3181,6 +3181,12 @@
     github = "beeb";
     githubId = 703631;
   };
+  BeLeap = {
+    name = "Changseo Jang";
+    email = "beleap@beleap.dev";
+    github = "BeLeap";
+    githubId = 46488521;
+  };
   bellackn = {
     name = "Nico Bellack";
     email = "blcknc@pm.me";

--- a/pkgs/by-name/km/kmp-lsp/package.nix
+++ b/pkgs/by-name/km/kmp-lsp/package.nix
@@ -11,6 +11,8 @@ rustPlatform.buildRustPackage rec {
   pname = "kmp-lsp";
   version = "0.20.0";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "Hessesian";
     repo = "kmp-lsp";
@@ -29,10 +31,12 @@ rustPlatform.buildRustPackage rec {
 
   postFixup = ''
     wrapProgram $out/bin/kmp-lsp \
-      --prefix PATH : ${lib.makeBinPath [
-        fd
-        ripgrep
-      ]}
+      --prefix PATH : ${
+        lib.makeBinPath [
+          fd
+          ripgrep
+        ]
+      }
   '';
 
   meta = {

--- a/pkgs/by-name/km/kmp-lsp/package.nix
+++ b/pkgs/by-name/km/kmp-lsp/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  makeWrapper,
+  fd,
+  ripgrep,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "kmp-lsp";
+  version = "0.20.0";
+
+  src = fetchFromGitHub {
+    owner = "Hessesian";
+    repo = "kmp-lsp";
+    tag = "v${version}";
+    hash = "sha256-78ooVOoySdMZAhgpDJZjqEaOEIzSPZ1mC2M79OSCt4o=";
+  };
+
+  cargoHash = "sha256-28SAdHRlOMyMgPfYzYtjfqPDCcei4uPk0X/mc4SIeYM=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  nativeCheckInputs = [
+    fd
+    ripgrep
+  ];
+
+  postFixup = ''
+    wrapProgram $out/bin/kmp-lsp \
+      --prefix PATH : ${lib.makeBinPath [
+        fd
+        ripgrep
+      ]}
+  '';
+
+  meta = {
+    description = "Fast, low-memory LSP server for Kotlin, Java, and Swift";
+    homepage = "https://github.com/Hessesian/kmp-lsp";
+    mainProgram = "kmp-lsp";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ BeLeap ];
+  };
+}


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] sandbox = relaxed
  - [ ] sandbox = true
- [x] Tested, as applicable:
  - `nix-build -A kmp-lsp --no-out-link`
  - `nix-build lib/tests/maintainers.nix --no-out-link`
  - `nix-instantiate -A kmp-lsp`
- [x] Package builds and executes basic test suite
- [x] Maintainer information is valid

## Notes

Adds kmp-lsp, a fast low-memory LSP server for Kotlin, Java, and Swift.