### PR TITLE
aflplusplus: 4.40c -> 5.00c

### DIFF
--- a/pkgs/tools/security/aflplusplus/default.nix
+++ b/pkgs/tools/security/aflplusplus/default.nix
@@ -53,7 +53,7 @@ let
 
   aflplusplus = stdenvNoCC.mkDerivation rec {
     pname = "aflplusplus";
-    version = "4.40c";
+    version = "5.00c";
 
     src = fetchFromGitHub {
       owner = "AFLplusplus";
@@ -61,9 +61,9 @@ let
       tag = "v${version}";
       hash =
         if withNyx then
-          "sha256-901rJfuMZvgUpQ6zzboa7lu9yhSyX+0u+HUk8oGsqgo="
+          "sha256-a11ff9cxaQd7I06xHDahrysuce92M5zSGsamTaFNLYU="
         else
-          "sha256-QtGazGShjybvjOONoWjqSg/c+l5sPpaFuuTI2S85YQM=";
+          "sha256-lox5UYCSjp4Vu6oBc5+wZDBAufGaCiVxJqp74LDrw8k=";
       fetchSubmodules = withNyx;
     };
 
@@ -251,7 +251,10 @@ let
       '';
       homepage = "https://aflplus.plus";
       changelog = "https://aflplus.plus/docs/changelog";
-      license = lib.licenses.asl20;
+      license = [
+        lib.licenses.asl20
+        lib.licenses.agpl3Plus
+      ];
       platforms = [
         "x86_64-linux"
         "i686-linux"


### PR DESCRIPTION
https://github.com/AFLplusplus/AFLplusplus/releases/tag/v5.00c

Note: license changed between 4.40c and 5.00c.

Tested by building with and without Nyx mode, and tried running afl-fuzz on system perl for a few seconds, seems to work.
`(nix-build --expr '(import ./. {}).aflplusplus.override { withNyx = false; }')` and `withNyx = true;`

I wasn't sure of the nix-build syntax, so I had to search how to override package attributes. I think this particular nix-build command syntax came from an AI summary(?), and I slightly modified it to override the correct package and attribute.

Tested afl-fuzz with following command: `/nix/store/pf9wa55r45knd5z2b75ji5r42b7vrahn-aflplusplus-5.00c/bin/afl-fuzz -i input -o output -Q /run/current-system/sw/bin/perl '@@'`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
