### PR TITLE
t3code: add code-cursor runtime option

### DIFF
--- a/pkgs/by-name/t3/t3code/package.nix
+++ b/pkgs/by-name/t3/t3code/package.nix
@@ -27,6 +27,8 @@
   claude-code,
   enableCodex ? true,
   codex,
+  enableCursor ? false,
+  code-cursor,
   enableGitHub ? true,
   gh,
   enableGit ? true,
@@ -55,6 +57,7 @@ stdenv.mkDerivation (
       ++ lib.optionals enableBitbucket [ bitbucket-cli ]
       ++ lib.optionals enableClaude [ claude-code ]
       ++ lib.optionals enableCodex [ codex ]
+      ++ lib.optionals enableCursor [ code-cursor ]
       ++ lib.optionals enableGitHub [ gh ]
       ++ lib.optionals enableGit [ git ]
       ++ lib.optionals enableGitLab [ glab ]


### PR DESCRIPTION
Adds an optional `enableCursor` runtime dependency for `t3code`, matching the existing optional agent integrations such as Claude and Codex.

When enabled, `code-cursor` is included in the runtime `PATH` used by the `t3code` wrappers, so T3 Code can find Cursor in the same way it can find other supported coding agents.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows [automation/AI policy].