### PR TITLE
gitlab-ci-local: 4.64.1 -> 4.73.0

### DIFF
--- a/pkgs/by-name/gi/gitlab-ci-local/package.nix
+++ b/pkgs/by-name/gi/gitlab-ci-local/package.nix
@@ -1,45 +1,114 @@
 {
   stdenv,
-  buildNpmPackage,
+  bun,
+  nodejs-slim,
   fetchFromGitHub,
   lib,
   nix-update-script,
-  gitlab-ci-local,
-  testers,
-  makeBinaryWrapper,
+  makeWrapper,
+  installShellFiles,
+  writableTmpDirAsHomeHook,
+  versionCheckHook,
   rsync,
   gitMinimal,
 }:
 
-buildNpmPackage rec {
+let
   pname = "gitlab-ci-local";
-  version = "4.64.1";
+  version = "4.73.0";
 
   src = fetchFromGitHub {
     owner = "firecow";
     repo = "gitlab-ci-local";
     rev = version;
-    hash = "sha256-scZ6KqpO/E3Ycu6Nn5o/4LaEpSAOWim8mOqpByjZlZE=";
+    hash = "sha256-gwjTnDc/JI645lLuaAz0gjIsBIxLFzJTMCsmrUKIz6U=";
   };
 
-  npmDepsHash = "sha256-IoycsUU+7o4A3d+pGQvyBvaIqg7fdvwS8Pay9MmRqM4=";
+  node_modules = stdenv.mkDerivation {
+    pname = "${pname}-node_modules";
+    inherit version src;
+
+    nativeBuildInputs = [
+      bun
+      writableTmpDirAsHomeHook
+    ];
+
+    strictDeps = true;
+    __structuredAttrs = true;
+
+    dontConfigure = true;
+    dontFixup = true;
+
+    buildPhase = ''
+      runHook preBuild
+
+      export BUN_INSTALL_CACHE_DIR=$(mktemp -d)
+      bun install --frozen-lockfile --ignore-scripts --no-progress --cpu="*" --os="*"
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/node_modules
+      cp -R ./node_modules $out
+
+      runHook postInstall
+    '';
+
+    outputHash = "sha256-EDGVXMyfPVoAxpMndHI3en6R6Wz/wJ9aKmuvAVg44ww=";
+
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+  };
+in
+stdenv.mkDerivation {
+  inherit pname version src;
 
   nativeBuildInputs = [
-    makeBinaryWrapper
+    bun
+    makeWrapper
+    installShellFiles
   ];
 
-  postPatch = ''
-    # remove cleanup which runs git commands
-    substituteInPlace package.json \
-      --replace-fail "npm run cleanup" "true"
+  strictDeps = true;
+  __structuredAttrs = true;
 
-    # set a script name to avoid yargs using index.js as $0
-    substituteInPlace src/handler.ts src/index.ts \
+  postPatch = ''
+    # set version during build
+    substituteInPlace package.json \
+      --replace-fail "0.0.0" "${version}"
+
+    # set a script name to avoid yargs using the script path as $0
+    substituteInPlace src/index.ts \
       --replace-fail 'yargs(process.argv.slice(2))' 'yargs(process.argv.slice(2)).scriptName("gitlab-ci-local")'
   '';
 
-  postInstall = ''
-    wrapProgram $out/bin/gitlab-ci-local \
+  configurePhase = ''
+    runHook preConfigure
+
+    cp -R ${node_modules}/node_modules .
+    patchShebangs node_modules
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    bun run build:node
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D dist/index.js $out/lib/gitlab-ci-local/index.js
+
+    makeWrapper ${lib.getExe nodejs-slim} $out/bin/gitlab-ci-local \
+      --add-flags "$out/lib/gitlab-ci-local/index.js" \
       --prefix PATH : "${
         lib.makeBinPath [
           rsync
@@ -51,12 +120,21 @@ buildNpmPackage rec {
     installShellCompletion --cmd gitlab-ci-local \
       --bash <(SHELL=bash $out/bin/gitlab-ci-local --completion) \
       --zsh <(SHELL=zsh $out/bin/gitlab-ci-local --completion)
+  ''
+  + ''
+    runHook postInstall
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
   passthru = {
-    updateScript = nix-update-script { };
-    tests.version = testers.testVersion {
-      package = gitlab-ci-local;
+    inherit node_modules;
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--custom-dep"
+        "node_modules"
+      ];
     };
   };
 


### PR DESCRIPTION
Updates gitlab-ci-local.

The upstream is using bun for their builder now. This PR includes a custom fetcher to get the node_modules similar to other packages that use bun.
(Edit): Also enabled strictDeps and structuredAttrs.

Assisted-by: opencode with DeepSeek V4 Flash Free


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
