### PR TITLE
licomp-toolkit: init at 0.5.20

### DIFF
--- a/pkgs/by-name/fo/foss-flame/package.nix
+++ b/pkgs/by-name/fo/foss-flame/package.nix
@@ -1,0 +1,3 @@
+{ python3Packages }:
+
+python3Packages.toPythonApplication python3Packages.foss-flame

--- a/pkgs/by-name/li/licomp-toolkit/package.nix
+++ b/pkgs/by-name/li/licomp-toolkit/package.nix
@@ -1,0 +1,3 @@
+{ python3Packages }:
+
+python3Packages.toPythonApplication python3Packages.licomp-toolkit

--- a/pkgs/development/python-modules/foss-flame/default.nix
+++ b/pkgs/development/python-modules/foss-flame/default.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  jsonschema,
+  license-expression,
+  osadl-matrix,
+  pyyaml,
+  spdx-license-list,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "foss-flame";
+  version = "0.21.8";
+  __structuredAttrs = true;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "hesa";
+    repo = "foss-licenses";
+    tag = finalAttrs.version;
+    hash = "sha256-vtiwY5l9zlNKQdoO3NSOG+9U1chqD5tvzBE20xSnGPA=";
+    postFetch = ''
+      # We have `CONSIDERATIONS.md` and `considerations.md` with almost the
+      # same contents, but because Darwin is case-insensitive, having both
+      # files results in a conflict, and therefore different source hashes than
+      # other platforms.
+      find $out -iname "considerations.md" -delete
+    '';
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/python";
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    jsonschema
+    license-expression
+    osadl-matrix
+    pyyaml
+    spdx-license-list
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  # Upstream setup.cfg has addopts, requiring pytest-{cov,forked,random-order}.
+  # Clearing it is simpler than replicating those plugins, especially since
+  # they only affect how tests run.
+  pytestFlags = [
+    "--override-ini=addopts="
+  ];
+
+  preCheck = ''
+    ln -s ../tests .
+  '';
+
+  pythonImportsCheck = [
+    "flame"
+  ];
+
+  meta = {
+    description = "License meta data: data and python module/cli";
+    homepage = "https://github.com/hesa/foss-licenses";
+    changelog = "https://github.com/hesa/foss-licenses/releases/tag/${finalAttrs.src.tag}";
+    mainProgram = "flame";
+    license = with lib.licenses; [
+      bsd2
+      cc-by-40
+      gpl3Plus
+    ];
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/development/python-modules/licomp-doubleopen/default.nix
+++ b/pkgs/development/python-modules/licomp-doubleopen/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  licomp,
+
+  # tests
+  pytestCheckHook,
+  jsonschema,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "licomp-doubleopen";
+  version = "0.1.5";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "hesa";
+    repo = "licomp-doubleopen";
+    tag = finalAttrs.version;
+    hash = "sha256-ju+Ewp5q3bzanLeldtE7NSSlfLpMe6muM4ZlpFgBDh0=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    licomp
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    jsonschema
+  ];
+
+  pythonImportsCheck = [
+    "licomp_doubleopen"
+  ];
+
+  meta = {
+    description = "Licomp implementation of Double Open Project's license classifications";
+    homepage = "https://github.com/hesa/licomp-doubleopen";
+    changelog = "https://github.com/hesa/licomp-doubleopen/releases/tag/${finalAttrs.src.tag}";
+    license = with lib.licenses; [
+      cc-by-30
+      cc-by-40
+      cc0
+      gpl3Plus
+    ];
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/development/python-modules/licomp-dwheeler/default.nix
+++ b/pkgs/development/python-modules/licomp-dwheeler/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  licomp,
+
+  # tests
+  pytestCheckHook,
+  jsonschema,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "licomp-dwheeler";
+  version = "0.5.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "hesa";
+    repo = "licomp-dwheeler";
+    tag = finalAttrs.version;
+    hash = "sha256-p6BSedKqauJCVpkr18UN6oNLwI2NknfJx8FHBIbi3I4=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    licomp
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    jsonschema
+  ];
+
+  pythonImportsCheck = [
+    "licomp_dwheeler"
+  ];
+
+  meta = {
+    description = "Implementation of Licomp using David Wheeler's graph";
+    homepage = "https://github.com/hesa/licomp-dwheeler";
+    changelog = "https://github.com/hesa/licomp-dwheeler/releases/tag/${finalAttrs.src.tag}";
+    license = with lib.licenses; [
+      cc-by-sa-30
+      gpl3Plus
+    ];
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/development/python-modules/licomp-gnuguide/default.nix
+++ b/pkgs/development/python-modules/licomp-gnuguide/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  licomp,
+
+  # tests
+  pytestCheckHook,
+  jsonschema,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "licomp-gnuguide";
+  version = "0.5.2";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "hesa";
+    repo = "licomp-gnuguide";
+    tag = finalAttrs.version;
+    hash = "sha256-DfjrmEktlTFvKqHIlmM/XeWZ4s24cRtWqs65OLDYZNQ=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    licomp
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    jsonschema
+  ];
+
+  pythonImportsCheck = [
+    "licomp_gnuguide"
+  ];
+
+  meta = {
+    description = "Implementation of Licomp using GNU resources";
+    homepage = "https://github.com/hesa/licomp-gnuguide";
+    changelog = "https://github.com/hesa/licomp-gnuguide/releases/tag/${finalAttrs.src.tag}";
+    license = with lib.licenses; [
+      cc-by-nd-40 # licomp-gnuguide.png & licomp_gnuguide/data/gnu-quick-guide-licenses.json
+      gpl3Plus
+    ];
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/development/python-modules/licomp-hermione/default.nix
+++ b/pkgs/development/python-modules/licomp-hermione/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  licomp,
+  pytestCheckHook,
+  jsonschema,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "licomp-hermione";
+  version = "0.5.2";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "hesa";
+    repo = "licomp-hermione";
+    tag = finalAttrs.version;
+    hash = "sha256-TIfi7E+BBChOz/EXRJxjFRYavVRPfnSkBHTaiY87k/Y=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    licomp
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    jsonschema
+  ];
+
+  pythonImportsCheck = [
+    "licomp_hermione"
+  ];
+
+  meta = {
+    description = "Implementation of Licomp using the Hermine license resource";
+    homepage = "https://github.com/hesa/licomp-hermione";
+    changelog = "https://github.com/hesa/licomp-hermione/releases/tag/${finalAttrs.src.tag}";
+    license = with lib.licenses; [
+      bsd0
+      gpl3Plus
+      odbl
+    ];
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/development/python-modules/licomp-osadl/default.nix
+++ b/pkgs/development/python-modules/licomp-osadl/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  licomp,
+
+  # tests
+  pytestCheckHook,
+  jsonschema,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "licomp-osadl";
+  version = "0.5.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "hesa";
+    repo = "licomp-osadl";
+    tag = finalAttrs.version;
+    hash = "sha256-aWJG7HxYs/8/Km3EpY8/XewCILlgePoKsdJyL8CM6LI=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    licomp
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    jsonschema
+  ];
+
+  pythonImportsCheck = [
+    "licomp_osadl"
+  ];
+
+  meta = {
+    description = "Implementation of Licomp using OSADL's matrix";
+    homepage = "https://github.com/hesa/licomp-osadl";
+    changelog = "https://github.com/hesa/licomp-osadl/releases/tag/${finalAttrs.src.tag}";
+    license = with lib.licenses; [
+      cc-by-40
+      gpl3Plus
+    ];
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/development/python-modules/licomp-oslc-handbook/default.nix
+++ b/pkgs/development/python-modules/licomp-oslc-handbook/default.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  licomp,
+
+  # tests
+  pytestCheckHook,
+  jsonschema,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "licomp-oslc-handbook";
+  version = "0.1.2";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "hesa";
+    repo = "licomp-oslc-handbook";
+    tag = finalAttrs.version;
+    hash = "sha256-cE3X7oT5Xg1W9lAMLJCYE6qRqrrXpVGLfBp18ynUYLE=";
+    postFetch = ''
+      # conflicts with `licenses` on Darwin, thus producing a different source
+      # hash.
+      mv $out/LICENSES $out/LICENSES_
+    '';
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    licomp
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    jsonschema
+  ];
+
+  pythonImportsCheck = [
+    "licomp_oslc_handbook"
+  ];
+
+  meta = {
+    description = "Licomp implementaiton of OSLC-handbook";
+    homepage = "https://github.com/hesa/licomp-oslc-handbook";
+    changelog = "https://github.com/hesa/licomp-oslc-handbook/releases/tag/${finalAttrs.src.tag}";
+    license = with lib.licenses; [
+      cc-by-40
+      cc-by-sa-40
+      gpl3Plus
+    ];
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+    # TODO: remove when this is resolved:
+    # https://github.com/hesa/licomp-oslc-handbook/issues/4
+    badPlatforms = lib.platforms.darwin;
+  };
+})

--- a/pkgs/development/python-modules/licomp-proprietary/default.nix
+++ b/pkgs/development/python-modules/licomp-proprietary/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  licomp,
+
+  # tests
+  pytestCheckHook,
+  jsonschema,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "licomp-proprietary";
+  version = "0.5.3";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "hesa";
+    repo = "licomp-proprietary";
+    tag = finalAttrs.version;
+    hash = "sha256-elEy/BOcuvo29ciRRSNQABWoBrOhRPDCNoaypuvWsx0=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    licomp
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    jsonschema
+  ];
+
+  pythonImportsCheck = [
+    "licomp_proprietary"
+  ];
+
+  meta = {
+    description = "Implementation of Licomp for linking a Propriettary licensed module";
+    homepage = "https://github.com/hesa/licomp-proprietary";
+    changelog = "https://github.com/hesa/licomp-proprietary/releases/tag/${finalAttrs.src.tag}";
+    license = with lib.licenses; [
+      cc-by-40
+      gpl3Plus
+    ];
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/development/python-modules/licomp-reclicense/default.nix
+++ b/pkgs/development/python-modules/licomp-reclicense/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  licomp,
+
+  # tests
+  pytestCheckHook,
+  jsonschema,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "licomp-reclicense";
+  version = "0.5.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "hesa";
+    repo = "licomp-reclicense";
+    tag = finalAttrs.version;
+    hash = "sha256-dCUsSZ70iKNCk8QcTtQ6Kn8BdyqK2E3Arkfx4aHmhmM=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    licomp
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    jsonschema
+  ];
+
+  pythonImportsCheck = [
+    "licomp_reclicense"
+  ];
+
+  meta = {
+    description = "Implementation of Licomp using the Recliense matrix";
+    homepage = "https://github.com/hesa/licomp-reclicense";
+    changelog = "https://github.com/hesa/licomp-reclicense/releases/tag/${finalAttrs.src.tag}";
+    license = with lib.licenses; [
+      gpl3Plus
+      mulan-psl2
+    ];
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/development/python-modules/licomp-toolkit/default.nix
+++ b/pkgs/development/python-modules/licomp-toolkit/default.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitea,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  foss-flame,
+  licomp,
+  licomp-doubleopen,
+  licomp-dwheeler,
+  licomp-gnuguide,
+  licomp-hermione,
+  licomp-osadl,
+  licomp-oslc-handbook,
+  licomp-proprietary,
+  licomp-reclicense,
+  pyyaml,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "licomp-toolkit";
+  version = "0.5.20";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "software-compliance-org";
+    repo = "licomp-toolkit";
+    tag = finalAttrs.version;
+    hash = "sha256-E6ehhQj1EcpW+8Cf2b+dtYSCH7fQ/AgS8uWIN4ipeCQ=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    foss-flame
+    licomp
+    licomp-doubleopen
+    licomp-dwheeler
+    licomp-gnuguide
+    licomp-hermione
+    licomp-osadl
+    licomp-oslc-handbook
+    licomp-proprietary
+    licomp-reclicense
+    pyyaml
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "licomp_toolkit"
+  ];
+
+  meta = {
+    description = "Python module and program to check compatibility between two licenses with context";
+    homepage = "https://codeberg.org/software-compliance-org/licomp-toolkit";
+    mainProgram = "licomp-toolkit";
+    license = with lib.licenses; [
+      gpl3Plus
+    ];
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+    # TODO: remove when this is resolved:
+    # https://github.com/hesa/licomp-oslc-handbook/issues/4
+    badPlatforms = lib.platforms.darwin;
+  };
+})

--- a/pkgs/development/python-modules/licomp/default.nix
+++ b/pkgs/development/python-modules/licomp/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitea,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  pyyaml,
+
+  # tests
+  pytestCheckHook,
+  jsonschema,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "licomp";
+  version = "0.5.22";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "software-compliance-org";
+    repo = "licomp";
+    tag = finalAttrs.version;
+    hash = "sha256-yZZfWinXdMmF/FQQ3+MwHRypK5Xz2EEMruJLCAtl/6Q=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    pyyaml
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    jsonschema
+  ];
+
+  pythonImportsCheck = [
+    "licomp"
+  ];
+
+  meta = {
+    description = "License Compatibility - Generalised API for use in license compatibility";
+    homepage = "https://codeberg.org/software-compliance-org/licomp";
+    license = with lib.licenses; [
+      gpl3Plus
+    ];
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/development/python-modules/osadl-matrix/default.nix
+++ b/pkgs/development/python-modules/osadl-matrix/default.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # tests
+  pytestCheckHook,
+  requests,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "osadl-matrix";
+  version = "2024.05.23.010555";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "priv-kweihmann";
+    repo = "osadl-matrix";
+    tag = finalAttrs.version;
+    hash = "sha256-vcSaWDX8P07Bj035vGq5dZYO+WkZOod7tTubWygl27k=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    requests
+  ];
+
+  # Upstream setup.cfg has addopts, requiring pytest-{cov,forked,random-order}.
+  # Clearing it is simpler than replicating those plugins, especially since
+  # they only affect how tests run.
+  pytestFlags = [
+    "--override-ini=addopts="
+  ];
+
+  disabledTests = [
+    # earlier in the tests, a full license db is cached and used, but these
+    # require a different db afterward, but it's not loaded
+    "test_compats"
+    "test_supported_licenes_size"
+    "test_supported_licenses"
+
+    # requires internet access
+    "test_license"
+  ];
+
+  pythonImportsCheck = [
+    "osadl_matrix"
+  ];
+
+  meta = {
+    description = "OSADL license compatibility matrix as a CSV";
+    homepage = "https://github.com/priv-kweihmann/osadl-matrix";
+    license = with lib.licenses; [
+      cc-by-40
+      unlicense
+    ];
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/development/python-modules/spdx-license-list/default.nix
+++ b/pkgs/development/python-modules/spdx-license-list/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "spdx-license-list";
+  version = "3.28.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "JJMC89";
+    repo = "spdx-license-list";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qzEWa2SY4XfW+DgAl6UNUItYWGJ/dJM6jZ/ZekoVgNc=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  # upstream has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "spdx_license_list"
+  ];
+
+  meta = {
+    description = "SPDX License List as a Python dictionary";
+    homepage = "https://github.com/JJMC89/spdx-license-list";
+    changelog = "https://github.com/JJMC89/spdx-license-list/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9077,6 +9077,8 @@ self: super: with self; {
 
   licomp-reclicense = callPackage ../development/python-modules/licomp-reclicense { };
 
+  licomp-toolkit = callPackage ../development/python-modules/licomp-toolkit { };
+
   lida = callPackage ../development/python-modules/lida { };
 
   lief = (toPythonModule (pkgs.lief.override { python3 = python; })).py;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9073,6 +9073,8 @@ self: super: with self; {
 
   licomp-oslc-handbook = callPackage ../development/python-modules/licomp-oslc-handbook { };
 
+  licomp-proprietary = callPackage ../development/python-modules/licomp-proprietary { };
+
   lida = callPackage ../development/python-modules/lida { };
 
   lief = (toPythonModule (pkgs.lief.override { python3 = python; })).py;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9067,6 +9067,8 @@ self: super: with self; {
 
   licomp-gnuguide = callPackage ../development/python-modules/licomp-gnuguide { };
 
+  licomp-hermione = callPackage ../development/python-modules/licomp-hermione { };
+
   lida = callPackage ../development/python-modules/lida { };
 
   lief = (toPythonModule (pkgs.lief.override { python3 = python; })).py;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9069,6 +9069,8 @@ self: super: with self; {
 
   licomp-hermione = callPackage ../development/python-modules/licomp-hermione { };
 
+  licomp-osadl = callPackage ../development/python-modules/licomp-osadl { };
+
   lida = callPackage ../development/python-modules/lida { };
 
   lief = (toPythonModule (pkgs.lief.override { python3 = python; })).py;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12053,6 +12053,8 @@ self: super: with self; {
 
   os-service-types = callPackage ../development/python-modules/os-service-types { };
 
+  osadl-matrix = callPackage ../development/python-modules/osadl-matrix/default.nix { };
+
   osc = callPackage ../development/python-modules/osc { };
 
   osc-diagram = callPackage ../development/python-modules/osc-diagram { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9063,6 +9063,8 @@ self: super: with self; {
 
   licomp-doubleopen = callPackage ../development/python-modules/licomp-doubleopen { };
 
+  licomp-dwheeler = callPackage ../development/python-modules/licomp-dwheeler { };
+
   lida = callPackage ../development/python-modules/lida { };
 
   lief = (toPythonModule (pkgs.lief.override { python3 = python; })).py;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9059,6 +9059,8 @@ self: super: with self; {
 
   license-expression = callPackage ../development/python-modules/license-expression { };
 
+  licomp = callPackage ../development/python-modules/licomp { };
+
   lida = callPackage ../development/python-modules/lida { };
 
   lief = (toPythonModule (pkgs.lief.override { python3 = python; })).py;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18417,6 +18417,8 @@ self: super: with self; {
 
   spdx = callPackage ../development/python-modules/spdx { };
 
+  spdx-license-list = callPackage ../development/python-modules/spdx-license-list { };
+
   spdx-tools = callPackage ../development/python-modules/spdx-tools { };
 
   speak2mary = callPackage ../development/python-modules/speak2mary { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5964,6 +5964,8 @@ self: super: with self; {
 
   fortune = callPackage ../development/python-modules/fortune { };
 
+  foss-flame = callPackage ../development/python-modules/foss-flame { };
+
   foundationdb = callPackage ../development/python-modules/foundationdb {
     inherit (pkgs) foundationdb;
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9061,6 +9061,8 @@ self: super: with self; {
 
   licomp = callPackage ../development/python-modules/licomp { };
 
+  licomp-doubleopen = callPackage ../development/python-modules/licomp-doubleopen { };
+
   lida = callPackage ../development/python-modules/lida { };
 
   lief = (toPythonModule (pkgs.lief.override { python3 = python; })).py;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9071,6 +9071,8 @@ self: super: with self; {
 
   licomp-osadl = callPackage ../development/python-modules/licomp-osadl { };
 
+  licomp-oslc-handbook = callPackage ../development/python-modules/licomp-oslc-handbook { };
+
   lida = callPackage ../development/python-modules/lida { };
 
   lief = (toPythonModule (pkgs.lief.override { python3 = python; })).py;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9075,6 +9075,8 @@ self: super: with self; {
 
   licomp-proprietary = callPackage ../development/python-modules/licomp-proprietary { };
 
+  licomp-reclicense = callPackage ../development/python-modules/licomp-reclicense { };
+
   lida = callPackage ../development/python-modules/lida { };
 
   lief = (toPythonModule (pkgs.lief.override { python3 = python; })).py;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9065,6 +9065,8 @@ self: super: with self; {
 
   licomp-dwheeler = callPackage ../development/python-modules/licomp-dwheeler { };
 
+  licomp-gnuguide = callPackage ../development/python-modules/licomp-gnuguide { };
+
   lida = callPackage ../development/python-modules/lida { };
 
   lief = (toPythonModule (pkgs.lief.override { python3 = python; })).py;


### PR DESCRIPTION
[licomp-toolkit](https://codeberg.org/software-compliance-org/licomp-toolkit) is a Python module and program to check compatibility between two licenses with context. It's also a part of the [Automate FOSS license compatibility determination](https://nlnet.nl/project/LicenseCompatibilityAutomation) project.

Related: https://github.com/ngi-nix/projects/issues/1034
Assisted-By: [nix-init](https://github.com/nix-community/nix-init)

> [!NOTE]
> Work done as part of the [Nix@NGI](https://nixos.org/community/teams/ngi) packaging effort 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
