### PR TITLE
[25.11] haveged: 1.9.19 -> 1.9.21

### DIFF
--- a/pkgs/by-name/ha/haveged/package.nix
+++ b/pkgs/by-name/ha/haveged/package.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "haveged";
-  version = "1.9.19";
+  version = "1.9.20";
 
   src = fetchFromGitHub {
     owner = "jirka-h";
     repo = "haveged";
     rev = "v${version}";
-    hash = "sha256-tq4OXLlyC6exJEZ80H1gQQRBgYGbu+3kGz99RxsyauI=";
+    hash = "sha256-7ymilQktEsCUTujGC2KTXN5LI2KQRbAd/4tEMxOZxpo=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/ha/haveged/package.nix
+++ b/pkgs/by-name/ha/haveged/package.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation rec {
   pname = "haveged";
-  version = "1.9.20";
+  version = "1.9.21";
 
   src = fetchFromGitHub {
     owner = "jirka-h";
     repo = "haveged";
     rev = "v${version}";
-    hash = "sha256-7ymilQktEsCUTujGC2KTXN5LI2KQRbAd/4tEMxOZxpo=";
+    hash = "sha256-ldJsB09xgACCI9ne10gxr2T2f20aVPXJXea32hoCYP8=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
Fixes CVE-2026-41054 (LPE). Backport of #521942

https://github.com/jirka-h/haveged/releases/tag/v1.9.21
https://www.openwall.com/lists/oss-security/2026/05/19/3

https://github.com/jirka-h/haveged/releases/tag/v1.9.20

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
