### PR TITLE
python3Packages.smpclient: set `__darwinAllowLocalNetworking` to true

### DIFF
--- a/pkgs/development/python-modules/smpclient/default.nix
+++ b/pkgs/development/python-modules/smpclient/default.nix
@@ -26,6 +26,7 @@ buildPythonPackage rec {
   };
 
   env.HATCH_BUILD_HOOK_VCS_VERSION = version;
+  __darwinAllowLocalNetworking = true;
 
   build-system = [
     hatchling


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes build locally on Darwin. Hydra doesn't crash, probably because of the relaxed sandbox.

<details>
<summary>Build log</summary>

```
Sourcing python-remove-tests-dir-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing pypa-build-hook
Using pypaBuildPhase
Sourcing python-runtime-deps-check-hook
Using pythonRuntimeDepsCheckHook
Sourcing pypa-install-hook
Using pypaInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing pytest-check-hook
Using pytestCheckPhase
Running phase: unpackPhase
@nix {"action":"setPhase","phase":"unpackPhase"}
unpacking source archive /nix/store/kkw9m7arg43w9qsmd1jqsbpz2n8bif22-source
source root is source
setting SOURCE_DATE_EPOCH to timestamp 315619200 of file "source/uv.lock"
Running phase: patchPhase
@nix {"action":"setPhase","phase":"patchPhase"}
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix {"action":"setPhase","phase":"updateAutotoolsGnuConfigScriptsPhase"}
Running phase: configurePhase
@nix {"action":"setPhase","phase":"configurePhase"}
no configure script, doing nothing
Running phase: buildPhase
@nix {"action":"setPhase","phase":"buildPhase"}
Executing pypaBuildPhase
Setting SETUPTOOLS_SCM_PRETEND_VERSION to 7.0.1
Including all tracked files automatically
Creating a wheel...
pypa build flags: --no-isolation --outdir dist/ --wheel
* Getting build dependencies for wheel...
* Building wheel...
Successfully built smpclient-7.0.1-py3-none-any.whl
Finished creating a wheel...
Finished executing pypaBuildPhase
Running phase: pythonRuntimeDepsCheckHook
@nix {"action":"setPhase","phase":"pythonRuntimeDepsCheckHook"}
Executing pythonRuntimeDepsCheck
Checking runtime dependencies for smpclient-7.0.1-py3-none-any.whl
Finished executing pythonRuntimeDepsCheck
Running phase: installPhase
@nix {"action":"setPhase","phase":"installPhase"}
Executing pypaInstallPhase
Successfully installed smpclient-7.0.1-py3-none-any.whl
Finished executing pypaInstallPhase
Running phase: pythonOutputDistPhase
@nix {"action":"setPhase","phase":"pythonOutputDistPhase"}
Executing pythonOutputDistPhase
Finished executing pythonOutputDistPhase
Running phase: fixupPhase
@nix {"action":"setPhase","phase":"fixupPhase"}
checking for references to /nix/var/nix/builds/nix-77888-603091421/ in /nix/store/yh0kkmzxk8c536y96s9xbhyysm5sng98-python3.13-smpclient-7.0.1...
patching script interpreter paths in /nix/store/yh0kkmzxk8c536y96s9xbhyysm5sng98-python3.13-smpclient-7.0.1
stripping (with command strip and flags -S) in  /nix/store/yh0kkmzxk8c536y96s9xbhyysm5sng98-python3.13-smpclient-7.0.1/lib /nix/store/yh0kkmzxk8c536y96s9xbhyysm5sng98-python3.13-smpclient-7.0.1/bin
checking for references to /nix/var/nix/builds/nix-77888-603091421/ in /nix/store/fw4wmmkx2my0w094myhni79i3qnvzal2-python3.13-smpclient-7.0.1-dist...
patching script interpreter paths in /nix/store/fw4wmmkx2my0w094myhni79i3qnvzal2-python3.13-smpclient-7.0.1-dist
Rewriting #!/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/bin/python3.13 to #!/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13
wrapping `/nix/store/yh0kkmzxk8c536y96s9xbhyysm5sng98-python3.13-smpclient-7.0.1/bin/mcuimg'...
Executing pythonRemoveTestsDir
Finished executing pythonRemoveTestsDir
Running phase: installCheckPhase
@nix {"action":"setPhase","phase":"installCheckPhase"}
no Makefile or custom installCheckPhase, doing nothing
Running phase: pythonCatchConflictsPhase
@nix {"action":"setPhase","phase":"pythonCatchConflictsPhase"}
Running phase: pythonRemoveBinBytecodePhase
@nix {"action":"setPhase","phase":"pythonRemoveBinBytecodePhase"}
Running phase: pythonImportsCheckPhase
@nix {"action":"setPhase","phase":"pythonImportsCheckPhase"}
Executing pythonImportsCheckPhase
Check whether the following modules can be imported: smpclient
Running phase: pytestCheckPhase
@nix {"action":"setPhase","phase":"pytestCheckPhase"}
Executing pytestCheckPhase
pytest flags: -m pytest
============================= test session starts ==============================
platform darwin -- Python 3.13.13, pytest-9.0.3, pluggy-1.6.0
rootdir: /nix/var/nix/builds/nix-77888-603091421/source
configfile: pyproject.toml
plugins: asyncio-1.3.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 199 items                                                            

tests/extensions/test_intercreate.py .                                   [  0%]
tests/test_base64.py .                                                   [  1%]
tests/test_mcuboot_tools.py ............                                 [  7%]
tests/test_requests.py .................................                 [ 23%]
tests/test_smp_ble_transport.py ..............                           [ 30%]
tests/test_smp_client.py ....................s......s......ss.....sss... [ 54%]
...........................s......s......ss.....sss........              [ 83%]
tests/test_smp_serial_transport.py ...........                           [ 89%]
tests/test_smp_udp_transport.py ........FF                               [ 94%]
tests/test_udp_client.py ..F..FEEFFF                                     [100%]

==================================== ERRORS ====================================
_________________________ ERROR at setup of test_send __________________________

    @pytest_asyncio.fixture
    async def udp_server() -> AsyncGenerator[tuple[asyncio.DatagramTransport, _ServerProtocol], None]:
>       transport, protocol = await asyncio.get_running_loop().create_datagram_endpoint(
            lambda: _ServerProtocol(), local_addr=("127.0.0.1", 1337)
        )

tests/test_udp_client.py:93: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/base_events.py:1486: in create_datagram_endpoint
    raise exceptions[0]
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <_UnixSelectorEventLoop running=False closed=False debug=False>
protocol_factory = <function udp_server.<locals>.<lambda> at 0x1038831a0>
local_addr = ('127.0.0.1', 1337), remote_addr = None

    async def create_datagram_endpoint(self, protocol_factory,
                                       local_addr=None, remote_addr=None, *,
                                       family=0, proto=0, flags=0,
                                       reuse_port=None,
                                       allow_broadcast=None, sock=None):
        """Create datagram connection."""
        if sock is not None:
            if sock.type == socket.SOCK_STREAM:
                raise ValueError(
                    f'A datagram socket was expected, got {sock!r}')
            if (local_addr or remote_addr or
                    family or proto or flags or
                    reuse_port or allow_broadcast):
                # show the problematic kwargs in exception msg
                opts = dict(local_addr=local_addr, remote_addr=remote_addr,
                            family=family, proto=proto, flags=flags,
                            reuse_port=reuse_port,
                            allow_broadcast=allow_broadcast)
                problems = ', '.join(f'{k}={v}' for k, v in opts.items() if v)
                raise ValueError(
                    f'socket modifier keyword arguments can not be used '
                    f'when sock is specified. ({problems})')
            sock.setblocking(False)
            r_addr = None
        else:
            if not (local_addr or remote_addr):
                if family == 0:
                    raise ValueError('unexpected address family')
                addr_pairs_info = (((family, proto), (None, None)),)
            elif hasattr(socket, 'AF_UNIX') and family == socket.AF_UNIX:
                for addr in (local_addr, remote_addr):
                    if addr is not None and not isinstance(addr, str):
                        raise TypeError('string is expected')
    
                if local_addr and local_addr[0] not in (0, '\x00'):
                    try:
                        if stat.S_ISSOCK(os.stat(local_addr).st_mode):
                            os.remove(local_addr)
                    except FileNotFoundError:
                        pass
                    except OSError as err:
                        # Directory may have permissions only to create socket.
                        logger.error('Unable to check or remove stale UNIX '
                                     'socket %r: %r',
                                     local_addr, err)
    
                addr_pairs_info = (((family, proto),
                                    (local_addr, remote_addr)), )
            else:
                # join address by (family, protocol)
                addr_infos = {}  # Using order preserving dict
                for idx, addr in ((0, local_addr), (1, remote_addr)):
                    if addr is not None:
                        if not (isinstance(addr, tuple) and len(addr) == 2):
                            raise TypeError('2-tuple is expected')
    
                        infos = await self._ensure_resolved(
                            addr, family=family, type=socket.SOCK_DGRAM,
                            proto=proto, flags=flags, loop=self)
                        if not infos:
                            raise OSError('getaddrinfo() returned empty list')
    
                        for fam, _, pro, _, address in infos:
                            key = (fam, pro)
                            if key not in addr_infos:
                                addr_infos[key] = [None, None]
                            addr_infos[key][idx] = address
    
                # each addr has to have info for each (family, proto) pair
                addr_pairs_info = [
                    (key, addr_pair) for key, addr_pair in addr_infos.items()
                    if not ((local_addr and addr_pair[0] is None) or
                            (remote_addr and addr_pair[1] is None))]
    
                if not addr_pairs_info:
                    raise ValueError('can not get address information')
    
            exceptions = []
    
            for ((family, proto),
                 (local_address, remote_address)) in addr_pairs_info:
                sock = None
                r_addr = None
                try:
                    sock = socket.socket(
                        family=family, type=socket.SOCK_DGRAM, proto=proto)
                    if reuse_port:
                        _set_reuseport(sock)
                    if allow_broadcast:
                        sock.setsockopt(
                            socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
                    sock.setblocking(False)
    
                    if local_addr:
>                       sock.bind(local_address)
E                       PermissionError: [Errno 1] Operation not permitted

/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/base_events.py:1470: PermissionError
________________________ ERROR at setup of test_receive ________________________

    @pytest_asyncio.fixture
    async def udp_server() -> AsyncGenerator[tuple[asyncio.DatagramTransport, _ServerProtocol], None]:
>       transport, protocol = await asyncio.get_running_loop().create_datagram_endpoint(
            lambda: _ServerProtocol(), local_addr=("127.0.0.1", 1337)
        )

tests/test_udp_client.py:93: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/base_events.py:1486: in create_datagram_endpoint
    raise exceptions[0]
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <_UnixSelectorEventLoop running=False closed=False debug=False>
protocol_factory = <function udp_server.<locals>.<lambda> at 0x1038837e0>
local_addr = ('127.0.0.1', 1337), remote_addr = None

    async def create_datagram_endpoint(self, protocol_factory,
                                       local_addr=None, remote_addr=None, *,
                                       family=0, proto=0, flags=0,
                                       reuse_port=None,
                                       allow_broadcast=None, sock=None):
        """Create datagram connection."""
        if sock is not None:
            if sock.type == socket.SOCK_STREAM:
                raise ValueError(
                    f'A datagram socket was expected, got {sock!r}')
            if (local_addr or remote_addr or
                    family or proto or flags or
                    reuse_port or allow_broadcast):
                # show the problematic kwargs in exception msg
                opts = dict(local_addr=local_addr, remote_addr=remote_addr,
                            family=family, proto=proto, flags=flags,
                            reuse_port=reuse_port,
                            allow_broadcast=allow_broadcast)
                problems = ', '.join(f'{k}={v}' for k, v in opts.items() if v)
                raise ValueError(
                    f'socket modifier keyword arguments can not be used '
                    f'when sock is specified. ({problems})')
            sock.setblocking(False)
            r_addr = None
        else:
            if not (local_addr or remote_addr):
                if family == 0:
                    raise ValueError('unexpected address family')
                addr_pairs_info = (((family, proto), (None, None)),)
            elif hasattr(socket, 'AF_UNIX') and family == socket.AF_UNIX:
                for addr in (local_addr, remote_addr):
                    if addr is not None and not isinstance(addr, str):
                        raise TypeError('string is expected')
    
                if local_addr and local_addr[0] not in (0, '\x00'):
                    try:
                        if stat.S_ISSOCK(os.stat(local_addr).st_mode):
                            os.remove(local_addr)
                    except FileNotFoundError:
                        pass
                    except OSError as err:
                        # Directory may have permissions only to create socket.
                        logger.error('Unable to check or remove stale UNIX '
                                     'socket %r: %r',
                                     local_addr, err)
    
                addr_pairs_info = (((family, proto),
                                    (local_addr, remote_addr)), )
            else:
                # join address by (family, protocol)
                addr_infos = {}  # Using order preserving dict
                for idx, addr in ((0, local_addr), (1, remote_addr)):
                    if addr is not None:
                        if not (isinstance(addr, tuple) and len(addr) == 2):
                            raise TypeError('2-tuple is expected')
    
                        infos = await self._ensure_resolved(
                            addr, family=family, type=socket.SOCK_DGRAM,
                            proto=proto, flags=flags, loop=self)
                        if not infos:
                            raise OSError('getaddrinfo() returned empty list')
    
                        for fam, _, pro, _, address in infos:
                            key = (fam, pro)
                            if key not in addr_infos:
                                addr_infos[key] = [None, None]
                            addr_infos[key][idx] = address
    
                # each addr has to have info for each (family, proto) pair
                addr_pairs_info = [
                    (key, addr_pair) for key, addr_pair in addr_infos.items()
                    if not ((local_addr and addr_pair[0] is None) or
                            (remote_addr and addr_pair[1] is None))]
    
                if not addr_pairs_info:
                    raise ValueError('can not get address information')
    
            exceptions = []
    
            for ((family, proto),
                 (local_address, remote_address)) in addr_pairs_info:
                sock = None
                r_addr = None
                try:
                    sock = socket.socket(
                        family=family, type=socket.SOCK_DGRAM, proto=proto)
                    if reuse_port:
                        _set_reuseport(sock)
                    if allow_broadcast:
                        sock.setsockopt(
                            socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
                    sock.setblocking(False)
    
                    if local_addr:
>                       sock.bind(local_address)
E                       PermissionError: [Errno 1] Operation not permitted

/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/base_events.py:1470: PermissionError
=================================== FAILURES ===================================
_______________________ test_ipv4_detection_real_socket ________________________

    @pytest.mark.asyncio
    async def test_ipv4_detection_real_socket() -> None:
        """Test IPv4 auto-detection with real socket connection."""
        t = SMPUDPTransport(mtu=1500)
    
        # Create a real UDP connection to localhost IPv4
>       await t.connect("127.0.0.1", 1.0)

tests/test_smp_udp_transport.py:141: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/nix/store/yh0kkmzxk8c536y96s9xbhyysm5sng98-python3.13-smpclient-7.0.1/lib/python3.13/site-packages/smpclient/transport/udp.py:56: in connect
    await asyncio.wait_for(self._client.connect(Addr(host=address, port=port)), timeout_s)
/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/tasks.py:507: in wait_for
    return await fut
           ^^^^^^^^^
/nix/store/yh0kkmzxk8c536y96s9xbhyysm5sng98-python3.13-smpclient-7.0.1/lib/python3.13/site-packages/smpclient/transport/_udp_client.py:34: in connect
    self._transport, self._protocol = await asyncio.get_running_loop().create_datagram_endpoint(
/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/base_events.py:1486: in create_datagram_endpoint
    raise exceptions[0]
/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/base_events.py:1473: in create_datagram_endpoint
    await self.sock_connect(sock, remote_address)
/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/selector_events.py:645: in sock_connect
    return await fut
           ^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <_UnixSelectorEventLoop running=False closed=False debug=False>
fut = None, sock = <socket.socket [closed] fd=-1, family=2, type=2, proto=17>
address = ('127.0.0.1', 1337)

    def _sock_connect(self, fut, sock, address):
        fd = sock.fileno()
        try:
>           sock.connect(address)
E           PermissionError: [Errno 1] Operation not permitted

/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/selector_events.py:653: PermissionError
_______________________ test_ipv6_detection_real_socket ________________________

    @pytest.mark.asyncio
    async def test_ipv6_detection_real_socket() -> None:
        """Test IPv6 auto-detection with real socket connection."""
        t = SMPUDPTransport(mtu=1500)
    
        # Create a real UDP connection to localhost IPv6
>       await t.connect("::1", 1.0)

tests/test_smp_udp_transport.py:156: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/nix/store/yh0kkmzxk8c536y96s9xbhyysm5sng98-python3.13-smpclient-7.0.1/lib/python3.13/site-packages/smpclient/transport/udp.py:56: in connect
    await asyncio.wait_for(self._client.connect(Addr(host=address, port=port)), timeout_s)
/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/tasks.py:507: in wait_for
    return await fut
           ^^^^^^^^^
/nix/store/yh0kkmzxk8c536y96s9xbhyysm5sng98-python3.13-smpclient-7.0.1/lib/python3.13/site-packages/smpclient/transport/_udp_client.py:34: in connect
    self._transport, self._protocol = await asyncio.get_running_loop().create_datagram_endpoint(
/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/base_events.py:1486: in create_datagram_endpoint
    raise exceptions[0]
/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/base_events.py:1473: in create_datagram_endpoint
    await self.sock_connect(sock, remote_address)
/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/selector_events.py:645: in sock_connect
    return await fut
           ^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <_UnixSelectorEventLoop running=False closed=False debug=False>
fut = None, sock = <socket.socket [closed] fd=-1, family=30, type=2, proto=17>
address = ('::1', 1337, 0, 0)

    def _sock_connect(self, fut, sock, address):
        fd = sock.fileno()
        try:
>           sock.connect(address)
E           PermissionError: [Errno 1] Operation not permitted

/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/selector_events.py:653: PermissionError
____________________________ test_UDPClient_connect ____________________________

_ = <MagicMock name='_UDPProtocol' spec='_UDPProtocol' id='4354270816'>

    @patch("smpclient.transport._udp_client._UDPProtocol", autospec=True)
    @pytest.mark.asyncio
    async def test_UDPClient_connect(_: MagicMock) -> None:
        c = UDPClient()
    
>       await c.connect(Addr("127.0.0.1", 1337))

tests/test_udp_client.py:38: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/nix/store/yh0kkmzxk8c536y96s9xbhyysm5sng98-python3.13-smpclient-7.0.1/lib/python3.13/site-packages/smpclient/transport/_udp_client.py:34: in connect
    self._transport, self._protocol = await asyncio.get_running_loop().create_datagram_endpoint(
/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/base_events.py:1486: in create_datagram_endpoint
    raise exceptions[0]
/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/base_events.py:1473: in create_datagram_endpoint
    await self.sock_connect(sock, remote_address)
/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/selector_events.py:645: in sock_connect
    return await fut
           ^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <_UnixSelectorEventLoop running=False closed=False debug=False>
fut = None, sock = <socket.socket [closed] fd=-1, family=2, type=2, proto=17>
address = ('127.0.0.1', 1337)

    def _sock_connect(self, fut, sock, address):
        fd = sock.fileno()
        try:
>           sock.connect(address)
E           PermissionError: [Errno 1] Operation not permitted

/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/selector_events.py:653: PermissionError
__________________________ test_UDPClient_disconnect ___________________________

_ = <MagicMock name='_UDPProtocol' spec='_UDPProtocol' id='4354271152'>

    @patch("smpclient.transport._udp_client._UDPProtocol", autospec=True)
    @pytest.mark.asyncio
    async def test_UDPClient_disconnect(_: MagicMock) -> None:
        c = UDPClient()
    
        c._transport = MagicMock()
        c.disconnect()
        c._transport.close.assert_called_once_with()
    
        c = UDPClient()
>       await c.connect(Addr("127.0.0.1", 1337))

tests/test_udp_client.py:74: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/nix/store/yh0kkmzxk8c536y96s9xbhyysm5sng98-python3.13-smpclient-7.0.1/lib/python3.13/site-packages/smpclient/transport/_udp_client.py:34: in connect
    self._transport, self._protocol = await asyncio.get_running_loop().create_datagram_endpoint(
/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/base_events.py:1486: in create_datagram_endpoint
    raise exceptions[0]
/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/base_events.py:1473: in create_datagram_endpoint
    await self.sock_connect(sock, remote_address)
/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/selector_events.py:645: in sock_connect
    return await fut
           ^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <_UnixSelectorEventLoop running=False closed=False debug=False>
fut = None, sock = <socket.socket [closed] fd=-1, family=2, type=2, proto=17>
address = ('127.0.0.1', 1337)

    def _sock_connect(self, fut, sock, address):
        fd = sock.fileno()
        try:
>           sock.connect(address)
E           PermissionError: [Errno 1] Operation not permitted

/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/selector_events.py:653: PermissionError
_____________________________ test_error_received ______________________________

    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
    @pytest.mark.asyncio
    async def test_error_received() -> None:
        c = UDPClient()
>       await c.connect(Addr("127.0.0.1", 1337))

tests/test_udp_client.py:134: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/nix/store/yh0kkmzxk8c536y96s9xbhyysm5sng98-python3.13-smpclient-7.0.1/lib/python3.13/site-packages/smpclient/transport/_udp_client.py:34: in connect
    self._transport, self._protocol = await asyncio.get_running_loop().create_datagram_endpoint(
/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/base_events.py:1486: in create_datagram_endpoint
    raise exceptions[0]
/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/base_events.py:1473: in create_datagram_endpoint
    await self.sock_connect(sock, remote_address)
/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/selector_events.py:645: in sock_connect
    return await fut
           ^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <_UnixSelectorEventLoop running=False closed=False debug=False>
fut = None, sock = <socket.socket [closed] fd=-1, family=2, type=2, proto=17>
address = ('127.0.0.1', 1337)

    def _sock_connect(self, fut, sock, address):
        fd = sock.fileno()
        try:
>           sock.connect(address)
E           PermissionError: [Errno 1] Operation not permitted

/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/selector_events.py:653: PermissionError
______________________ test_connection_lost_no_exception _______________________

    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
    @pytest.mark.asyncio
    async def test_connection_lost_no_exception() -> None:
        c = UDPClient()
>       await c.connect(Addr("127.0.0.1", 1337))

tests/test_udp_client.py:147: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/nix/store/yh0kkmzxk8c536y96s9xbhyysm5sng98-python3.13-smpclient-7.0.1/lib/python3.13/site-packages/smpclient/transport/_udp_client.py:34: in connect
    self._transport, self._protocol = await asyncio.get_running_loop().create_datagram_endpoint(
/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/base_events.py:1486: in create_datagram_endpoint
    raise exceptions[0]
/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/base_events.py:1473: in create_datagram_endpoint
    await self.sock_connect(sock, remote_address)
/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/selector_events.py:645: in sock_connect
    return await fut
           ^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <_UnixSelectorEventLoop running=False closed=False debug=False>
fut = None, sock = <socket.socket [closed] fd=-1, family=2, type=2, proto=17>
address = ('127.0.0.1', 1337)

    def _sock_connect(self, fut, sock, address):
        fd = sock.fileno()
        try:
>           sock.connect(address)
E           PermissionError: [Errno 1] Operation not permitted

/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/selector_events.py:653: PermissionError
_____________________________ test_connection_lost _____________________________

    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
    @pytest.mark.asyncio
    async def test_connection_lost() -> None:
        c = UDPClient()
>       await c.connect(Addr("127.0.0.1", 1337))

tests/test_udp_client.py:158: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/nix/store/yh0kkmzxk8c536y96s9xbhyysm5sng98-python3.13-smpclient-7.0.1/lib/python3.13/site-packages/smpclient/transport/_udp_client.py:34: in connect
    self._transport, self._protocol = await asyncio.get_running_loop().create_datagram_endpoint(
/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/base_events.py:1486: in create_datagram_endpoint
    raise exceptions[0]
/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/base_events.py:1473: in create_datagram_endpoint
    await self.sock_connect(sock, remote_address)
/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/selector_events.py:645: in sock_connect
    return await fut
           ^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <_UnixSelectorEventLoop running=False closed=False debug=False>
fut = None, sock = <socket.socket [closed] fd=-1, family=2, type=2, proto=17>
address = ('127.0.0.1', 1337)

    def _sock_connect(self, fut, sock, address):
        fd = sock.fileno()
        try:
>           sock.connect(address)
E           PermissionError: [Errno 1] Operation not permitted

/nix/store/ygxqin6ydzjfawywqpp5pal8wv6sf5bh-python3-3.13.13/lib/python3.13/asyncio/selector_events.py:653: PermissionError
=========================== short test summary info ============================
FAILED tests/test_smp_udp_transport.py::test_ipv4_detection_real_socket - PermissionError: [Errno 1] Operation not permitted
FAILED tests/test_smp_udp_transport.py::test_ipv6_detection_real_socket - PermissionError: [Errno 1] Operation not permitted
FAILED tests/test_udp_client.py::test_UDPClient_connect - PermissionError: [Errno 1] Operation not permitted
FAILED tests/test_udp_client.py::test_UDPClient_disconnect - PermissionError: [Errno 1] Operation not permitted
FAILED tests/test_udp_client.py::test_error_received - PermissionError: [Errno 1] Operation not permitted
FAILED tests/test_udp_client.py::test_connection_lost_no_exception - PermissionError: [Errno 1] Operation not permitted
FAILED tests/test_udp_client.py::test_connection_lost - PermissionError: [Errno 1] Operation not permitted
ERROR tests/test_udp_client.py::test_send - PermissionError: [Errno 1] Operation not permitted
ERROR tests/test_udp_client.py::test_receive - PermissionError: [Errno 1] Operation not permitted
============= 7 failed, 176 passed, 14 skipped, 2 errors in 4.23s ==============
```
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
  I did not use AI

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
