### PR TITLE
slack-cli-official: init at 4.2.0

### DIFF
--- a/pkgs/by-name/sl/slack-cli-official/package.nix
+++ b/pkgs/by-name/sl/slack-cli-official/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "slack-cli-official";
+  version = "4.2.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "slackapi";
+    repo = "slack-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5mI0pJ/QSU+gh1Lx7ss5xRWMOafYOfku3CAe2gD+UIM=";
+  };
+
+  vendorHash = "sha256-Xdb2TrvStvxzbY18obNV3GESoVtwp3Q1+7mhJ1WMvXY=";
+
+  subPackages = [ "." ];
+
+  ldflags = [
+    "-s"
+    "-X github.com/slackapi/slack-cli/internal/version.Version=v${finalAttrs.version}"
+  ];
+
+  # As per the usage documentation of this package, it expects the program to be named `slack`
+  postInstall = ''
+    mv "$out/bin/slack-cli" "$out/bin/slack"
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "Official Slack developer CLI";
+    homepage = "https://docs.slack.dev/tools/slack-cli/";
+    downloadPage = "https://github.com/slackapi/slack-cli";
+    changelog = "https://github.com/slackapi/slack-cli/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    mainProgram = "slack";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ alexnortung ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds the official slack cli

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
