### PR TITLE
nixos/inventree: fix duplicate Host header causing Django DisallowedHost

### DIFF
--- a/nixos/modules/services/misc/inventree.nix
+++ b/nixos/modules/services/misc/inventree.nix
@@ -252,12 +252,13 @@ in
             in
             {
               "/" = {
+                # recommendedProxySettings sets the standard headers (Host, X-Forwarded-*), so
+                # don't also set them via proxy_set_header in extraConfig below. Nginx would then
+                # send Host twice and Django rejects it with DisallowedHost. Enabled per-location
+                # so it works even if the host's global recommendedProxySettings is off.
+                recommendedProxySettings = true;
                 extraConfig = ''
-                  proxy_set_header Host $host;
                   proxy_set_header X-Forwarded-By $server_addr:$server_port;
-                  proxy_set_header X-Forwarded-For $remote_addr;
-                  proxy_set_header X-Forwarded-Proto $scheme;
-                  proxy_set_header X-Real-IP $remote_addr;
                   proxy_set_header CLIENT_IP $remote_addr;
 
                   proxy_pass_request_headers on;
@@ -272,6 +273,8 @@ in
                 proxyPass = "http://unix:${unixPath}";
               };
               "/auth" = {
+                # same reasoning as "/"; this subrequest also reaches Django
+                recommendedProxySettings = true;
                 extraConfig = ''
                   internal;
                   proxy_pass_request_body off;


### PR DESCRIPTION
Fix the Django `DisallowedHost` error caused by nginx sending a duplicate `Host` header. Rely on `recommendedProxySettings` for the standard proxy headers instead of setting them again, so `Host` is sent only once.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
