### PR TITLE
firecrawl-mcp: init at 3.24.0

### DIFF
--- a/pkgs/by-name/fi/firecrawl-mcp/package.nix
+++ b/pkgs/by-name/fi/firecrawl-mcp/package.nix
@@ -1,0 +1,105 @@
+{
+  lib,
+  stdenvNoCC,
+
+  fetchFromGitHub,
+  fetchPnpmDeps,
+
+  makeWrapper,
+  nodejs,
+  pnpm_11,
+  pnpmConfigHook,
+
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "firecrawl-mcp";
+  version = "3.24.0";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "firecrawl";
+    repo = "firecrawl-mcp-server";
+    # currently no tags for latest releases
+    # https://github.com/firecrawl/firecrawl-mcp-server/issues/255
+    rev = "2ca018dcf85356f5299959eebd184baabb1f40c0";
+    hash = "sha256-uLJ+tWrCd7BkBDf8JsSybMLqrVYaw/boyMySv123cCY=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    nodejs
+    pnpmConfigHook
+    pnpm_11
+  ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_11;
+    fetcherVersion = 4;
+    hash = "sha256-LcLWmGRQN7Y0jzr1JECdOmNP3hLZG1i5/hRMvq+ae1M=";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/lib/firecrawl-mcp
+
+    # `pnpm build` doesn't bundle dependencies so we'll need to keep node_modules
+    # - remove unnecessary files
+    CI=true pnpm --ignore-scripts --prod prune
+    find -type f \( -name "*.ts" -o -name "*.map" \) -exec rm -rf {} +
+    # https://github.com/pnpm/pnpm/issues/3645
+    find node_modules -xtype l -delete
+    # - remove non-deterministic files
+    rm node_modules/{.modules.yaml,.pnpm-workspace-state-v1.json}
+    # - copy over node modules
+    cp -r dist node_modules $out/lib/firecrawl-mcp
+    cp package.json $out/lib/firecrawl-mcp
+
+    # patch executable index.js just in-case
+    patchShebangs $out/lib/firecrawl-mcp/dist/index.js
+    # prepare an entrypoint in /bin
+    makeWrapper ${lib.getExe nodejs} "$out/bin/firecrawl-mcp" --add-flags "$out/lib/firecrawl-mcp/dist/index.js"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://docs.firecrawl.dev/mcp-server";
+    changelog = "https://github.com/firecrawl/firecrawl-mcp-server/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    description = "A Model Context Protocol (MCP) server that brings Firecrawl to MCP-compatible AI agents";
+    longDescription = ''
+      A Model Context Protocol (MCP) server implementation that integrates
+      Firecrawl for searching, scraping, and interacting with the web.
+      You can either use the remote hosted Firecrawl or a self-hosted instance.
+
+      Features:
+      * Search the web and get full page content
+      * Scrape any URL into clean, structured data
+      * Interact with pages — click, navigate, and operate
+      * Deep research with autonomous agent
+      * Browser session management
+      * Cloud and self-hosted support
+      * Streamable HTTP support
+    '';
+    license = lib.licenses.mit;
+    mainProgram = "firecrawl-mcp";
+    maintainers = with lib.maintainers; [
+      jk
+    ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Package `firecrawl-mcp` at `3.24.0`
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
