### PR TITLE
nixos/homer: add caching headers and compression to caddy vhost

### DIFF
--- a/nixos/modules/services/web-apps/homer.nix
+++ b/nixos/modules/services/web-apps/homer.nix
@@ -169,11 +169,25 @@ in
       enable = true;
       virtualHosts."${cfg.virtualHost.domain}".extraConfig = ''
         root * ${cfg.package}
-        file_server
+        encode zstd gzip
+
+        @immutable path /resources/*
+        header @immutable Cache-Control "public, max-age=31536000, immutable"
+
+        @html not path /resources/*
+        header @html Cache-Control "no-store"
+
+        header {
+          -ETag
+          -Last-Modified
+        }
+
         handle_path /assets/config.yml {
           root * ${configFile}
           file_server
         }
+
+        file_server
       '';
     };
   };


### PR DESCRIPTION
I noticed an issue with the caddy integration of homer. After rebuilding my config, I had to hard-reset my browser's cache in order to see the changes. It seems that caddy uses the mtime of files to identify whether they need to be refreshed in the client, which is incompatible with files served from the nix-store. The solution for me was to strip the ETag and Last-Modified headers. To mitigate that, I added an immutable filter/route to the Caddyfile since every file under resources/ has a fingerprint attached to it that forces re-fetching. Finally, I enabled compression.

I've been using a similar config for another static website in one of my projects and so far it seems to work just fine.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
