### PR TITLE
gitify: 6.17.0 -> 6.20.0

### DIFF
--- a/pkgs/by-name/gi/gitify/package.nix
+++ b/pkgs/by-name/gi/gitify/package.nix
@@ -13,39 +13,57 @@
   makeWrapper,
   nix-update-script,
 }:
+let
+  pnpm = pnpm_10_29_2;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gitify";
-  version = "6.17.0";
+  version = "6.20.0";
 
   src = fetchFromGitHub {
     owner = "gitify-app";
     repo = "gitify";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-A9LeitceqDGictQbB7OYOI/pggrW9u8A7TUMblK/LHM=";
+    hash = "sha256-zKvI9uwKiKKbHTzM/LIhCzUCcM104UNReRJb51iQonc=";
   };
 
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
-    pnpm_10_29_2
+    pnpm
     copyDesktopItems
     imagemagick
     makeWrapper
   ];
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_10_29_2;
-    fetcherVersion = 3;
-    hash = "sha256-0iTvrIe5PVj99ePWt8rn+laikdJ5TaNQ8GZGHyUTTQI=";
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-KjRcUVeByCXetX7skJoxt6LU6EZcOG+5U2y3sr3XP7A=";
   };
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
 
   postPatch = ''
-    substituteInPlace config/electron-builder.js \
+    substituteInPlace electron-builder.js \
       --replace-fail "'Adam Setch (5KD23H9729)'" "null" \
       --replace-fail "'scripts/afterSign.js'" "null"
+
+    # With a nixpkgs electron wrapper, app.isPackaged always returns false,
+    # so isDevMode() is always true. This causes the config.ts getter for
+    # indexHtml to return VITE_DEV_SERVER_URL (which is empty) instead of the
+    # packaged file:// URL, resulting in a blank white window.
+    # Patch isDevMode() to false so the file:// path is always used.
+    substituteInPlace src/main/config.ts \
+      --replace-fail "isDevMode()" "false"
+
+    # Disable auto-updater; updates are handled via nixpkgs.
+    substituteInPlace src/main/updater.ts \
+      --replace-fail "if (!this.menubar.app.isPackaged)" "if (true)"
   '';
 
   buildPhase = ''
@@ -57,7 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     pnpm build
     pnpm exec electron-builder \
-        --config config/electron-builder.js \
+        --config electron-builder.js \
         --dir \
         -c.electronDist=electron-dist \
         -c.electronVersion="${electron.version}" \


### PR DESCRIPTION
This PR updates gitify and the following:
- Migrates electron-builder config path from config/ to root.
- Patch isDevMode() to false: it was causing the app to render a blank window.
- Disable auto updater.
- (Edit) Enabled strictDeps and structuredAttrs.

Assisted-by: opencode with DeepSeek V4 Flash Free


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
