### PR TITLE
[Backport release-26.05] various: don't depend on cargoDeps internal directory naming

### DIFF
--- a/pkgs/by-name/go/gossip/package.nix
+++ b/pkgs/by-name/go/gossip/package.nix
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-rE7SErOhl2fcmvLairq+mvdnbDIk1aPo3eYqwRx5kkA=";
 
   postPatch = ''
-    substituteInPlace $cargoDepsCopy/source-registry-0/sdl2-sys-0.37.0/SDL/CMakeLists.txt \
+    substituteInPlace $cargoDepsCopy/*/sdl2-sys-0.37.0/SDL/CMakeLists.txt \
       --replace-fail "cmake_minimum_required(VERSION 3.0.0)" "cmake_minimum_required(VERSION 3.0.0...3.5)" \
       --replace-fail "cmake_minimum_required(VERSION 3.4)" "cmake_minimum_required(VERSION 3.4...3.5)"
   '';

--- a/pkgs/by-name/oc/oculante/libaom-sys-0.17.2+libaom.3.11.0-cmake-nasm-fix.patch
+++ b/pkgs/by-name/oc/oculante/libaom-sys-0.17.2+libaom.3.11.0-cmake-nasm-fix.patch
@@ -1,5 +1,5 @@
---- a/libaom-sys-0.17.2+libaom.3.11.0/vendor/build/cmake/aom_optimization.cmake
-+++ b/libaom-sys-0.17.2+libaom.3.11.0/vendor/build/cmake/aom_optimization.cmake
+--- a/vendor/build/cmake/aom_optimization.cmake
++++ b/vendor/build/cmake/aom_optimization.cmake
 @@ -212,7 +212,7 @@ endfunction()
  # Currently checks only for presence of required object formats and support for
  # the -Ox argument (multipass optimization).

--- a/pkgs/by-name/oc/oculante/package.nix
+++ b/pkgs/by-name/oc/oculante/package.nix
@@ -67,17 +67,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=thumbnails::test_thumbs" # broken as of v0.9.2
   ];
 
-  patches = [
-    # The below patch is needed to fix this build, until the upstream dependency (libavif-rs) fixes the problem.
-    # The explicit `patchFlags` can also be removed when this patch becomes obsolete.
-    # <https://github.com/njaard/libavif-rs/issues/122>
-    ./libaom-sys-0.17.2+libaom.3.11.0-cmake-nasm-fix.patch
-  ];
-
-  patchFlags = [
-    "-p1"
-    "--directory=../${finalAttrs.pname}-${finalAttrs.version}-vendor/source-registry-0"
-  ];
+  # The below patch is needed to fix this build, until the upstream dependency (libavif-rs) fixes the problem.
+  # <https://github.com/njaard/libavif-rs/issues/122>
+  postPatch = ''
+    patch -p1 -d "$cargoDepsCopy"/*/libaom-sys-0.17.2+libaom.3.11.0 -i ${./libaom-sys-0.17.2+libaom.3.11.0-cmake-nasm-fix.patch}
+  '';
 
   postInstall = ''
     install -Dm444 $src/res/icons/icon.png $out/share/icons/hicolor/128x128/apps/oculante.png


### PR DESCRIPTION
Manual backport of https://github.com/NixOS/nixpkgs/pull/529334
Only two packages out of the 5 exist on stable.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
