### PR TITLE
libretro.dolphin: removed unnecessary dependencies, add glslang as extraBuildInputs

### DIFF
--- a/pkgs/applications/emulators/libretro/cores/dolphin.nix
+++ b/pkgs/applications/emulators/libretro/cores/dolphin.nix
@@ -3,25 +3,18 @@
   fetchFromGitHub,
   cmake,
   curl,
-  gettext,
-  hidapi,
   libGL,
   libGLU,
   libevdev,
   mkLibretroCore,
-  pcre,
   pkg-config,
-  sfml,
   udev,
   libxcb-util,
-  libxxf86vm,
   libxrandr,
   libxi,
   libxinerama,
   libxext,
   libx11,
-  libsm,
-  libpthread-stubs,
   libxcb,
 }:
 mkLibretroCore {
@@ -41,23 +34,17 @@ mkLibretroCore {
     curl
     pkg-config
   ];
+
   extraBuildInputs = [
-    gettext
-    hidapi
     libGL
     libGLU
     libevdev
-    pcre
-    sfml
     udev
-    libsm
     libx11
     libxext
     libxi
     libxinerama
     libxrandr
-    libxxf86vm
-    libpthread-stubs
     libxcb
     libxcb-util
   ];

--- a/pkgs/applications/emulators/libretro/cores/dolphin.nix
+++ b/pkgs/applications/emulators/libretro/cores/dolphin.nix
@@ -3,19 +3,20 @@
   fetchFromGitHub,
   cmake,
   curl,
+  glslang,
+  libevdev,
   libGL,
   libGLU,
-  libevdev,
+  libx11,
+  libxcb,
+  libxcb-util,
+  libxext,
+  libxi,
+  libxinerama,
+  libxrandr,
   mkLibretroCore,
   pkg-config,
   udev,
-  libxcb-util,
-  libxrandr,
-  libxi,
-  libxinerama,
-  libxext,
-  libx11,
-  libxcb,
 }:
 mkLibretroCore {
   core = "dolphin";
@@ -36,17 +37,18 @@ mkLibretroCore {
   ];
 
   extraBuildInputs = [
+    glslang
     libGL
     libGLU
     libevdev
-    udev
     libx11
+    libxcb
+    libxcb-util
     libxext
     libxi
     libxinerama
     libxrandr
-    libxcb
-    libxcb-util
+    udev
   ];
 
   makefile = "Makefile";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Remove unnecessary dependencies that are not even detected by `pkg-config`/`cmake` step. Probably they got copied from `dolphin-emu` package, or some other reason lost in time.

In special this removes `pcre`, part of https://github.com/NixOS/nixpkgs/issues/356387.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
