### PR TITLE
rcu: 4.0.34 -> 5.1.0

### DIFF
--- a/pkgs/by-name/rc/rcu/package.nix
+++ b/pkgs/by-name/rc/rcu/package.nix
@@ -9,22 +9,17 @@
   coreutils,
   desktopToDarwinBundle,
   gnutar,
-  libsForQt5,
+  qt6,
   makeDesktopItem,
   net-tools,
   protobuf,
-  python312Packages,
+  python3Packages,
   system-config-printer,
   wget,
 }:
-
-let
-  # shiboken2 is broken on Python > 3.12
-  python3Packages = python312Packages;
-in
 python3Packages.buildPythonApplication rec {
   pname = "rcu";
-  version = "4.0.34";
+  version = "5.1.0";
 
   pyproject = false;
 
@@ -32,7 +27,7 @@ python3Packages.buildPythonApplication rec {
     let
       src-tarball = requireFile {
         name = "rcu-${version}-source.tar.gz";
-        hash = "sha256-9YhhsLqAcevjJmENWVWfA1ursPz3mgFz8mzLLSNlXVM=";
+        hash = "sha256-s5cqUu2hJEHpLVUwTbNYLQCNXMjv0vFGzQb041+XEqA=";
         url = "https://www.davisr.me/projects/rcu/";
         meta = {
           # `requireFile` sets `lib.licenses.unfree` by default
@@ -69,15 +64,16 @@ python3Packages.buildPythonApplication rec {
   nativeBuildInputs = [
     copyDesktopItems
     protobuf
-    libsForQt5.wrapQtAppsHook
+    qt6.wrapQtAppsHook
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     desktopToDarwinBundle
   ];
 
   buildInputs = [
-    libsForQt5.qtbase
-    libsForQt5.qtwayland
+    qt6.qtbase
+    qt6.qtwayland
+    qt6.qtsvg
   ];
 
   propagatedBuildInputs = with python3Packages; [
@@ -88,7 +84,7 @@ python3Packages.buildPythonApplication rec {
     pikepdf
     pillow
     python3Packages.protobuf # otherwise it picks up protobuf from function args
-    pyside2
+    pyside6
   ];
 
   desktopItems = [


### PR DESCRIPTION
Update rcu from 4.0.34 to 5.1.0.

## Upstream changes

- Adds hardware compatibility with reMarkable Paper Pure
- Adds system software compatibility for 3.27.2.2
- Upgrades graphical framework from Qt 5 (PySide2) to Qt 6 (PySide6)
- Adds native support for macOS ARM
- Raises minimum Python requirement to 3.10
- Boosts performance and reduces CPU utilization while the Notebooks pane is open
- Fixes a defect with Flip Boot Partition between system software 3.26 and 2.x erroneously
  showing the Carousel widget in the Notebooks pane

Full release notes: https://www.davisr.me/projects/rcu/

## Packaging changes

- Migrate from `libsForQt5` to `qt6` (Qt 5 -> Qt 6)
- Replace `pyside2` with `pyside6` in `propagatedBuildInputs`
- Drop Python 3.12 pin: `python312Packages` was pinned solely because `shiboken2`
  (PySide2's binding generator) was broken on Python > 3.12; `pyside6` has no such constraint
- Add `qt6.qtsvg` to `buildInputs`: Qt 6 moved `QSvgWidget` into a separate `QtSvgWidgets`
  module, which the codebase now imports
- Keep the existing paramiko 4.x compatibility patch: `src/model/transport.py` is unchanged
  between versions and still references removed APIs (`DSSKey`, `py3compat`, `retry_on_signal`)

<img width="870" height="282" alt="image" src="https://github.com/user-attachments/assets/32625ea2-756c-4cab-8b27-b4d6edb0de88" />


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
