### PR TITLE
python3Packages.pymeshlab: add missing dep

### DIFF
--- a/pkgs/development/python-modules/pymeshlab/default.nix
+++ b/pkgs/development/python-modules/pymeshlab/default.nix
@@ -17,6 +17,7 @@
 
   # buildInputs
   libsForQt5,
+  libsm,
   llvmPackages,
   glew,
   vcg,
@@ -60,6 +61,7 @@ buildPythonPackage {
   buildInputs = [
     glew
     libsForQt5.qtbase
+    libsm
     vcg
   ]
   ++ lib.optionals stdenv.cc.isClang [
@@ -95,6 +97,9 @@ buildPythonPackage {
   '';
 
   pythonImportsCheck = [ "pymeshlab" ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   meta = {
     description = "Open source mesh processing python library";


### PR DESCRIPTION
fix:

```python
Executing pythonImportsCheckPhase
Check whether the following modules can be imported: pymeshlab
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import sys; import importlib; list(map(lambda mod: importlib.import_module(mod), sys.argv[1:]))
                                  ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<string>", line 1, in <lambda>
    import sys; import importlib; list(map(lambda mod: importlib.import_module(mod), sys.argv[1:]))
                                                       ~~~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "/nix/store/60m4rxhg2fldqaak400c0lry96ijrzqn-python3-3.13.13/lib/python3.13/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1395, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 1023, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/nix/store/jmjl11ib1a84chnzqrajixraa5v1f0sh-python3.13-pymeshlab-2025.7.post1/lib/python3.13/site-packages/pymeshlab/__init__.py", line 11, in <module>
    from .pmeshlab import *
ImportError: libSM.so.6: cannot open shared object file: No such file or directory
```

While here add strictDeps & __structuredAttrs


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
