### PR TITLE
bluesky-pds: 0.4.219 -> 0.4.5001

### DIFF
--- a/pkgs/by-name/bl/bluesky-pds/package.nix
+++ b/pkgs/by-name/bl/bluesky-pds/package.nix
@@ -8,7 +8,7 @@
   fetchPnpmDeps,
   pnpmConfigHook,
   fetchFromGitHub,
-  nodejs_22,
+  nodejs_24,
   vips,
   pkg-config,
   nixosTests,
@@ -18,22 +18,22 @@
 }:
 
 let
-  # build failure against better-sqlite3, so we use nodejs_22; upstream
-  # bluesky-pds uses 20
-  nodejs = nodejs_22;
+  # upstream bluesky-social/atproto uses nodejs 22+
+  nodejs = nodejs_24;
   nodeSources = srcOnly nodejs;
   pythonEnv = python3.withPackages (p: [ p.setuptools ]);
+  pnpm = pnpm_9;
 in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pds";
-  version = "0.4.219";
+  version = "0.4.5001";
 
   src = fetchFromGitHub {
     owner = "bluesky-social";
     repo = "pds";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-zXNg1rtXN9qdTBvRlSiPlRu6k1Pv3T8nhROsEarev5U=";
+    hash = "sha256-j7XNZYZHHj5HdtEuTAhNU9TD7S7eMILMflZJn0nDVaY=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/service";
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     pythonEnv
     pkg-config
     pnpmConfigHook
-    pnpm_9
+    pnpm
     removeReferencesTo
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
@@ -61,9 +61,9 @@ stdenv.mkDerivation (finalAttrs: {
       src
       sourceRoot
       ;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-rZpimxX4oDXIaUdAkkNPEff6qYJ9C8KptsPWJKwPiFo=";
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-3/gjhQIMxI/mwqmKV1wZ6oMiCGHutXuDY2CFSN3QnE4=";
   };
 
   buildPhase = ''
@@ -76,7 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     makeWrapper "${lib.getExe nodejs}" "$out/bin/pds" \
       --add-flags --enable-source-maps \
-      --add-flags "$out/lib/pds/index.js" \
+      --add-flags "$out/lib/pds/index.ts" \
       --set-default NODE_ENV production
 
     runHook postBuild
@@ -87,7 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     mkdir -p $out/{bin,lib/pds}
     mv node_modules $out/lib/pds
-    mv index.js $out/lib/pds
+    mv index.ts $out/lib/pds
 
     runHook postInstall
   '';


### PR DESCRIPTION
Diff: https://github.com/bluesky-social/pds/compare/v0.4.219...v0.4.5001

currently running this with no issues

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
