### PR TITLE
extism-js-core: mark as broken on darwin

### DIFF
--- a/pkgs/by-name/ex/extism-js-core/package.nix
+++ b/pkgs/by-name/ex/extism-js-core/package.nix
@@ -79,6 +79,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   __structuredAttrs = true;
 
   meta = {
+    # Fails to build on darwin due to libiconv linking failure (ld: library not found for -liconv)
+    # See https://github.com/NixOS/nixpkgs/pull/523442 for a (failed) attempt at fixing the issue
+    broken = stdenv.buildPlatform.isDarwin;
     changelog = "https://github.com/extism/js-pdk/releases/tag/${finalAttrs.src.tag}";
     description = "Write Extism plugins in JavaScript & TypeScript (WASM core)";
     homepage = "https://github.com/extism/js-pdk";


### PR DESCRIPTION
Build fails due to a linking error: "ld: library not found for -liconv".

I have attempted to fix this in https://github.com/NixOS/nixpkgs/pull/523442, but without success. As such, I'm instead marking it as broken, and whoever needs it for darwin can attempt to fix it instead (I do not own a darwin machine, therefore cannot easily debug the issue).

Closes https://github.com/NixOS/nixpkgs/pull/523442

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
