### PR TITLE
ugee-s640-tablet-driver: init at 4.3.4

### DIFF
--- a/pkgs/by-name/ug/ugee-s640-tablet-driver/package.nix
+++ b/pkgs/by-name/ug/ugee-s640-tablet-driver/package.nix
@@ -1,0 +1,123 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  autoPatchelfHook,
+  libx11,
+  libxrandr,
+  libGL,
+  libgcc,
+  libusb1,
+  libxtst,
+  libxi,
+  libxinerama,
+  libz,
+  glib,
+  dbus,
+  libxext,
+  libsm,
+  libice,
+  libxcb,
+  fontconfig,
+  freetype,
+  libxrender,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ugee-s640-tablet-driver";
+  version = "4.3.4";
+
+  src = fetchzip {
+    url = "https://download.ugee.com.cn/upload/download/20241217/ugeeTablet-4.3.4-241031.tar.gz";
+    name = "${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
+    hash = "sha256-KCoDTnE7RhciCRVMnNXkTK0trkO5OsNNm29UWdnYD7E=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    libx11
+    libxrandr
+    libGL
+    libgcc
+    libusb1
+    libxtst
+    libxi
+    libxinerama
+    libz
+    glib
+    dbus
+    libxext
+    libsm
+    libice
+    libxcb
+    fontconfig
+    freetype
+    libxrender
+  ];
+
+  buildInputs = [
+  ];
+
+  installPhase = ''
+    AppDir=ugeeTablet
+
+    #Copy rule
+    sysRuleDir="/lib/udev/rules.d"
+    appRuleDir=./App$sysRuleDir
+    ruleName="ugee4-1.rules"
+
+    mkdir -p $out$sysRuleDir
+    cp $appRuleDir/$ruleName $out$sysRuleDir/$ruleName
+
+    #install app
+    sysAppDir="/usr/lib"
+    appAppDir=./App$sysAppDir/$AppDir
+
+    mkdir -p $out$sysAppDir
+    cp -rf $appAppDir $out$sysAppDir
+
+    ##install shortcut
+    #sysDesktopDir=/usr/share/applications
+    #sysAppIconDir=/usr/share/icons/hicolor/256x256/apps
+    #sysAutoStartDir=/etc/xdg/autostart
+
+    #appDesktopDir=./App$sysDesktopDir
+    #appAppIconDir=./App$sysAppIconDir
+    #appAutoStartDir=./App$sysAutoStartDir
+
+    #appDesktopName=ugeetablet.desktop
+    #appIconName=ugeetablet.png
+
+    #cp $appDesktoopDir/$appDesktopName $out$sysDesktopDir/$appDesktopName
+    #chmod +0555 $out$sysDesktopDir/$appDesktopName
+
+    #cp $appAppIconDir/$appIconName $out$sysAppIconDir/$appIconName
+    #chmod +0555 $out$sysAppIconDir/$appIconName
+
+    #Copy config files
+    chmod +0555 $out/usr/lib/ugeeTablet/ugeeTablet
+    chmod +0555 $out/usr/lib/ugeeTablet/ugeeTabletDriver.sh
+    chmod +0555 $out/usr/lib/ugeeTablet/ugeeTabletDriver
+    confPath="/usr/lib/ugeeTablet/conf"
+
+    chmod +0777 $out$confPath
+
+    chmod +0666 $out$confPath/Ugee_Tablet.xml
+    chmod +0666 $out$confPath/language.ini
+    chmod +0666 $out$confPath/name_config.ini
+    chmod +0666 $out/usr/lib/ugeeTablet/resource.rcc
+  '';
+
+  meta = {
+    homepage = "https://www.ugee.com.cn/download/125.html";
+    description = " Driver for ugee s640 drawing tablet. And if you are installing for the first time, please use it after restart.";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ ];
+  };
+  platforms = [
+    "x86_64-linux"
+  ];
+
+})

--- a/pkgs/by-name/ug/ugee-s640-tablet-driver/package.nix
+++ b/pkgs/by-name/ug/ugee-s640-tablet-driver/package.nix
@@ -27,6 +27,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "ugee-s640-tablet-driver";
   version = "4.3.4";
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   src = fetchzip {
     url = "https://download.ugee.com.cn/upload/download/20241217/ugeeTablet-4.3.4-241031.tar.gz";
     name = "${finalAttrs.pname}-${finalAttrs.version}.tar.gz";


### PR DESCRIPTION
Add "ugee-s640-tablet-driver" -- a driver for Ugee S640 tablet

Homepage: https://www.ugee.com/download/s1060w?_hw_did=24895ea5e14651e0937bf577f6f2a92f

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
