### PR TITLE
ucs: init at 0.8.0

### DIFF
--- a/pkgs/by-name/uc/ucs/package.nix
+++ b/pkgs/by-name/uc/ucs/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+}:
+buildGoModule (finalAttrs: {
+  pname = "ucs";
+  version = "0.8.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "vmikk";
+    repo = "ucs";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-cw6hjEwY0f+B6Sqy3dITxebPDy22IOmr/zA/c0ZMK8o=";
+  };
+
+  vendorHash = "sha256-tH//UfQPcPf0Yo5wDINqzBxZG5A7nlGNSW/po9LLe2U=";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = {
+    description = "UC file summarizer";
+    homepage = "https://github.com/vmikk/ucs";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ artur-sannikov ];
+  };
+})


### PR DESCRIPTION
The ucs tool reads USEARCH cluster format (UC) files, which are tab-separated text files commonly used in clustering and database searches.

Repo: https://github.com/vmikk/ucs

## Things done
The tool builds and runs with `ucs --help`. I'm not sure what test data can be used to see if it works. Probably the creator knows @vmikk.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
