### PR TITLE
maintainers: remove rb2k

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23085,12 +23085,6 @@
     githubId = 7775707;
     name = "RB";
   };
-  rb2k = {
-    email = "nix@marc-seeger.com";
-    github = "rb2k";
-    githubId = 9519;
-    name = "Marc Seeger";
-  };
   rbasso = {
     email = "rbasso@sharpgeeks.net";
     github = "rbasso";

--- a/pkgs/by-name/li/libdnf/package.nix
+++ b/pkgs/by-name/li/libdnf/package.nix
@@ -103,9 +103,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/rpm-software-management/libdnf/releases/tag/${finalAttrs.version}";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
-    maintainers = with lib.maintainers; [
-      rb2k
-      katexochen
-    ];
+    maintainers = with lib.maintainers; [ katexochen ];
   };
 })

--- a/pkgs/by-name/mi/microdnf/package.nix
+++ b/pkgs/by-name/mi/microdnf/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Lightweight implementation of dnf in C";
     homepage = "https://github.com/rpm-software-management/microdnf";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ rb2k ];
+    maintainers = [ ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     mainProgram = "microdnf";
   };


### PR DESCRIPTION
## Reasons

- Last commented in [August 2024](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Arb2k)
- Hasn't created any PRs / Issues since [September 2022](https://github.com/NixOS/nixpkgs/issues?q=author%3Arb2k)
- About 21 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Arb2k%20-commenter%3Arb2k%20-author%3Arb2k%20-reviewed-by%3Arb2k) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] microdnf