### PR TITLE
qpdf: build with zopfli support

### DIFF
--- a/pkgs/by-name/qp/qpdf/package.nix
+++ b/pkgs/by-name/qp/qpdf/package.nix
@@ -6,6 +6,7 @@
   libjpeg,
   perl,
   zlib,
+  zopfli,
   ctestCheckHook,
 
   # for passthru.tests
@@ -41,8 +42,9 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    zlib
     libjpeg
+    zlib
+    zopfli
   ];
 
   nativeCheckInputs = [ ctestCheckHook ];
@@ -52,6 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "SHOW_FAILED_TEST_OUTPUT" true)
+    (lib.cmakeBool "ZOPFLI" true)
   ];
 
   preConfigure = ''


### PR DESCRIPTION
Build QPDF with Zopfli support.
Tested by running `qpdf --zopfli`.
Build option is documented here: https://qpdf.readthedocs.io/en/stable/installation.html#basic-dependencies

This does not effect behavior of QPDF unless the environment variable `QPDF_ZOPFLI` is set to anything other than `disabled`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
