### PR TITLE
fingwit: init at 1.0.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13928,6 +13928,12 @@
     githubId = 6544084;
     name = "Kai Harries";
   };
+  kajusnau = {
+    name = "Kajus";
+    email = "kajusn@gmail.com";
+    github = "kajusnau";
+    githubId = 180287497;
+  };
   kalbasit = {
     email = "wael.nasreddine@gmail.com";
     matrix = "@kalbasit:matrix.org";

--- a/pkgs/by-name/fi/fingwit/0001-check-all-pam-services-for-fprintd.patch
+++ b/pkgs/by-name/fi/fingwit/0001-check-all-pam-services-for-fprintd.patch
@@ -1,0 +1,39 @@
+From: Kajus Naujokaitis <kajusn@gmail.com>
+Date: Thu, 5 Jun 2026 00:00:00 +0000
+Subject: [PATCH] check all PAM service files for pam_fprintd.so
+
+/etc/pam.d/common-auth is a Debian convention. On other distributions
+(NixOS, Fedora, Arch, etc.) there is no common-auth; each PAM service
+has its own complete configuration. Scan all files under /etc/pam.d/
+instead so the check works generically.
+
+Also widen the search to pam_fprintd.so (the actual fingerprint module)
+in addition to pam_fingwit.so so that deployments which configure
+fprintd directly without pam_fingwit.so are still recognised.
+---
+ fingwit | 9 +++++++--
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/fingwit b/fingwit
+index 1111111..2222222 100755
+--- a/fingwit
++++ b/fingwit
+@@ -384,11 +384,14 @@
+
+     def check_pam_fprintd_enabled(self):
+         try:
+-            with open('/etc/pam.d/common-auth', 'r') as f:
+-                content = f.read()
+-                if 'pam_fingwit.so' in content:
+-                    return True
++            for filename in os.listdir('/etc/pam.d'):
++                filepath = os.path.join('/etc/pam.d', filename)
++                if os.path.isfile(filepath):
++                    with open(filepath, 'r', errors='replace') as f:
++                        content = f.read()
++                        if 'pam_fprintd.so' in content or 'pam_fingwit.so' in content:
++                            return True
+         except Exception as e:
+             print(e)
+         return False
+

--- a/pkgs/by-name/fi/fingwit/package.nix
+++ b/pkgs/by-name/fi/fingwit/package.nix
@@ -82,5 +82,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;
     mainProgram = "fingwit";
+    maintainers = with lib.maintainers; [
+      kajusnau
+    ];
   };
 })

--- a/pkgs/by-name/fi/fingwit/package.nix
+++ b/pkgs/by-name/fi/fingwit/package.nix
@@ -1,0 +1,86 @@
+{
+  fetchFromGitHub,
+  gettext,
+  glib,
+  gobject-introspection,
+  gtk3,
+  lib,
+  meson,
+  ninja,
+  pam,
+  pkg-config,
+  python3,
+  python3Packages,
+  wrapGAppsHook3,
+  xapp,
+}:
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "fingwit";
+  version = "1.0.8";
+  format = "other";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "xapp-project";
+    repo = "fingwit";
+    tag = finalAttrs.version;
+    hash = "sha256-Pyyl79cwKHAfir8uQ4nzjcxc6yz50EbX6VCJDBNLJTs=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    gettext
+    wrapGAppsHook3
+    gobject-introspection
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtk3
+    xapp
+    glib
+    pam
+  ];
+
+  dependencies = with python3Packages; [
+    pygobject3
+    setproctitle
+    python-pam
+  ];
+
+  patches = [ ./0001-check-all-pam-services-for-fprintd.patch ];
+
+  postPatch = ''
+    patchShebangs data/meson_install_schemas.py
+
+    substituteInPlace pam_fingwit.py \
+      --replace-fail "import PAM" "import pam" \
+      --replace-fail "PAM." "pam."
+
+    substituteInPlace pam_fingwit.c \
+      --replace-fail '"python3"' '"${lib.getExe python3}"'
+  '';
+
+  postInstall = ''
+    # Fix hard-coded non-FHS paths
+    substituteInPlace $out/bin/fingwit \
+      --replace-fail "/usr/share" "$out/share"
+
+    # Use standard freedesktop icon names
+    substituteInPlace $out/share/fingwit/fingwit.ui \
+      --replace-fail "xsi-fingerprint-symbolic" "auth-fingerprint-symbolic" \
+      --replace-fail "xsi-open-menu-symbolic" "open-menu-symbolic"
+    substituteInPlace $out/bin/fingwit \
+      --replace-fail "xsi-fingerprint-symbolic" "auth-fingerprint-symbolic"
+  '';
+
+  meta = {
+    description = "Fingerprint configuration tool (XApp)";
+    homepage = "https://github.com/xapp-project/fingwit";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    mainProgram = "fingwit";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

A Python GUI wrapper for libfprint. Allows user-friendly management of fingerprints.

Upstream: https://github.com/xapp-project/fingwit

Some notes about patches and fixes done in this packaging:
- Replaced hardcoded `/usr/share/...` paths with Nix store paths
- python `PAM` module name changed to `pam` (lowercase) in `pam_fingwit.py`
- "python3" in pam_fingwit.c replaced with full Nix store path pointing to python3
- meson_install_schemas.py shebang patched so it runs correctly during meson install
- `check_pam_fprintd_enabled` scans all of `/etc/pam.d/` instead of Debian-only `common-auth` to verify fprint authentication is enabled on the system
- XApp-specific icon names replaced with standard freedesktop equivalents

Other stuff worth mentioning:
- If fprint authentication is not enabled (`config.services.fprintd.enable`), the app will open to a page informing the user that `Fingerprint authentication disabled`, along with a button labeled "Enable".
   Clicking said button calls `pam-auth-update` under the hood, which is a Debian/Ubuntu exclusive tool. As a result, on NixOS nothing happens.
- If fprint authentication **_is_** enabled (`config.services.fprintd.enable = true;`), the user can find a "Disable fingerprint authentication" button in the top-left menu.
   Clicking this button on NixOS does nothing, due to the same reason as above.
- fingwit ships with its own PAM module (`lib/security/pam_fingwit.so`), which gates fingerprint authentication
   Below is an example of how it can be used in a NixOS config:
   
<details>

<summary>pam_fingwit.so module usage example</summary>

```nix
security.pam.services.custom-pam-service = {
  fprintAuth = true;
  rules.auth = {
    fprintd = {
      args = [
        "max-tries=3"
        "timeout=15"
      ];
    };

    fingwit = {
      enable = true;
      control = "[authinfo_unavail=1 default=ignore]";
      modulePath = "${pkgs.fingwit}/lib/security/pam_fingwit.so";
      order = 11300; # Order it before fprintd
      args = [
        "debug"
      ];
      settings.config_file = "${pkgs.fingwit}/share/pam-configs/fingwit";
    };
  };
};
```

</details>

I've confirmed this PAM module works as it should when unlocking an already active user session (screensaver).
For initial logins (reboot/power-on) where the user keyring requires a password to unlock or the user home dir is encrypted, this module should simply skip fprintd and prompt the user for a password.
I have not confirmed this behavior yet.

Related issue: https://github.com/NixOS/nixpkgs/issues/417966

### Discussion points
1. Should this package be added to `config.services.fprintd`, and maybe even enabled by default, as `config.services.fprintd.fingwit`?
2. Similarly as above, should the accompanying PAM module be added to `security.pam.services.<name>.fprintAuth`?

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
