### PR TITLE
treewide: update pnpm_9 to pnpm_10

### DIFF
--- a/pkgs/by-name/ao/aonsoku/package.nix
+++ b/pkgs/by-name/ao/aonsoku/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   nodejs,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   makeWrapper,
@@ -31,14 +31,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-oBwqYOx2KEtF0qdMKEIgdArZ4xs/AyeOqFoU4nHl3xY=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-9K9gxfMxZHvUpeCeXCXGJbB3p2aL0qsMqfnRLPA9wRw=";
   };
 
   nativeBuildInputs = [
     nodejs
-    pnpm_9
+    pnpm_10
     pnpmConfigHook
     makeWrapper
     electron

--- a/pkgs/by-name/ar/artalk/package.nix
+++ b/pkgs/by-name/ar/artalk/package.nix
@@ -3,7 +3,7 @@
   buildGoModule,
   fetchFromGitHub,
   nodejs,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   installShellFiles,
@@ -31,14 +31,14 @@ let
     nativeBuildInputs = [
       nodejs
       pnpmConfigHook
-      pnpm_9
+      pnpm_10
     ];
 
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname version src;
-      pnpm = pnpm_9;
-      fetcherVersion = 3;
-      hash = "sha256-HypDGYb0MRCIDBHY8pVgwFoZQWC8us44cunORZRk3RM=";
+      pnpm = pnpm_10;
+      fetcherVersion = 4;
+      hash = "sha256-RSz/bx8/BAqLZH3/yQ6/H/nnwGvcCg8EzIEJ4/xkQgQ=";
     };
 
     buildPhase = ''

--- a/pkgs/by-name/au/autoprefixer/package.nix
+++ b/pkgs/by-name/au/autoprefixer/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   nodejs,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   fetchFromGitHub,
@@ -23,14 +23,14 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
   ];
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-PPYyEsc0o5ufBexUdiX9EJLEsQZ0wX7saBzxJGsnseU=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-fnharTNtW16Il/O+RFZZdy1S6PZsi3tctcLfaH1oJ2o=";
   };
 
   installPhase = ''

--- a/pkgs/by-name/ba/backrest/package.nix
+++ b/pkgs/by-name/ba/backrest/package.nix
@@ -6,7 +6,7 @@
   lib,
   libredirect,
   nodejs,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   restic,
@@ -33,14 +33,14 @@ let
     nativeBuildInputs = [
       nodejs
       pnpmConfigHook
-      pnpm_9
+      pnpm_10
     ];
 
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname version src;
-      pnpm = pnpm_9;
-      fetcherVersion = 3;
-      hash = "sha256-9wzPNZxLE0l/AJ8SyE0SkhkBImiibhqJgsG3UrGj3aA=";
+      pnpm = pnpm_10;
+      fetcherVersion = 4;
+      hash = "sha256-r72WLWFyYuPL2QuT14VqyG8leqADFX4XZQpl7Nqe77A=";
     };
 
     buildPhase = ''

--- a/pkgs/by-name/da/daed/package.nix
+++ b/pkgs/by-name/da/daed/package.nix
@@ -1,5 +1,5 @@
 {
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   nodejs,
@@ -33,15 +33,15 @@ let
         version
         src
         ;
-      pnpm = pnpm_9;
-      fetcherVersion = 3;
-      hash = "sha256-FBZk7qeYNi7JX99Sk1qe52YUE8GUYINJKid0mEBXMjU=";
+      pnpm = pnpm_10;
+      fetcherVersion = 4;
+      hash = "sha256-sGDHsXlzOcXSYNARzMMpQT8AyKAOG/q2bq1qgDBXlsM=";
     };
 
     nativeBuildInputs = [
       nodejs
       pnpmConfigHook
-      pnpm_9
+      pnpm_10
     ];
 
     buildPhase = ''

--- a/pkgs/by-name/do/dorion/package.nix
+++ b/pkgs/by-name/do/dorion/package.nix
@@ -16,7 +16,7 @@
   openssl,
   pkg-config,
   yq-go,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   webkitgtk_4_1,
@@ -60,9 +60,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-E45X3JEns1TE+SVbtbBEl+RzwRgTiGN7/N4OgJ5o63o=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-otcOYoPXjEbTMGAUH6fEKmBKlR07dAFpeXaL8TRB25s=";
   };
 
   # CMake (webkit extension, Linux only)
@@ -78,7 +78,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
     cargo-tauri.hook
     nodejs
     pkg-config

--- a/pkgs/by-name/em/emmet-language-server/package.nix
+++ b/pkgs/by-name/em/emmet-language-server/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenvNoCC,
   nodejs,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   fetchFromGitHub,
@@ -21,15 +21,15 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-livnY/iwd7gqy6SKFBMF2MSIs7LVFec4BFqMBVasGWE=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-B8dtz87d0PifOSywhTLrMSZiP4F0TsKMxr43qjogcA4=";
   };
 
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
   ];
 
   buildPhase = ''

--- a/pkgs/by-name/et/etherpad-lite/package.nix
+++ b/pkgs/by-name/et/etherpad-lite/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   nix-update-script,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   makeWrapper,
@@ -30,14 +30,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-2nKpmGxC+KVg0oF0BsswS9L84QxzpRF7NvKyqyQ7WJM=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-scJhcZDyqUVdKv/EQvB5+EJN/SvMw220+QOcTUxTFJQ=";
   };
 
   nativeBuildInputs = [
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
     makeWrapper
   ];
 
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper ${lib.getExe nodejs} $out/bin/etherpad-lite \
       --inherit-argv0 \
       --add-flags "--require tsx/cjs $out/lib/etherpad-lite/node_modules/ep_etherpad-lite/node/server.ts" \
-      --suffix PATH : "${lib.makeBinPath [ pnpm_9 ]}" \
+      --suffix PATH : "${lib.makeBinPath [ pnpm_10 ]}" \
       --set NODE_PATH "$out/lib/node_modules:$out/lib/etherpad-lite/node_modules/ep_etherpad-lite/node_modules" \
       --set-default NODE_ENV production
     find $out/lib -xtype l -delete

--- a/pkgs/by-name/fi/firezone-gui-client/package.nix
+++ b/pkgs/by-name/fi/firezone-gui-client/package.nix
@@ -19,7 +19,7 @@
   libayatana-appindicator,
   webkitgtk_4_1,
   wrapGAppsHook3,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   nodejs,
@@ -41,10 +41,10 @@ let
 
     pnpmDeps = fetchPnpmDeps {
       inherit pname version;
-      pnpm = pnpm_9;
+      pnpm = pnpm_10;
       src = "${src}/rust/gui-client";
-      fetcherVersion = 3;
-      hash = "sha256-akanXiWehhQRx6WHN75PjYvFxFiSsJ5dJaguJBTM9J0=";
+      fetcherVersion = 4;
+      hash = "sha256-K17MbAoA+nC2pscW+YuJMQHAP5Tcumuec1sIbT/CF7E=";
     };
     pnpmRoot = "rust/gui-client";
 
@@ -52,7 +52,7 @@ let
 
     nativeBuildInputs = [
       pnpmConfigHook
-      pnpm_9
+      pnpm_10
       nodejs
     ];
 

--- a/pkgs/by-name/fi/firezone-server/package.nix
+++ b/pkgs/by-name/fi/firezone-server/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   beam27Packages,
   gitMinimal,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   nodejs,
@@ -34,10 +34,10 @@ beam27Packages.mixRelease rec {
 
   pnpmDeps = fetchPnpmDeps {
     inherit pname version;
-    pnpm = pnpm_9;
+    pnpm = pnpm_10;
     src = "${src}/apps/web/assets";
-    fetcherVersion = 3;
-    hash = "sha256-tB0y3T/dZBe8BHz7AV913zQ4oQu7VLyqHCnzBycNg18=";
+    fetcherVersion = 4;
+    hash = "sha256-Uq6dAYYWT8G6upYcNEzVc8Gb2HUj8SaWRD0/w0quaRE=";
   };
   pnpmRoot = "apps/web/assets";
 
@@ -63,7 +63,7 @@ beam27Packages.mixRelease rec {
 
   nativeBuildInputs = [
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
     nodejs
   ];
 

--- a/pkgs/by-name/fl/flood/package.nix
+++ b/pkgs/by-name/fl/flood/package.nix
@@ -3,7 +3,7 @@
   buildNpmPackage,
   fetchFromGitHub,
   nixosTests,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   nix-update-script,
@@ -19,7 +19,7 @@ buildNpmPackage (finalAttrs: {
     hash = "sha256-gSjkpAGkvgRRh8WDpL/F7fS8KDxHRJUuWVqHGcFEGAc=";
   };
 
-  nativeBuildInputs = [ pnpm_9 ];
+  nativeBuildInputs = [ pnpm_10 ];
   npmConfigHook = pnpmConfigHook;
   npmDeps = finalAttrs.pnpmDeps;
   dontNpmPrune = true;
@@ -29,9 +29,9 @@ buildNpmPackage (finalAttrs: {
       version
       src
       ;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-Los6faQJ4it0fVqtRvPvYmyANK4qBcwHxmZBacR7Q6E=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-yNRC5sCBn002gxUfHMUvh3DZeVYOokfz4MTvqXR2MzI=";
   };
 
   passthru = {

--- a/pkgs/by-name/ga/garage-webui/package.nix
+++ b/pkgs/by-name/ga/garage-webui/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   buildGoModule,
   nodejs,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   nix-update-script,
@@ -27,14 +27,14 @@ buildGoModule (finalAttrs: {
     nativeBuildInputs = [
       nodejs
       pnpmConfigHook
-      pnpm_9
+      pnpm_10
     ];
 
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs') pname version src;
-      pnpm = pnpm_9;
-      fetcherVersion = 3;
-      hash = "sha256-z/Y9q/SE2c/KYzIOAfATlprjr6NjmmUHQB+ZbO39OK4=";
+      pnpm = pnpm_10;
+      fetcherVersion = 4;
+      hash = "sha256-GgqvoxdRdQv41G/T/7CmYM+Yp4ZVR1HmR+adNxgQCxc=";
     };
 
     buildPhase = ''

--- a/pkgs/by-name/im/immich-kiosk/package.nix
+++ b/pkgs/by-name/im/immich-kiosk/package.nix
@@ -3,7 +3,7 @@
   buildGoModule,
   fetchFromGitHub,
   nodejs,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
 }:
@@ -31,10 +31,10 @@ buildGoModule rec {
       version
       src
       ;
-    pnpm = pnpm_9;
+    pnpm = pnpm_10;
     sourceRoot = "${src.name}/frontend";
-    hash = "sha256-8iKug4zsX3u0vS68osKRW6iOP+A3OdjI3yxNPIJaQqM=";
-    fetcherVersion = 3;
+    fetcherVersion = 4;
+    hash = "sha256-51mjYuRNAnyxFAeO2+S+r54XuK5AfG4bpYs4WBkpvrk=";
   };
 
   # Frontend is in a subdirectory
@@ -43,7 +43,7 @@ buildGoModule rec {
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
   ];
 
   # Generate templ templates during vendor hash calculation

--- a/pkgs/by-name/me/meshtastic-web/package.nix
+++ b/pkgs/by-name/me/meshtastic-web/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   nodejs,
@@ -29,19 +29,19 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmWorkspaces = [ "*" ];
   pnpmRoot = "packages/web";
   pnpmDeps = fetchPnpmDeps {
-    pnpm = pnpm_9;
+    pnpm = pnpm_10;
     inherit (finalAttrs)
       pname
       version
       src
       pnpmWorkspaces
       ;
-    fetcherVersion = 3;
-    hash = "sha256-yUdPrZAnCsxIiF++SxTm1VuVAEKIzTsp2qd/WcCPOcQ=";
+    fetcherVersion = 4;
+    hash = "sha256-0o/g5FVzSGX9xtQ8DZGjakwOnPXvlA95tdD/VNymB1M=";
   };
 
   nativeBuildInputs = [
-    pnpm_9
+    pnpm_10
     pnpmConfigHook
     nodejs
   ];

--- a/pkgs/by-name/n8/n8n-nodes-evolution-api/package.nix
+++ b/pkgs/by-name/n8/n8n-nodes-evolution-api/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   fetchPnpmDeps,
   nodejs,
-  pnpm_9,
+  pnpm_10,
   pnpmConfigHook,
   nix-update-script,
   n8n,
@@ -24,14 +24,14 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
   ];
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-hMjWFjDhc61HGkQOG/q2EU8pPShUhtHSTe+6wUAa5M4=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-jAHeQHUPUzC4NiKl/h7i8UwStyzw2tCKs42ZkeGZVSw=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/op/openspec/package.nix
+++ b/pkgs/by-name/op/openspec/package.nix
@@ -3,7 +3,7 @@
   stdenvNoCC,
   fetchFromGitHub,
   nodejs,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   makeWrapper,
@@ -24,15 +24,15 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-9s2kdvd7svK4hofnD66HkDc86WTQeayfF5y7L2dmjNg=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-fF0nhxvNHSJB++NNGRFp44c10IdK2EaGaOGH8qg0Lsc=";
   };
 
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
     makeWrapper
     installShellFiles
   ];

--- a/pkgs/by-name/ov/overlayed/package.nix
+++ b/pkgs/by-name/ov/overlayed/package.nix
@@ -8,7 +8,7 @@
   moreutils,
   nodejs,
   pkg-config,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
 
@@ -35,9 +35,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-KJZuucXB7BEMnqPmgytveG/IBEzq4mgMo9ZJHPe/gVs=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-DkVV5Dz5UV/xMuteSXWgSko3e8t8u1Saq1X1UxaaZFA=";
   };
 
   nativeBuildInputs = [
@@ -47,7 +47,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     nodejs
     pkg-config
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
   ];
 
   buildInputs = [

--- a/pkgs/by-name/pa/parca/package.nix
+++ b/pkgs/by-name/pa/parca/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   lib,
   nodejs,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   stdenv,
@@ -26,16 +26,16 @@ let
 
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname src version;
-      pnpm = pnpm_9;
-      fetcherVersion = 3;
-      hash = "sha256-zHdMwJyeafzbIlp+Fhh1khcUVrLsoUg6ViSGm/ByGAA=";
+      pnpm = pnpm_10;
+      fetcherVersion = 4;
+      hash = "sha256-cd9sA01DTXsrKm4enFeS3zmn3w4A5N7QXhtZ0wcpNss=";
     };
 
     nativeBuildInputs = [
       faketty
       nodejs
       pnpmConfigHook
-      pnpm_9
+      pnpm_10
     ];
 
     # faketty is required to work around a bug in nx.

--- a/pkgs/by-name/pg/pgrok/package.nix
+++ b/pkgs/by-name/pg/pgrok/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   nix-update-script,
   nodejs,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
 }:
@@ -31,7 +31,7 @@ buildGoModule {
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
   ];
 
   env.pnpmDeps = fetchPnpmDeps {
@@ -40,9 +40,9 @@ buildGoModule {
       version
       src
       ;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-D8UZoN0ZnjB8CXQiHmBZwBEt57XGb5SDLg61xxSqNus=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-dH8IKC9NXrdizW4MZfPix7g2JCmMNUk41nccmloHEXk=";
   };
 
   vendorHash = "sha256-ob8s1jYL2+JGaqjCsM10jgirPiEyTY4U3IVVlHVdoGQ=";

--- a/pkgs/by-name/pi/piped/package.nix
+++ b/pkgs/by-name/pi/piped/package.nix
@@ -1,14 +1,14 @@
 {
   lib,
   buildNpmPackage,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   fetchFromGitHub,
   unstableGitUpdater,
 }:
 let
-  pnpm = pnpm_9;
+  pnpm = pnpm_10;
 in
 buildNpmPackage rec {
   pname = "piped";
@@ -21,7 +21,7 @@ buildNpmPackage rec {
     hash = "sha256-o3TwE0s5rim+0VKR+oW9Rv3/eQRf2dgRQK4xjZ9pqCE=";
   };
 
-  nativeBuildInputs = [ pnpm_9 ];
+  nativeBuildInputs = [ pnpm_10 ];
   npmConfigHook = pnpmConfigHook;
 
   installPhase = ''
@@ -37,9 +37,9 @@ buildNpmPackage rec {
       version
       src
       ;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-IB/suR1I1hNip1qpIcUCP0YyUEDV2EwE5F2WXW8OhmU=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-o5NKMMIVPkKiPx++ALcZ+3oN80DMQHPwQqGT4f4q5P8=";
   };
 
   passthru.updateScript = unstableGitUpdater { };

--- a/pkgs/by-name/pr/prettier/package.nix
+++ b/pkgs/by-name/pr/prettier/package.nix
@@ -6,7 +6,7 @@
   makeBinaryWrapper,
   nodejs,
   pnpmConfigHook,
-  pnpm_9,
+  pnpm_10,
   stdenv,
   versionCheckHook,
   yarn-berry,
@@ -87,7 +87,7 @@ let
     nativeBuildInputs = [
       nodejs
       pnpmConfigHook
-      pnpm_9
+      pnpm_10
     ];
 
     patches = [
@@ -102,9 +102,9 @@ let
         patches
         ;
 
-      pnpm = pnpm_9;
-      fetcherVersion = 3;
-      hash = "sha256-WPsVL05rVku2YSbfjHX4/BoFM+qvIm4sZip7pISg0vA=";
+      pnpm = pnpm_10;
+      fetcherVersion = 4;
+      hash = "sha256-JXKzYoZhO6dtYLXBG20BGdxZSGhJRROM7r3ILmoZ0Rc=";
     };
 
     buildPhase = ''

--- a/pkgs/by-name/rm/rmfakecloud/package.nix
+++ b/pkgs/by-name/rm/rmfakecloud/package.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   buildGoModule,
   enableWebui ? true,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   nodejs,
@@ -33,9 +33,9 @@ buildGoModule rec {
       ;
     sourceRoot = "${src.name}/ui";
     pnpmLock = "${src}/ui/pnpm-lock.yaml";
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-5dsrf6Iff8z4ujzUccuNFwChChbWzXeXDilh8uZyl+U=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-eINcY464UUroyxcPWR2POnJovcy+Mrij4zIqe/7ycec=";
   };
   preBuild = lib.optionals enableWebui ''
     # using sass-embedded fails at executing node_modules/sass-embedded-linux-x64/dart-sass/src/dart
@@ -49,7 +49,7 @@ buildGoModule rec {
   nativeBuildInputs = lib.optionals enableWebui [
     nodejs
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
   ];
 
   # ... or don't embed it in the server

--- a/pkgs/by-name/rq/rquickshare/package.nix
+++ b/pkgs/by-name/rq/rquickshare/package.nix
@@ -9,7 +9,7 @@
   nodejs,
   openssl,
   pkg-config,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   protobuf,
@@ -48,10 +48,10 @@ rustPlatform.buildRustPackage rec {
       src
       patches
       ;
-    pnpm = pnpm_9;
+    pnpm = pnpm_10;
     postPatch = "cd ${pnpmRoot}";
-    fetcherVersion = 3;
-    hash = "sha256-ESm7YVVbsfjpgYeNf3aVhJawpWhbeNdo0u7cBzLmEMw=";
+    fetcherVersion = 4;
+    hash = "sha256-uugI9ztwHPYn7WdXfo3XlBxjhVczGnpWvTb3IEMJUqg=";
   };
 
   cargoRoot = "app/main/src-tauri";
@@ -68,7 +68,7 @@ rustPlatform.buildRustPackage rec {
     # Setup pnpm
     nodejs
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
 
     protobuf
   ]

--- a/pkgs/by-name/se/serve/package.nix
+++ b/pkgs/by-name/se/serve/package.nix
@@ -4,7 +4,7 @@
   lib,
   makeWrapper,
   nodejs,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
 }:
@@ -22,12 +22,12 @@ buildNpmPackage (finalAttrs: {
   npmDeps = null;
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-N5oasGilHECndJZYdRHZFvAa4aYwmPtOTBZtcty4g/k=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-RiZrQFvEya7l3bhfIhDmdegovGrNYG+95GsAj1H828g=";
   };
 
-  nativeBuildInputs = [ pnpm_9 ];
+  nativeBuildInputs = [ pnpm_10 ];
   npmConfigHook = pnpmConfigHook;
 
   dontNpmBuild = true;

--- a/pkgs/by-name/sh/shadcn/package.nix
+++ b/pkgs/by-name/sh/shadcn/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   makeBinaryWrapper,
   nodejs,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   testers,
@@ -29,16 +29,16 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       src
       pnpmWorkspaces
       ;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-OESxer0YIbWql3NgdhvUhgMW4wc0nIyUYRESjmM1A1s=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-Xdeld6Dhu3gL/Un5gRWXSC9XQH4R1W4OnWxibDaxZGs=";
   };
 
   nativeBuildInputs = [
     makeBinaryWrapper
     nodejs
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
   ];
 
   buildPhase = ''

--- a/pkgs/by-name/sk/sketchybar-app-font/package.nix
+++ b/pkgs/by-name/sk/sketchybar-app-font/package.nix
@@ -1,7 +1,7 @@
 {
   fetchFromGitHub,
   lib,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   stdenvNoCC,
@@ -21,15 +21,15 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-/nYH3ZgfNv9krvH/ZjCJ2F3aanLZzlkNwOizgTRtqXE=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-C8kPbREUf2jAVLBvKtdCsVxDcY7r8Yrq8uAWY9r/8QI=";
   };
 
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
   ];
 
   buildPhase = ''

--- a/pkgs/by-name/sl/slimevr/package.nix
+++ b/pkgs/by-name/sl/slimevr/package.nix
@@ -6,7 +6,7 @@
   replaceVars,
   nodejs,
   pnpmConfigHook,
-  pnpm_9,
+  pnpm_10,
   electron,
   makeWrapper,
   slimevr-server,
@@ -30,9 +30,9 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     pname = "${finalAttrs.pname}-pnpm-deps";
     inherit (finalAttrs) version src;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-gGBwE6QxJsbVmQc1e390SSXAjs/T992ju8y9wz1H1QQ=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-Y8TSsoXqRxexar9uFKHiIuogAuLSTMqK9blFbMVTwOE=";
   };
 
   patches = [
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
     makeWrapper
     copyDesktopItems
     udevCheckHook

--- a/pkgs/by-name/sy/syncyomi/package.nix
+++ b/pkgs/by-name/sy/syncyomi/package.nix
@@ -6,7 +6,7 @@
   libredirect,
   buildGoModule,
   nodejs,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   esbuild,
@@ -51,15 +51,15 @@ buildGoModule (finalAttrs: {
         src
         sourceRoot
         ;
-      pnpm = pnpm_9;
-      fetcherVersion = 3;
-      hash = "sha256-paCYfh7tjDuPm8JCpzhCNjL1ZsyQTNxofW8UNIKjqmE=";
+      pnpm = pnpm_10;
+      fetcherVersion = 4;
+      hash = "sha256-i4ji/NjK6/hpqrma+DJ2x5kKq/YEN3Cy8mKQLy1M+dU=";
     };
 
     nativeBuildInputs = [
       nodejs
       pnpmConfigHook
-      pnpm_9
+      pnpm_10
     ];
 
     env.ESBUILD_BINARY_PATH = lib.getExe lockedEsbuild;

--- a/pkgs/by-name/ta/tabby-agent/package.nix
+++ b/pkgs/by-name/ta/tabby-agent/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   nix-update-script,
   nodejs,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   wrapGAppsHook3,
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
     wrapGAppsHook3
   ];
 
@@ -51,9 +51,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-xx45vudeW6OnUgyH0N+gQI5GPT8k5B4x0HdCvHF+f9A=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-ZGJbN3HroMO0XOnigbe/z+yJYmUA5CwwxB6pKUfJNvc=";
   };
 
   passthru.updateScript = nix-update-script {

--- a/pkgs/by-name/ta/tailwindcss-language-server/package.nix
+++ b/pkgs/by-name/ta/tailwindcss-language-server/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   nodejs,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   nix-update-script,
@@ -26,14 +26,14 @@ stdenv.mkDerivation (finalAttrs: {
       src
       pnpmWorkspaces
       ;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-3pHEmYMgQuHFFMyGeFzo9BWRFt6yvWzFFMJEdRhwS2w=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-x/Cd4aTdqbOVfptJXa2PHT7W1dgRijA/zODi5n9r2G0=";
   };
 
   nativeBuildInputs = [
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
   ];
 
   buildInputs = [

--- a/pkgs/by-name/ta/taler-wallet-core/package.nix
+++ b/pkgs/by-name/ta/taler-wallet-core/package.nix
@@ -8,7 +8,7 @@
   srcOnly,
   removeReferencesTo,
   nodejs-slim_24,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   python3,
@@ -20,7 +20,7 @@ let
   nodeSources = (srcOnly nodejs-slim_24).overrideAttrs {
     outputChecks = { };
   };
-  pnpm' = pnpm_9.override { nodejs-slim = nodejs-slim_24; };
+  pnpm' = pnpm_10.override { nodejs-slim = nodejs-slim_24; };
   esbuild' = esbuild.override {
     buildGoModule =
       args:
@@ -57,8 +57,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm';
-    fetcherVersion = 3;
-    hash = "sha256-W5C2JVFbEccf4b+ppeEJ68au/2Tqfsry7ri6Qi1M50k=";
+    fetcherVersion = 4;
+    hash = "sha256-ba83jxVdwNLvFZXZ0VokvgHVctcvcqquOxQHKrsWN0M=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ta/taze/package.nix
+++ b/pkgs/by-name/ta/taze/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   nodejs,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   npmHooks,
@@ -23,15 +23,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-c2jBLdxQuIw028xo9cGhLykxARlOjK/R4e63U2UsXCQ=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-p/Kd0n377ZOMLxy7u8vRTH834Q142CWHgNQIy8W/q2g=";
   };
 
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
     npmHooks.npmInstallHook
   ];
 

--- a/pkgs/by-name/we/wealthfolio/package.nix
+++ b/pkgs/by-name/we/wealthfolio/package.nix
@@ -9,7 +9,7 @@
   nodejs,
   openssl,
   pkg-config,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   rustPlatform,
@@ -30,9 +30,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) src pname version;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-LXPQpQFXwPEHxktLoRiWTi8NbtzrS5ItUmoKJki3zcs";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-ErUFMYnMKdeO78iG0wBx5k8SiXKszdCaER/T6x6bdh0=";
   };
 
   cargoRoot = ".";
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     nodejs
     pkg-config
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
     rustPlatform.cargoSetupHook
     wrapGAppsHook3
   ];

--- a/pkgs/by-name/yo/your_spotify/client.nix
+++ b/pkgs/by-name/yo/your_spotify/client.nix
@@ -6,7 +6,7 @@
   pnpmDeps,
   apiEndpoint ? "http://localhost:3000",
   pnpmConfigHook,
-  pnpm_9,
+  pnpm_10,
   nodejs,
 }:
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
     nodejs
   ];
 

--- a/pkgs/by-name/yo/your_spotify/package.nix
+++ b/pkgs/by-name/yo/your_spotify/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   fetchPnpmDeps,
   pnpmConfigHook,
-  pnpm_9,
+  pnpm_10,
   nodejs,
   makeWrapper,
   callPackage,
@@ -25,15 +25,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-j6COg8Q0uj+5TjN/BUVst2UMhXLT3drLWUzdG/x51rk=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-yWWB9fVdLQXbYMAes5BPvrGGULvNdEeklBnRb8Zukhg=";
   };
 
   nativeBuildInputs = [
     makeWrapper
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
     nodejs
   ];
 

--- a/pkgs/by-name/zi/zigbee2mqtt/package.nix
+++ b/pkgs/by-name/zi/zigbee2mqtt/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   nodejs,
   npmHooks,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   systemdMinimal,
@@ -25,16 +25,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-KSPdu9v34WYxyZtcL0NtP58LWmhK0KU0be6Z/VkZjH0=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-0jFNbUOaWJBlkDeq2oU7fkpX0P5rPqR3n03v0dkEr/o=";
   };
 
   nativeBuildInputs = [
     nodejs
     npmHooks.npmInstallHook
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
   ];
 
   buildInputs = lib.optionals withSystemd [

--- a/pkgs/servers/web-apps/lemmy/pin.json
+++ b/pkgs/servers/web-apps/lemmy/pin.json
@@ -4,5 +4,5 @@
   "serverHash": "sha256-NUr96dsH3Gd+1ouOAgPheU0hnDI37a87EN642u482Sg=",
   "serverCargoHash": "sha256-oI8o+29kqjkAP2DIoSopPMQb5YlZNja1hV1bVmfMIvU=",
   "uiHash": "sha256-7WcPujev7VrkoX5vvGUvS0hUVJnCZjsceO5zK36jPbw=",
-  "uiPNPMDepsHash": "sha256-dRUD/R7Qtlfy2saX7grfdi5qBDP8gc3L3+C2m7ro1CU="
+  "uiPNPMDepsHash": "sha256-D+Ug7guqGjiH0tv2oQP0zoc3t+M3z57JyHImgEPNdro="
 }

--- a/pkgs/servers/web-apps/lemmy/ui.nix
+++ b/pkgs/servers/web-apps/lemmy/ui.nix
@@ -3,7 +3,7 @@
   stdenvNoCC,
   libsass,
   nodejs,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   fetchFromGitHub,
@@ -31,7 +31,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
   ];
 
   buildInputs = [
@@ -42,9 +42,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   extraBuildInputs = [ libsass ];
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = pinData.uiPNPMDepsHash;
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-D+Ug7guqGjiH0tv2oQP0zoc3t+M3z57JyHImgEPNdro=";
   };
 
   buildPhase = ''


### PR DESCRIPTION
cc #529285
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->



These changes were made semi-autonomously by Grok Build in a way so one can quickly cherry pick a commit and bring to their own PRs

The prompt:

```
pnpm 9 is deprecated, eol and it's going to be removed. There are a relevant amount of Nix packages still using it.

For each package using pnpm_9:
- Update pnpm to 10
- Update fetcherVersion to 4
- Update the pnpm fetcher hash (remove it and when running builds change the hash to the new hash)
- If the build fails for a reason outside the fetcher keep going but let me know when you finish

After doing the changes, do one commit per package following the commit message of CONTRIBUTING
```

What I did:
- Asked it to continue when it did the first round but it was incomplete
- Guided it to run all builds into one nix build, instead of one nix build per package, now it essentially watches the build output and updates the hashes as they come and commit
- Took a look on the diffs if there is anything weird

Is it exaustive?
- I told it to skip build failures, like, if the FOD fails for a reason that is not the wrong hash, then skip it.
## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->


- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
