### PR TITLE
fastfetch: 2.63.1 -> 2.64.2

### DIFF
--- a/pkgs/by-name/fa/fastfetch/package.nix
+++ b/pkgs/by-name/fa/fastfetch/package.nix
@@ -21,6 +21,8 @@
   libsepol,
   libsysprof-capture,
   libxcb,
+  libva,
+  libvdpau,
   makeBinaryWrapper,
   moltenvk,
   nix-update-script,
@@ -48,6 +50,7 @@
   # Feature flags
   audioSupport ? true,
   brightnessSupport ? true,
+  codecSupport ? true,
   dbusSupport ? true,
   flashfetchSupport ? false,
   terminalSupport ? true,
@@ -92,9 +95,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs =
     let
-      commonDeps = [
-        yyjson
-      ];
+      commonDeps = [ yyjson ];
 
       # Cross-platform optional dependencies
       imageDeps = lib.optionals imageSupport [
@@ -111,9 +112,7 @@ stdenv.mkDerivation (finalAttrs: {
       ];
 
       linuxCoreDeps = lib.optionals stdenv.hostPlatform.isLinux (
-        [
-          hwdata
-        ]
+        [ hwdata ]
         # Fallback if both `wayland` and `x11` are not available. AMD GPU properties detection
         ++ lib.optional (!x11Support && !waylandSupport) libdrm
       );
@@ -126,6 +125,11 @@ stdenv.mkDerivation (finalAttrs: {
         ++ lib.optionals brightnessSupport [
           # Brightness detection of external displays
           ddcutil
+        ]
+        ++ lib.optionals codecSupport [
+          # Hardware-accelerated video codec detection
+          libva
+          libvdpau
         ]
         ++ lib.optionals dbusSupport [
           # Bluetooth, wifi, player & media detection
@@ -223,6 +227,9 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     (lib.cmakeBool "ENABLE_PULSE" audioSupport)
 
+    (lib.cmakeBool "ENABLE_VA" codecSupport)
+    (lib.cmakeBool "ENABLE_VDPAU" codecSupport)
+
     (lib.cmakeBool "ENABLE_DDCUTIL" brightnessSupport)
 
     (lib.cmakeBool "ENABLE_DBUS" dbusSupport)
@@ -281,6 +288,7 @@ stdenv.mkDerivation (finalAttrs: {
     minimal = fastfetch.override {
       audioSupport = false;
       brightnessSupport = false;
+      codecSupport = false;
       dbusSupport = false;
       enlightenmentSupport = false;
       flashfetchSupport = false;
@@ -316,6 +324,7 @@ stdenv.mkDerivation (finalAttrs: {
       Feature flags (all default to 'true' except rpmSupport, flashfetchSupport and zfsSupport):
       * audioSupport: PulseAudio functionality
       * brightnessSupport: External display brightness detection via DDCUtil
+      * codecSupport: Hardware-accelerated video codec detection
       * dbusSupport: DBus functionality for Bluetooth, WiFi, player & media detection
       * enlightenmentSupport: Enlightenment configuration detection via EFL's Eet
       * flashfetchSupport: Build the flashfetch utility (default: false)

--- a/pkgs/by-name/fa/fastfetch/package.nix
+++ b/pkgs/by-name/fa/fastfetch/package.nix
@@ -66,7 +66,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "fastfetch";
-  version = "2.63.1";
+  version = "2.64.2";
 
   strictDeps = true;
   __structuredAttrs = true;
@@ -75,7 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "fastfetch-cli";
     repo = "fastfetch";
     tag = finalAttrs.version;
-    hash = "sha256-6c3vA8AFSfew1TdSeUmJ4mIbFyDaJPVWUc93iZyqRY0=";
+    hash = "sha256-isSVcmtNglHy7+F3yemGyY8Jnsy3h5mjOnl159CyJ2Q=";
   };
 
   outputs = [


### PR DESCRIPTION
Changelog: https://github.com/fastfetch-cli/fastfetch/releases/tag/2.64.2
Diff: https://github.com/fastfetch-cli/fastfetch/compare/2.63.1...2.64.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
