### PR TITLE
moltengamepad: unstable-2016-05-04 -> 1.2.1

### DIFF
--- a/pkgs/by-name/mo/moltengamepad/package.nix
+++ b/pkgs/by-name/mo/moltengamepad/package.nix
@@ -3,35 +3,54 @@
   stdenv,
   fetchFromGitHub,
   udev,
+  go-md2man,
+  linuxHeaders,
+  installShellFiles,
+  versionCheckHook,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "moltengamepad";
-  version = "unstable-2016-05-04";
+  version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "jgeumlek";
     repo = "MoltenGamepad";
-    rev = "6656357964c22be97227fc5353b53c6ab1e69929";
-    sha256 = "05cpxfzxgm86kxx0a9f76bshjwpz9w1g8bn30ib1i5a3fv7bmirl";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pfUx5wUkXcshHvBoD47ZRHfJPGHPSzz72H3WBIauFw0=";
   };
 
-  hardeningDisable = [ "format" ];
+  postPatch = ''
+    # https://github.com/jgeumlek/MoltenGamepad/pull/99
+    sed -e '16i#include <memory>' -i source/core/uinput.h
+    sed -e '8i#include <string>' -i source/core/udev.h
+  '';
 
+  strictDeps = true;
+  __structuredAttrs = true;
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    go-md2man
+    installShellFiles
+  ];
   buildInputs = [ udev ];
 
-  buildPhase = ''
-    make
+  preBuild = ''
+    make eventlists INPUT_HEADER=${linuxHeaders}/include/linux/input-event-codes.h
   '';
 
   installPhase = ''
-    mkdir -p $out/bin
-    cp moltengamepad $out/bin
+    runHook preInstall
+
+    installBin moltengamepad
+    installManPage documentation/moltengamepad.1
+
+    runHook postInstall
   '';
 
-  patchPhase = ''
-    sed -i -e '159d;161d;472d;473d;474d;475d' source/eventlists/key_list.cpp
-  '';
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     homepage = "https://github.com/jgeumlek/MoltenGamepad";
@@ -40,5 +59,4 @@ stdenv.mkDerivation {
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
   };
-
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
