### PR TITLE
prqlc: 0.13.10 -> 0.13.12, adopt

### DIFF
--- a/pkgs/by-name/pr/prqlc/package.nix
+++ b/pkgs/by-name/pr/prqlc/package.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "prqlc";
-  version = "0.13.10";
+  version = "0.13.12";
 
   src = fetchFromGitHub {
     owner = "prql";
     repo = "prql";
     rev = finalAttrs.version;
-    hash = "sha256-SYIrME3iE1SpqjLvP/TxXXeiURfdrRSedN3FlcTwrt8=";
+    hash = "sha256-dVabMpXrdNV6hvUVk80mWuIpg8Vb0ZaJnrezO+FtbKg=";
   };
 
-  cargoHash = "sha256-4426LQ8X5iGPyjtyHnlmOQmYNHwmTvf6TowpCa463O4=";
+  cargoHash = "sha256-hL52k61pgqOFpn3aN8DIlx2KlaOjMVD60/x6dMkZ5Rg=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/pr/prqlc/package.nix
+++ b/pkgs/by-name/pr/prqlc/package.nix
@@ -45,6 +45,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/prql/prql";
     changelog = "https://github.com/prql/prql/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ hythera ];
   };
 })

--- a/pkgs/by-name/pr/prqlc/package.nix
+++ b/pkgs/by-name/pr/prqlc/package.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "prql";
     repo = "prql";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-dVabMpXrdNV6hvUVk80mWuIpg8Vb0ZaJnrezO+FtbKg=";
   };
 
@@ -33,9 +33,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     zlib
   ];
 
-  env = {
-    PYO3_PYTHON = "${python3}/bin/python3";
-  };
+  env.PYO3_PYTHON = "${python3}/bin/python3";
 
   # we are only interested in the prqlc binary
   postInstall = ''
@@ -45,7 +43,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "CLI for the PRQL compiler - a simple, powerful, pipelined SQL replacement";
     homepage = "https://github.com/prql/prql";
-    changelog = "https://github.com/prql/prql/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/prql/prql/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };


### PR DESCRIPTION
changelog: https://github.com/PRQL/prql/blob/0.13.12/CHANGELOG.md
diff: https://github.com/PRQL/prql/compare/0.13.10...0.13.12

Supersedes #501397

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
