### PR TITLE
sqlpage: 0.41.0 -> 0.44.0, adopt

### DIFF
--- a/pkgs/by-name/sq/sqlpage/package.nix
+++ b/pkgs/by-name/sq/sqlpage/package.nix
@@ -45,7 +45,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   version = "0.44.0";
 
   src = fetchFromGitHub {
-    owner = "lovasoa";
+    owner = "sqlpage";
     repo = "SQLpage";
     tag = "v${finalAttrs.version}";
     hash = "sha256-qhfJHzPUBQZ6GKGet/6IZfU5zjKXqDxftJX3ylVwOQE=";
@@ -92,8 +92,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "SQL-only webapp builder, empowering data analysts to build websites and applications quickly";
-    homepage = "https://github.com/lovasoa/SQLpage";
-    changelog = "https://github.com/lovasoa/SQLpage/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    homepage = "https://github.com/sqlpage/SQLpage";
+    changelog = "https://github.com/sqlpage/SQLpage/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "sqlpage";

--- a/pkgs/by-name/sq/sqlpage/package.nix
+++ b/pkgs/by-name/sq/sqlpage/package.nix
@@ -95,7 +95,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/sqlpage/SQLpage";
     changelog = "https://github.com/sqlpage/SQLpage/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ hythera ];
     mainProgram = "sqlpage";
   };
 })

--- a/pkgs/by-name/sq/sqlpage/package.nix
+++ b/pkgs/by-name/sq/sqlpage/package.nix
@@ -11,15 +11,15 @@
 
 let
   apexcharts = {
-    url = "https://cdn.jsdelivr.net/npm/apexcharts@5.3.6/dist/apexcharts.min.js";
-    hash = "sha256-qNJtESJROYHRKwS/u3zdu4Fev69db17hKHZvrqGiqRs=";
+    url = "https://cdn.jsdelivr.net/npm/apexcharts@5.13.0/dist/apexcharts.min.js";
+    hash = "sha256-DgRUn+X1cxT0z5O+QcrX48NuVrY1KhoCmHPvVZAvS8k=";
   };
   tablerCss = {
     url = "https://cdn.jsdelivr.net/npm/@tabler/core@1.4.0/dist/css/tabler.min.css";
     hash = "sha256-fvdQvRBUamldCxJ2etgEi9jz7F3n2u+xBn+dDao9HJo=";
   };
   tomSelectCss = {
-    url = "https://cdn.jsdelivr.net/npm/tom-select@2.4.3/dist/css/tom-select.bootstrap5.css";
+    url = "https://cdn.jsdelivr.net/npm/tom-select@2.6.1/dist/css/tom-select.bootstrap5.css";
     hash = "sha256-vW5UjM/Ka9/jIY8I5s5KcudaTRWh/cCGE1ZUsrJvlI0=";
   };
   tablerVendorsCss = {
@@ -31,24 +31,24 @@ let
     hash = "sha256-tgx2Fg6XYkV027jPEKvmrummSTtgCW/fwV3R3SvZnrk=";
   };
   tablerIcons = {
-    url = "https://cdn.jsdelivr.net/npm/@tabler/icons-sprite@3.34.0/dist/tabler-sprite.svg";
-    hash = "sha256-pCPkhrx0GnPg5/EthJ7pLdMxb7wbYMJ0R7WchDcffpg=";
+    url = "https://cdn.jsdelivr.net/npm/@tabler/icons-sprite@3.44.0/dist/tabler-sprite.svg";
+    hash = "sha256-aHeH8IGC75mepyW2gj/aYrW7LCEtjobwxvGnVp5j3Uc=";
   };
   tomselect = {
-    url = "https://cdn.jsdelivr.net/npm/tom-select@2.4.1/dist/js/tom-select.popular.min.js";
-    hash = "sha256-Cb1Xmb9qQO8I1mMVkz4t2bT8l7HX+1JeKncGBSytSHQ=";
+    url = "https://cdn.jsdelivr.net/npm/tom-select@2.6.1/dist/js/tom-select.popular.min.js";
+    hash = "sha256-KmjMBvL4Ni3AYc9OCi9xSEuamESyLEBL4B2gzFrWPGE=";
   };
 in
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sqlpage";
-  version = "0.41.0";
+  version = "0.44.0";
 
   src = fetchFromGitHub {
     owner = "lovasoa";
     repo = "SQLpage";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rUij1nhXcLEwdUUVpKoUbgNqV47TvmMCEds4ihP9QL4=";
+    hash = "sha256-qhfJHzPUBQZ6GKGet/6IZfU5zjKXqDxftJX3ylVwOQE=";
   };
 
   postPatch = ''
@@ -72,11 +72,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail '/* !include ${tomselect.url} */' \
       "$(cat ${fetchurl tomselect})"
     substituteInPlace build.rs \
-      --replace-fail "https://cdn.jsdelivr.net/npm/@tabler/icons-sprite@3.35.0/dist/tabler-sprite.svg" "${fetchurl tablerIcons}" \
+      --replace-fail "${tablerIcons.url}" "${fetchurl tablerIcons}" \
       --replace-fail "copy_url_to_opened_file(&client, sprite_url, &mut sprite_content).await;" "sprite_content = std::fs::read(sprite_url).unwrap();"
   '';
 
-  cargoHash = "sha256-jyhvhViPz/tj76mvmaIih4LaCH+ODFa8gs0/MTYbuQg=";
+  cargoHash = "sha256-VNKRXzy9TQdNlk/kEfFKBEWALP/r+hBcd32n6bwK/J0=";
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
changelog: https://github.com/sqlpage/SQLPage/blob/v0.44.0/CHANGELOG.md
diff: https://github.com/sqlpage/SQLPage/compare/v0.41.0...v0.44.0

Supersedes #481122

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
