### PR TITLE
slimevr: use pnpm 10 and `fetcherVersion` 4

### DIFF
--- a/pkgs/by-name/sl/slimevr-server/package.nix
+++ b/pkgs/by-name/sl/slimevr-server/package.nix
@@ -99,6 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
       loucass003
     ];
     platforms = with lib.platforms; darwin ++ linux;
+    broken = stdenv.hostPlatform.isDarwin;
     mainProgram = "slimevr-server";
   };
 })

--- a/pkgs/by-name/sl/slimevr/package.nix
+++ b/pkgs/by-name/sl/slimevr/package.nix
@@ -6,7 +6,7 @@
   replaceVars,
   nodejs,
   pnpmConfigHook,
-  pnpm_9,
+  pnpm_10,
   electron,
   makeWrapper,
   slimevr-server,
@@ -30,9 +30,9 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     pname = "${finalAttrs.pname}-pnpm-deps";
     inherit (finalAttrs) version src;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-gGBwE6QxJsbVmQc1e390SSXAjs/T992ju8y9wz1H1QQ=";
+    pnpm = pnpm_10;
+    fetcherVersion = 4;
+    hash = "sha256-Y8TSsoXqRxexar9uFKHiIuogAuLSTMqK9blFbMVTwOE=";
   };
 
   patches = [
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
-    pnpm_9
+    pnpm_10
     makeWrapper
     copyDesktopItems
     udevCheckHook


### PR DESCRIPTION
See #529285.

Upstream switched to pnpm 10 in https://github.com/SlimeVR/SlimeVR-Server/commit/110e0ce840c13ec9c69c27bf04512d2b5b8c3306.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
