### PR TITLE
immudb: 1.10.0 -> 1.11.0, adopt

### DIFF
--- a/pkgs/by-name/im/immudb/package.nix
+++ b/pkgs/by-name/im/immudb/package.nix
@@ -15,13 +15,13 @@ let
 in
 buildGoModule (finalAttrs: {
   pname = "immudb";
-  version = "1.10.0";
+  version = "1.11.0";
 
   src = fetchFromGitHub {
     owner = "codenotary";
     repo = "immudb";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-RsDM+5/a3huBJ6HfaALpw+KpcIfg198gZfC4c4DsDlU=";
+    sha256 = "sha256-YL6L3WqazzdpXQiLGnuQ7ZRKzmx2Z8C9raFXkN1D1Zk=";
   };
 
   postPatch = ''
@@ -36,10 +36,10 @@ buildGoModule (finalAttrs: {
   preBuild = ''
     mkdir -p webconsole/dist
     cp -r ${webconsoleDist}/* ./webconsole/dist
-    go generate -tags webconsole ./webconsole
+    go generate -mod=mod -tags webconsole ./webconsole
   '';
 
-  vendorHash = "sha256-6DHmJrE+xkf8K38a8h1VSD33W6qj594Q5bJJXnfSW0Q=";
+  vendorHash = "sha256-D1dEVnYNpCGSJ5lxzV0+ukDVbQntxcNw6mB3UKDBdQA=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/im/immudb/package.nix
+++ b/pkgs/by-name/im/immudb/package.nix
@@ -71,6 +71,6 @@ buildGoModule (finalAttrs: {
       asl20
       bsl11
     ];
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ hythera ];
   };
 })

--- a/pkgs/by-name/im/immudb/package.nix
+++ b/pkgs/by-name/im/immudb/package.nix
@@ -20,8 +20,8 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "codenotary";
     repo = "immudb";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-YL6L3WqazzdpXQiLGnuQ7ZRKzmx2Z8C9raFXkN1D1Zk=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-YL6L3WqazzdpXQiLGnuQ7ZRKzmx2Z8C9raFXkN1D1Zk=";
   };
 
   postPatch = ''
@@ -64,9 +64,13 @@ buildGoModule (finalAttrs: {
   '';
 
   meta = {
+    changelog = "https://github.com/codenotary/immudb/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "Immutable database based on zero trust, SQL and Key-Value, tamperproof, data change history";
     homepage = "https://github.com/codenotary/immudb";
-    license = lib.licenses.asl20;
+    license = with lib.licenses; [
+      asl20
+      bsl11
+    ];
     maintainers = [ ];
   };
 })


### PR DESCRIPTION
changelog: https://github.com/codenotary/immudb/blob/v1.11.0/CHANGELOG.md
diff: https://github.com/codenotary/immudb/compare/v1.10.0...v1.11.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
