### PR TITLE
python3Packages.aiohttp: 3.14.0 -> 3.14.1

### DIFF
--- a/pkgs/development/python-modules/aiohttp/default.nix
+++ b/pkgs/development/python-modules/aiohttp/default.nix
@@ -51,14 +51,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "aiohttp";
-  version = "3.14.0";
+  version = "3.14.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "aio-libs";
     repo = "aiohttp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-RRXdDDkQlL7erfYgs4+gSy6GMlVUG7PrDLTQBYJJ1To=";
+    hash = "sha256-OJSLv/NfVrKESZqNr51FJUzLRz7wLMRdGoNjKC5EhlI=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Diff: https://github.com/aio-libs/aiohttp/compare/v3.14.0...v3.14.1

Changelog: https://docs.aiohttp.org/en/v3.14.1/changes.html

fixes https://github.com/aio-libs/aiohttp/security/advisories/GHSA-2fqr-mr3j-6wp8, https://github.com/aio-libs/aiohttp/security/advisories/GHSA-hpj7-wq8m-9hgp, https://github.com/aio-libs/aiohttp/security/advisories/GHSA-63hw-fmq6-xxg2, https://github.com/aio-libs/aiohttp/security/advisories/GHSA-g3cq-j2xw-wf74, https://github.com/aio-libs/aiohttp/security/advisories/GHSA-4fvr-rgm6-gqmc, https://github.com/aio-libs/aiohttp/security/advisories/GHSA-9x8q-7h8h-wcw9, https://github.com/aio-libs/aiohttp/security/advisories/GHSA-4m7w-qmgq-4wj5, https://github.com/aio-libs/aiohttp/security/advisories/GHSA-xcgm-r5h9-7989

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
