### PR TITLE
ttnn-visualizer: init 0.88.0

### DIFF
--- a/pkgs/by-name/tt/ttnn-visualizer/package.nix
+++ b/pkgs/by-name/tt/ttnn-visualizer/package.nix
@@ -1,0 +1,163 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  nodejs_24,
+  pnpmConfigHook,
+  pnpm_11,
+  python3,
+  stdenvNoCC,
+  writeShellScriptBin,
+}:
+
+let
+  version = "0.88.0";
+
+  patchNodeEngine = ''
+    substituteInPlace package.json \
+      --replace-fail '"node": "24.15.0"' '"node": ">=24.15.0"'
+    substituteInPlace pnpm-workspace.yaml \
+      --replace-fail 'engineStrict: true' 'engineStrict: false'
+  '';
+
+  ps = python3.pkgs;
+  src = fetchFromGitHub {
+    owner = "tenstorrent";
+    repo = "ttnn-visualizer";
+    tag = "v${version}";
+    hash = "sha256-9ohL+xjiu56gasor8+eKsJPWhoDVD1zxFw60QYbWsHQ=";
+  };
+
+  frontendSource = stdenvNoCC.mkDerivation (finalAttrs: {
+    pname = "ttnn-visualizer-frontend-source";
+    inherit version;
+    inherit src;
+
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalAttrs) src pname version;
+      pnpm = pnpm_11;
+      fetcherVersion = 4;
+      hash = "sha256-25yC1PR8o3zppmIsK1fkYsB9K2XBUVLHk5+qJlHJfLI=";
+      postPatch = patchNodeEngine;
+    };
+
+    nativeBuildInputs = [
+      nodejs_24
+      pnpm_11
+      pnpmConfigHook
+    ];
+
+    env = {
+      CI = "true";
+      npm_config_yes = "true";
+      pnpm_config_confirm_modules_purge = "false";
+    };
+
+    postPatch = ''
+      ${patchNodeEngine}
+
+      ${python3}/bin/python - <<'PY'
+      import json
+      from pathlib import Path
+
+      package_json = Path("package.json")
+      data = json.loads(package_json.read_text())
+      scripts = data.get("scripts", {})
+      scripts.pop("prepare", None)
+      data["scripts"] = scripts
+      package_json.write_text(json.dumps(data, indent=2) + "\n")
+      PY
+    '';
+
+    buildPhase = ''
+      runHook preBuild
+      pnpm build
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out"
+      cp -r . "$out/"
+      runHook postInstall
+    '';
+  });
+
+  ttnnVisualizer = ps.buildPythonPackage (finalAttrs: {
+    pname = "ttnn-visualizer";
+    inherit version;
+    pyproject = true;
+    src = frontendSource;
+
+    build-system = [
+      ps.setuptools
+      ps.wheel
+    ];
+
+    postPatch = ''
+      substituteInPlace pyproject.toml \
+        --replace-fail 'setuptools==78.1.1' 'setuptools'
+    '';
+
+    propagatedBuildInputs = [
+      ps.alembic
+      ps.build
+      ps.flask
+      ps.flask-cors
+      ps.flask-socketio
+      ps.flask-sqlalchemy
+      ps.flask-static-digest
+      ps.gevent
+      ps.gunicorn
+      ps.orjson
+      ps.pandas
+      ps.pydantic
+      ps.pydantic-core
+      ps.python-dotenv
+      ps.pyyaml
+      ps.tt-perf-report
+      ps.uvicorn
+      ps.zstd
+    ];
+
+    pythonRelaxDeps = [
+      "flask-cors"
+      "flask-socketio"
+      "flask"
+      "gevent"
+      "gunicorn"
+      "pandas"
+      "pydantic"
+      "pydantic-core"
+      "pyyaml"
+      "setuptools"
+      "uvicorn"
+      "zstd"
+    ];
+
+    pythonImportsCheck = [ "ttnn_visualizer" ];
+  });
+
+  pythonEnv = python3.withPackages (ps: [
+    ttnnVisualizer
+    ps.gunicorn
+    ps.gevent
+  ]);
+in
+(writeShellScriptBin "ttnn-visualizer" ''
+  export FLASK_ENV=production
+  export PATH="${lib.makeBinPath [ pythonEnv ]}:$PATH"
+  exec ${pythonEnv}/bin/python -m ttnn_visualizer.app "$@"
+'').overrideAttrs
+  (_: {
+    strictDeps = true;
+    __structuredAttrs = true;
+    meta = {
+      description = "Tool for visualizing and analyzing TT-NN model execution";
+      homepage = "https://github.com/tenstorrent/ttnn-visualizer";
+      license = lib.licenses.asl20;
+      mainProgram = "ttnn-visualizer";
+      maintainers = with lib.maintainers; [ mert-kurttutan ];
+      platforms = lib.platforms.linux;
+    };
+  })


### PR DESCRIPTION
<!--
Adds support for ttnn-visualizer, a software to benchmark, trace models, debug performance of workloads on tenstorrent devices

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
