### PR TITLE
python3Packages.trsfile: move env variable into env for structuredAttrs, modernize

### DIFF
--- a/pkgs/development/python-modules/trsfile/default.nix
+++ b/pkgs/development/python-modules/trsfile/default.nix
@@ -7,20 +7,20 @@
   numpy,
   pytestCheckHook,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "trsfile";
   version = "2.2.5";
 
   src = fetchFromGitHub {
     owner = "Keysight";
     repo = "python-trsfile";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-mY4L1FFg2wDWAGVadOca7GDffA05O3v317SCqHxt4F0=";
   };
 
   pyproject = true;
 
-  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
 
   build-system = [
     setuptools
@@ -39,10 +39,10 @@ buildPythonPackage rec {
     "trsfile"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Python library for reading/writing .trs files used by Riscure Inspector";
     homepage = "https://github.com/Keysight/python-trsfile";
-    license = licenses.bsd3;
+    license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ mach ];
   };
-}
+})

--- a/pkgs/development/python-modules/trsfile/default.nix
+++ b/pkgs/development/python-modules/trsfile/default.nix
@@ -20,7 +20,7 @@ buildPythonPackage rec {
 
   pyproject = true;
 
-  SETUPTOOLS_SCM_PRETEND_VERSION = version;
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
   build-system = [
     setuptools


### PR DESCRIPTION
Just some followup on this new package:

* Environment variables should live in `env`, in preparation for structuredAttrs
* `finalAttrs` is preferred over `rec`
* Use of `with lib;` (in `meta` in particular) is discouraged
* A tag can be specified via `tag` instead of `rev` in the fetcher, which will turn it into `refs/tags/<tag>`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
