### PR TITLE
openmm: 8.5.1 -> 8.5.2

### DIFF
--- a/pkgs/by-name/op/openmm/package.nix
+++ b/pkgs/by-name/op/openmm/package.nix
@@ -1,12 +1,13 @@
 {
-  stdenv,
   lib,
+  stdenv,
   fetchFromGitHub,
   cmake,
   gfortran,
   fftwSinglePrec,
   doxygen,
   swig,
+  graphviz,
   enablePython ? false,
   python3Packages,
   enableOpencl ? true,
@@ -15,18 +16,27 @@
   config,
   enableCuda ? config.cudaSupport,
   cudaPackages,
-  addDriverRunpath,
+  autoAddDriverRunpath,
+
+  # passthru
+  nix-update-script,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+let
+  effectiveStdenv = if enableCuda then cudaPackages.backendStdenv else stdenv;
+in
+effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "openmm";
-  version = "8.5.1";
+  version = "8.5.2";
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "openmm";
     repo = "openmm";
-    rev = finalAttrs.version;
-    hash = "sha256-YGoQGOP6Use4ivhxlWfKMpEjpm5ovFH1Qf0yVK5jr48=";
+    tag = finalAttrs.version;
+    hash = "sha256-9mOgnMgRU7zE9UWJ03VNoOTt76nPTHXZ4xkSKtOTwng=";
   };
 
   # "This test is stochastic and may occasionally fail". It does.
@@ -42,6 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     gfortran
     swig
     doxygen
+    graphviz # doxygen missing components: dot
     python3Packages.python
   ]
   ++ lib.optionals enablePython [
@@ -49,7 +60,10 @@ stdenv.mkDerivation (finalAttrs: {
     python3Packages.installer
     python3Packages.wheel
   ]
-  ++ lib.optional enableCuda addDriverRunpath;
+  ++ lib.optionals enableCuda [
+    cudaPackages.cuda_nvcc
+    autoAddDriverRunpath
+  ];
 
   buildInputs = [
     fftwSinglePrec
@@ -58,7 +72,12 @@ stdenv.mkDerivation (finalAttrs: {
     ocl-icd
     opencl-headers
   ]
-  ++ lib.optional enableCuda cudaPackages.cudatoolkit;
+  ++ lib.optionals enableCuda [
+    cudaPackages.cuda_cudart # CUDA::cuda_driver (driver stub)
+    cudaPackages.cuda_nvrtc # runtime kernel compilation
+    cudaPackages.cuda_profiler_api # cudaProfiler.h
+    cudaPackages.libcufft # CUDA::cufft
+  ];
 
   propagatedBuildInputs = lib.optionals enablePython (
     with python3Packages;
@@ -71,31 +90,29 @@ stdenv.mkDerivation (finalAttrs: {
   );
 
   cmakeFlags = [
-    "-DBUILD_TESTING=ON"
-    "-DOPENMM_BUILD_AMOEBA_PLUGIN=ON"
-    "-DOPENMM_BUILD_CPU_LIB=ON"
-    "-DOPENMM_BUILD_C_AND_FORTRAN_WRAPPERS=ON"
-    "-DOPENMM_BUILD_DRUDE_PLUGIN=ON"
-    "-DOPENMM_BUILD_PME_PLUGIN=ON"
-    "-DOPENMM_BUILD_RPMD_PLUGIN=ON"
-    "-DOPENMM_BUILD_SHARED_LIB=ON"
+    (lib.cmakeBool "BUILD_TESTING" true)
+    (lib.cmakeBool "OPENMM_BUILD_AMOEBA_PLUGIN" true)
+    (lib.cmakeBool "OPENMM_BUILD_CPU_LIB" true)
+    (lib.cmakeBool "OPENMM_BUILD_C_AND_FORTRAN_WRAPPERS" true)
+    (lib.cmakeBool "OPENMM_BUILD_DRUDE_PLUGIN" true)
+    (lib.cmakeBool "OPENMM_BUILD_PME_PLUGIN" true)
+    (lib.cmakeBool "OPENMM_BUILD_RPMD_PLUGIN" true)
+    (lib.cmakeBool "OPENMM_BUILD_SHARED_LIB" true)
   ]
   ++ lib.optionals enablePython [
-    "-DOPENMM_BUILD_PYTHON_WRAPPERS=ON"
+    (lib.cmakeBool "OPENMM_BUILD_PYTHON_WRAPPERS" true)
   ]
   ++ lib.optionals enableOpencl [
-    "-DOPENMM_BUILD_OPENCL_LIB=ON"
-    "-DOPENMM_BUILD_AMOEBA_OPENCL_LIB=ON"
-    "-DOPENMM_BUILD_DRUDE_OPENCL_LIB=ON"
-    "-DOPENMM_BUILD_RPMD_OPENCL_LIB=ON"
+    (lib.cmakeBool "OPENMM_BUILD_AMOEBA_OPENCL_LIB" true)
+    (lib.cmakeBool "OPENMM_BUILD_DRUDE_OPENCL_LIB" true)
+    (lib.cmakeBool "OPENMM_BUILD_OPENCL_LIB" true)
+    (lib.cmakeBool "OPENMM_BUILD_RPMD_OPENCL_LIB" true)
   ]
   ++ lib.optionals enableCuda [
-    "-DCUDA_SDK_ROOT_DIR=${cudaPackages.cudatoolkit}"
-    "-DOPENMM_BUILD_AMOEBA_CUDA_LIB=ON"
-    "-DOPENMM_BUILD_CUDA_LIB=ON"
-    "-DOPENMM_BUILD_DRUDE_CUDA_LIB=ON"
-    "-DOPENMM_BUILD_RPMD_CUDA_LIB=ON"
-    "-DCMAKE_LIBRARY_PATH=${cudaPackages.cudatoolkit}/lib64/stubs"
+    (lib.cmakeBool "OPENMM_BUILD_AMOEBA_CUDA_LIB" true)
+    (lib.cmakeBool "OPENMM_BUILD_CUDA_LIB" true)
+    (lib.cmakeBool "OPENMM_BUILD_DRUDE_CUDA_LIB" true)
+    (lib.cmakeBool "OPENMM_BUILD_RPMD_CUDA_LIB" true)
   ];
 
   postInstall = lib.strings.optionalString enablePython ''
@@ -106,14 +123,12 @@ stdenv.mkDerivation (finalAttrs: {
     ${python3Packages.python.pythonOnBuildForHost.interpreter} -m installer --prefix $out dist/*.whl
   '';
 
-  postFixup = ''
-    for lib in $out/lib/plugins/*CUDA.so $out/lib/plugins/*Cuda*.so; do
-      addDriverRunpath "$lib"
-    done
-  '';
-
   # Couldn't get CUDA to run properly in the sandbox
   doCheck = !enableCuda && !enableOpencl;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Toolkit for molecular simulation using high performance GPU code";


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/openmm/openmm/compare/8.5.1...8.5.2

cc @sheepforce

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test