### PR TITLE
chiri: 0.9.0 -> 0.9.1

### DIFF
--- a/pkgs/by-name/ch/chiri/package.nix
+++ b/pkgs/by-name/ch/chiri/package.nix
@@ -22,104 +22,122 @@
   webkitgtk_4_1,
 }:
 
-rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "chiri";
-  version = "0.9.0";
+rustPlatform.buildRustPackage (
+  finalAttrs:
+  let
+    # on macOS, Node.js worker threads default to `trackUnmanagedFds: true`
+    # when used with pnpm's graceful-fs EAGAIN retry loop, this causes file descriptor
+    # churn that leads to a crash during cleanup (presenting as `Killed: 9` / SIGKILL)
+    # within the Nix sandbox. so we just disable `trackUnmanagedFds` to prevent this
+    # see: https://github.com/NixOS/nixpkgs/issues/525627
+    pnpm-patched = pnpm_11.overrideAttrs (old: {
+      postPatch = (old.postPatch or "") + ''
+        substituteInPlace dist/pnpm.mjs \
+          --replace-fail \
+            'resourceLimits: this._workerResourceLimits' \
+            'resourceLimits: this._workerResourceLimits, trackUnmanagedFds: false'
+      '';
+    });
+  in
+  {
+    pname = "chiri";
+    version = "0.9.1";
 
-  src = fetchFromGitHub {
-    owner = "chiriapp";
-    repo = "chiri";
-    tag = "app-v${finalAttrs.version}";
-    hash = "sha256-xlB7VqHXBljOjOOK96hK3HYENsuICMqRqfgJdtEnlUI=";
-  };
+    src = fetchFromGitHub {
+      owner = "chiriapp";
+      repo = "chiri";
+      tag = "app-v${finalAttrs.version}";
+      hash = "sha256-rkkyp36EIfvD0DXq0Tn+uLS/cBtgGk4x4sVkppTDaLg=";
+    };
 
-  cargoHash = "sha256-MTPd8HqbU35wmYVCv8HtfAuooBPsZk+p5J2Y5HjHTsA=";
+    cargoHash = "sha256-nSK4oyaW+chFHKrCI80d9785UsqBlX8YAdU26b/aa0s=";
 
-  pnpmDeps = fetchPnpmDeps {
-    inherit (finalAttrs) pname version src;
-    pnpm = pnpm_11;
-    hash = "sha256-dxfoo5Ajjt7zUsdQojXhePHp0K2itpdjequvGqqnZ7k=";
-    fetcherVersion = 3;
-  };
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalAttrs) pname version src;
+      pnpm = pnpm-patched;
+      hash = "sha256-dxfoo5Ajjt7zUsdQojXhePHp0K2itpdjequvGqqnZ7k=";
+      fetcherVersion = 3;
+    };
 
-  nativeBuildInputs = [
-    cargo-tauri.hook
-    nodejs_26
-    pnpmConfigHook
-    pnpm_11
-    pkg-config
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    wrapGAppsHook4
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    makeBinaryWrapper
-  ];
+    nativeBuildInputs = [
+      cargo-tauri.hook
+      nodejs_26
+      pnpmConfigHook
+      pnpm-patched
+      pkg-config
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      wrapGAppsHook4
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      makeBinaryWrapper
+    ];
 
-  buildInputs = [
-    openssl
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    glib-networking
-    libayatana-appindicator
-    webkitgtk_4_1
-  ];
+    buildInputs = [
+      openssl
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      glib-networking
+      libayatana-appindicator
+      webkitgtk_4_1
+    ];
 
-  cargoRoot = "src-tauri";
-  buildAndTestSubdir = "src-tauri";
+    cargoRoot = "src-tauri";
+    buildAndTestSubdir = "src-tauri";
 
-  postPatch =
-    lib.optionalString stdenv.hostPlatform.isLinux ''
-      for libappindicatorRs in $cargoDepsCopy/*/libappindicator-sys-*/src/lib.rs; do
-        if [[ -f "$libappindicatorRs" ]]; then
-          substituteInPlace "$libappindicatorRs" \
-            --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
-        fi
-      done
-    ''
-    + ''
-      substituteInPlace src-tauri/tauri.conf.json \
-        --replace-fail '"createUpdaterArtifacts": true' '"createUpdaterArtifacts": false'
-    '';
-
-  # This is needed since the signing keys are private, and are only used in CI during releases anyways. Regular users won't need this.
-  preBuild = ''
-    unset TAURI_SIGNING_PRIVATE_KEY
-    unset TAURI_SIGNING_PUBLIC_KEY
-    pnpm build
-  '';
-
-  postInstall =
-    if stdenv.hostPlatform.isDarwin then
-      ''
-        mkdir -p $out/bin
-        makeWrapper "$out/Applications/Chiri.app/Contents/MacOS/chiri" "$out/bin/chiri"
-      ''
-    else
-      ''
-        mv $out/bin/Chiri $out/bin/chiri
-        for desktopFile in \
-          $out/share/applications/Chiri.desktop \
-          $out/share/applications/garden.chiri.Chiri.desktop
-        do
-          if [ -f "$desktopFile" ]; then
-            substituteInPlace "$desktopFile" \
-              --replace-fail "Exec=Chiri" "Exec=chiri"
+    postPatch =
+      lib.optionalString stdenv.hostPlatform.isLinux ''
+        for libappindicatorRs in $cargoDepsCopy/*/libappindicator-sys-*/src/lib.rs; do
+          if [[ -f "$libappindicatorRs" ]]; then
+            substituteInPlace "$libappindicatorRs" \
+              --replace-fail "libayatana-appindicator3.so.1" "${libayatana-appindicator}/lib/libayatana-appindicator3.so.1"
           fi
         done
+      ''
+      + ''
+        substituteInPlace src-tauri/tauri.conf.json \
+          --replace-fail '"createUpdaterArtifacts": true' '"createUpdaterArtifacts": false'
       '';
 
-  doCheck = false;
+    # This is needed since the signing keys are private, and are only used in CI during releases anyways. Regular users won't need this.
+    preBuild = ''
+      unset TAURI_SIGNING_PRIVATE_KEY
+      unset TAURI_SIGNING_PUBLIC_KEY
+      pnpm build
+    '';
 
-  passthru.updateScript = nix-update-script;
+    postInstall =
+      if stdenv.hostPlatform.isDarwin then
+        ''
+          mkdir -p $out/bin
+          makeWrapper "$out/Applications/Chiri.app/Contents/MacOS/chiri" "$out/bin/chiri"
+        ''
+      else
+        ''
+          mv $out/bin/Chiri $out/bin/chiri
+          for desktopFile in \
+            $out/share/applications/Chiri.desktop \
+            $out/share/applications/garden.chiri.Chiri.desktop
+          do
+            if [ -f "$desktopFile" ]; then
+              substituteInPlace "$desktopFile" \
+                --replace-fail "Exec=Chiri" "Exec=chiri"
+            fi
+          done
+        '';
 
-  meta = {
-    description = "Cross-platform CalDAV task management app";
-    homepage = "https://github.com/chiriapp/chiri";
-    changelog = "https://github.com/chiriapp/chiri/releases/tag/app-v${finalAttrs.version}";
-    license = lib.licenses.zlib;
-    maintainers = with lib.maintainers; [ SapphoSys ];
-    mainProgram = "chiri";
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
-  };
-})
+    doCheck = false;
+
+    passthru.updateScript = nix-update-script;
+
+    meta = {
+      description = "Cross-platform CalDAV task management app";
+      homepage = "https://github.com/chiriapp/chiri";
+      changelog = "https://github.com/chiriapp/chiri/releases/tag/app-v${finalAttrs.version}";
+      license = lib.licenses.zlib;
+      maintainers = with lib.maintainers; [ SapphoSys ];
+      mainProgram = "chiri";
+      platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    };
+  }
+)


### PR DESCRIPTION
emergency release to fix chiri v0.9.0 crashing on linux systems
also added a patch to prevent pnpm 11 from OOMing under the nix sandbox
see https://github.com/NixOS/nixpkgs/issues/525627

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
