### PR TITLE
offlineimap: 8.0.2 -> 8.0.3

### DIFF
--- a/pkgs/by-name/of/offlineimap/package.nix
+++ b/pkgs/by-name/of/offlineimap/package.nix
@@ -14,14 +14,14 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "offlineimap";
-  version = "8.0.2";
+  version = "8.0.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "OfflineIMAP";
     repo = "offlineimap3";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-mysvqltO4x2dD8V+FAGOnDw5lQ8bgDwXFK9n15fbUdI=";
+    hash = "sha256-JWWv3zpiKzQmG8FRFb9h+TnCyR+f7LY3SBgYlcZA+1A=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Changelog: https://github.com/OfflineIMAP/offlineimap3/blob/v8.0.3/Changelog.md#offlineimap-v803-2026-06-08


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
