### PR TITLE
nixos/zfs: fix missing systemd-udev-settle dependency

### DIFF
--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -942,11 +942,17 @@ in
           map createImportService' dataPools
           ++ map createSyncService allPools
           ++ map createZfsService [
-            "zfs-mount"
             "zfs-share"
             "zfs-zed"
           ]
-        );
+        )
+        // {
+          zfs-mount = {
+            after = [ "systemd-modules-load.service" ];
+            wantedBy = [ "zfs.target" ];
+            serviceConfig.ExecStartPre = "-${lib.getExe' pkgs.systemd "udevadm"} settle --timeout=180";
+          };
+        };
 
       systemd.targets.zfs-import.wantedBy = [ "zfs.target" ];
 


### PR DESCRIPTION
Follow up to #504510 @rnhmjoj

zfs-mount.service had a dependency on systemd-udev-settle.service which was removed in the referenced PR. Sadly this broke some mount-depdency on my systemd. Adding the workaround from the original PR also to this unit fixes the mount-dependency error for me.

```
Jun 08 18:52:45 elf-forge01 systemd[1]: var-lib-forgejo.mount: Mount process exited, code=exited, status=2/INVALIDARGUMENT
Jun 08 18:52:45 elf-forge01 systemd[1]: var-lib-forgejo.mount: Failed with result 'exit-code'.
Jun 08 18:52:45 elf-forge01 systemd[1]: Failed to mount /var/lib/forgejo.
Jun 08 18:52:45 elf-forge01 systemd[1]: Dependency failed for Forgejo (Beyond coding. We forge.).
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
