### PR TITLE
opn2bankeditor: 1.3-unstable-2026-01-01 -> 1.3-unstable-2026-05-05, switch to Qt6

### DIFF
--- a/pkgs/by-name/op/opn2bankeditor/package.nix
+++ b/pkgs/by-name/op/opn2bankeditor/package.nix
@@ -5,45 +5,39 @@
   unstableGitUpdater,
   cmake,
   pkg-config,
-  # No Qt6 yet: https://github.com/Wohlstand/OPN2BankEditor/issues/126
-  libsForQt5,
+  qt6Packages,
   rtaudio,
   rtmidi,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "opn2bankeditor";
-  version = "1.3-unstable-2026-01-01";
+  version = "1.3-unstable-2026-05-05";
 
   src = fetchFromGitHub {
     owner = "Wohlstand";
     repo = "opn2bankeditor";
-    rev = "0371db0867ac23f49e8d160f9fd3163cf1fe41a2";
+    rev = "c3e12e6b1fc1a6a295fe66c64eceeba5e52832f2";
     fetchSubmodules = true;
-    hash = "sha256-+BgvzZoGAh9KlKjAyn7BsWnfGDB5njW8tJoFwtY0fCo=";
+    hash = "sha256-NosvIFVqu2b0p6QAzd+r5+TcxTNB66PZS358pWB8xpk=";
   };
-
-  # https://github.com/Wohlstand/OPN2BankEditor/issues/125
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace-fail 'cmake_minimum_required(VERSION 3.2)' 'cmake_minimum_required(VERSION 3.2...3.10)'
-  '';
 
   nativeBuildInputs = [
     cmake
     pkg-config
-    libsForQt5.qttools
-    libsForQt5.wrapQtAppsHook
+    qt6Packages.qttools
+    qt6Packages.wrapQtAppsHook
   ];
 
   buildInputs = [
-    libsForQt5.qtbase
-    libsForQt5.qwt
+    qt6Packages.qtbase
+    qt6Packages.qwt
     rtaudio
     rtmidi
   ];
 
   cmakeFlags = [
+    (lib.strings.cmakeFeature "BUILD_MAJOR_QT" "6")
     (lib.strings.cmakeBool "USE_RTAUDIO" true)
     (lib.strings.cmakeBool "USE_RTMIDI" true)
     (lib.strings.cmakeBool "USE_VENDORED_RTAUDIO" false)
@@ -54,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir $out/{bin,Applications}
     mv "OPN2 Bank Editor.app" $out/Applications/
 
-    install_name_tool -change {,${libsForQt5.qwt}/lib/}libqwt.6.dylib "$out/Applications/OPN2 Bank Editor.app/Contents/MacOS/OPN2 Bank Editor"
+    install_name_tool -change {,${qt6Packages.qwt}/lib/}libqwt.6.dylib "$out/Applications/OPN2 Bank Editor.app/Contents/MacOS/OPN2 Bank Editor"
 
     ln -s "$out/Applications/OPN2 Bank Editor.app/Contents/MacOS/OPN2 Bank Editor" $out/bin/opn2_bank_editor
   '';


### PR DESCRIPTION
Qt6 support now available (https://github.com/Wohlstand/OPN2BankEditor/issues/126).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
