### PR TITLE
libvirt: Prevent future update script mistakes

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -166,6 +166,15 @@ following are specific to `buildPythonPackage`:
 * `disabled ? false`: If `true`, package is not built for the particular Python
   interpreter version.
 * `dontWrapPythonPrograms ? false`: Skip wrapping of Python programs.
+* `enableDefaultUpdateScript ? true`: If `true`, the package will automatically
+  be given a `passthru.updateScript` attribute (see [the “Automatic package
+  updates” section of
+  `pkgs/README.md`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#automatic-package-updates)).
+  You can explicitly set `passthru.updateScript` in order to replace the
+  default update script with a custom one. If `false`, the package will not
+  automatically be given any sort of update script. Set
+  `enableDefaultUpdateScript` to `false` if you want the package to have no
+  update script at all.
 * `permitUserSite ? false`: Skip setting the `PYTHONNOUSERSITE` environment
   variable in wrapped programs.
 * `pyproject`: Whether the pyproject format should be used. As all other formats

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -190,6 +190,9 @@ lib.extendMkDerivation {
       # "other" : Provide your own buildPhase and installPhase.
       format ? null,
 
+      # Whether or not a default update script will automatically be added.
+      enableDefaultUpdateScript ? true,
+
       meta ? { },
 
       doCheck ? true,
@@ -417,13 +420,15 @@ lib.extendMkDerivation {
           dependencies
           optional-dependencies
           ;
-        updateScript = nix-update-script { };
         # __stdenvPythonCompat[Pos] attributes are here for overrideStdenvCompat in `python-packages-base.nix` to work.
         # They are internal and subject to changes.
         # TODO(@ShamrockLee): Remove when overrideStdenvCompat gets removed.
         ${if attrs ? stdenv then "__stdenvPythonCompat" else null} = attrs.stdenv;
         ${if attrs ? stdenv then "__stdenvPythonCompatPos" else null} =
           builtins.unsafeGetAttrPos "stdenv" attrs;
+      }
+      // optionalAttrs enableDefaultUpdateScript {
+        updateScript = nix-update-script { };
       }
       // attrs.passthru or { };
 

--- a/pkgs/development/python-modules/libvirt/default.nix
+++ b/pkgs/development/python-modules/libvirt/default.nix
@@ -15,6 +15,11 @@ buildPythonPackage rec {
   version = "12.4.0";
   pyproject = true;
 
+  # @r-ryantm should not try to automatically update this package. Instead,
+  # @r-ryantm should run the update script for the libvirt package. (See the
+  # below comment that’s about enableDefaultUpdateScript).
+  #
+  # nixpkgs-update: no auto update
   src = fetchFromGitLab {
     owner = "libvirt";
     repo = "libvirt-python";

--- a/pkgs/development/python-modules/libvirt/default.nix
+++ b/pkgs/development/python-modules/libvirt/default.nix
@@ -39,6 +39,14 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  # This next line prevents the python3Packages.libvirt package from
+  # automatically having an update script. If you would like to update the
+  # python3Packages.libvirt package, then please run the libvirt package’s
+  # update script. The libvirt package’s update script will update the libvirt
+  # package, the python3Packages.libvirt package and the perlPackages.SysVirt
+  # package.
+  enableDefaultUpdateScript = false;
+
   meta = {
     homepage = "https://libvirt.org/python.html";
     description = "Libvirt Python bindings";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The `libvirt` package has an update script that updates the `libvirt` package, the `python3Packages.libvirt` package and the `perlPackages.SysVirt` package. In general, those three packages should be updated by running the `libvirt` package’s update script. Unfortunately, the `python3Packages.libvirt` package has its own update script that only updates the `python3Packages.libvirt` package. This pull request gets rid of the `python3Packages.libvirt` package’s update script in order to prevent confusion.

Additionally, [@r-ryantm recently opened a pull request which updates the `python3Packages.libvirt` package, but doesn’t do anything to the `libvirt` package or the `perPackages.SysVirt` package](https://github.com/NixOS/nixpkgs/pull/517865). [The fact that @r-ryantm had opened that pull request was preventing @r-ryantm from opening an additional pull request that would update the `libvirt` package and the `perPackages.SysVirt` package.](https://web.archive.org/web/20260608153716/https://nixpkgs-update-logs.nix-community.org/libvirt/2026-06-03.log) This pull request prevents @r-ryantm from attempting to update the `python3Packages.libvirt` package directly. This pull request makes it so that @r-ryantm will instead only update those three packages by running the `libvirt` package’s update script.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `3aed8f71817f7a1818f528b3d63efe129ed21f71`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 6 packages built:</summary>
  <ul>
    <li>fdroidserver</li>
    <li>nixpkgs-manual</li>
    <li>python313Packages.libvirt</li>
    <li>python314Packages.libvirt</li>
    <li>virt-manager</li>
    <li>virtnbdbackup</li>
  </ul>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
