### PR TITLE
teams/redis: init

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -689,6 +689,10 @@ with lib.maintainers;
     github = "radicle";
   };
 
+  redis = {
+    github = "redis";
+  };
+
   rocm = {
     github = "rocm";
   };

--- a/nixos/modules/services/databases/redis.nix
+++ b/nixos/modules/services/databases/redis.nix
@@ -30,6 +30,8 @@ let
 
 in
 {
+  meta.teams = [ lib.teams.redis ];
+
   imports = [
     (lib.mkRemovedOptionModule [
       "services"

--- a/nixos/tests/redis.nix
+++ b/nixos/tests/redis.nix
@@ -19,11 +19,7 @@ let
     }:
     makeTest {
       inherit name;
-      meta.maintainers = [
-        lib.maintainers.das_j
-        lib.maintainers.flokli
-        lib.maintainers.helsinki-Jo
-      ];
+      meta.maintainers = lib.teams.redis.members;
 
       nodes = {
         machine =

--- a/pkgs/by-name/hi/hiredis/package.nix
+++ b/pkgs/by-name/hi/hiredis/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/redis/hiredis";
     description = "Minimalistic C client for Redis >= 1.2";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ hythera ];
     platforms = lib.platforms.all;
+    teams = [ lib.teams.redis ];
   };
 })

--- a/pkgs/by-name/me/memtier-benchmark/package.nix
+++ b/pkgs/by-name/me/memtier-benchmark/package.nix
@@ -37,10 +37,8 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/redis/memtier_benchmark";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [
-      thoughtpolice
-      hythera
-    ];
+    maintainers = with lib.maintainers; [ thoughtpolice ];
     mainProgram = "memtier_benchmark";
+    teams = [ lib.teams.redis ];
   };
 })

--- a/pkgs/by-name/re/redis/package.nix
+++ b/pkgs/by-name/re/redis/package.nix
@@ -137,7 +137,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.agpl3Only;
     platforms = lib.platforms.all;
     changelog = "https://github.com/redis/redis/releases/tag/${finalAttrs.version}";
-    maintainers = with lib.maintainers; [ hythera ];
     mainProgram = "redis-cli";
+    teams = [ lib.teams.redis ];
   };
 })

--- a/pkgs/by-name/re/redisTestHook/package.nix
+++ b/pkgs/by-name/re/redisTestHook/package.nix
@@ -16,5 +16,8 @@ makeSetupHook {
     simple = callPackage ./test.nix { };
     python3-valkey = python3Packages.valkey;
   };
-  meta.license = lib.licenses.mit;
+  meta = {
+    license = lib.licenses.mit;
+    teams = [ lib.teams.redis ];
+  };
 } ./redis-test-hook.sh

--- a/pkgs/by-name/re/redisinsight/package.nix
+++ b/pkgs/by-name/re/redisinsight/package.nix
@@ -177,5 +177,6 @@ stdenv.mkDerivation (finalAttrs: {
       tomasajt
     ];
     platforms = lib.platforms.linux;
+    teams = [ lib.teams.redis ];
   };
 })

--- a/pkgs/by-name/ri/riot-redis/package.nix
+++ b/pkgs/by-name/ri/riot-redis/package.nix
@@ -39,5 +39,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.asl20;
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     maintainers = with lib.maintainers; [ wesnel ];
+    teams = [ lib.teams.redis ];
   };
 })

--- a/pkgs/by-name/va/valkey/package.nix
+++ b/pkgs/by-name/va/valkey/package.nix
@@ -117,9 +117,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "High-performance data structure server that primarily serves key/value workloads";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [
-      debtquity
-    ];
+    teams = [ lib.teams.redis ];
     changelog = "https://github.com/valkey-io/valkey/releases/tag/${finalAttrs.version}";
     mainProgram = "valkey-cli";
   };

--- a/pkgs/development/python-modules/hiredis/default.nix
+++ b/pkgs/development/python-modules/hiredis/default.nix
@@ -38,6 +38,6 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/redis/hiredis-py";
     changelog = "https://github.com/redis/hiredis-py/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ hythera ];
+    teams = [ lib.teams.redis ];
   };
 })

--- a/pkgs/development/python-modules/redis-om/default.nix
+++ b/pkgs/development/python-modules/redis-om/default.nix
@@ -87,5 +87,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/redis/redis-om-python/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ natsukium ];
+    teams = [ lib.teams.redis ];
   };
 }

--- a/pkgs/development/python-modules/redis/default.nix
+++ b/pkgs/development/python-modules/redis/default.nix
@@ -73,5 +73,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/redis/redis-py/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.dotlambda ];
+    teams = [ lib.teams.redis ];
   };
 }

--- a/pkgs/development/python-modules/redisvl/default.nix
+++ b/pkgs/development/python-modules/redisvl/default.nix
@@ -49,9 +49,7 @@ buildPythonPackage (finalAttrs: {
     changelog = "https://github.com/redis/redis-vl-python/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     mainProgram = "rvl";
-    maintainers = with lib.maintainers; [
-      codgician
-      hythera
-    ];
+    maintainers = with lib.maintainers; [ codgician ];
+    teams = [ lib.teams.redis ];
   };
 })


### PR DESCRIPTION
We have quite a few packages in `nixpkgs` from the vendor Redis plus a module, test hoook and test. I've noticed that a few of them haven't been maintained for a bit. This PR tries to scope them under a new "Redis" team that is going to be responsible for Redis enablement in `nixpkgs`. Anyone should feel free to join the team if they are interested and active. I've removed the existing maintainers from the nixos test but if there is any objection, just let me know.
~~We could also add `valkey` to the team in the future too since it is basically the same package.~~ Talked with `debtquity`, they are fine with it. Thanks!


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
