### PR TITLE
digikam: 9.0.0 -> 9.1.0

### DIFF
--- a/pkgs/by-name/di/digikam/disable-tests-download.patch
+++ b/pkgs/by-name/di/digikam/disable-tests-download.patch
@@ -1,15 +1,16 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 43636fa9b9...e8da76c480 100644
+index f0dbdd9aa5..368d481fd8 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -208,10 +208,6 @@
+@@ -237,11 +237,6 @@ if(BUILD_TESTING)
      # For CI runners to run tests, the following custom target serves to perform the download automatically.
      # If the directory "test-data" has already been created, the target becomes a "no-op".
      #
--    add_custom_command(OUTPUT ${CMAKE_SOURCE_DIR}/test-data 
+-    add_custom_command(OUTPUT  ${CMAKE_SOURCE_DIR}/test-data
 -                       COMMENT "Checkout unit-test data repository. Please wait..."
 -                       COMMAND git
--                       ARGS clone https://invent.kde.org/graphics/digikam-test-data.git ${CMAKE_SOURCE_DIR}/test-data)
+-                       ARGS    clone https://invent.kde.org/graphics/digikam-test-data.git ${CMAKE_SOURCE_DIR}/test-data
+-    )
      add_custom_target(test-data ALL DEPENDS ${CMAKE_SOURCE_DIR}/test-data)
  
  endif()

--- a/pkgs/by-name/di/digikam/package.nix
+++ b/pkgs/by-name/di/digikam/package.nix
@@ -63,14 +63,14 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "digikam";
-  version = "9.0.0";
+  version = "9.1.0";
 
   src = fetchFromGitLab {
     domain = "invent.kde.org";
     owner = "graphics";
     repo = "digikam";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-zYOtTL4qEjXa/ZYlDIvneziYBXq4tIiVjRsrSJMaS0k=";
+    hash = "sha256-rrAqHSG7AsyG8DM0zYfyuGyu6jI/ZDmSYco91nhdmhQ=";
   };
 
   patches = [
@@ -169,6 +169,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_WITH_QT6" true)
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doCheck)
     (lib.cmakeBool "ENABLE_KFILEMETADATASUPPORT" true)
     #(lib.cmakeBool "ENABLE_AKONADICONTACTSUPPORT" true)
     (lib.cmakeBool "ENABLE_MEDIAPLAYER" true)


### PR DESCRIPTION
Changelog: https://invent.kde.org/graphics/digikam/-/blob/v9.1.0/NEWS

Incorporate the new `BUILD_TESTING` option such that tests are build when doCheck is enabled.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
