### PR TITLE
libwebsockets: 4.4.1 -> 4.4.5

### DIFF
--- a/pkgs/by-name/li/libwebsockets/package.nix
+++ b/pkgs/by-name/li/libwebsockets/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   openssl,
   zlib,
@@ -13,27 +12,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libwebsockets";
-  version = "4.4.1";
+  version = "4.4.5";
 
   src = fetchFromGitHub {
     owner = "warmcat";
     repo = "libwebsockets";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-Xvcnfvm9UCNXm3G3tVe7jExE3fwpzYuz8wllvINymeI=";
+    hash = "sha256-VY5caFHEJY06Vb4abDKmfcL12lRkmk0auxb/4ZZwqqc=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "CVE-2025-11677.patch";
-      url = "https://libwebsockets.org/git/libwebsockets/patch?id=2f082ec31261f556969160143ba94875d783971a";
-      hash = "sha256-FeiZAbr1kpt+YNjhi2gfG2A6nXKiSssMFRmlALaneu4=";
-    })
-    (fetchpatch {
-      name = "CVE-2025-11678.patch";
-      url = "https://libwebsockets.org/git/libwebsockets/patch?id=2bb9598562b37c942ba5b04bcde3f7fdf66a9d3a";
-      hash = "sha256-1uQUkoMbK+3E/QYMIBLlBZypwHBIrWBtm+KIW07WRj8=";
-    })
-  ];
 
   outputs = [
     "out"
@@ -69,8 +55,13 @@ stdenv.mkDerivation (finalAttrs: {
       ]
   );
 
+  postPatch = ''
+    substituteInPlace lib/CMakeLists.txt \
+      --replace-fail '=\''${exec_prefix}/''${LWS_INSTALL_LIB_DIR}' '=''${CMAKE_INSTALL_FULL_LIBDIR}' \
+      --replace-fail '=\''${prefix}/''${LWS_INSTALL_INCLUDE_DIR}' '=''${CMAKE_INSTALL_FULL_INCLUDEDIR}'
+  ''
   # Remove after https://github.com/warmcat/libwebsockets/pull/3567 has been merged or otherwise addressed
-  postPatch = lib.optionalString stdenv.hostPlatform.isStatic ''
+  + lib.optionalString stdenv.hostPlatform.isStatic ''
     substituteInPlace "cmake/libwebsockets-config.cmake.in" --replace-fail \
       "set(LIBWEBSOCKETS_LIBRARIES websockets websockets_shared)" \
       "set(LIBWEBSOCKETS_LIBRARIES websockets)"


### PR DESCRIPTION
Diff: https://github.com/warmcat/libwebsockets/compare/v4.4.1...v4.4.5

closes https://github.com/NixOS/nixpkgs/pull/483036
cc @fomichevmi

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
