### PR TITLE
noctalia-greeter: init at 1.0.0

### DIFF
--- a/pkgs/by-name/no/noctalia-greeter/package.nix
+++ b/pkgs/by-name/no/noctalia-greeter/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  meson,
+  ninja,
+  pkg-config,
+  wayland-scanner,
+
+  cairo,
+  fontconfig,
+  freetype,
+  glib,
+  gtk4,
+  libGL,
+  librsvg,
+  libwebp,
+  libxkbcommon,
+  pango,
+  wayland,
+  wayland-protocols,
+
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "noctalia-greeter";
+  version = "1.0.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "noctalia-dev";
+    repo = "noctalia-greeter";
+    rev = "367ab83dcd9190010f093cfe0e123ba132a75b5a";
+    hash = "sha256-/jQ/lkgjaH5EOTZRXk4YZaFrjrKhq/fzZsU6nm7wPt0=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    cairo
+    fontconfig
+    freetype
+    glib
+    gtk4
+    libGL
+    librsvg
+    libwebp
+    libxkbcommon
+    pango
+    wayland
+    wayland-protocols
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "`greetd` greeter for Noctalia";
+    homepage = "https://github.com/noctalia-dev/noctalia-greeter";
+    changelog = "https://github.com/noctalia-dev/noctalia-greeter/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      dtomvan
+      spacedentist
+    ];
+    mainProgram = "noctalia-greeter-session";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
https://github.com/noctalia-dev/noctalia-greeter

CC @spacedentist for maintaining `noctalia-shell`. Also your package will probably have a big rewrite soon due to [`v5` being merged into master](https://github.com/noctalia-dev/noctalia/commit/17c6ebdea119f89944dbdd479611a4231ee925d5), just a heads-up. (also, how do we handle the rename of `noctalia-shell` -> `noctalia`? with an alias?)

This PR complements that change (draft as everything involved is pre-release) by introducing the greeter that's designed for usage with noctalia v5...

Future work: implement a NixOS module to wire this up with `greetd`

Assisted-by: nix-init


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
