### PR TITLE
nixos/malloc: check legacy scudo options exist before use

### DIFF
--- a/nixos/modules/config/malloc.nix
+++ b/nixos/modules/config/malloc.nix
@@ -142,10 +142,14 @@ in
         # so we can warn the user about the change.
         legacyOptionsUsed = lib.lists.filter (opt: lib.strings.hasInfix opt scudoOpts) legacyOptionNames;
       in
-      lib.optional (cfg.provider == "scudo" && legacyOptionsUsed != [ ]) ''
-        environment.variables.SCUDO_OPTIONS: ${lib.concatStringsSep ", " legacyOptionsUsed} is/are no longer valid Scudo options.
-        Use snake_case instead of CamelCase: https://llvm.org/docs/ScudoHardenedAllocator.html#options
-      '';
+      lib.optional
+        (
+          config.environment.variables ? SCUDO_OPTIONS && cfg.provider == "scudo" && legacyOptionsUsed != [ ]
+        )
+        ''
+          environment.variables.SCUDO_OPTIONS: ${lib.concatStringsSep ", " legacyOptionsUsed} is/are no longer valid Scudo options.
+          Use snake_case instead of CamelCase: https://llvm.org/docs/ScudoHardenedAllocator.html#options
+        '';
 
     environment.etc."ld-nix.so.preload".text = ''
       ${providerLibPath}


### PR DESCRIPTION
>        … while evaluating definitions from `/nix/store/vlq3lnsh2xij0d9blab16pq0sr09z4nl-source/nixos/modules/config/malloc.nix':
>
>       (stack trace truncated; use '--show-trace' to show the full, detailed trace)
>
>       error: attribute 'SCUDO_OPTIONS' missing
>       at «github:NixOS/nixpkgs/bd0ff2d3eac24699c3664d5966b9ef36f388e2ca?narHash=sha256-q8yYEC5f1mFlQO9RGna4LTc9QrcvWunX6FYp83munkQ%3D»/nixos/modules/config/malloc.nix:130:21:
>          129|       let
>          130|         scudoOpts = config.environment.variables.SCUDO_OPTIONS;
>             |                     ^
>          131|

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
