### PR TITLE
neovim-require-check-hook: remove `$out` from `rtp`

### DIFF
--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -558,4 +558,25 @@ pkgs.lib.recurseIntoAttrs rec {
       EOF
     '';
   };
+
+  nvim_require_check_rtp_no_duplicate = vimUtils.buildVimPlugin {
+    pname = "neovim-require-check-rtp-no-duplicate-test";
+    version = "0";
+    src = runCommandLocal "neovim-require-check-rtp-no-duplicate-src" { } ''
+      mkdir -p "$out/lua/require-check-rtp-dedup"
+      cat > "$out/lua/require-check-rtp-dedup/init.lua" <<'EOF'
+      local target = "lua/require-check-rtp-dedup/init.lua"
+      local matches = vim.api.nvim_get_runtime_file(target, true)
+      if #matches ~= 1 then
+        error(
+          ("expected plugin on runtimepath exactly once, found %d:\n%s"):format(
+            #matches,
+            table.concat(matches, "\n")
+          )
+        )
+      end
+      return {}
+      EOF
+    '';
+  };
 }

--- a/pkgs/applications/editors/vim/plugins/hooks/neovim-require-check-hook.sh
+++ b/pkgs/applications/editors/vim/plugins/hooks/neovim-require-check-hook.sh
@@ -98,9 +98,9 @@ run_require_checks() {
         if [ "$skip" = false ]; then
             echo "Attempting to require module: $name"
             if @nvimBinary@ -es --headless -n -u NONE -i NONE --clean -V1 \
-                --cmd "set rtp+=$out,${deps// /,}" \
-                --cmd "set rtp+=$out,${nativeCheckInputs// /,}" \
-                --cmd "set rtp+=$out,${checkInputs// /,}" \
+                --cmd "set rtp+=${deps// /,}" \
+                --cmd "set rtp+=${nativeCheckInputs// /,}" \
+                --cmd "set rtp+=${checkInputs// /,}" \
                 "${luaPathArgs[@]}" \
                 --cmd "set packpath^=$packPathDir" \
                 --cmd "packadd testPlugin" \


### PR DESCRIPTION
Previously, the tested plugin appeared in `rtp` under two paths:
- `/nix/store/<hash>-vimPlugins-my-plugin` from `$out`
- `/build/.local/share/nvim/site/pack/nvimRequireCheckHook/opt/testPlugin` from `packadd testPlugin`

This was causing problems for plugins that use
`vim.api.nvim_get_runtime_file()`. For example, `blink.lib` uses this function to locate rust libraries and raises an error when duplicate libraries are found, causing the require check to fail.

The plugin is already loaded via `packadd testPlugin`, so adding `$out` to `rtp` is unnecessary. Remove `$out` from `rtp` to avoid duplicate runtime entries.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
