### PR TITLE
python3Packages.black: 25.1.0 -> 26.5.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25572,6 +25572,12 @@
     github = "sinanmohd";
     githubId = 69694713;
   };
+  singhc7 = {
+    name = "Chahatpreet Singh";
+    email = "c@chahat.dev";
+    github = "singhc7";
+    githubId = 113715161;
+  };
   sinics = {
     name = "Zhifan";
     email = "nonno.felice69uwu@gmail.com";

--- a/pkgs/development/python-modules/black/default.nix
+++ b/pkgs/development/python-modules/black/default.nix
@@ -3,7 +3,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  fetchpatch,
   pytestCheckHook,
   aiohttp,
   click,
@@ -17,37 +16,20 @@
   pathspec,
   parameterized,
   platformdirs,
+  pytokens,
   tokenize-rt,
   uvloop,
 }:
 
 buildPythonPackage rec {
   pname = "black";
-  version = "25.1.0";
+  version = "26.5.1";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-M0ltXNEiKtczkTUrSujaFSU8Xeibk6gLPiyNmhnsJmY=";
+    hash = "sha256-3TIfZoBTlhgkvMG+HMHfdIstfk+igIawgzHld7AQCnM=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "click-8.2-compat-1.patch";
-      url = "https://github.com/psf/black/commit/14e1de805a5d66744a08742cad32d1660bf7617a.patch";
-      hash = "sha256-fHRlMetE6+09MKkuFNQQr39nIKeNrqwQuBNqfIlP4hc=";
-    })
-    (fetchpatch {
-      name = "click-8.2-compat-2.patch";
-      url = "https://github.com/psf/black/commit/ed64d89faa7c738c4ba0006710f7e387174478af.patch";
-      hash = "sha256-df/J6wiRqtnHk3mAY3ETiRR2G4hWY1rmZMfm2rjP2ZQ=";
-    })
-    (fetchpatch {
-      name = "click-8.2-compat-3.patch";
-      url = "https://github.com/psf/black/commit/b0f36f5b4233ef4cf613daca0adc3896d5424159.patch";
-      hash = "sha256-SGLCxbgrWnAi79IjQOb2H8mD/JDbr2SGfnKyzQsJrOA=";
-    })
-  ];
 
   nativeBuildInputs = [
     hatch-fancy-pypi-readme
@@ -61,6 +43,7 @@ buildPythonPackage rec {
     packaging
     pathspec
     platformdirs
+    pytokens
   ];
 
   optional-dependencies = {

--- a/pkgs/development/python-modules/pytokens/default.nix
+++ b/pkgs/development/python-modules/pytokens/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  mypy,
+}:
+
+buildPythonPackage rec {
+  pname = "pytokens";
+  version = "0.4.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-KSBS/oCSOq4iYMBz+CLOuiHzhyztmmi7eVOzSOVhF5o=";
+  };
+
+  build-system = [
+    setuptools
+    mypy
+  ];
+
+  pythonImportsCheck = [ "pytokens" ];
+
+  meta = with lib; {
+    description = "A Fast, spec compliant Python 3.14+ tokenizer that runs on older Pythons.";
+    homepage = "https://github.com/tusharsadhwani/pytokens";
+    license = licenses.mit;
+    mainProgram = "pytokens";
+    maintainers = with lib.maintainers; [ singhc7 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16347,6 +16347,8 @@ self: super: with self; {
 
   pytmx = callPackage ../development/python-modules/pytmx { };
 
+  pytokens = callPackage ../development/python-modules/pytokens { };
+
   pytomlpp = callPackage ../development/python-modules/pytomlpp { };
 
   pytomorrowio = callPackage ../development/python-modules/pytomorrowio { };


### PR DESCRIPTION
Replaces closed PR #529644 (closed due to base branch and rebase issues).

Update `black` to 26.5.1 and init `pytokens` at 0.4.1.

- **`python3Packages.black`**: Updated to 26.5.1.
  - Removed `click-8.2-compat` patches (merged upstream).
  - Added `pytokens` to `propagatedBuildInputs` (new core dependency
    for Python 3.14+ syntax parsing).
- **`python3Packages.pytokens`**: Init at 0.4.1.
  - Added myself to `maintainers/maintainer-list.nix`.

**Release notes:** https://github.com/psf/black/releases/tag/26.5.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
