### PR TITLE
home-assistant-custom-components.opendisplay: init at 2.0.2

### DIFF
--- a/pkgs/development/python-modules/python-resize-image/default.nix
+++ b/pkgs/development/python-modules/python-resize-image/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  pillow,
+  requests,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "python-resize-image";
+  version = "1.1.20";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-sFXauRnWI+zo7JUmLUvb8AbLGhDoGOmzYiHIsYhfmSI=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    pillow
+    requests
+  ];
+
+  pythonImportsCheck = [
+    "resizeimage"
+  ];
+
+  doCheck = false; # sdist missing test artifact
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Python package to easily resize images";
+    homepage = "https://pypi.org/project/python-resize-image";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hexa ];
+  };
+})

--- a/pkgs/servers/home-assistant/custom-components/opendisplay/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/opendisplay/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+
+  # dependencies
+  bleak,
+  bleak-retry-connector,
+  python-resize-image,
+  numpy,
+  qrcode,
+  requests-toolbelt,
+  websocket-client,
+  websockets,
+
+  # tests
+  pytest-asyncio,
+  pytest-homeassistant-custom-component,
+  pytestCheckHook,
+}:
+
+buildHomeAssistantComponent (finalAttrs: {
+  owner = "OpenDisplay";
+  domain = "opendisplay";
+  version = "2.0.2";
+
+  src = fetchFromGitHub {
+    inherit (finalAttrs) owner;
+    repo = "Home_Assistant_Integration";
+    tag = finalAttrs.version;
+    hash = "sha256-EmcDY31cTWK+JRErM6EWO0jrQvIaxKXgeI6i5qiwYGU=";
+  };
+
+  dependencies = [
+    bleak
+    bleak-retry-connector
+    numpy
+    python-resize-image
+    qrcode
+    requests-toolbelt
+    websocket-client
+    websockets
+  ]
+  ++ qrcode.optional-dependencies.pil;
+
+  ignoreVersionRequirement = [
+    "qrcode"
+    "websocket-client"
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-homeassistant-custom-component
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # Probably mismatch in fontconfig priorities
+    "tests/drawcustom/text_multiline_test.py::test_text_multiline_delimiter" # AssertionError: Multiline text with delimiter rendering failed
+    "tests/drawcustom/text_multiline_test.py::test_text_multiline_empty_line" # AssertionError: Multiline text with empty line rendering failed
+    "tests/drawcustom/text_multiline_test.py::test_text_multiline_delimiter_and_newline" # AssertionError: Multiline text with delimiter and newline rendering failed
+    "tests/drawcustom/text_test.py::test_small_font_size" # AssertionError: Small font size rendering failed
+    "tests/drawcustom/text_test.py::test_large_font_size" # AssertionError: Large font size rendering failed
+    "tests/drawcustom/text_test.py::test_text_wrapping" # AssertionError: Text wrapping failed
+    "tests/drawcustom/text_test.py::test_text_wrapping_with_anchor" # AssertionError: Text wrapping failed
+    "tests/drawcustom/text_test.py::test_text_with_special_characters" # AssertionError: Special characters rendering failed
+    "tests/drawcustom/text_test.py::test_text_percentage" # AssertionError: Text with percentage rendering failed
+    "tests/drawcustom/text_test.py::test_text_anchors" # AssertionError: Text anchor points failed
+    "tests/drawcustom/text_test.py::test_text_truncate" # AssertionError: Text truncation failed
+  ];
+
+  meta = {
+    description = "Home Assistant Integration for OpenDisplay";
+    homepage = "https://github.com/OpenDisplay/Home_Assistant_Integration";
+    changelog = "https://github.com/OpenDisplay/Home_Assistant_Integration/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ hexa ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16201,6 +16201,8 @@ self: super: with self; {
 
   python-registry = callPackage ../development/python-modules/python-registry { };
 
+  python-resize-image = callPackage ../development/python-modules/python-resize-image { };
+
   python-ripple-api = callPackage ../development/python-modules/python-ripple-api { };
 
   python-roborock = callPackage ../development/python-modules/python-roborock { };


### PR DESCRIPTION
https://github.com/OpenDisplay/Home_Assistant_Integration
https://github.com/VingtCinq/python-resize-image

Tested over BLE and works.

<img width="1687" height="914" alt="image" src="https://github.com/user-attachments/assets/4a346657-4368-4ace-854b-ea315fdad359" />



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
