### PR TITLE
bindery: init at 1.17.0

### DIFF
--- a/pkgs/by-name/bi/bindery/package.nix
+++ b/pkgs/by-name/bi/bindery/package.nix
@@ -1,0 +1,69 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  lib,
+  nodejs,
+  npmHooks,
+}:
+buildGoModule (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "bindery";
+  version = "1.17.0";
+
+  src = fetchFromGitHub {
+    owner = "vavallee";
+    repo = "bindery";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Xwm1U5sz4qY0M57TPkI3pmVxmPdefBENB4ucgO6djtE=";
+  };
+  vendorHash = "sha256-G97Q6yOlGF+LSadmkm3afrHedUSZUro6VxOd8RUD7vw=";
+  subPackages = "cmd/bindery";
+
+  npmDeps = fetchNpmDeps {
+    src = "${finalAttrs.src}/web";
+    hash = "sha256-EHgKGEbiZ6Yousddczmsn9cAhBM8tLq2VgmqAL5y15M=";
+  };
+
+  npmRoot = "web";
+
+  nativeBuildInputs = [
+    nodejs
+    npmHooks.npmConfigHook
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=main.version=${finalAttrs.version}"
+    "-X=main.commit=${finalAttrs.src.rev}"
+  ];
+
+  preBuild = ''
+    npm --prefix="$npmRoot" run build
+    cp -r "$npmRoot"/dist/* internal/webui/dist/
+    CC="$CC_FOR_BUILD" LD="$CC_FOR_BUILD" GOOS= GOARCH= go generate ./...
+  '';
+
+  env.CGO_ENABLED = 0;
+
+  checkFlags =
+    let
+      skippedTests = [
+        "TestIndexerCRUD"
+        "TestIndexerCreate_DuplicateURL"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+
+  meta = {
+    description = "Automated book download manager for Usenet";
+    homepage = "https://github.com/vavallee/bindery";
+    changelog = "https://github.com/vavallee/bindery/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ flyingpeakock ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    mainProgram = "bindery";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/vavallee/bindery

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
