### PR TITLE
pinentry_mac: 1.1.1.1 -> 1.3.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19078,6 +19078,12 @@
     matrix = "@n4ch7:n3831.net";
     name = "N4CH723HR3R";
   };
+  n4kama = {
+    name = "nakama";
+    github = "n4kama";
+    githubId = 22456015;
+    email = "git@nakama.mov";
+  };
   n8henrie = {
     name = "Nathan Henrie";
     email = "nate@n8henrie.com";

--- a/pkgs/tools/security/pinentry/mac.nix
+++ b/pkgs/tools/security/pinentry/mac.nix
@@ -17,13 +17,13 @@ stdenv.mkDerivation rec {
 
   # NOTE: Don't update manually. Use passthru.updateScript on a Mac with XCode
   # installed.
-  version = "1.1.1.1";
+  version = "1.3.1.1";
 
   src = fetchFromGitHub {
     owner = "GPGTools";
     repo = "pinentry";
     rev = "v${version}";
-    sha256 = "sha256-QnDuqFrI/U7aZ5WcOCp5vLE+w59LVvDGOFNQy9fSy70=";
+    sha256 = "sha256-iVd8Gy8XhQOHCSY7caP2QCgs/MufA+p9RN2pNilrJ9E=";
   };
 
   patches = [
@@ -37,6 +37,9 @@ stdenv.mkDerivation rec {
     chmod -R u+w macosx/*.nib
     # pinentry_mac requires updated macros to correctly detect v2 API support in libassuan 3.x.
     cp '${lib.getDev libassuan}/share/aclocal/libassuan.m4' m4/libassuan.m4
+    # Likewise, the bundled gpg-error.m4 is too old to detect libgpg-error via gpgrt-config
+    # (the gpg-error-config it falls back to is now a deprecated stub), so use the updated macro.
+    cp '${lib.getDev libgpg-error}/share/aclocal/gpg-error.m4' m4/gpg-error.m4
     substituteInPlace macosx/copyInfoPlist.sh \
       --replace-fail "/usr/libexec/PlistBuddy" "PlistBuddy"
   '';
@@ -102,6 +105,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
     homepage = "https://github.com/GPGTools/pinentry";
     platforms = lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ n4kama ];
     mainProgram = "pinentry-mac";
   };
 }


### PR DESCRIPTION
Updates `pinentry_mac` from 1.1.1.1 to the latest GPGTools release, [v1.3.1.1](https://github.com/GPGTools/pinentry/releases/tag/v1.3.1.1), and adds myself as maintainer of this previously-unmaintained package.

Two notes for reviewers:

- The `gpg-error.m4` bundled in the 1.3.1.1 source is too old to locate `libgpg-error` via `gpgrt-config` (it only finds the now-deprecated `gpg-error-config` stub), which breaks `configure`. Fixed in `postPatch` by copying the updated macro from `libgpg-error`'s dev output — mirroring the existing `libassuan.m4` workaround already in the file.
- The `macosx/*.xib` UI sources are byte-identical between v1.1.1.1 and v1.3.1.1, so the pregenerated `.nib` files are intentionally kept as-is; no Xcode/`ibtool` regeneration was needed (the package's `updateScript` would normally regenerate them on a Mac with Xcode).

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].