### PR TITLE
nixos/btrfs-heatmap: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -28,6 +28,8 @@
   firewall, is available through
   [services.portmaster](#opt-services.portmaster.enable).
 
+- [btrfs-heatmap](https://github.com/knorrie/btrfs-heatmap), setcap wrapper for `btrfs-heatmap` package, a visualizer of how a btrfs filesystem is using the underlying disk space of the block devices. Available as [programs.btrfs-heatmap](#opt-programs.btrfs-heatmap.enable)
+
 - [tranquil](https://tangled.org/tranquil.farm/tranquil-pds) is an ATProto PDS (personal data server) implementation in Rust. A featureful, spec conscious and community driven alternative to the Bluesky reference implementation PDS. Available as [services.tranquil-pds](#opt-services.tranquil-pds.enable).
 
 - [Moonlight Qt](https://moonlight-stream.org/), a client for playing your PC games on almost any device. Available as [programs.moonlight-qt](#opt-programs.moonlight-qt.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -185,6 +185,7 @@
   ./programs/bcc.nix
   ./programs/benchexec.nix
   ./programs/browserpass.nix
+  ./programs/btrfs-heatmap.nix
   ./programs/calls.nix
   ./programs/captive-browser.nix
   ./programs/ccache.nix

--- a/nixos/modules/programs/btrfs-heatmap.nix
+++ b/nixos/modules/programs/btrfs-heatmap.nix
@@ -1,0 +1,32 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+{
+  meta.maintainers = with lib.maintainers; [ sandarukasa ];
+
+  options = {
+    programs.btrfs-heatmap = {
+      enable = lib.mkEnableOption "btrfs-heatmap + setcap wrapper";
+      package = lib.mkPackageOption pkgs "btrfs-heatmap" { };
+    };
+  };
+
+  config =
+    let
+      cfg = config.programs.btrfs-heatmap;
+    in
+    lib.mkIf cfg.enable {
+      # for the man page
+      environment.systemPackages = [ cfg.package ];
+
+      security.wrappers.btrfs-heatmap = {
+        owner = config.users.users.root.name;
+        group = config.users.users.root.group;
+        capabilities = "cap_sys_admin+p";
+        source = lib.getExe cfg.package;
+      };
+    };
+}


### PR DESCRIPTION
See also:
- https://github.com/NixOS/nixpkgs/pull/528078
- https://github.com/NixOS/nixpkgs/pull/527199
- https://github.com/NixOS/nixpkgs/pull/527207

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
