### PR TITLE
devin-cli: optimize update.sh, bump

### DIFF
--- a/pkgs/by-name/de/devin-cli/package.nix
+++ b/pkgs/by-name/de/devin-cli/package.nix
@@ -7,29 +7,29 @@
 }:
 
 let
-  version = "2026.5.26-6";
+  version = "2026.5.26-8";
 
   throwSystem = throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}";
 
   srcs = {
     x86_64-linux = fetchurl {
       url = "https://static.devin.ai/cli/${version}/devin-${version}-x86_64-unknown-linux.tar.gz";
-      hash = "sha256-8jEq0X2owEnOdSWzEhDOYahAdq/3G/JIUZShHbYrR2c=";
+      hash = "sha256-TqSABBxigiYTafi0vxFYnssLjHbiXYaNxI8prkkp8CE=";
     };
 
     aarch64-linux = fetchurl {
       url = "https://static.devin.ai/cli/${version}/devin-${version}-aarch64-unknown-linux.tar.gz";
-      hash = "sha256-i8m05WrmO/KQCt/4jVFkRxz9nIXZEDi8idVhXkXxDig=";
+      hash = "sha256-1hoTd6JR43nR+heLqU7igP+debI1bhWcIlG6BGyaj3I=";
     };
 
     aarch64-darwin = fetchurl {
       url = "https://static.devin.ai/cli/${version}/devin-${version}-aarch64-apple-darwin.tar.gz";
-      hash = "sha256-WPL1kPMSmqh9/n2m9CvNnUcyLfjHz3PC9tAjGrjaZfw=";
+      hash = "sha256-/8vd26V0z1qyt8EOJ2Z/JdWNGjb+iN+YkgaJQRoBHUk=";
     };
 
     x86_64-darwin = fetchurl {
       url = "https://static.devin.ai/cli/${version}/devin-${version}-x86_64-apple-darwin.tar.gz";
-      hash = "sha256-HtB5iCT3d3AprPM+1uNkPkX0v4wSerTJlEu5F4P6pp0=";
+      hash = "sha256-uF6ORbWwC0hgIURFoXFQh/5oPvfS4cgRBaCui4S0E0E=";
     };
   };
 

--- a/pkgs/by-name/de/devin-cli/update.sh
+++ b/pkgs/by-name/de/devin-cli/update.sh
@@ -3,8 +3,8 @@
 
 set -euo pipefail
 
-currentVersion=$(nix-instantiate --eval -E "with import ./. {}; devin-cli.version or (lib.getVersion devin-cli)" | tr -d '"')
-latestVersion=$(curl https://static.devin.ai/cli/current/manifest.json | jq '.version' | tr -d '"')
+currentVersion=$(nix-instantiate --eval --raw -E "with import ./. {}; devin-cli.version or (lib.getVersion devin-cli)")
+latestVersion=$(curl https://static.devin.ai/cli/current/manifest.json | jq -r '.version')
 
 if [[ "$currentVersion" == "$latestVersion" ]]; then
     echo "package is up-to-date: $currentVersion"
@@ -18,6 +18,7 @@ for system in \
     aarch64-linux \
     x86_64-darwin \
     aarch64-darwin; do
-    hash=$(nix --extra-experimental-features nix-command hash convert --to sri --hash-algo sha256 $(nix-prefetch-url $(nix-instantiate --eval -E "with import ./. {}; devin-cli.src.url" --system "$system" | tr -d '"')))
+    hash=$(nix store prefetch-file --json --hash-type sha256 \
+      $(nix-instantiate --eval --raw -E "with import ./. {}; devin-cli.src.url" --system "$system") | jq -r '.hash')
     update-source-version devin-cli $latestVersion $hash --system=$system --ignore-same-version
 done


### PR DESCRIPTION
Bits and bobs


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
