### PR TITLE
teleport_17: 17.7.23 -> 17.7.24; teleport_18: 18.7.6 -> 18.8.3

### DIFF
--- a/pkgs/build-support/teleport/0001-fix-add-nix-path-to-exec-env-reexec.patch
+++ b/pkgs/build-support/teleport/0001-fix-add-nix-path-to-exec-env-reexec.patch
@@ -1,0 +1,28 @@
+From e3651ca79c0edb66c04e0d3381f3b0b6f76d37d2 Mon Sep 17 00:00:00 2001
+From: 5aaee9 <jiduye@gmail.com>
+Date: Thu, 24 Mar 2022 17:34:38 +0800
+Subject: [PATCH] fix: add nix path to exec env
+# Adapted to new path starting from 18.8
+
+---
+ session/reexec/exec.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/session/reexec/exec.go b/session/reexec/exec.go
+index 253fbafef..815a2e1e0 100644
+--- a/session/reexec/exec.go
++++ b/session/reexec/exec.go
+@@ -30,8 +30,8 @@ import (
+ )
+ 
+ const (
+-	defaultPath          = "/bin:/usr/bin:/usr/local/bin:/sbin"
++	defaultPath          = "/run/wrappers/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:/bin:/usr/bin:/usr/local/bin:/sbin"
+ 	defaultEnvPath       = "PATH=" + defaultPath
+-	defaultRootPath      = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
++	defaultRootPath      = "/run/wrappers/bin:/etc/profiles/per-user/root/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+ 	defaultEnvRootPath   = "PATH=" + defaultRootPath
+ 	defaultLoginDefsPath = "/etc/login.defs"
+-- 
+2.32.0 (Apple Git-132)
+

--- a/pkgs/build-support/teleport/default.nix
+++ b/pkgs/build-support/teleport/default.nix
@@ -157,10 +157,17 @@ buildGoModule (finalAttrs: {
     pkg-config
   ];
 
-  patches = extPatches ++ [
-    ./0001-fix-add-nix-path-to-exec-env.patch
-    ./rdpclient.patch
-  ];
+  patches =
+    extPatches
+    ++ [
+      ./rdpclient.patch
+    ]
+    ++ lib.optional (lib.versionOlder version "18.8.0") [
+      ./0001-fix-add-nix-path-to-exec-env.patch
+    ]
+    ++ lib.optional (lib.versionAtLeast version "18.8.0") [
+      ./0001-fix-add-nix-path-to-exec-env-reexec.patch
+    ];
 
   # Reduce closure size for client machines
   outputs = [

--- a/pkgs/by-name/te/teleport_17/package.nix
+++ b/pkgs/by-name/te/teleport_17/package.nix
@@ -7,11 +7,11 @@
 }:
 
 buildTeleport {
-  version = "17.7.23";
-  hash = "sha256-o1aYmNN4yytgJFQ7V1sPjq6r2pDzf4mG/juyYK5IF3A=";
-  vendorHash = "sha256-cL2U1GOV6PtxSl8N8gjKOHCpj5jhun5D+DbeWBixnxI=";
+  version = "17.7.24";
+  hash = "sha256-45vaxznxRfa4X/V7hZsQKVIWvbVG8F2cEQN19xp4WQg=";
+  vendorHash = "sha256-ERwCdWdp230wkqsRUCnd1hbO4PqXo+gDPsoGbxQqt04=";
   cargoHash = "sha256-cDcDfptq8z0pwjImuAovv/5XwoaPb/ostyxkyNEbkRM=";
-  pnpmHash = "sha256-NTH5YnqeZg/jEkjguSXGS3/MI/r8us11By/fZ1m1caQ=";
+  pnpmHash = "sha256-hk9DI3GSBm2XttCYCi5kjhEhUMm5ToRQcbT+RYI+S2Q=";
 
   wasm-bindgen-cli = wasm-bindgen-cli_0_2_95;
   inherit buildGoModule withRdpClient extPatches;

--- a/pkgs/by-name/te/teleport_18/package.nix
+++ b/pkgs/by-name/te/teleport_18/package.nix
@@ -7,11 +7,11 @@
 }:
 
 buildTeleport {
-  version = "18.7.6";
-  hash = "sha256-p7qwsUr6n6OAl/b20SgropAubfPfwBiVTvbReb2HpO8=";
-  vendorHash = "sha256-/ZY0J0yB/8qMG6vEIta7Nf2Uv3xTZ/WPoMz+Dj5hwZA=";
-  pnpmHash = "sha256-uRsS5m0Q4fAFvJ3Qp6xcEAB8QFriLXbeGtD0o0n46RE=";
-  cargoHash = "sha256-KkFwMSBXsRmDuaPU1n6FPq2P5UQiQnb7+HEDOhhmjd0=";
+  version = "18.8.3";
+  hash = "sha256-DHPOWIvzBCOT3GU0YHBtG46ctB0Nh8XwSmpl9vgCET8=";
+  vendorHash = "sha256-0+fIoprAQyoom9xBpXGiEgmE4dWktcqlZQOzkRXYlKo=";
+  pnpmHash = "sha256-8FlC9Sm12A5kfS9X0qYDNJOePZjeJU7LDTRlWUIEneA=";
+  cargoHash = "sha256-IX0HCeCosXCe/oTYa8PImemf9op2AeagSnl44uBnSbM=";
 
   wasm-bindgen-cli = wasm-bindgen-cli_0_2_99;
   buildGoModule = buildGo125Module;


### PR DESCRIPTION
Upstream moved the declaration of default paths into a module from 18.8.0 onwards, which breaks applying a patch.
Adapting the patch and applying it conditionally based on the version mitigates this problem.
The conditional can be dropped as soon as v17 is EOL.

Changelog: https://github.com/gravitational/teleport/releases/tag/v17.7.24
Diff: https://github.com/gravitational/teleport/compare/v17.7.23...v17.7.24

Changelogs: https://github.com/gravitational/teleport/releases/tag/v18.8.0 https://github.com/gravitational/teleport/releases/tag/v18.8.1 https://github.com/gravitational/teleport/releases/tag/v18.8.2 https://github.com/gravitational/teleport/releases/tag/v18.8.3
Diff: https://github.com/gravitational/teleport/compare/v18.7.6...v18.8.3

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
