### PR TITLE
moonfire-nvr: 0.7.20 -> 0.7.31

### DIFF
--- a/pkgs/by-name/mo/moonfire-nvr/package.nix
+++ b/pkgs/by-name/mo/moonfire-nvr/package.nix
@@ -9,19 +9,19 @@
   testers,
   moonfire-nvr,
   nodejs,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
 }:
 
 let
   pname = "moonfire-nvr";
-  version = "0.7.20";
+  version = "0.7.31";
   src = fetchFromGitHub {
     owner = "scottlamb";
     repo = "moonfire-nvr";
     tag = "v${version}";
-    hash = "sha256-0EaGqZUmYGxLHcJAhlbG2wZMDiVv8U1bcTQqMx0aTo0=";
+    hash = "sha256-QgsaiWcXeU4y7z9mcqUAl4mQ/M4p38yRjOB/4MKlpVA=";
   };
   ui = stdenv.mkDerivation (finalAttrs: {
     inherit version src;
@@ -30,14 +30,14 @@ let
     nativeBuildInputs = [
       nodejs
       pnpmConfigHook
-      pnpm_9
+      pnpm_10
     ];
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname version src;
-      pnpm = pnpm_9;
+      pnpm = pnpm_10;
       sourceRoot = "${finalAttrs.src.name}/ui";
-      fetcherVersion = 3;
-      hash = "sha256-1bkuou8jfWqdev4ZlpqvC4BRrFj//LK6ImVvSeMUEuM=";
+      fetcherVersion = 4;
+      hash = "sha256-U/SHOVlx0kj1hfl09KcPg3CQZX9HZE5SghVEThWL1RA=";
     };
     installPhase = ''
       runHook preInstall
@@ -53,7 +53,7 @@ rustPlatform.buildRustPackage {
 
   sourceRoot = "${src.name}/server";
 
-  cargoHash = "sha256-+L4XofUFvhJDPGv4fAGYXFNpuNd01k/P63LH2tXXHE0=";
+  cargoHash = "sha256-TDFe5pD+8eSwvw0h9GLM+JfODlSBU1CO8fw4FVjy8xk=";
 
   env.VERSION = "v${version}";
 

--- a/pkgs/by-name/mo/moonfire-nvr/package.nix
+++ b/pkgs/by-name/mo/moonfire-nvr/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  callPackage,
   rustPlatform,
   fetchFromGitHub,
   pkg-config,
@@ -8,54 +8,26 @@
   sqlite,
   testers,
   moonfire-nvr,
-  nodejs,
-  pnpm_10,
-  fetchPnpmDeps,
-  pnpmConfigHook,
+  nix-update,
+  writeShellApplication,
 }:
 
-let
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "moonfire-nvr";
   version = "0.7.31";
+
   src = fetchFromGitHub {
     owner = "scottlamb";
     repo = "moonfire-nvr";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-QgsaiWcXeU4y7z9mcqUAl4mQ/M4p38yRjOB/4MKlpVA=";
   };
-  ui = stdenv.mkDerivation (finalAttrs: {
-    inherit version src;
-    pname = "${pname}-ui";
-    sourceRoot = "${src.name}/ui";
-    nativeBuildInputs = [
-      nodejs
-      pnpmConfigHook
-      pnpm_10
-    ];
-    pnpmDeps = fetchPnpmDeps {
-      inherit (finalAttrs) pname version src;
-      pnpm = pnpm_10;
-      sourceRoot = "${finalAttrs.src.name}/ui";
-      fetcherVersion = 4;
-      hash = "sha256-U/SHOVlx0kj1hfl09KcPg3CQZX9HZE5SghVEThWL1RA=";
-    };
-    installPhase = ''
-      runHook preInstall
 
-      cp -r public $out
-
-      runHook postInstall
-    '';
-  });
-in
-rustPlatform.buildRustPackage {
-  inherit pname version src;
-
-  sourceRoot = "${src.name}/server";
+  sourceRoot = "${finalAttrs.src.name}/server";
 
   cargoHash = "sha256-TDFe5pD+8eSwvw0h9GLM+JfODlSBU1CO8fw4FVjy8xk=";
 
-  env.VERSION = "v${version}";
+  env.VERSION = "v${finalAttrs.version}";
 
   nativeBuildInputs = [
     pkg-config
@@ -68,26 +40,40 @@ rustPlatform.buildRustPackage {
 
   postInstall = ''
     mkdir -p $out/lib
-    ln -s ${ui} $out/lib/ui
+    ln -s ${moonfire-nvr.ui} $out/lib/ui
   '';
 
   doCheck = false;
 
   passthru = {
-    inherit ui;
+    ui = callPackage ./ui.nix { };
     tests.version = testers.testVersion {
       package = moonfire-nvr;
       command = "moonfire-nvr --version";
-      version = "Version: v${version}";
+      version = "Version: v${finalAttrs.version}";
     };
+    updateScript = lib.getExe (writeShellApplication {
+      name = "update-moonfire-nvr";
+
+      runtimeInputs = [
+        nix-update
+      ];
+
+      text = ''
+        set -euo pipefail
+
+        nix-update moonfire-nvr
+        nix-update moonfire-nvr.ui --version=skip
+      '';
+    });
   };
 
   meta = {
     description = "Moonfire NVR, a security camera network video recorder";
     homepage = "https://github.com/scottlamb/moonfire-nvr";
-    changelog = "https://github.com/scottlamb/moonfire-nvr/releases/tag/v${version}";
+    changelog = "https://github.com/scottlamb/moonfire-nvr/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Only;
     maintainers = [ ];
     mainProgram = "moonfire-nvr";
   };
-}
+})

--- a/pkgs/by-name/mo/moonfire-nvr/ui.nix
+++ b/pkgs/by-name/mo/moonfire-nvr/ui.nix
@@ -1,0 +1,41 @@
+{
+  stdenv,
+  moonfire-nvr,
+  nodejs,
+  pnpmConfigHook,
+  pnpm_10,
+  fetchPnpmDeps,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "moonfire-nvr-ui";
+  inherit (moonfire-nvr) version src;
+
+  sourceRoot = "${finalAttrs.src.name}/ui";
+
+  nativeBuildInputs = [
+    nodejs
+    pnpmConfigHook
+    pnpm_10
+  ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_10;
+    sourceRoot = "${finalAttrs.src.name}/ui";
+    fetcherVersion = 4;
+    hash = "sha256-U/SHOVlx0kj1hfl09KcPg3CQZX9HZE5SghVEThWL1RA=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r public $out
+
+    runHook postInstall
+  '';
+
+  meta = moonfire-nvr.meta // {
+    description = "Moonfire UI";
+  };
+})


### PR DESCRIPTION
https://github.com/scottlamb/moonfire-nvr/releases/tag/v0.7.21
https://github.com/scottlamb/moonfire-nvr/releases/tag/v0.7.22 
https://github.com/scottlamb/moonfire-nvr/releases/tag/v0.7.23 
https://github.com/scottlamb/moonfire-nvr/releases/tag/v0.7.24 
https://github.com/scottlamb/moonfire-nvr/releases/tag/v0.7.25 
https://github.com/scottlamb/moonfire-nvr/releases/tag/v0.7.26 
https://github.com/scottlamb/moonfire-nvr/releases/tag/v0.7.27 
https://github.com/scottlamb/moonfire-nvr/releases/tag/v0.7.28 
https://github.com/scottlamb/moonfire-nvr/releases/tag/v0.7.29 
https://github.com/scottlamb/moonfire-nvr/releases/tag/v0.7.30 
https://github.com/scottlamb/moonfire-nvr/releases/tag/v0.7.31

Part of #529285 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
