### PR TITLE
ceph: fuse3

### DIFF
--- a/pkgs/by-name/ce/ceph/ceph.nix
+++ b/pkgs/by-name/ce/ceph/ceph.nix
@@ -66,7 +66,7 @@
   # Optional Dependencies
   curl,
   expat,
-  fuse,
+  fuse3,
   libatomic_ops,
   libedit,
   libs3,
@@ -106,7 +106,7 @@ let
   optYasm = shouldUsePkg yasm;
   optExpat = shouldUsePkg expat;
   optCurl = shouldUsePkg curl;
-  optFuse = shouldUsePkg fuse;
+  optFuse = shouldUsePkg fuse3;
   optLibedit = shouldUsePkg libedit;
   optLibatomic_ops = shouldUsePkg libatomic_ops;
   optLibs3 = shouldUsePkg libs3;


### PR DESCRIPTION
Migrate from fuse (2.x) to fuse3 (3.x) as per [the fuse migration tracking issue](https://redirect.github.com/NixOS/nixpkgs/issues/526161).

Note that the fuse specific patching (for remounting) is still required. There is an intersecting version check for 3, however it does not affect functionality.

---

Above is the commit message verbatim.

Relevant links:

- #526161
- https://github.com/NixOS/nixpkgs/pull/494583#issuecomment-4227195568
- [*x86_64-linux* build in my personal Hydra](https://hydra.cloud.bsocat.net/build/1122545) ([with some caveats](https://github.com/NixOS/nixpkgs/pull/529717#issuecomment-4655008060))

I [tested this manually](https://github.com/NixOS/nixpkgs/pull/529717#issuecomment-4655498782) and it seems to work as expected.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
