### PR TITLE
t3code: 0.0.25 -> 0.0.27, add optional Cursor CLI and OpenCode integrations

### DIFF
--- a/pkgs/by-name/t3/t3code/package.nix
+++ b/pkgs/by-name/t3/t3code/package.nix
@@ -80,7 +80,7 @@ stdenv.mkDerivation (
   in
   {
     pname = "t3code";
-    version = "0.0.25";
+    version = "0.0.27";
     strictDeps = true;
     __structuredAttrs = true;
 
@@ -88,7 +88,7 @@ stdenv.mkDerivation (
       owner = "pingdotgg";
       repo = "t3code";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-R9FTqKT67POU9dED/EdPJVsu/rSEQ2C4WoNUwgkL0e8=";
+      hash = "sha256-KwiF6A7pTlkzr43FJ9XM+oEXBOEtw3vrazVOjBaD5lU=";
     };
 
     postPatch = ''
@@ -136,7 +136,7 @@ stdenv.mkDerivation (
         ;
 
       fetcherVersion = 4;
-      hash = "sha256-gctAlOtQMAbw4xWH9QyyVae6f0fk+o+EkLW+4rpmF9c=";
+      hash = "sha256-vpL0kjDAtxnBpm+izcJ06KXuzX888yxmzrcEc9yKtm0=";
     };
 
     # This workaround turns the `pnpmWorkspaces` array into a space-separated

--- a/pkgs/by-name/t3/t3code/package.nix
+++ b/pkgs/by-name/t3/t3code/package.nix
@@ -31,6 +31,8 @@
   codex,
   enableCursor ? false,
   code-cursor,
+  enableCursorCli ? false,
+  cursor-cli,
   enableGitHub ? true,
   gh,
   enableGit ? true,
@@ -39,6 +41,8 @@
   glab,
   enableJujutsu ? false,
   jujutsu,
+  enableOpencode ? false,
+  opencode,
 }:
 
 stdenv.mkDerivation (
@@ -52,6 +56,7 @@ stdenv.mkDerivation (
         "assets/prod/black-macos-1024.png"
       else
         "assets/prod/black-universal-1024.png";
+
     runtimePackages =
       lib.optionals enableAzureDevOps [
         azure-cli.withExtensions
@@ -61,10 +66,13 @@ stdenv.mkDerivation (
       ++ lib.optionals enableClaude [ claude-code ]
       ++ lib.optionals enableCodex [ codex ]
       ++ lib.optionals enableCursor [ code-cursor ]
+      ++ lib.optionals enableCursorCli [ cursor-cli ]
       ++ lib.optionals enableGitHub [ gh ]
       ++ lib.optionals enableGit [ git ]
       ++ lib.optionals enableGitLab [ glab ]
-      ++ lib.optionals enableJujutsu [ jujutsu ];
+      ++ lib.optionals enableJujutsu [ jujutsu ]
+      ++ lib.optionals enableOpencode [ opencode ];
+
     runtimePathWrapperArgs = lib.optionalString (runtimePackages != [ ]) ''
       \
         --prefix PATH : ${lib.makeBinPath runtimePackages}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
