### PR TITLE
cups: Adopt package and modernize --replace usage

### DIFF
--- a/pkgs/by-name/cu/cups/package.nix
+++ b/pkgs/by-name/cu/cups/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace cups/testfile.c \
-      --replace 'cupsFileFind("cat", "/bin' 'cupsFileFind("cat", "${coreutils}/bin'
+      --replace-fail 'cupsFileFind("cat", "/bin' 'cupsFileFind("cat", "${coreutils}/bin'
 
       # The cups.socket unit shouldn't be part of cups.service: stopping the
       # service would stop the socket and break subsequent socket activations.
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
       (stdenv.hostPlatform.isDarwin && lib.versionOlder stdenv.hostPlatform.darwinSdkVersion "12")
       ''
         substituteInPlace backend/usb-darwin.c \
-          --replace "kIOMainPortDefault" "kIOMasterPortDefault"
+          --replace-fail "kIOMainPortDefault" "kIOMasterPortDefault"
       '';
 
   nativeBuildInputs = [
@@ -160,13 +160,13 @@ stdenv.mkDerivation (finalAttrs: {
         -i "$dev/bin/cups-config"
 
     for f in "$out"/lib/systemd/system/*; do
-      substituteInPlace "$f" --replace "$lib/$libexec" "$out/$libexec"
+      substituteInPlace "$f" --replace-quiet "$lib/$libexec" "$out/$libexec"
     done
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
     # Use xdg-open when on Linux
     substituteInPlace "$out"/share/applications/cups.desktop \
-      --replace "Exec=htmlview" "Exec=xdg-open"
+      --replace-fail "Exec=htmlview" "Exec=xdg-open"
   '';
 
   passthru.tests = {

--- a/pkgs/by-name/cu/cups/package.nix
+++ b/pkgs/by-name/cu/cups/package.nix
@@ -183,7 +183,9 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://openprinting.github.io/cups/";
     description = "Standards-based printing system for UNIX";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      nick-linux
+    ];
     platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
## Summary
I wish to adopt Cups as it was unmaintained and it is necessary for not only my system but many others and want to help keep it that way. I updated the --replace flags with --replace-fail where the argument is required to finish the build and 1 instance of --replace-quiet where it attempts to replace lib systemd units but replace-fail as soon as it hit a unit not in scope. it failed the build and -quiet will do all of the ones in scope and skip over out of scope.

## Tests Completed
Ran `nix-build -A cups` Built successfully tested and had full functionality  
Ran `nix-build -A cups.tests` locally, all passed:

/nix/store/94ga2f4h31x6j08q13bw0mnlcjfam147-vm-test-run-cups-pdf
/nix/store/nihplb2v3dzbi4da42jaysafljmysmlr-vm-test-run-printing
/nix/store/399n6zm4scxqvnsmazvm3pnd3j2k8p0g-vm-test-run-printing
/nix/store/fd836k6bl2dql4c3ynw161fraiwvpxsa-vm-test-run-printing
/nix/store/ddcddqrjlqjf01qcs12p4kx6p2k5vd0n-vm-test-run-printing

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
