### PR TITLE
terminal-notifier: replace binary fetch with build

### DIFF
--- a/pkgs/by-name/te/terminal-notifier/package.nix
+++ b/pkgs/by-name/te/terminal-notifier/package.nix
@@ -2,7 +2,9 @@
   stdenv,
   runtimeShell,
   lib,
-  fetchzip,
+  fetchFromGitHub,
+  ibtool,
+  xcbuildHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -10,18 +12,22 @@ stdenv.mkDerivation rec {
 
   version = "2.0.0";
 
-  src = fetchzip {
-    url = "https://github.com/alloy/terminal-notifier/releases/download/${version}/terminal-notifier-${version}.zip";
-    sha256 = "0gi54v92hi1fkryxlz3k5s5d8h0s66cc57ds0vbm1m1qk3z4xhb0";
-    stripRoot = false;
+  src = fetchFromGitHub {
+    owner = "julienXX";
+    repo = "terminal-notifier";
+    rev = version;
+    sha256 = "sha256-Hd9cI3R2nQK2deBb5CBYz4DTHAEcO4vzqtA5qZwa1Ao=";
   };
 
-  dontBuild = true;
+  nativeBuildInputs = [
+    ibtool
+    xcbuildHook
+  ];
 
   installPhase = ''
     mkdir -p $out/Applications
     mkdir -p $out/bin
-    cp -r terminal-notifier.app $out/Applications
+    cp -r Products/Release/terminal-notifier.app $out/Applications
     cat >$out/bin/terminal-notifier <<EOF
     #!${runtimeShell}
     cd $out/Applications/terminal-notifier.app

--- a/pkgs/by-name/te/terminal-notifier/package.nix
+++ b/pkgs/by-name/te/terminal-notifier/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "julienXX";
     repo = "terminal-notifier";
-    rev = version;
+    tag = version;
     sha256 = "sha256-Hd9cI3R2nQK2deBb5CBYz4DTHAEcO4vzqtA5qZwa1Ao=";
   };
 

--- a/pkgs/by-name/te/terminal-notifier/package.nix
+++ b/pkgs/by-name/te/terminal-notifier/package.nix
@@ -9,7 +9,6 @@
 
 stdenv.mkDerivation rec {
   pname = "terminal-notifier";
-
   version = "2.0.0";
 
   src = fetchFromGitHub {
@@ -39,6 +38,7 @@ stdenv.mkDerivation rec {
   meta = {
     maintainers = [ ];
     homepage = "https://github.com/julienXX/terminal-notifier";
+    description = "Send User Notifications on macOS from the command-line";
     license = lib.licenses.mit;
     platforms = lib.platforms.darwin;
     mainProgram = "terminal-notifier";


### PR DESCRIPTION
With 26.4.1 we now get notified of x86_64 applications running under rosetta 2. Since this was built prior to apple silicon this triggers the warning. There isn't really any reason why we couldn't build from source however. So the PR replaces the fetchzip of the compiled release binary with the xcbuild of the binary


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
