### PR TITLE
container: 0.12.3 -> 1.0.0

### DIFF
--- a/pkgs/by-name/co/container/package.nix
+++ b/pkgs/by-name/co/container/package.nix
@@ -5,23 +5,25 @@
   libarchive,
   xar,
   installShellFiles,
+  makeWrapper,
   versionCheckHook,
   nix-update-script,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "container";
-  version = "0.12.3";
+  version = "1.0.0";
 
   src = fetchurl {
     url = "https://github.com/apple/container/releases/download/${finalAttrs.version}/container-${finalAttrs.version}-installer-signed.pkg";
-    hash = "sha256-g/NjEmrB8GRYjeOc1rR0NA1InBkmSSosTlnE1Uqm2OM=";
+    hash = "sha256-E/RfJtqUw1Sty+/h6PdjHn8SbpPF1N1qWlOKpmtPR50=";
   };
 
   nativeBuildInputs = [
     libarchive
     xar
     installShellFiles
+    makeWrapper
   ];
 
   dontUnpack = true;
@@ -41,6 +43,13 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       --bash <($out/bin/${finalAttrs.meta.mainProgram} --generate-completion-script bash) \
       --fish <($out/bin/${finalAttrs.meta.mainProgram} --generate-completion-script fish) \
       --zsh <($out/bin/${finalAttrs.meta.mainProgram} --generate-completion-script zsh)
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/container \
+      --set-default CONTAINER_INSTALL_ROOT "$out"
+    wrapProgram $out/bin/container-apiserver \
+      --set-default CONTAINER_INSTALL_ROOT "$out"
   '';
 
   nativeInstallCheckInputs = [


### PR DESCRIPTION
Update `container` from 0.12.3 to 1.0.0.

This also sets `CONTAINER_INSTALL_ROOT` by default for `container` and `container-apiserver`, so the generated launchd service plists and helper processes use the Nix store output as the install root.

Changelog: https://github.com/apple/container/releases/tag/1.0.0

Automation disclosure: this PR body was prepared with OpenAI Codex harness (gpt-5.5). The commit includes the required `Assisted-by:` trailer.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Validation:

- Built the package locally and with `nixpkgs-review` on `aarch64-darwin`.
- Started the packaged `container` services and confirmed the API server reported version 1.0.0 with the Nix store output as its install root.
- Ran an Ubuntu 24.04 Linux container end to end and confirmed it executed successfully on `aarch64`.
- Confirmed the temporary test container was removed afterward and stopped the services used for validation.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
