### PR TITLE
dump978: init at 11.0

### DIFF
--- a/pkgs/by-name/du/dump978/package.nix
+++ b/pkgs/by-name/du/dump978/package.nix
@@ -1,0 +1,43 @@
+{
+  fetchFromGitHub,
+  lib,
+  stdenv,
+  boost186,
+  soapysdr-with-plugins,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dump978";
+  version = "11.0";
+  src = fetchFromGitHub {
+    owner = "flightaware";
+    repo = "dump978";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-phXdZNin0wuV8lSOUIgQ1IvtqH+WClD2ApuI8nftQUo=";
+  };
+
+  enableParallelBuilding = true;
+
+  buildInputs = [
+    boost186
+    soapysdr-with-plugins
+  ];
+
+  makeFlags = [ "VERSION=${finalAttrs.version}" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp -v dump978-fa skyaware978 $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "FlightAware's 978MHz UAT demodulator";
+    homepage = "https://github.com/flightaware/dump978";
+    license = licenses.bsd2;
+    maintainers = with maintainers; [ xddxdd ];
+    mainProgram = "dump978-fa";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`dump978` is a 978MHz UAT decoder, similar to `dump1090` but works on a US-specific frequency.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
