### PR TITLE
treefmt.withConfig: add `check` function

### DIFF
--- a/pkgs/by-name/tr/treefmt/check-wrapper.nix
+++ b/pkgs/by-name/tr/treefmt/check-wrapper.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  gitMinimal,
+  runCommandLocal,
+  stdenv,
+  wrapper,
+}:
+/**
+  Test that the given project tree is formatted with the treefmt config.
+
+  Input argument is the path to the project tree.
+*/
+project:
+runCommandLocal "${lib.getName wrapper}-check"
+  {
+    __structuredAttrs = true;
+    strictDeps = true;
+    nativeBuildInputs = [
+      gitMinimal
+      wrapper
+    ];
+    inherit project;
+    env = {
+      LANG = if stdenv.buildPlatform.isDarwin then "en_US.UTF-8" else "C.UTF-8";
+      LC_ALL = if stdenv.buildPlatform.isDarwin then "en_US.UTF-8" else "C.UTF-8";
+    };
+    meta.description = "Check that the project tree is formatted";
+  }
+  ''
+    # Copy project files into the build-dir
+    cp -r "$project" project
+    chmod -R a+w project
+    cd project
+
+    # Setup a git repo
+    git init --initial-branch main
+    git config user.name nixbld
+    git config user.email nixbld@example.com
+    git add .
+    git commit -m init --quiet
+
+    # Run treefmt
+    treefmt --version
+    treefmt --no-cache
+
+    # Ensure nothing changed
+    git status
+    git --no-pager diff --exit-code
+    touch "$out"
+  ''

--- a/pkgs/by-name/tr/treefmt/lib.nix
+++ b/pkgs/by-name/tr/treefmt/lib.nix
@@ -40,6 +40,20 @@
   /**
     Wrap treefmt, configured using structured settings.
 
+    # Check
+
+    The resulting package has a `check` attribute of type `Path -> Derivation`.
+    The derivation returned will only build if the path supplied is already formatted correctly.
+
+    ```
+    { pkgs }:
+    let
+      myTreefmt = pkgs.treefmt.withConfig ./treefmt-config.nix;
+      project = ../.;
+    in
+    myTreefmt.check project
+    ```
+
     # Type
 
     ```

--- a/pkgs/by-name/tr/treefmt/modules/wrapper.nix
+++ b/pkgs/by-name/tr/treefmt/modules/wrapper.nix
@@ -15,7 +15,7 @@
     internal = true;
   };
 
-  config.result = pkgs.symlinkJoin {
+  config.result = pkgs.symlinkJoin (finalAttrs: {
     pname = config.name;
     inherit (config.package) meta version;
     nativeBuildInputs = [ pkgs.makeBinaryWrapper ];
@@ -27,11 +27,14 @@
     passthru = {
       inherit (config) runtimeInputs;
       inherit config options;
+      check = pkgs.callPackage ../check-wrapper.nix {
+        wrapper = finalAttrs.finalPackage;
+      };
     };
     postBuild = ''
       wrapProgram "$out/bin/treefmt" \
         --prefix PATH : "$binPath" \
         --add-flags "--config-file $configFile"
     '';
-  };
+  });
 }

--- a/pkgs/by-name/tr/treefmt/tests.nix
+++ b/pkgs/by-name/tr/treefmt/tests.nix
@@ -1,6 +1,7 @@
 {
   lib,
   runCommand,
+  runCommandLocal,
   testers,
   treefmt,
   nixfmt,
@@ -31,6 +32,28 @@ let
     settings = nixfmtExampleConfig;
     runtimeInputs = [ nixfmt ];
   };
+
+  wellFormattedTree = runCommandLocal "well-formatted-project" { } ''
+    mkdir "$out"
+    cat > "$out/file.nix" <<EOF
+    {
+      foo = "bar";
+      attrs = { };
+      list = [ ];
+    }
+    EOF
+  '';
+
+  unformattedTree = runCommandLocal "unformatted-project" { } ''
+    mkdir "$out"
+    cat > "$out/file.nix" <<EOF
+    {
+      foo="bar";
+      attrs={};
+      list=[];
+    }
+    EOF
+  '';
 in
 {
   buildConfigEmpty = testEqualContents {
@@ -66,6 +89,22 @@ in
       command = "nixfmt"
       includes = ["*.nix"]
     '';
+  };
+
+  nixfmtExampleCheckPasses = nixfmtExamplePackage.check wellFormattedTree;
+
+  nixfmtExampleCheckFails = testers.testBuildFailure' {
+    drv = nixfmtExamplePackage.check unformattedTree;
+    expectedBuilderExitCode = 1;
+    expectedBuilderLogEntries = [
+      "diff --git a/file.nix b/file.nix"
+      "-  foo=\"bar\";"
+      "+  foo = \"bar\";"
+      "-  attrs={};"
+      "+  attrs = { };"
+      "-  list=[];"
+      "+  list = [ ];"
+    ];
   };
 
   runNixfmtExample =


### PR DESCRIPTION
Inspired by treefmt-nix's `config.build.check` option, add a similar check function to `treefmt.withConfig`'s wrapper.

`check` is a function of `Path → Derivation`, which returns a derivation that builds ok when the path is already formatted, or fails to build if the wrapped-treefmt would change the path's formatting.

```nix
{ pkgs }:
let
  myTreefmt = pkgs.treefmt.withConfig ./treefmt-config.nix;
  project = ../.;
in
myTreefmt.check project
```


See treefmt-nix' implementation for reference: https://github.com/numtide/treefmt-nix/blob/db947814/module-options.nix#L301-L349

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
