### PR TITLE
sonar-scanner-cli-minimal: add required modules

### DIFF
--- a/pkgs/by-name/so/sonar-scanner-cli-minimal/package.nix
+++ b/pkgs/by-name/so/sonar-scanner-cli-minimal/package.nix
@@ -10,8 +10,11 @@ sonar-scanner-cli.override {
     jdk = jdk_headless;
     modules = [
       "java.base"
+      "java.desktop"
       "java.logging"
+      "java.management"
       "java.naming"
+      "java.net.http"
       "java.sql"
       "java.xml"
       "jdk.crypto.ec"


### PR DESCRIPTION
This change fixes a `NoClassDefFoundError` on `java/beans/IntrospectionException` when communicating with newer SonarQube Server versions (e.g. `2026.1.3.123084`).

Example log:

```
15:51:59.141 INFO  Scanner configuration file: /nix/store/q6wn7232ss3plfjnp4h7wlcnn5khwfrr-sonar-scanner-cli-7.3.0.5189/conf/sonar-scanner.properties
15:51:59.147 INFO  Project root configuration file: /home/agrucza/iress-wealth/xplan-ai-landing/sonar-project.properties
15:51:59.178 INFO  SonarScanner CLI 7.3-SNAPSHOT
15:51:59.184 INFO  Linux 6.6.87.2-microsoft-standard-WSL2 amd64
15:52:01.680 INFO  Communicating with SonarQube Server 2026.1.3.123084
15:52:01.680 INFO  JRE provisioning: os[linux], arch[x86_64]
15:52:01.868 INFO  No JRE found for this OS/architecture
15:52:01.869 INFO  Using the java executable '/nix/store/lwv5llycm0wknj4p2v956c5b3cnkpg60-openjdk-headless-minimal-jre-21.0.12+2/bin/java' from JAVA_HOME
15:52:13.936 INFO  Starting SonarScanner Engine...
15:52:13.937 INFO  Java 21.0.12 N/A (64-bit)
15:52:14.110 ERROR Error during SonarScanner Engine execution
java.lang.NoClassDefFoundError: java/beans/IntrospectionException
        at org.springframework.context.support.AbstractApplicationContext.resetCommonCaches(AbstractApplicationContext.java:1044)
        at org.springframework.context.support.AbstractApplicationContext.doClose(AbstractApplicationContext.java:1195)
        at org.springframework.context.support.AbstractApplicationContext.close(AbstractApplicationContext.java:1132)
        at org.sonar.core.platform.SpringComponentContainer.stopComponents(SpringComponentContainer.java:235)
        at org.sonar.core.platform.SpringComponentContainer.execute(SpringComponentContainer.java:211)
        at org.sonar.scanner.bootstrap.ScannerMain.runScannerEngine(ScannerMain.java:157)
        at org.sonar.scanner.bootstrap.ScannerMain.run(ScannerMain.java:72)
        at org.sonar.scanner.bootstrap.ScannerMain.main(ScannerMain.java:56)
Caused by: java.lang.ClassNotFoundException: java.beans.IntrospectionException
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
        ... 8 common frames omitted
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
