### PR TITLE
[Backport release-26.05] misskey: 2025.12.2 -> 2026.5.4

### DIFF
--- a/pkgs/by-name/mi/misskey/package.nix
+++ b/pkgs/by-name/mi/misskey/package.nix
@@ -108,6 +108,7 @@ stdenv.mkDerivation (finalAttrs: {
       runHook preInstall
 
       mkdir -p $out/data
+      sed -i '/"packageManager":/d' package.json
       cp -r . $out/data
 
       # Set up symlink for use at runtime
@@ -119,6 +120,7 @@ stdenv.mkDerivation (finalAttrs: {
       makeWrapper ${pnpm}/bin/pnpm $out/bin/misskey \
         --run "${checkEnvVarScript} || exit" \
         --chdir $out/data \
+        --add-flag "--config.store-dir=/tmp/pnpm-store" \
         --add-flag "--config.verify-deps-before-run=false" \
         --add-flag run \
         --set-default NODE_ENV production \

--- a/pkgs/by-name/mi/misskey/package.nix
+++ b/pkgs/by-name/mi/misskey/package.nix
@@ -5,25 +5,29 @@
   fetchFromGitHub,
   nix-update-script,
   nodejs,
-  pnpm_9,
+  pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
   makeWrapper,
   python3,
+  dart-sass,
   bash,
   jemalloc,
   ffmpeg-headless,
   writeShellScript,
 }:
+let
+  pnpm = pnpm_11;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "misskey";
-  version = "2025.12.2";
+  version = "2026.5.4";
 
   src = fetchFromGitHub {
     owner = "misskey-dev";
     repo = "misskey";
     tag = finalAttrs.version;
-    hash = "sha256-7S6m97wHFeITABLcnQiPVGLg6d1xcPCHCp7/7d/w48E=";
+    hash = "sha256-ENq5V1lIFGKIr1xZccy1LFRYVqZVEhDzBhAbDNcG5sM=";
     fetchSubmodules = true;
   };
 
@@ -35,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     substituteInPlace packages/backend/src/config.ts \
       --replace-fail \
-        "resolve(_dirname, '../../../built/.config.json')" \
+        "resolve(projectBuiltDir, '.config.json')" \
         "resolve('/run/misskey/default.json')"
     substituteInPlace {.,packages/backend}/package.json \
       --replace-fail "pnpm compile-config && " ""
@@ -44,21 +48,21 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
-    pnpm_9
+    pnpm
     makeWrapper
     python3
+    dart-sass
   ];
 
-  # https://nixos.org/manual/nixpkgs/unstable/#javascript-pnpm
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs)
       pname
       version
       src
       ;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-iMS+sFDnGShOQfFQjGtj4+7McqMQvfE8KK1MV/jPC2s=";
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-wEbYkfp+zfytOPBjEcyTHCaoohGRNRjG5oTUefI5BVw=";
   };
 
   buildPhase = ''
@@ -74,12 +78,16 @@ stdenv.mkDerivation (finalAttrs: {
     export npm_config_nodedir=${nodejs}
     (
       cd node_modules/.pnpm/node_modules/re2
-      pnpm run rebuild
+      pnpm run rebuild --nodedir=${nodejs}
     )
     (
       cd node_modules/.pnpm/node_modules/sharp
       pnpm run install
     )
+
+    # Force sass-embedded npm package to use our dart-sass instead of bundled binaries.
+    substituteInPlace node_modules/.pnpm/sass-embedded@*/node_modules/sass-embedded/dist/lib/src/compiler-path.js \
+      --replace-fail 'compilerCommand = (() => {' 'compilerCommand = (() => { return ["${lib.getExe dart-sass}"];'
 
     pnpm build
 
@@ -108,15 +116,16 @@ stdenv.mkDerivation (finalAttrs: {
       # Otherwise, maybe somehow bindmount a writable directory into <package>/data/files.
       ln -s /var/lib/misskey $out/data/files
 
-      makeWrapper ${pnpm_9}/bin/pnpm $out/bin/misskey \
+      makeWrapper ${pnpm}/bin/pnpm $out/bin/misskey \
         --run "${checkEnvVarScript} || exit" \
         --chdir $out/data \
-        --add-flags run \
+        --add-flag "--config.verify-deps-before-run=false" \
+        --add-flag run \
         --set-default NODE_ENV production \
         --prefix PATH : ${
           lib.makeBinPath [
             nodejs
-            pnpm_9
+            pnpm
             bash
           ]
         } \


### PR DESCRIPTION
- replaces & closes https://github.com/NixOS/nixpkgs/pull/529531
- Backport of
  - https://github.com/NixOS/nixpkgs/pull/527568
  - https://github.com/NixOS/nixpkgs/pull/529787
