### PR TITLE
earthbuild: init at 0.8.17

### DIFF
--- a/pkgs/by-name/ea/earthbuild/package.nix
+++ b/pkgs/by-name/ea/earthbuild/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  stdenv,
+  testers,
+  earthbuild,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "earthbuild";
+  version = "0.8.17";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Earthbuild";
+    repo = "earthbuild";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ATdNA9KjAXsxMiez3AF6TxK7OujNDABY8jB6hXeSNpc=";
+  };
+
+  vendorHash = "sha256-49FWzLHEbgwWOXT1uPshdY5risFHInA541Mfhu7v08A=";
+  subPackages = [
+    "cmd/earthly"
+    "cmd/debugger"
+  ];
+
+  env.CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=v${finalAttrs.src.tag}"
+    "-X main.DefaultBuildkitdImage=docker.io/earthbuild/buildkitd:v${finalAttrs.src.tag}"
+    "-X main.GitSha=v${finalAttrs.src.tag}"
+    "-X main.DefaultInstallationName=earthbuild"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    "-extldflags '-static'"
+  ];
+
+  tags = [
+    "dfrunmount"
+    "dfrunnetwork"
+    "dfrunsecurity"
+    "dfsecrets"
+    "dfssh"
+  ];
+
+  postInstall = ''
+    mv $out/bin/debugger $out/bin/earthly-debugger
+  '';
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = earthbuild;
+      version = "v${finalAttrs.src.tag}";
+    };
+  };
+
+  meta = {
+    description = "Simple, fast, and consistent build system for containerized, reproducible builds. Community-maintained fork of Earthly";
+    homepage = "https://www.earthbuild.dev/";
+    changelog = "https://github.com/Earthbuild/earthbuild/releases/tag/v${finalAttrs.src.tag}";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [
+      eonpatapon
+    ];
+  };
+})


### PR DESCRIPTION
This is the community fork of Earthly.

Earthly is no longer actively maintained.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Also tested on a real earthly build I have

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
