### PR TITLE
maintainers: remove tcbravo 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27156,12 +27156,6 @@
     githubId = 101565936;
     name = "Tautvydas Cerniauskas";
   };
-  tcbravo = {
-    email = "tomas.bravo@protonmail.ch";
-    github = "tcbravo";
-    githubId = 66133083;
-    name = "Tomas Bravo";
-  };
   tchab = {
     email = "dev@chabs.name";
     github = "t-chab";

--- a/pkgs/by-name/as/ashuffle/package.nix
+++ b/pkgs/by-name/as/ashuffle/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     homepage = "https://github.com/joshkunz/ashuffle";
     description = "Automatic library-wide shuffle for mpd";
-    maintainers = [ lib.maintainers.tcbravo ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
     license = lib.licenses.mit;
     mainProgram = "ashuffle";

--- a/pkgs/by-name/so/songrec/package.nix
+++ b/pkgs/by-name/so/songrec/package.nix
@@ -68,10 +68,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/marin-m/SongRec/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [
-      tcbravo
-      tomasrivera
-    ];
+    maintainers = with lib.maintainers; [ tomasrivera ];
     mainProgram = "songrec";
   };
 })


### PR DESCRIPTION
## Reasons

- Last commented in [December 2021](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Atcbravo)
- Hasn't created any PRs / Issues since [December 2021](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Atcbravo)
- About 19 [unanswered ](https://github.com/NixOS/nixpkgs/issues?q=involves%3Atcbravo%20-commenter%3Atcbravo%20-author%3Atcbravo%20-reviewed-by%3Atcbravo) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers/README.md#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

I already adopted songrec in #528351. Only ashuffle will become orphan.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
