### PR TITLE
zig: fix zig 0.16 errors when passed -dynamic-linker

### DIFF
--- a/pkgs/development/compilers/zig/default.nix
+++ b/pkgs/development/compilers/zig/default.nix
@@ -24,6 +24,9 @@ let
     "0.16.0" = {
       llvmPackages = llvmPackages_21;
       hash = "sha256-2sTMhaasyrKoBnyH/hQrNCbi0Vh6HekIrpE4XkyQulQ=";
+      patches = [
+        ./patches/0.16/Config.resolve-don-t-error-on-explicit-dynamic-linke.patch
+      ];
     };
   }
   // zigVersions;
@@ -33,6 +36,7 @@ let
       version,
       hash,
       llvmPackages,
+      patches ? [ ],
     }@args:
     callPackage ./generic.nix args;
 

--- a/pkgs/development/compilers/zig/patches/0.16/Config.resolve-don-t-error-on-explicit-dynamic-linke.patch
+++ b/pkgs/development/compilers/zig/patches/0.16/Config.resolve-don-t-error-on-explicit-dynamic-linke.patch
@@ -1,0 +1,68 @@
+From 6a37df00ece82f6c9c73b07a77c22c918fc3257c Mon Sep 17 00:00:00 2001
+From: johan0A <arnaudchesse@outlook.com>
+Date: Sat, 14 Mar 2026 21:25:59 +0100
+Subject: [PATCH] Config.resolve: don't error on explicit dynamic linker for
+ Lib/Obj outputs
+
+---
+ src/Compilation/Config.zig | 9 +--------
+ src/main.zig               | 2 --
+ 2 files changed, 1 insertion(+), 10 deletions(-)
+
+diff --git a/src/Compilation/Config.zig b/src/Compilation/Config.zig
+index b7f6df90..0c508b2e 100644
+--- a/src/Compilation/Config.zig
++++ b/src/Compilation/Config.zig
+@@ -123,7 +123,6 @@ pub const ResolveError = error{
+     WasiExecModelRequiresWasi,
+     SharedMemoryIsWasmOnly,
+     ObjectFilesCannotShareMemory,
+-    ObjectFilesCannotSpecifyDynamicLinker,
+     SharedMemoryRequiresAtomicsAndBulkMemory,
+     ThreadsRequireSharedMemory,
+     EmittingLlvmModuleRequiresLlvmBackend,
+@@ -132,7 +131,6 @@ pub const ResolveError = error{
+     EmittingBinaryRequiresLlvmLibrary,
+     LldIncompatibleObjectFormat,
+     LldCannotIncrementallyLink,
+-    LldCannotSpecifyDynamicLinkerForSharedLibraries,
+     LtoRequiresLld,
+     SanitizeThreadRequiresLibCpp,
+     LibCRequiresLibUnwind,
+@@ -421,12 +419,7 @@ pub fn resolve(options: Options) ResolveError!Config {
+             // linking to any shared libraries.
+             if (link_mode == .dynamic) return error.DynamicLinkingWithLldRequiresSharedLibraries;
+         },
+-        .Lib => if (use_lld and options.resolved_target.is_explicit_dynamic_linker) {
+-            return error.LldCannotSpecifyDynamicLinkerForSharedLibraries;
+-        },
+-        .Obj => if (options.resolved_target.is_explicit_dynamic_linker) {
+-            return error.ObjectFilesCannotSpecifyDynamicLinker;
+-        },
++        .Lib, .Obj => {},
+     }
+ 
+     const use_new_linker = b: {
+diff --git a/src/main.zig b/src/main.zig
+index 95ee9a82..cc3ed331 100644
+--- a/src/main.zig
++++ b/src/main.zig
+@@ -4144,7 +4144,6 @@ fn createModule(
+             error.WasiExecModelRequiresWasi => fatal("only WASI OS targets support execution model", .{}),
+             error.SharedMemoryIsWasmOnly => fatal("only WebAssembly CPU targets support shared memory", .{}),
+             error.ObjectFilesCannotShareMemory => fatal("object files cannot share memory", .{}),
+-            error.ObjectFilesCannotSpecifyDynamicLinker => fatal("object files cannot specify --dynamic-linker", .{}),
+             error.SharedMemoryRequiresAtomicsAndBulkMemory => fatal("shared memory requires atomics and bulk_memory CPU features", .{}),
+             error.ThreadsRequireSharedMemory => fatal("threads require shared memory", .{}),
+             error.EmittingLlvmModuleRequiresLlvmBackend => fatal("emitting an LLVM module requires using the LLVM backend", .{}),
+@@ -4153,7 +4152,6 @@ fn createModule(
+             error.EmittingBinaryRequiresLlvmLibrary => fatal("producing machine code via LLVM requires using the LLVM library", .{}),
+             error.LldIncompatibleObjectFormat => fatal("using LLD to link {s} files is unsupported", .{@tagName(target.ofmt)}),
+             error.LldCannotIncrementallyLink => fatal("self-hosted backends do not support linking with LLD", .{}),
+-            error.LldCannotSpecifyDynamicLinkerForSharedLibraries => fatal("LLD does not support --dynamic-linker on shared libraries", .{}),
+             error.LtoRequiresLld => fatal("LTO requires using LLD", .{}),
+             error.SanitizeThreadRequiresLibCpp => fatal("thread sanitization is (for now) implemented in C++, so it requires linking libc++", .{}),
+             error.LibCRequiresLibUnwind => fatal("libc of the specified target requires linking libunwind", .{}),
+-- 
+2.53.0
+


### PR DESCRIPTION
This is backported from zig's master branch and should fix zig.stdenv and pkgsZig failing to build packages as our cc wrapper passes -Wl,-dynamic-linker.

Upstream bug report: https://codeberg.org/ziglang/zig/issues/31921

Fixes: #529540


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
