### PR TITLE
piu-piu: init at 1.2

### DIFF
--- a/pkgs/by-name/pi/piu-piu/package.nix
+++ b/pkgs/by-name/pi/piu-piu/package.nix
@@ -1,0 +1,48 @@
+{
+  hostname,
+  fetchFromGitHub,
+  lib,
+  makeWrapper,
+  netcat-gnu,
+  nix-update-script,
+  stdenv,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "piu-piu";
+  version = "1.2";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  src = fetchFromGitHub {
+    owner = "vaniacer";
+    repo = "piu-piu-SH";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lwInRjaASHejyqwXuZLuKGj/vEbipgdHgVhQLX09nsc=";
+  };
+
+  passthru.updateScript = nix-update-script { };
+
+  # netcata and hostname are used for the multiplayer
+  installPhase = ''
+    install -m755 -D piu-piu "$out/bin/piu-piu"
+    wrapProgram "$out/bin/piu-piu" --prefix PATH : "${
+      lib.makeBinPath [
+        hostname
+        netcat-gnu
+      ]
+    }"
+  '';
+
+  meta = {
+    description = "Old School horizontal scroller 'Shoot Them All' game in bash";
+    homepage = "https://github.com/vaniacer/piu-piu-SH";
+    changelog = "https://github.com/vaniacer/piu-piu-SH/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ tomasrivera ];
+    mainProgram = "piu-piu";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Adds [piu-piu](https://github.com/vaniacer/piu-piu-SH), an Old School horizontal scroller 'Shoot Them All' game in bash

Part of #380688


I followed this [example](https://github.com/NixOS/nixpkgs/blob/nixos-26.05/pkgs/by-name/ba/bash-supergenpass/package.nix) for the derivation.

I wanted to use versionCheckHook, but the program doesn't support any flag.

No AI/Automation was used in this PR.

Note : if someone want's to test it, you might wanna change your terminal colors. The game starts quickly and at first I didn't saw the enemies over the background.

Note 2: You should open port 54321 for multiplayer to work
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
