### PR TITLE
steelix: refactor to wrap helix, fix missing themes and grammars

### DIFF
--- a/pkgs/by-name/st/steelix/package.nix
+++ b/pkgs/by-name/st/steelix/package.nix
@@ -1,80 +1,80 @@
 {
+  rustPlatform,
   fetchFromGitHub,
   fetchpatch,
-  helix,
-  installShellFiles,
   lib,
-  rustPlatform,
-  makeBinaryWrapper,
+  helix,
+  helix-unwrapped,
 }:
+let
+  steelix-unwrapped = helix-unwrapped.overrideAttrs (
+    finalAttrs: _: {
+      pname = "steelix-unwrapped";
+      version = "0-unstable-2026-05-21";
 
-rustPlatform.buildRustPackage (finalAttrs: {
-  pname = "steelix";
-  version = "0-unstable-2026-05-21";
+      src = fetchFromGitHub {
+        owner = "mattwparas";
+        repo = "helix";
+        rev = "4d86612df48447088ef4190bf503fd54a7562aa9";
+        hash = "sha256-qAUODNxHM9K6CrRCFgfBcbqzRd+YHiWn9fEfmIzrohA=";
+      };
 
-  src = fetchFromGitHub {
-    owner = "mattwparas";
-    repo = "helix";
-    rev = "4d86612df48447088ef4190bf503fd54a7562aa9";
-    hash = "sha256-qAUODNxHM9K6CrRCFgfBcbqzRd+YHiWn9fEfmIzrohA=";
-  };
+      cargoDeps = rustPlatform.fetchCargoVendor {
+        inherit (finalAttrs) src pname version;
+        hash = "sha256-6bu8sIM4So3AbnHHYbh8uu+rEB4IjMQjDgh7/AkLQs0=";
+      };
 
-  # This fork is built from Helix master, whose loader expects tree-sitter
-  # grammars with the platform-native extension (`.dylib` on Darwin) since
-  # helix-editor/helix#14982. We reuse the grammars from `helix.runtime`, built
-  # from the last Helix *release*, which still names them `.so` on Darwin, so
-  # revert that commit to make the loader look for `.so`. Remove once a Helix
-  # release ships #14982 and nixpkgs' grammars switch to `.dylib`.
-  patches = [
-    (fetchpatch {
-      name = "revert-dylib-grammar-extension.patch";
-      url = "https://github.com/helix-editor/helix/commit/430914b298a32653ab1847fdfdf2177a002be04c.patch";
-      revert = true;
-      hash = "sha256-4KUFppkso4/XwNU+mGIgLvl+mJXHZWkmaguYMy8oTyI=";
-    })
-  ];
+      cargoBuildFlags = [
+        "--package"
+        "helix-term"
+        "--features"
+        "steel,git"
+      ];
 
-  cargoHash = "sha256-6bu8sIM4So3AbnHHYbh8uu+rEB4IjMQjDgh7/AkLQs0=";
+      # This fork is built from Helix master, whose loader expects tree-sitter
+      # grammars with the platform-native extension (`.dylib` on Darwin) since
+      # helix-editor/helix#14982. We reuse the grammars from `helix.runtime`, built
+      # from the last Helix *release*, which still names them `.so` on Darwin, so
+      # revert that commit to make the loader look for `.so`. Remove once a Helix
+      # release ships #14982 and nixpkgs' grammars switch to `.dylib`.
+      patches = [
+        (fetchpatch {
+          name = "revert-dylib-grammar-extension.patch";
+          url = "https://github.com/helix-editor/helix/commit/430914b298a32653ab1847fdfdf2177a002be04c.patch";
+          revert = true;
+          hash = "sha256-4KUFppkso4/XwNU+mGIgLvl+mJXHZWkmaguYMy8oTyI=";
+        })
+      ];
 
-  nativeBuildInputs = [
-    installShellFiles
-    makeBinaryWrapper
-  ];
+      doInstallCheck = false;
+    }
+  );
+in
+(helix.override {
+  helix-unwrapped = steelix-unwrapped;
+}).overrideAttrs
+  (
+    _: previousAttrs: {
+      pname = "steelix";
+      strictDeps = true;
 
-  cargoBuildFlags = [
-    "--package"
-    "helix-term"
-    "--features"
-    "steel,git"
-  ];
+      meta = previousAttrs.meta // {
+        description = "Helix editor with Steel (Scheme) scripting support";
+        longDescription = ''
+          Steelix is a fork of the Helix editor with Steel (Scheme) scripting support.
+        '';
+        homepage = "https://github.com/mattwparas/helix";
+        changelog = "https://github.com/mattwparas/helix/blob/${steelix-unwrapped.src.rev}/CHANGELOG.md";
+        license = lib.licenses.mpl20;
+        mainProgram = "hx";
+        maintainers = with lib.maintainers; [
+          aciceri
+          Ra77a3l3-jar
+        ];
+      };
 
-  env = {
-    HELIX_DISABLE_AUTO_GRAMMAR_BUILD = "1";
-    HELIX_DEFAULT_RUNTIME = helix.runtime;
-  };
-
-  postInstall = ''
-    installShellCompletion contrib/completion/hx.{bash,fish,zsh}
-    mkdir -p $out/share/{applications,icons/hicolor/256x256/apps}
-    cp contrib/Helix.desktop $out/share/applications
-    cp contrib/helix.png $out/share/icons/hicolor/256x256/apps
-    wrapProgram $out/bin/hx --set HELIX_RUNTIME "${helix.runtime}"
-  '';
-
-  passthru.updateScript = ./update.sh;
-
-  meta = {
-    description = "Helix editor with Steel (Scheme) scripting support";
-    longDescription = ''
-      Steelix is a fork of the Helix editor with Steel (Scheme) scripting support.
-    '';
-    homepage = "https://github.com/mattwparas/helix";
-    changelog = "https://github.com/mattwparas/helix/blob/${finalAttrs.src.rev}/CHANGELOG.md";
-    license = lib.licenses.mpl20;
-    mainProgram = "hx";
-    maintainers = with lib.maintainers; [
-      aciceri
-      Ra77a3l3-jar
-    ];
-  };
-})
+      passthru = previousAttrs.passthru // {
+        updateScript = ./update.sh;
+      };
+    }
+  )


### PR DESCRIPTION
## Changes

- Refactored derivation from standalone `buildRustPackage` to wrap `helix` via `helix-unwrapped.overrideAttrs` + `helix.override`, inheriting helix's packaging infrastructure (postInstall, shell completions, desktop entry, runtime)
- Fixes themes and tree-sitter grammars from `helix.runtime` not being included

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].
