### PR TITLE
python3Packages.tensorflow-metadata: 1.17.3 -> 1.21.0

### DIFF
--- a/pkgs/development/python-modules/tensorflow-metadata/build.patch
+++ b/pkgs/development/python-modules/tensorflow-metadata/build.patch
@@ -1,13 +1,13 @@
 diff --git a/setup.py b/setup.py
-index 30ac370..a05812d 100644
+index 9c2a17f..c7e120d 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -141,8 +141,4 @@ setup(
-     keywords='tensorflow metadata tfx',
-     download_url='https://github.com/tensorflow/metadata/tags',
+@@ -154,8 +154,4 @@ setup(
+     keywords="tensorflow metadata tfx",
+     download_url="https://github.com/tensorflow/metadata/tags",
      requires=[],
 -    cmdclass={
--        'build': _BuildCommand,
--        'bazel_build': _BazelBuildCommand,
+-        "build": _BuildCommand,
+-        "bazel_build": _BazelBuildCommand,
 -    },
  )

--- a/pkgs/development/python-modules/tensorflow-metadata/default.nix
+++ b/pkgs/development/python-modules/tensorflow-metadata/default.nix
@@ -14,17 +14,23 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "tensorflow-metadata";
-  version = "1.17.3";
+  version = "1.21.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "tensorflow";
     repo = "metadata";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-4xj2JfQryGy7a9ho9/JJtyg+0H5VLQzq9JevOmOWJZk=";
+    hash = "sha256-k+SJmR5n4S31wpSuMhJwrjJfX/Bow0QwLpw+TwRPS7U=";
   };
 
   patches = [ ./build.patch ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools<70" "setuptools"
+  '';
 
   # Default build pulls in Bazel + extra deps, given the actual build
   # is literally three lines (see below) - replace it with custom build.


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/tensorflow/metadata/compare/v1.17.3...v1.21.0
Changelog: https://github.com/tensorflow/metadata/releases/tag/v1.21.0

cc @ndl

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test