### PR TITLE
badger: 4.9.1 -> 4.9.2, adopt

### DIFF
--- a/pkgs/by-name/ba/badger/package.nix
+++ b/pkgs/by-name/ba/badger/package.nix
@@ -21,9 +21,12 @@ buildGoModule (finalAttrs: {
 
   doCheck = false;
 
+  __structuredAttrs = true;
+
   meta = {
+    changelog = "https://github.com/dgraph-io/badger/releases/tag/${finalAttrs.src.tag}";
     description = "Fast key-value DB in Go";
-    homepage = "https://github.com/dgraph-io/badger";
+    homepage = "https://dgraph-io.github.io/badger";
     license = lib.licenses.asl20;
     mainProgram = "badger";
     maintainers = [ ];

--- a/pkgs/by-name/ba/badger/package.nix
+++ b/pkgs/by-name/ba/badger/package.nix
@@ -29,6 +29,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://dgraph-io.github.io/badger";
     license = lib.licenses.asl20;
     mainProgram = "badger";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ hythera ];
   };
 })

--- a/pkgs/by-name/ba/badger/package.nix
+++ b/pkgs/by-name/ba/badger/package.nix
@@ -6,16 +6,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "badger";
-  version = "4.9.1";
+  version = "4.9.2";
 
   src = fetchFromGitHub {
     owner = "dgraph-io";
     repo = "badger";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-BsKFi4oMNJE09PBjFmqNhbMcQcHk5uR5QssbwN2ZNCk=";
+    hash = "sha256-L6qGeOZlIl6I87t9Ohk57bA+WXT7NwMOJkiA3WaMFhM=";
   };
 
-  vendorHash = "sha256-+rXXCVH2xuULPzdM0KVPwYht+tu0qyxPjLLaBMWVIuI=";
+  vendorHash = "sha256-KDIwEH83nPMJPJGTN3UgO00pjYwR17XqGdPXioP1YcY=";
 
   subPackages = [ "badger" ];
 


### PR DESCRIPTION
changelog: https://github.com/dgraph-io/badger/releases/tag/v4.9.2
diff: https://github.com/dgraph-io/badger/compare/v4.9.1...v4.9.2

Supersedes #529781

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
