### PR TITLE
oidcwarden: init at 2026.4.2-1

### DIFF
--- a/pkgs/by-name/oi/oidcwarden/package.nix
+++ b/pkgs/by-name/oi/oidcwarden/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  libiconv,
+  stdenv,
+  dbBackend ? "sqlite",
+  libmysqlclient,
+  libpq,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "oidcwarden";
+  version = "2026.4.2-1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Timshel";
+    repo = "OIDCWarden";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-tHacn9RtoByWpqnWX2/gWwODDSeXJa4mk4MfxHiiJ8A=";
+  };
+
+  cargoHash = "sha256-eGsYNaLYRCrTRaoyfhxnoeA2ytYeyGGvHnAbpEIayzs=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    openssl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ]
+  ++ lib.optional (dbBackend == "mysql") libmysqlclient
+  ++ lib.optional (dbBackend == "postgresql") libpq;
+
+  buildFeatures = dbBackend;
+
+  meta = {
+    description = "Unofficial Bitwarden-compatible server with OpenID Connect support";
+    homepage = "https://github.com/Timshel/OIDCWarden";
+    changelog = "https://github.com/Timshel/OIDCWarden/releases/tag/v${finalAttrs.src.tag}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ DerGrumpf ];
+    mainProgram = "oidcwarden";
+  };
+})


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

OIDCWarden is a Drop-in Replacement for Vaultwarden with the added bonus on supporting OpenID.
It can be used for `services.vaultwarden.package = pkgs.oidcwarden`.
 If I forgot anything im happy do add it :)
