### PR TITLE
plantuml-server: 1.2026.5 -> 1.2026.6 + switch to jetty 12

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -40,6 +40,8 @@
 
 - The `services.syncthing` module now updates the Syncthing REST API using partial updates (`PATCH`) instead of full replacements (`PUT`) for general settings. Updating these settings was broken and prone to errors after updates, see [#428808](https://github.com/NixOS/nixpkgs/issues/428808) and [#528889](https://github.com/NixOS/nixpkgs/issues/528889). As a result, settings modified manually through the Syncthing Web UI that are not explicitly defined in your Nix configuration will now persist across rebuilds.
 
+- `services.plantuml-server.packages.jetty` now supports `jetty_12`, it no longer supports `jetty_11`.
+
 ## Other Notable Changes {#sec-release-26.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/services/web-apps/plantuml-server.nix
+++ b/nixos/modules/services/web-apps/plantuml-server.nix
@@ -37,15 +37,7 @@ in
       packages = {
         jdk = mkPackageOption pkgs "jdk" { };
         jetty = mkPackageOption pkgs "jetty" {
-          default = [ "jetty_11" ];
-          extraDescription = ''
-            At the time of writing (v1.2023.12), PlantUML Server does not support
-            Jetty versions higher than 12.x.
-
-            Jetty 12.x has introduced major breaking changes, see
-            <https://github.com/jetty/jetty.project/releases/tag/jetty-12.0.0> and
-            <https://eclipse.dev/jetty/documentation/jetty-12/programming-guide/index.html#pg-migration-11-to-12>
-          '';
+          default = [ "jetty_12" ];
         };
       };
 
@@ -115,11 +107,11 @@ in
       script = ''
         ${cfg.packages.jdk}/bin/java \
           -jar ${cfg.packages.jetty}/start.jar \
-            --module=deploy,http,jsp \
-            jetty.home=${cfg.packages.jetty} \
-            jetty.base=${cfg.package} \
-            jetty.http.host=${cfg.listenHost} \
-            jetty.http.port=${toString cfg.listenPort}
+            --module=http,ee11-deploy,ee11-jsp \
+            -Djetty.home=${cfg.packages.jetty} \
+            -Djetty.base=${cfg.package} \
+            -Djetty.http.host=${cfg.listenHost} \
+            -Djetty.http.port=${toString cfg.listenPort}
       '';
 
       serviceConfig = {

--- a/pkgs/by-name/pl/plantuml-server/package.nix
+++ b/pkgs/by-name/pl/plantuml-server/package.nix
@@ -7,11 +7,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "plantuml-server";
-  version = "1.2026.5";
+  version = "1.2026.6";
 
   src = fetchurl {
     url = "https://github.com/plantuml/plantuml-server/releases/download/v${finalAttrs.version}/plantuml-v${finalAttrs.version}.war";
-    hash = "sha256-Ub6Ao+m1hC+tEerkVnMXN2CMRf8CKg9XcB9E8JsunvY=";
+    hash = "sha256-1jcX6GMknJK5dGL74DMwYTDZNVkKI07MpL8qbb0WMi4=";
   };
 
   dontUnpack = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Based on https://github.com/NixOS/nixpkgs/pull/529743

Switch to jetty 12, because plantuml-server broke with jetty 11.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
