### PR TITLE
haskellPackages.yesod-middleware-csp: jailbreak & unbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1165,6 +1165,10 @@ with haskellLib;
     hz3
     ;
 
+  # 2026-06-10: Too strict bounds on template-haskell <2.23 and time <1.13
+  # https://github.com/SupercedeTech/yesod-middleware-csp/issues/13
+  yesod-middleware-csp = doJailbreak super.yesod-middleware-csp;
+
   # test suite requires git and does a bunch of git operations
   restless-git = dontCheck super.restless-git;
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -7438,7 +7438,6 @@ broken-packages:
   - yesod-links # failure in job https://hydra.nixos.org/build/233257763 at 2023-09-02
   - yesod-lucid # failure in job https://hydra.nixos.org/build/233231687 at 2023-09-02
   - yesod-media-simple # failure in job https://hydra.nixos.org/build/307611606 at 2025-09-19
-  - yesod-middleware-csp # failure in job https://hydra.nixos.org/build/295098382 at 2025-04-22
   - yesod-paginate # failure in job https://hydra.nixos.org/build/233218563 at 2023-09-02
   - yesod-pagination # failure in job https://hydra.nixos.org/build/233204022 at 2023-09-02
   - yesod-pnotify # failure in job https://hydra.nixos.org/build/233258047 at 2023-09-02


### PR DESCRIPTION
Bump & unbreak yesod-middleware-csp package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
