### PR TITLE
msedit: 1.2.1 -> 2.0.0

### DIFF
--- a/pkgs/by-name/ms/msedit/package.nix
+++ b/pkgs/by-name/ms/msedit/package.nix
@@ -5,20 +5,20 @@
   fetchFromGitHub,
   versionCheckHook,
   nix-update-script,
-  icu,
+  icu76,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "msedit";
-  version = "1.2.1";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "edit";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Sb73awgdajBKKW0QIpmKF6g9mIIS/1f0a6D/jQulnUM=";
+    hash = "sha256-9HoK5i0IimujfTQxDplBNJRO7qmD/S+SnLLnR95RHiQ=";
   };
 
-  cargoHash = "sha256-U8U70nzTmpY6r8J661EJ4CGjx6vWrGovu5m25dvz5sY=";
+  cargoHash = "sha256-r7AR6Mf13UUeooPV5/8gyp7HvmOeSaOJNotWWqU10SQ=";
 
   # Requires nightly features
   env = {
@@ -30,17 +30,24 @@ rustPlatform.buildRustPackage (finalAttrs: {
         "-headerpad_max_install_names"
       ]
     );
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isLinux {
+    # https://github.com/microsoft/edit/releases/tag/v2.0.0
+    # see section 'Additonal notes to Building & Packaging
+    EDIT_CFG_ICUUC_SONAME = "${lib.getLib icu76}/lib/libicuuc.so.76";
+    EDIT_CFG_ICUI18N_SONAME = "${lib.getLib icu76}/lib/libicui18n.so.76";
+    EDIT_CFG_ICU_RENAMING_VERSION = 76;
   };
 
   buildInputs = [
-    icu
+    icu76
   ];
 
   # https://github.com/microsoft/edit/blob/f8bea2be191d00baa2a4551817541ea3f8c5b03e/src/icu.rs#L834
   # Required for Ctrl+F searching to work
   postFixup =
     let
-      rpathAppend = lib.makeLibraryPath [ icu ];
+      rpathAppend = lib.makeLibraryPath [ icu76 ];
     in
     lib.optionalString stdenv.hostPlatform.isElf ''
       patchelf $out/bin/edit \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/microsoft/edit/releases/tag/v2.0.0

supersedes: #529860
closes: #527866


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
