### PR TITLE
libkrunfw: 5.3.0 -> 5.5.0, libkrun: 1.17.4 -> 1.18.1, krunvm: 0.2.4 -> 0.2.6

### DIFF
--- a/pkgs/applications/virtualization/krunvm/default.nix
+++ b/pkgs/applications/virtualization/krunvm/default.nix
@@ -16,18 +16,18 @@
 
 stdenv.mkDerivation rec {
   pname = "krunvm";
-  version = "0.2.4";
+  version = "0.2.6";
 
   src = fetchFromGitHub {
-    owner = "containers";
+    owner = "libkrun";
     repo = "krunvm";
     rev = "v${version}";
-    hash = "sha256-YbK4DKw0nh9IO1F7QsJcbOMlHekEdeUBbDHwuQ2x1Ww=";
+    hash = "sha256-peOaPivQKOwioh5skPNFiA3ptHv9pSsnjpy43cms8O8=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
-    hash = "sha256-TMV9xCcqBQgPsUSzsTJAi4qsplTOSm3ilaUmtmdaGnE=";
+    hash = "sha256-MRcQ0Vnd3PJqE2q981JpXPjwMUKT4t+RcOvzWptK7PQ=";
   };
 
   nativeBuildInputs = [
@@ -51,12 +51,12 @@ stdenv.mkDerivation rec {
   postPatch = ''
     # do not pollute etc
     substituteInPlace src/utils.rs \
-      --replace "etc/containers" "share/krunvm/containers"
+      --replace-fail "etc/containers" "share/krunvm/containers"
   '';
 
   postInstall = ''
     mkdir -p $out/share/krunvm/containers
-    install -D -m755 ${buildah-unwrapped.src}/docs/samples/registries.conf $out/share/krunvm/containers/registries.conf
+    install -D -m755 ${buildah-unwrapped.src}/tests/registries.conf $out/share/krunvm/containers/registries.conf
     install -D -m755 ${buildah-unwrapped.src}/tests/policy.json $out/share/krunvm/containers/policy.json
   '';
 
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "CLI-based utility for creating microVMs from OCI images";
-    homepage = "https://github.com/containers/krunvm";
+    homepage = "https://github.com/libkrun/krunvm";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ nickcao ];
     platforms = libkrun.meta.platforms;

--- a/pkgs/by-name/li/libkrun/package.nix
+++ b/pkgs/by-name/li/libkrun/package.nix
@@ -34,13 +34,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "libkrun" + lib.optionalString (variant != null) "-${variant}";
-  version = "1.17.4";
+  version = "1.18.1";
 
   src = fetchFromGitHub {
-    owner = "containers";
+    owner = "libkrun";
     repo = "libkrun";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Th4vCg3xHb6lbo26IDZES7tLOUAJTebQK2+h3xSYX7U=";
+    hash = "sha256-JXbCDByrWhmcEqwREX/kgVAtS4K8blfpjknTdJwQCLo=";
   };
 
   outputs = [
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
-    hash = "sha256-0xpAyNe1jF1OMtc7FXMsejqIv0xKc1ktEvm3rj/mVFU=";
+    hash = "sha256-dfIe2pl957MRcY1hIv6wPPX/4He+ou+eCZLbylVeGAE=";
   };
 
   # Make sure libkrunfw can be found by dlopen()
@@ -106,7 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Dynamic library providing Virtualization-based process isolation capabilities";
-    homepage = "https://github.com/containers/libkrun";
+    homepage = "https://github.com/libkrun/libkrun";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       nickcao

--- a/pkgs/by-name/li/libkrunfw/package.nix
+++ b/pkgs/by-name/li/libkrunfw/package.nix
@@ -21,19 +21,19 @@ assert lib.elem variant [
 
 let
   kernelSrc = fetchurl {
-    url = "mirror://kernel/linux/kernel/v6.x/linux-6.12.76.tar.xz";
-    hash = "sha256-u7Q+g0xG5r1JpcKPIuZ5qTdENATh9lMgTUskkp862JY=";
+    url = "mirror://kernel/linux/kernel/v6.x/linux-6.12.91.tar.xz";
+    hash = "sha256-D/KrnhafnxlIVXRx+7RQ0wGPjFt3yvKI4aOYJYJZeWk=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "libkrunfw" + lib.optionalString (variant != null) "-${variant}";
-  version = "5.3.0";
+  version = "5.5.0";
 
   src = fetchFromGitHub {
-    owner = "containers";
+    owner = "libkrun";
     repo = "libkrunfw";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-fhG/bP1HzmhyU2N+wnr1074WEGsD9RdTUUBhYUFpWlA=";
+    hash = "sha256-MF1oDqhS4xqyQJIntl4DBfDBvuqCxQn9Zdws82Tn5Gg=";
   };
 
   postPatch = ''
@@ -74,7 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Dynamic library bundling the guest payload consumed by libkrun";
-    homepage = "https://github.com/containers/libkrunfw";
+    homepage = "https://github.com/libkrun/libkrunfw";
     license = with lib.licenses; [
       lgpl2Only
       lgpl21Only


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
