### PR TITLE
adscan: init at 9.1.0, python3Packages.credsweeper: init at 1.16.0, python3Packages.pybase62: init at 0.5.0

### DIFF
--- a/pkgs/by-name/ad/adscan/package.nix
+++ b/pkgs/by-name/ad/adscan/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "adscan";
+  version = "9.1.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "ADScanPro";
+    repo = "adscan";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-YsJFOJtf2rubfAXHWlu6c7ZLX8QE1KZFcFof56MsPVo=";
+  };
+
+  pythonRelaxDeps = [ "credsweeper" ];
+
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
+    aardwolf
+    aiosmb
+    badldap
+    certifi
+    credsweeper
+    dnspython
+    graphviz
+    impacket
+    jinja2
+    kerbad
+    markitdown
+    netifaces
+    packaging
+    playwright
+    posthog
+    prompt-toolkit
+    psutil
+    pydantic-ai-slim
+    pydantic-settings
+    pypsrp
+    pypykatz
+    python-docx
+    python-magic
+    questionary
+    redis
+    requests
+    rich
+    scapy
+    selenium
+    sentry-sdk
+    textual
+    weasyprint
+    winacl
+  ];
+
+  pythonImportsCheck = [
+    "adscan_core"
+    "adscan_launcher"
+  ];
+
+  # Project has no tests
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Active Directory pentesting tool for Linux";
+    homepage = "https://github.com/ADScanPro/adscan";
+    changelog = "https://github.com/ADScanPro/adscan/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.bsl11;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "adscan";
+  };
+})

--- a/pkgs/by-name/cr/credsweeper/package.nix
+++ b/pkgs/by-name/cr/credsweeper/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: with python3Packages; toPythonApplication credsweeper

--- a/pkgs/development/python-modules/credsweeper/default.nix
+++ b/pkgs/development/python-modules/credsweeper/default.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  base58,
+  beautifulsoup4,
+  buildPythonPackage,
+  colorama,
+  cryptography,
+  deepdiff,
+  fetchFromGitHub,
+  gitpython,
+  hatchling,
+  humanfriendly,
+  hypothesis,
+  lxml,
+  nix-update-script,
+  numpy,
+  odfpy,
+  onnxruntime,
+  openpyxl,
+  pandas,
+  pdfminer-six,
+  pybase62,
+  pyjks,
+  pytestCheckHook,
+  python-dateutil,
+  python-docx,
+  python-pptx,
+  pyxlsb,
+  pyyaml,
+  rpmfile,
+  striprtf,
+  whatthepatch,
+  xlrd,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "credsweeper";
+  version = "1.16.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Samsung";
+    repo = "CredSweeper";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DiIT7DzH6ut/Ax2qgga5vKjeXocROGbHdARLWJijejY=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    base58
+    beautifulsoup4
+    colorama
+    cryptography
+    gitpython
+    humanfriendly
+    lxml
+    numpy
+    odfpy
+    onnxruntime
+    openpyxl
+    pandas
+    pdfminer-six
+    pybase62
+    pyjks
+    python-dateutil
+    python-docx
+    python-pptx
+    pyxlsb
+    pyyaml
+    rpmfile
+    striprtf
+    whatthepatch
+    xlrd
+  ];
+
+  nativeCheckInputs = [
+    deepdiff
+    hypothesis
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "credsweeper" ];
+
+  disabledTests = [
+    # Probability tests
+    "test_data_p"
+    "test_depth_n"
+    "test_depth_p"
+    "test_match_n"
+    "test_multi_jobs_p"
+    "test_rules_ml_p"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tool to detect credentials in any directories or files";
+    homepage = "https://github.com/Samsung/CredSweeper";
+    changelog = "https://github.com/Samsung/CredSweeper/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "credsweeper";
+  };
+})

--- a/pkgs/development/python-modules/pybase62/default.nix
+++ b/pkgs/development/python-modules/pybase62/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pybase62";
+  version = "0.5.0";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "suminb";
+    repo = "base62";
+    tag = finalAttrs.version;
+    hash = "sha256-/H16MT3mKCdXItoeOn1LWTHlgWmtwJdQHUaCp18eMz0=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "base62" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Module for base62 encoding";
+    homepage = "https://github.com/suminb/base62";
+    changelog = "https://github.com/suminb/base62/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.bsd2WithViews;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3338,6 +3338,8 @@ self: super: with self; {
 
   credstash = callPackage ../development/python-modules/credstash { };
 
+  credsweeper = callPackage ../development/python-modules/credsweeper { };
+
   crewai = callPackage ../development/python-modules/crewai { };
 
   crispy-bootstrap3 = callPackage ../development/python-modules/crispy-bootstrap3 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13617,6 +13617,8 @@ self: super: with self; {
 
   pybars3 = callPackage ../development/python-modules/pybars3 { };
 
+  pybase62 = callPackage ../development/python-modules/pybase62 { };
+
   pybase64 = callPackage ../development/python-modules/pybase64 { };
 
   pybbox = callPackage ../development/python-modules/pybbox { };


### PR DESCRIPTION
- Active Directory pentesting tool for Linux: https://github.com/ADScanPro/adscan
- Tool to detect credentials in any directories or files: https://github.com/Samsung/CredSweeper
- Module for base62 encoding: https://github.com/suminb/base62

Related to https://github.com/NixOS/nixpkgs/issues/81418

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
