### PR TITLE
[25.11] flake-checker: 0.2.11 -> 0.2.13

### DIFF
--- a/pkgs/by-name/fl/flake-checker/package.nix
+++ b/pkgs/by-name/fl/flake-checker/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "flake-checker";
-  version = "0.2.11";
+  version = "0.2.13";
 
   src = fetchFromGitHub {
     owner = "DeterminateSystems";
     repo = "flake-checker";
     rev = "v${version}";
-    hash = "sha256-0ftHzqFpFkKZKByWJ49/YySrXBU4lCxvcpbTuMY8ZXs=";
+    hash = "sha256-QE/Druzo/EDiuh7Vb+kipPgUxkIRPLsHFMSpSRMFIVw=";
   };
 
-  cargoHash = "sha256-5zzSLk5QT3X6rdGEPHPelXFd5nOxNtlbqDHwV7fFDKY=";
+  cargoHash = "sha256-kKEHYKXtccXRsa1cON0oMHOWagi3mVdnf3pEgkoNn/k=";
 
   meta = {
     description = "Health checks for your Nix flakes";


### PR DESCRIPTION
This is a backport of #525396 to the `release-25.11` branch.

---

At the moment, [the “Changes acceptable for releases” section of `CONTRIBUTING.md` says:](https://github.com/NixOS/nixpkgs/blob/872eb0174d0d5a1bc37388ff84eea2bca44b1065/CONTRIBUTING.md#changes-acceptable-for-releases)

> The release branches should generally only receive backwards-compatible changes, both for the Nix expressions and derivations.
> Here are some examples of changes that are okay to backport:
> - ✔️ New packages, modules and functions
> - ✔️ Security fixes
> - ✔️ Package version updates
>   - ✔️ Patch versions with fixes
>   - ✔️ Minor versions with new functionality, but no breaking changes

Looking through the changelogs [for version 0.2.12](https://github.com/DeterminateSystems/flake-checker/releases/tag/v0.2.12) and [for version 0.2.13](https://github.com/DeterminateSystems/flake-checker/releases/tag/v0.2.13) of Nix Flake Checker, it looks like most of the changes are backwards-compatible internal changes. Other than backwards-compatible internal changes, the changelogs for both versions talk about `ref-statuses.json` being updated. Updates to `ref-statuses.json` are backwards-compatible changes.

In other words, it looks like all of the changes from this pull request are acceptable for releases.

---

I tested the version of `flake-checker` from this pull request with multiple different `flake.lock` files. It gave errors when I expected it to give errors, and it did not give errors when I expected it to not give errors.

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `aeed3d350314701c919cc1e37a3aca476aff6536`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>flake-checker</li>
  </ul>
</details>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
