### PR TITLE
Frida python add update script

### DIFF
--- a/pkgs/development/python-modules/frida-python/default.nix
+++ b/pkgs/development/python-modules/frida-python/default.nix
@@ -56,7 +56,10 @@ buildPythonPackage {
       lgpl2Plus
       wxWindowsException31
     ];
-    maintainers = with lib.maintainers; [ s1341 ];
+    maintainers = with lib.maintainers; [
+      s1341
+      eyjhb
+    ];
     platforms = [
       "x86_64-linux"
       "aarch64-linux"

--- a/pkgs/development/python-modules/frida-python/default.nix
+++ b/pkgs/development/python-modules/frida-python/default.nix
@@ -49,6 +49,8 @@ buildPythonPackage {
     "frida._frida"
   ];
 
+  passthru.updateScript = ./update.sh;
+
   meta = {
     description = "Dynamic instrumentation toolkit for developers, reverse-engineers, and security researchers (Python bindings)";
     homepage = "https://www.frida.re";

--- a/pkgs/development/python-modules/frida-python/update.sh
+++ b/pkgs/development/python-modules/frida-python/update.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p curl jq nix
+
+set -euox pipefail
+
+dir="$(dirname "$0")"
+latest=$(curl -s https://pypi.org/pypi/frida/json | jq -r '.info.version')
+
+sed -i "s/version = \".*\"/version = \"$latest\"/" "$dir/default.nix"
+
+for system_platform in \
+  "x86_64-linux|manylinux1_x86_64" \
+  "aarch64-linux|manylinux2014_aarch64" \
+  "x86_64-darwin|macosx_10_13_x86_64" \
+  "aarch64-darwin|macosx_11_0_arm64"
+do
+  system="${system_platform%%|*}"
+  platform="${system_platform##*|}"
+  url=$(curl -s "https://pypi.org/pypi/frida/${latest}/json" | \
+    jq -r ".urls[] | select(.filename | test(\"${platform}\")) | .url")
+  hash=$(nix-prefetch-url --type sha256 "$url" 2>/dev/null | tail -1)
+  sri=$(nix hash to-sri --type sha256 "$hash")
+
+  old_sri=$(grep -A1 "${system} = {" "$dir/default.nix" | grep -o 'sha256-[^"]*')
+  sed -i "s|${old_sri}|${sri}|" "$dir/default.nix"
+done


### PR DESCRIPTION
Adds myself as maintainer + adds an update script for auto updating this package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
