### PR TITLE
git-bug: fix fish completions

### DIFF
--- a/pkgs/by-name/gi/git-bug/package.nix
+++ b/pkgs/by-name/gi/git-bug/package.nix
@@ -53,6 +53,7 @@ buildGoModule (finalAttrs: {
 
   postInstall = ''
     installShellCompletion \
+      --cmd git-bug \
       --bash misc/completion/bash/git-bug \
       --zsh misc/completion/zsh/git-bug \
       --fish misc/completion/fish/git-bug


### PR DESCRIPTION
Resolves #529848

Fish completions were broken for `git-bug` because fish requires the completion file to end in the `.fish` extension and the upstream completion file (named "git-bug") was copied over verbatim by `installShellCompletion`.

Bash and Zsh were not broken - a more minimal fix would be to add `--cmd` after `--fish`, so if that is preferred let me know and I'll make the change.

Validate on this branch with:

```sh
out="$(nix build --no-link --print-out-paths .#git-bug)"
# or "set out" if fish ;)
find "$out/share" -maxdepth 4 -type f | grep -E 'bash-completion|vendor_completions|site-functions' | sort
fish -C "set -g fish_complete_path $out/share/fish/vendor_completions.d; set -gx PATH $out/bin \$PATH" -c 'complete -C "git-bug "'
"$out/bin/git-bug" version
```

@royneary @DeeUnderscore

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
