### PR TITLE
throne: update to 1.1.6

### DIFF
--- a/pkgs/by-name/th/throne/core-also-check-capabilities.patch
+++ b/pkgs/by-name/th/throne/core-also-check-capabilities.patch
@@ -1,7 +1,7 @@
-diff --git a/server.go b/server.go
+diff --git a/core/server/server.go b/core/server/server.go
 index 4499a6d..4c14d1a 100644
---- a/server.go
-+++ b/server.go
+--- a/core/server/server.go
++++ b/core/server/server.go
 @@ -24,6 +24,7 @@ import (
  	"github.com/sagernet/sing-box/experimental/clashapi"
  	"github.com/sagernet/sing/common"

--- a/pkgs/by-name/th/throne/dont-check-parent.patch
+++ b/pkgs/by-name/th/throne/dont-check-parent.patch
@@ -1,0 +1,13 @@
+diff --git a/core/server/parentcheck/parentcheck.go b/core/server/parentcheck/parentcheck.go
+index 0991a7f..58fd32f 100644
+--- a/core/server/parentcheck/parentcheck.go
++++ b/core/server/parentcheck/parentcheck.go
+@@ -11,6 +11,8 @@ import (
+ )
+ 
+ func CheckParentProcess() {
++	return
++
+ 	parentPath, err := getParentExePath(ParentPID)
+ 	if err != nil {
+ 		log.Fatalf("parent check: cannot read parent executable: %v", err)

--- a/pkgs/by-name/th/throne/fix-desktop-exec.patch
+++ b/pkgs/by-name/th/throne/fix-desktop-exec.patch
@@ -1,0 +1,39 @@
+diff --git a/src/sys/linux/AutoRun.cpp b/src/sys/linux/AutoRun.cpp
+index 1fafe35..a32e7fe 100644
+--- a/src/sys/linux/AutoRun.cpp
++++ b/src/sys/linux/AutoRun.cpp
+@@ -31,18 +31,9 @@ void AutoRun_SetEnabled(bool enable) {
+     QString desktopFileLocation = userAutoStartPath + appName + QLatin1String(".desktop");
+     QStringList appCmdList;
+ 
+-    if (QProcessEnvironment::systemEnvironment().contains("APPIMAGE")) {
+-        appCmdList << QProcessEnvironment::systemEnvironment().value("APPIMAGE");
+-    } else {
+-        appCmdList << QApplication::applicationFilePath();
+-    }
+-
++    appCmdList << "Throne";
+     appCmdList << "-tray";
+ 
+-    if (Configs::dataManager->settingsRepo->flag_use_appdata) {
+-        appCmdList << "-appdata";
+-    }
+-
+     if (enable) {
+         if (!QDir().exists(userAutoStartPath) && !QDir().mkpath(userAutoStartPath)) {
+             // qCWarning(lcUtility) << "Could not create autostart folder"
+diff --git a/src/sys/linux/UrlScheme.cpp b/src/sys/linux/UrlScheme.cpp
+index 63e4118..a9d3a42 100644
+--- a/src/sys/linux/UrlScheme.cpp
++++ b/src/sys/linux/UrlScheme.cpp
+@@ -14,9 +14,7 @@ static const QString kDesktopId = "throne-url-handler.desktop";
+ // For AppImage the launcher must point at the outer image ($APPIMAGE), not the
+ // extracted binary inside the mount, which disappears after exit.
+ static QString execTarget() {
+-    auto env = QProcessEnvironment::systemEnvironment();
+-    if (env.contains("APPIMAGE")) return env.value("APPIMAGE");
+-    return QApplication::applicationFilePath();
++    return "Throne";
+ }
+ 
+ static QString desktopFilePath() {

--- a/pkgs/by-name/th/throne/nixos-disable-setuid-request.patch
+++ b/pkgs/by-name/th/throne/nixos-disable-setuid-request.patch
@@ -20,15 +20,15 @@ index 9acfee4..c0c313a 100644
 --- a/src/ui/mainwindow.cpp
 +++ b/src/ui/mainwindow.cpp
 @@ -163,8 +163,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
-     Configs::dataManager->settingsRepo->core_port = MkPort();
-     if (Configs::dataManager->settingsRepo->core_port <= 0) Configs::dataManager->settingsRepo->core_port = 19810;
+     runOnNewThread([=, this] {GetDeviceDetails(); });
  
+     // Prepare core
 -    auto core_path = QApplication::applicationDirPath() + "/";
 -    core_path += "ThroneCore";
 +    auto core_path = Configs::FindCoreRealPath();
  
-     QStringList args;
-     args.push_back("-port");
+     bool coreDebugMode = (Configs::dataManager->settingsRepo->log_level == "debug");
+ 
 @@ -1296,6 +1295,15 @@ bool MainWindow::get_elevated_permissions(int reason) {
          return true;
      }

--- a/pkgs/by-name/th/throne/package.nix
+++ b/pkgs/by-name/th/throne/package.nix
@@ -26,13 +26,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "throne";
-  version = "1.1.2";
+  version = "1.1.6";
 
   src = fetchFromGitHub {
     owner = "throneproj";
     repo = "Throne";
     tag = finalAttrs.version;
-    hash = "sha256-gtbGKyEOTq+1IP7v4ZhVVohGQFlDtP7NbbhyFD2rCnA=";
+    hash = "sha256-qzQWUG4pAnNAtF/FmboNvj/XULCn+ww2ImG/d5DbR5w=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/th/throne/package.nix
+++ b/pkgs/by-name/th/throne/package.nix
@@ -6,6 +6,7 @@
   fetchFromGitHub,
   fetchurl,
   makeDesktopItem,
+  nix-update-script,
 
   protobuf,
   protoc-gen-go,
@@ -19,8 +20,8 @@
 
   # override if you want to have more up-to-date rulesets
   throne-srslist ? fetchurl {
-    url = "https://raw.githubusercontent.com/throneproj/routeprofiles/c637d0bb8a3707eb5e122c81753600d3e18a5969/srslist.h";
-    hash = "sha256-Kf3TAGXi7Y0PhWjdTOZdPUMlimszWkcrQw9zv8pb76s=";
+    url = "https://raw.githubusercontent.com/throneproj/routeprofiles/ee86f2c19bf86ec3f9c4c8ed99f49f3c3e496f08/srslist.h";
+    hash = "sha256-Do/dOKlqCIAHHaYhKiTL2F2kk8Rvi+SrP/zEy00jv3k=";
   },
 }:
 
@@ -60,8 +61,8 @@ stdenv.mkDerivation (finalAttrs: {
     # to make use of security wrappers
     ./nixos-disable-setuid-request.patch
 
-    # sets the Exec field of the auto-run .desktop file to use the Throne binary from PATH
-    ./fix-autorun-desktop-exec.patch
+    # sets the Exec field of the auto-run and the scheme-handler .desktop files to use the Throne binary from PATH
+    ./fix-desktop-exec.patch
   ];
 
   preBuild = ''
@@ -100,15 +101,17 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.core = buildGoModule {
     pname = "throne-core";
     inherit (finalAttrs) version src;
-    sourceRoot = "${finalAttrs.src.name}/core/server";
+    modRoot = "./core/server";
 
     patches = [
       # also check cap_net_admin so we don't have to set suid
       ./core-also-check-capabilities.patch
+
+      # disable a security check, which hopefully is not too bad
+      ./dont-check-parent.patch
     ];
 
-    proxyVendor = true;
-    vendorHash = "sha256-G0ev2my+sHQFYdmfkR2Zq3ujSeqi5fZ4BdrnUS8mfDE=";
+    vendorHash = "sha256-1yVQspaI0wLLJ6IrGABTpF3YSL3uhJTbapo1A0hAPZo=";
 
     nativeBuildInputs = [
       protobuf
@@ -116,14 +119,22 @@ stdenv.mkDerivation (finalAttrs: {
       protoc-gen-go-grpc
     ];
 
-    # taken from script/build_go.sh
     preBuild = ''
-      pushd gen
-      protoc -I . --go_out=. --go-grpc_out=. libcore.proto
-      popd
+      # run only if we're not in the FOD fetcher
+      if [ -d vendor ]; then
+        install -Dm755 vendor/github.com/sagernet/cronet-go/lib/"$GOOS"_"$GOARCH"/libcronet.so -t "$out/lib/"
 
-      VERSION_SINGBOX=$(go list -m -f '{{.Version}}' github.com/sagernet/sing-box)
-      ldflags+=("-X 'github.com/sagernet/sing-box/constant.Version=$VERSION_SINGBOX'")
+        substituteInPlace vendor/github.com/sagernet/cronet-go/internal/cronet/loader_unix.go \
+          --replace-fail "path = findLibrary()" "path = \"$out/lib/libcronet.so\""
+
+        # taken from script/build_go.sh
+        pushd gen
+        protoc -I . --go_out=. --go-grpc_out=. libcore.proto
+        popd
+
+        VERSION_SINGBOX=$(go list -m -f '{{.Version}}' github.com/sagernet/sing-box)
+        ldflags+=("-X 'github.com/sagernet/sing-box/constant.Version=$VERSION_SINGBOX'")
+      fi
     '';
 
     # ldflags and tags are taken from script/build_go.sh
@@ -146,12 +157,16 @@ stdenv.mkDerivation (finalAttrs: {
       "badlinkname"
       "tfogo_checklinkname"
       "with_naive_outbound"
-      "with_purego" # prebuilt .a files inside cronet-go are annoying to fix
+      "with_purego" # use prebuilt .so instead of prebuilt .a files for cronet-go
     ];
   };
 
-  # this tricks nix-update into also updating the vendorHash of passthru.core
-  passthru.goModules = finalAttrs.passthru.core.goModules;
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--subpackage"
+      "core"
+    ];
+  };
 
   meta = {
     description = "Qt based cross-platform GUI proxy configuration manager";
@@ -163,5 +178,9 @@ stdenv.mkDerivation (finalAttrs: {
       aleksana
     ];
     platforms = lib.platforms.linux;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryNativeCode # libcronet.so used by throne.core
+    ];
   };
 })


### PR DESCRIPTION
Upstream moved the location of `srslist.h` to an external branch (`rule-set`), which caused the previous derivation to fail during compilation. 

This PR:
- Updates `throne` to version 1.1.6.
- Updates the `throne-srslist` source URL and fixed-output hash to point to the correct upstream location.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test