### PR TITLE
yfklog: init at 0.7.0

### DIFF
--- a/pkgs/by-name/yf/yfklog/package.nix
+++ b/pkgs/by-name/yf/yfklog/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  perl,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "yfklog";
+  version = "0.7.0";
+
+  src = fetchurl {
+    url = "https://fkurz.net/ham/yfklog/yfklog-${finalAttrs.version}.tar.gz";
+    hash = "sha256-P18Iq7bPgC/zndPjyAsPQ0jO6I0H2Bi9MttRvYQNFmg=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  buildInputs = [
+    (perl.withPackages (
+      ps: with ps; [
+        Curses
+        DBDSQLite
+        DBI
+        IOSocketTimeout
+        NetTelnet
+        libwwwperl
+      ]
+    ))
+  ];
+
+  #in upstream Makefile DESTDIR only need during installation
+  installFlags = [ "DESTDIR=$(out)" ];
+
+  #yfksubs.pl is installed as non-executable
+  postInstall = ''
+    chmod +x $out/share/yfklog/yfksubs.pl
+    patchShebangs $out/share/yfklog/yfksubs.pl
+    chmod 044 $out/share/yfklog/yfksubs.pl
+  '';
+
+  meta = {
+    description = "General purpose ham radio logbook";
+    homepage = "https://fkurz.net/ham/yfklog.html";
+    changelog = "https://fkurz.net/ham/yfklog/CHANGELOG";
+    mainProgram = "yfk";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ castorNova2 ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add a package of [yfklog](https://fkurz.net/ham/yfklog.html) which is a ham radio logbook.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
