### PR TITLE
python3Packages.pyxdg: migrate to pyproject, enable __structuredAttrs, use finalAttrs, enable tests, adopt

### DIFF
--- a/pkgs/development/python-modules/pyxdg/default.nix
+++ b/pkgs/development/python-modules/pyxdg/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitLab,
+  fetchpatch2,
   pytestCheckHook,
   setuptools,
 }:
@@ -20,6 +21,14 @@ buildPythonPackage (finalAttrs: {
     tag = "rel-${finalAttrs.version}";
     hash = "sha256-TrFQzfkXabmfpGYwhxD1UVY1F645KycfSPPrMJFAe+0=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      name = "python314-ast.diff";
+      url = "https://gitlab.freedesktop.org/xdg/pyxdg/-/commit/9291d419017263c922869d79ac1fe8d423e5f929.diff";
+      sha256 = "sha256-sFChDLwBvJWkZES7mZszVChmwCuc9+oAi9fMUcwF298=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace test/test_basedirectory.py \

--- a/pkgs/development/python-modules/pyxdg/default.nix
+++ b/pkgs/development/python-modules/pyxdg/default.nix
@@ -9,6 +9,8 @@ buildPythonPackage (finalAttrs: {
   version = "0.28";
   format = "setuptools";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "xdg";

--- a/pkgs/development/python-modules/pyxdg/default.nix
+++ b/pkgs/development/python-modules/pyxdg/default.nix
@@ -28,6 +28,11 @@ buildPythonPackage (finalAttrs: {
       url = "https://gitlab.freedesktop.org/xdg/pyxdg/-/commit/9291d419017263c922869d79ac1fe8d423e5f929.diff";
       sha256 = "sha256-sFChDLwBvJWkZES7mZszVChmwCuc9+oAi9fMUcwF298=";
     })
+    (fetchpatch2 {
+      name = "python315-ast.diff";
+      url = "https://gitlab.freedesktop.org/xdg/pyxdg/-/commit/63033ac306aa26d32e1439417e59ae8f8a4c9820.diff";
+      sha256 = "sha256-dK+d8DSCM9N9wzJHJssVkFElqutLkmBQvT1dg3v17MY=";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/development/python-modules/pyxdg/default.nix
+++ b/pkgs/development/python-modules/pyxdg/default.nix
@@ -2,12 +2,13 @@
   lib,
   buildPythonPackage,
   fetchFromGitLab,
+  setuptools,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "pyxdg";
   version = "0.28";
-  format = "setuptools";
+  pyproject = true;
 
   __structuredAttrs = true;
 
@@ -18,6 +19,10 @@ buildPythonPackage (finalAttrs: {
     rev = "rel-${finalAttrs.version}";
     hash = "sha256-TrFQzfkXabmfpGYwhxD1UVY1F645KycfSPPrMJFAe+0=";
   };
+
+  build-system = [
+    setuptools
+  ];
 
   # Tests failed (errors=4, failures=4) on NixOS
   doCheck = false;

--- a/pkgs/development/python-modules/pyxdg/default.nix
+++ b/pkgs/development/python-modules/pyxdg/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage (finalAttrs: {
     domain = "gitlab.freedesktop.org";
     owner = "xdg";
     repo = "pyxdg";
-    rev = "rel-${finalAttrs.version}";
+    tag = "rel-${finalAttrs.version}";
     hash = "sha256-TrFQzfkXabmfpGYwhxD1UVY1F645KycfSPPrMJFAe+0=";
   };
 

--- a/pkgs/development/python-modules/pyxdg/default.nix
+++ b/pkgs/development/python-modules/pyxdg/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitLab,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pyxdg";
   version = "0.28";
   format = "setuptools";
@@ -13,7 +13,7 @@ buildPythonPackage rec {
     domain = "gitlab.freedesktop.org";
     owner = "xdg";
     repo = "pyxdg";
-    rev = "rel-${version}";
+    rev = "rel-${finalAttrs.version}";
     hash = "sha256-TrFQzfkXabmfpGYwhxD1UVY1F645KycfSPPrMJFAe+0=";
   };
 
@@ -28,4 +28,4 @@ buildPythonPackage rec {
     license = lib.licenses.lgpl2;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/pyxdg/default.nix
+++ b/pkgs/development/python-modules/pyxdg/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitLab,
+  pytestCheckHook,
   setuptools,
 }:
 
@@ -20,12 +21,30 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-TrFQzfkXabmfpGYwhxD1UVY1F645KycfSPPrMJFAe+0=";
   };
 
+  postPatch = ''
+    substituteInPlace test/test_basedirectory.py \
+      --replace-fail "from imp import reload" "from importlib import reload"
+  '';
+
   build-system = [
     setuptools
   ];
 
-  # Tests failed (errors=4, failures=4) on NixOS
-  doCheck = false;
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  # Disable tests doing MIME type lookups, as those are not installed in the build environment
+  disabledTests = [
+    "test_by_name"
+    "test_canonical"
+    "test_get_type"
+    "test_get_type2"
+    "test_get_type_by_contents"
+    "test_get_type_by_data"
+    "test_get_type_by_name"
+    "test_inheritance"
+  ];
 
   pythonImportsCheck = [ "xdg" ];
 

--- a/pkgs/development/python-modules/pyxdg/default.nix
+++ b/pkgs/development/python-modules/pyxdg/default.nix
@@ -52,6 +52,6 @@ buildPythonPackage (finalAttrs: {
     homepage = "http://freedesktop.org/wiki/Software/pyxdg";
     description = "Contains implementations of freedesktop.org standards";
     license = lib.licenses.lgpl2;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ ambossmann ];
   };
 })


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974
- use `finalAttrs`
- enable `__structuredAttrs`
- enable most tests
- adopt the package
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
