### PR TITLE
nixos/murmur: Gracefully reload the ACME certificates

### DIFF
--- a/nixos/modules/services/networking/murmur.nix
+++ b/nixos/modules/services/networking/murmur.nix
@@ -479,5 +479,8 @@ in
     '';
   };
 
-  meta.maintainers = with lib.maintainers; [ felixsinger ];
+  meta.maintainers = with lib.maintainers; [
+    felixsinger
+    ldesgoui
+  ];
 }

--- a/nixos/modules/services/networking/murmur.nix
+++ b/nixos/modules/services/networking/murmur.nix
@@ -278,6 +278,7 @@ in
             create any certificates and it doesn't add subdomains to
             existing ones – you will need to create them manually using
             {option}`security.acme.certs`.*
+            The server gracefully reloads after certificates are renewed.
           '';
         };
       };
@@ -359,6 +360,10 @@ in
         ${pkgs.envsubst}/bin/envsubst \
           -o /run/murmur/murmurd.ini \
           -i ${configFile}
+      '';
+      reload = ''
+        echo 'Reloading TLS settings specified in murmur.ini'
+        kill -USR1 $MAINPID
       '';
 
       serviceConfig = {


### PR DESCRIPTION
mumble-server supports reloading TLS certs via SIGUSR1, this is strictly better than using `reloadServices` which causes the service to restart as there's no `ExecReload` implementation
Note that `kill SIGUSR1` would not be a valid `ExecReload` implementation because it doesn't reload the rest of the configuration, see `mumble-server(1)`

cc @felixsinger 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
