### PR TITLE
proton-pass-cli: build from source

### DIFF
--- a/pkgs/by-name/pr/proton-pass-cli/package.nix
+++ b/pkgs/by-name/pr/proton-pass-cli/package.nix
@@ -1,48 +1,40 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  autoPatchelfHook,
-  curl,
-  common-updater-scripts,
-  jq,
+  rustPlatform,
+  fetchFromGitHub,
   keyutils,
   libgcc,
   makeBinaryWrapper,
+  perl,
   versionCheckHook,
-  writeShellScript,
+  nix-update-script,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "proton-pass-cli";
   version = "2.2.5";
 
-  __structuredAttrs = true;
-  strictDeps = true;
+  src = fetchFromGitHub {
+    owner = "protonpass";
+    repo = "pass-cli";
+    tag = finalAttrs.version;
+    hash = "sha256-4Bjx+M1ChAY2+VVjFLkLNXmIxNOXGOF3xhd19DBcRSE=";
+  };
 
-  src = finalAttrs.passthru.sources.${stdenv.hostPlatform.system};
+  cargoHash = "sha256-GKd9BmpzVBnZDNPFmQyhDFClXgNhUX7eM/f/leJJT/E=";
+
+  __structuredAttrs = true;
 
   nativeBuildInputs = [
     makeBinaryWrapper
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    autoPatchelfHook
+    perl
   ];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     keyutils
     libgcc
   ];
-
-  dontUnpack = true;
-
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm755 $src $out/bin/pass-cli
-
-    runHook postInstall
-  '';
 
   postFixup = ''
     wrapProgram $out/bin/pass-cli --set PROTON_PASS_NO_UPDATE_CHECK 1
@@ -53,40 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     versionCheckHook
   ];
 
-  passthru = {
-    sources = {
-      "aarch64-darwin" = fetchurl {
-        url = "https://proton.me/download/pass-cli/${finalAttrs.version}/pass-cli-macos-aarch64";
-        hash = "sha256-u6rAmSEkRxoMocwmJPzoH9rFxdUOjzGmu3Kfdx9/NuE=";
-      };
-      "aarch64-linux" = fetchurl {
-        url = "https://proton.me/download/pass-cli/${finalAttrs.version}/pass-cli-linux-aarch64";
-        hash = "sha256-qFl+r5JjEkKkTFubE7D9DA/FayGmxPCHt9TAMWUSSbM=";
-      };
-      "x86_64-linux" = fetchurl {
-        url = "https://proton.me/download/pass-cli/${finalAttrs.version}/pass-cli-linux-x86_64";
-        hash = "sha256-OXG/21ZJvFljTCGV41JZ6j9LeIm7paT2aYtq9Qsnz38=";
-      };
-    };
-    updateScript = writeShellScript "update-proton-pass-cli" ''
-      set -o errexit
-      export PATH="${
-        lib.makeBinPath [
-          curl
-          jq
-          common-updater-scripts
-        ]
-      }"
-      NEW_VERSION=$(curl --silent https://proton.me/download/pass-cli/versions.json | jq '.passCliVersions.version' --raw-output)
-      if [[ "${finalAttrs.version}" = "$NEW_VERSION" ]]; then
-          echo "No update available."
-          exit 0
-      fi
-      for platform in ${lib.escapeShellArgs finalAttrs.meta.platforms}; do
-        update-source-version "proton-pass-cli" "$NEW_VERSION" --ignore-same-version --source-key="sources.$platform"
-      done
-    '';
-  };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Command-line interface for managing your Proton Pass vaults, items, and secrets";
@@ -94,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     mainProgram = "pass-cli";
     maintainers = with lib.maintainers; [ delafthi ];
-    platforms = lib.attrNames finalAttrs.passthru.sources;
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = lib.platforms.unix;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
   };
 })


### PR DESCRIPTION
The source code to `pass-cli` has been released: https://github.com/protonpass/pass-cli/tree/main

Depends on #549664

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
