### PR TITLE
geometry-central: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20332,6 +20332,12 @@
     githubId = 1767648;
     name = "Nikolas Moya";
   };
+  nmwsharp = {
+    email = "nmwsharp@gmail.com";
+    github = "nmwsharp";
+    githubId = 12726725;
+    name = "Nicholas Sharp";
+  };
   noaccos = {
     name = "Francesco Noacco";
     email = "francesco.noacco2000@gmail.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15830,6 +15830,12 @@
     githubId = 54590679;
     name = "Liam Murphy";
   };
+  liamnwhite1 = {
+    email = "whiteln@ornl.gov";
+    github = "liamnwhite1";
+    githubId = 47892904;
+    name = "Liam White";
+  };
   Liamolucko = {
     name = "Liam Murphy";
     email = "liampm32@gmail.com";

--- a/pkgs/by-name/ge/geometry-central/package.nix
+++ b/pkgs/by-name/ge/geometry-central/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  eigen,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "geometry-central";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "nmwsharp";
+    repo = "geometry-central";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ipQoLqieAp1KImfCMnUxaqq+7R1//HuNeNlhRkbDt9U=";
+    fetchSubmodules = true;
+  };
+
+  __structuredAttrs = true;
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  propagatedBuildInputs = [
+    eigen
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeOptionType "path" "GC_EIGEN_LOCATION" "${lib.getDev eigen}/include/eigen3")
+    (lib.cmakeBool "SUITESPARSE" false)
+  ];
+
+  meta = {
+    description = "Geometry-central is a modern C++ library of data structures and algorithms for geometry processing, with a particular focus on surface meshes.";
+    longDescription = ''
+      Geometry-central is a modern C++ library of data structures and algorithms for geometry processing, with a particular focus on surface meshes.
+
+      Features include:
+
+      - A polished surface mesh class, with efficient support for mesh modification, and a system of containers for associating data with mesh elements.
+      - Implementations of canonical geometric quantities on surfaces, ranging from normals and curvatures to tangent vector bases to operators from discrete differential geometry.
+      - A suite of powerful algorithms, including computing distances on surface, generating direction fields, and manipulating intrinsic Delaunay triangulations.
+      - A coherent set of sparse linear algebra tools, based on Eigen and augmented to automatically utilize better solvers if available on your system.
+    '';
+    homepage = "https://geometry-central.net";
+    changelog = "https://github.com/nmwsharp/geometry-central/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      nmwsharp
+      liamnwhite1
+    ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Summary

Adds `geometry-central` as a new by-name package at version 1.1.0.

`geometry-central` is a C++ library providing algorithms and data structures for discrete differential geometry. The package builds with CMake/Ninja, fetches upstream submodules, uses nixpkgs `eigen` via `GC_EIGEN_LOCATION`, disables optional SuiteSparse support for now, and propagates `eigen` for downstream consumers.

This also adds maintainer entries for `nmwsharp` and `liamnwhite1`, and assigns both as maintainers of the package.

Homepage: https://geometry-central.net  
Changelog: https://github.com/nmwsharp/geometry-central/releases/tag/v1.1.0


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test