### PR TITLE
xen: patch with XSAs 490 through 494

### DIFF
--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -296,6 +296,28 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-qNWe3iw+bYDtvBZ2KVfcy4VKu/waOyhoKZ0L8bqLdNc=";
     })
 
+    # XSA #493
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa493/xsa493-4.20-01.patch";
+      hash = "sha256-SvAj+9CIyedpFENCB/lQTJUB4kpVkGh+z+NNk82lQqM=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa493/xsa493-4.20-02.patch";
+      hash = "sha256-4fajBBBKMnMTy7mvFSUghwkRbYo833s3jATeGfiOrjc=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa493/xsa493-4.20-03.patch";
+      hash = "sha256-/AI9gtd60UWf89NNd7+Zx1g+KyAIM2wCih/07LN5zt4=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa493/xsa493-4.20-04.patch";
+      hash = "sha256-qvXQG9VZkgca/za3bx1zTDkmRz5lFT3JPkbdI1mlBGY=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa493/xsa493-4.20-05.patch";
+      hash = "sha256-6pGjjPjalw6TY0n9TInE3nCXNmt6BUxwy1r1xf55U7k=";
+    })
+
     # patch `libxl` to search for `qemu-system-i386` properly. (Before 4.21)
     (fetchpatch {
       url = "https://github.com/xen-project/xen/commit/f6281291704aa356489f4bd927cc7348a920bd01.diff?full_index=1";

--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -216,6 +216,12 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-PF4zNeaS8aXHBNKLcgjVBUqmREg+nvdyHyLlhX2YBiw=";
     })
 
+    # XSA #491
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa491-4.21.patch";
+      hash = "sha256-I21YIcaK1v7BfBJi/aiVACgR3QyN+/gXnB4YMprT4zA=";
+    })
+
     # patch `libxl` to search for `qemu-system-i386` properly. (Before 4.21)
     (fetchpatch {
       url = "https://github.com/xen-project/xen/commit/f6281291704aa356489f4bd927cc7348a920bd01.diff?full_index=1";

--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -318,6 +318,12 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-6pGjjPjalw6TY0n9TInE3nCXNmt6BUxwy1r1xf55U7k=";
     })
 
+    # XSA #494
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa494-4.20.patch";
+      hash = "sha256-ns0s++J2adUD/HWuMiYad/g3MITs+twlMnkpFnP7T0w=";
+    })
+
     # patch `libxl` to search for `qemu-system-i386` properly. (Before 4.21)
     (fetchpatch {
       url = "https://github.com/xen-project/xen/commit/f6281291704aa356489f4bd927cc7348a920bd01.diff?full_index=1";

--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -222,6 +222,80 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-I21YIcaK1v7BfBJi/aiVACgR3QyN+/gXnB4YMprT4zA=";
     })
 
+    # XSA #492
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa492/xsa492-4.20-01.patch";
+      hash = "sha256-U3nE7jgTKh2HmS9tMVQG+TIGvgU5B1aikC3NSER0CaY=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa492/xsa492-4.20-02.patch";
+      hash = "sha256-Y3k9ICThfnIcu59F2pFDbFWD5DL6siPJmINmC7nT2uY=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa492/xsa492-4.20-03.patch";
+      hash = "sha256-k4nPft59/MQwYKcdrzj5d80+LDhp05e86iJWzabjkQc=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa492/xsa492-4.20-04.patch";
+      hash = "sha256-Mn+8q9zsstXbmrS/rkDdtwWEiD3EGNlmpa+eB1wESA4=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa492/xsa492-4.20-05.patch";
+      hash = "sha256-csf9nf6cz3skhq1ph8HIs2AEVgBkw29hP39zwqy2vwM=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa492/xsa492-4.20-06.patch";
+      hash = "sha256-urY9bjqqzKSGqGqEhDnagLUrzDsKkARMERT7vmukeUU=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa492/xsa492-4.20-07.patch";
+      hash = "sha256-OyUC9bJevxiMuJuyJO9Z3ScXebe7lZM95HkK5YxGino=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa492/xsa492-4.20-08.patch";
+      hash = "sha256-g3zV+r9LKjuMbkl4gprhWqClOgDU/Kbesr39LQiM+Aw=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa492/xsa492-4.20-09.patch";
+      hash = "sha256-Wuc5dqwm+zwlYOzDXpRgyQH584sKwETi+xcE7HASHyI=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa492/xsa492-4.20-10.patch";
+      hash = "sha256-ggln1O+epVOErBSUhIxX7xhwBy808vnQtcae3KYoQdo=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa492/xsa492-4.20-11.patch";
+      hash = "sha256-/Yb1i/ms8MaVsEa/nK84CTFclOKcJoWMjjQJQab7l40=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa492/xsa492-4.20-12.patch";
+      hash = "sha256-IpUeM+t7AZ8IVlzake+PiFAe0FCeFzChy+eaN9MAiSM=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa492/xsa492-4.20-13.patch";
+      hash = "sha256-3vZj9VrDcFtlKrlMy1OD//F+6O252m23jJ0BRShQ6wA=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa492/xsa492-4.20-14.patch";
+      hash = "sha256-LiBavW+FTfXdELs8Fm79KeOvskRqDXytv/e7eYRgSvY=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa492/xsa492-4.20-15.patch";
+      hash = "sha256-0eK2hIFPNDIfv2W0ivkGL8Z3F+NpN4p2X0JVKjeBYWE=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa492/xsa492-4.20-16.patch";
+      hash = "sha256-iEEkPC9mIuSF6Swt3/myUizsc8DubSPEkLkf1zm0/NE=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa492/xsa492-4.20-17.patch";
+      hash = "sha256-YNo1wr+fRKk8+78Jf/zqJ7q9ugbzg7gyiyJ3zU+nB60=";
+    })
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa492/xsa492-4.20-18.patch";
+      hash = "sha256-qNWe3iw+bYDtvBZ2KVfcy4VKu/waOyhoKZ0L8bqLdNc=";
+    })
+
     # patch `libxl` to search for `qemu-system-i386` properly. (Before 4.21)
     (fetchpatch {
       url = "https://github.com/xen-project/xen/commit/f6281291704aa356489f4bd927cc7348a920bd01.diff?full_index=1";

--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -210,6 +210,12 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-QttKWdmWC6Zn5k2hd6RIMCpLWv71HB/A9mCbDP+i8to=";
     })
 
+    # XSA #490
+    (fetchpatch {
+      url = "https://xenbits.xenproject.org/xsa/xsa490-4.21.patch";
+      hash = "sha256-PF4zNeaS8aXHBNKLcgjVBUqmREg+nvdyHyLlhX2YBiw=";
+    })
+
     # patch `libxl` to search for `qemu-system-i386` properly. (Before 4.21)
     (fetchpatch {
       url = "https://github.com/xen-project/xen/commit/f6281291704aa356489f4bd927cc7348a920bd01.diff?full_index=1";


### PR DESCRIPTION
Patches from:
- [XSA-490](https://xenbits.xen.org/xsa/advisory-490.html)
- [XSA-491](https://xenbits.xen.org/xsa/advisory-491.html)
- [XSA-492](https://xenbits.xen.org/xsa/advisory-492.html)
- [XSA-493](https://xenbits.xen.org/xsa/advisory-493.html)
- [XSA-494](https://xenbits.xen.org/xsa/advisory-494.html)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
