### PR TITLE
Beeper - fix launcher badge

### DIFF
--- a/pkgs/by-name/be/beeper/package.nix
+++ b/pkgs/by-name/be/beeper/package.nix
@@ -44,7 +44,11 @@ appimageTools.wrapAppImage {
 
   src = appimageContents;
 
-  extraPkgs = pkgs: [ pkgs.libsecret ];
+  # add libunity because Electron loads it dynamically for app.setBadgeCount();
+  extraPkgs = pkgs: [
+    pkgs.libsecret
+    pkgs.libunity
+  ];
 
   extraInstallCommands = ''
     install -Dm 644 ${appimageContents}/beepertexts.png $out/share/icons/hicolor/512x512/apps/beepertexts.png

--- a/pkgs/by-name/be/beeper/package.nix
+++ b/pkgs/by-name/be/beeper/package.nix
@@ -52,8 +52,9 @@ appimageTools.wrapAppImage {
 
   extraInstallCommands = ''
     install -Dm 644 ${appimageContents}/beepertexts.png $out/share/icons/hicolor/512x512/apps/beepertexts.png
-    install -Dm 644 ${appimageContents}/beepertexts.desktop -t $out/share/applications/
-    substituteInPlace $out/share/applications/beepertexts.desktop --replace-fail "AppRun" "beeper"
+    # name desktop launcher BeeperTexts.desktop to match the ID used by launcher updates (DBUS signals sent using libunity)
+    install -Dm 644 ${appimageContents}/beepertexts.desktop $out/share/applications/BeeperTexts.desktop
+    substituteInPlace $out/share/applications/BeeperTexts.desktop --replace-fail "AppRun" "beeper"
 
     . ${makeWrapper}/nix-support/setup-hook
     wrapProgram $out/bin/beeper \


### PR DESCRIPTION
This fixes issue #529862. Changes:

- Adds libunity as a runtime dependency.
- Use `BeeperTexts.desktop` for the launcher instead of lowercase version.

Beeper calls Electron's app.setBadgeCount(), but launcher badges were not displayed before this fix because Electron, which Beeper uses, implements Linux badges by dynamically loading libunity, but since it was not bundled in the AppImage it did nothing.

Additionally, Beeper emits launcher updates for BeeperTexts.desktop, while nixpkgs installs beepertexts.desktop. Launcher matching is case-sensitive so I added a fix to produce a desktop file matching the app id used in emitted DBUS signal. 

## What are launcher badges

A badge count is the red little dot showing a number on a launcher icon, in the case of Beeper it is the number of unread threads.

## How launcher badge updates are implemented on linux

The de-facto standart is to use Unity Launcher API. This is supported by major shells like Gnome or KDE.
Electron apps use libunity which establish a DBUS connection and sends a signal indicating badge count change.
This signal is watched by the launchers (for instance Dash to Dock or Dash to Panel) and they update the badge count accordingly.

## Future

As I said in the issue Electron removed the libunity implementation in Electron 44 but it might be a while before Beeper switches to it so this fix is useful in the meantime (Beeper from nix pkgs 25.11 ( v4.2.179) uses Electron 38 and Beeper from nixos-unstable (v4.2.892) uses Electron 41).

When this package eventually uses Electron 44 we should remove this libunity runtime dependency and maybe re-implement the launcher badge update  as a patch if Electron does not implement it at all anymore.  

## Things done

Tested with GNOME Dash-to-Dock and Dash-to-Panel. Launcher badge updates now match Beeper's unread thread count.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage]. **I did run the command `nix run nixpkgs#nixpkgs-review -- rev HEAD` but it never completed on my low perf laptop**
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Tested launcher badge updates with GNOME Dash-to-Dock and Dash-to-Panel
- [x] Tested compilation using `nix build .#beeper`


- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
