### PR TITLE
cppcheck: 2.18.3 -> 2.21.0

### DIFF
--- a/pkgs/by-name/ay/ayatana-indicator-display/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-display/package.nix
@@ -39,6 +39,14 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-rsZjEfAiz1HC5XMjPume1Y6miNAv1kmPFP4J/+NKlsA=";
   };
 
+  patches = [
+    # This should be dropped once the issue is fixed upstream.
+    # https://github.com/AyatanaIndicators/ayatana-indicator-display/pull/108
+    ./patches/0001-service.cpp-Mark-create_phone_menu-as-static.patch
+    ./patches/0002-cppcheck-Workaround-undefined-function-like-macro-fo.patch
+    ./patches/0003-Fix-cppcheck-warning-has-no-initializer.patch
+  ];
+
   postPatch = ''
     # Replace systemd prefix in pkg-config query, use GNUInstallDirs location for /etc
     substituteInPlace data/CMakeLists.txt \

--- a/pkgs/by-name/ay/ayatana-indicator-display/patches/0001-service.cpp-Mark-create_phone_menu-as-static.patch
+++ b/pkgs/by-name/ay/ayatana-indicator-display/patches/0001-service.cpp-Mark-create_phone_menu-as-static.patch
@@ -1,0 +1,26 @@
+From 5a1ce0ea5fd630efc7d85d681dacb562c356c3a3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jeremy=20B=C3=ADcha?= <jbicha@ubuntu.com>
+Date: Sun, 29 Mar 2026 21:49:07 -0700
+Subject: [PATCH 1/3] service.cpp: Mark create_phone_menu as static
+
+to satisfy cppcheck
+---
+ src/service.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/service.cpp b/src/service.cpp
+index d6b4ed7..ced370c 100644
+--- a/src/service.cpp
++++ b/src/service.cpp
+@@ -1058,7 +1058,7 @@ private:
+     static_cast<Impl*>(gself)->update_phone_header();
+   }
+ 
+-  GMenuModel* create_phone_menu()
++  static GMenuModel* create_phone_menu()
+   {
+     GMenu* menu;
+     GMenu* section;
+-- 
+2.43.0
+

--- a/pkgs/by-name/ay/ayatana-indicator-display/patches/0002-cppcheck-Workaround-undefined-function-like-macro-fo.patch
+++ b/pkgs/by-name/ay/ayatana-indicator-display/patches/0002-cppcheck-Workaround-undefined-function-like-macro-fo.patch
@@ -1,0 +1,49 @@
+From 3f30df763c2b0ac84b1c754faaedc69107539508 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jeremy=20B=C3=ADcha?= <jbicha@ubuntu.com>
+Date: Sun, 29 Mar 2026 17:02:56 -0700
+Subject: [PATCH 2/3] cppcheck: Workaround undefined function-like macro for
+ GLIB_CHECK_VERSION
+
+Copy a snippet from gtk.cfg.
+
+I didn't include gtk.cfg directly because its config triggers
+additional failures, so only copy the one line that we need
+
+https://github.com/danmar/cppcheck/commit/8c762adcdd9e
+
+https://bugs.debian.org/1125642
+
+Closes: #106
+---
+ tests/CMakeLists.txt | 2 +-
+ tests/ayatana.cfg    | 5 +++++
+ 2 files changed, 6 insertions(+), 1 deletion(-)
+ create mode 100644 tests/ayatana.cfg
+
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index bdc074f..97d6be0 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -28,7 +28,7 @@ endif()
+ 
+ add_compile_options(${CXX_WARNING_ARGS})
+ 
+-add_test(cppcheck cppcheck --enable=all -USCHEMA_DIR --check-level=exhaustive --error-exitcode=2 --inline-suppr --library=qt -I${CMAKE_SOURCE_DIR} -i${CMAKE_SOURCE_DIR}/tests/utils/qmain.cpp -i${CMAKE_SOURCE_DIR}/tests/gmock ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/tests --suppress=missingIncludeSystem --suppress=uninitDerivedMemberVar --suppress=unmatchedSuppression --suppress=constParameter --suppress=constParameterCallback --suppress=unusedFunction --suppress=uselessOverride)
++add_test(cppcheck cppcheck --enable=all -USCHEMA_DIR --check-level=exhaustive --error-exitcode=2 --inline-suppr --library=qt --library=${CMAKE_SOURCE_DIR}/tests/ayatana.cfg -I${CMAKE_SOURCE_DIR} -i${CMAKE_SOURCE_DIR}/tests/utils/qmain.cpp -i${CMAKE_SOURCE_DIR}/tests/gmock ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/tests --suppress=missingIncludeSystem --suppress=uninitDerivedMemberVar --suppress=unmatchedSuppression --suppress=constParameter --suppress=constParameterCallback --suppress=unusedFunction --suppress=uselessOverride)
+ 
+ add_subdirectory (unit)
+ 
+diff --git a/tests/ayatana.cfg b/tests/ayatana.cfg
+new file mode 100644
+index 0000000..035020a
+--- /dev/null
++++ b/tests/ayatana.cfg
+@@ -0,0 +1,5 @@
++<?xml version="1.0"?>
++<def format="2">
++  <!-- cppcheck override copied from gtk.cfg -->
++  <define name="GLIB_CHECK_VERSION(major, minor, micro)" value="1"/>
++</def>
+-- 
+2.43.0
+

--- a/pkgs/by-name/ay/ayatana-indicator-display/patches/0003-Fix-cppcheck-warning-has-no-initializer.patch
+++ b/pkgs/by-name/ay/ayatana-indicator-display/patches/0003-Fix-cppcheck-warning-has-no-initializer.patch
@@ -1,0 +1,30 @@
+From 172bf8a7d8e232d31a85ef61d21ee54b6c2eab7c Mon Sep 17 00:00:00 2001
+From: fliiiix <hi@l33t.name>
+Date: Tue, 9 Jun 2026 15:33:29 +0200
+Subject: [PATCH 3/3] Fix cppcheck warning has no initializer
+
+cppcheck 2.21.0
+---
+ src/service.cpp | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/service.cpp b/src/service.cpp
+index ced370c..251df5b 100644
+--- a/src/service.cpp
++++ b/src/service.cpp
+@@ -50,9 +50,9 @@ extern "C"
+ 
+     typedef struct
+     {
+-       guint nTempLow;
+-       guint nTempHigh;
+-       const gchar *sName;
++       guint nTempLow{};
++       guint nTempHigh{};
++       const gchar *sName = nullptr;
+     } TempProfile;
+ 
+     TempProfile m_lTempProfiles[] =
+-- 
+2.43.0
+

--- a/pkgs/by-name/cp/cppcheck/package.nix
+++ b/pkgs/by-name/cp/cppcheck/package.nix
@@ -21,7 +21,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cppcheck";
-  version = "2.18.3";
+  version = "2.21.0";
 
   outputs = [
     "out"
@@ -29,10 +29,10 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   src = fetchFromGitHub {
-    owner = "danmar";
+    owner = "cppcheck-opensource";
     repo = "cppcheck";
     tag = finalAttrs.version;
-    hash = "sha256-c32dNM1tNN+Nqv5GmKHnAhWx8r9RTcv3FQ/+ROGurkw=";
+    hash = "sha256-y7P25ThLC54IwuMIc4UGt9bz1HoafB0/b2rus28GcGo=";
   };
 
   nativeBuildInputs = [
@@ -115,7 +115,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "http://cppcheck.sourceforge.net";
     license = lib.licenses.gpl3Plus;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ l33tname ];
     platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
## Things done

Based on https://github.com/NixOS/nixpkgs/pull/473800 update cppcheck to latest version and patch issue in ayatana-indicator-display to work with 2.21.0.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
