### PR TITLE
ona-cli: init at 20260522.11804.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9044,6 +9044,12 @@
     githubId = 40620903;
     name = "figsoda";
   };
+  filiptronicek = {
+    email = "filip@trnck.dev";
+    github = "filiptronicek";
+    githubId = 29888641;
+    name = "Filip Troníček";
+  };
   fin-w = {
     email = "fin-w@tutanota.com";
     github = "fin-w";

--- a/pkgs/by-name/on/ona-cli/package.nix
+++ b/pkgs/by-name/on/ona-cli/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  versionCheckHook,
+}:
+
+let
+  stdenv = stdenvNoCC;
+
+  platform =
+    {
+      aarch64-darwin = "darwin-arm64";
+      aarch64-linux = "linux-arm64";
+      x86_64-darwin = "darwin-amd64";
+      x86_64-linux = "linux-amd64";
+    }
+    .${stdenv.hostPlatform.system};
+
+  hashes = {
+    aarch64-darwin = "sha256-qMmR5vD+qK61eb5zXZhl7taOUIS3i0wDm57m40cmZ0M=";
+    aarch64-linux = "sha256-45S7PM3X3Q8/IksfWwHPSwpqp9oFZFF2iFvPLAoDd2M=";
+    x86_64-darwin = "sha256-c0fWI6OeqBCqtyO4JAGiS9FyaZgkpOI6JjPgLzxKCPU=";
+    x86_64-linux = "sha256-Je5I5TA8I+mwGOvlGResP8u+DcZKz2LhxtZ6MAvv46k=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ona-cli";
+  version = "20260522.11804.0";
+
+  src = fetchurl {
+    url = "https://releases.gitpod.io/cli/releases/${finalAttrs.version}/gitpod-${platform}";
+    hash = hashes.${stdenv.hostPlatform.system};
+  };
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 ${finalAttrs.src} $out/bin/ona
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "CLI for Ona development environments";
+    homepage = "https://ona.com";
+    license = lib.licenses.unfree;
+    mainProgram = "ona";
+    maintainers = [ lib.maintainers.filiptronicek ];
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/on/ona-cli/update.sh
+++ b/pkgs/by-name/on/ona-cli/update.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash common-updater-scripts curl jq nix
+
+set -euo pipefail
+
+attr=ona-cli
+manifest_url="https://releases.gitpod.io/cli/stable/manifest.json"
+
+current_version=$(nix-instantiate --eval -E "with import ./. {}; ${attr}.version or (lib.getVersion ${attr})" | tr -d '"')
+latest_version=$(curl --fail --silent --show-error --location "$manifest_url" | jq --raw-output '.version')
+
+if [[ "$current_version" == "$latest_version" ]]; then
+    echo "package is up-to-date: $current_version"
+    exit 0
+fi
+
+update-source-version "$attr" "$latest_version" || true
+
+for system in \
+    aarch64-darwin \
+    aarch64-linux \
+    x86_64-darwin \
+    x86_64-linux; do
+    url=$(nix-instantiate --eval -E "with import ./. {}; ${attr}.src.url" --system "$system" | tr -d '"')
+    hash=$(nix --extra-experimental-features nix-command hash convert --to sri --hash-algo sha256 "$(nix-prefetch-url "$url")")
+    update-source-version "$attr" "$latest_version" "$hash" --system="$system" --ignore-same-version
+done


### PR DESCRIPTION
Hi there 👋, I'm Filip, an SWE at [Ona](https://ona.com/) and a big Nix fan.

This PR proposes to add the Ona CLI for managing Ona environments locally to the registry. As a disclaimer, the contribution itself was made by GPT 5.5. The CLI's code is proprietary, but it includes well-known endpoints for updating.

I hope the agent figured out the rest of the structure of this PR correctly, but very sorry for me overlooking something crucial in the process of my first contribution here!

---

The package installs the upstream released binary as `ona`, matching the command name users run. It is marked unfree and uses the published per-platform release digests from the Ona CLI stable manifest. A custom `passthru.updateScript` is included because upstream publishes the current stable version through `https://releases.gitpod.io/cli/stable/manifest.json` rather than GitHub release tags.

Assisted-by: Ona Codex (GPT-5)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
