### PR TITLE
nixos/etc-overlay: ship empty /etc/machine-id placeholder on immutable /etc

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -67,6 +67,8 @@
 
 - `security.run0.enableSudoAlias` now uses the `run0-sudo-shim` instead of a shell-script to improve compatibility.
 
+- With `system.etc.overlay.mutable = false`, NixOS now ships an empty `/etc/machine-id` in the image. Previously the file was absent and systemd logged `System cannot boot: Missing /etc/machine-id and /etc/ is read-only` while `ConditionFirstBoot` fired on every boot. With this change, systemd now overlays a transient ID from `/run/machine-id` for the session, and `systemd-machine-id-commit.service` has `ConditionFirstBoot` so it writes the machine-id through to a persistent backing file when one is bind-mounted over `/etc/machine-id`. To persist the machine-id across reboots, bind-mount a writable file containing `uninitialized` over `/etc/machine-id` from the initrd, or set `systemd.machine_id=` on the kernel command line (use `systemd.machine_id=firmware` to derive a stable ID on hardware that supports it).
+
 - `security.run0.persistentAuth` options have been added to support persistent Authentication of session. Timeout configurable via `security.polkit.settings.Polkitd.ExpirationSeconds`.
 
 - `boot.loader.systemd-boot` gained support for [Automatic Boot Assessment](https://systemd.io/AUTOMATIC_BOOT_ASSESSMENT/) via the new [`boot.loader.systemd-boot.bootCounting`](#opt-boot.loader.systemd-boot.bootCounting.enable) options, allowing automatic detection of and recovery from bad NixOS generations. As part of this change, boot loader entries on the ESP/XBOOTLDR partition are now named `nixos-<content-hash>.conf` instead of `nixos-generation-<n>.conf`; existing entries are migrated automatically on the next `nixos-rebuild boot`/`switch`.

--- a/nixos/modules/system/etc/etc-activation.nix
+++ b/nixos/modules/system/etc/etc-activation.nix
@@ -194,6 +194,25 @@
         text = "";
         mode = "0444";
       };
+
+      # The upstream unit has ConditionPathIsReadWrite=/etc, which is always
+      # false here. Replace it with ConditionFirstBoot: with the empty
+      # placeholder above first-boot is "no" and commit stays skipped, but
+      # when a persistence module bind-mounts a writable file containing
+      # "uninitialized" over /etc/machine-id, first-boot is "yes" once and
+      # commit writes the generated ID through the bind mount.
+      #
+      # An empty Condition*= assignment resets *all* condition types, and
+      # this attrset is serialised in key order, so the reset goes through
+      # ConditionFirstBoot (sorts first) and we re-add the upstream
+      # ConditionPathIsMountPoint afterwards.
+      systemd.services.systemd-machine-id-commit.unitConfig = {
+        ConditionFirstBoot = lib.mkDefault [
+          ""
+          "true"
+        ];
+        ConditionPathIsMountPoint = lib.mkDefault "/etc/machine-id";
+      };
     })
 
   ];

--- a/nixos/modules/system/etc/etc-activation.nix
+++ b/nixos/modules/system/etc/etc-activation.nix
@@ -182,16 +182,18 @@
     })
 
     (lib.mkIf (config.system.etc.overlay.enable && !config.system.etc.overlay.mutable) {
-      # Systemd requires /etc/machine-id exists or can be initialized on first
-      # boot. This file should not be part of an image or system config because
-      # it is unique to the machine, so it is initialized at first boot and
-      # persisted in the system state directory, /var/lib/nixos.
-      environment.etc."machine-id".source = lib.mkDefault "/var/lib/nixos/machine-id";
-      boot.initrd.systemd.tmpfiles.settings.machine-id."/sysroot/var/lib/nixos/machine-id".f =
-        lib.mkDefault
-          {
-            argument = "uninitialized";
-          };
+      # An empty regular file means systemd will bind mount /run/machine-id
+      # on top, and ConditionFirstBoot will be false (the file will never
+      # change, so this makes sense). See machine-id(5) "First Boot
+      # Semantics". It also serves as a target to bind mount an actually
+      # persistent machine-id onto. A symlink doesn't work here since
+      # systemd-machine-id-commit checks /etc/machine-id itself for being a
+      # mountpoint without following symlinks, so it would never commit
+      # through a symlink.
+      environment.etc.machine-id = lib.mkDefault {
+        text = "";
+        mode = "0444";
+      };
     })
 
   ];

--- a/nixos/tests/activation/etc-overlay-immutable.nix
+++ b/nixos/tests/activation/etc-overlay-immutable.nix
@@ -76,6 +76,19 @@
       with subtest("/etc is mounted as an overlay"):
         machine.succeed("findmnt --kernel --type overlay /etc")
 
+      with subtest("machine-id is set up without first-boot looping"):
+        # The baked-in placeholder is an empty regular file; systemd overlays
+        # /run/machine-id on top so the session has a valid ID while the
+        # commit service is condition-skipped (no writable /etc to commit to).
+        machine.succeed("stat --format '%F' /etc/machine-id | tee /dev/stderr | grep -q 'regular'")
+        machine.succeed("grep -qE '^[0-9a-f]{32}$' /etc/machine-id")
+        machine.fail("journalctl -b | grep -F 'System cannot boot: Missing /etc/machine-id'")
+        machine.fail("journalctl -b | grep -F 'Detected first boot'")
+        machine.fail("systemctl is-failed --quiet systemd-machine-id-commit.service")
+        assert machine.succeed(
+            "systemctl show -P ConditionResult systemd-machine-id-commit.service"
+        ).strip() == "no"
+
       with subtest("modes work correctly"):
         machine.succeed("stat --format '%F' /etc/modetest | tee /dev/stderr | grep -q 'regular file'")
         machine.succeed("stat --format '%F' /etc/modetest2 | tee /dev/stderr | grep -q 'regular file'")


### PR DESCRIPTION
#523894 made `/etc/machine-id` a symlink to `/var/lib/nixos/machine-id` and
created the target with content `uninitialized`.
Unfortunately the generated id is never committed, because:

* `systemd-machine-id-commit.service` has `ConditionPathIsReadWrite=/etc`,
  which is always false on the read-only overlay, so the unit is skipped.
* Even with that condition cleared, `machine_id_commit()` checks whether
  `/etc/machine-id` itself is a mountpoint (no symlink following), finds the
  symlink isn't, and exits without writing.

So `/var/lib/nixos/machine-id` stays `uninitialized` forever, every boot is
`ConditionFirstBoot=yes`, and the machine-id is random on every boot.

I think it's more correct to have an empty regular file in the etc image so that:

* systemd bind-mounts `/run/machine-id` over it for the session.
* `ConditionFirstBoot` is `no`, which is the only logical default for a file
  that can never change. The previous behaviour fired first-boot units on every boot.
* `systemd-machine-id-commit` is cleanly condition-skipped, no failed unit.
* Users who want persistence can bind a writable backing file onto the file
  and have commit write through it, which does not work with a symlink.

The whole attrset is `mkDefault`, so any user definition of
`environment.etc.machine-id` overrides it.

For users who need a persistent ID, there are two main options:
* bind-mount a writable backing file from initrd (and clear the commit condition)
* pass `systemd.machine_id=` / `systemd.machine_id=firmware` on the kernel command line.

cc @anglesideangle @rebmit @nikstur

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
