### PR TITLE
kubernetes-helm: 3.20.2 -> 4.2.0

### DIFF
--- a/pkgs/applications/networking/cluster/helm/default.nix
+++ b/pkgs/applications/networking/cluster/helm/default.nix
@@ -5,26 +5,30 @@
   fetchFromGitHub,
   installShellFiles,
   testers,
+  writableTmpDirAsHomeHook,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "kubernetes-helm";
-  version = "3.20.2";
+  version = "4.2.0";
 
   src = fetchFromGitHub {
     owner = "helm";
     repo = "helm";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-YF5djCmCoPdLlEa/cksQgGtscEmIsQTiRqYZNyFjsEY=";
+    hash = "sha256-Wyihzf7KpnVuIdp5lmjhB7uLAGgtmI0TXYl29uaVC5Y=";
   };
-  vendorHash = "sha256-kqx23LekpuZJFisVZUoXBY9vHh9zviKyaW5NSa4ecxM=";
+
+  vendorHash = "sha256-QTDC0v0BPE3FoK9AAq1n2jWxOE9gB9OsoY2wnpcCDUQ=";
 
   subPackages = [ "cmd/helm" ];
   ldflags = [
     "-w"
     "-s"
-    "-X helm.sh/helm/v3/internal/version.version=v${finalAttrs.version}"
-    "-X helm.sh/helm/v3/internal/version.gitCommit=${finalAttrs.src.rev}"
+    "-X helm.sh/helm/v4/internal/version.version=v${finalAttrs.version}"
+    "-X helm.sh/helm/v4/internal/version.metadata="
+    "-X helm.sh/helm/v4/internal/version.gitCommit=${finalAttrs.src.rev}"
+    "-X helm.sh/helm/v4/internal/version.gitTreeState=clean"
   ];
 
   preBuild = ''
@@ -33,10 +37,14 @@ buildGoModule (finalAttrs: {
     K8S_MODULES_MAJOR_VER="$(($(cut -d. -f1 <<<"$K8S_MODULES_VER") + 1))"
     K8S_MODULES_MINOR_VER="$(cut -d. -f2 <<<"$K8S_MODULES_VER")"
     old_ldflags="''${ldflags}"
-    ldflags="''${ldflags} -X helm.sh/helm/v3/pkg/lint/rules.k8sVersionMajor=''${K8S_MODULES_MAJOR_VER}"
-    ldflags="''${ldflags} -X helm.sh/helm/v3/pkg/lint/rules.k8sVersionMinor=''${K8S_MODULES_MINOR_VER}"
-    ldflags="''${ldflags} -X helm.sh/helm/v3/pkg/chartutil.k8sVersionMajor=''${K8S_MODULES_MAJOR_VER}"
-    ldflags="''${ldflags} -X helm.sh/helm/v3/pkg/chartutil.k8sVersionMinor=''${K8S_MODULES_MINOR_VER}"
+    ldflags="''${ldflags} -X helm.sh/helm/v4/pkg/chart/v2/lint/rules.k8sVersionMajor=''${K8S_MODULES_MAJOR_VER}"
+    ldflags="''${ldflags} -X helm.sh/helm/v4/pkg/chart/v2/lint/rules.k8sVersionMinor=''${K8S_MODULES_MINOR_VER}"
+    ldflags="''${ldflags} -X helm.sh/helm/v4/pkg/internal/v3/lint/rules.k8sVersionMajor=''${K8S_MODULES_MAJOR_VER}"
+    ldflags="''${ldflags} -X helm.sh/helm/v4/pkg/internal/v3/lint/rules.k8sVersionMinor=''${K8S_MODULES_MINOR_VER}"
+    ldflags="''${ldflags} -X helm.sh/helm/v4/pkg/chart/common/util.k8sVersionMajor=''${K8S_MODULES_MAJOR_VER}"
+    ldflags="''${ldflags} -X helm.sh/helm/v4/pkg/chart/common/util.k8sVersionMinor=''${K8S_MODULES_MINOR_VER}"
+    ldflags="''${ldflags} -X helm.sh/helm/v4/internal/version.kubeClientVersionMajor=''${K8S_MODULES_MAJOR_VER}"
+    ldflags="''${ldflags} -X helm.sh/helm/v4/internal/version.kubeClientVersionMinor=''${K8S_MODULES_MINOR_VER}"
   '';
 
   overrideModAttrs = _: {
@@ -50,15 +58,17 @@ buildGoModule (finalAttrs: {
     # restore ldflags for tests
     ldflags="''${old_ldflags}"
 
+    patchShebangs pkg/cmd/testdata/helmhome/helm/plugins/exitwith/exitwith.sh
+
     # skipping version tests because they require dot git directory
-    substituteInPlace cmd/helm/version_test.go \
+    substituteInPlace pkg/cmd/version_test.go \
       --replace-fail "TestVersion" "SkipVersion"
     # skipping plugin tests
-    substituteInPlace cmd/helm/plugin_test.go \
+    substituteInPlace pkg/cmd/plugin_test.go \
       --replace-fail "TestPluginDynamicCompletion" "SkipPluginDynamicCompletion" \
-      --replace-fail "TestLoadPlugins" "SkipLoadPlugins"
+      --replace-fail "TestLoadCLIPlugins" "SkipLoadCLIPlugins"
     substituteInPlace cmd/helm/helm_test.go \
-      --replace-fail "TestPluginExitCode" "SkipPluginExitCode"
+      --replace-fail "TestCliPluginExitCode" "TestCliPluginExitCode"
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
     # skipping as test fails in sandbox
@@ -76,6 +86,7 @@ buildGoModule (finalAttrs: {
   '';
 
   nativeBuildInputs = [ installShellFiles ];
+  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     $out/bin/helm completion bash > helm.bash
     $out/bin/helm completion zsh > helm.zsh


### PR DESCRIPTION
Continuation of #461007

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
