### PR TITLE
headroom-ai, ast-grep-cli: init

### DIFF
--- a/pkgs/development/python-modules/ast-grep-cli/default.nix
+++ b/pkgs/development/python-modules/ast-grep-cli/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  rustPlatform,
+  nix-update-script,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "ast-grep-cli";
+  version = "0.43.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ast-grep";
+    repo = "ast-grep";
+    tag = finalAttrs.version;
+    hash = "sha256-qQkG04aGaw3U/FFP1omlsoAKfNsVKafgJlVzAxvHkcA=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-YL76pCvCco9u8nAGIuiEciQrgUgaPx1s8hHyu2x3KmI=";
+  };
+
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Structural search and rewrite code using AST patterns";
+    homepage = "https://ast-grep.github.io/";
+    changelog = "https://github.com/ast-grep/ast-grep/blob/${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ch4s3r ];
+    mainProgram = "sg";
+  };
+})

--- a/pkgs/development/python-modules/headroom/default.nix
+++ b/pkgs/development/python-modules/headroom/default.nix
@@ -13,6 +13,7 @@
   # dependencies
   click,
   fastapi,
+  h2,
   httpx,
   litellm,
   opentelemetry-api,
@@ -70,6 +71,7 @@ buildPythonPackage (finalAttrs: {
     ast-grep-cli
     click
     fastapi
+    h2
     httpx
     litellm
     opentelemetry-api

--- a/pkgs/development/python-modules/headroom/default.nix
+++ b/pkgs/development/python-modules/headroom/default.nix
@@ -46,6 +46,10 @@ buildPythonPackage (finalAttrs: {
   postPatch = ''
     substituteInPlace crates/headroom-core/Cargo.toml \
       --replace-fail '"ort-download-binaries-rustls-tls"' '"ort-load-dynamic"'
+    substituteInPlace headroom/cli/wrap.py \
+      --replace-fail \
+        '[sys.executable, "-m", "headroom.cli", "proxy",' \
+        '["headroom", "proxy",'
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/headroom/default.nix
+++ b/pkgs/development/python-modules/headroom/default.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  rustPlatform,
+  stdenv,
+  libiconv,
+  onnxruntime,
+
+  # build-system
+  cffi,
+
+  # dependencies
+  click,
+  fastapi,
+  httpx,
+  litellm,
+  opentelemetry-api,
+  pydantic,
+  rich,
+  tiktoken,
+  uvicorn,
+  ast-grep-cli,
+  tomli,
+
+  nix-update-script,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "headroom-ai";
+  version = "0.24.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "chopratejas";
+    repo = "headroom";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-765aekIjf9oMdY7prRT2CqeDGtXEEDQn43GQkaTeAaY=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-WQBvil0bsS6/Z6b+uRauwOQq4VZ57VwAoghcyFdVgLE=";
+  };
+
+  postPatch = ''
+    substituteInPlace crates/headroom-core/Cargo.toml \
+      --replace-fail '"ort-download-binaries-rustls-tls"' '"ort-load-dynamic"'
+  '';
+
+  nativeBuildInputs = [
+    cffi
+  ]
+  ++ (with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+  ]);
+
+  buildInputs = [ onnxruntime ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
+
+  env = {
+    ORT_DYLIB_PATH = "${onnxruntime}/lib/libonnxruntime${stdenv.hostPlatform.extensions.sharedLibrary}";
+  };
+
+  propagatedBuildInputs = [
+    ast-grep-cli
+    click
+    fastapi
+    httpx
+    litellm
+    opentelemetry-api
+    pydantic
+    rich
+    tiktoken
+    uvicorn
+  ]
+  ++ lib.optionals (lib.versionOlder "3.11" finalAttrs.pythonVersion or "3.11") [ tomli ];
+
+  pythonRelaxDeps = [ "litellm" ];
+
+  doCheck = false;
+
+  pythonImportsCheck = [ "headroom" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Context compression layer for LLM applications — 60–95% fewer tokens";
+    homepage = "https://github.com/chopratejas/headroom";
+    changelog = "https://github.com/chopratejas/headroom/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ch4s3r ];
+    mainProgram = "headroom";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2396,6 +2396,8 @@ with pkgs;
 
   hpccm = with python3Packages; toPythonApplication hpccm;
 
+  headroom = with python3Packages; toPythonApplication headroom-ai;
+
   html-proofer = callPackage ../tools/misc/html-proofer { };
 
   httpie = with python3Packages; toPythonApplication httpie;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1092,6 +1092,8 @@ self: super: with self; {
 
   asserts = callPackage ../development/python-modules/asserts { };
 
+  ast-grep-cli = callPackage ../development/python-modules/ast-grep-cli { };
+
   ast-grep-py = callPackage ../development/python-modules/ast-grep-py { };
 
   asterisk-mbox = callPackage ../development/python-modules/asterisk-mbox { };
@@ -7093,6 +7095,8 @@ self: super: with self; {
   hdmedians = callPackage ../development/python-modules/hdmedians { };
 
   headerparser = callPackage ../development/python-modules/headerparser { };
+
+  headroom-ai = callPackage ../development/python-modules/headroom { };
 
   heapdict = callPackage ../development/python-modules/heapdict { };
 


### PR DESCRIPTION
Context compression layer for LLM applications — reduces token counts 60–95%.
https://github.com/chopratejas/headroom

Also adds `ast-grep-cli` (Python binary wheel wrapping the ast-grep Rust CLI, same source as existing `ast-grep` package) as a required dependency.

## Things done

- Built on platform:
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] Tested basic functionality of all binary files (`headroom --version`)
- [ ] Runs `nixpkgs-review` on this PR.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.

**Notes:**
- Patches `crates/headroom-core/Cargo.toml` to use `ort-load-dynamic` instead of `ort-download-binaries-rustls-tls` (download-at-build-time is incompatible with the nix sandbox).
- Tests disabled: all tests require `fastapi` and other optional proxy dependencies.
- `pythonRelaxDeps = [ "litellm" ]` because nixpkgs ships litellm 1.86.0, headroom requires `>=1.86.2`.