### PR TITLE
pipewalker: init at 1.1-unstable-2026-03-09

### DIFF
--- a/pkgs/by-name/pi/pipewalker/package.nix
+++ b/pkgs/by-name/pi/pipewalker/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  sdl3,
+  ninja,
+  meson,
+  pkg-config,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pipewalker";
+  version = "1.1-unstable-2026-03-09";
+
+  src = fetchFromGitHub {
+    owner = "artemsen";
+    repo = "pipewalker";
+    rev = "8b23069f430a5ac4eabf231cba2247ddc96488b9";
+    hash = "sha256-56gd2A23+byR5/RfXS0LSwqXrA0zN6iWlpYLz+H29z8=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [ sdl3 ];
+
+  mesonFlags = [
+    "-Dversion=${finalAttrs.version}"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Combine components into single circuit puzzle game";
+    homepage = "https://github.com/artemsen/pipewalker/";
+    mainProgram = "pipewalker";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ castorNova2 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add a package of [pipewalker](https://github.com/artemsen/pipewalker/tree/master) which is a puzzle game.

Note: Was able to run on my wayland machine when I set SDL_VIDEODRIVER env var to x11, wayland rendering is failing and only x11 is working.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
