### PR TITLE
cudaPackages.tensorrt: Init 11.0.0

### DIFF
--- a/pkgs/development/cuda-modules/_cuda/manifests/tensorrt/helper.bash
+++ b/pkgs/development/cuda-modules/_cuda/manifests/tensorrt/helper.bash
@@ -11,26 +11,34 @@ mkRedistUrlRelativePath() {
   local -r redistSystem=${3:?}
 
   local -r tensorrtMajorMinorPatchVersion="$(echo "$tensorrtMajorMinorPatchBuildVersion" | cut -d. -f1-3)"
+  local -r tensorrtMajorVersion="$(echo "$tensorrtMajorMinorPatchVersion" | cut -d. -f1)"
   local -r tensorrtMinorVersion="$(echo "$tensorrtMajorMinorPatchVersion" | cut -d. -f2)"
+
+  local tarExtension=""
+  local platformExtension=""
+  case "$tensorrtMajorVersion" in
+  10) tarExtension="tar.gz" && platformExtension="-gnu" ;;
+  *) tarExtension="tar.zst" ;;
+  esac
 
   local archiveDir=""
   local archiveExtension=""
   local osName=""
   local platformName=""
   case "$redistSystem" in
-  linux-aarch64) archiveDir="tars" && archiveExtension="tar.gz" && osName="l4t" && platformName="aarch64-gnu" ;;
+  linux-aarch64) archiveDir="tars" && archiveExtension="$tarExtension" && osName="l4t" && platformName="aarch64$platformExtension" ;;
   linux-sbsa)
-    archiveDir="tars" && archiveExtension="tar.gz" && platformName="aarch64-gnu"
+    archiveDir="tars" && archiveExtension="$tarExtension" && platformName="aarch64$platformExtension"
     # 10.0-10.3 use Ubuntu 22.40
     # 10.4-10.6 use Ubuntu 24.04
     # 10.7+ use Linux
-    case "$tensorrtMinorVersion" in
-    0 | 1 | 2 | 3) osName="Ubuntu-22.04" ;;
-    4 | 5 | 6) osName="Ubuntu-24.04" ;;
+    case "$tensorrtMajorVersion.$tensorrtMinorVersion" in
+    10.0 | 10.1 | 10.2 | 10.3) osName="Ubuntu-22.04" ;;
+    10.4 | 10.5 | 10.6) osName="Ubuntu-24.04" ;;
     *) osName="Linux" ;;
     esac
     ;;
-  linux-x86_64) archiveDir="tars" && archiveExtension="tar.gz" && osName="Linux" && platformName="x86_64-gnu" ;;
+  linux-x86_64) archiveDir="tars" && archiveExtension="$tarExtension" && osName="Linux" && platformName="x86_64$platformExtension" ;;
   windows-x86_64)
     archiveExtension="zip" && platformName="win10"
     # Windows info is different for 10.0.*
@@ -45,8 +53,16 @@ mkRedistUrlRelativePath() {
     ;;
   esac
 
-  local -r relativePath="tensorrt/$tensorrtMajorMinorPatchVersion/$archiveDir/TensorRT-${tensorrtMajorMinorPatchBuildVersion}.${osName}.${platformName}.cuda-${cudaMajorMinorVersion}.${archiveExtension}"
-  echo "$relativePath"
+  case "$tensorrtMajorVersion" in
+  *)
+    local -r relativePath="tensorrt/$tensorrtMajorMinorPatchVersion/$archiveDir/TensorRT-Enterprise-${tensorrtMajorMinorPatchBuildVersion}-${osName}-${platformName}-cuda-${cudaMajorMinorVersion}-Release-external.${archiveExtension}"
+    echo "$relativePath"
+    ;;
+  10)
+    local -r relativePath="tensorrt/$tensorrtMajorMinorPatchVersion/$archiveDir/TensorRT-${tensorrtMajorMinorPatchBuildVersion}.${osName}.${platformName}.cuda-${cudaMajorMinorVersion}.${archiveExtension}"
+    echo "$relativePath"
+    ;;
+  esac
 }
 
 getNixStorePath() {

--- a/pkgs/development/cuda-modules/_cuda/manifests/tensorrt/redistrib_11.0.0.json
+++ b/pkgs/development/cuda-modules/_cuda/manifests/tensorrt/redistrib_11.0.0.json
@@ -1,0 +1,37 @@
+
+{
+    "release_date": "2026-05-26",
+    "release_label": "11.0.0",
+    "release_product": "tensorrt",
+    "tensorrt": {
+        "name": "NVIDIA TensorRT",
+        "license": "TensorRT",
+        "version": "11.0.0.114",
+        "cuda_variant": [
+            "12",
+            "13"
+        ],
+        "linux-sbsa": {
+         "cuda13": {
+            "md5": "2e7da5837d01e2241417807c9b5a4c94",
+            "relative_path": "tensorrt/11.0.0/tars/TensorRT-Enterprise-11.0.0.114-Linux-aarch64-cuda-13.2-Release-external.tar.zst",
+            "sha256": "64dc3c9668f84f9765856aaa3a58d60e8eaca583d16027cce581b53ff11bf9da",
+            "size": "2488916774"
+          }
+        },
+        "linux-x86_64": {
+          "cuda12": {
+            "md5": "81645a39fd79679a4409c1030218f0e0",
+            "relative_path": "tensorrt/11.0.0/tars/TensorRT-Enterprise-11.0.0.114-Linux-x86_64-cuda-12.9-Release-external.tar.zst",
+            "sha256": "dc31c95dcadff91f57205ca82e0623f01912c0419d8b3154f5285ca4b76fbdac",
+            "size": "3454651633"
+          },
+          "cuda13": {
+            "md5": "7c82fb6cb93fad01dba05f9be3314f0d",
+            "relative_path": "tensorrt/11.0.0/tars/TensorRT-Enterprise-11.0.0.114-Linux-x86_64-cuda-13.2-Release-external.tar.zst",
+            "sha256": "ba9ce9c39da5b202bf1a3653002d66fa94e9dbfe5678a1f9fb4d931e6ba5c657",
+            "size": "3649471156"
+          }
+        }
+    }
+}

--- a/pkgs/development/cuda-modules/buildRedist/default.nix
+++ b/pkgs/development/cuda-modules/buildRedist/default.nix
@@ -17,6 +17,7 @@
   srcOnly,
   stdenv,
   stdenvNoCC,
+  zstd,
 }:
 let
   inherit (backendStdenv) hostRedistSystem;
@@ -256,6 +257,7 @@ extendMkDerivation {
             url = mkRedistUrl finalAttrs.passthru.redistName relative_path;
             inherit sha256;
           };
+          nativeBuildInputs = lib.optional (lib.hasSuffix ".zst" relative_path) zstd;
         }
       ) (getPreferredRelease finalAttrs.passthru.supportedReleases);
 

--- a/pkgs/development/cuda-modules/default.nix
+++ b/pkgs/development/cuda-modules/default.nix
@@ -141,6 +141,7 @@ let
           srcOnly
           stdenv
           stdenvNoCC
+          zstd
           ;
         inherit (finalCudaPackages)
           autoAddCudaCompatRunpath

--- a/pkgs/development/cuda-modules/packages/tensorrt-samples/package.nix
+++ b/pkgs/development/cuda-modules/packages/tensorrt-samples/package.nix
@@ -121,6 +121,10 @@ backendStdenv.mkDerivation (finalAttrs: {
         tag = "v10.16";
         hash = "sha256-Wm5oOXxAIpIlwiJKhH0WjgUAuTB9H2xFEVpM/sO36qk=";
       };
+      "11.0.0" = {
+        tag = "v11.0";
+        hash = "sha256-xbGMxCSDTixR0fOoOABWyEVE4S9x031L3i5KQwPu24Y=";
+      };
     }
   );
 
@@ -135,7 +139,8 @@ backendStdenv.mkDerivation (finalAttrs: {
       --replace-fail \
         'find_program(CMAKE_CXX_COMPILER NAMES $ENV{CXX} g++)' \
         '# find_program(CMAKE_CXX_COMPILER NAMES $ENV{CXX} g++)'
-
+  ''
+  + optionalString (lib.versionOlder finalAttrs.version "11.0") ''
     nixLog "patching $PWD/CMakeLists.txt to use find_package(CUDAToolkit) instead of find_package(CUDA)"
     substituteInPlace "$PWD"/CMakeLists.txt \
       --replace-fail \

--- a/pkgs/development/cuda-modules/packages/tensorrt-samples/passthru.nix
+++ b/pkgs/development/cuda-modules/packages/tensorrt-samples/passthru.nix
@@ -20,6 +20,12 @@ in
         url = "https://github.com/NVIDIA/TensorRT/releases/download/v10.14/tensorrt_sample_data_20251106.zip";
         hash = "sha256-IA1pH8idtk/7FD1Tf0hKtyP7A5SW/2ugezyBRluG8yk=";
       };
+
+      sample-data_11_0_0 = {
+        url = "https://github.com/NVIDIA/TensorRT/releases/download/v11.0/tensorrt_sample_data_20260602.zip";
+        hash = "sha256-4SFzdg1fQS/ot1AtF5VsECjgxCGrV9E62S1B7/1g5c4=";
+        stripRoot = false;
+      };
     in
     fetchzip (
       if older "10.14.1" then
@@ -28,6 +34,7 @@ in
         lib.getAttr finalAttrs.version {
           "10.14.1" = sample-data_10_14_1;
           "10.16.1" = sample-data_10_14_1; # Release 10.16 is missing sample data
+          "11.0.0" = sample-data_11_0_0;
         }
     );
 

--- a/pkgs/development/cuda-modules/packages/tensorrt.nix
+++ b/pkgs/development/cuda-modules/packages/tensorrt.nix
@@ -46,7 +46,7 @@ buildRedist (
     ++ optionals (tensorrtOlder "10.14.1") [
       "samples"
     ]
-    ++ [
+    ++ optionals (tensorrtOlder "11.0.0") [
       "static"
       # "stubs" removed in postInstall
     ];


### PR DESCRIPTION
Adds 11.0.0 manifest for TensorRT

## Things done

- [x] Ran TensorRT's [sample Hello World from ONNX](https://github.com/NVIDIA/TensorRT/blob/release/11.0/samples/sampleOnnxMNIST/README.md) on a Jetson Thor
- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
