### PR TITLE
matterbridge: 1.26.0-unstable-2024-08-27 -> unstable-2026-06-05-5000072

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -52,7 +52,7 @@
 
 ### Breaking changes {#sec-nixpkgs-release-26.11-lib-breaking}
 
-- Create the first release note entry in this section!
+- The source of the Matterbridge package (`pkgs.matterbridge`) was switched from https://github.com/42wim/matterbridge to https://github.com/matterbridge-org/matterbridge, as the old repository is not maintained anymore and doesn't work properly. This breaks some configurations made with the older version. Please check whether your configurations still work. There were no changes to the NixOS module itself.
 
 
 ### Deprecations {#sec-nixpkgs-release-26.11-lib-deprecations}

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30499,6 +30499,11 @@
     githubId = 26011724;
     name = "Burim Augustin Berisa";
   };
+  ymarkus = {
+    name = "Yannick Schneider";
+    github = "ymarkus";
+    githubId = 62380378;
+  };
   ymatsiuk = {
     name = "Yurii Matsiuk";
     github = "ymatsiuk";

--- a/pkgs/by-name/ma/matterbridge/package.nix
+++ b/pkgs/by-name/ma/matterbridge/package.nix
@@ -2,28 +2,31 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  nomsteams ? true, # msteams uses a lot of RAM (3GB) while building, without msteams 0,5GB
+  nozulip ? false
 }:
 
 buildGoModule {
   pname = "matterbridge";
-  version = "1.26.0-unstable-2024-08-27";
+  version = "unstable-2026-06-05-5000072";
 
   src = fetchFromGitHub {
-    owner = "42wim";
+    owner = "matterbridge-org";
     repo = "matterbridge";
-    rev = "c4157a4d5b49fce79c80a30730dc7c404bacd663";
-    hash = "sha256-ZnNVDlrkZd/I0NWmQMZzJ3RIruH0ARoVKJ4EyYVdMiw=";
+    rev = "50000724391eec1cf368ba615ee8973dede97a98";
+    hash = "sha256-fgYbHKQytC7Lq6ksHTN7pnqTJF1Rb0D1DB7BCjkjdXw=";
   };
 
   subPackages = [ "." ];
 
-  vendorHash = null;
+  tags = [ "goolm" ] ++ lib.optionals nomsteams [ "nomsteams" ] ++ lib.optionals nozulip [ "nozulip" ];
+
+  vendorHash = "sha256-NsR2Np5QOXiwBsQ7tydU18eC789kpIAkYpMHmrQNmaI=";
 
   meta = {
-    description = "Simple bridge between Mattermost, IRC, XMPP, Gitter, Slack, Discord, Telegram, Rocket.Chat, Hipchat(via xmpp), Matrix and Steam";
-    homepage = "https://github.com/42wim/matterbridge";
-    license = with lib.licenses; [ asl20 ];
-    maintainers = with lib.maintainers; [ ryantm ];
+    description = "Multi-protocol chat bridge (IRC, Matrix, XMPP, Discord, Telegram, etc…) for Mattermost";
+    homepage = "https://github.com/matterbridge-org/matterbridge";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ ymarkus ];
     mainProgram = "matterbridge";
   };
-}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
The old matterbridge repository sits abandoned and hasn't had any commits since 2024. There are a massive amount of open issues which break functionality. There is a "community" fork that is actively maintained and which I have been using for some time now.
BTW: I'm happy to say, I finally have time to be a maintainer again! 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
