### PR TITLE
home-assistant-custom-components.blueprints-updater: use httpx optional-dependency to get h2

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/blueprints-updater/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/blueprints-updater/package.nix
@@ -2,7 +2,7 @@
   lib,
   buildHomeAssistantComponent,
   fetchFromGitHub,
-  h2,
+  httpx,
   home-assistant,
   pytest-cov-stub,
   pytest-homeassistant-custom-component,
@@ -34,11 +34,7 @@ buildHomeAssistantComponent rec {
       --replace-fail '"--timeout=60",' ""
   '';
 
-  dependencies = [
-    # Uncodumented, but otherwise the home-assistant helpers/httpx_client.py fails like:
-    # ImportError: Using http2=True, but the 'h2' package is not installed. Make sure to install httpx using `pip install httpx[http2]`.
-    h2
-  ];
+  dependencies = httpx.optional-dependencies.http2;
 
   nativeCheckInputs = [
     home-assistant


### PR DESCRIPTION
Diff: https://github.com/luuquangvu/blueprints-updater/compare/2.7.2...2.7.3

Changelog: https://github.com/luuquangvu/blueprints-updater/releases/tag/2.7.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
