### PR TITLE
supercollider: re-enable QtWebEngine and enable compiler optimizations

### DIFF
--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -65,6 +65,7 @@ stdenv.mkDerivation rec {
     qt6.qtbase
     qt6.qtwebsockets
     qt6.qtwayland
+    qt6.qtwebengine
     readline
   ]
   ++ lib.optional (!stdenv.hostPlatform.isDarwin) alsa-lib;
@@ -74,7 +75,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DSC_WII=OFF"
     "-DSC_EL=${if useSCEL then "ON" else "OFF"}"
-    (lib.cmakeBool "SC_USE_QTWEBENGINE" false)
+    (lib.cmakeBool "SC_USE_QTWEBENGINE" true)
   ];
 
   passthru = {

--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -16,6 +16,7 @@
   libxt,
   readline,
   useSCEL ? false,
+  useQtWebEngine ? true,
   emacs,
   gitUpdater,
   supercollider-with-plugins,
@@ -76,7 +77,7 @@ stdenv.mkDerivation rec {
     "-DSC_WII=OFF"
     "-DCMAKE_BUILD_TYPE=Release"
     "-DSC_EL=${if useSCEL then "ON" else "OFF"}"
-    (lib.cmakeBool "SC_USE_QTWEBENGINE" true)
+    (lib.cmakeBool "SC_USE_QTWEBENGINE" useQtWebEngine)
   ];
 
   passthru = {

--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -75,7 +75,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DSC_WII=OFF"
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DSC_EL=${if useSCEL then "ON" else "OFF"}"
     (lib.cmakeBool "SC_USE_QTWEBENGINE" useQtWebEngine)
   ];

--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -74,6 +74,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DSC_WII=OFF"
+    "-DCMAKE_BUILD_TYPE=Release"
     "-DSC_EL=${if useSCEL then "ON" else "OFF"}"
     (lib.cmakeBool "SC_USE_QTWEBENGINE" true)
   ];

--- a/pkgs/development/interpreters/supercollider/plugins/sc3-plugins.nix
+++ b/pkgs/development/interpreters/supercollider/plugins/sc3-plugins.nix
@@ -6,6 +6,7 @@
   cmake,
   supercollider,
   fftw,
+  fftwFloat,
   gitUpdater,
 }:
 
@@ -25,6 +26,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     supercollider
     fftw
+    fftwFloat  # builds without this will return an error message about no FFTW3F-INCLUDE-DIR
   ];
 
   cmakeFlags = [

--- a/pkgs/development/interpreters/supercollider/plugins/sc3-plugins.nix
+++ b/pkgs/development/interpreters/supercollider/plugins/sc3-plugins.nix
@@ -26,11 +26,12 @@ stdenv.mkDerivation rec {
   buildInputs = [
     supercollider
     fftw
-    fftwFloat  # builds without this will return an error message about no FFTW3F-INCLUDE-DIR
+    fftwFloat # builds without this will return an error message about no FFTW3F-INCLUDE-DIR
   ];
 
   cmakeFlags = [
     "-DSC_PATH=${supercollider}/include/SuperCollider"
+    "-DCMAKE_BUILD_TYPE=Release"
     "-DSUPERNOVA=ON"
   ];
 


### PR DESCRIPTION
SuperCollider uses QtWebEngine in order to browse the language's documentation on a local machine—this is critical for people using the language, since the online documentation may not have access to the custom UGens or classes that people may have on their computer. Compilation with QtWebEngine was removed around eight months ago, and this commit re-enables it.

I have also enabled compiler optimizations, since they are not on by default in SuperCollider, and while they're probably not completely critical, they do likely help with performance.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
