### PR TITLE
libssh: Add optional support for gssapi

### DIFF
--- a/pkgs/by-name/li/libssh/package.nix
+++ b/pkgs/by-name/li/libssh/package.nix
@@ -8,6 +8,9 @@
   openssl,
   libsodium,
 
+  withGssapi ? false,
+  krb5,
+
   # for passthru.tests
   ffmpeg,
   sshping,
@@ -28,20 +31,29 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ];
 
+  strictDeps = true;
+
+  __structuredAttrs = true;
+
   postPatch = ''
     # Fix headers to use libsodium instead of NaCl
     sed -i 's,nacl/,sodium/,g' ./include/libssh/curve25519.h src/curve25519.c
   '';
 
-  # Don’t build examples, which are not installed and require additional dependencies not
-  # included in `buildInputs` such as libx11.
-  cmakeFlags = [ "-DWITH_EXAMPLES=OFF" ];
+  cmakeFlags = [
+    # Don’t build examples, which are not installed and require additional dependencies not
+    # included in `buildInputs` such as libx11.
+    "-DWITH_EXAMPLES=OFF"
+
+    (lib.cmakeBool "USE_GSSAPI" withGssapi)
+  ];
 
   buildInputs = [
     zlib
     openssl
     libsodium
-  ];
+  ]
+  ++ lib.optional withGssapi krb5;
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/li/libsshWithGssapi/package.nix
+++ b/pkgs/by-name/li/libsshWithGssapi/package.nix
@@ -1,0 +1,3 @@
+{ libssh }:
+
+libssh.override { withGssapi = true; }


### PR DESCRIPTION
Similar to the openssh package, I am introducing a new package, libsshWithGssapi, which enables the gssapi flag


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
