### PR TITLE
nixos/networkmanager: create the correct configured keyfile.path

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -24,6 +24,9 @@ let
       rc-manager = if config.networking.resolvconf.enable then "resolvconf" else "unmanaged";
     };
     keyfile = {
+      # NM's compiled-in default; made explicit so the tmpfiles rule below
+      # can follow it when the user redirects the keyfile store elsewhere.
+      path = "/etc/NetworkManager/system-connections";
       unmanaged-devices = if cfg.unmanaged == [ ] then null else lib.concatStringsSep ";" cfg.unmanaged;
     };
     logging = {
@@ -602,7 +605,7 @@ in
     systemd.packages = packages;
 
     systemd.tmpfiles.settings.networkmanager = {
-      "/etc/NetworkManager/system-connections".d = {
+      ${configAttrs.keyfile.path}.d = {
         mode = "0700";
         user = "root";
         group = "root";

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -601,13 +601,27 @@ in
 
     systemd.packages = packages;
 
-    systemd.tmpfiles.rules = [
-      "d /etc/NetworkManager/system-connections 0700 root root -"
-      "d /var/lib/misc 0755 root root -" # for dnsmasq.leases
+    systemd.tmpfiles.settings.networkmanager = {
+      "/etc/NetworkManager/system-connections".d = {
+        mode = "0700";
+        user = "root";
+        group = "root";
+      };
+      # for dnsmasq.leases
+      "/var/lib/misc".d = {
+        mode = "0755";
+        user = "root";
+        group = "root";
+      };
       # ppp isn't able to mkdir that directory at runtime
-      "d /run/pppd/lock 0700 root root -"
-    ]
-    ++ pluginTmpfilesRules;
+      "/run/pppd/lock".d = {
+        mode = "0700";
+        user = "root";
+        group = "root";
+      };
+    };
+
+    systemd.tmpfiles.rules = pluginTmpfilesRules;
 
     systemd.services.NetworkManager = {
       wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION
The tmpfiles rule that pre-creates the keyfile store directory was
hardcoded to `/etc/NetworkManager/system-connections`, while
`networking.networkmanager.settings.keyfile.path` can point elsewhere.

First commit converts the module's tmpfiles rules to the structured
`systemd.tmpfiles.settings` format, no functional change.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
