### PR TITLE
beamPackages.elixir-ls: 0.30.0 -> 0.31.0

### DIFF
--- a/pkgs/development/beam-modules/elixir-ls/default.nix
+++ b/pkgs/development/beam-modules/elixir-ls/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "elixir-ls";
-  version = "0.30.0";
+  version = "0.31.0";
 
   src = fetchFromGitHub {
     owner = "elixir-lsp";
     repo = "elixir-ls";
     rev = "v${version}";
-    hash = "sha256-GtkFuof60cOTlHuhcwCnIVtGx6KlHrcazTa/UjAIGAQ=";
+    hash = "sha256-AKJJyQUCZSsFpqVPtwL7+arCOzDC0251MwooEM8JFM4=";
   };
 
   patches = [

--- a/pkgs/development/beam-modules/elixir-ls/launch.sh.patch
+++ b/pkgs/development/beam-modules/elixir-ls/launch.sh.patch
@@ -1,8 +1,8 @@
 diff --git c/scripts/launch.sh w/scripts/launch.sh
-index 524f2294..bbea062d 100755
+index d5247535..bbea062d 100755
 --- c/scripts/launch.sh
 +++ w/scripts/launch.sh
-@@ -1,114 +1,4 @@
+@@ -1,119 +1,4 @@
 -#!/bin/sh
 -# Actual launcher. This does the hard work of figuring out the best way
 -# to launch the language server or the debug adapter.
@@ -98,7 +98,12 @@ index 524f2294..bbea062d 100755
 -        # Look for mise executable
 -        if command -v mise >/dev/null 2>&1; then
 -            >&2 echo "mise executable found at $(command -v mise), activating"
--            eval "$($(command -v mise) env -s "$preferred_shell")"
+-            # mise env does not support all shells (e.g. nushell); fall back to bash
+-            case "$preferred_shell" in
+-              bash|zsh|fish|elvish|xonsh|pwsh) mise_shell="$preferred_shell" ;;
+-              *) mise_shell="bash" ;;
+-            esac
+-            eval "$($(command -v mise) env -s "$mise_shell")"
 -            export_stdlib_path "mise which elixir"
 -        else
 -            >&2 echo "mise not found"
@@ -115,13 +120,13 @@ index 524f2294..bbea062d 100755
 -    fi
 -fi
 +#!/usr/bin/env bash
- 
+
  # In case that people want to tweak the path, which Elixir to use, or
  # whatever prior to launching the language server or the debug adapter, we
-@@ -127,12 +17,8 @@ fi
+@@ -132,12 +17,8 @@ fi
  # script so we can correctly configure the Erlang library path to
  # include the local .ez files, and then do what we were asked to do.
- 
+
 -if [ -z "${ELS_INSTALL_PREFIX}" ]; then
 -  SCRIPT=$(readlink_f "$0")
 -  SCRIPTPATH=$(dirname "$SCRIPT")
@@ -130,18 +135,18 @@ index 524f2294..bbea062d 100755
 -fi
 +SCRIPT=$(readlink -f "$0")
 +SCRIPTPATH=$(dirname "$SCRIPT")/../scripts
- 
+
  # Unset MIX_OS_DEPS_COMPILE_PARTITION_COUNT as it pollutes stdout
  # breaking LSP protocol. See https://github.com/elixir-lsp/elixir-ls/issues/1195
-@@ -141,19 +27,16 @@ unset MIX_OS_DEPS_COMPILE_PARTITION_COUNT
+@@ -146,19 +27,16 @@ unset MIX_OS_DEPS_COMPILE_PARTITION_COUNT
  export MIX_ENV=prod
  # Mix.install prints to stdout and reads from stdin
  # we need to make sure it doesn't interfere with LSP/DAP
 -echo "" | elixir "$SCRIPTPATH/quiet_install.exs" >/dev/null || exit 1
 +echo "" | @elixir@/bin/elixir "$SCRIPTPATH/quiet_install.exs" >/dev/null || exit 1
- 
+
  default_erl_opts="-kernel standard_io_encoding latin1 +sbwt none +sbwtdcpu none +sbwtdio none"
- 
+
 -if [ "$preferred_shell" = "bash" ]; then
 -  . "$dirname/exec.bash"
 -elif [ "$preferred_shell" = "zsh" ]; then


### PR DESCRIPTION
Changelog: https://github.com/elixir-lsp/elixir-ls/releases/tag/v0.31.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
