### PR TITLE
[Backport release-26.05] taler-wallet-core: update pnpm & fetcher versions

### DIFF
--- a/pkgs/by-name/ta/taler-wallet-core/package.nix
+++ b/pkgs/by-name/ta/taler-wallet-core/package.nix
@@ -8,7 +8,7 @@
   srcOnly,
   removeReferencesTo,
   nodejs_24,
-  pnpm_9,
+  pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
   python3,
@@ -18,7 +18,7 @@
 }:
 let
   nodeSources = srcOnly nodejs_24;
-  pnpm' = pnpm_9.override { nodejs = nodejs_24; };
+  pnpm' = pnpm_11.override { nodejs = nodejs_24; };
   esbuild' = esbuild.override {
     buildGoModule =
       args:
@@ -55,8 +55,8 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm';
-    fetcherVersion = 3;
-    hash = "sha256-W5C2JVFbEccf4b+ppeEJ68au/2Tqfsry7ri6Qi1M50k=";
+    fetcherVersion = 4;
+    hash = "sha256-ZoxAZ5f3Szz2goGOE5yn/aCZ5fuhDt1owZ/o1kvX7d0=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
(cherry picked from commit c5059c32b6c014e9d03c12121768942f2641af28)

Manual backport of https://github.com/NixOS/nixpkgs/pull/529956, to fix conflict with https://github.com/NixOS/nixpkgs/commit/36b6c90e6b2a4189806cc4859ce9756a522cfbed
Reason for packporting: pnpm 9 EOL (tracking: https://github.com/NixOS/nixpkgs/issues/529285)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
