### PR TITLE
netbox_4_6: init at 4.6.8

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -205,6 +205,10 @@
 
 - `chatgpt` has been retargeted to OpenAI's new ChatGPT desktop app, while the previous app has been renamed to `chatgpt-classic`.
 
+- NetBox was updated to `>= 4.6.8`. Have a look at the breaking changes
+  of the [4.6 release](https://github.com/netbox-community/netbox/releases/tag/v4.6.0),
+  make the required changes to your database, if needed, then upgrade by setting `services.netbox.package = pkgs.netbox_4_6;` in your configuration.
+
 ## Other Notable Changes {#sec-release-26.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/services/web-apps/netbox.nix
+++ b/nixos/modules/services/web-apps/netbox.nix
@@ -434,11 +434,12 @@ in
     package = lib.mkOption {
       type = types.package;
       default =
-        if lib.versionAtLeast config.system.stateVersion "26.05" then pkgs.netbox_4_5 else pkgs.netbox_4_4;
+        if lib.versionAtLeast config.system.stateVersion "26.11" then pkgs.netbox_4_6 else pkgs.netbox_4_5;
       defaultText = lib.literalExpression ''
-        if lib.versionAtLeast config.system.stateVersion "26.05"
-        then pkgs.netbox_4_5
-        else pkgs.netbox_4_4;
+        if lib.versionAtLeast config.system.stateVersion "26.11" then
+          pkgs.netbox_4_6
+        else
+          pkgs.netbox_4_5;
       '';
       description = ''
         NetBox package to use.

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1156,6 +1156,7 @@ in
   netbox-upgrade = runTest ./web-apps/netbox-upgrade.nix;
   netbox_4_4 = handleTest ./web-apps/netbox/default.nix { netbox = pkgs.netbox_4_4; };
   netbox_4_5 = handleTest ./web-apps/netbox/default.nix { netbox = pkgs.netbox_4_5; };
+  netbox_4_6 = handleTest ./web-apps/netbox/default.nix { netbox = pkgs.netbox_4_6; };
   netdata = runTest ./netdata.nix;
   netfoil = runTest ./netfoil.nix;
   netplan = runTest ./netplan.nix;

--- a/nixos/tests/web-apps/netbox-upgrade.nix
+++ b/nixos/tests/web-apps/netbox-upgrade.nix
@@ -1,7 +1,7 @@
 { lib, pkgs, ... }:
 let
-  oldNetbox = "netbox_4_4";
-  newNetbox = "netbox_4_5";
+  oldNetbox = "netbox_4_5";
+  newNetbox = "netbox_4_6";
 
   apiVersion =
     version:

--- a/pkgs/by-name/ne/netbox_4_6/custom-static-root.patch
+++ b/pkgs/by-name/ne/netbox_4_6/custom-static-root.patch
@@ -1,0 +1,13 @@
+diff --git a/netbox/netbox/settings.py b/netbox/netbox/settings.py
+index f334a73a7..8e8d76f0e 100644
+--- a/netbox/netbox/settings.py
++++ b/netbox/netbox/settings.py
+@@ -604,7 +604,7 @@ X_FRAME_OPTIONS = 'SAMEORIGIN'
+ 
+ # Static files (CSS, JavaScript, Images)
+ # STATIC_ROOT is deliberately not a configuration parameter; static files are collected to <NETBOX_ROOT>/static.
+-STATIC_ROOT = os.path.join(NETBOX_ROOT, 'static')
++STATIC_ROOT = getattr(configuration, 'STATIC_ROOT', os.path.join(NETBOX_ROOT, 'static')).rstrip('/')
+ STATIC_URL = f'/{BASE_PATH}static/'
+ STATICFILES_DIRS = (
+     os.path.join(BASE_DIR, 'project-static', 'dist'),

--- a/pkgs/by-name/ne/netbox_4_6/package.nix
+++ b/pkgs/by-name/ne/netbox_4_6/package.nix
@@ -10,26 +10,28 @@
 let
   py = python3.override {
     self = py;
-    packageOverrides = _final: prev: { django = prev.django_5; };
+    packageOverrides = _final: prev: { django = prev.django_6; };
   };
 
   extraBuildInputs = plugins py.pkgs;
 in
-py.pkgs.buildPythonApplication rec {
+py.pkgs.buildPythonApplication (finalAttrs: {
+  __structuredAttrs = true;
+
   pname = "netbox";
-  version = "4.5.10";
+  version = "4.6.8";
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "netbox-community";
     repo = "netbox";
-    tag = "v${version}";
-    hash = "sha256-ilhjRWoV2Z1e1sAiRT9PEGhhnznkKRp5RnV3lUdnBRQ=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-fhEcQBYL5R9Tv9CpAf3Ce1oIzsXCjtH5j+dP9sD6kdg=";
   };
 
   patches = [
     ./custom-static-root.patch
-    # TODO: check if change is applied upstream before upgrading to NetBox v4.6
+    # TODO: remove before upgrading to NetBox v4.7
     (fetchpatch2 {
       name = "upgrade-django-tables2-v3.0.patch";
       url = "https://github.com/netbox-community/netbox/commit/d57346d9f0eef8126eafcd5033ea43864faeaf0d.patch";
@@ -101,7 +103,7 @@ py.pkgs.buildPythonApplication rec {
 
   postBuild = ''
     PYTHONPATH=$PYTHONPATH:netbox/
-    ${py.interpreter} -m mkdocs build
+    ${py.pythonOnBuildForHost.interpreter} -m mkdocs build
   '';
 
   installPhase = ''
@@ -115,10 +117,10 @@ py.pkgs.buildPythonApplication rec {
   passthru = {
     python = py;
     # PYTHONPATH of all dependencies used by the package
-    pythonPath = py.pkgs.makePythonPath dependencies;
+    pythonPath = py.pkgs.makePythonPath finalAttrs.passthru.dependencies;
     inherit (py.pkgs) gunicorn;
     tests = {
-      netbox = nixosTests.netbox_4_5;
+      netbox = nixosTests.netbox_4_6;
       inherit (nixosTests) netbox-upgrade;
     };
     updateScript = nix-update-script { };
@@ -135,16 +137,13 @@ py.pkgs.buildPythonApplication rec {
 
   meta = {
     homepage = "https://github.com/netbox-community/netbox";
-    changelog = "https://github.com/netbox-community/netbox/blob/${src.tag}/docs/release-notes/version-${lib.versions.majorMinor version}.md";
+    changelog = "https://github.com/netbox-community/netbox/blob/${finalAttrs.src.tag}/docs/release-notes/version-${lib.versions.majorMinor finalAttrs.version}.md";
     description = "IP address management (IPAM) and data center infrastructure management (DCIM) tool";
     mainProgram = "netbox";
     license = lib.licenses.asl20;
-    knownVulnerabilities = [
-      "Netbox Version ${version} is EOL; please upgrade by following the current release notes instructions"
-    ];
     maintainers = with lib.maintainers; [
       minijackson
       transcaffeine
     ];
   };
-}
+})

--- a/pkgs/by-name/ne/netbox_4_6/plugins/netbox-attachments/package.nix
+++ b/pkgs/by-name/ne/netbox_4_6/plugins/netbox-attachments/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  python,
+  netbox,
+  django,
+  netaddr,
+}:
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "netbox-attachments";
+  version = "11.2.3";
+  pyproject = true;
+
+  disabled = python.pythonVersion != netbox.python.pythonVersion;
+
+  src = fetchFromGitHub {
+    owner = "Kani999";
+    repo = "netbox-attachments";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-zuRwUKYywiyIm7qvOUmbxYfct+ZR+GmaQ4oxf3gMVY4=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [
+    netbox
+    django
+    netaddr
+  ];
+
+  preFixup = ''
+    export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH
+  '';
+
+  pythonImportsCheck = [ "netbox_attachments" ];
+
+  passthru.pluginName = "netbox_attachments";
+
+  meta = {
+    description = "Plugin to manage attachments for any model";
+    homepage = "https://github.com/Kani999/netbox-attachments";
+    changelog = "https://github.com/Kani999/netbox-attachments/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/by-name/ne/netbox_4_6/plugins/netbox-bgp/package.nix
+++ b/pkgs/by-name/ne/netbox_4_6/plugins/netbox-bgp/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  netbox,
+  python,
+}:
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "netbox-bgp";
+  version = "0.19.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "netbox-community";
+    repo = "netbox-bgp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6LZLsUPC9L9L19KeXJilJvmZYcl6YwqysGO8nFAUmcI=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ netbox ];
+
+  preFixup = ''
+    export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH
+  '';
+
+  dontUsePythonImportsCheck = python.pythonVersion != netbox.python.pythonVersion;
+  pythonImportsCheck = [ "netbox_bgp" ];
+
+  passthru.pluginName = "netbox_bgp";
+
+  meta = {
+    description = "NetBox plugin for BGP related objects documentation";
+    homepage = "https://github.com/netbox-community/netbox-bgp";
+    changelog = "https://github.com/netbox-community/netbox-bgp/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/by-name/ne/netbox_4_6/plugins/netbox-config-backup/package.nix
+++ b/pkgs/by-name/ne/netbox_4_6/plugins/netbox-config-backup/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  netbox,
+  python,
+  netbox-napalm-plugin,
+  pydriller,
+}:
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "netbox-config-backup";
+  version = "2.2.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "DanSheps";
+    repo = "netbox-config-backup";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-PT7/RCpB7SAinQ8McQV59b9ouqqUSoEqEj0ultL37cs=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonRemoveDeps = [ "uuid" ]; # python builtin
+
+  dependencies = [
+    netbox-napalm-plugin
+    pydriller
+  ];
+
+  nativeCheckInputs = [ netbox ];
+
+  preFixup = ''
+    export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH
+  '';
+
+  dontUsePythonImportsCheck = python.pythonVersion != netbox.python.pythonVersion;
+  pythonImportsCheck = [ "netbox_config_backup" ];
+
+  passthru.pluginName = "netbox_config_backup";
+
+  meta = {
+    description = "NetBox plugin for configuration backups using napalm";
+    homepage = "https://github.com/DanSheps/netbox-config-backup";
+    changelog = "https://github.com/DanSheps/netbox-config-backup/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/by-name/ne/netbox_4_6/plugins/netbox-contextmenus/package.nix
+++ b/pkgs/by-name/ne/netbox_4_6/plugins/netbox-contextmenus/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+}:
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "netbox-contextmenus";
+  version = "1.4.14";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "PieterL75";
+    repo = "netbox_contextmenus";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-YqyxZaHKXhMLDdBTAAKQsCBBSXikxBgcOvXEfa6f+0Y=";
+  };
+
+  build-system = [ setuptools ];
+
+  # pythonImportsCheck fails due to improperly configured django app
+
+  passthru.pluginName = "netbox_contextmenus";
+
+  meta = {
+    description = "Netbox plugin to add context buttons to the links, making navigating less clicky";
+    homepage = "https://github.com/PieterL75/netbox_contextmenus/";
+    changelog = "https://github.com/PieterL75/netbox_contextmenus/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/by-name/ne/netbox_4_6/plugins/netbox-contract/package.nix
+++ b/pkgs/by-name/ne/netbox_4_6/plugins/netbox-contract/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  python,
+  fetchFromGitHub,
+  setuptools,
+  python-dateutil,
+  drf-yasg,
+  netbox,
+  netaddr,
+}:
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "netbox-contract";
+  version = "2.4.6";
+  pyproject = true;
+
+  disabled = python.pythonVersion != netbox.python.pythonVersion;
+
+  src = fetchFromGitHub {
+    owner = "mlebreuil";
+    repo = "netbox-contract";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-e8DYjU2UtlWu044e4b5eJWOA/fXDRKLl5AVtaepG0sg=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    python-dateutil
+    drf-yasg
+  ];
+
+  # running tests requires initialized django project
+  nativeCheckInputs = [
+    netbox
+    netaddr
+  ];
+
+  preFixup = ''
+    export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH
+  '';
+
+  pythonImportsCheck = [ "netbox_contract" ];
+
+  passthru.pluginName = "netbox_contract";
+
+  meta = {
+    description = "Contract plugin for netbox";
+    homepage = "https://github.com/mlebreuil/netbox-contract";
+    changelog = "https://github.com/mlebreuil/netbox-contract/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/by-name/ne/netbox_4_6/plugins/netbox-custom-objects/package.nix
+++ b/pkgs/by-name/ne/netbox_4_6/plugins/netbox-custom-objects/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  netbox,
+  python,
+}:
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "netbox-custom-objects";
+  version = "0.6.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "netboxlabs";
+    repo = "netbox-custom-objects";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-HnA2CJL0EOJctQpsu/G+9fULBIa8rrrYNiT0aaDw/rI=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ netbox ];
+
+  preFixup = ''
+    export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH
+  '';
+
+  dontUsePythonImportsCheck = python.pythonVersion != netbox.python.pythonVersion;
+  dontCheckPythonMetadata = true;
+  pythonImportsCheck = [ "netbox_custom_objects" ];
+  passthru.pluginName = "netbox_custom_objects";
+
+  meta = {
+    description = "NetBox plugin to create new object types";
+    homepage = "https://github.com/netboxlabs/netbox-custom-objects";
+    changelog = "https://github.com/netboxlabs/netbox-custom-objects/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.netboxLimitedUse;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/by-name/ne/netbox_4_6/plugins/netbox-data-flows/package.nix
+++ b/pkgs/by-name/ne/netbox_4_6/plugins/netbox-data-flows/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  netbox,
+  python,
+}:
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "netbox-data-flows";
+  version = "1.5.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Alef-Burzmali";
+    repo = "netbox-data-flows";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-LrClGEmei1IHK/mv0MkZQnEzbH4afg46W5miMLM9a0g=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ netbox ];
+
+  preFixup = ''
+    export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH
+  '';
+
+  dontUsePythonImportsCheck = python.pythonVersion != netbox.python.pythonVersion;
+  pythonImportsCheck = [ "netbox_data_flows" ];
+
+  passthru.pluginName = "netbox_data_flows";
+
+  meta = {
+    description = "NetBox plugin to document data flows between systems and applications";
+    homepage = "https://github.com/Alef-Burzmali/netbox-data-flows";
+    changelog = "https://github.com/Alef-Burzmali/netbox-data-flows/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/by-name/ne/netbox_4_6/plugins/netbox-dns/package.nix
+++ b/pkgs/by-name/ne/netbox_4_6/plugins/netbox-dns/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  dnspython,
+}:
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "netbox-plugin-dns";
+  version = "1.5.10";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "peteeckel";
+    repo = "netbox-plugin-dns";
+    tag = finalAttrs.version;
+    hash = "sha256-wxTW/qiwp+1CXUeCDJnllEW2oCTjlFVUot7JfWPooaw=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    dnspython
+  ];
+
+  # pythonImportsCheck fails due to improperly configured django app
+
+  passthru.pluginName = "netbox_dns";
+
+  meta = {
+    description = "Netbox plugin for managing DNS data";
+    homepage = "https://github.com/peteeckel/netbox-plugin-dns";
+    changelog = "https://github.com/peteeckel/netbox-plugin-dns/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/by-name/ne/netbox_4_6/plugins/netbox-documents/package.nix
+++ b/pkgs/by-name/ne/netbox_4_6/plugins/netbox-documents/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  drf-extra-fields,
+  python,
+  netbox,
+}:
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "netbox-documents";
+  version = "0.8.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jasonyates";
+    repo = "netbox-documents";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hupJ5gbRj/70oslEosob4gT2y2le5vOrq30t3NWl0nQ=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ drf-extra-fields ];
+
+  nativeCheckInputs = [ netbox ];
+
+  preFixup = ''
+    export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH
+  '';
+
+  dontUsePythonImportsCheck = python.pythonVersion != netbox.python.pythonVersion;
+  pythonImportsCheck = [ "netbox_documents" ];
+
+  passthru.pluginName = "netbox_documents";
+
+  meta = {
+    description = "Plugin designed to faciliate the storage of site, circuit, device type and device specific documents within NetBox";
+    homepage = "https://github.com/jasonyates/netbox-documents";
+    changelog = "https://github.com/jasonyates/netbox-documents/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/by-name/ne/netbox_4_6/plugins/netbox-floorplan-plugin/package.nix
+++ b/pkgs/by-name/ne/netbox_4_6/plugins/netbox-floorplan-plugin/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  netbox,
+  django,
+  netaddr,
+  python,
+}:
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "netbox-floorplan-plugin";
+  version = "0.9.2";
+  pyproject = true;
+
+  disabled = python.pythonVersion != netbox.python.pythonVersion;
+
+  src = fetchFromGitHub {
+    owner = "netbox-community";
+    repo = "netbox-floorplan-plugin";
+    tag = finalAttrs.version;
+    hash = "sha256-I7cz0IONU+RESCA8C57Yxg5ieheryZ31ed9N9OxSeLA=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [
+    netbox
+    django
+    netaddr
+  ];
+
+  preFixup = ''
+    export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH
+  '';
+
+  dontUsePythonImportsCheck = python.pythonVersion != netbox.python.pythonVersion;
+  pythonImportsCheck = [ "netbox_floorplan" ];
+
+  passthru.pluginName = "netbox_floorplan";
+
+  meta = {
+    description = "Netbox plugin providing floorplan mapping capability for locations and sites";
+    homepage = "https://github.com/netbox-community/netbox-floorplan-plugin";
+    changelog = "https://github.com/netbox-community/netbox-floorplan-plugin/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.lgpl3;
+    maintainers = with lib.maintainers; [ cobalt ];
+  };
+})

--- a/pkgs/by-name/ne/netbox_4_6/plugins/netbox-interface-synchronization/package.nix
+++ b/pkgs/by-name/ne/netbox_4_6/plugins/netbox-interface-synchronization/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  django,
+  netaddr,
+  numpy,
+  psycopg,
+  requests,
+
+  # tests
+  netbox,
+  python,
+}:
+
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "netbox-interface-synchronization";
+  version = "4.5.8";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "NetTech2001";
+    repo = "netbox-interface-synchronization";
+    tag = finalAttrs.version;
+    hash = "sha256-DZ1xOfHop/rASWbBzVILVqvll94tQM7tRiSXwOo/QQI=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    django
+    netaddr
+    requests
+    numpy
+    psycopg # not specified in pyproject.toml, but required at import time
+  ];
+
+  # netbox is required for the pythonImportsCheck; plugin does not provide unit tests
+  nativeCheckInputs = [ netbox ];
+
+  preFixup = ''
+    export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH
+  '';
+
+  dontUsePythonImportsCheck = python.pythonVersion != netbox.python.pythonVersion;
+  pythonImportsCheck = [ "netbox_interface_synchronization" ];
+
+  passthru.pluginName = "netbox_interface_synchronization";
+
+  meta = {
+    description = "Netbox plugin to compare and synchronize interfaces between devices and device types";
+    homepage = "https://github.com/NetTech2001/netbox-interface-synchronization";
+    changelog = "https://github.com/NetTech2001/netbox-interface-synchronization/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/by-name/ne/netbox_4_6/plugins/netbox-inventory/package.nix
+++ b/pkgs/by-name/ne/netbox_4_6/plugins/netbox-inventory/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  netbox,
+  python,
+}:
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "netbox-inventory";
+  version = "2.6.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ArnesSI";
+    repo = "netbox-inventory";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NTo9WYkjY4BdE3gSkzNKxjHiWVnLQGVZQ5s8e9u3VY0=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ netbox ];
+
+  preFixup = ''
+    export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH
+  '';
+
+  dontUsePythonImportsCheck = python.pythonVersion != netbox.python.pythonVersion;
+  pythonImportsCheck = [ "netbox_inventory" ];
+
+  passthru.pluginName = "netbox_inventory";
+
+  meta = {
+    description = "NetBox plugin to manage hardware inventory";
+    homepage = "https://github.com/ArnesSI/netbox-inventory";
+    changelog = "https://github.com/ArnesSI/netbox-inventory/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/by-name/ne/netbox_4_6/plugins/netbox-lifecycle/package.nix
+++ b/pkgs/by-name/ne/netbox_4_6/plugins/netbox-lifecycle/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  netbox,
+  python,
+  django-polymorphic,
+}:
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "netbox-lifecycle";
+  version = "1.1.9";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "DanSheps";
+    repo = "netbox-lifecycle";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-iCBlwhaf6IFdni7FQyRPtRJVwt04w0Jc4R0CeQlIWCY=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ netbox ];
+
+  preFixup = ''
+    export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH
+  '';
+
+  dontUsePythonImportsCheck = python.pythonVersion != netbox.python.pythonVersion;
+  pythonImportsCheck = [ "netbox_lifecycle" ];
+
+  dependencies = [ django-polymorphic ];
+
+  passthru.pluginName = "netbox_lifecycle";
+
+  meta = {
+    description = "NetBox plugin for managing Hardware EOL/EOS, and Support Contracts";
+    homepage = "https://github.com/DanSheps/netbox-lifecycle";
+    changelog = "https://github.com/DanSheps/netbox-lifecycle/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/by-name/ne/netbox_4_6/plugins/netbox-lists/package.nix
+++ b/pkgs/by-name/ne/netbox_4_6/plugins/netbox-lists/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  netbox,
+  python,
+}:
+
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "netbox-lists";
+  version = "4.0.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "devon-mar";
+    repo = "netbox-lists";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RRUuvoeB3xfqlZr1v1zpRdmVZK9av52ZsADOh9s4toQ=";
+  };
+
+  build-system = [ hatchling ];
+
+  nativeCheckInputs = [ netbox ];
+
+  preFixup = ''
+    export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH
+  '';
+
+  dontUsePythonImportsCheck = python.pythonVersion != netbox.python.pythonVersion;
+  pythonImportsCheck = [ "netbox_lists" ];
+
+  passthru.pluginName = "netbox_lists";
+
+  meta = {
+    description = "NetBox plugin to generate IP and prefix lists. Integrates with Ansible, Terraform, Prometheus, Oxidized and more";
+    homepage = "https://github.com/devon-mar/netbox-lists";
+    changelog = "https://github.com/devon-mar/netbox-lists/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/by-name/ne/netbox_4_6/plugins/netbox-napalm-plugin/package.nix
+++ b/pkgs/by-name/ne/netbox_4_6/plugins/netbox-napalm-plugin/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  netbox,
+  python,
+  napalm,
+  django,
+}:
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "netbox-napalm-plugin";
+  version = "0.3.5";
+  pyproject = true;
+
+  disabled = python.pythonVersion != netbox.python.pythonVersion;
+
+  src = fetchFromGitHub {
+    owner = "netbox-community";
+    repo = "netbox-napalm-plugin";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dtoiA6gvWL6aGBHmHTwqK8L0qRyA83GcUCGAmg9Xo8w=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ napalm ];
+
+  nativeCheckInputs = [
+    netbox
+    django
+  ];
+
+  preFixup = ''
+    export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH
+  '';
+
+  pythonImportsCheck = [ "netbox_napalm_plugin" ];
+
+  passthru.pluginName = "netbox_napalm_plugin";
+
+  meta = {
+    description = "Netbox plugin for Napalm integration";
+    homepage = "https://github.com/netbox-community/netbox-napalm-plugin";
+    changelog = "https://github.com/netbox-community/netbox-napalm-plugin/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/by-name/ne/netbox_4_6/plugins/netbox-plugin-prometheus-sd/package.nix
+++ b/pkgs/by-name/ne/netbox_4_6/plugins/netbox-plugin-prometheus-sd/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  poetry-core,
+
+  # dependencies
+  django,
+  netaddr,
+  netbox,
+  psycopg,
+}:
+
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "netbox-plugin-prometheus-sd";
+  version = "2.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "FlxPeters";
+    repo = "netbox-plugin-prometheus-sd";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/TvpRRtyCNPmAuFk+wmcJldDniHEkV1t4Vvwa9Sl5eg=";
+  };
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    django
+    netaddr
+    psycopg # not specified in pyproject.toml, but required at import time
+  ];
+
+  nativeCheckInputs = [ netbox ];
+
+  preFixup = ''
+    export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH
+  '';
+
+  pythonImportsCheck = [ "netbox_prometheus_sd" ];
+
+  passthru.pluginName = "netbox_prometheus_sd";
+
+  meta = {
+    description = "Netbox plugin to provide Netbox entires to Prometheus HTTP service discovery";
+    homepage = "https://github.com/FlxPeters/netbox-plugin-prometheus-sd";
+    changelog = "https://github.com/FlxPeters/netbox-plugin-prometheus-sd/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ xanderio ];
+  };
+})

--- a/pkgs/by-name/ne/netbox_4_6/plugins/netbox-qrcode/package.nix
+++ b/pkgs/by-name/ne/netbox_4_6/plugins/netbox-qrcode/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  pillow,
+  qrcode,
+  psycopg2,
+
+  # nativeCheckInputs
+  django,
+  netaddr,
+  netbox,
+  python,
+}:
+
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "netbox-qrcode";
+  version = "0.0.21";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "netbox-community";
+    repo = "netbox-qrcode";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-A4qjpbfTULzS0UchUN9eX8jZmwoX/ej/18L/YAB8dKA=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    qrcode
+    pillow
+  ];
+
+  nativeCheckInputs = [
+    django
+    netaddr
+    netbox
+    psycopg2 # not specified in pyproject.toml, but required at import time
+  ];
+
+  preFixup = ''
+    export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH
+  '';
+
+  dontUsePythonImportsCheck = python.pythonVersion != netbox.python.pythonVersion;
+  pythonImportsCheck = [ "netbox_qrcode" ];
+
+  passthru.pluginName = "netbox_qrcode";
+
+  meta = {
+    description = "Netbox plugin for generate QR codes for objects: Rack, Device, Cable";
+    homepage = "https://github.com/netbox-community/netbox-qrcode";
+    changelog = "https://github.com/netbox-community/netbox-qrcode/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/by-name/ne/netbox_4_6/plugins/netbox-reorder-rack/package.nix
+++ b/pkgs/by-name/ne/netbox_4_6/plugins/netbox-reorder-rack/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  netbox,
+  python,
+}:
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "netbox-reorder-rack";
+  version = "1.1.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "netbox-community";
+    repo = "netbox-reorder-rack";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lWC+Br66POJe3M8L+Pt5D1pWBr9qSpRLn2TcVMXKje4=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  checkInputs = [ netbox ];
+
+  preFixup = ''
+    export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH
+  '';
+
+  dontUsePythonImportsCheck = python.pythonVersion != netbox.python.pythonVersion;
+  pythonImportsCheck = [ "netbox_reorder_rack" ];
+
+  passthru.pluginName = "netbox_reorder_rack";
+
+  meta = {
+    description = "NetBox plugin to allow users to reorder devices within a rack using a drag and drop UI";
+    homepage = "https://github.com/netbox-community/netbox-reorder-rack";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ minijackson ];
+  };
+})

--- a/pkgs/by-name/ne/netbox_4_6/plugins/netbox-routing/package.nix
+++ b/pkgs/by-name/ne/netbox_4_6/plugins/netbox-routing/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  netbox,
+  python,
+  django-polymorphic,
+}:
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "netbox-routing";
+  version = "0.4.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "DanSheps";
+    repo = "netbox-routing";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-3biANhaAi3uRtaXnAw4i6nWnHkARkkBVqyBHLXIMOdA=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ netbox ];
+
+  preFixup = ''
+    export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH
+  '';
+
+  dontUsePythonImportsCheck = python.pythonVersion != netbox.python.pythonVersion;
+  pythonImportsCheck = [ "netbox_routing" ];
+
+  dependencies = [ django-polymorphic ];
+
+  passthru.pluginName = "netbox_routing";
+
+  meta = {
+    description = "NetBox plugin for tracking all kinds of routing information";
+    homepage = "https://github.com/DanSheps/netbox-routing";
+    changelog = "https://github.com/DanSheps/netbox-routing/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ benley ];
+  };
+})

--- a/pkgs/by-name/ne/netbox_4_6/plugins/netbox-secrets/package.nix
+++ b/pkgs/by-name/ne/netbox_4_6/plugins/netbox-secrets/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  netbox,
+  python,
+  pycryptodome,
+}:
+
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "netbox-secrets";
+  version = "3.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Onemind-Services-LLC";
+    repo = "netbox-secrets";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XB4upeu2C2ok0jmLX47tOjrjV4b/WXCpgtlRz9+MgAs=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ pycryptodome ];
+
+  nativeCheckInputs = [ netbox ];
+
+  preFixup = ''
+    export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH
+  '';
+
+  dontUsePythonImportsCheck = python.pythonVersion != netbox.python.pythonVersion;
+  pythonImportsCheck = [ "netbox_secrets" ];
+
+  passthru.pluginName = "netbox_secrets";
+
+  meta = {
+    description = "NetBox plugin to enhance secret management with encrypted storage and flexible, user-friendly features";
+    homepage = "https://github.com/Onemind-Services-LLC/netbox-secrets";
+    changelog = "https://github.com/Onemind-Services-LLC/netbox-secrets/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/by-name/ne/netbox_4_6/plugins/netbox-security/package.nix
+++ b/pkgs/by-name/ne/netbox_4_6/plugins/netbox-security/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  netbox,
+  python,
+}:
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "netbox-security";
+  version = "1.5.10";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "andy-shady-org";
+    repo = "netbox-security";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DOutzFIF/ey2o9M3sb15rmbGJyzsTXfiwC5Rqks8vxc=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ netbox ];
+
+  preFixup = ''
+    export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH
+  '';
+
+  dontUsePythonImportsCheck = python.pythonVersion != netbox.python.pythonVersion;
+  pythonImportsCheck = [ "netbox_security" ];
+
+  passthru.pluginName = "netbox_security";
+
+  meta = {
+    description = "NetBox plugin covering various security and NAT related models";
+    homepage = "https://github.com/andy-shady-org/netbox-security";
+    changelog = "https://github.com/andy-shady-org/netbox-security/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/by-name/ne/netbox_4_6/plugins/netbox-topology-views/package.nix
+++ b/pkgs/by-name/ne/netbox_4_6/plugins/netbox-topology-views/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  netbox,
+  django,
+  netaddr,
+  python,
+}:
+buildPythonPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "netbox-topology-views";
+  version = "4.5.1";
+  pyproject = true;
+
+  disabled = python.pythonVersion != netbox.python.pythonVersion;
+
+  src = fetchFromGitHub {
+    owner = "netbox-community";
+    repo = "netbox-topology-views";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-uKxIu8IPeEwBdRbtQaLWGwLnxvFyJ5FrScsU/ufyTuM=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [
+    netbox
+    django
+    netaddr
+  ];
+
+  preFixup = ''
+    export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH
+  '';
+
+  dontUsePythonImportsCheck = python.pythonVersion != netbox.python.pythonVersion;
+  pythonImportsCheck = [ "netbox_topology_views" ];
+
+  passthru.pluginName = "netbox_topology_views";
+
+  meta = {
+    description = "Netbox plugin for generate topology views/maps from your devices";
+    homepage = "https://github.com/netbox-community/netbox-topology-views";
+    changelog = "https://github.com/netbox-community/netbox-topology-views/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2513,7 +2513,7 @@ with pkgs;
   ioskeley-mono = recurseIntoAttrs (callPackage ../data/fonts/ioskeley-mono { });
 
   # Not in aliases because it wouldn't get picked up by callPackage
-  netbox = netbox_4_5;
+  netbox = netbox_4_6;
 
   netboxPlugins = recurseIntoAttrs netbox.plugins;
 


### PR DESCRIPTION
Release notes:

- https://github.com/netbox-community/netbox/releases/tag/v4.6.0
- https://github.com/netbox-community/netbox/releases/tag/v4.6.1
- https://github.com/netbox-community/netbox/releases/tag/v4.6.2
- https://github.com/netbox-community/netbox/releases/tag/v4.6.3
- https://github.com/netbox-community/netbox/releases/tag/v4.6.4
- https://github.com/netbox-community/netbox/releases/tag/v4.6.5
- https://github.com/netbox-community/netbox/releases/tag/v4.6.6
- https://github.com/netbox-community/netbox/releases/tag/v4.6.7
- https://github.com/netbox-community/netbox/releases/tag/v4.6.8

Full changelog: https://github.com/netbox-community/netbox/compare/v4.5.9...v4.6.8

Also updates the following plugins from netbox_4_5:

netbox-attachments: 11.2.1 -> 11.2.3
netbox-bgp: 0.18.1 -> 0.19.0
netbox-contract: 2.4.5 -> 2.4.6
netbox-custom-objects: 0.5.1 -> 0.5.2
netbox-dns: 1.5.9 -> 1.5.10
netbox-data-flows: 1.5.2 -> 1.5.3
netbox-floorplan-plugin: 0.9.1 -> 0.9.2
netbox-inventory: 2.5.1 -> 2.6.0
netbox-qrcode: 0.0.20 -> 0.0.21
netbox-secrets: 3.0.2 -> 3.1.0
netbox-security: 1.4.5 -> 1.5.9

Replaces #518557

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [X] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
