### PR TITLE
restic: 0.18.1 -> 0.19.0

### DIFF
--- a/nixos/tests/restic.nix
+++ b/nixos/tests/restic.nix
@@ -122,7 +122,7 @@ in
             ];
           };
           remote-from-file-backup = {
-            inherit passwordFile exclude pruneOpts;
+            inherit passwordFile pruneOpts;
             initialize = true;
             repositoryFile = pkgs.writeText "repositoryFile" remoteFromFileRepository;
             paths = [
@@ -130,7 +130,8 @@ in
               "/opt/a_dir/a_file_2"
             ];
             dynamicFilesFrom = ''
-              find /opt -mindepth 1 -maxdepth 1 ! -name a_dir # all files in /opt except for a_dir
+              # all files in /opt except for a_dir and excluded_file_*
+              find /opt -mindepth 1 -maxdepth 1 ! -name a_dir ! -name excluded_file_*
             '';
           };
           remote-from-command-backup = {

--- a/pkgs/by-name/re/restic/package.nix
+++ b/pkgs/by-name/re/restic/package.nix
@@ -14,13 +14,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "restic";
-  version = "0.18.1";
+  version = "0.19.0";
 
   src = fetchFromGitHub {
     owner = "restic";
     repo = "restic";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-lLinqZUOsZCPPybvVDB1f8o9Hl5qKYi0eHwJAaydsD8=";
+    hash = "sha256-9o67zhGDnWNuKGDun3OXtzZHKqw/vCzx5sLuQd/HzRY=";
   };
 
   patches = [
@@ -28,7 +28,7 @@ buildGoModule (finalAttrs: {
     ./0001-Skip-testing-restore-with-permission-failure.patch
   ];
 
-  vendorHash = "sha256-4GVhG1sjFiuKyDUAgmSmFww5bDKIoCjejkkoSqkvU4E=";
+  vendorHash = "sha256-iJLnmxReBoHnt1xfewmmNs+fG3nqcNSpfJ1998wXKNU=";
 
   subPackages = [ "cmd/restic" ];
 


### PR DESCRIPTION
https://github.com/restic/restic/releases/tag/v0.19.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
