### PR TITLE
macos-instantview: 3.22R0002 -> 3.24R0004

### DIFF
--- a/pkgs/by-name/ma/macos-instantview/package.nix
+++ b/pkgs/by-name/ma/macos-instantview/package.nix
@@ -7,11 +7,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "instantview";
-  version = "3.22R0002";
+  version = "3.24R0004";
 
   src = fetchurl {
     url = "https://www.siliconmotion.com/downloads/macOS_InstantView_V${finalAttrs.version}.dmg";
-    hash = "sha256-PdgX9zCrVYtNbuOCYKVo9cegCG/VY7QXetivVsUltbg=";
+    hash = "sha256-lozVykKK1edUQlwxNKy/GyMKjsQaXeR9XVoau72Bwhg=";
   };
 
   nativeBuildInputs = [ _7zz ];
@@ -19,6 +19,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   dontUnpack = true;
   dontConfigure = true;
   dontBuild = true;
+  dontFixup = true;
 
   installPhase = ''
     runHook preInstall
@@ -27,8 +28,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     # Extract the DMG using 7zip
     7zz x "$src" -oextracted -y
 
-    # Move the extracted contents to $out
-    cp -r extracted/* "$out/Applications/"
+    cp -r extracted/*.app "$out/Applications/"
 
     runHook postInstall
   '';


### PR DESCRIPTION
Update macos-instantview to V3.24 R04, the current recommended Silicon Motion release for macOS 13 Ventura through macOS 26 Tahoe.

Also fixes two install issues in the initial packaging:
- Copy only `*.app` from the extracted DMG (the old `cp -r extracted/*` left a broken `Applications` symlink in the store path)
- Set `dontFixup = true` so bundled helper scripts keep `#!/bin/sh` instead of being rewritten to a nix-store bash

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - Built with `nix build --impure .#macos-instantview` (unfree)
  - Launched `macOS InstantView.app`; process started and code signature verified (Developer ID, notarized)
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Made with [Cursor](https://cursor.com)