### PR TITLE
[Backport release-26.05] zenoh: 1.4.0 -> 1.9.0

### DIFF
--- a/nixos/tests/zenohd.nix
+++ b/nixos/tests/zenohd.nix
@@ -84,7 +84,7 @@
     client.wait_for_unit("multi-user.target")
 
     for be in ["fs", "rocksdb", "mem" ]:
-      client.succeed(f"mosquitto_pub -h router -t {be}/test -m hello")
+      client.succeed(f"mosquitto_pub -q 1 -h router -t {be}/test -m hello")
       client.succeed(f"curl router:8000/{be}/test | grep hello")
   '';
 }

--- a/pkgs/by-name/ze/zenoh-backend-filesystem/package.nix
+++ b/pkgs/by-name/ze/zenoh-backend-filesystem/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zenoh-backend-filesystem";
-  version = "1.4.0"; # nixpkgs-update: no auto update
+  version = "1.9.0"; # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "eclipse-zenoh";
     repo = "zenoh-backend-filesystem";
     tag = finalAttrs.version;
-    hash = "sha256-aMIVBs3K9h2aVPuaU5DzOjm3xzpHJn8MnjxdCDCANCw=";
+    hash = "sha256-xyGRL8cSTiObuFDZN+c7e9Sggfn5jx9555PU0JSPh6o=";
   };
 
-  cargoHash = "sha256-d7LgxaZHcMpqx0/+qmcHlAn1pAjBrGqjeTsiqZEJ+1Q=";
+  cargoHash = "sha256-kbMOAL/CvmbOjKVpnZrZlRsl0sibTBwvqCq5GzXjGx8=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/ze/zenoh-backend-filesystem/package.nix
+++ b/pkgs/by-name/ze/zenoh-backend-filesystem/package.nix
@@ -45,6 +45,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       asl20
     ];
     maintainers = with lib.maintainers; [ markuskowa ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/ze/zenoh-backend-influxdb/package.nix
+++ b/pkgs/by-name/ze/zenoh-backend-influxdb/package.nix
@@ -25,6 +25,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       asl20
     ];
     maintainers = with lib.maintainers; [ markuskowa ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/ze/zenoh-backend-influxdb/package.nix
+++ b/pkgs/by-name/ze/zenoh-backend-influxdb/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zenoh-backend-influxdb";
-  version = "1.4.0"; # nixpkgs-update: no auto update
+  version = "1.9.0"; # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "eclipse-zenoh";
     repo = "zenoh-backend-influxdb";
     tag = finalAttrs.version;
-    hash = "sha256-OwIVaWy3rgnn9Cm7sqBvFua2FOCgMQBoxPh+8HkvpB0=";
+    hash = "sha256-W+hrkmjvWPhUJgbPGwzo9159wd269P0vBIxDV+oX6H4=";
   };
 
-  cargoHash = "sha256-yOcbg4+hXdecBN3oeuhs6J1PQ43s8oYOBX/CJ3IyoJ0=";
+  cargoHash = "sha256-+wJqrGQhcrVW9un+2rPZwZl8/MzttduO9Nhn1w2cNag=";
 
   meta = {
     description = "Backend and Storages for zenoh using InfluxDB";

--- a/pkgs/by-name/ze/zenoh-backend-rocksdb/package.nix
+++ b/pkgs/by-name/ze/zenoh-backend-rocksdb/package.nix
@@ -45,6 +45,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       asl20
     ];
     maintainers = with lib.maintainers; [ markuskowa ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/ze/zenoh-backend-rocksdb/package.nix
+++ b/pkgs/by-name/ze/zenoh-backend-rocksdb/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zenoh-backend-rocksdb";
-  version = "1.4.0"; # nixpkgs-update: no auto update
+  version = "1.9.0"; # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "eclipse-zenoh";
     repo = "zenoh-backend-rocksdb";
     tag = finalAttrs.version;
-    hash = "sha256-7IXBzrtab7NNskO6JkPkXGxqnAFmVyIe7dLqbYAKyLs=";
+    hash = "sha256-D+gc29pje4cXfIXP++572iqvzkHDrF6JVdRkdHnEY4E=";
   };
 
-  cargoHash = "sha256-Lqrhu19Z++K7GIMxBHnFNyiBDfq0MxL4tUM2VDkezHw=";
+  cargoHash = "sha256-IOdwGre7j5vyJ5Zut+Q3/548xAlXxbRTVePp9V5nssI=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/ze/zenoh-c/package.nix
+++ b/pkgs/by-name/ze/zenoh-c/package.nix
@@ -10,18 +10,20 @@
 
 stdenv.mkDerivation rec {
   pname = "zenoh-c";
-  version = "1.4.0"; # nixpkgs-update: no auto update
+  version = "1.9.0"; # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "eclipse-zenoh";
     repo = "zenoh-c";
-    tag = version;
-    hash = "sha256-Mn3diwJgMkYXP9Dn5AqquN1UJ+P+b4QadiXqzzYZK+o=";
+    # tag = version;
+    # Use 1.9.0 PR merge commit with up-to-date Cargo.lock file
+    rev = "8858e129271f4e05bb34d8ae6df3f3d221ef5299";
+    hash = "sha256-rNvtFFM9tRttuBAIrpaYTadFcUe1El7q5t7PNnMEJXA=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src pname version;
-    hash = "sha256-Z9xKC7svGPSuQm4KCKOfGAFOdWgSjBK+/LFT3rAebTg=";
+    hash = "sha256-7xWu9wgZqDzd60buMnF9B6Y5LRkG5C2JWiG7VwgSCvU=";
   };
 
   outputs = [

--- a/pkgs/by-name/ze/zenoh-cpp/package.nix
+++ b/pkgs/by-name/ze/zenoh-cpp/package.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zenoh-cpp";
-  version = "1.4.0"; # nixpkgs-update: no auto update
+  version = "1.9.0"; # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "eclipse-zenoh";
     repo = "zenoh-cpp";
     tag = finalAttrs.version;
-    hash = "sha256-rznvif87UZbYzZB4yHG4R850qm6Z3beJ1NSG4wrf58M=";
+    hash = "sha256-MwQKTxrQqfoASCRk+vBeS9EHvmh6sqrpqygQVrdGkWw=";
   };
 
   cmakeFlags = [

--- a/pkgs/by-name/ze/zenoh-plugin-dds/package.nix
+++ b/pkgs/by-name/ze/zenoh-plugin-dds/package.nix
@@ -36,7 +36,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       asl20
     ];
     maintainers = with lib.maintainers; [ kaweees ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     mainProgram = "zenoh-bridge-dds";
   };
 })

--- a/pkgs/by-name/ze/zenoh-plugin-dds/package.nix
+++ b/pkgs/by-name/ze/zenoh-plugin-dds/package.nix
@@ -6,16 +6,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zenoh-plugin-dds";
-  version = "1.4.0"; # nixpkgs-update: no auto update
+  version = "1.9.0"; # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "eclipse-zenoh";
     repo = "zenoh-plugin-dds";
     tag = finalAttrs.version;
-    hash = "sha256-vSFgxSSbLEwpwPznvy+m66Z5grgmxZiIom/I4p0xris=";
+    hash = "sha256-MOZmyZGaMJieWISZnnSTU+3+ER4FcGhg3YCTlmuWmuE=";
   };
 
-  cargoHash = "sha256-oMmO4N1EqqpWcujbm8sPPwEzNC1Gy2UdCCRqcgyQqdI=";
+  cargoHash = "sha256-O7OrgEPPkWMYCtmtdgYIcE8YUa+YpHWttwW0Gu5BLJA=";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/ze/zenoh-plugin-mqtt/package.nix
+++ b/pkgs/by-name/ze/zenoh-plugin-mqtt/package.nix
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       asl20
     ];
     maintainers = with lib.maintainers; [ markuskowa ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     mainProgram = "zenoh-bridge-mqtt";
   };
 })

--- a/pkgs/by-name/ze/zenoh-plugin-mqtt/package.nix
+++ b/pkgs/by-name/ze/zenoh-plugin-mqtt/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zenoh-plugin-mqtt";
-  version = "1.4.0"; # nixpkgs-update: no auto update
+  version = "1.9.0"; # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "eclipse-zenoh";
     repo = "zenoh-plugin-mqtt";
     tag = finalAttrs.version;
-    hash = "sha256-ijoKL8TReNER3a9dwsPeh56l1Ze2rz6jN6L9rYQLYRU=";
+    hash = "sha256-f5y9zCUTvNG/ubw0K+AwqfQlsfeLvoUL8gy3v9T0oQ4=";
   };
 
-  cargoHash = "sha256-ZKpyVVzXC+c7JzktSOMubWl610ujoZ3Vgo4tC0/1JHk=";
+  cargoHash = "sha256-vL5lZOH8juX8zaLJZnw1y8aDZsdFC3gELNvp5MPft2o=";
 
   # Some test time out
   doCheck = false;

--- a/pkgs/by-name/ze/zenoh-plugin-webserver/package.nix
+++ b/pkgs/by-name/ze/zenoh-plugin-webserver/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zenoh-plugin-webserver";
-  version = "1.4.0"; # nixpkgs-update: no auto update
+  version = "1.9.0"; # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "eclipse-zenoh";
     repo = "zenoh-plugin-webserver";
     tag = finalAttrs.version;
-    hash = "sha256-R+MLM42m3UTBFHqCAGezU4jz0Hi1+X2W1Yje7+ctl6k=";
+    hash = "sha256-U2xcx3TVPkEgea2gdSdbEa+jDI6h6vftLUi8AZPY3fU=";
   };
 
-  cargoHash = "sha256-/WVMdSGEawvAJ0viV/2eVhWGlvgaGUpe9ZHDCBUOc1I=";
+  cargoHash = "sha256-PLmmOw2ZMPn/ODBJn1NBvWyeGEPOcKB+aepoDqhqzZc=";
 
   meta = {
     description = "Implements an HTTP server mapping URLs to zenoh paths";

--- a/pkgs/by-name/ze/zenoh-plugin-webserver/package.nix
+++ b/pkgs/by-name/ze/zenoh-plugin-webserver/package.nix
@@ -25,6 +25,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       asl20
     ];
     maintainers = with lib.maintainers; [ markuskowa ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/ze/zenoh/package.nix
+++ b/pkgs/by-name/ze/zenoh/package.nix
@@ -60,6 +60,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ ck3d ];
     mainProgram = "zenohd";
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })

--- a/pkgs/by-name/ze/zenoh/package.nix
+++ b/pkgs/by-name/ze/zenoh/package.nix
@@ -8,22 +8,22 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zenoh";
-  version = "1.4.0"; # nixpkgs-update: no auto update
+  version = "1.9.0"; # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "eclipse-zenoh";
     repo = "zenoh";
     rev = finalAttrs.version;
-    hash = "sha256-XibcNrT9R8gdOnf4BtOi5Jqu+4XjeWngA3i/MXnkfn8=";
+    hash = "sha256-sFHUphFu5a+buSa3GQvSmGo8SFtn3V5ZqTOnWMPlvs8=";
   };
 
-  cargoHash = "sha256-z0hSjcmVOefSiPgk6ige4wsR+LikNIjwi0On1/hyi78=";
+  cargoHash = "sha256-1PjtZ5/bAnLlMbkcKAA6DCKDafItGiATjct5Pv8muas=";
 
   cargoBuildFlags = [
     "--workspace"
-    # exclude examples
-    "--exclude"
-    "examples"
+    "--bins"
+    "--lib"
+    "--examples"
     "--exclude"
     "zenoh-backend-example"
     "--exclude"
@@ -33,6 +33,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   doCheck = false;
+
+  preInstall = ''
+    cp -r $releaseDir/examples/* $tmpDir/
+    bins=$(find $tmpDir \
+      -maxdepth 1 \
+      -type f \
+      -executable \
+      -regextype posix-extended \
+      ! -regex ".*\.(so\.[0-9.]+|so|a|d|dylib)|.*-[0-9a-f]{16,}")
+  '';
 
   passthru.tests = {
     version = testers.testVersion {

--- a/pkgs/development/python-modules/zenoh/default.nix
+++ b/pkgs/development/python-modules/zenoh/default.nix
@@ -9,19 +9,19 @@
 
 buildPythonPackage rec {
   pname = "zenoh";
-  version = "1.6.2"; # nixpkgs-update: no auto update
+  version = "1.9.0"; # nixpkgs-update: no auto update
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "eclipse-zenoh";
     repo = "zenoh-python";
     rev = version;
-    hash = "sha256-GGqZGtHSCaPeO6wFFBxPjdjhsIdcgI1RJ4mZbGq4uzc=";
+    hash = "sha256-rKWbJti5bgwAfc8LpQFsU6KhhcWyWAwOX+SF1UAGRbk=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src pname version;
-    hash = "sha256-2Hieow0+GzcNQmvqsJd+5bpE9RWUDbaBR9jah+O4GtI=";
+    hash = "sha256-g7Om2QvlbwVmB0wGcbuafUELh53IJ2uM+miHyzBKQQI=";
   };
 
   build-system = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^
Backport https://github.com/NixOS/nixpkgs/pull/525450, https://github.com/NixOS/nixpkgs/pull/525644, and https://github.com/NixOS/nixpkgs/pull/530054 to `release-26.05`.
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
