### PR TITLE
Update treesitter org and org-nvim grammars to maintained fork

### DIFF
--- a/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
+++ b/pkgs/by-name/tr/tree-sitter/grammars/grammar-sources.nix
@@ -1874,10 +1874,9 @@
   };
 
   org = {
-    version = "1.3.1-unstable-2023-06-19";
-    url = "github:milisims/tree-sitter-org";
-    rev = "64cfbc213f5a83da17632c95382a5a0a2f3357c1";
-    hash = "sha256-/03eZBbv23W5s/GbDgPgaJV5TyK+/lrWUVeINRS5wtA=";
+    version = "2.0.4";
+    url = "github:nvim-orgmode/tree-sitter-org";
+    hash = "sha256-76ImC8GMW+yAKG++AHryUi+MYTmtJ5ogygC+bgNMErA=";
     meta = {
       license = lib.licenses.mit;
       maintainers = with lib.maintainers; [
@@ -1887,10 +1886,9 @@
   };
 
   org-nvim = {
-    version = "1.3.1-unstable-2023-06-19";
-    url = "github:emiasims/tree-sitter-org";
-    rev = "64cfbc213f5a83da17632c95382a5a0a2f3357c1";
-    hash = "sha256-/03eZBbv23W5s/GbDgPgaJV5TyK+/lrWUVeINRS5wtA=";
+    version = "2.0.4";
+    url = "github:nvim-orgmode/tree-sitter-org";
+    hash = "sha256-76ImC8GMW+yAKG++AHryUi+MYTmtJ5ogygC+bgNMErA=";
     meta = {
       license = lib.licenses.mit;
     };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Supersedes #403455

Switched both org and org-nvim treesitter grammars from [old archived community repo](https://github.com/emiasims/tree-sitter-org) to [nvim-org's official org-nvim repo](https://github.com/nvim-orgmode/tree-sitter-org).

Changelog: https://github.com/nvim-orgmode/tree-sitter-org/compare/v1.3.1...2.0.4

@aciceri 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
