### PR TITLE
npmHooks: Adjust so it's possible to use outside the standard phases

### DIFF
--- a/doc/hooks/npm-build-hook.section.md
+++ b/doc/hooks/npm-build-hook.section.md
@@ -83,7 +83,48 @@ Controls the arguments to the {command}`npm run $npmBuildScript` command.
 
 #### `dontNpmBuild` {#npm-build-hook-dont}
 
-Disables `npmBuildHook` when enabled
+Disables running `npmBuildHook` when enabled.
+Allows usage of the hook logic outside of `buildPhase` via the bash command `npmBuildPhase`.
+Primarily for use in multi-language builds.
+
+:::{.example #ex-npm-build-hook-multilanguage}
+# npmHooks in multilanguage environments
+```nix
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  npmHooks,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rust-web-app";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "rusty-web-app";
+    repo = "cool-web-app";
+    tag = finalAttrs.version;
+    hash = lib.fakeHash;
+  };
+
+  cargoHash = lib.fakeHash;
+
+  nativeBuildInputs = [
+    npmHooks.npmConfigHook
+    npmHooks.npmBuildHook
+    npmHooks.npmInstallHook
+  ];
+
+  preBuild = ''
+    npmBuildPhase
+  '';
+
+  preInstall = ''
+    npmInstallPhase
+  '';
+})
+```
+:::
 
 ### Honored Variables {#npm-build-hook-honored-variables}
 

--- a/doc/hooks/npm-install-hook.section.md
+++ b/doc/hooks/npm-install-hook.section.md
@@ -25,7 +25,10 @@ Defaults to `--omit=dev --no-save` which cannot be modified.
 #### `dontNpmInstall` {#npm-install-hook-dont}
 
 Controls whether `npmInstallHook` is enabled or not.
-Defaults to `true`, so the hook will run.
+Primarily for use in multi-language environments. Allow disabling the setting of `installPhase`, and
+the core logic can then be called in `postInstall` or `preInstall` via `npmInstallPhase`.
+
+[](#ex-npm-build-hook-multilanguage)
 
 ### Honored Variables {#npm-install-hook-honored-variables}
 

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -105,6 +105,9 @@
   "ex-build-helpers-extendMkDerivation": [
     "index.html#ex-build-helpers-extendMkDerivation"
   ],
+  "ex-npm-build-hook-multilanguage": [
+    "index.html#ex-npm-build-hook-multilanguage"
+  ],
   "ex-pkgs-replace-vars": [
     "index.html#ex-pkgs-replace-vars",
     "index.html#ex-pkgs-substituteAll",

--- a/pkgs/build-support/node/build-npm-package/hooks/npm-build-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-build-hook.sh
@@ -1,9 +1,8 @@
 # shellcheck shell=bash
 
-npmBuildHook() {
+# For running npm build in a multi-language environment
+npmBuildPhase() {
     echo "Executing npmBuildHook"
-
-    runHook preBuild
 
     if [ -z "${npmBuildScript-}" ]; then
         echo
@@ -28,9 +27,17 @@ npmBuildHook() {
         exit 1
     fi
 
-    runHook postBuild
-
     echo "Finished npmBuildHook"
+
+}
+
+# Hook for building automatically
+npmBuildHook() {
+    runHook preBuild
+
+    npmBuildPhase
+
+    runHook postBuild
 }
 
 if [ -z "${dontNpmBuild-}" ] && [ -z "${buildPhase-}" ]; then

--- a/pkgs/build-support/node/build-npm-package/hooks/npm-install-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-install-hook.sh
@@ -1,9 +1,8 @@
 # shellcheck shell=bash
 
-npmInstallHook() {
+# For use outside installPhase
+npmInstallPhase() {
     echo "Executing npmInstallHook"
-
-    runHook preInstall
 
     local -r packageOut="$out/lib/node_modules/$(@jq@ --raw-output '.name' package.json)"
 
@@ -39,9 +38,15 @@ npmInstallHook() {
         cp -r node_modules "$nodeModulesPath"
     fi
 
-    runHook postInstall
-
     echo "Finished npmInstallHook"
+}
+
+npmInstallHook() {
+    runHook preInstall
+
+    npmInstallPhase
+
+    runHook postInstall
 }
 
 if [ -z "${dontNpmInstall-}" ] && [ -z "${installPhase-}" ]; then


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Previously, if attempted to use in a multi-language environment one would often run into infreq at the Bash level, since for example `npmBuildHook` would called `runHook preBuild`, which would call `preBuild`, which would call `npmBuildHook`...

This fixes that so that the npm logic can be more unified. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
