### PR TITLE
gitlab-workhorse: migrate to by-name

### DIFF
--- a/pkgs/by-name/gi/gitlab-workhorse/package.nix
+++ b/pkgs/by-name/gi/gitlab-workhorse/package.nix
@@ -1,32 +1,28 @@
 {
   lib,
-  fetchFromGitLab,
   git,
   buildGoModule,
+  gitlab,
 }:
-let
-  data = lib.importJSON ../data.json;
-in
+
 buildGoModule (finalAttrs: {
   pname = "gitlab-workhorse";
 
-  version = "18.11.7";
+  version = gitlab.passthru.GITLAB_WORKHORSE_VERSION;
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   # nixpkgs-update: no auto update
-  src = fetchFromGitLab {
-    owner = data.owner;
-    repo = data.repo;
-    rev = data.rev;
-    sha256 = data.repo_hash;
-  };
+  src = gitlab.src;
 
   sourceRoot = "${finalAttrs.src.name}/workhorse";
 
-  vendorHash = "sha256-X1+neA2g61BR1VRKXzeqNath0+SYXRbU4vzEg1KD2sY=";
+  vendorHash = "sha256-6/50YxOW3NK5qzy0ALERCMK3JpLJflnw8ePAvNXANxQ=";
   buildInputs = [ git ];
   ldflags = [ "-X main.Version=${finalAttrs.version}" ];
   doCheck = false;
-  prodyVendor = true;
+  proxyVendor = true;
 
   meta = {
     homepage = "http://www.gitlab.com/";

--- a/pkgs/by-name/gi/gitlab/update.py
+++ b/pkgs/by-name/gi/gitlab/update.py
@@ -455,6 +455,7 @@ def commit_gitlab(old_version: str, new_version: str, new_rev: str) -> None:
             "pkgs/by-name/gi/gitlab-kas",
             "pkgs/by-name/gi/gitlab-pages",
             "pkgs/by-name/gi/gitlab-shell",
+            "pkgs/by-name/gi/gitlab-workhorse",
         ],
         cwd=NIXPKGS_PATH,
     )

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2054,8 +2054,6 @@ with pkgs;
     gitlabEnterprise = true;
   };
 
-  gitlab-workhorse = callPackage ../by-name/gi/gitlab/gitlab-workhorse { };
-
   gmrender-resurrect = callPackage ../tools/networking/gmrender-resurrect {
     inherit (gst_all_1)
       gstreamer


### PR DESCRIPTION
migrate to by-name, use finalAttrs, use strictDeps and structuredAttrs, fix typo in proxyVendor, update vendorHash
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
