### PR TITLE
nixos/bootspec: remove enable option

### DIFF
--- a/nixos/modules/system/activation/bootspec.nix
+++ b/nixos/modules/system/activation/bootspec.nix
@@ -97,13 +97,13 @@ let
   };
 in
 {
+  imports = [
+    (lib.mkRemovedOptionModule [ "boot" "bootspec" "enable" ] ''
+      Bootspec is now always generated and can no longer be disabled.
+    '')
+  ];
+
   options.boot.bootspec = {
-    enable =
-      lib.mkEnableOption "the generation of RFC-0125 bootspec in $system/boot.json, e.g. /run/current-system/boot.json"
-      // {
-        default = true;
-        internal = true;
-      };
     enableValidation = lib.mkEnableOption ''
       the validation of bootspec documents for each build.
             This will introduce Go in the build-time closure as we are relying on [Cuelang](https://cuelang.org/) for schema validation.

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -44,7 +44,7 @@ let
 
     printf "%s " "''${extraDependencies[@]}" > "$out/extra-dependencies"
 
-    ${optionalString (!config.boot.isContainer && config.boot.bootspec.enable) ''
+    ${optionalString (!config.boot.isContainer) ''
       ${config.boot.bootspec.writer}
       ${optionalString config.boot.bootspec.enableValidation ''${config.boot.bootspec.validator} "$out/${config.boot.bootspec.filename}"''}
     ''}

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -27,7 +27,6 @@ NIXOS_DIR = Path(
 TIMEOUT = "@timeout@"
 EDITOR = "@editor@" == "1"  # noqa: PLR0133
 CONSOLE_MODE = "@consoleMode@"
-BOOTSPEC_TOOLS = "@bootspecTools@"
 DISTRO_NAME = "@distroName@"
 NIX = "@nix@"
 SYSTEMD = "@systemd@"
@@ -291,31 +290,26 @@ def write_loader_conf(default_entry_id: str | None) -> None:
     os.rename(tmp, LOADER_CONF)
 
 
-def get_bootspec(profile: str | None, generation: int) -> BootSpec:
+def get_bootspec(profile: str | None, generation: int) -> BootSpec | None:
     system_directory = system_dir(profile, generation, None)
     boot_json_path = (system_directory / "boot.json").resolve()
-    if boot_json_path.is_file():
-        with boot_json_path.open("r") as f:
-            # check if json is well-formed, else throw error with filepath
-            try:
-                bootspec_json = json.load(f)
-            except ValueError as e:
-                print(
-                    f"error: Malformed Json: {e}, in {boot_json_path}", file=sys.stderr
-                )
-                sys.exit(1)
-    else:
-        boot_json_str = run(
-            [
-                f"{BOOTSPEC_TOOLS}/bin/synthesize",
-                "--version",
-                "1",
-                system_directory,
-                "/dev/stdout",
-            ],
-            stdout=subprocess.PIPE,
-        ).stdout
-        bootspec_json = json.loads(boot_json_str)
+    if not boot_json_path.is_file():
+        print(
+            f"warning: skipping generation {generation}"
+            + (f" of profile {profile}" if profile else "")
+            + f": {boot_json_path} does not exist",
+            file=sys.stderr,
+        )
+        return None
+    with boot_json_path.open("r") as f:
+        # check if json is well-formed, else throw error with filepath
+        try:
+            bootspec_json = json.load(f)
+        except ValueError as e:
+            print(
+                f"error: Malformed Json: {e}, in {boot_json_path}", file=sys.stderr
+            )
+            sys.exit(1)
     return bootspec_from_json(bootspec_json)
 
 
@@ -551,6 +545,8 @@ def install_bootloader(args: argparse.Namespace) -> None:
 
     for gen in gens:
         bootspec = get_bootspec(gen.profile, gen.generation)
+        if bootspec is None:
+            continue
         is_default = Path(bootspec.init).parent == default_config
         new_boot_files, new_bootctl_id = boot_file(*gen, machine_id, bootspec)
         boot_files.extend(new_boot_files)

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot.nix
@@ -47,8 +47,6 @@ let
 
       systemd = config.systemd.package;
 
-      bootspecTools = config.boot.bootspec.package;
-
       nix = config.nix.package.out;
 
       timeout = if config.boot.loader.timeout == null then "menu-force" else config.boot.loader.timeout;

--- a/nixos/tests/bootspec.nix
+++ b/nixos/tests/bootspec.nix
@@ -24,8 +24,6 @@ let
     environment.systemPackages = [ pkgs.efibootmgr ];
   };
   standard = {
-    boot.bootspec.enable = true;
-
     imports = [
       baseline
       systemd-boot
@@ -53,8 +51,6 @@ in
     meta.maintainers = with pkgs.lib.maintainers; [ raitobezarius ];
 
     nodes.machine = {
-      boot.bootspec.enable = true;
-
       imports = [
         baseline
         grub
@@ -75,8 +71,6 @@ in
     meta.maintainers = with pkgs.lib.maintainers; [ raitobezarius ];
 
     nodes.machine = {
-      boot.bootspec.enable = true;
-
       imports = [
         baseline
         grub

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -793,7 +793,6 @@ let
                 ++ optionals (bootLoader == "systemd-boot") [
                   pkgs.zstd.bin
                   pkgs.mypy
-                  config.boot.bootspec.package
                 ]
                 ++ optionals clevisTest [ pkgs.klibc ]
                 ++ optional systemdStage1 config.system.nixos-init.package;

--- a/nixos/tests/systemd-boot.nix
+++ b/nixos/tests/systemd-boot.nix
@@ -772,26 +772,6 @@ in
     }
   );
 
-  no-bootspec = runTest (
-    { lib, ... }:
-    {
-      name = "systemd-boot-no-bootspec";
-      meta.maintainers = with lib.maintainers; [ julienmalka ];
-
-      nodes.machine = {
-        imports = [ common ];
-        boot.bootspec.enable = false;
-      };
-
-      testScript =
-        # python
-        ''
-          machine.start()
-          machine.wait_for_unit("multi-user.target")
-        '';
-    }
-  );
-
   bootCounting =
     let
       baseConfig = {


### PR DESCRIPTION
Bootspec has been on by default and internal since 23.05. Dropping the
option lets bootloader scripts assume `boot.json` always exists.

The systemd-boot builder no longer carries the `synthesize` fallback
and skips generations without `boot.json` with a warning.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
