### PR TITLE
python3Packages.atopile: disable more tests prone to time out

### DIFF
--- a/pkgs/development/python-modules/atopile/default.nix
+++ b/pkgs/development/python-modules/atopile/default.nix
@@ -187,7 +187,7 @@ buildPythonPackage (finalAttrs: {
   ];
 
   disabledTests = [
-    # timeout
+    # Timeout (>10.0s) from pytest-timeout.
     "test_build_error_logging"
     "test_can_evaluate_literals"
     "test_examples_build"
@@ -196,6 +196,11 @@ buildPythonPackage (finalAttrs: {
     "test_regression_rp2040_usb_diffpair"
     "test_reserved_attrs"
     "test_resistor"
+    "test_loooooong_chain"
+    "test_parser_netlist"
+    "test_dump_load_equality"
+    "test_performance_mifs_connect_check"
+
     # requires internet
     "test_simple_pick"
     "test_simple_negative_pick"


### PR DESCRIPTION
discovered in https://github.com/NixOS/nixpkgs/pull/528735
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
