### PR TITLE
projectm-sdl-cpp: 0-unstable-2026-01-20 -> 2.0.0-pre1

### DIFF
--- a/pkgs/by-name/pr/projectm-sdl-cpp/package.nix
+++ b/pkgs/by-name/pr/projectm-sdl-cpp/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   cmake,
+  ninja,
   libprojectm,
   libGL,
   libx11,
@@ -12,33 +13,21 @@
   unstableGitUpdater,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "projectm-sdl-cpp";
-  version = "0-unstable-2026-01-20";
+  version = "2.0.0-pre1";
 
   src = fetchFromGitHub {
     owner = "projectM-visualizer";
     repo = "frontend-sdl-cpp";
-    rev = "7a07229428c51378f43843cf160bcddc21ef70ff";
-    hash = "sha256-hz1Au5Gn10Yi5f7d7UiQOHTCU00Ze5UoQ40jirg54Pc=";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-JCnvlX1pQeLsqI/74tBGKd2ONydABqulOZ8kghiDn8s=";
     fetchSubmodules = true;
   };
 
-  # Probably an artifact of the vcpkg package
-  postPatch = ''
-    substituteInPlace ImGui.cmake \
-      --replace-fail "SDL2::SDL2main" ""
-    substituteInPlace src/CMakeLists.txt \
-      --replace-fail "SDL2::SDL2main" ""
-  '';
-
-  cmakeFlags = [
-    # Doesn't seem to be present in the source tree, so the installation fails if enabled
-    (lib.cmakeBool "ENABLE_DESKTOP_ICON" false)
-  ];
-
   nativeBuildInputs = [
     cmake
+    ninja
   ];
 
   buildInputs = [
@@ -50,12 +39,7 @@ stdenv.mkDerivation {
     SDL2
   ];
 
-  # poco 1.14 requires c++17
-  env.NIX_CFLAGS_COMPILE = toString [ "-std=gnu++17" ];
-
   strictDeps = true;
-
-  passthru.updateScript = unstableGitUpdater { };
 
   meta = {
     description = "Standalone application based on libprojectM and libSDL that turns your desktop audio into awesome visuals";
@@ -66,4 +50,4 @@ stdenv.mkDerivation {
     platforms = lib.platforms.all;
     broken = stdenv.hostPlatform.isDarwin; # TODO build probably needs some fixing
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
