### PR TITLE
sandhole: 0.9.5 -> 0.10.0

### DIFF
--- a/pkgs/by-name/sa/sandhole/package.nix
+++ b/pkgs/by-name/sa/sandhole/package.nix
@@ -1,6 +1,7 @@
 {
   cmake,
   fetchFromGitHub,
+  installShellFiles,
   lib,
   lld,
   perl,
@@ -10,19 +11,20 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sandhole";
-  version = "0.9.5";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "EpicEric";
     repo = "sandhole";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-l+9DcqAxrrjLxs/7KxY6QlfIAlwMVjQztt4lgJJMsyI=";
+    hash = "sha256-nOh9JRb1T85gEsQzd0BJqvR941QMoqeIjRFg4d8eASc=";
   };
 
-  cargoHash = "sha256-euWvpEjSW2JeDysBul5eR4M27LwkRSZDlsp57lMBpAE=";
+  cargoHash = "sha256-EZxRKq5r5Cgp/WqcL1dY4ypf2K73YjaadqI5Tl+6Kec=";
 
   nativeBuildInputs = [
     cmake
+    installShellFiles
     perl
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ lld ];
@@ -34,6 +36,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd sandhole \
+      --bash <($out/bin/sandhole --completions bash) \
+      --fish <($out/bin/sandhole --completions fish) \
+      --zsh <($out/bin/sandhole --completions zsh)
+  '';
 
   meta = {
     description = "Expose HTTP/SSH/TCP services through SSH port forwarding";


### PR DESCRIPTION
Breaking version bump, so no backport. This release also adds shell completions.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
