### PR TITLE
qtwirediff: unbreak build

### DIFF
--- a/pkgs/by-name/qt/qtwirediff/package.nix
+++ b/pkgs/by-name/qt/qtwirediff/package.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation {
   pname = "qtwirediff";
-  version = "unstable-2023-03-07";
+  version = "0-unstable-2026-06-10";
 
   src = fetchFromGitHub {
     owner = "aaptel";
     repo = "qtwirediff";
-    rev = "e0a38180cdf9d94b7535c441487dcefb3a8ec72e";
-    hash = "sha256-QS4PslSHe2qhxayF7IHvtFASgd4A7vVtSY8tFQ6dqXM=";
+    rev = "61d7a7013a74ab4ad5fb2c1041d1f2559bd70644";
+    hash = "sha256-mE8AiY1KVVLDJyz4yRoVqW2Gae021Ww7u9Qb4EGXetA=";
   };
 
   nativeBuildInputs = [
@@ -52,7 +52,5 @@ stdenv.mkDerivation {
     homepage = "https://github.com/aaptel/qtwirediff";
     license = lib.licenses.gpl3Plus;
     maintainers = [ ];
-    # error: assignment of member 'trivial' in read-only object
-    broken = true;
   };
 }


### PR DESCRIPTION
Had the patch lying around for this for some time, and finally opened a PR upstream at https://github.com/aaptel/qtwirediff/pull/14/
This commit applies the patch and fixes the build.

## Things done
- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].