### PR TITLE
sif: 0-unstable-2026-04-24 -> 0-unstable-2026-06-09

### DIFF
--- a/pkgs/by-name/si/sif/package.nix
+++ b/pkgs/by-name/si/sif/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule {
   pname = "sif";
-  version = "0-unstable-2026-04-24";
+  version = "0-unstable-2026-06-09";
 
   src = fetchFromGitHub {
     owner = "vmfunc";
     repo = "sif";
-    rev = "bf802a7c0b83e7ba41b837fe9e1e3265e52d11f1";
-    hash = "sha256-wkK3VCvpS2ETbAvgb5onsluLy1pXj0u8kpFy9AtvaBk=";
+    rev = "83ac92a4b82a0ab92257c580c9b6a3b82ab66af9";
+    hash = "sha256-VeURSRwvuh+VJd94mG2F8wQWD6NIitxqwRQr3IJ0QzU=";
   };
 
-  vendorHash = "sha256-1U8LV5ZVQkMZUK282FE42RRXdWz7HcpzOK03mA0f0r0=";
+  vendorHash = "sha256-fR63/dStMsZon22vancuLWIAvZiEYMLjMwY1kmRDNgM=";
 
   subPackages = [ "cmd/sif" ];
 


### PR DESCRIPTION
Bumps `sif` to the latest default-branch commit (`0-unstable-2026-06-09`). The r-ryantm auto-update has been lagging (last bump 2026-05-03), so this is a manual bump, I maintain this package.

rev + `hash` + `vendorHash` were refreshed with `nix-update`.

###### Things done

- Built the package locally (`nix-build -A sif`) and ran the resulting binary
- `doCheck` stays off — the test suite needs network (httptest)
- Tested via `nix-update sif --version=branch`
