### PR TITLE
gromacs: cleanup

### DIFF
--- a/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
+++ b/pkgs/applications/science/molecular-dynamics/gromacs/default.nix
@@ -27,6 +27,9 @@ assert enableCuda -> singlePrec;
 let
   inherit (cudaPackages.flags) cmakeCudaArchitecturesString;
 
+  effectiveStdenv = if enableCuda then cudaPackages.backendStdenv else stdenv;
+  inherit (effectiveStdenv) hostPlatform;
+
   # Select reasonable defaults for all major platforms
   # The possible values are defined in CMakeLists.txt:
   # AUTO None SSE2 SSE4.1 AVX_128_FMA AVX_256 AVX2_256
@@ -35,15 +38,15 @@ let
     x:
     if (cpuAcceleration != null) then
       x
-    else if stdenv.hostPlatform.system == "i686-linux" then
+    else if hostPlatform.system == "i686-linux" then
       "SSE2"
-    else if stdenv.hostPlatform.system == "x86_64-linux" then
+    else if hostPlatform.system == "x86_64-linux" then
       "SSE4.1"
-    else if stdenv.hostPlatform.system == "x86_64-darwin" then
+    else if hostPlatform.system == "x86_64-darwin" then
       "SSE4.1"
-    else if stdenv.hostPlatform.system == "aarch64-darwin" then
+    else if hostPlatform.system == "aarch64-darwin" then
       "ARM_NEON_ASIMD"
-    else if stdenv.hostPlatform.system == "aarch64-linux" then
+    else if hostPlatform.system == "aarch64-linux" then
       "ARM_NEON_ASIMD"
     else
       "None";
@@ -61,12 +64,12 @@ let
       };
 
 in
-stdenv.mkDerivation rec {
+effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "gromacs";
   version = source.version;
 
   src = fetchurl {
-    url = "ftp://ftp.gromacs.org/pub/gromacs/gromacs-${version}.tar.gz";
+    url = "ftp://ftp.gromacs.org/pub/gromacs/gromacs-${finalAttrs.version}.tar.gz";
     inherit (source) hash;
   };
 
@@ -74,13 +77,13 @@ stdenv.mkDerivation rec {
     # Fix pkg-config paths for the version-specific gromacs variant.
     (if enablePlumed then ./pkgconfig-2024.patch else ./pkgconfig-2025.patch)
   ]
-  ++ lib.optional enablePlumed (
+  ++ lib.optionals enablePlumed [
     # Backport gcc 15 cstdint include fix.
-    fetchpatch2 {
+    (fetchpatch2 {
       url = "https://gitlab.com/gromacs/gromacs/-/commit/e0180bc37f3111d7dcaffca3854c088ed910c3b4.diff";
       hash = "sha256-TvTzfb/RETAzFpYfFFr6/L5GV1Pile16gVJhNigwAB4=";
-    }
-  );
+    })
+  ];
 
   postPatch = lib.optionalString enablePlumed ''
     plumed patch -p -e gromacs-${source.version}
@@ -95,7 +98,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
   ]
-  ++ lib.optional enablePlumed plumed
+  ++ lib.optionals enablePlumed [ plumed ]
   ++ lib.optionals enableCuda [ cudaPackages.cuda_nvcc ];
 
   buildInputs = [
@@ -105,48 +108,34 @@ stdenv.mkDerivation rec {
     blas
     lapack
   ]
-  ++ lib.optional enableMpi mpi
+  ++ lib.optionals enableMpi [ mpi ]
   ++ lib.optionals enableCuda [
     cudaPackages.cuda_cccl
     cudaPackages.cuda_cudart
     cudaPackages.libcufft
     cudaPackages.cuda_profiler_api
   ]
-  ++ lib.optional stdenv.hostPlatform.isDarwin llvmPackages.openmp;
+  ++ lib.optionals hostPlatform.isDarwin [ llvmPackages.openmp ];
 
-  propagatedBuildInputs = lib.optional enableMpi mpi;
-  propagatedUserEnvPkgs = lib.optional enableMpi mpi;
+  propagatedBuildInputs = lib.optionals enableMpi [ mpi ];
+  propagatedUserEnvPkgs = lib.optionals enableMpi [ mpi ];
 
   cmakeFlags = [
     (lib.cmakeBool "GMX_HWLOC" true)
-    "-DGMX_SIMD:STRING=${SIMD cpuAcceleration}"
-    "-DGMX_OPENMP:BOOL=TRUE"
-    "-DBUILD_SHARED_LIBS=ON"
+    (lib.cmakeFeature "GMX_SIMD" (SIMD cpuAcceleration))
+    (lib.cmakeBool "GMX_OPENMP" true)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" true)
+
+    (lib.cmakeBool "GMX_DOUBLE" (!singlePrec))
+    (lib.cmakeBool "GMX_DEFAULT_SUFFIX" singlePrec)
+
+    (lib.cmakeBool "GMX_MPI" enableMpi)
   ]
-  ++ (
-    if singlePrec then
-      [
-        "-DGMX_DOUBLE=OFF"
-      ]
-    else
-      [
-        "-DGMX_DOUBLE=ON"
-        "-DGMX_DEFAULT_SUFFIX=OFF"
-      ]
-  )
-  ++ (
-    if enableMpi then
-      [
-        "-DGMX_MPI:BOOL=TRUE"
-        "-DGMX_THREAD_MPI:BOOL=FALSE"
-      ]
-    else
-      [
-        "-DGMX_MPI:BOOL=FALSE"
-      ]
-  )
+  ++ lib.optionals enableMpi [
+    (lib.cmakeBool "GMX_THREAD_MPI" false)
+  ]
   ++ lib.optionals enableCuda [
-    "-DGMX_GPU=CUDA"
+    (lib.cmakeFeature "GMX_GPU" "CUDA")
     (lib.cmakeFeature "CMAKE_CUDA_ARCHITECTURES" cmakeCudaArchitecturesString)
 
     # Gromacs seems to ignore and override the normal variables, so we add this ad hoc:
@@ -186,4 +175,4 @@ stdenv.mkDerivation rec {
       markuskowa
     ];
   };
-}
+})


### PR DESCRIPTION
## Things done

cc @sheepforce @markuskowa

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
