### PR TITLE
fontconfig: add `doc` & `man` outputs

### DIFF
--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -25,6 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     "lib"
     "out"
     "man"
+    "doc"
   ]; # $out contains all the config
 
   # GitLab repositrory does not include pre-generated man pages.

--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -67,6 +67,8 @@ stdenv.mkDerivation (finalAttrs: {
     "ac_cv_va_copy=C99"
   ];
 
+  __structuredAttrs = true;
+  strictDeps = true;
   enableParallelBuilding = true;
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;

--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
     "lib"
     "out"
+    "man"
   ]; # $out contains all the config
 
   # GitLab repositrory does not include pre-generated man pages.
@@ -88,9 +89,6 @@ stdenv.mkDerivation (finalAttrs: {
       ${./make-fonts-conf.xsl} $out/etc/fonts/fonts.conf \
       > fonts.conf.tmp
     mv fonts.conf.tmp $out/etc/fonts/fonts.conf
-    # We don't keep section 3 of the manpages, as they are quite large and
-    # probably not so useful.
-    rm -r $bin/share/man/man3
   '';
 
   nativeInstallCheckInputs = [
@@ -102,8 +100,9 @@ stdenv.mkDerivation (finalAttrs: {
   installCheckPhase = ''
     runHook preInstallCheck
 
-    [ -d "$bin/share/man/man1" ]
-    [ -d "$bin/share/man/man5" ]
+    [ -d "$man/share/man/man1" ]
+    [ -d "$man/share/man/man3" ]
+    [ -d "$man/share/man/man5" ]
     echo "man pages exist"
 
     runHook postInstallCheck


### PR DESCRIPTION
Also set `__structuredAttrs` and `strictDeps` while we're here.

Size changes:
- `out`: `-1108K` (down to just `372K`)
- `bin` `-48K` (down to `208K`)
- `doc`: `+1108K` (new output)
- `man`: `+952K` (new output)

CC:
- https://github.com/NixOS/nixpkgs/issues/515268
- https://github.com/NixOS/nixpkgs/issues/205690

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
