### PR TITLE
netflow2ng: init at 0.2.2

### DIFF
--- a/pkgs/by-name/ne/netflow2ng/package.nix
+++ b/pkgs/by-name/ne/netflow2ng/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  pkg-config,
+  versionCheckHook,
+  zeromq,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "netflow2ng";
+  version = "0.2.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "synfinatic";
+    repo = "netflow2ng";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-cBAgZhHYA9YpQ9NoiW6WNQvPi5nnZ0V3R/bbL8mNXuo=";
+  };
+
+  vendorHash = "sha256-2hGY58ofzY7BTIrecdSDoo6JuQwJe4AyNPGiBpGY9lA=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ zeromq ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  ldflags = [
+    "-s"
+    "-X=main.Version=${finalAttrs.version}"
+    "-X=main.Buildinfos=nixpkgs"
+    "-X=main.Tag=${finalAttrs.src.tag}"
+    "-X=main.CommitID=${finalAttrs.src.rev}"
+  ];
+
+  doInstallCheck = true;
+
+  postInstall = ''
+    mv $out/bin/cmd $out/bin/${finalAttrs.pname}
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "NetFlow v9 collector for ntopng";
+    homepage = "https://github.com/synfinatic/netflow2ng";
+    changelog = "https://github.com/synfinatic/netflow2ng/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "netflow2ng";
+  };
+})


### PR DESCRIPTION
NetFlow v9 collector for ntopng

https://github.com/synfinatic/netflow2ng


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
