### PR TITLE
zigdoc: init at 0.5.1

### DIFF
--- a/pkgs/by-name/zi/zigdoc/package.nix
+++ b/pkgs/by-name/zi/zigdoc/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  zig_0_16,
+}:
+
+let
+  zig = zig_0_16;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "zigdoc";
+  version = "0.5.1";
+
+  src = fetchFromGitHub {
+    owner = "rockorager";
+    repo = "zigdoc";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OC84SxB0N+QbyXGAfdHDSWde16IwdCkIPbU699wnvY0=";
+  };
+
+  nativeBuildInputs = [ zig.hook ];
+
+  strictDeps = true;
+
+  __structuredAttrs = true;
+
+  meta = {
+    homepage = "https://github.com/rockorager/zigdoc";
+    description = "CLI tool to view documentation for zig library symbols";
+    changelog = "https://github.com/rockorager/zigdoc/releases";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ddogfoodd ];
+    mainProgram = "zigdoc";
+    inherit (zig.meta) platforms;
+  };
+})


### PR DESCRIPTION
`zigdoc` is a CLI tool to view documentation of zig library symbols including those of the standard library

https://github.com/rockorager/zigdoc

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
