### PR TITLE
maintainers/scripts: add coverage script

### DIFF
--- a/maintainers/scripts/coverage.nix
+++ b/maintainers/scripts/coverage.nix
@@ -206,20 +206,20 @@ let
   helpText = ''
     Please run:
 
-        % nix-shell maintainers/scripts/update.nix --argstr maintainer garbas
+        % nix-shell maintainers/scripts/coverage.nix --argstr maintainer garbas
 
     to run all update scripts for all packages that lists \`garbas\` as a maintainer
     and have \`updateScript\` defined, or:
 
-        % nix-shell maintainers/scripts/update.nix --argstr package nautilus
+        % nix-shell maintainers/scripts/coverage.nix --argstr package nautilus
 
     to run update script for specific package, or
 
-        % nix-shell maintainers/scripts/update.nix --arg predicate '(path: pkg: pkg.updateScript.name or null == "gnome-update-script")'
+        % nix-shell maintainers/scripts/coverage.nix --arg predicate '(path: pkg: pkg.updateScript.name or null == "gnome-update-script")'
 
     to run update script for all packages matching given predicate, or
 
-        % nix-shell maintainers/scripts/update.nix --argstr path gnome
+        % nix-shell maintainers/scripts/coverage.nix --argstr path gnome
 
     to run update script for all package under an attribute path.
 
@@ -247,10 +247,8 @@ let
   # Transform a matched package into an object for update.py.
   packageData =
     { package, attrPath }:
-    let
-      updateScript = get-script package;
-    in
     lib.filterAttrsRecursive (_: v: v != { }) {
+      package = attrPath;
       name = package.name;
       pname = lib.getName package;
       version = lib.getVersion package;

--- a/maintainers/scripts/coverage.nix
+++ b/maintainers/scripts/coverage.nix
@@ -1,0 +1,250 @@
+/*
+  To run:
+
+      nix-shell maintainers/scripts/coverage.nix
+
+  See the issues labeled as 'tracking' for more ideas
+*/
+{
+  package ? null,
+  maintainer ? null,
+  predicate ? null,
+  get-script ? pkg: pkg.updateScript or null,
+  path ? null,
+  max-workers ? null,
+  include-overlays ? false,
+  order ? null,
+}:
+
+let
+  pkgs = import ./../../default.nix (
+    (
+      if include-overlays == false then
+        { overlays = [ ]; }
+      else if include-overlays == true then
+        { } # Let Nixpkgs include overlays impurely.
+      else
+        { overlays = include-overlays; }
+    )
+    // {
+      config.allowAliases = false;
+    }
+  );
+
+  inherit (pkgs) lib;
+
+  # Remove duplicate elements from the list based on some extracted value. O(n^2) complexity.
+  nubOn =
+    f: list:
+    if list == [ ] then
+      [ ]
+    else
+      let
+        x = lib.head list;
+        xs = lib.filter (p: f x != f p) (lib.drop 1 list);
+      in
+      [ x ] ++ nubOn f xs;
+
+  /*
+    Recursively find all packages (derivations) in `pkgs` matching `cond` predicate.
+
+    Type: packagesWithPath :: AttrPath → (AttrPath → derivation → bool) → AttrSet → List<AttrSet{attrPath :: str; package :: derivation; }>
+          AttrPath :: [str]
+
+    The packages will be returned as a list of named pairs comprising of:
+      - attrPath: stringified attribute path (based on `rootPath`)
+      - package: corresponding derivation
+  */
+  packagesWithPath =
+    rootPath: cond: pkgs:
+    let
+      packagesWithPathInner =
+        path: pathContent:
+        let
+          result = builtins.tryEval pathContent;
+
+          somewhatUniqueRepresentant =
+            { package, attrPath }:
+            {
+              updateScript = (get-script package);
+              # Some updaters use the same `updateScript` value for all packages.
+              # Also compare `meta.description`.
+              position = package.meta.position or null;
+              # We cannot always use `meta.position` since it might not be available
+              # or it might be shared among multiple packages.
+            };
+
+          dedupResults = lst: nubOn somewhatUniqueRepresentant (lib.concatLists lst);
+        in
+        if result.success then
+          let
+            evaluatedPathContent = result.value;
+          in
+          if lib.isDerivation evaluatedPathContent then
+            lib.optional (cond path evaluatedPathContent) {
+              attrPath = lib.concatStringsSep "." path;
+              package = evaluatedPathContent;
+            }
+          else if lib.isAttrs evaluatedPathContent then
+            # If user explicitly points to an attrSet or it is marked for recursion, we recur.
+            if
+              path == rootPath
+              || evaluatedPathContent.recurseForDerivations or false
+              || evaluatedPathContent.recurseForRelease or false
+            then
+              dedupResults (
+                lib.mapAttrsToList (name: elem: packagesWithPathInner (path ++ [ name ]) elem) evaluatedPathContent
+              )
+            else
+              [ ]
+          else
+            [ ]
+        else
+          [ ];
+    in
+    packagesWithPathInner rootPath pkgs;
+
+  # Recursively find all packages (derivations) in `pkgs` matching `cond` predicate.
+  packagesWith = packagesWithPath [ ];
+
+  # Recursively find all packages in `pkgs` with updateScript matching given predicate.
+  packagesWithUpdateScriptMatchingPredicate =
+    cond: packagesWith (path: pkg: (get-script pkg != null) && cond path pkg);
+
+  # Recursively find all packages in `pkgs` with updateScript by given maintainer.
+  packagesWithUpdateScriptAndMaintainer =
+    maintainer':
+    let
+      maintainer =
+        if !builtins.hasAttr maintainer' lib.maintainers then
+          throw "Maintainer with name `${maintainer'} does not exist in `maintainers/maintainer-list.nix`."
+        else
+          builtins.getAttr maintainer' lib.maintainers;
+    in
+    packagesWithUpdateScriptMatchingPredicate (
+      path: pkg:
+      (
+        if builtins.hasAttr "maintainers" pkg.meta then
+          (
+            if builtins.isList pkg.meta.maintainers then
+              builtins.elem maintainer pkg.meta.maintainers
+            else
+              maintainer == pkg.meta.maintainers
+          )
+        else
+          false
+      )
+    );
+
+  # Recursively find all packages under `path` in `pkgs` with updateScript.
+  packagesWithUpdateScript =
+    path: pkgs:
+    let
+      prefix = lib.splitString "." path;
+      pathContent = lib.attrByPath prefix null pkgs;
+    in
+    if pathContent == null then
+      throw "Attribute path `${path}` does not exist."
+    else
+      packagesWithPath prefix (path: pkg: (get-script pkg != null)) pathContent;
+
+  # Find a package under `path` in `pkgs` and require that it has an updateScript.
+  packageByName =
+    path: pkgs:
+    let
+      package = lib.attrByPath (lib.splitString "." path) null pkgs;
+    in
+    if package == null then
+      throw "Package with an attribute name `${path}` does not exist."
+    else if get-script package == null then
+      throw "Package with an attribute name `${path}` does not have a `passthru.updateScript` attribute defined."
+    else
+      {
+        attrPath = path;
+        inherit package;
+      };
+
+  # List of packages matched based on the CLI arguments.
+  packages =
+    if package != null then
+      [ (packageByName package pkgs) ]
+    else if predicate != null then
+      packagesWithUpdateScriptMatchingPredicate predicate pkgs
+    else if maintainer != null then
+      packagesWithUpdateScriptAndMaintainer maintainer pkgs
+    else if path != null then
+      packagesWithUpdateScript path pkgs
+    else
+      throw "No arguments provided.\n\n${helpText}";
+
+  helpText = ''
+    Please run:
+
+        % nix-shell maintainers/scripts/update.nix --argstr maintainer garbas
+
+    to run all update scripts for all packages that lists \`garbas\` as a maintainer
+    and have \`updateScript\` defined, or:
+
+        % nix-shell maintainers/scripts/update.nix --argstr package nautilus
+
+    to run update script for specific package, or
+
+        % nix-shell maintainers/scripts/update.nix --arg predicate '(path: pkg: pkg.updateScript.name or null == "gnome-update-script")'
+
+    to run update script for all packages matching given predicate, or
+
+        % nix-shell maintainers/scripts/update.nix --argstr path gnome
+
+    to run update script for all package under an attribute path.
+
+    You can also add
+
+        --argstr max-workers 8
+
+    By default, the updater will update the packages in arbitrary order. Alternately, you can force a specific order based on the packages’ dependency relations:
+
+        - Reverse topological order (e.g. {"gnome-text-editor", "gimp"}, {"gtk3", "gtk4"}, {"glib"}) is useful when you want checkout each commit one by one to build each package individually but some of the packages to be updated would cause a mass rebuild for the others. Of course, this requires that none of the updated dependents require a new version of the dependency.
+
+            --argstr order reverse-topological
+
+        - Topological order (e.g. {"glib"}, {"gtk3", "gtk4"}, {"gnome-text-editor", "gimp"}) is useful when the updated dependents require a new version of updated dependency.
+
+            --argstr order topological
+
+    Note that sorting requires instantiating each package and then querying Nix store for requisites so it will be pretty slow with large number of packages.
+  '';
+
+  # Transform a matched package into an object for update.py.
+  packageData =
+    { package, attrPath }:
+    let
+      updateScript = get-script package;
+    in
+    {
+      name = package.name;
+      pname = lib.getName package;
+      version = lib.getVersion package;
+      strictDeps = package.strictDeps;
+      __structuredAttrs = package.__structuredAttrs;
+    };
+
+  # JSON file with data for update.py.
+  packagesJson = pkgs.writeText "packages.json" (builtins.toJSON (map packageData packages));
+in
+pkgs.stdenv.mkDerivation {
+  name = "nixpkgs-update-script";
+  buildCommand = ''
+    echo ""
+    echo "----------------------------------------------------------------"
+    echo ""
+    echo "Not possible to observe coverage using \`nix-build\`"
+    echo ""
+    echo "${helpText}"
+    echo "----------------------------------------------------------------"
+    exit 1
+  '';
+  shellHook = ''
+    unset shellHook # do not contaminate nested shells
+    exec ${lib.getExe' pkgs.toybox "cat"} ${packagesJson} | ${lib.getExe pkgs.jq}
+  '';
+}

--- a/maintainers/scripts/coverage.nix
+++ b/maintainers/scripts/coverage.nix
@@ -250,7 +250,7 @@ let
     let
       updateScript = get-script package;
     in
-    {
+    lib.filterAttrsRecursive (_: v: v != { }) {
       name = package.name;
       pname = lib.getName package;
       version = lib.getVersion package;

--- a/maintainers/scripts/coverage.nix
+++ b/maintainers/scripts/coverage.nix
@@ -226,17 +226,20 @@ let
       __structuredAttrs = package.__structuredAttrs;
       # https://github.com/NixOS/nixpkgs/issues/325892
       srihash = !(lib.hasInfix ":" package.src.hash);
+      ${if package.src ? gitRepoUrl then "gittag" else null} = package.src.tag != null;
+
       # ${ if ? then } syntax over // optionalAttrs for perf benefits
       # see https://github.com/NixOS/nixpkgs/pull/506793
       # premature optimization can be fun :)
       languageAttrs = {
-        # python
+        ## python
         ${if package ? pyproject then "pyproject" else null} =
           package.pyproject != null && package.pyproject != false;
+
         # checks pyproject because its in all python builders
         ${if package ? pyproject then "pythonImportsCheck" else null} = package ? pythonImportsCheck;
 
-        # node/npm
+        ## node/npm
         # https://github.com/NixOS/nixpkgs/issues/529285
         ${if package ? pnpmDeps then "pnpm" else null} =
           package.pnpmDeps.pnpm.version or (lib.getVersion package.pnpmDeps.pnpm);
@@ -249,7 +252,7 @@ let
         } =
           true;
 
-        # rust
+        ## rust
         # https://github.com/NixOS/nixpkgs/issues/327064
         ${if package ? cargoDeps && package.cargoDeps ? lockFile then "lockFile" else null} = true; # want to get rid of these
 

--- a/maintainers/scripts/coverage.nix
+++ b/maintainers/scripts/coverage.nix
@@ -156,8 +156,6 @@ let
     in
     if package == null then
       throw "Package with an attribute name `${path}` does not exist."
-    else if get-script package == null then
-      throw "Package with an attribute name `${path}` does not have a `passthru.updateScript` attribute defined."
     else
       {
         attrPath = path;
@@ -226,13 +224,41 @@ let
       version = lib.getVersion package;
       strictDeps = package.strictDeps;
       __structuredAttrs = package.__structuredAttrs;
+      # ${ if ? then } syntax over // optionalAttrs for perf benefits
+      # see https://github.com/NixOS/nixpkgs/pull/506793
+      # premature optimization can be fun :)
+      languageAttrs = {
+        # python
+        ${if package ? pyproject then "pyproject" else null} =
+          package.pyproject != null && package.pyproject != false;
+        # checks pyproject because its in all python builders
+        ${if package ? pyproject then "pythonImportsCheck" else null} = package ? pythonImportsCheck;
+
+        # node/npm
+        # https://github.com/NixOS/nixpkgs/issues/529285
+        ${if package ? pnpmDeps then "pnpm" else null} =
+          package.pnpmDeps.pnpm.version or (lib.getVersion package.pnpmDeps.pnpm);
+        # kinda hacky but seems mostly consistent across the repo?.. tested on mdx-language-server
+        ${
+          if package ? postPatch && lib.hasInfix "package-lock.json" package.postPatch then
+            "lockFile"
+          else
+            null
+        } =
+          true;
+
+        # rust
+        # https://github.com/NixOS/nixpkgs/issues/327064
+        ${if package ? cargoDeps && package.cargoDeps ? lockFile then "lockFile" else null} = true; # want to get rid of these
+
+      };
     };
 
   # JSON file with data for update.py.
   packagesJson = pkgs.writeText "packages.json" (builtins.toJSON (map packageData packages));
 in
-pkgs.stdenv.mkDerivation {
-  name = "nixpkgs-update-script";
+pkgs.stdenvNoCC.mkDerivation {
+  name = "nixpkgs-coverage-checker";
   buildCommand = ''
     echo ""
     echo "----------------------------------------------------------------"
@@ -246,5 +272,6 @@ pkgs.stdenv.mkDerivation {
   shellHook = ''
     unset shellHook # do not contaminate nested shells
     exec ${lib.getExe' pkgs.toybox "cat"} ${packagesJson} | ${lib.getExe pkgs.jq}
+    exit 0 # prevent new shell
   '';
 }

--- a/maintainers/scripts/coverage.nix
+++ b/maintainers/scripts/coverage.nix
@@ -224,6 +224,8 @@ let
       version = lib.getVersion package;
       strictDeps = package.strictDeps;
       __structuredAttrs = package.__structuredAttrs;
+      # https://github.com/NixOS/nixpkgs/issues/325892
+      srihash = !(lib.hasInfix ":" package.src.hash);
       # ${ if ? then } syntax over // optionalAttrs for perf benefits
       # see https://github.com/NixOS/nixpkgs/pull/506793
       # premature optimization can be fun :)

--- a/maintainers/scripts/coverage.nix
+++ b/maintainers/scripts/coverage.nix
@@ -8,6 +8,7 @@
 {
   package ? null,
   maintainer ? null,
+  team ? null,
   predicate ? null,
   get-script ? pkg: pkg.updateScript or null,
   path ? null,
@@ -28,6 +29,8 @@ let
     )
     // {
       config.allowAliases = false;
+      # allow maintainers to run this script on multiple platforms
+      config.allowUnsupportedSystem = true;
     }
   );
 
@@ -136,6 +139,31 @@ let
       )
     );
 
+    # Recursively find all packages in `pkgs` with updateScript by given team.
+  packagesWithUpdateScriptAndTeam =
+    team':
+    let
+      team =
+        if !builtins.hasAttr team' lib.teams then
+          throw "Team with name `${team'} does not exist in `maintainers/team-list.nix`."
+        else
+          builtins.getAttr team' lib.teams;
+    in
+    packagesWithUpdateScriptMatchingPredicate (
+      path: pkg:
+      (
+        if builtins.hasAttr "teams" pkg.meta then
+          (
+            if builtins.isList pkg.meta.teams then
+              builtins.elem team pkg.meta.teams
+            else
+              team == pkg.meta.teams
+          )
+        else
+          false
+      )
+    );
+
   # Recursively find all packages under `path` in `pkgs` with updateScript.
   packagesWithUpdateScript =
     path: pkgs:
@@ -170,6 +198,8 @@ let
       packagesWithUpdateScriptMatchingPredicate predicate pkgs
     else if maintainer != null then
       packagesWithUpdateScriptAndMaintainer maintainer pkgs
+    else if team != null then
+      packagesWithUpdateScriptAndTeam team pkgs
     else if path != null then
       packagesWithUpdateScript path pkgs
     else
@@ -222,11 +252,12 @@ let
       name = package.name;
       pname = lib.getName package;
       version = lib.getVersion package;
+      outputs = package.outputs;
       strictDeps = package.strictDeps;
       __structuredAttrs = package.__structuredAttrs;
       # https://github.com/NixOS/nixpkgs/issues/325892
       srihash = !(lib.hasInfix ":" package.src.hash);
-      ${if package.src ? gitRepoUrl then "gittag" else null} = package.src.tag != null;
+      ${if package.src ? gitRepoUrl && package.src.gitRepoUrl ? tag then "gittag" else null} = package.src.tag != null;
 
       # ${ if ? then } syntax over // optionalAttrs for perf benefits
       # see https://github.com/NixOS/nixpkgs/pull/506793
@@ -241,8 +272,9 @@ let
 
         ## node/npm
         # https://github.com/NixOS/nixpkgs/issues/529285
-        ${if package ? pnpmDeps then "pnpm" else null} =
+        ${if package ? pnpmDeps && package.pnpmDeps ? version then "pnpm" else null} =
           package.pnpmDeps.pnpm.version or (lib.getVersion package.pnpmDeps.pnpm);
+        ${if package ? pnpmDeps then "pnpmfetcher" else null} = package.pnpmDeps.fetcherVersion;
         # kinda hacky but seems mostly consistent across the repo?.. tested on mdx-language-server
         ${
           if package ? postPatch && lib.hasInfix "package-lock.json" package.postPatch then

--- a/maintainers/scripts/coverage.nix
+++ b/maintainers/scripts/coverage.nix
@@ -247,6 +247,9 @@ let
   # Transform a matched package into an object for update.py.
   packageData =
     { package, attrPath }:
+    let
+      inherit (lib) optionalAttrs;
+    in
     lib.filterAttrsRecursive (_: v: v != { }) {
       package = attrPath;
       name = package.name;
@@ -254,17 +257,13 @@ let
       version = lib.getVersion package;
       outputs = package.outputs;
 
-      # see https://github.com/NixOS/nixpkgs/pull/506793
-      # premature optimization can be fun :)
-      # ${ if ? then } syntax over // optionalAttrs for perf benefits
       attributes = {
-        src = {
-          # currently fetchFromSourcehut doesn't support tag which breaks eval here
-          # ${if package ? src.gitRepoUrl then "tag" else null} = package.src.tag != null;
-
+        src = { }
           # https://github.com/NixOS/nixpkgs/issues/325892
-          ${if package ? src.hash then "srihash" else null} = !(lib.hasInfix ":" package.src.hash);
-        };
+          // optionalAttrs (package ? src.hash) { srihash = !(lib.hasInfix ":" package.src.hash); };
+
+          # currently fetchFromSourcehut doesn't support tag which breaks eval here
+          # // optionalAttrs (package ? src.gitRepoUrl) { tag = package.src.tag != null; };
 
         common = {
           # https://github.com/NixOS/nixpkgs/issues/178468
@@ -281,83 +280,41 @@ let
 
           # list found from `rg runHook (pre|post)` and stdenv.chapter.md
           # not comprehensive by any means, but these are the most common
-          usesRunHooks = {
-            ${if package ? unpackPhase then "unpackPhase" else null} =
-              checkPhaseHooks "preUnpack" "postUnpack"
-                package.unpackPhase;
-
-            ${if package ? patchPhase then "patchPhase" else null} =
-              checkPhaseHooks "prePatch" "postPatch"
-                package.patchPhase;
-
-            ${if package ? configurePhase then "configurePhase" else null} =
-              checkPhaseHooks "preConfigure" "postConfigure"
-                package.configurePhase;
-
-            ${if package ? buildPhase then "buildPhase" else null} =
-              checkPhaseHooks "preBuild" "postBuild"
-                package.buildPhase;
-
-            ${if package ? installPhase then "installPhase" else null} =
-              checkPhaseHooks "preInstall" "postInstal"
-                package.installPhase;
-
-            ${if package ? checkPhase then "checkPhase" else null} =
-              checkPhaseHooks "preCheck" "postCheck"
-                package.checkPhase;
-
-            ${if package ? installCheckPhase then "installCheckPhase" else null} =
-              checkPhaseHooks "preInstallCheck" "postInstallCheck"
-                package.installCheckPhase;
-
-            ${if package ? fixupPhase then "fixupPhase" else null} =
-              checkPhaseHooks "preFixup" "postFixup"
-                package.fixupPhase;
-          };
+          usesRunHooks = { }
+            // optionalAttrs (package ? unpackPhase) { unpackPhase = checkPhaseHooks "preUnpack" "postUnpack" package.unpackPhase; }
+            // optionalAttrs (package ? patchPhase) { patchPhase = checkPhaseHooks "prePatch" "postPatch" package.patchPhase; }
+            // optionalAttrs (package ? configurePhase) { configurePhase = checkPhaseHooks "preConfigure" "postConfigure" package.configurePhase; }
+            // optionalAttrs (package ? buildPhase) { buildPhase = checkPhaseHooks "preBuild" "postBuild" package.buildPhase; }
+            // optionalAttrs (package ? installPhase) { installPhase = checkPhaseHooks "preInstall" "postInstall" package.installPhase; }
+            // optionalAttrs (package ? checkPhase) { checkPhase = checkPhaseHooks "preCheck" "postCheck" package.checkPhase; }
+            // optionalAttrs (package ? installCheckPhase) { installCheckPhase = checkPhaseHooks "preInstallCheck" "postInstallCheck" package.installCheckPhase; }
+            // optionalAttrs (package ? fixupPhase) { fixupPhase = checkPhaseHooks "preFixup" "postFixup" package.fixupPhase; };
         };
 
-        # https://github.com/NixOS/nixpkgs/issues/79303
-        stdenv = {
-          NIX_CFLAGS_COMPILE = package ? env.NIX_CFLAGS_COMPILE || package ? NIX_CFLAGS_COMPILE;
-        };
+        stdenv = { }
+          # https://github.com/NixOS/nixpkgs/issues/79303
+          // optionalAttrs (package ? env.NIX_CFLAGS_COMPILE || package ? NIX_CFLAGS_COMPILE) { NIX_CFLAGS_COMPILE = true; };
 
-        python = {
+        python = { }
           # https://github.com/NixOS/nixpkgs/issues/515974
           # https://github.com/NixOS/nixpkgs/issues/253154
-          ${if package ? pyproject then "pyproject" else null} =
-            package.pyproject != null && package.pyproject != false;
-
+          // optionalAttrs (package ? pyproject) { pyproject = package.pyproject != false; }
           # checks pyproject because its in all python builders
-          ${if package ? pyproject then "pythonImportsCheck" else null} = package ? pythonImportsCheck;
-        };
+          // optionalAttrs (package ? pyproject) { pythonImportsCheck = package ? pythonImportsCheck; };
 
-        node = {
+        node = { }
           # https://github.com/NixOS/nixpkgs/issues/529285
-          ${if package ? pnpmDeps.pnpm.version then "pnpm" else null} = package.pnpmDeps.pnpm.version;
-
-          ${if package ? pnpmDeps then "pnpmfetcher" else null} = package.pnpmDeps.fetcherVersion;
+          // optionalAttrs (package ? pnpmDeps.pnpm.version) { pnpm = package.pnpmDeps.pnpm.version; }
+          // optionalAttrs (package ? pnpmDeps) { pnpmfetcher = package.pnpmDeps.fetcherVersion; }
           # kinda hacky but seems mostly consistent across the repo?.. tested on mdx-language-server
-          ${
-            if
-              package ? postPatch
-              && builtins.typeOf package.postPatch == "string"
-              && lib.hasInfix "package-lock.json" package.postPatch
-            then
-              "lockFile"
-            else
-              null
-          } =
-            true;
-        };
+          // optionalAttrs (package ? postPatch && builtins.typeOf package.postPatch == "string" && lib.hasInfix "package-lock.json" package.postPatch) { lockFile = true; };
 
-        rust = {
+        rust = { }
           # https://github.com/NixOS/nixpkgs/issues/327064
-          ${if package ? cargoDeps && package.cargoDeps ? lockFile then "lockFile" else null} = true; # want to get rid of these
-        };
+         // optionalAttrs (package ? cargoDeps.lockFile) { lockFile = true; };
 
-        go = {
-          ${if package ? ldflags then "ldflags" else null} = package.ldflags;
-        };
+        go = { }
+          // optionalAttrs (package ? ldflags) { ldflags = package.ldflags; };
       };
 
     };

--- a/maintainers/scripts/coverage.nix
+++ b/maintainers/scripts/coverage.nix
@@ -31,6 +31,7 @@ let
       config.allowAliases = false;
       # allow maintainers to run this script on multiple platforms
       config.allowUnsupportedSystem = true;
+      config.allowUnfree = true;
     }
   );
 
@@ -241,7 +242,7 @@ let
 
   checkPhaseHooks =
     pre: post: package:
-    lib.hasInfix "runHook ${pre}" package && lib.hasInfix "runHook ${post}" package;
+    package != null && lib.hasInfix "runHook ${pre}" package && lib.hasInfix "runHook ${post}" package;
 
   # Transform a matched package into an object for update.py.
   packageData =
@@ -260,14 +261,25 @@ let
       # ${ if ? then } syntax over // optionalAttrs for perf benefits
       attributes = {
         src = {
-          ${if package ? src.gitRepoUrl then "tag" else null} = package.src.tag != null;
+          # currently fetchFromSourcehut doesn't support tag which breaks eval here
+          # ${if package ? src.gitRepoUrl then "tag" else null} = package.src.tag != null;
+
           # https://github.com/NixOS/nixpkgs/issues/325892
-          srihash = !(lib.hasInfix ":" package.src.hash);
+          ${if package ? src.hash then "srihash" else null} = !(lib.hasInfix ":" package.src.hash);
         };
 
         common = {
+          # https://github.com/NixOS/nixpkgs/issues/178468
           strictDeps = package.strictDeps;
+          # https://github.com/NixOS/nixpkgs/issues/205690
           __structuredAttrs = package.__structuredAttrs;
+
+          # https://github.com/NixOS/nixpkgs/issues/205690#issuecomment-4710988930
+          parallel = {
+            enableParallelBuilding = package ? enableParallelBuilding && package.enableParallelBuilding;
+            enableParallelChecking = package ? enableParallelChecking && package.enableParallelChecking;
+            enableParallelInstalling = package ? enableParallelInstalling && package.enableParallelInstalling;
+          };
 
           # list found from `rg runHook (pre|post)` and stdenv.chapter.md
           # not comprehensive by any means, but these are the most common
@@ -275,31 +287,45 @@ let
             ${if package ? unpackPhase then "unpackPhase" else null} =
               checkPhaseHooks "preUnpack" "postUnpack"
                 package.unpackPhase;
+
             ${if package ? patchPhase then "patchPhase" else null} =
               checkPhaseHooks "prePatch" "postPatch"
                 package.patchPhase;
+
             ${if package ? configurePhase then "configurePhase" else null} =
               checkPhaseHooks "preConfigure" "postConfigure"
                 package.configurePhase;
+
             ${if package ? buildPhase then "buildPhase" else null} =
               checkPhaseHooks "preBuild" "postBuild"
                 package.buildPhase;
+
             ${if package ? installPhase then "installPhase" else null} =
               checkPhaseHooks "preInstall" "postInstal"
                 package.installPhase;
+
             ${if package ? checkPhase then "checkPhase" else null} =
               checkPhaseHooks "preCheck" "postCheck"
                 package.checkPhase;
+
             ${if package ? installCheckPhase then "installCheckPhase" else null} =
               checkPhaseHooks "preInstallCheck" "postInstallCheck"
                 package.installCheckPhase;
+
             ${if package ? fixupPhase then "fixupPhase" else null} =
               checkPhaseHooks "preFixup" "postFixup"
                 package.fixupPhase;
           };
         };
 
+        # https://github.com/NixOS/nixpkgs/issues/79303
+        stdenv = {
+          NIX_CFLAGS_COMPILE = package ? env.NIX_CFLAGS_COMPILE || package ? NIX_CFLAGS_COMPILE;
+        };
+
         python = {
+          # https://github.com/NixOS/nixpkgs/issues/515974
+          # https://github.com/NixOS/nixpkgs/issues/253154
           ${if package ? pyproject then "pyproject" else null} =
             package.pyproject != null && package.pyproject != false;
 
@@ -309,12 +335,16 @@ let
 
         node = {
           # https://github.com/NixOS/nixpkgs/issues/529285
-          ${if package ? pnpmDeps && package.pnpmDeps ? version then "pnpm" else null} =
-            package.pnpmDeps.pnpm.version or (lib.getVersion package.pnpmDeps.pnpm);
+          ${if package ? pnpmDeps.pnpm.version then "pnpm" else null} = package.pnpmDeps.pnpm.version;
+
           ${if package ? pnpmDeps then "pnpmfetcher" else null} = package.pnpmDeps.fetcherVersion;
           # kinda hacky but seems mostly consistent across the repo?.. tested on mdx-language-server
           ${
-            if package ? postPatch && lib.hasInfix "package-lock.json" package.postPatch then
+            if
+              package ? postPatch
+              && builtins.typeOf package.postPatch == "string"
+              && lib.hasInfix "package-lock.json" package.postPatch
+            then
               "lockFile"
             else
               null

--- a/maintainers/scripts/coverage.nix
+++ b/maintainers/scripts/coverage.nix
@@ -139,7 +139,7 @@ let
       )
     );
 
-    # Recursively find all packages in `pkgs` with updateScript by given team.
+  # Recursively find all packages in `pkgs` with updateScript by given team.
   packagesWithUpdateScriptAndTeam =
     team':
     let
@@ -154,10 +154,7 @@ let
       (
         if builtins.hasAttr "teams" pkg.meta then
           (
-            if builtins.isList pkg.meta.teams then
-              builtins.elem team pkg.meta.teams
-            else
-              team == pkg.meta.teams
+            if builtins.isList pkg.meta.teams then builtins.elem team pkg.meta.teams else team == pkg.meta.teams
           )
         else
           false
@@ -242,6 +239,10 @@ let
     Note that sorting requires instantiating each package and then querying Nix store for requisites so it will be pretty slow with large number of packages.
   '';
 
+  checkPhaseHooks =
+    pre: post: package:
+    lib.hasInfix "runHook ${pre}" package && lib.hasInfix "runHook ${post}" package;
+
   # Transform a matched package into an object for update.py.
   packageData =
     { package, attrPath }:
@@ -253,42 +254,84 @@ let
       pname = lib.getName package;
       version = lib.getVersion package;
       outputs = package.outputs;
-      strictDeps = package.strictDeps;
-      __structuredAttrs = package.__structuredAttrs;
-      # https://github.com/NixOS/nixpkgs/issues/325892
-      srihash = !(lib.hasInfix ":" package.src.hash);
-      ${if package.src ? gitRepoUrl && package.src.gitRepoUrl ? tag then "gittag" else null} = package.src.tag != null;
 
-      # ${ if ? then } syntax over // optionalAttrs for perf benefits
       # see https://github.com/NixOS/nixpkgs/pull/506793
       # premature optimization can be fun :)
-      languageAttrs = {
-        ## python
-        ${if package ? pyproject then "pyproject" else null} =
-          package.pyproject != null && package.pyproject != false;
+      # ${ if ? then } syntax over // optionalAttrs for perf benefits
+      attributes = {
+        src = {
+          ${if package ? src.gitRepoUrl then "tag" else null} = package.src.tag != null;
+          # https://github.com/NixOS/nixpkgs/issues/325892
+          srihash = !(lib.hasInfix ":" package.src.hash);
+        };
 
-        # checks pyproject because its in all python builders
-        ${if package ? pyproject then "pythonImportsCheck" else null} = package ? pythonImportsCheck;
+        common = {
+          strictDeps = package.strictDeps;
+          __structuredAttrs = package.__structuredAttrs;
 
-        ## node/npm
-        # https://github.com/NixOS/nixpkgs/issues/529285
-        ${if package ? pnpmDeps && package.pnpmDeps ? version then "pnpm" else null} =
-          package.pnpmDeps.pnpm.version or (lib.getVersion package.pnpmDeps.pnpm);
-        ${if package ? pnpmDeps then "pnpmfetcher" else null} = package.pnpmDeps.fetcherVersion;
-        # kinda hacky but seems mostly consistent across the repo?.. tested on mdx-language-server
-        ${
-          if package ? postPatch && lib.hasInfix "package-lock.json" package.postPatch then
-            "lockFile"
-          else
-            null
-        } =
-          true;
+          # list found from `rg runHook (pre|post)` and stdenv.chapter.md
+          # not comprehensive by any means, but these are the most common
+          usesRunHooks = {
+            ${if package ? unpackPhase then "unpackPhase" else null} =
+              checkPhaseHooks "preUnpack" "postUnpack"
+                package.unpackPhase;
+            ${if package ? patchPhase then "patchPhase" else null} =
+              checkPhaseHooks "prePatch" "postPatch"
+                package.patchPhase;
+            ${if package ? configurePhase then "configurePhase" else null} =
+              checkPhaseHooks "preConfigure" "postConfigure"
+                package.configurePhase;
+            ${if package ? buildPhase then "buildPhase" else null} =
+              checkPhaseHooks "preBuild" "postBuild"
+                package.buildPhase;
+            ${if package ? installPhase then "installPhase" else null} =
+              checkPhaseHooks "preInstall" "postInstal"
+                package.installPhase;
+            ${if package ? checkPhase then "checkPhase" else null} =
+              checkPhaseHooks "preCheck" "postCheck"
+                package.checkPhase;
+            ${if package ? installCheckPhase then "installCheckPhase" else null} =
+              checkPhaseHooks "preInstallCheck" "postInstallCheck"
+                package.installCheckPhase;
+            ${if package ? fixupPhase then "fixupPhase" else null} =
+              checkPhaseHooks "preFixup" "postFixup"
+                package.fixupPhase;
+          };
+        };
 
-        ## rust
-        # https://github.com/NixOS/nixpkgs/issues/327064
-        ${if package ? cargoDeps && package.cargoDeps ? lockFile then "lockFile" else null} = true; # want to get rid of these
+        python = {
+          ${if package ? pyproject then "pyproject" else null} =
+            package.pyproject != null && package.pyproject != false;
 
+          # checks pyproject because its in all python builders
+          ${if package ? pyproject then "pythonImportsCheck" else null} = package ? pythonImportsCheck;
+        };
+
+        node = {
+          # https://github.com/NixOS/nixpkgs/issues/529285
+          ${if package ? pnpmDeps && package.pnpmDeps ? version then "pnpm" else null} =
+            package.pnpmDeps.pnpm.version or (lib.getVersion package.pnpmDeps.pnpm);
+          ${if package ? pnpmDeps then "pnpmfetcher" else null} = package.pnpmDeps.fetcherVersion;
+          # kinda hacky but seems mostly consistent across the repo?.. tested on mdx-language-server
+          ${
+            if package ? postPatch && lib.hasInfix "package-lock.json" package.postPatch then
+              "lockFile"
+            else
+              null
+          } =
+            true;
+        };
+
+        rust = {
+          # https://github.com/NixOS/nixpkgs/issues/327064
+          ${if package ? cargoDeps && package.cargoDeps ? lockFile then "lockFile" else null} = true; # want to get rid of these
+        };
+
+        go = {
+          ${if package ? ldflags then "ldflags" else null} = package.ldflags;
+        };
       };
+
     };
 
   # JSON file with data for update.py.

--- a/maintainers/scripts/coverage.nix
+++ b/maintainers/scripts/coverage.nix
@@ -261,10 +261,11 @@ let
         src =
           { }
           # https://github.com/NixOS/nixpkgs/issues/325892
-          // optionalAttrs (package ? src.hash) { srihash = !(lib.hasInfix ":" package.src.hash); };
+          # checking if outputHashAlgo != null may be better here? basically the same thing tho
+          // optionalAttrs (package ? src.hash) { srihash = !(lib.hasInfix ":" package.src.hash); }
 
-        # currently fetchFromSourcehut doesn't support tag which breaks eval here
-        # // optionalAttrs (package ? src.gitRepoUrl) { tag = package.src.tag != null; };
+          # currently fetchFromSourcehut doesn't support tag which breaks eval here
+          // optionalAttrs (package ? src.gitRepoUrl) { tag = package.src.tag != null; };
 
         common = {
           # https://github.com/NixOS/nixpkgs/issues/178468

--- a/maintainers/scripts/coverage.nix
+++ b/maintainers/scripts/coverage.nix
@@ -258,12 +258,13 @@ let
       outputs = package.outputs;
 
       attributes = {
-        src = { }
+        src =
+          { }
           # https://github.com/NixOS/nixpkgs/issues/325892
           // optionalAttrs (package ? src.hash) { srihash = !(lib.hasInfix ":" package.src.hash); };
 
-          # currently fetchFromSourcehut doesn't support tag which breaks eval here
-          # // optionalAttrs (package ? src.gitRepoUrl) { tag = package.src.tag != null; };
+        # currently fetchFromSourcehut doesn't support tag which breaks eval here
+        # // optionalAttrs (package ? src.gitRepoUrl) { tag = package.src.tag != null; };
 
         common = {
           # https://github.com/NixOS/nixpkgs/issues/178468
@@ -280,41 +281,67 @@ let
 
           # list found from `rg runHook (pre|post)` and stdenv.chapter.md
           # not comprehensive by any means, but these are the most common
-          usesRunHooks = { }
-            // optionalAttrs (package ? unpackPhase) { unpackPhase = checkPhaseHooks "preUnpack" "postUnpack" package.unpackPhase; }
-            // optionalAttrs (package ? patchPhase) { patchPhase = checkPhaseHooks "prePatch" "postPatch" package.patchPhase; }
-            // optionalAttrs (package ? configurePhase) { configurePhase = checkPhaseHooks "preConfigure" "postConfigure" package.configurePhase; }
-            // optionalAttrs (package ? buildPhase) { buildPhase = checkPhaseHooks "preBuild" "postBuild" package.buildPhase; }
-            // optionalAttrs (package ? installPhase) { installPhase = checkPhaseHooks "preInstall" "postInstall" package.installPhase; }
-            // optionalAttrs (package ? checkPhase) { checkPhase = checkPhaseHooks "preCheck" "postCheck" package.checkPhase; }
-            // optionalAttrs (package ? installCheckPhase) { installCheckPhase = checkPhaseHooks "preInstallCheck" "postInstallCheck" package.installCheckPhase; }
-            // optionalAttrs (package ? fixupPhase) { fixupPhase = checkPhaseHooks "preFixup" "postFixup" package.fixupPhase; };
+          usesRunHooks =
+            { }
+            // optionalAttrs (package ? unpackPhase) {
+              unpackPhase = checkPhaseHooks "preUnpack" "postUnpack" package.unpackPhase;
+            }
+            // optionalAttrs (package ? patchPhase) {
+              patchPhase = checkPhaseHooks "prePatch" "postPatch" package.patchPhase;
+            }
+            // optionalAttrs (package ? configurePhase) {
+              configurePhase = checkPhaseHooks "preConfigure" "postConfigure" package.configurePhase;
+            }
+            // optionalAttrs (package ? buildPhase) {
+              buildPhase = checkPhaseHooks "preBuild" "postBuild" package.buildPhase;
+            }
+            // optionalAttrs (package ? installPhase) {
+              installPhase = checkPhaseHooks "preInstall" "postInstall" package.installPhase;
+            }
+            // optionalAttrs (package ? checkPhase) {
+              checkPhase = checkPhaseHooks "preCheck" "postCheck" package.checkPhase;
+            }
+            // optionalAttrs (package ? installCheckPhase) {
+              installCheckPhase = checkPhaseHooks "preInstallCheck" "postInstallCheck" package.installCheckPhase;
+            }
+            // optionalAttrs (package ? fixupPhase) {
+              fixupPhase = checkPhaseHooks "preFixup" "postFixup" package.fixupPhase;
+            };
         };
 
-        stdenv = { }
+        stdenv =
+          { }
           # https://github.com/NixOS/nixpkgs/issues/79303
-          // optionalAttrs (package ? env.NIX_CFLAGS_COMPILE || package ? NIX_CFLAGS_COMPILE) { NIX_CFLAGS_COMPILE = true; };
+          // optionalAttrs (package ? env.NIX_CFLAGS_COMPILE || package ? NIX_CFLAGS_COMPILE) {
+            NIX_CFLAGS_COMPILE = true;
+          };
 
-        python = { }
+        python =
+          { }
           # https://github.com/NixOS/nixpkgs/issues/515974
           # https://github.com/NixOS/nixpkgs/issues/253154
           // optionalAttrs (package ? pyproject) { pyproject = package.pyproject != false; }
           # checks pyproject because its in all python builders
           // optionalAttrs (package ? pyproject) { pythonImportsCheck = package ? pythonImportsCheck; };
 
-        node = { }
+        node =
+          { }
           # https://github.com/NixOS/nixpkgs/issues/529285
           // optionalAttrs (package ? pnpmDeps.pnpm.version) { pnpm = package.pnpmDeps.pnpm.version; }
           // optionalAttrs (package ? pnpmDeps) { pnpmfetcher = package.pnpmDeps.fetcherVersion; }
           # kinda hacky but seems mostly consistent across the repo?.. tested on mdx-language-server
-          // optionalAttrs (package ? postPatch && builtins.typeOf package.postPatch == "string" && lib.hasInfix "package-lock.json" package.postPatch) { lockFile = true; };
+          // optionalAttrs (
+            package ? postPatch
+            && builtins.typeOf package.postPatch == "string"
+            && lib.hasInfix "package-lock.json" package.postPatch
+          ) { lockFile = true; };
 
-        rust = { }
+        rust =
+          { }
           # https://github.com/NixOS/nixpkgs/issues/327064
-         // optionalAttrs (package ? cargoDeps.lockFile) { lockFile = true; };
+          // optionalAttrs (package ? cargoDeps.lockFile) { lockFile = true; };
 
-        go = { }
-          // optionalAttrs (package ? ldflags) { ldflags = package.ldflags; };
+        go = { } // optionalAttrs (package ? ldflags) { ldflags = package.ldflags; };
       };
 
     };


### PR DESCRIPTION
This is a script that's meant to help maintainers understand their coverage on certain more modern migrations to Nixpkgs. Heaviliy based off of the update.nix script. WIP and open to ideas from others.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
