### PR TITLE
python3Packages.perplexityai: init at 0.38.0

### DIFF
--- a/pkgs/development/python-modules/langchain-perplexity/default.nix
+++ b/pkgs/development/python-modules/langchain-perplexity/default.nix
@@ -9,6 +9,7 @@
   # dependencies
   langchain-core,
   openai,
+  perplexityai,
 
   # tests
   langchain-tests,
@@ -23,14 +24,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "langchain-perplexity";
-  version = "1.1.0";
+  version = "1.3.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain";
     tag = "langchain-perplexity==${finalAttrs.version}";
-    hash = "sha256-bm7sIa62CIvsYNDdaN+XZKpRnCv5bg9kPZ1Ym8utFcM=";
+    hash = "sha256-XSfnoJaj2VRXSxHHVnRNBvr4Ko7GAqnFEDM90ohaufo=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/libs/partners/perplexity";
@@ -40,6 +41,7 @@ buildPythonPackage (finalAttrs: {
   dependencies = [
     langchain-core
     openai
+    perplexityai
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/perplexityai/default.nix
+++ b/pkgs/development/python-modules/perplexityai/default.nix
@@ -1,0 +1,102 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatch-fancy-pypi-readme,
+  hatchling,
+
+  # dependencies (incl. optional)
+  anyio,
+  distro,
+  httpx,
+  pydantic,
+  sniffio,
+  typing-extensions,
+  aiohttp,
+  httpx-aiohttp,
+
+  # tests
+  pyright,
+  mypy,
+  respx,
+  pytest,
+  pytest-asyncio,
+  ruff,
+  time-machine,
+  nox,
+  dirty-equals,
+  importlib-metadata,
+  rich,
+  pytest-xdist,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "perplexityai";
+  version = "0.38.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "perplexityai";
+    repo = "perplexity-py";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Yp5A3aoKtAjWRPZ1Un2OYwezZohWirNm2JhAWLhd6uQ=";
+  };
+
+  # Can't use relaxPythonDeps as this is a version lock in the build system
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"hatchling==1.26.3"' '"hatchling"'
+  '';
+
+  build-system = [
+    hatch-fancy-pypi-readme
+    hatchling
+  ];
+
+  dependencies = [
+    anyio
+    distro
+    httpx
+    pydantic
+    sniffio
+    typing-extensions
+  ];
+
+  optional-dependencies = {
+    aiohttp = [
+      aiohttp
+      httpx-aiohttp
+    ];
+  };
+
+  nativeCheckInputs = [
+    pyright
+    mypy
+    respx
+    pytest
+    pytest-asyncio
+    ruff
+    time-machine
+    nox
+    dirty-equals
+    importlib-metadata
+    rich
+    pytest-xdist
+  ]
+  ++ finalAttrs.passthru.optional-dependencies.aiohttp;
+
+  pythonImportsCheck = [
+    "perplexity"
+  ];
+
+  meta = {
+    description = "API for Perplexity AI";
+    homepage = "https://github.com/perplexityai/perplexity-py";
+    changelog = "https://github.com/perplexityai/perplexity-py/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ sarahec ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12558,6 +12558,8 @@ self: super: with self; {
 
   permissionedforms = callPackage ../development/python-modules/permissionedforms { };
 
+  perplexityai = callPackage ../development/python-modules/perplexityai { };
+
   persim = callPackage ../development/python-modules/persim { };
 
   persist-queue = callPackage ../development/python-modules/persist-queue { };


### PR DESCRIPTION
Required by langchain-perplexity update

1. `python3Packages.perplexityai`: init at 0.38.0
2. `python313Packages.langchain-perplexity`: 1.1.0 -> 1.3.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
