### PR TITLE
vesktop: disable_xdg_mime patch

### DIFF
--- a/pkgs/by-name/ve/vesktop/disable_xdg_mime.patch
+++ b/pkgs/by-name/ve/vesktop/disable_xdg_mime.patch
@@ -1,0 +1,12 @@
+diff --git a/src/main/utils/setAsDefaultProtocolClient.ts b/src/main/utils/setAsDefaultProtocolClient.ts
+index c4b3580..8361226 100644
+--- a/src/main/utils/setAsDefaultProtocolClient.ts
++++ b/src/main/utils/setAsDefaultProtocolClient.ts
+@@ -11,6 +11,7 @@ export async function setAsDefaultProtocolClient(protocol: string) {
+     if (process.platform !== "linux") {
+         return app.setAsDefaultProtocolClient(protocol);
+     }
++    return true;
+ 
+     // electron setAsDefaultProtocolClient uses xdg-settings instead of xdg-mime.
+     // xdg-settings had a bug where it would also register the app as a handler for text/html,

--- a/pkgs/by-name/ve/vesktop/package.nix
+++ b/pkgs/by-name/ve/vesktop/package.nix
@@ -77,11 +77,15 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.getLib stdenv.cc.cc)
   ];
 
-  patches = lib.optional withSystemVencord (
-    replaceVars ./use_system_vencord.patch {
-      inherit vencord;
-    }
-  );
+  patches =
+    lib.optional withSystemVencord (
+      replaceVars ./use_system_vencord.patch {
+        inherit vencord;
+      }
+    )
+    # prevent vesktop from setting itself as a sceme handler on linux
+    # this is taken care of in the .desktop file already
+    ++ lib.optional stdenv.hostPlatform.isLinux ./disable_xdg_mime.patch;
 
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = 1;


### PR DESCRIPTION
Adds a patch for linux to vesktop to disable the `xdg-mime` command from being run on start. [[source]](https://github.com/Vencord/Vesktop/blob/61ecf66936ed5069b661306781e396edf26b1e01/src/main/utils/setAsDefaultProtocolClient.ts#L25)

This causes the `.config/mimeapps.list` file to be overwritten with the new url scheme association, which conflicts with home-manager's `xdg.mimeApps` linking.
Which causes home-manager to complain:
```
Existing file '/home/user/.config/mimeapps.list' would be clobbered
```

Since the scheme association is already in the .desktop file (#504668), I don't see a need for the desktop app to register itself as a scheme handler.
The scheme still works on my machine without being registered in mimeapps.list

This patch only applies on linux. It appears related to [this commit](https://github.com/Vencord/Vesktop/commit/0d9ca2270ce7a39566bd45b9315e72497c081527), however the issue didn't seem to appear in 25.11, only after the upgrade to 26.05.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
