### PR TITLE
nut: fix systemd units to more closely match upstream units

### DIFF
--- a/nixos/modules/services/monitoring/ups.nix
+++ b/nixos/modules/services/monitoring/ups.nix
@@ -606,14 +606,15 @@ in
         after = [ "network.target" ];
         wantedBy = [ "multi-user.target" ];
         serviceConfig = {
-          Type = "forking";
+          Type = "notify-reload";
           ExecStartPre = "${createUpsmonConf}";
-          ExecStart = "${cfg.package}/sbin/upsmon -u ${cfg.upsmon.user}";
-          ExecReload = "${cfg.package}/sbin/upsmon -c reload";
+          ExecStart = "${cfg.package}/sbin/upsmon -F -u ${cfg.upsmon.user}";
           LoadCredential = lib.mapAttrsToList (
             name: monitor: "upsmon_password_${name}:${monitor.passwordFile}"
           ) cfg.upsmon.monitor;
           Slice = "system-ups.slice";
+          NotifyAccess = "all";
+          PIDFile = "/run/upsmon.pid";
         };
         environment = envVars;
       };
@@ -632,15 +633,16 @@ in
         ];
         wantedBy = [ "multi-user.target" ];
         serviceConfig = {
-          Type = "forking";
+          Type = "notify-reload";
           ExecStartPre = "${createUpsdUsers}";
           # TODO: replace 'root' by another username.
-          ExecStart = "${cfg.package}/sbin/upsd -u root";
-          ExecReload = "${cfg.package}/sbin/upsd -c reload";
+          ExecStart = "${cfg.package}/sbin/upsd -FF -u root";
           LoadCredential = lib.mapAttrsToList (
             name: user: "upsdusers_password_${name}:${user.passwordFile}"
           ) cfg.users;
           Slice = "system-ups.slice";
+          NotifyAccess = "main";
+          PIDFile = "/var/lib/nut/upsd.pid";
         };
         environment = envVars;
         restartTriggers = [

--- a/nixos/modules/services/monitoring/ups.nix
+++ b/nixos/modules/services/monitoring/ups.nix
@@ -605,6 +605,10 @@ in
         description = "Uninterruptible Power Supplies (Monitor)";
         after = [ "network.target" ];
         wantedBy = [ "multi-user.target" ];
+        path = [
+          # for wall command
+          pkgs.util-linux
+        ];
         serviceConfig = {
           Type = "notify-reload";
           ExecStartPre = "${createUpsmonConf}";

--- a/pkgs/by-name/nu/nut/hardcode-systemd-analyze.patch
+++ b/pkgs/by-name/nu/nut/hardcode-systemd-analyze.patch
@@ -1,0 +1,53 @@
+diff --git a/configure.ac b/configure.ac
+index c27d6f532..26c2e4167 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -4993,46 +4993,8 @@ AC_MSG_RESULT(${with_libsystemd})
+ 
+ AC_PATH_PROG([SYSTEMD_ANALYZE_PROGRAM], [systemd-analyze], [/usr/bin/systemd-analyze])
+ 
+-dnl Relevant since 2023: https://github.com/systemd/systemd/pull/25916
+-SYSTEMD_SUPPORTS_DAEMON_TYPE_NOTIFY=no
+-AS_IF([test -x "$SYSTEMD_ANALYZE_PROGRAM"], [
+-	AC_MSG_CHECKING([if your systemd version supports Type=notify])
+-	myFILE="`mktemp systemd-analyze-XXXXXX.service`"
+-	cat > "$myFILE" << EOF
+-@<:@Unit@:>@
+-Description=temp
+-@<:@Service@:>@
+-ExecStart=/bin/true
+-Type=notify
+-EOF
+-	if myOUT="`"$SYSTEMD_ANALYZE_PROGRAM" verify "$myFILE" 2>&1`" \
+-	&& ! (echo "$myOUT" | grep "Failed to parse service type, ignoring") \
+-	; then
+-		SYSTEMD_SUPPORTS_DAEMON_TYPE_NOTIFY=yes
+-	fi
+-	rm -f "$myFILE"
+-	AC_MSG_RESULT([${SYSTEMD_SUPPORTS_DAEMON_TYPE_NOTIFY}])
+-	])
+-
+-SYSTEMD_SUPPORTS_DAEMON_TYPE_NOTIFY_RELOAD=no
+-AS_IF([test -x "$SYSTEMD_ANALYZE_PROGRAM"], [
+-	AC_MSG_CHECKING([if your systemd version supports Type=notify-reload])
+-	myFILE="`mktemp systemd-analyze-XXXXXX.service`"
+-	cat > "$myFILE" << EOF
+-@<:@Unit@:>@
+-Description=temp
+-@<:@Service@:>@
+-ExecStart=/bin/true
+-Type=notify-reload
+-EOF
+-	if myOUT="`"$SYSTEMD_ANALYZE_PROGRAM" verify "$myFILE" 2>&1`" \
+-	&& ! (echo "$myOUT" | grep "Failed to parse service type, ignoring") \
+-	; then
+-		SYSTEMD_SUPPORTS_DAEMON_TYPE_NOTIFY_RELOAD=yes
+-	fi
+-	rm -f "$myFILE"
+-	AC_MSG_RESULT([${SYSTEMD_SUPPORTS_DAEMON_TYPE_NOTIFY_RELOAD}])
+-	])
++SYSTEMD_SUPPORTS_DAEMON_TYPE_NOTIFY=yes
++SYSTEMD_SUPPORTS_DAEMON_TYPE_NOTIFY_RELOAD=yes
+ 
+ AS_IF([test x"${with_libsystemd}" = xyes && test x"${SYSTEMD_SUPPORTS_DAEMON_TYPE_NOTIFY}" = xyes], [
+ 	dnl Built with sd_notify support

--- a/pkgs/by-name/nu/nut/package.nix
+++ b/pkgs/by-name/nu/nut/package.nix
@@ -73,6 +73,8 @@ stdenv.mkDerivation (finalAttrs: {
       libmodbus = "${modbus}/lib";
       netsnmp = "${net-snmp.lib}/lib";
     })
+
+    ./hardcode-systemd-analyze.patch
   ];
 
   buildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

First, this includes a patch to the configure script to force the systemd units generated by the build to use the notify service type. I couldn't figure out a way to do this without a patch, because the configure script's way of checking for support for it automatically does not work inside the Nix build sandbox. Oh well. We are well past a version of systemd that supports this, so we can hardcode it to yes.

That change only affects the unit files included in the package output though. The `power.ups` NixOS module doesn't use these, so that module has been updated to match the service type and related behavior from those unit files.

And a bonus fix: I was seeing errors due to not being able to call the `wall` command to post notifications from upsmon, so util-linux is now included in the path of that service.

I've been running these changes on my home machines for about a month now without issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
