### PR TITLE
ocamlPackages.ocaml-r: 0.6.0 → 0.7.0

### DIFF
--- a/pkgs/development/ocaml-modules/ocaml-r/default.nix
+++ b/pkgs/development/ocaml-modules/ocaml-r/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitHub,
+  fetchurl,
   fetchpatch,
   buildDunePackage,
   pkg-config,
@@ -12,24 +12,22 @@
 
 buildDunePackage (finalAttrs: {
   pname = "ocaml-r";
-  version = "0.6.0";
+  version = "0.7.0";
 
-  duneVersion = "3";
-
-  minimalOCamlVersion = "4.08";
-
-  src = fetchFromGitHub {
-    owner = "pveber";
-    repo = "ocaml-r";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-jPyVMxjeh9+xu0dD1gelAxcOhxouKczyvzVoKZ5oSrs=";
+  src = fetchurl {
+    url = "https://github.com/pveber/ocaml-r/releases/download/v${finalAttrs.version}/ocaml-r-${finalAttrs.version}.tbz";
+    hash = "sha256-nbO36z/bSMb2vQjW5A9O2hjuF2RVzefFN53l/u3KF+o=";
   };
 
-  # Finds R and Rmathlib separately
+  # Compatibility with R 4.6
   patches = [
     (fetchpatch {
-      url = "https://github.com/pveber/ocaml-r/commit/aa96dc5.patch";
-      sha256 = "sha256-xW33W2ciesyUkDKEH08yfOXv0wP0V6X80or2/n2Nrb4=";
+      url = "https://github.com/pveber/ocaml-r/commit/c70704dd9ff1ed6b4035beef3316dc95275aaf4f.patch";
+      hash = "sha256-I3SX+6gVo9l7epeFhtae8Ji4q51mr53sv7MPxvRBdJg=";
+    })
+    (fetchpatch {
+      url = "https://github.com/pveber/ocaml-r/commit/c90ce656bd55236e74907f2ef5bc70ff11a0cedc.patch";
+      hash = "sha256-ACU4d8Npq1IXR3hysk6npHHU8ZRcAgRkHg/c+Sb8dkM=";
     })
   ];
 
@@ -48,7 +46,7 @@ buildDunePackage (finalAttrs: {
 
   meta = {
     description = "OCaml bindings for the R interpreter";
-    inherit (finalAttrs.src.meta) homepage;
+    homepage = "https://github.com/pveber/ocaml-r/";
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.bcdarwin ];
   };


### PR DESCRIPTION
Fixes build with R 4.6

The patches have been submitted upstream.

cc @jbedo

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
