### PR TITLE
libtpms: fix building with `-march=x86-64-v4`

### DIFF
--- a/pkgs/by-name/li/libtpms/package.nix
+++ b/pkgs/by-name/li/libtpms/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     (fetchpatch2 {
-      url = "https://github.com/stefanberger/libtpms/pull/588.patch?full_index=1";
+      url = "https://github.com/stefanberger/libtpms/commit/2d9b00c4e42677cd0a9b67344f4d873ddc409a21.patch?full_index=1";
       hash = "sha256-MVHy0sdg8ywKzu9M4ueRjH786uXQK8al21k8f+mAdR0=";
     })
   ];

--- a/pkgs/by-name/li/libtpms/package.nix
+++ b/pkgs/by-name/li/libtpms/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
   pkg-config,
   autoreconfHook,
   openssl,
@@ -18,6 +19,13 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "521c51073fe6f7c56023db78e56961fcaf7906e8";
     hash = "sha256-wCipOOr3LnLq1NqDtxw6hq0VTyniDwp18vBxyET/WGM=";
   };
+
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/stefanberger/libtpms/pull/588.patch?full_index=1";
+      hash = "sha256-MVHy0sdg8ywKzu9M4ueRjH786uXQK8al21k8f+mAdR0=";
+    })
+  ];
 
   nativeBuildInputs = [
     autoreconfHook


### PR DESCRIPTION
fix #528643
https://github.com/stefanberger/libtpms/pull/588

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
