### PR TITLE
gpaste: 45.3 -> 50.1

### DIFF
--- a/pkgs/by-name/gp/gpaste/fix-paths.patch
+++ b/pkgs/by-name/gp/gpaste/fix-paths.patch
@@ -1,16 +1,18 @@
 diff --git a/src/libgpaste/gpaste/gpaste-settings.c b/src/libgpaste/gpaste/gpaste-settings.c
-index 830f5e0b..c8df0e11 100644
+index 10d9ad00..1be971a5 100644
 --- a/src/libgpaste/gpaste/gpaste-settings.c
 +++ b/src/libgpaste/gpaste/gpaste-settings.c
-@@ -1039,7 +1039,10 @@ create_g_settings (void)
+@@ -1071,7 +1071,12 @@ create_g_settings (void)
+         return g_settings_new_with_backend (G_PASTE_SETTINGS_NAME, backend);
      }
      else
-     {
 -        return g_settings_new (G_PASTE_SETTINGS_NAME);
++    {
 +        // library used by introspection requires schemas but we cannot set XDG_DATA_DIRS for the library
 +        g_autoptr (GSettingsSchemaSource) schema_source = g_settings_schema_source_new_from_directory ("@gschemasCompiled@", NULL, FALSE, NULL);
 +        g_autoptr (GSettingsSchema) schema = g_settings_schema_source_lookup (schema_source, G_PASTE_SETTINGS_NAME, FALSE);
 +        return g_settings_new_full (schema, NULL, NULL);
-     }
++    }
  }
  
+ static void

--- a/pkgs/by-name/gp/gpaste/package.nix
+++ b/pkgs/by-name/gp/gpaste/package.nix
@@ -20,11 +20,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gpaste";
-  version = "45.3";
+  version = "50.1";
 
   src = fetchurl {
     url = "https://www.imagination-land.org/files/gpaste/GPaste-${finalAttrs.version}.tar.xz";
-    hash = "sha256-UU8pw7bqEwg2Vh7S6GTx8swI/2IhlwjQgkGNZCzoMwc=";
+    hash = "sha256-h30xl8bqpQjx4mLXxLYJXm8D9XovmSpUvK9RUC60WUg=";
   };
 
   patches = [
@@ -36,10 +36,6 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     substituteInPlace src/libgpaste/gpaste/gpaste-settings.c \
       --subst-var-by gschemasCompiled ${glib.makeSchemaPath (placeholder "out") "${finalAttrs.pname}-${finalAttrs.version}"}
-
-    substituteInPlace src/gnome-shell/metadata.json.in --replace-fail \
-      '"shell-version": [ "45", "46", "47", "48" ],' \
-      '"shell-version": [ "45", "46", "47", "48", "49" ],'
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
NixOS 26.05 ships GNOME 50, but the GPaste GNOME Shell extension in 45.3 only advertises (patched) compatibility up to GNOME 49, so it is rejected as out-of-date and fails to load on the 26.05 desktop. Updating to 50.1 declares GNOME 50 support, restoring the extension under the shell version shipped in this release.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
