### PR TITLE
nixos/wireless: fix for multiple interfaces

### DIFF
--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -127,7 +127,7 @@ let
           ]
           ++ lib.optionals cfg.userControlled [
             # set up client sockets directory
-            "+${pkgs.coreutils}/bin/mkdir /run/wpa_supplicant/client"
+            "+${pkgs.coreutils}/bin/mkdir -p /run/wpa_supplicant/client"
             "+${pkgs.coreutils}/bin/chown wpa_supplicant:wpa_supplicant /run/wpa_supplicant/client"
             "+${pkgs.coreutils}/bin/chmod g=u /run/wpa_supplicant/client"
           ];

--- a/nixos/tests/wpa_supplicant.nix
+++ b/nixos/tests/wpa_supplicant.nix
@@ -283,18 +283,22 @@ in
         enable = lib.mkOverride 0 true;
         userControlled = true;
         allowAuxiliaryImperativeNetworks = true;
-        interfaces = [ "wlan1" ];
+        interfaces = [
+          "wlan0"
+          "wlan1"
+        ];
       };
     };
 
     testScript = ''
       wpa_cli = "sudo -u alice -g wpa_supplicant wpa_cli"
 
-      with subtest("Daemon is running and accepting connections"):
-          machine.wait_for_unit("wpa_supplicant-wlan1.service")
-          status = machine.wait_until_succeeds(f"{wpa_cli} -i wlan1 status")
-          assert "Failed to connect" not in status, \
-                 "Failed to connect to the daemon"
+      with subtest("Daemons are running and accepting connections"):
+          for iface in ["wlan0", "wlan1"]:
+            machine.wait_for_unit(f"wpa_supplicant-{iface}.service")
+            status = machine.wait_until_succeeds(f"{wpa_cli} -i {iface} status")
+            assert "Failed to connect" not in status, \
+                   f"Failed to connect to the daemon for {iface}"
 
       with subtest("Daemon can be configured imperatively"):
           machine.succeed(f"{wpa_cli} -i wlan1 add_network")


### PR DESCRIPTION
Closes issue #529889

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests] (`nixosTests.wpa_supplicant`).
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
