### PR TITLE
rs-lxmf: init at 0.9.2

### DIFF
--- a/pkgs/by-name/rs/rs-lxmf/package.nix
+++ b/pkgs/by-name/rs/rs-lxmf/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  rs-reticulum,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rs-lxmf";
+  version = "0.9.2";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "ratspeak";
+    repo = "rsLXMF";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jba/uiQQUO3MdmF2+6AOtdbUXYW43yqplRFUGujN0Oo=";
+  };
+
+  postPatch = ''
+    for crate in rns-crypto rns-wire rns-identity rns-link rns-protocol rns-transport rns-runtime rns-interface; do
+      substituteInPlace Cargo.toml \
+        --replace-fail "../rsReticulum/crates/$crate" "${rs-reticulum.src}/crates/$crate"
+    done
+  '';
+
+  cargoHash = "sha256-ReWw16r9cYIEzilzSsFXYap9ZGhk1mrUVl/bKkQMcVA=";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Rust implementation of LXMF for Reticulum";
+    homepage = "https://github.com/ratspeak/rsLXMF";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ drupol ];
+    mainProgram = "lxmd-rs";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
