### PR TITLE
amule: 2.3.3 -> 3.0.0; amule-cmd: init at 3.0.0

### DIFF
--- a/pkgs/by-name/am/amule-cmd/package.nix
+++ b/pkgs/by-name/am/amule-cmd/package.nix
@@ -1,0 +1,13 @@
+{
+  amule,
+  ...
+}@args:
+
+amule.override (
+  {
+    monolithic = false;
+    textClient = true;
+    mainProgram = "amulecmd";
+  }
+  // removeAttrs args [ "amule" ]
+)

--- a/pkgs/by-name/am/amule/package.nix
+++ b/pkgs/by-name/am/amule/package.nix
@@ -3,94 +3,144 @@
   enableDaemon ? false, # build amule daemon
   httpServer ? false, # build web interface for the daemon
   client ? false, # build amule remote gui
+  textClient ? false, # build amule remote command line client
   mainProgram ? "amule",
   fetchFromGitHub,
-  fetchpatch,
   stdenv,
   lib,
   cmake,
   zlib,
   wxwidgets_3_2,
-  perl,
+  curl,
   cryptopp,
   libupnp,
-  boost186, # Not using boost leads to crashes with gtk3
+  boost,
   gettext,
+  glib,
+  libintl,
+  gtk3,
+  libayatana-appindicator,
+  libsysprof-capture,
   libpng,
   pkg-config,
-  makeWrapper,
+  readline,
+  nix-update-script,
+  writeShellScript,
+  xcbuild,
   libx11,
 }:
 
-# daemon and client are not build monolithic
-assert monolithic || (!monolithic && (enableDaemon || client || httpServer));
+let
+  # MacOS's plutil lives under /usr/bin, which the build sandbox blocks
+  # so we use `xcbuild`'s pure reimplementation instead.
+  # CMake generates the bundle plist read-only, so we make i
+  # writable before plutil rewrites it in place.
+  plutil = writeShellScript "amule-plutil" ''
+    for plist; do :; done
+    chmod u+w "$plist"
+    exec ${lib.getExe' xcbuild "plutil"} "$@"
+  '';
+in
+
+# daemon, clients and web interface are not built monolithic
+assert monolithic || (!monolithic && (enableDaemon || client || textClient || httpServer));
 
 stdenv.mkDerivation (finalAttrs: {
   pname =
     "amule"
     + lib.optionalString httpServer "-web"
     + lib.optionalString enableDaemon "-daemon"
-    + lib.optionalString client "-gui";
-  version = "2.3.3";
+    + lib.optionalString client "-gui"
+    + lib.optionalString textClient "-cmd";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
-    owner = "amule-project";
+    owner = "amule-org";
     repo = "amule";
     tag = finalAttrs.version;
-    sha256 = "1nm4vxgmisn1b6l3drmz0q04x067j2i8lw5rnf0acaapwlp8qwvi";
+    hash = "sha256-2qQof2/JFTfOmqd25+YVWBpZgCDCOwf3NBo1aHcMPds=";
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://sources.debian.org/data/main/a/amule/1%3A2.3.3-3/debian/patches/wx3.2.patch";
-      hash = "sha256-OX5Ef80bL+dQqHo2OBLZvzMUrU6aOHfsF7AtoE1r7rs=";
-    })
-  ];
+  __structuredAttrs = true;
+  strictDeps = true;
 
   nativeBuildInputs = [
     cmake
     gettext
-    makeWrapper
     pkg-config
   ];
+
+  postPatch =
+    lib.optionalString (stdenv.hostPlatform.isDarwin && (monolithic || client)) ''
+      substituteInPlace src/CMakeLists.txt \
+        --replace-fail "/usr/bin/plutil" "${plutil}"
+    ''
+    # The __WXMAC__ branch casts to the pre-libedit-3.0 `Function` typedef,
+    # which neither the modern SDK libedit headers nor GNU readline 8.3
+    # provide; both declare rl_completion_entry_function with the typedef
+    # used here.
+    + lib.optionalString (stdenv.hostPlatform.isDarwin && (textClient || httpServer)) ''
+      substituteInPlace src/ExternalConnector.cpp \
+        --replace-fail "(Function *)&command_completion" "(rl_compentry_func_t *)&command_completion"
+    '';
 
   buildInputs = [
     zlib
     wxwidgets_3_2
-    perl
     cryptopp.dev
     libupnp
-    boost186
+    boost
+  ]
+  # the GUI and daemon bind the Wayland app_id / X11 WM_CLASS via g_set_prgname();
+  # libsysprof-capture satisfies glib-2.0.pc's Requires.private so the
+  # pkg-config checks resolve cleanly
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && (monolithic || enableDaemon || client)) [
+    glib
+    libsysprof-capture
+  ]
+  # CURLOPT tuning (NOSIGNAL/CONNECTTIMEOUT) on wxWebRequest's curl backend
+  ++ lib.optional stdenv.hostPlatform.isLinux curl
+  # StatusNotifierItem tray icon; without it aMule falls back to the legacy
+  # GtkStatusIcon, invisible on modern GNOME/wlroots. gtk3 brings the
+  # gtk+-3.0.pc that ayatana-appindicator3-0.1.pc requires.
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && monolithic) [
+    gtk3
+    libayatana-appindicator
   ]
   ++ lib.optional httpServer libpng
+  # gettext runtime for NLS; on glibc libintl is part of libc
+  ++ lib.optional (!stdenv.hostPlatform.isGnu) libintl
+  # line editing in the interactive consoles of amulecmd and amuleweb
+  ++ lib.optional (textClient || httpServer) readline
   ++ lib.optional client libx11;
 
   cmakeFlags = [
-    "-DBUILD_MONOLITHIC=${if monolithic then "ON" else "OFF"}"
-    "-DBUILD_DAEMON=${if enableDaemon then "ON" else "OFF"}"
-    "-DBUILD_REMOTEGUI=${if client then "ON" else "OFF"}"
-    "-DBUILD_WEBSERVER=${if httpServer then "ON" else "OFF"}"
-    # building only the daemon fails when these are not set... this is
-    # due to mistakes in the Amule cmake code, but it does not cause
-    # extra code to be built...
-    "-Dwx_NEED_GUI=ON"
-    "-Dwx_NEED_ADV=ON"
-    "-Dwx_NEED_NET=ON"
+    (lib.cmakeBool "BUILD_MONOLITHIC" monolithic)
+    (lib.cmakeBool "BUILD_DAEMON" enableDaemon)
+    (lib.cmakeBool "BUILD_REMOTEGUI" client)
+    (lib.cmakeBool "BUILD_AMULECMD" textClient)
+    (lib.cmakeBool "BUILD_WEBSERVER" httpServer)
+    # with strictDeps FindwxWidgets cannot find wx-config in PATH; the
+    # script runs on the build machine even when wxwidgets is a host dep
+    (lib.cmakeFeature "wxWidgets_CONFIG_EXECUTABLE" (
+      lib.getExe' (lib.getDev wxwidgets_3_2) "wx-config"
+    ))
   ];
 
-  postPatch = ''
-    echo "find_package(Threads)" >> cmake/options.cmake
-
-    substituteInPlace src/libs/ec/abstracts/CMakeLists.txt \
-      --replace-fail "CMAKE_MINIMUM_REQUIRED (VERSION 2.8)" "CMAKE_MINIMUM_REQUIRED (VERSION 3.10)"
+  # On darwin the GUIs are installed as app bundles in $out; move them to
+  # $out/Applications and expose the inner binaries in $out/bin.
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    for app in "$out"/*.app; do
+      [ -e "$app" ] || continue
+      mkdir -p "$out/Applications" "$out/bin"
+      mv "$app" "$out/Applications/"
+      name=$(basename "$app" .app)
+      ln -s "$out/Applications/$name.app/Contents/MacOS/$name" \
+        "$out/bin/$(echo "$name" | tr '[:upper:]' '[:lower:]')"
+    done
   '';
 
-  # aMule will try to `dlopen' libupnp and libixml, so help it
-  # find them.
-  postInstall = lib.optionalString monolithic ''
-    wrapProgram $out/bin/amule \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libupnp ]}
-  '';
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Peer-to-peer client for the eD2K and Kademlia networks";
@@ -104,12 +154,11 @@ stdenv.mkDerivation (finalAttrs: {
       no adware or spyware as is often found in proprietary P2P
       applications.
     '';
-    homepage = "https://github.com/amule-project/amule";
+    homepage = "https://amule-org.github.io/";
+    changelog = "https://github.com/amule-org/amule/releases/tag/${finalAttrs.version}";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ aciceri ];
     inherit mainProgram;
     platforms = lib.platforms.unix;
-    # Undefined symbols for architecture arm64: "_FSFindFolder"
-    broken = stdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/by-name/am/amule/package.nix
+++ b/pkgs/by-name/am/amule/package.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
     libupnp
     boost
   ]
-  # the GUI and daemon bind the Wayland app_id / X11 WM_CLASS via g_set_prgname();
+  # the GUI and daemon bind the Wayland app_id/X11 WM_CLASS via g_set_prgname();
   # libsysprof-capture satisfies glib-2.0.pc's Requires.private so the
   # pkg-config checks resolve cleanly
   ++ lib.optionals (stdenv.hostPlatform.isLinux && (monolithic || enableDaemon || client)) [
@@ -102,7 +102,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional stdenv.hostPlatform.isLinux curl
   # StatusNotifierItem tray icon; without it aMule falls back to the legacy
   # GtkStatusIcon, invisible on modern GNOME/wlroots. gtk3 brings the
-  # gtk+-3.0.pc that ayatana-appindicator3-0.1.pc requires.
+  # gtk+-3.0.pc that ayatana-appindicator3-0.1.pc requires
   ++ lib.optionals (stdenv.hostPlatform.isLinux && monolithic) [
     gtk3
     libayatana-appindicator
@@ -120,15 +120,15 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "BUILD_REMOTEGUI" client)
     (lib.cmakeBool "BUILD_AMULECMD" textClient)
     (lib.cmakeBool "BUILD_WEBSERVER" httpServer)
-    # with strictDeps FindwxWidgets cannot find wx-config in PATH; the
-    # script runs on the build machine even when wxwidgets is a host dep
+    # with strictDeps FindwxWidgets cannot find wx-config in PATH
+    # the script runs on the build machine even when wxwidgets is a host dependency
     (lib.cmakeFeature "wxWidgets_CONFIG_EXECUTABLE" (
       lib.getExe' (lib.getDev wxwidgets_3_2) "wx-config"
     ))
   ];
 
-  # On darwin the GUIs are installed as app bundles in $out; move them to
-  # $out/Applications and expose the inner binaries in $out/bin.
+  # On darwin the GUIs are installed as app bundles in $out
+  # move them to $out/Applications and expose the inner binaries in $out/bin
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     for app in "$out"/*.app; do
       [ -e "$app" ] || continue


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- [x] bumped all `amule-*` packages to `3.0.0` (first release in ~5 years!)
- [x] added `amule-cmd` package (it already existed before `3.0.0`, didn't know why it wasn't packaged, wasn't aware of it when I adopted this package)
- [x] made everything build on darwin (and run, though I haven't tested extensively frankly)
- [X] tested `amule-daemon` from the NixOS module (on `x86_64-linux`) by downloading a file, connected to it through both `amule-cmd` and `amule-gui` (from `aarch64-darwin`)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
