### PR TITLE
fcitx5-ilo-sitelen: init at 0-unstable-2023-02-14

### DIFF
--- a/pkgs/by-name/fc/fcitx5-ilo-sitelen/package.nix
+++ b/pkgs/by-name/fc/fcitx5-ilo-sitelen/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fcitx5,
+  cmake,
+  pkg-config
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fcitx5-ilo-sitelen";
+  version = "0-unstable-2023-2-14";
+
+  src = fetchFromGitHub {
+    owner = "0x182d4454fb211940";
+    repo = "ilo-sitelen";
+    rev = "42be249c27efc21173984bf538e94ba5bb130695";
+    hash = "sha256-caQVPBPuZjOwbtcDhxAdmG7PHXe50OeSLkSBoCtMcrQ=";
+  };
+  
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    fcitx5
+  ];
+
+  meta = {
+    description = "Input method for Sitelen Pona";
+    homepage = "https://github.com/0x182d4454fb211940/ilo-sitelen";
+    maintainers = with lib.maintainers; [ toadhog ];
+    platforms = lib.platforms.linux;
+    license = lib.licenses.mit;
+  };
+})


### PR DESCRIPTION
Added a wrapper plugin for fcitx5 for Sitalen Pona. Link to the repo: https://github.com/0x182d4454fb211940/ilo-sitelen
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
