### PR TITLE
fcitx5-ilo-sitelen: init at 0-unstable-2023-02-14

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28068,6 +28068,11 @@
     githubId = 9853194;
     name = "Philipp Bartsch";
   };
+  toadhog = {
+    name = "ToadHog";
+    github = "Sir0ne";
+    githubId = 96101308;
+  };
   toast = {
     name = "Toast";
     github = "toast003";

--- a/pkgs/by-name/fc/fcitx5-ilo-sitelen/package.nix
+++ b/pkgs/by-name/fc/fcitx5-ilo-sitelen/package.nix
@@ -32,6 +32,8 @@ stdenv.mkDerivation {
   ];
   
   strictDeps = true;
+  _structuredArrts = true;
+  
 
   meta = {
     description = "Input method for Sitelen Pona";

--- a/pkgs/by-name/fc/fcitx5-ilo-sitelen/package.nix
+++ b/pkgs/by-name/fc/fcitx5-ilo-sitelen/package.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation {
   buildInputs = [
     fcitx5
   ];
+  
+  strictDeps = true;
 
   meta = {
     description = "Input method for Sitelen Pona";

--- a/pkgs/by-name/fc/fcitx5-ilo-sitelen/package.nix
+++ b/pkgs/by-name/fc/fcitx5-ilo-sitelen/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
   ];
   
   strictDeps = true;
-  _structuredArrts = true;
+  _structuredAttrs = true;
   
 
   meta = {

--- a/pkgs/by-name/fc/fcitx5-ilo-sitelen/package.nix
+++ b/pkgs/by-name/fc/fcitx5-ilo-sitelen/package.nix
@@ -4,10 +4,10 @@
   fetchFromGitHub,
   fcitx5,
   cmake,
-  pkg-config
+  pkg-config,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation {
   pname = "fcitx5-ilo-sitelen";
   version = "0-unstable-2023-2-14";
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "42be249c27efc21173984bf538e94ba5bb130695";
     hash = "sha256-caQVPBPuZjOwbtcDhxAdmG7PHXe50OeSLkSBoCtMcrQ=";
   };
-  
+
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE=Release"
   ];
@@ -38,4 +38,4 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.linux;
     license = lib.licenses.mit;
   };
-})
+}

--- a/pkgs/by-name/fc/fcitx5-ilo-sitelen/package.nix
+++ b/pkgs/by-name/fc/fcitx5-ilo-sitelen/package.nix
@@ -30,10 +30,9 @@ stdenv.mkDerivation {
   buildInputs = [
     fcitx5
   ];
-  
+
   strictDeps = true;
   __structuredAttrs = true;
-  
 
   meta = {
     description = "Input method for Sitelen Pona";

--- a/pkgs/by-name/fc/fcitx5-ilo-sitelen/package.nix
+++ b/pkgs/by-name/fc/fcitx5-ilo-sitelen/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
   ];
   
   strictDeps = true;
-  _structuredAttrs = true;
+  __structuredAttrs = true;
   
 
   meta = {

--- a/pkgs/by-name/fc/fcitx5-ilo-sitelen/package.nix
+++ b/pkgs/by-name/fc/fcitx5-ilo-sitelen/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fcitx5,
+  cmake,
+  pkg-config
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fcitx5-ilo-sitelen";
+  version = "0-unstable-2023-2-14";
+
+  src = fetchFromGitHub {
+    owner = "0x182d4454fb211940";
+    repo = "ilo-sitelen";
+    rev = "42be249c27efc21173984bf538e94ba5bb130695";
+    hash = "sha256-caQVPBPuZjOwbtcDhxAdmG7PHXe50OeSLkSBoCtMcrQ=";
+  };
+  
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    fcitx5
+  ];
+
+  meta = {
+    description = "Input method for Sitelen Pona";
+    homepage = "https://github.com/0x182d4454fb211940/ilo-sitelen";
+    maintainers = with lib.maintainers; [ toadhog ];
+    platforms = lib.platforms.linux;
+    license = lib.licenses.mit;
+  };
+})


### PR DESCRIPTION
Added fcitx5 Ilo Sitelen plugin that adds a wrapper for Sitelen Pona. Added myself to the maintainers list. Link to repo: https://github.com/0x182d4454fb211940/ilo-sitelen

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].