### PR TITLE
vim-classic: init at 8.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5726,6 +5726,11 @@
     githubId = 3077118;
     name = "David McFarland";
   };
+  corps-fini = {
+    github = "corps-fini";
+    githubId = 44802527;
+    name = "corps-fini";
+  };
   costrouc = {
     email = "chris.ostrouchov@gmail.com";
     github = "costrouc";

--- a/pkgs/by-name/vi/vim-classic/package.nix
+++ b/pkgs/by-name/vi/vim-classic/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchFromSourcehut,
+  ncurses,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vim-classic";
+  version = "8.3.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromSourcehut {
+    owner = "~sircmpwn";
+    repo = "vim-classic";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BJuxs7pOMmPVew+W3d/6KFEah6I8TQoRJ4SK8/4daas=";
+  };
+
+  buildInputs = [
+    ncurses
+  ];
+
+  # Same as `vim`: fortified glibc aborts on `:syntax on` ("buffer overflow detected")
+  hardeningDisable =
+    if stdenv.cc.isClang then
+      [
+        "strictflexarrays1"
+      ]
+    else
+      [ "fortify" ];
+
+  enableParallelBuilding = true;
+  # The `install` target races between `strip`ping the installed binary and running it to generate
+  # the help tags: "strip: ...: Text file busy"
+  enableParallelInstalling = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Long-term maintenance fork of Vim 8.2";
+    homepage = "https://vim-classic.org";
+    downloadPage = "https://sr.ht/~sircmpwn/vim-classic/";
+    changelog = "https://git.sr.ht/~sircmpwn/vim-classic/refs/${finalAttrs.src.tag}";
+    license = lib.licenses.vim;
+    maintainers = with lib.maintainers; [ corps-fini ];
+    platforms = lib.platforms.unix;
+    mainProgram = "vim";
+  };
+})


### PR DESCRIPTION
Add Vim Classic, a LTS fork of Vim 8.2.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
