### PR TITLE
melos: fix hashing in update script

### DIFF
--- a/pkgs/by-name/me/melos/update.sh
+++ b/pkgs/by-name/me/melos/update.sh
@@ -55,21 +55,20 @@ tar -xzf "$archive_path" -C "$tmpdir"
 extracted_dir=$(tar -tzf "$archive_path" | head -1 | cut -d/ -f1)
 source_dir="$tmpdir/$extracted_dir"
 
+# Compute the hash from the downloaded and unpacked archive
+echo "Computing source hash..." >&2
+new_hash=$(nix-hash --type sha256 --sri "$source_dir")
+if [ -z "$new_hash" ]; then
+  echo "Error: Failed to compute source hash" >&2
+  exit 1
+fi
+
 echo "Generating pubspec.lock..." >&2
 cd "$source_dir"
 dart pub get > /dev/null 2>&1
 
 echo "Converting to JSON..." >&2
 yq eval --output-format=json --prettyPrint pubspec.lock > "$tmpdir/pubspec.lock.json"
-
-# Compute the hash from the downloaded archive
-echo "Computing source hash..." >&2
-nix_hash=$(nix-hash --flat --base32 --type sha256 "$archive_path")
-if [ -z "$nix_hash" ]; then
-  echo "Error: Failed to compute source hash" >&2
-  exit 1
-fi
-new_hash="sha256-$(nix-hash --to-sri --type sha256 "$nix_hash")"
 
 cp "$tmpdir/pubspec.lock.json" "$script_dir/pubspec.lock.json"
 echo "Updated pubspec.lock.json" >&2


### PR DESCRIPTION
The current update script hashes the archive instead of the contents and therefore fails (see the [nixpkgs-update logs][0]). This changes that behavior to hash the unpacked contents before anything is altered.

[0]: https://nixpkgs-update-logs.nix-community.org/melos/2026-06-03.log


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
