### PR TITLE
[25.11] forgejo-lts: 11.0.14 -> 11.0.15, forgejo: 15.0.2 -> 15.0.3

### DIFF
--- a/pkgs/by-name/fo/forgejo/lts.nix
+++ b/pkgs/by-name/fo/forgejo/lts.nix
@@ -1,8 +1,8 @@
 import ./generic.nix {
-  version = "11.0.14";
-  hash = "sha256-rFF+naEEvTj1UqcX8Y2UTHGcBdM8mGgZWJgcC69jdxQ=";
-  npmDepsHash = "sha256-B5ndsIk9Jntu7f7w6NrsBxfFSxhYFeq1NfXTtzckklw=";
-  vendorHash = "sha256-bdp3Qy/09qa/bwPUIDmdrJXma39zdgovIZqENo+AVyY=";
+  version = "11.0.15";
+  hash = "sha256-zClEFsf/DisvaDIFtHKLw4GXKpcGnmtR0XaSzKc+PdA=";
+  npmDepsHash = "sha256-6tX/JCWJAYyboeRv5fb59wGnLTCdSYfGYDu0lJy5EQk=";
+  vendorHash = "sha256-w49FOP3ZUbme0eZ+KPs6EVvDh9eljgghDND+xr+Pdkc=";
   lts = true;
   nixUpdateExtraArgs = [
     "--override-filename"

--- a/pkgs/by-name/fo/forgejo/package.nix
+++ b/pkgs/by-name/fo/forgejo/package.nix
@@ -1,8 +1,8 @@
 import ./generic.nix {
-  version = "15.0.2";
-  hash = "sha256-ba5jog6eXY4TTmBblhfVa2LSLPGE1/HPfslIb30b3kk=";
-  npmDepsHash = "sha256-70w39jbMWpuAsbzBC9oFHaUMwshtFDeTSEOXDgFNPmE=";
-  vendorHash = "sha256-I6bGvXBP2K3+Xx9E9DS/AyG6Ilqf/s8VjfBnCmLUHsk=";
+  version = "15.0.3";
+  hash = "sha256-tGZ83TEG6iyZd5mfSuSvVkmUJINWLN661YpOk1+dgbM=";
+  npmDepsHash = "sha256-BZSYjEsjUqMYWu3EUP+K35hqSOniv8Y6ek5bEC2vTPg=";
+  vendorHash = "sha256-z3YTjt+SM9yPCsJdfSQbTpy3vRiXaFV2QMz1y6J6k/Q=";
   lts = false;
   nixUpdateExtraArgs = [
     "--override-filename"


### PR DESCRIPTION
https://codeberg.org/forgejo/forgejo/milestone/86943

and manual backport of #530254 (https://codeberg.org/forgejo/forgejo/milestone/86949)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
