### PR TITLE
asciimol: init at 1.2.5

### DIFF
--- a/pkgs/by-name/as/asciimol/package.nix
+++ b/pkgs/by-name/as/asciimol/package.nix
@@ -1,0 +1,38 @@
+{
+  fetchPypi,
+  lib,
+  nix-update-script,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "asciimol";
+  version = "1.2.5";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-sB8hHtjfCv5jFHXEoUG7zNn3d3QKihPLbgnR+Jyz4GQ=";
+  };
+
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
+    numpy
+    ase
+    rdkit
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Curses based ASCII molecule viewer for terminals";
+    license = lib.licenses.bsd2;
+    homepage = "https://github.com/dewberryants/asciimol";
+    downloadPage = "https://pypi.org/project/asciimol/";
+    maintainers = with lib.maintainers; [ tomasrivera ];
+    mainProgram = "asciimol";
+  };
+})


### PR DESCRIPTION
Adds [asciimol](https://github.com/dewberryants/asciiMol), a  Curses based ASCII molecule viewer for terminals.

I use Pypi instead of Github as the source, as the maintainer only sets release tags (after 1.2) in Pypi.

If you want to test and/or play with the program, you'll need to familiarize yourself with either the .xyz format and/or SMILES syntax. If you want examples, use [pubchem](https://pubchem.ncbi.nlm.nih.gov/) for SMILES. For .xyz i tested with this [wikipedia example](https://en.wikipedia.org/wiki/XYZ_file_format#Example). I couldn't find a database for this format.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
