### PR TITLE
[26.05] pnpm: switch to nodejs-slim

### DIFF
--- a/doc/languages-frameworks/javascript.section.md
+++ b/doc/languages-frameworks/javascript.section.md
@@ -364,7 +364,7 @@ It is highly recommended to use a pinned version of pnpm (i.e., `pnpm_9` or `pnp
 +let
 +  # Optionally override pnpm to use a custom nodejs version
 +  # Make sure that the same nodejs version is referenced in nativeBuildInputs
-+  # pnpm = pnpm_10.override { nodejs = nodejs-slim_22; };
++  # pnpm = pnpm_10.override { nodejs-slim = nodejs-slim_22; };
 +in
  stdenv.mkDerivation (finalAttrs: {
    pname = "foo";

--- a/pkgs/build-support/node/fetch-pnpm-deps/default.nix
+++ b/pkgs/build-support/node/fetch-pnpm-deps/default.nix
@@ -52,9 +52,21 @@ in
       filterFlags = lib.map (package: "--filter=${package}") pnpmWorkspaces;
 
       pnpm-fixup-state-db' =
-        if pnpm.nodejs or null != null then
+        if pnpm.nodejs-slim or null != null then
           pnpm-fixup-state-db.override {
-            inherit (pnpm) nodejs;
+            # FIXME: make npm-config-hook accept nodejs-slim
+            nodejs =
+              let
+                inherit (pnpm) nodejs-slim;
+              in
+              if nodejs-slim ? paths && builtins.isList nodejs-slim.paths then
+                # If nodejs-slim has a list `paths` attribute, it's likely a simlinkJoin
+                nodejs-slim
+              else
+                # Otherwise we need to recreate one by overriding the default one
+                pnpm-fixup-state-db.nodejs.override {
+                  inherit nodejs-slim;
+                };
           }
         else
           pnpm-fixup-state-db;

--- a/pkgs/build-support/node/fetch-pnpm-deps/default.nix
+++ b/pkgs/build-support/node/fetch-pnpm-deps/default.nix
@@ -54,19 +54,7 @@ in
       pnpm-fixup-state-db' =
         if pnpm.nodejs-slim or null != null then
           pnpm-fixup-state-db.override {
-            # FIXME: make npm-config-hook accept nodejs-slim
-            nodejs =
-              let
-                inherit (pnpm) nodejs-slim;
-              in
-              if nodejs-slim ? paths && builtins.isList nodejs-slim.paths then
-                # If nodejs-slim has a list `paths` attribute, it's likely a simlinkJoin
-                nodejs-slim
-              else
-                # Otherwise we need to recreate one by overriding the default one
-                pnpm-fixup-state-db.nodejs.override {
-                  inherit nodejs-slim;
-                };
+            inherit (pnpm) nodejs-slim;
           }
         else
           pnpm-fixup-state-db;

--- a/pkgs/build-support/src-only/default.nix
+++ b/pkgs/build-support/src-only/default.nix
@@ -37,37 +37,44 @@
 
 attrs:
 let
-  argsToOverride = args: {
-    name = "${args.name or "${args.pname}-${args.version}"}-source";
+  argsToOverride =
+    args:
+    {
+      name = "${args.name or "${args.pname}-${args.version}"}-source";
 
-    outputs = [ "out" ];
+      outputs = [ "out" ];
 
-    phases = [
-      "unpackPhase"
-      "patchPhase"
-      "installPhase"
-    ];
-    separateDebugInfo = false;
+      phases = [
+        "unpackPhase"
+        "patchPhase"
+        "installPhase"
+      ];
+      separateDebugInfo = false;
 
-    dontUnpack = lib.warnIf (args.dontUnpack or false
-    ) "srcOnly: derivation has dontUnpack set, overriding" false;
+      dontUnpack = lib.warnIf (args.dontUnpack or false
+      ) "srcOnly: derivation has dontUnpack set, overriding" false;
 
-    dontInstall = false;
-    installPhase = "cp -pr --reflink=auto -- . $out";
+      dontInstall = false;
+      installPhase = "cp -pr --reflink=auto -- . $out";
 
-    # the original derivation might've set something like outputDev = "lib", but "lib" isn't an output anymore
-    # some things get confused and error if one of these is set to an output that doesn't exist
-    # ex: pkgs/build-support/setup-hooks/multiple-outputs.sh
-    outputDev = "out";
-    outputBin = "out";
-    outputInclude = "out";
-    outputLib = "out";
-    outputDoc = "out";
-    outputDevdoc = "out";
-    outputMan = "out";
-    outputDevman = "out";
-    outputInfo = "out";
-  };
+      # the original derivation might've set something like outputDev = "lib", but "lib" isn't an output anymore
+      # some things get confused and error if one of these is set to an output that doesn't exist
+      # ex: pkgs/build-support/setup-hooks/multiple-outputs.sh
+      outputDev = "out";
+      outputBin = "out";
+      outputInclude = "out";
+      outputLib = "out";
+      outputDoc = "out";
+      outputDevdoc = "out";
+      outputMan = "out";
+      outputDevman = "out";
+      outputInfo = "out";
+
+    }
+    // lib.optionalAttrs (lib.isAttrs args.outputChecks or null) {
+      # If the original derivation includes outputChecks for output we are removing, we need to reset it to an empty check.
+      outputChecks = { };
+    };
 in
 
 # If we are passed a derivation (based on stdenv*), we can use overrideAttrs to

--- a/pkgs/by-name/op/openclaw/package.nix
+++ b/pkgs/by-name/op/openclaw/package.nix
@@ -6,7 +6,7 @@
   fetchPnpmDeps,
   pnpmConfigHook,
   pnpm_10,
-  nodejs_22,
+  nodejs-slim_22,
   makeWrapper,
   versionCheckHook,
   rolldown,
@@ -38,7 +38,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     pnpmConfigHook
     pnpm_10
-    nodejs_22
+    nodejs-slim_22
     makeWrapper
     installShellFiles
   ];
@@ -83,7 +83,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     # Remove symlinks pointing back to the build sandbox
     find $libdir/dist/extensions -type l -lname "$NIX_BUILD_TOP/*" -delete
 
-    makeWrapper ${lib.getExe nodejs_22} $out/bin/openclaw \
+    makeWrapper ${lib.getExe nodejs-slim_22} $out/bin/openclaw \
       --add-flags "$libdir/dist/index.js" \
       --set NODE_PATH "$libdir/node_modules"
     ln -s $out/bin/openclaw $out/bin/moltbot

--- a/pkgs/by-name/pn/pnpm-fixup-state-db/package.nix
+++ b/pkgs/by-name/pn/pnpm-fixup-state-db/package.nix
@@ -1,7 +1,7 @@
 {
   buildNpmPackage,
   lib,
-  nodejs,
+  nodejs-slim,
   pnpm,
   tests,
 }:
@@ -11,12 +11,13 @@ buildNpmPackage {
 
   src = ./src;
 
-  inherit nodejs;
+  nodejs = nodejs-slim;
+  nativeBuildInputs = lib.optional (builtins.hasAttr "npm" nodejs-slim) nodejs-slim.npm;
 
   npmDepsHash = "sha256-um6a4pEtPtdxHBRq9g5ZW20wIQAMjWJ3qF96XuxJg8o=";
 
   postInstall = ''
-    makeWrapper ${lib.getExe nodejs} $out/bin/pnpm-fixup-state-db \
+    makeWrapper ${lib.getExe nodejs-slim} $out/bin/pnpm-fixup-state-db \
       --add-flags "$out/lib/node_modules/pnpm-fixup-state-db"
   '';
 

--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -5,7 +5,7 @@
   makeBinaryWrapper,
   copyDesktopItems,
   electron_41,
-  nodejs_24,
+  nodejs-slim_24,
   pnpm_10_29_2,
   fetchPnpmDeps,
   pnpmConfigHook,
@@ -21,8 +21,8 @@
 }:
 
 let
-  nodejs = nodejs_24;
-  pnpm = pnpm_10_29_2.override { inherit nodejs; };
+  nodejs-slim = nodejs-slim_24;
+  pnpm = pnpm_10_29_2.override { inherit nodejs-slim; };
   electron = electron_41;
   appName = "Podman Desktop";
 in
@@ -91,7 +91,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     makeBinaryWrapper
-    nodejs
+    nodejs-slim
+    nodejs-slim.npm
     pnpm
     pnpmConfigHook
   ]

--- a/pkgs/by-name/po/porn-vault/package.nix
+++ b/pkgs/by-name/po/porn-vault/package.nix
@@ -6,7 +6,7 @@
   fetchPnpmDeps,
   pnpmConfigHook,
   stdenvNoCC,
-  nodejs_22,
+  nodejs-slim_22,
   ffmpeg,
   imagemagick,
   makeWrapper,
@@ -37,8 +37,8 @@ let
       mainProgram = "izzy";
     };
   };
-  nodejs = nodejs_22;
-  pnpm' = pnpm_9.override { nodejs = nodejs_22; };
+  nodejs-slim = nodejs-slim_22;
+  pnpm' = pnpm_9.override { inherit nodejs-slim; };
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "porn-vault";
@@ -59,7 +59,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    nodejs
+    nodejs-slim
     pnpmConfigHook
     pnpm'
     makeWrapper
@@ -92,7 +92,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   preFixup = ''
-    makeWrapper "${lib.getExe nodejs}" "$out/bin/porn-vault" \
+    makeWrapper "${lib.getExe nodejs-slim}" "$out/bin/porn-vault" \
       --chdir "$out/share/porn-vault" \
       --add-flags "dist/index.js" \
       --set-default IZZY_PATH "${lib.getExe izzy}" \
@@ -110,7 +110,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://gitlab.com/porn-vault/porn-vault";
     license = lib.licenses.gpl3Plus;
     maintainers = [ lib.maintainers.luNeder ];
-    inherit (nodejs.meta) platforms;
+    inherit (nodejs-slim.meta) platforms;
     mainProgram = "porn-vault";
   };
 })

--- a/pkgs/by-name/se/seerr/package.nix
+++ b/pkgs/by-name/se/seerr/package.nix
@@ -6,7 +6,7 @@
   fetchFromGitHub,
   stdenv,
   makeWrapper,
-  nodejs_22,
+  nodejs-slim_22,
   python3,
   python3Packages,
   sqlite,
@@ -15,8 +15,8 @@
 }:
 
 let
-  nodejs = nodejs_22;
-  pnpm = pnpm_10.override { inherit nodejs; };
+  nodejs-slim = nodejs-slim_22;
+  pnpm = pnpm_10.override { inherit nodejs-slim; };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "seerr";
@@ -41,14 +41,14 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     python3
     python3Packages.distutils
-    nodejs
+    nodejs-slim
     makeWrapper
     pnpmConfigHook
     pnpm
   ];
 
   preBuild = ''
-    export npm_config_nodedir=${nodejs}
+    export npm_config_nodedir=${nodejs-slim}
     pushd node_modules
     pnpm rebuild bcrypt sqlite3
     popd
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postInstall = ''
     mkdir -p $out/bin
-    makeWrapper '${nodejs}/bin/node' "$out/bin/seerr" \
+    makeWrapper '${nodejs-slim}/bin/node' "$out/bin/seerr" \
       --add-flags "$out/share/dist/index.js" \
       --chdir "$out/share" \
       --set NODE_ENV production

--- a/pkgs/by-name/sh/sharkey/package.nix
+++ b/pkgs/by-name/sh/sharkey/package.nix
@@ -11,7 +11,7 @@
   jemalloc,
   makeWrapper,
   nix-update-script,
-  nodejs_22,
+  nodejs-slim_22,
   pango,
   pixman,
   pkg-config,
@@ -24,7 +24,7 @@
 }:
 
 let
-  pnpm = pnpm_10.override { nodejs = nodejs_22; };
+  pnpm = pnpm_10.override { nodejs-slim = nodejs-slim_22; };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "sharkey";
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     makeWrapper
-    nodejs_22
+    nodejs-slim_22
     pkg-config
     pnpmConfigHook
     pnpm
@@ -79,7 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
     popd
 
     # rebuild some node modules that have native dependencies
-    export npm_config_nodedir=${nodejs_22}
+    export npm_config_nodedir=${nodejs-slim_22}
 
     pushd node_modules/.pnpm/node_modules/re2
     pnpm rebuild
@@ -105,7 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
     let
       binPath = lib.makeBinPath [
         bash
-        nodejs_22
+        nodejs-slim_22
         pnpm
       ];
       libPath = lib.makeLibraryPath [

--- a/pkgs/by-name/sh/shopify-cli/package.nix
+++ b/pkgs/by-name/sh/shopify-cli/package.nix
@@ -6,7 +6,7 @@
   pnpmConfigHook,
   pnpm_10,
   faketty,
-  nodejs_22,
+  nodejs-slim_22,
   versionCheckHook,
   makeBinaryWrapper,
   nix-update-script,
@@ -14,8 +14,8 @@
 let
   pnpm = pnpm_10;
 
-  nodejs = nodejs_22;
-  pnpm' = pnpm.override { inherit nodejs; };
+  nodejs-slim = nodejs-slim_22;
+  pnpm' = pnpm.override { inherit nodejs-slim; };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "shopify";
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     faketty
-    nodejs
+    nodejs-slim
     pnpmConfigHook
     pnpm'
     makeBinaryWrapper
@@ -73,7 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
     pnpm install --offline --prod --ignore-scripts --frozen-lockfile
     mv node_modules $out/lib/node_modules/@shopify/cli/node_modules
 
-    makeWrapper ${lib.getExe nodejs} $out/bin/shopify \
+    makeWrapper ${lib.getExe nodejs-slim} $out/bin/shopify \
       --add-flags "$out/lib/node_modules/@shopify/cli/bin/run.js"
 
     runHook postInstall

--- a/pkgs/by-name/ta/taler-wallet-core/package.nix
+++ b/pkgs/by-name/ta/taler-wallet-core/package.nix
@@ -7,7 +7,7 @@
   fetchgit,
   srcOnly,
   removeReferencesTo,
-  nodejs_24,
+  nodejs-slim_24,
   pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
@@ -17,8 +17,10 @@
   zip,
 }:
 let
-  nodeSources = srcOnly nodejs_24;
-  pnpm' = pnpm_11.override { nodejs = nodejs_24; };
+  nodeSources = (srcOnly nodejs-slim_24).overrideAttrs {
+    outputChecks = { };
+  };
+  pnpm' = pnpm_11.override { nodejs-slim = nodejs-slim_24; };
   esbuild' = esbuild.override {
     buildGoModule =
       args:
@@ -61,7 +63,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     customPython
-    nodejs_24
+    nodejs-slim_24
+    nodejs-slim_24.npm
     pnpmConfigHook
     pnpm'
     gitMinimal
@@ -70,7 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    nodejs_24
+    nodejs-slim_24
   ];
 
   # Make a fake git repo with a commit.

--- a/pkgs/by-name/ts/tsx/package.nix
+++ b/pkgs/by-name/ts/tsx/package.nix
@@ -5,12 +5,12 @@
   pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
-  nodejs_22,
+  nodejs-slim_22,
   versionCheckHook,
   nix-update-script,
 }:
 let
-  pnpm' = pnpm_10.override { nodejs = nodejs_22; };
+  pnpm' = pnpm_10.override { nodejs-slim = nodejs-slim_22; };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "tsx";
@@ -35,13 +35,13 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    nodejs_22
+    nodejs-slim_22
     pnpmConfigHook
     pnpm'
   ];
 
   buildInputs = [
-    nodejs_22
+    nodejs-slim_22
   ];
 
   patchPhase = ''

--- a/pkgs/by-name/vt/vtsls/package.nix
+++ b/pkgs/by-name/vt/vtsls/package.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  nodejs_22,
+  nodejs-slim_22,
   gitMinimal,
   gitSetupHook,
   pnpm_8,
@@ -11,7 +11,7 @@
   nix-update-script,
 }:
 let
-  pnpm' = pnpm_8.override { nodejs = nodejs_22; };
+  pnpm' = pnpm_8.override { nodejs-slim = nodejs-slim_22; };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "vtsls";
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    nodejs_22
+    nodejs-slim_22
     # patches are applied with git during build
     gitMinimal
     gitSetupHook
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     pnpm'
   ];
 
-  buildInputs = [ nodejs_22 ];
+  buildInputs = [ nodejs-slim_22 ];
 
   pnpmWorkspaces = [ "@vtsls/language-server" ];
 

--- a/pkgs/by-name/zi/zipline/package.nix
+++ b/pkgs/by-name/zi/zipline/package.nix
@@ -31,7 +31,7 @@ let
     PRISMA_FMT_BINARY = lib.getExe' prisma-engines_6 "prisma-fmt";
   };
 
-  pnpm' = pnpm_10.override { nodejs = nodejs_24; };
+  pnpm' = pnpm_10.override { nodejs-slim = nodejs_24; };
 in
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/development/python-modules/gradio/default.nix
+++ b/pkgs/development/python-modules/gradio/default.nix
@@ -15,7 +15,7 @@
 
   # web assets
   zip,
-  nodejs_24,
+  nodejs-slim,
   pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
@@ -77,8 +77,7 @@
   writableTmpDirAsHomeHook,
 }:
 let
-  nodejs = nodejs_24;
-  pnpm = pnpm_10.override { inherit nodejs; };
+  pnpm = pnpm_10;
 in
 buildPythonPackage (finalAttrs: {
   pname = "gradio";
@@ -109,7 +108,7 @@ buildPythonPackage (finalAttrs: {
 
   nativeBuildInputs = [
     zip
-    nodejs
+    nodejs-slim
     pnpm
     pnpmConfigHook
     writableTmpDirAsHomeHook

--- a/pkgs/development/tools/pnpm/default.nix
+++ b/pkgs/development/tools/pnpm/default.nix
@@ -31,7 +31,13 @@ let
     };
   };
 
-  callPnpm = variant: callPackage ./generic.nix { inherit (variant) version hash; };
+  callPnpm =
+    variant:
+    callPackage ./generic.nix {
+      inherit (variant) version hash;
+      #FIXME: remove this hack in a future version.
+      nodejs = null; # Passing null to detect out-of-tree overrides
+    };
 
   mkPnpm = versionSuffix: variant: nameValuePair "pnpm_${versionSuffix}" (callPnpm variant);
 in

--- a/pkgs/development/tools/pnpm/generic.nix
+++ b/pkgs/development/tools/pnpm/generic.nix
@@ -6,7 +6,9 @@
   pnpmConfigHook,
   fetchurl,
   installShellFiles,
-  nodejs,
+  #FIXME: remove this arg in a future version.
+  nodejs, # Should be null, unless overridden.
+  nodejs-slim,
   testers,
   buildPackages,
   bashNonInteractive,
@@ -18,6 +20,12 @@
 }:
 let
   majorVersion = lib.versions.major version;
+  nodejs-slim' =
+    #FIXME: remove this hack in a future version.
+    if nodejs == null then
+      nodejs-slim
+    else
+      lib.warn "pnpm: Override nodejs-slim instead of nodejs" nodejs;
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "pnpm";
@@ -30,13 +38,13 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     installShellFiles
-    nodejs
+    nodejs-slim'
   ];
 
   buildInputs = [
     bashNonInteractive # needed for node-gyp wrapper script
   ]
-  ++ lib.optionals withNode [ nodejs ];
+  ++ lib.optionals withNode [ nodejs-slim' ];
 
   # Remove binary files from src, we don't need them, and this way we make sure
   # our distribution is free of binaryNativeCode
@@ -109,7 +117,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
               ];
             })
           );
-      inherit nodejs majorVersion;
+      nodejs-slim = nodejs-slim';
+      #FIXME: remove this in a future version.
+      nodejs = lib.warn "pnpm.nodejs: Use pnpm.nodejs-slim instead of pnpm.nodejs" nodejs-slim';
+      inherit majorVersion;
 
       tests = {
         inherit (tests) pnpm;

--- a/pkgs/development/web/nodejs/symlink.nix
+++ b/pkgs/development/web/nodejs/symlink.nix
@@ -44,6 +44,10 @@
                 "man"
                 "out"
                 "static"
+
+                # Filter out outputs that didn't exist on 25.11
+                "npm"
+                "corepack"
               ])
               && !(builtins.hasAttr name nodejs)
             ) (builtins.attrNames nodejs-slim)

--- a/pkgs/test/pnpm/pnpm_11_v3/default.nix
+++ b/pkgs/test/pnpm/pnpm_11_v3/default.nix
@@ -2,7 +2,7 @@
   fetchPnpmDeps,
   lib,
   makeShellWrapper,
-  nodejs,
+  nodejs-slim,
   pnpmConfigHook,
   pnpm_11,
   stdenv,
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     makeShellWrapper
-    nodejs
+    nodejs-slim
     pnpm
     pnpmConfigHook
   ];
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     install -Dm644 -t $out/lib/pnpm-11-test dist/index.js
 
-    makeWrapper ${lib.getExe nodejs} $out/bin/pnpm-11-test \
+    makeWrapper ${lib.getExe nodejs-slim} $out/bin/pnpm-11-test \
       --add-flags "$out/lib/pnpm-11-test"
 
     runHook postInstall

--- a/pkgs/test/pnpm/pnpm_11_v4/default.nix
+++ b/pkgs/test/pnpm/pnpm_11_v4/default.nix
@@ -2,7 +2,7 @@
   fetchPnpmDeps,
   lib,
   makeShellWrapper,
-  nodejs,
+  nodejs-slim,
   pnpmConfigHook,
   pnpm_11,
   stdenv,
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     makeShellWrapper
-    nodejs
+    nodejs-slim
     pnpm
     pnpmConfigHook
   ];
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     install -Dm644 -t $out/lib/pnpm-11-test dist/index.js
 
-    makeWrapper ${lib.getExe nodejs} $out/bin/pnpm-11-test \
+    makeWrapper ${lib.getExe nodejs-slim} $out/bin/pnpm-11-test \
       --add-flags "$out/lib/pnpm-11-test"
 
     runHook postInstall


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new pacasdkages please briefly describe the package or provide a link to its homepage.
-->

Backport of https://github.com/NixOS/nixpkgs/pull/514575 and https://github.com/NixOS/nixpkgs/pull/528786

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
