### PR TITLE
teleport_17: 17.7.24 -> 17.7.25; teleport_18: 18.8.3 -> 18.9.1

### DIFF
--- a/pkgs/by-name/te/teleport_17/package.nix
+++ b/pkgs/by-name/te/teleport_17/package.nix
@@ -7,11 +7,11 @@
 }:
 
 buildTeleport {
-  version = "17.7.24";
-  hash = "sha256-45vaxznxRfa4X/V7hZsQKVIWvbVG8F2cEQN19xp4WQg=";
+  version = "17.7.25";
+  hash = "sha256-IrelrkTvOBcTkO7cHf572MU5KkOQq3we53dgFsDCSRo=";
   vendorHash = "sha256-ERwCdWdp230wkqsRUCnd1hbO4PqXo+gDPsoGbxQqt04=";
-  cargoHash = "sha256-cDcDfptq8z0pwjImuAovv/5XwoaPb/ostyxkyNEbkRM=";
-  pnpmHash = "sha256-hk9DI3GSBm2XttCYCi5kjhEhUMm5ToRQcbT+RYI+S2Q=";
+  cargoHash = "sha256-BE/TBZoOaB3Th14E+t3qJ+0Uww56TtRA1sRQ+usFo+Y=";
+  pnpmHash = "sha256-TARwHswSWbKk2eoyynuaOm7pvt2CwbjtklqnM+9/YXM=";
 
   wasm-bindgen-cli = wasm-bindgen-cli_0_2_95;
   inherit buildGoModule withRdpClient extPatches;

--- a/pkgs/by-name/te/teleport_18/package.nix
+++ b/pkgs/by-name/te/teleport_18/package.nix
@@ -7,11 +7,11 @@
 }:
 
 buildTeleport {
-  version = "18.8.3";
-  hash = "sha256-DHPOWIvzBCOT3GU0YHBtG46ctB0Nh8XwSmpl9vgCET8=";
-  vendorHash = "sha256-0+fIoprAQyoom9xBpXGiEgmE4dWktcqlZQOzkRXYlKo=";
-  pnpmHash = "sha256-8FlC9Sm12A5kfS9X0qYDNJOePZjeJU7LDTRlWUIEneA=";
-  cargoHash = "sha256-IX0HCeCosXCe/oTYa8PImemf9op2AeagSnl44uBnSbM=";
+  version = "18.9.1";
+  hash = "sha256-FIPExc8tMoPXfWc7pQjwQRkxmiQEOxdkYgWS0GejQuk=";
+  vendorHash = "sha256-BlQhypAoK85ID0pgmXbUboks88qjSg3p5E8qxyTIc9M=";
+  pnpmHash = "sha256-ZGbuBMPwC3u/2qDTVLH2InOGVc94Vq0i3AKHMsOwq3k=";
+  cargoHash = "sha256-KbmacTEOElmboHMK6YxWGC0brlDsX7kcvpaOOZmuops=";
 
   wasm-bindgen-cli = wasm-bindgen-cli_0_2_99;
   buildGoModule = buildGo125Module;


### PR DESCRIPTION
Changelog: https://github.com/gravitational/teleport/releases/tag/v17.7.25
Diff: https://github.com/gravitational/teleport/compare/v17.7.24...v17.7.25
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
