### PR TITLE
ReGreet: add missing GStreamer dependencies

### DIFF
--- a/pkgs/by-name/re/regreet/package.nix
+++ b/pkgs/by-name/re/regreet/package.nix
@@ -7,6 +7,7 @@
   accountsservice,
   dbus,
   glib,
+  gst_all_1,
   gtk4,
   pango,
   librsvg,
@@ -37,6 +38,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     dbus
     glib
     gtk4
+    gst_all_1.gstreamer # Used for animated wallpapers or video playback
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-base
     pango
     librsvg
   ];


### PR DESCRIPTION
ReGreet implemented a feature that allows for animated playbacks utilizing GStreamer since commit https://github.com/rharish101/ReGreet/commit/3385f81a1502e969c4b76cdf137901cef114b6d8, however, seems like this feature was accidentally enabled unanimously for every media type(as per https://github.com/rharish101/ReGreet/pull/163), this resulted in ReGreet refusing to launch if any wallpaper were present, due to missing `playbin3`. Recent pull request didn't oversee this change, resulted in ReGreet being essentially broken.
Effectively reflecting https://github.com/NixOS/nixpkgs/pull/502010.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
