### PR TITLE
blink1-tool: support darwin

### DIFF
--- a/pkgs/by-name/bl/blink1-tool/package.nix
+++ b/pkgs/by-name/bl/blink1-tool/package.nix
@@ -21,10 +21,17 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     substituteInPlace Makefile \
       --replace "@git submodule update --init" "true"
+    substituteInPlace Makefile \
+      --replace-fail "INSTALL = install''\n" "INSTALL = install -D''\n"
+  ''
+  # Drop the hardcoded universal-binary flags so we build a single-arch.
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace Makefile \
+      --replace-fail "-arch x86_64 -arch arm64" ""
   '';
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ libusb1 ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ libusb1 ];
 
   makeFlags = [
     "GIT_TAG_RAW=v${finalAttrs.version}"
@@ -42,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://blink1.thingm.com/";
     license = with lib.licenses; [ cc-by-sa-40 ];
     maintainers = with lib.maintainers; [ cransom ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
     mainProgram = "blink1-tool";
   };
 })


### PR DESCRIPTION
This adds darwin support to blink1-tool. The package was marked
`platforms = lib.platforms.linux`, so it refused to evaluate on macOS even
though upstream supports macOS and has a Darwin build path in its Makefile.

Four changes, three of them guarded to darwin so Linux is unaffected:

- Add darwin to `meta.platforms`.
- The macOS branch of the upstream Makefile sets `INSTALL = install` (BSD
  install, no `-D`) and the install targets do not create their destination
  directories, so the install phase fails when writing `libBlink1.dylib` and
  the binary into a clean prefix:
  `install: cannot create regular file '.../lib/libBlink1.dylib': No such file or directory`.
  A darwin-only `preInstall` creates `$out/bin` and `$out/lib` first.
- The macOS branch hardcodes `-arch x86_64 -arch arm64`, producing a
  universal binary. nixpkgs builds for a single architecture and only ships
  compiler-rt for the host, so the non-native slice emits linker warnings and
  cannot link the compiler runtime. A darwin-only `substituteInPlace` drops
  the flags so the build produces a single-architecture binary for the host.
- libusb is only needed by the HIDAPI libusb backend on Linux. On macOS the
  HIDAPI backend uses IOKit directly, so `libusb1` is moved behind an
  `isLinux` guard.

Linux behavior is unchanged: `libusb1` stays in `buildInputs`, the
darwin-only `postPatch` and `preInstall` do not run, and the platform list
still contains all of `lib.platforms.linux`.

Tested on aarch64-darwin: builds and `./result/bin/blink1-tool --version` and
`--list` work against a real blink(1) mk3. Not built locally on
x86_64-darwin or Linux; the Linux change paths were evaluated but not built.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
