### PR TITLE
Make PATH have colon only when extraPath is set

### DIFF
--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -335,7 +335,7 @@ let
           install -Dm755 ./build/docker $out/libexec/docker/docker
 
           makeWrapper $out/libexec/docker/docker $out/bin/docker \
-            --prefix PATH : "$out/libexec/docker:$extraPath" \
+            --prefix PATH : "$out/libexec/docker${extraPath:+:$extraPath}" \
             --prefix DOCKER_CLI_PLUGIN_DIRS : "${dockerCliPluginsDirs}"
         ''
         + lib.optionalString (!clientOnly) ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Summary

closes https://github.com/NixOS/nixpkgs/issues/530304

I saw bin/docker mentioning this

```
# ------------------------------------------------------------------------------------
# The C-code for this binary wrapper has been generated using the following command:


makeCWrapper '/nix/store/2w06n3nsc152qgw8dv6xkrlch9chnh3v-docker-29.5.2/libexec/docker/docker' \
    --prefix 'PATH' ':' '/nix/store/2w06n3nsc152qgw8dv6xkrlch9chnh3v-docker-29.5.2/libexec/docker:' \
    --prefix 'DOCKER_CLI_PLUGIN_DIRS' ':' '/nix/store/8fkc3bx2x6wzvdwmhbkcwwgs96h3fvxd-docker-buildx-0.31.1/libexec/docker/cli-plugins:/nix/store/10lkwjrsagc44zs0vn3gzpy12vjgi91b-docker-compose-5.1.4/libexec/doc
ker/cli-plugins'


# (Use `nix-shell -p makeBinaryWrapper` to get access to makeCWrapper in your shell)
# ------------------------------------------------------------------------------------
```

`/nix/store/2w06n3nsc152qgw8dv6xkrlch9chnh3v-docker-29.5.2/libexec/docker:` this trailing colon is not required. This causes adding "." to the PATH, which is bad idea.

Mine should be the least change to fix this.

Note that I'm not good at writing nix syntax, so it might be wrong (claude told me we can use bash syntax). I just open a pull request to put the detailed analysis.

## How I tested the functionality at least

I have tested the functionality by editing wrapper's `/nix/store/2w06n3nsc152qgw8dv6xkrlch9chnh3v-docker-29.5.2/libexec/docker:` string by ghex.

```
$ diff <(strings ./docker_nix_wrap_orig) <(strings ./docker_nix_wrap)
40c40
< /nix/store/2w06n3nsc152qgw8dv6xkrlch9chnh3v-docker-29.5.2/libexec/docker:
---
> /nix/store/2w06n3nsc152qgw8dv6xkrlch9chnh3v-docker-29.5.2/libexec/docker
```

And after editing the issue is gone.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
