### PR TITLE
comma: install completion

### DIFF
--- a/pkgs/by-name/co/comma/package.nix
+++ b/pkgs/by-name/co/comma/package.nix
@@ -36,26 +36,44 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail '"fzy"' '"${lib.getExe fzy}"'
   '';
 
-  postInstall = ''
-    ln -s $out/bin/comma $out/bin/,
+  postInstall =
+    let
+      emulator = stdenv.hostPlatform.emulator buildPackages;
+    in
+    ''
+      ln -s $out/bin/comma $out/bin/,
 
-    mkdir -p $out/share/comma
+      mkdir -p $out/share/comma
 
-    cp $src/etc/command-not-found.sh $out/share/comma
-    cp $src/etc/command-not-found.nu $out/share/comma
-    cp $src/etc/command-not-found.fish $out/share/comma
+      cp $src/etc/command-not-found.sh $out/share/comma
+      cp $src/etc/command-not-found.nu $out/share/comma
+      cp $src/etc/command-not-found.fish $out/share/comma
 
-    patchShebangs $out/share/comma/command-not-found.sh
-    substituteInPlace \
-      "$out/share/comma/command-not-found.sh" \
-      "$out/share/comma/command-not-found.nu" \
-      "$out/share/comma/command-not-found.fish" \
-      --replace-fail "comma --ask" "$out/bin/comma --ask"
-  ''
-  + lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) ''
-    ${stdenv.hostPlatform.emulator buildPackages} "$out/bin/comma" --mangen > comma.1
-    installManPage comma.1
-  '';
+      patchShebangs $out/share/comma/command-not-found.sh
+      substituteInPlace \
+        "$out/share/comma/command-not-found.sh" \
+        "$out/share/comma/command-not-found.nu" \
+        "$out/share/comma/command-not-found.fish" \
+        --replace-fail "comma --ask" "$out/bin/comma --ask"
+    ''
+    + lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) ''
+      ${emulator} "$out/bin/comma" --mangen > comma.1
+      installManPage comma.1
+
+      installShellCompletion --cmd comma \
+        --bash <(${emulator} $out/bin/comma --print-completions bash) \
+        --fish <(${emulator} $out/bin/comma --print-completions fish) \
+        --zsh <(${emulator} $out/bin/comma --print-completions zsh)
+
+      # TODO: Add , to other shells too
+      cat >>$out/share/zsh/site-functions/_comma <<'EOF'
+        if [ "$funcstack[1]" = "_comma" ]; then
+            _comma "$@"
+        else
+            compdef _comma ,
+        fi
+      EOF
+    '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Taken (almost) verbatim from upstream's `flake.nix` (I fixed the `TODO` which was missing a word).

CC @Artturin. Since you wrote upstream's commit for this, you'll find it familiar.

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
