### PR TITLE
andcli, gradia, netpeek, jocalsend, tauno-monitor: set structuredAttrs; librepods: set structuredAttrs & strictDeps

### DIFF
--- a/pkgs/by-name/an/andcli/package.nix
+++ b/pkgs/by-name/an/andcli/package.nix
@@ -11,6 +11,8 @@ buildGoModule (finalAttrs: {
   pname = "andcli";
   version = "2.7.0";
 
+  __structuredAttrs = true;
+
   subPackages = [ "cmd/andcli" ];
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/gr/gradia/package.nix
+++ b/pkgs/by-name/gr/gradia/package.nix
@@ -27,6 +27,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
   version = "1.13.0";
   pyproject = false;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "AlexanderVanhee";
     repo = "Gradia";
@@ -79,7 +81,9 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   dontWrapGApps = true;
 
-  makeWrapperArgs = [ "\${gappsWrapperArgs[@]}" ];
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/jo/jocalsend/package.nix
+++ b/pkgs/by-name/jo/jocalsend/package.nix
@@ -11,6 +11,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "jocalsend";
   version = "1.618033988";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitea {
     domain = "git.kittencollective.com";
     owner = "nebkor";

--- a/pkgs/by-name/li/librepods/package.nix
+++ b/pkgs/by-name/li/librepods/package.nix
@@ -13,6 +13,9 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "librepods";
   version = "0.2.5";
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   src = fetchFromGitHub {
     owner = "kavishdevar";
     repo = "librepods";

--- a/pkgs/by-name/ne/netpeek/package.nix
+++ b/pkgs/by-name/ne/netpeek/package.nix
@@ -17,6 +17,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
   version = "0.2.7";
   pyproject = false;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "ZingyTomato";
     repo = "NetPeek";

--- a/pkgs/by-name/ta/tauno-monitor/package.nix
+++ b/pkgs/by-name/ta/tauno-monitor/package.nix
@@ -17,6 +17,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
   version = "0.2.20";
   pyproject = false;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "taunoe";
     repo = "tauno-monitor";
@@ -45,7 +47,9 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   dontWrapGApps = true;
 
-  makeWrapperArgs = [ "\${gappsWrapperArgs[@]}" ];
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
Set `__structuredAttrs = true;` and `strictDeps = true;` for some packages I maintain.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
