### PR TITLE
kubernetes-helm: fix darwin side to use correct substitute paths

### DIFF
--- a/pkgs/applications/networking/cluster/helm/default.nix
+++ b/pkgs/applications/networking/cluster/helm/default.nix
@@ -72,15 +72,15 @@ buildGoModule (finalAttrs: {
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
     # skipping as test fails in sandbox
-    substituteInPlace cmd/helm/dependency_build_test.go \
+    substituteInPlace pkg/cmd/dependency_build_test.go \
       --replace-fail "TestDependencyBuildCmd" "SkipDependencyBuildCmd"
-    substituteInPlace cmd/helm/dependency_update_test.go \
+    substituteInPlace pkg/cmd/dependency_update_test.go \
       --replace-fail "TestDependencyUpdateCmd" "SkipDependencyUpdateCmd"
     # skipping as test fails in sandbox
-    substituteInPlace cmd/helm/install_test.go \
+    substituteInPlace pkg/cmd/install_test.go \
       --replace-fail "TestInstall" "SkipInstall"
     # skipping as test fails in sandbox
-    substituteInPlace cmd/helm/pull_test.go \
+    substituteInPlace pkg/cmd/pull_test.go \
       --replace-fail "TestPullCmd" "SkipPullCmd" \
       --replace-fail "TestPullWithCredentialsCmd" "SkipPullWithCredentialsCmd"
   '';


### PR DESCRIPTION
darwin part was ignore in the recent upgrade to 4.2.0, so builds are failing on darwin.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
