### PR TITLE
cryfs: fix static build and tests

### DIFF
--- a/pkgs/by-name/cr/cryfs/package.nix
+++ b/pkgs/by-name/cr/cryfs/package.nix
@@ -13,37 +13,33 @@
   range-v3,
   spdlog,
   llvmPackages,
+  writableTmpDirAsHomeHook,
+  versionCheckHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "cryfs";
   version = "1.0.3";
 
   src = fetchFromGitHub {
     owner = "cryfs";
     repo = "cryfs";
-    rev = version;
-    hash = "sha256-bBe//AjA9QmdSDlb0xiOboE5F4g6LJ03cHQZpfOk+Y4=";
+    tag = finalAttrs.version;
+    hash = "sha256-DbXZxPACisAcdaqaqRiBK2Su/Wp6E9Mh+w62EkJrpYA=";
   };
 
   postPatch = ''
-    patchShebangs src
-
-    # remove tests that require network access
-    substituteInPlace test/cpp-utils/CMakeLists.txt \
-      --replace "network/CurlHttpClientTest.cpp" "" \
-      --replace "network/FakeHttpClientTest.cpp" ""
-
-    # remove CLI test trying to access /dev/fuse
-    substituteInPlace test/cryfs-cli/CMakeLists.txt \
-      --replace "CliTest_IntegrityCheck.cpp" "" \
-      --replace "CliTest_Setup.cpp" "" \
-      --replace "CliTest_WrongEnvironment.cpp" "" \
-      --replace "CryfsUnmountTest.cpp" ""
-
-    # downsize large file test as 4.5G is too big for Hydra
+    patchShebangs src/
+  ''
+  # Set Boost_USE_STATIC_LIBS via CMake command line. (see cmakeFlags below)
+  + ''
+    substituteInPlace cmake-utils/Dependencies.cmake \
+      --replace-fail "set(Boost_USE_STATIC_LIBS OFF)" ""
+  ''
+  # Downsize large file test as 4.5G is too big for Hydra.
+  + ''
     substituteInPlace test/cpp-utils/data/DataTest.cpp \
-      --replace "(4.5L*1024*1024*1024)" "(0.5L*1024*1024*1024)"
+      --replace-fail "(4.5L*1024*1024*1024)" "(0.5L*1024*1024*1024)"
   '';
 
   nativeBuildInputs = [
@@ -66,38 +62,86 @@ stdenv.mkDerivation rec {
   ++ lib.optional stdenv.cc.isClang llvmPackages.openmp;
 
   cmakeFlags = [
-    "-DDEPENDENCY_CONFIG='../cmake-utils/DependenciesFromLocalSystem.cmake'"
-    "-DCRYFS_UPDATE_CHECKS:BOOL=FALSE"
-    "-DBoost_USE_STATIC_LIBS:BOOL=FALSE" # this option is case sensitive
-    "-DBUILD_TESTING:BOOL=${if doCheck then "TRUE" else "FALSE"}"
+    (lib.cmakeFeature "DEPENDENCY_CONFIG" "../cmake-utils/DependenciesFromLocalSystem.cmake")
+    (lib.cmakeBool "CRYFS_UPDATE_CHECKS" false)
+    (lib.cmakeBool "Boost_USE_STATIC_LIBS" stdenv.hostPlatform.isStatic) # This option is case sensitive.
+    (lib.cmakeBool "BUILD_TESTING" finalAttrs.doCheck)
   ];
 
-  # macFUSE needs to be installed for the test to succeed on Darwin
+  # macFUSE needs to be installed for the tests to succeed on Darwin.
   doCheck = !stdenv.hostPlatform.isDarwin;
 
-  checkPhase = ''
-    runHook preCheck
-    export HOME=$(mktemp -d)
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+  ];
 
-    # Skip CMakeFiles directory and tests depending on fuse (does not work well with sandboxing)
-    SKIP_IMPURE_TESTS="CMakeFiles|fspp|my-gtest-main"
+  checkPhase =
+    let
+      runTest =
+        {
+          path,
+          filter ? null,
+        }:
+        "command ./${path}${lib.optionalString (!isNull filter) " '--gtest_filter=${filter}'"}";
+    in
+    ''
+      runHook preCheck
 
-    for t in $(ls -d test/*/ | grep -E -v "$SKIP_IMPURE_TESTS") ; do
-      "./$t$(basename $t)-test"
-    done
+      pushd test/
+    ''
+    # See the test runner at https://github.com/cryfs/cryfs/blob/1.0.3/.github/workflows/actions/run_tests/action.yaml.
+    + (lib.concatLines [
+      (runTest {
+        path = "gitversion/gitversion-test";
+      })
+      (runTest {
+        path = "cpp-utils/cpp-utils-test";
+        filter =
+          if stdenv.hostPlatform.isStatic then "*-BacktraceTest.*:*.AssertMessageContainsBacktrace" else null;
+      })
+      (runTest {
+        path = "parallelaccessstore/parallelaccessstore-test";
+      })
+      (runTest {
+        path = "blockstore/blockstore-test";
+      })
+      (runTest {
+        path = "blobstore/blobstore-test";
+      })
+      (runTest {
+        path = "cryfs/cryfs-test";
+      })
+      # Skip tests trying to access /dev/fuse inside the build sandbox.
+      (runTest {
+        path = "fspp/fspp-test";
+        filter = ""; # Skip all tests.
+      })
+      (runTest {
+        path = "cryfs-cli/cryfs-cli-test";
+        filter = "*-CliTest.WorksWithCommasInBasedir:CliTest_IntegrityCheck.*:CliTest_Setup.*:CliTest_Unmount.*:RunningInForeground*";
+      })
+    ])
+    + ''
+      popd
 
-    runHook postCheck
-  '';
+      runHook postCheck
+    '';
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
 
   meta = {
     description = "Cryptographic filesystem for the cloud";
     homepage = "https://www.cryfs.org/";
-    changelog = "https://github.com/cryfs/cryfs/raw/${version}/ChangeLog.txt";
+    changelog = "https://github.com/cryfs/cryfs/raw/${finalAttrs.version}/ChangeLog.txt";
     license = lib.licenses.lgpl3Only;
     maintainers = with lib.maintainers; [
       peterhoeg
       sigmasquadron
     ];
-    platforms = lib.platforms.unix;
+    platforms = lib.systems.inspect.patterns.isUnix;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Fix the static build and refactor the way that the tests are run based on how upstream runs the tests in CI.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
