### PR TITLE
nixos/language: add option to configure n-grams

### DIFF
--- a/nixos/modules/services/misc/languagetool.nix
+++ b/nixos/modules/services/misc/languagetool.nix
@@ -36,6 +36,57 @@ in
       '';
     };
 
+    n-grams =
+      let
+        mkNGramsLangModule =
+          {
+            language,
+            url,
+            hash,
+          }:
+          {
+            enable = lib.mkEnableOption "${language} n-gram data";
+            package = lib.mkOption {
+              description = "The ${language} n-gram data package.";
+              type = lib.types.package;
+              default = pkgs.fetchzip { inherit url hash; };
+              defaultText = lib.literalExpression ''
+                pkgs.fetchzip {
+                  url = "${url}";
+                  hash = "${hash}";
+                }
+              '';
+            };
+          };
+      in
+      {
+        de = mkNGramsLangModule {
+          language = "German";
+          url = "https://languagetool.org/download/ngram-data/ngrams-de-20150819.zip";
+          hash = "sha256-b+dPqDhXZQpVOGwDJOO4bFTQ15hhOSG6WPCx8RApfNg=";
+        };
+        en = mkNGramsLangModule {
+          language = "English";
+          url = "https://languagetool.org/download/ngram-data/ngrams-en-20150817.zip";
+          hash = "sha256-v3Ym6CBJftQCY5FuY6s5ziFvHKAyYD3fTHr99i6N8sE=";
+        };
+        es = mkNGramsLangModule {
+          language = "Spanish";
+          url = "https://languagetool.org/download/ngram-data/ngrams-es-20150915.zip";
+          hash = "sha256-mA2dFEscDNr4tJQzQnpssNAmiSpd9vaDX8e+21OJUgQ=";
+        };
+        fr = mkNGramsLangModule {
+          language = "French";
+          url = "https://languagetool.org/download/ngram-data/ngrams-fr-20150913.zip";
+          hash = "sha256-z+JJe8MeI9YXE2wUA2acK9SuQrMZ330QZCF9e234FCk=";
+        };
+        nl = mkNGramsLangModule {
+          language = "Dutch";
+          url = "https://languagetool.org/download/ngram-data/ngrams-nl-20181229.zip";
+          hash = "sha256-bHOEdb2R7UYvXjqL7MT4yy3++hNMVwnG7TJvvd3Feg8=";
+        };
+      };
+
     settings = lib.mkOption {
       type = lib.types.submodule {
         freeformType = settingsFormat.type;
@@ -76,8 +127,17 @@ in
     ] "The jre is now always taken from the package's jre attribute.")
   ];
 
-  config = lib.mkIf cfg.enable {
-    systemd.services.languagetool = {
+  config = {
+    services.languagetool.settings.languageModel =
+      let
+        enabledNGrams = lib.filterAttrs (_: v: v.enable) cfg.n-grams;
+        buildCommand = lib.concatLines (
+          [ "mkdir $out" ] ++ lib.mapAttrsToList (n: v: "ln -s ${v.package} $out/${n}") enabledNGrams
+        );
+      in
+      lib.mkIf (enabledNGrams != { }) (pkgs.runCommand "languagetool_n-grams" { } buildCommand);
+
+    systemd.services.languagetool = lib.mkIf cfg.enable {
       description = "LanguageTool HTTP server";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];

--- a/nixos/modules/services/misc/languagetool.nix
+++ b/nixos/modules/services/misc/languagetool.nix
@@ -97,13 +97,13 @@ in
           [
             (lib.getExe cfg.package.jre)
             "-cp ${cfg.package}/share/languagetool-server.jar"
-            (toString cfg.jvmOptions)
+            (lib.escapeShellArgs cfg.jvmOptions)
             "org.languagetool.server.HTTPServer"
             "--config ${settingsFormat.generate "languagetool.conf" cfg.settings}"
             "--port ${toString cfg.port}"
           ]
           ++ lib.optional cfg.public "--public"
-          ++ lib.optional (cfg.allowOrigin != null) "--allow-origin ${cfg.allowOrigin}"
+          ++ lib.optional (cfg.allowOrigin != null) "--allow-origin ${lib.escapeShellArg cfg.allowOrigin}"
         );
       };
     };

--- a/nixos/modules/services/misc/languagetool.nix
+++ b/nixos/modules/services/misc/languagetool.nix
@@ -93,16 +93,18 @@ in
         ];
         ProtectHome = "yes";
         Restart = "on-failure";
-        ExecStart = ''
-          ${lib.getExe cfg.package.jre} \
-            -cp ${cfg.package}/share/languagetool-server.jar \
-            ${toString cfg.jvmOptions} \
-            org.languagetool.server.HTTPServer \
-              --port ${toString cfg.port} \
-              ${lib.optionalString cfg.public "--public"} \
-              ${lib.optionalString (cfg.allowOrigin != null) "--allow-origin ${cfg.allowOrigin}"} \
-              "--config" ${settingsFormat.generate "languagetool.conf" cfg.settings}
-        '';
+        ExecStart = lib.concatStringsSep " " (
+          [
+            (lib.getExe cfg.package.jre)
+            "-cp ${cfg.package}/share/languagetool-server.jar"
+            (toString cfg.jvmOptions)
+            "org.languagetool.server.HTTPServer"
+            "--config ${settingsFormat.generate "languagetool.conf" cfg.settings}"
+            "--port ${toString cfg.port}"
+          ]
+          ++ lib.optional cfg.public "--public"
+          ++ lib.optional (cfg.allowOrigin != null) "--allow-origin ${cfg.allowOrigin}"
+        );
       };
     };
   };

--- a/nixos/tests/languagetool.nix
+++ b/nixos/tests/languagetool.nix
@@ -1,19 +1,15 @@
-{ pkgs, lib, ... }:
+{ lib, ... }:
 let
   port = 8082;
 in
 {
   name = "languagetool";
-  meta = with lib.maintainers; {
-    maintainers = [ fbeffa ];
-  };
+  meta.maintainers = [ lib.maintainers.fbeffa ];
 
-  nodes.machine =
-    { ... }:
-    {
-      services.languagetool.enable = true;
-      services.languagetool.port = port;
-    };
+  containers.machine.services.languagetool = {
+    enable = true;
+    inherit port;
+  };
 
   testScript = ''
     machine.start()

--- a/nixos/tests/languagetool.nix
+++ b/nixos/tests/languagetool.nix
@@ -1,6 +1,7 @@
 { lib, ... }:
 let
   port = 8082;
+  apiCheck = "http://localhost:${toString port}/v2/check";
 in
 {
   name = "languagetool";
@@ -9,12 +10,28 @@ in
   containers.machine.services.languagetool = {
     enable = true;
     inherit port;
+    n-grams = {
+      de.enable = true;
+      en.enable = true;
+      es.enable = true;
+      fr.enable = true;
+      nl.enable = true;
+    };
   };
 
   testScript = ''
     machine.start()
     machine.wait_for_unit("languagetool.service")
     machine.wait_for_open_port(${toString port})
-    machine.wait_until_succeeds('curl -d "language=en-US" -d "text=a simple test" http://localhost:${toString port}/v2/check')
+    machine.wait_until_succeeds('curl -d "language=en-US" -d "text=a simple test" ${apiCheck}')
+
+    with subtest("n-grams are enabled"):
+      import json
+      response = machine.succeed('curl -d "language=en-US" -d "text=Don’t forget to put on the breaks." ${apiCheck}')
+      data = json.loads(response)
+      t.assertEqual(data["matches"][0]["rule"]["id"], "CONFUSION_RULE_BREAKS_BRAKES")
+      response = machine.succeed('curl -d "language=de-DE" -d "text=In den christlichen Traditionen gibt es unterschiedliche Anleitungen zur Mediation und Kontemplation." ${apiCheck}')
+      data = json.loads(response)
+      t.assertEqual(data["matches"][0]["rule"]["id"], "CONFUSION_RULE_MEDIATION_MEDITATION")
   '';
 }


### PR DESCRIPTION
LanguageTool can make use of large n-gram data sets to detect errors with words that are often confused. This PR adds an `n-gram` option sets up this feature by downloading the enabled n-gram data sets and setting the LanguageTool instance's language model. See https://dev.languagetool.org/finding-errors-using-n-gram-data for more information.

Additionally, this PR

- escapes the usage of the `jvmOptions` and `allowOrigin` options, and
- replaces the QEMU VM by systemd-nspawn containers in the NixOS test.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
