### PR TITLE
technitium-dns-server: fix missing DNSSEC DO bit in authoritative response

### DIFF
--- a/pkgs/by-name/te/technitium-dns-server/dnssec-do-bit-fix.patch
+++ b/pkgs/by-name/te/technitium-dns-server/dnssec-do-bit-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/DnsServerCore/Dns/ZoneManagers/AuthZoneManager.cs b/DnsServerCore/Dns/ZoneManagers/AuthZoneManager.cs
+index 352ea6c0..41a9a1c7 100644
+--- a/DnsServerCore/Dns/ZoneManagers/AuthZoneManager.cs
++++ b/DnsServerCore/Dns/ZoneManagers/AuthZoneManager.cs
+@@ -3536,7 +3536,7 @@ namespace DnsServerCore.Dns.ZoneManagers
+                     }
+                 }
+ 
+-                return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, true, false, request.RecursionDesired, isRecursionAllowed, false, false, rCode, request.Question, answer, authority, additional, udpPayloadSize: _dnsServer.UdpPayloadSize, options: eDnsOptions);
++                return new DnsDatagram(request.Identifier, true, DnsOpcode.StandardQuery, true, false, request.RecursionDesired, isRecursionAllowed, false, false, rCode, request.Question, answer, authority, additional, _dnsServer.UdpPayloadSize, request.DnssecOk ? EDnsHeaderFlags.DNSSEC_OK : EDnsHeaderFlags.None, eDnsOptions);
+             }
+         }
+ 

--- a/pkgs/by-name/te/technitium-dns-server/package.nix
+++ b/pkgs/by-name/te/technitium-dns-server/package.nix
@@ -41,6 +41,12 @@ buildDotnetModule rec {
     libmsquic
   ];
 
+  # Confirmed correct by upstream, remove when fixed in a release:
+  # https://github.com/TechnitiumSoftware/DnsServer/issues/1967
+  patches = [
+    ./dnssec-do-bit-fix.patch
+  ];
+
   passthru.tests = {
     inherit (nixosTests) technitium-dns-server;
   };


### PR DESCRIPTION
Authoritative responses did not set the DNSSEC_OK EDNS flag when the
client requested it. Not yet fixed upstream, but upstream confirmed
this is the correct fix:
https://github.com/TechnitiumSoftware/DnsServer/issues/1967

This is needed in nixpkgs now rather than with the next upstream
release because the .de TLD (DENIC) currently rejects DNSSEC-signed
domains served by Technitium: its predelegation checks fail when the
authoritative server does not set the DO bit, so no new .de domains
can be set up with DNSSEC at all.

Tested locally: with the patch applied, authoritative responses to
queries with the DO bit set now include DNSSEC_OK.

Parts I used an LLM (Claude Code, Fable 5) for:
- Commit message.
- Finding where in the upstream code the issue is.
- The comment in package.nix.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
