### PR TITLE
Revert "pkgs-lib/formats: Use .attrs.json directly for TOML"

### DIFF
--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -472,12 +472,14 @@ optionalAttrs allowAliases aliases
           runCommand name
             {
               nativeBuildInputs = [ json2x ];
-              inherit value;
+              value = builtins.toJSON value;
               preferLocalBuild = true;
               __structuredAttrs = true;
             }
             ''
-              json2x toml --unwrap value "$NIX_ATTRS_JSON_FILE" "$out"
+              valuePath="$TMPDIR/value"
+              printf "%s" "$value" > "$valuePath"
+              json2x toml "$valuePath" "$out"
             ''
         ) { };
 

--- a/pkgs/pkgs-lib/formats/json2x/src/main.rs
+++ b/pkgs/pkgs-lib/formats/json2x/src/main.rs
@@ -10,9 +10,6 @@ use argh::{FromArgValue, FromArgs};
 /// Convert a JSON file to another format
 #[derive(FromArgs)]
 struct Args {
-    /// convert only value of this attribute
-    #[argh(option)]
-    unwrap: Option<String>,
     /// format of the output file, possible values: toml
     #[argh(positional)]
     format: Format,
@@ -32,31 +29,16 @@ enum Format {
 fn main() -> anyhow::Result<()> {
     let args: Args = argh::from_env();
 
-    let json_text = read_to_string(&args.input)
+    let input = read_to_string(&args.input)
         .with_context(|| format!("failed to read {}", args.input.display()))?;
-    let parsed_json: serde_json::Value = serde_json::from_str(&json_text)
+    let input: serde_json::Value = serde_json::from_str(&input)
         .with_context(|| format!("failed to parse {}", args.input.display()))?;
-    let output_value = if let Some(unwrap_key) = args.unwrap {
-        parsed_json
-            .as_object()
-            .ok_or_else(|| anyhow::anyhow!("{} does not contain an object", args.input.display()))?
-            .get(&unwrap_key)
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "{} does not containt attribute '{unwrap_key}'",
-                    args.input.display()
-                )
-            })?
-    } else {
-        &parsed_json
-    };
     let mut output = File::create(&args.output)
         .with_context(|| format!("failed to create {}", args.output.display()))?;
 
     match args.format {
         Format::Toml => {
-            let content =
-                toml::to_string(output_value).context("failed to serialize value to toml")?;
+            let content = toml::to_string(&input).context("failed to serialize value to toml")?;
             output
                 .write_all(content.as_bytes())
                 .with_context(|| format!("failed to write to {}", args.output.display()))?;


### PR DESCRIPTION
Reverts NixOS/nixpkgs#528060

See https://github.com/NixOS/nixpkgs/pull/524404#issuecomment-4664269013