### PR TITLE
Add cable

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6957,6 +6957,12 @@
     github = "DimitarNestorov";
     githubId = 8790386;
   };
+  DimseBoms = {
+     name = "Dmitriy Safiullin";
+     github = "DimseBoms";
+     githubId = 72513291;
+     email = "dmisaf@posteo.net";
+   };
   diniamo = {
     name = "diniamo";
     email = "diniamo53@gmail.com";

--- a/pkgs/by-name/ca/cable/package.nix
+++ b/pkgs/by-name/ca/cable/package.nix
@@ -89,7 +89,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     description = "GUI to dynamically modify PipeWire and WirePlumber settings at runtime";
     homepage = "https://github.com/magillos/Cable";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ DimseBoms ];
     mainProgram = "cable";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/ca/cable/package.nix
+++ b/pkgs/by-name/ca/cable/package.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  qt6,
+  hicolor-icon-theme,
+  pipewire,
+  wireplumber,
+  pulseaudio,
+  aj-snapshot,
+  jack-example-tools,
+  graphviz,
+}:
+
+python3.pkgs.buildPythonApplication (finalAttrs: {
+  pname = "cable";
+  version = "0.10.9";
+
+  src = fetchFromGitHub {
+    owner = "magillos";
+    repo = "Cable";
+    rev = finalAttrs.version;
+    hash = "sha256-o5OsJ2mOUr+51C0oB3owKXDr9qvG+D7L07j6cGhrS1o=";
+  };
+
+  pyproject = true;
+  nativeBuildInputs = [
+    python3.pkgs.setuptools
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt6.qtsvg
+  ];
+
+  propagatedBuildInputs = [
+    python3.pkgs.dbus-python
+    python3.pkgs.pyqt6
+    python3.pkgs.requests
+    python3.pkgs.packaging
+    python3.pkgs.pyalsaaudio
+    python3.pkgs.graphviz
+    python3.pkgs.jack-client
+  ];
+
+  dontWrapQtApps = true;
+
+  # Full transitive closure is required: the child process launched via
+  # QProcess(sys.executable, …) inherits PYTHONPATH but not the wrapper's
+  # site.addsitedir() calls, so transitive deps must be explicit.
+  postFixup =
+    let
+      inherit (python3) sitePackages;
+      allPythonDeps = python3.pkgs.requiredPythonModules finalAttrs.propagatedBuildInputs;
+      pythonpath = lib.concatMapStringsSep ":" (pkg: "${pkg}/${sitePackages}") allPythonDeps;
+      runtimePath = lib.makeBinPath [
+        pipewire
+        wireplumber
+        pulseaudio
+        aj-snapshot
+        jack-example-tools
+        graphviz
+      ];
+    in
+    ''
+      wrapQtApp "$out/bin/cable" \
+        --prefix PATH : "${runtimePath}" \
+        --set PYTHONPATH "$out/${sitePackages}:${pythonpath}"
+    '';
+
+  postInstall = ''
+    # process.py spawns connection-manager.py via QProcess(sys.executable, …),
+    # bypassing the Nix wrapper. Place it in site-packages so the relative
+    # path lookup in process.py resolves correctly at runtime.
+    cp $src/connection-manager.py \
+       $out/${python3.sitePackages}/connection-manager.py
+
+    mkdir -p $out/share/icons/hicolor/scalable/apps
+    cp $src/*.svg $out/share/icons/hicolor/scalable/apps
+    # index.theme is required for Qt to recognise this as a valid icon search path.
+    cp ${hicolor-icon-theme}/share/icons/hicolor/index.theme \
+       $out/share/icons/hicolor/index.theme
+
+    install -Dm644 $src/com.github.magillos.cable.desktop \
+      $out/share/applications/com.github.magillos.cable.desktop
+  '';
+
+  meta = {
+    description = "GUI to dynamically modify PipeWire and WirePlumber settings at runtime";
+    homepage = "https://github.com/magillos/Cable";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ ];
+    mainProgram = "cable";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/development/python-modules/jack-client/default.nix
+++ b/pkgs/development/python-modules/jack-client/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  cffi,
+  numpy,
+  pipewire,
+}:
+
+buildPythonPackage rec {
+  pname = "jack-client";
+  version = "0.5.5";
+
+  src = fetchFromGitHub {
+    owner = "spatialaudio";
+    repo = "jackclient-python";
+    rev = version;
+    hash = "sha256-SqDHFUlAtGbT/UJALykPvdP7+5KUlZkMpwYDjq+rU98=";
+  };
+
+  pyproject = true;
+
+  nativeBuildInputs = [
+    setuptools
+    cffi
+  ];
+
+  propagatedBuildInputs = [
+    numpy
+    cffi
+    pipewire.jack
+  ];
+
+  # Patch in the absolute path to PipeWire's libjack shim directly so JACK calls are routed to PipeWire.
+  postPatch = ''
+    substituteInPlace src/jack.py \
+      --replace "_libname = _find_library('jack')" "_libname = '${pipewire.jack}/lib/libjack.so'"
+  '';
+
+  meta = {
+    description = "JACK Audio Connection Kit client for Python";
+    homepage = "https://github.com/spatialaudio/jackclient-python";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/development/python-modules/jack-client/default.nix
+++ b/pkgs/development/python-modules/jack-client/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
     description = "JACK Audio Connection Kit client for Python";
     homepage = "https://github.com/spatialaudio/jackclient-python";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ DimseBoms ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7961,6 +7961,8 @@ self: super: with self; {
 
   j2lint = callPackage ../development/python-modules/j2lint { };
 
+  jack-client = callPackage ../development/python-modules/jack-client { };
+
   jaconv = callPackage ../development/python-modules/jaconv { };
 
   jalali-core = callPackage ../development/python-modules/jalali-core { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds two packages to nixpkgs:
1. [Cable](https://github.com/magillos/Cable) - GUI application to control pipewire settings at runtime.
2. [jack-client](https://github.com/spatialaudio/jackclient-python/) - Jack bindings for python. Cable depends on this.

Cable is really useful for musicians and I personally use it a lot. It also adds jack-client since I could not find it available in the repos.

Claude has been involved in getting this PR ready as it is my first contribution. The nested dependency handling for the application turned out quite complex since the application spawns more applications that need to inherit the main application's dependencies.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
