### PR TITLE
pkgs-lib/hocon: use structuredAttrs instead of passAsFile

### DIFF
--- a/pkgs/pkgs-lib/formats/hocon/default.nix
+++ b/pkgs/pkgs-lib/formats/hocon/default.nix
@@ -140,20 +140,19 @@ in
               hocon-validator,
               writeText,
             }:
-            stdenvNoCC.mkDerivation rec {
+            stdenvNoCC.mkDerivation (finalAttrs: {
               inherit name;
 
               dontUnpack = true;
               preferLocalBuild = true;
 
               json = builtins.toJSON value;
-              passAsFile = [ "json" ];
 
               strictDeps = true;
               nativeBuildInputs = [ hocon-generator ];
               buildPhase = ''
                 runHook preBuild
-                hocon-generator < $jsonPath > output.conf
+                printf "%s" "$json" | hocon-generator > output.conf
                 runHook postBuild
               '';
 
@@ -171,8 +170,10 @@ in
                 runHook postInstall
               '';
 
-              passthru.json = writeText "${name}.json" json;
-            }
+              __structuredAttrs = true;
+
+              passthru.json = writeText "${finalAttrs.name}.json" finalAttrs.json;
+            })
           )
           {
             hocon-generator = generator;


### PR DESCRIPTION
Also use `finalAttrs` pattern.

Tested via `nix-build -A tests.pkgs-lib.hocon`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
