### PR TITLE
formats.javaProperties: use structuredAttrs instead of passAsFile

### DIFF
--- a/pkgs/pkgs-lib/formats/java-properties/default.nix
+++ b/pkgs/pkgs-lib/formats/java-properties/default.nix
@@ -106,12 +106,13 @@ in
               #    general.
 
               preferLocalBuild = true;
-              passAsFile = [ "value" ];
               value = builtins.toJSON value;
               nativeBuildInputs = [
                 jq
                 libiconvReal
               ];
+
+              __structuredAttrs = true;
 
               jqCode =
                 let
@@ -151,7 +152,7 @@ in
               (
                 echo "$comment" | while read -r ln; do echo "# $ln"; done
                 echo
-                jq -r --arg hash '#' "$jqCode" "$valuePath" \
+                printf "%s" "$value" | jq -r --arg hash '#' "$jqCode" \
                   | iconv --from-code "$inputEncoding" --to-code JAVA \
               ) > "$out"
             ''

--- a/pkgs/pkgs-lib/formats/java-properties/test/default.nix
+++ b/pkgs/pkgs-lib/formats/java-properties/test/default.nix
@@ -53,13 +53,13 @@ stdenv.mkDerivation {
     jdk
     glibcLocales
   ];
-
+  __structuredAttrs = true;
+  strictDeps = true;
   # technically should go through the type.merge first, but that's tested
   # in tests/formats.nix.
   properties = javaProperties.generate "example.properties" input;
 
   # Expected output as printed by Main.java
-  passAsFile = [ "expected" ];
   expected = concatStrings (
     attrValues (
       mapAttrs (key: value: ''
@@ -76,7 +76,7 @@ stdenv.mkDerivation {
     "**/*.java"
   ];
   # On Linux, this can be C.UTF-8, but darwin + zulu requires en_US.UTF-8
-  LANG = "en_US.UTF-8";
+  env.LANG = "en_US.UTF-8";
   buildPhase = ''
     javac Main.java
   '';
@@ -84,7 +84,7 @@ stdenv.mkDerivation {
   checkPhase = ''
     cat -v $properties
     java Main $properties >actual
-    diff -U3 $expectedPath actual
+    diff -U3 <(printf "%s" "$expected") actual
   '';
   installPhase = "touch $out";
 }


### PR DESCRIPTION
Tested via `nix-build -A tests.pkgs-lib.java-properties`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
