### PR TITLE
python3Packages.labgrid: 25.0.1 -> 26.0

### DIFF
--- a/pkgs/development/python-modules/labgrid/default.nix
+++ b/pkgs/development/python-modules/labgrid/default.nix
@@ -10,6 +10,7 @@
   grpcio-reflection,
   jinja2,
   lib,
+  nix-update-script,
   mock,
   openssh,
   pexpect,
@@ -40,6 +41,8 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-cLofkkp2T6Y9nQ5LIS7w9URZlt8DQNN8dm3NnrvcKWY=";
   };
+
+  passthru.updateScript = nix-update-script { };
 
   # Remove after package bump
   patches = [

--- a/pkgs/development/python-modules/labgrid/default.nix
+++ b/pkgs/development/python-modules/labgrid/default.nix
@@ -30,7 +30,7 @@
   xmodem,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "labgrid";
   version = "25.0.1";
   pyproject = true;
@@ -38,7 +38,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "labgrid-project";
     repo = "labgrid";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-cLofkkp2T6Y9nQ5LIS7w9URZlt8DQNN8dm3NnrvcKWY=";
   };
 
@@ -123,4 +123,4 @@ buildPythonPackage rec {
     maintainers = with lib.maintainers; [ emantor ];
     platforms = with lib.platforms; linux;
   };
-}
+})

--- a/pkgs/development/python-modules/labgrid/default.nix
+++ b/pkgs/development/python-modules/labgrid/default.nix
@@ -2,6 +2,7 @@
   ansicolors,
   attrs,
   buildPythonPackage,
+  exceptiongroup,
   fetchFromGitHub,
   fetchpatch,
   fetchpatch2,
@@ -24,46 +25,27 @@
   pyudev,
   pyusb,
   pyyaml,
+  py-netgear-plus,
   requests,
   setuptools,
   setuptools-scm,
+  util-linux,
   xmodem,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "labgrid";
-  version = "25.0.1";
+  version = "26.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "labgrid-project";
     repo = "labgrid";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-cLofkkp2T6Y9nQ5LIS7w9URZlt8DQNN8dm3NnrvcKWY=";
+    hash = "sha256-SX7FIaSl2sy1hMPEmgGCQQAzXUeFZRw/CrXf/ZHRBDU=";
   };
 
   passthru.updateScript = nix-update-script { };
-
-  # Remove after package bump
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/Emantor/labgrid/commit/4a66b43882811d50600e37aa39b24ec40398d184.patch";
-      sha256 = "sha256-eJMB1qFWiDzQXEB4dYOHYMQqCPHXEWCwWjNNY0yTC2s=";
-    })
-    (fetchpatch {
-      url = "https://github.com/Emantor/labgrid/commit/d9933b3ec444c35d98fd41685481ecae8ff28bf4.patch";
-      sha256 = "sha256-Zx5j+CD6Q89dLmTl5QSKI9M1IcZ97OCjEWtEbG+CKWE=";
-    })
-    (fetchpatch {
-      url = "https://github.com/Emantor/labgrid/commit/f0b672afe1e8976c257f0adff9bf6e7ee9760d6f.patch";
-      sha256 = "sha256-M7rg+W9SjWDdViWyWe3ERzbUowxzf09c4w1yG3jQGak=";
-    })
-    # Fix test_help under python 3.14 argparse colored output.
-    (fetchpatch2 {
-      url = "https://github.com/labgrid-project/labgrid/commit/417ace60b9dc043767afb312113a02bcb0807b17.patch?full_index=1";
-      hash = "sha256-QCkO/PQbosqUldzJiOyF6BHvyzZI06CGs9IxHPPa6Ek=";
-    })
-  ];
 
   build-system = [
     setuptools
@@ -73,6 +55,7 @@ buildPythonPackage (finalAttrs: {
   dependencies = [
     ansicolors
     attrs
+    exceptiongroup
     jinja2
     grpcio
     grpcio-tools
@@ -99,6 +82,8 @@ buildPythonPackage (finalAttrs: {
     pytest-benchmark
     pytest-mock
     pytest-dependency
+    util-linux
+    py-netgear-plus
   ];
 
   disabledTests = [
@@ -112,6 +97,15 @@ buildPythonPackage (finalAttrs: {
 
     # flaky: teardown race on x86_64-linux
     "test_remoteplace_target"
+
+    # netns tests require working SSH & Agentwrapper
+    "test_tcp"
+    "test_udp"
+    "test_getaddrinfo"
+    "test_closed_socket"
+    "test_dup"
+    "test_detach"
+    "test_socks"
   ];
 
   pytestFlags = [ "--benchmark-disable" ];


### PR DESCRIPTION
## Things done

Update package to 26.0, add nix-update-script. cc @AiyionPrime.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
