### PR TITLE
formats.libconfig: use structuredAttrs instead of passAsFile

### DIFF
--- a/pkgs/pkgs-lib/formats/libconfig/default.nix
+++ b/pkgs/pkgs-lib/formats/libconfig/default.nix
@@ -86,20 +86,19 @@ in
               libconfig-validator,
               writeText,
             }:
-            stdenvNoCC.mkDerivation rec {
+            stdenvNoCC.mkDerivation (finalAttrs: {
               inherit name;
 
               dontUnpack = true;
               preferLocalBuild = true;
 
               json = builtins.toJSON value;
-              passAsFile = [ "json" ];
 
               strictDeps = true;
               nativeBuildInputs = [ libconfig-generator ];
               buildPhase = ''
                 runHook preBuild
-                libconfig-generator < $jsonPath > output.cfg
+                printf "%s" "$json" | libconfig-generator > output.cfg
                 runHook postBuild
               '';
 
@@ -117,8 +116,10 @@ in
                 runHook postInstall
               '';
 
-              passthru.json = writeText "${name}.json" json;
-            }
+              __structuredAttrs = true;
+
+              passthru.json = writeText "${finalAttrs.name}.json" finalAttrs.json;
+            })
           )
           {
             libconfig-generator = generator;


### PR DESCRIPTION
Also use finalAttrs pattern instead of rec.

Tested via `nix-build -A tests.pkgs-lib.libconfig`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
