### PR TITLE
sd: remove xtask build tool from package output

### DIFF
--- a/pkgs/by-name/sd/sd/package.nix
+++ b/pkgs/by-name/sd/sd/package.nix
@@ -21,6 +21,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeBuildInputs = [ installShellFiles ];
 
   postInstall = ''
+    rm $out/bin/xtask
+
     installManPage gen/sd.1
 
     installShellCompletion gen/completions/sd.{bash,fish}


### PR DESCRIPTION
## Summary

The `sd` crate is a Cargo workspace with three members: `sd` (library), `sd-cli` (binary), and `xtask` (internal build task runner). When `buildRustPackage` builds the whole workspace, the `xtask` binary ends up installed in `$out/bin`, but it serves no purpose for end users.

This removes `xtask` from the installed output by deleting it in `postInstall`.

Fixes #512682