### PR TITLE
python3Packages.plover_{4,5}: install desktop entry

### DIFF
--- a/pkgs/development/python-modules/plover/4.nix
+++ b/pkgs/development/python-modules/plover/4.nix
@@ -70,6 +70,10 @@ buildPythonPackage (finalAttrs: {
   # Segfaults?!
   disabledTestPaths = [ "test/gui_qt/test_dictionaries_widget.py" ];
 
+  postInstall = ''
+    install -Dm 444 linux/plover.desktop $out/share/applications/plover.desktop
+  '';
+
   preFixup = ''
     makeWrapperArgs+=("''${qtWrapperArgs[@]}")
   '';

--- a/pkgs/development/python-modules/plover/5.nix
+++ b/pkgs/development/python-modules/plover/5.nix
@@ -124,6 +124,10 @@ buildPythonPackage (finalAttrs: {
     "test/gui_qt/test_i18n_files.py" # babel errors
   ];
 
+  postInstall = ''
+    install -Dm 444 linux/plover.desktop $out/share/applications/plover.desktop
+  '';
+
   preFixup = ''
     makeWrapperArgs+=("''${qtWrapperArgs[@]}")
   '';


### PR DESCRIPTION
as is, plover has a desktop entry in the source tree but it is not actually shipped in nixpkgs. we place it in the standard $out/share/applications directory so it can be found by e.g. launchers.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
