### PR TITLE
nixbang: migrate to pyproject; use tag and hash

### DIFF
--- a/pkgs/by-name/ni/nixbang/package.nix
+++ b/pkgs/by-name/ni/nixbang/package.nix
@@ -8,7 +8,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pname = "nixbang";
   version = "0.1.2";
   pyproject = true;
-  namePrefix = "";
 
   src = fetchFromGitHub {
     owner = "madjar";

--- a/pkgs/by-name/ni/nixbang/package.nix
+++ b/pkgs/by-name/ni/nixbang/package.nix
@@ -4,18 +4,20 @@
   fetchFromGitHub,
 }:
 
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "nixbang";
   version = "0.1.2";
-  format = "setuptools";
+  pyproject = true;
   namePrefix = "";
 
   src = fetchFromGitHub {
     owner = "madjar";
     repo = "nixbang";
-    rev = version;
-    sha256 = "1kzk53ry60i814wa6n9y2ni0bcxhbi9p8gdv10b974gf23mhi8vc";
+    tag = finalAttrs.version;
+    hash = "sha256-bKMI6xDukZMWCLs9dFNcsLMFohU+WaM4CSgC4/Mo888=";
   };
+
+  build-system = with python3Packages; [ setuptools ];
 
   meta = {
     homepage = "https://github.com/madjar/nixbang";
@@ -24,4 +26,4 @@ python3Packages.buildPythonApplication rec {
     maintainers = [ lib.maintainers.madjar ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
Part of #515974

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
