### PR TITLE
schildi-revenge: 2026.05.05 -> 2026.06.06

### DIFF
--- a/pkgs/by-name/sc/schildi-revenge/deps.json
+++ b/pkgs/by-name/sc/schildi-revenge/deps.json
@@ -27,90 +27,81 @@
    "module": "sha256-v+t72E8/fdp71ztnCdSh9h9aN/hDcouuCKBn49+aCu8=",
    "pom": "sha256-LWXI0LNtS0+q3ESv+breI9hx1xWe7fKz8C2AKzS3elc="
   },
-  "compose/runtime#runtime-annotation-jvm/1.10.5": {
-   "jar": "sha256-+J3ai81zh20PwWVohEsr15RD7nymKBCHTSXH3Ko5S9Y=",
-   "module": "sha256-tjv/82rZJ/SUVGt0m3o2Ox324fobKSyXihkr7fTv6EQ=",
-   "pom": "sha256-DJECRC6QE5BNF+fZNHyNvKRjSt6Met9yVGwOe6ei/F8="
+  "compose/runtime#runtime-annotation-jvm/1.11.0-rc01": {
+   "jar": "sha256-4oaoUgcJ173GZIHCcmYMKo0msSdA92ECVDzkVwQ3A5Y=",
+   "module": "sha256-JJMFQNItrRK1aVpERxiOx5N/eKYqVKRapnPK2ftwRlI=",
+   "pom": "sha256-wshTQYcZD+NmeWky/a0PL6PqPjYIj+5Qp5AvyXIdSB8="
   },
-  "compose/runtime#runtime-annotation-jvm/1.9.0": {
-   "jar": "sha256-mJstoov1unlmwIyi2z9IpgfmhOSrT/DegOnNXsZjwHY=",
-   "module": "sha256-BwRUw9jx/YX9sCztcMXdVbnJUGqfHJYwmVrWtUhbweY=",
-   "pom": "sha256-kTdIOF0hz/MrNeJZUR7w4mo4lt9+4P8Sv2rGEOreq2A="
+  "compose/runtime#runtime-annotation-jvm/1.11.2": {
+   "jar": "sha256-4oaoUgcJ173GZIHCcmYMKo0msSdA92ECVDzkVwQ3A5Y=",
+   "module": "sha256-mAOREpmtfxBJH7AM7QZ3H0dLv7UNLLk0sExeV79pFZA=",
+   "pom": "sha256-Wn8tmNFKL4YHDqKdhJDiYpn0jwhQtpG3lU0293kQ5T8="
   },
-  "compose/runtime#runtime-annotation-jvm/1.9.4": {
-   "jar": "sha256-mJstoov1unlmwIyi2z9IpgfmhOSrT/DegOnNXsZjwHY=",
-   "module": "sha256-cdTwQFv/4v7dHZuLZJ63DhuW0HBnQLVjhhhMEhZiALk=",
-   "pom": "sha256-OMb8W3u9UXzgpBSKwe+P1E+GoMLOHmlkm/FXhWDPLpY="
+  "compose/runtime#runtime-annotation/1.11.0-rc01": {
+   "module": "sha256-pnylTwY8OPboC3lNrvVJNVUVS69V6xil3z7n7ct4N0A=",
+   "pom": "sha256-/V+nj8Fb55Ttiaikhp5CdiQqpGjc7FI4SSpB41QDhzc="
   },
-  "compose/runtime#runtime-annotation/1.10.5": {
-   "jar": "sha256-XUzoJpn1AaDI4eZyZY8fgIlTTgaYm/JTvfqxHixzBZU=",
-   "module": "sha256-VYNtTRHcFC32bcSxz/XoMXiyN5jbwAQUyhYZOBNkeFE=",
-   "pom": "sha256-9gQoKGzJ35GwfaC8gQvnBRtkts7o3ZVM4gD9nbBVs6E="
+  "compose/runtime#runtime-annotation/1.11.2": {
+   "jar": "sha256-GQ42On8pUXlPW08JhtpFTzmkJbh3mbLVksKniXLRdd8=",
+   "module": "sha256-NhSpP6QePns7dSfjf64wXhswojyyKF+s428wXbuC9Fk=",
+   "pom": "sha256-Smd2+thKJeT9sP3AaLiAilcuXMDpvscSsilMHjmsCTY="
   },
-  "compose/runtime#runtime-annotation/1.9.0": {
-   "module": "sha256-aI/PepDHx6su4gF+reuc2inzWuF+aq3sct/QdA8C5iQ=",
-   "pom": "sha256-0Vin/5qk2CFOCF+dXHndAAKjLRgWoCOqn6omucRtg6c="
+  "compose/runtime#runtime-desktop/1.11.0-rc01": {
+   "jar": "sha256-UMm1xchPpj0MKqcTGjxvVbM9FrUhFXWWReQ3D0yZhY8=",
+   "module": "sha256-WuLpf5rVMLT9FWxbJzjII9glpQFdP1kHjnt7sMikYYY=",
+   "pom": "sha256-xUBbjIh6dBleBjsbR9Wd5uq4cwUIJrIQzASS0N6RMN8="
   },
-  "compose/runtime#runtime-annotation/1.9.4": {
-   "module": "sha256-JmaBc8UooQ3RpzXY0LF6q10ujJYWlTg72PHUSPCHws0=",
-   "pom": "sha256-zrmsMOstfKN8qXafyC3CFsEkeSHLC3eKW2q6YuVbhqI="
+  "compose/runtime#runtime-desktop/1.11.2": {
+   "jar": "sha256-aVUa7o+SEUkhgW89mqpmBiEE2yKO1XEKZmb3rb36/jw=",
+   "module": "sha256-b5bQGrIJuGKdS8crPLYqzT/hKshtjg/0349RsopLKkQ=",
+   "pom": "sha256-EtXDwmN11h2Sv/Bn09S8gJ5H3KE/I9H2BuVUcBJ80Do="
   },
-  "compose/runtime#runtime-desktop/1.10.5": {
-   "jar": "sha256-sZWGBUL2Et4FErVKdTU+D21YgV8MlTCgO8Ww5zRHSCk=",
-   "module": "sha256-dAYUqXRffpcEq2deze7GeSljSAPNxdIhsjIAHGaiBmI=",
-   "pom": "sha256-ijTm+Hv20HzRPXJaCdf/e9Ox0KNzKalD9ANKyJv6a94="
+  "compose/runtime#runtime-retain-desktop/1.11.0-rc01": {
+   "jar": "sha256-m35ip98zPDPv+eGm1sJQik2P5LekN3gHVTj+PaS8RIU=",
+   "module": "sha256-rYhJPsh9RcM4BOFBSWvvuRUqyDP6A3pPjiIHPyxQz1k=",
+   "pom": "sha256-wB6g2unzf3ouoBbiMFgR+0Uw3FdKCVymkX3CdRmzD8Y="
   },
-  "compose/runtime#runtime-desktop/1.9.0": {
-   "jar": "sha256-rmV+QzL7cvobQ3zlyqSGxrSl4XWIqu8CZ6qSkYu6dFg=",
-   "module": "sha256-vVE7iwcDHUB2Y2i/ILOSanNAU3lGxuhXJK1pknOn+g8=",
-   "pom": "sha256-4ybvc2sUSnnTBXjuMcSiY0F1U5tcMyZPBcmrxvpl0fo="
+  "compose/runtime#runtime-retain-desktop/1.11.2": {
+   "jar": "sha256-m35ip98zPDPv+eGm1sJQik2P5LekN3gHVTj+PaS8RIU=",
+   "module": "sha256-jnF2lFlOIuU+IBhrzSS9g6J/QcAQP1sr3LPsRXNCQn0=",
+   "pom": "sha256-x7EjehNSlhZPkgt+FUwmSyv9rQVSVQBDdhV4cA6jNdA="
   },
-  "compose/runtime#runtime-desktop/1.9.4": {
-   "jar": "sha256-tWObLfBAhyh7WIbUfbHveRwnnBB07mKEgXJu2Qz/A+c=",
-   "module": "sha256-9NbvOvLHfjiA2GuAEzw8S2XhAaQTzYhks8FCZW8NZT8=",
-   "pom": "sha256-auYydwtkdmu36sMLZF+AarEk9kLOiFKKg4xsfOXtUkk="
+  "compose/runtime#runtime-retain/1.11.0-rc01": {
+   "module": "sha256-d7+iDvl5cCm/1OeY+q7OmWf3OAqfnEADlwKLCWBT5uQ=",
+   "pom": "sha256-lUVDAEJaV/dC7d4G2YRGBzNIcxC/GZZajaIS8S2yukM="
   },
-  "compose/runtime#runtime-retain-desktop/1.10.5": {
-   "jar": "sha256-Rj7pwek9G5E0WL/syW0SijV0qAL0HIyXgdcyDDtV7Ys=",
-   "module": "sha256-vdwnS3pYT/sW5EvEwnnxErsY9O6it4DfdNkC6/hLumw=",
-   "pom": "sha256-tHAngJ/qZQmY2Jm8NEKnS808DnBJQ/rYufkHd0lEoK0="
+  "compose/runtime#runtime-retain/1.11.2": {
+   "jar": "sha256-o2qxCWSG9aiFkeqG9u1S8RLD+E8b+cM0PcGS00EOhCo=",
+   "module": "sha256-zetoCiKgEn2QY9hj1syYoi6BIXIeGHCZYdU9EpytGHI=",
+   "pom": "sha256-H9Opc9dmUGpvO9tc80BY7xISKV3219XNeSPWtkXPoZw="
   },
-  "compose/runtime#runtime-retain/1.10.5": {
-   "jar": "sha256-rxY11W6En8ruAC2dqeHeZsy3FULLodGWdkRBGU3BVEM=",
-   "module": "sha256-gCOC/hCAMjMXl6ZFBKpN4Hjk7WtHUytVepzWMGEeO10=",
-   "pom": "sha256-AKXSE6cZrSVhpJbmr56y1jku9O2riTdo/zYyolZv8zM="
+  "compose/runtime#runtime-saveable-desktop/1.11.0-rc01": {
+   "jar": "sha256-saF+bCJt67Qsoif1gEWdnZ3qYtQqqOaF71bNfOdwsaE=",
+   "module": "sha256-LlNO/IXS7Of611IBgz2SAnWXq7jU+EyOQs8vrJLPlCE=",
+   "pom": "sha256-OwnxBF1mzdZ9aIA3eS53NkRbN9YXHv1slz6wRMbuQXA="
   },
-  "compose/runtime#runtime-saveable-desktop/1.10.5": {
-   "jar": "sha256-7yTiTMjJw7mHEAf731ie2aquz5WXmma3SEgG+fDiTZE=",
-   "module": "sha256-+pRBxpkgZazdTbMuBwtQHZDtW0m56OV6j7gkruBser8=",
-   "pom": "sha256-iRqrmg0pxbsMXMX00ff+OJmkvjCa5UK2+kZjHA/zfiQ="
+  "compose/runtime#runtime-saveable-desktop/1.11.2": {
+   "jar": "sha256-saF+bCJt67Qsoif1gEWdnZ3qYtQqqOaF71bNfOdwsaE=",
+   "module": "sha256-qRjbULEcx/dEJhf9My0a3Ut72bIqIOpMfYHfAeZNe1g=",
+   "pom": "sha256-nUKDfFDNQ3n/5QKT55cT1APh4+73w4HEES6XX24TtDk="
   },
-  "compose/runtime#runtime-saveable-desktop/1.9.4": {
-   "jar": "sha256-35kHo+Zyw/qdp+iAMTZ5zbB+gKfzFB9UrB7IFJ0MW+Y=",
-   "module": "sha256-BwrIv4Rv7/f5a+6uF++WBCvgs10uNdwOPHOv2aXLM4A=",
-   "pom": "sha256-t2I5gDlhPCa1EgSoOGyWicjr8lWD1DiXiG/IQew7aeU="
+  "compose/runtime#runtime-saveable/1.11.0-rc01": {
+   "module": "sha256-fHZc5oTwYER/CkeFgB4Nz0GWATkAAx7a4VQKGJ/SvhQ=",
+   "pom": "sha256-vl2THwygv0IJwVJODwJ81FXvFZe8l/U6tSGe4Sam2JU="
   },
-  "compose/runtime#runtime-saveable/1.10.5": {
-   "jar": "sha256-+ivj7IPEsSm8t6mxXOH8sNHXYzTn7dt7jzXOmt97CBE=",
-   "module": "sha256-bgFdVYIl2LhxzwZy0YYfVuQCrCfNV6ib7xV2KayxMZs=",
-   "pom": "sha256-tKcjpST7DEAunfM29gPk+gKDWDTgH3FunEU/6H6IodA="
+  "compose/runtime#runtime-saveable/1.11.2": {
+   "jar": "sha256-16wwfVhrLKq/C97ElJohyPSaZT+miOZi2fSn6y2UdW4=",
+   "module": "sha256-L0uS8+cbpnQ5rVI2sge9WWYmzNVb7nDYEfLU1+CApk0=",
+   "pom": "sha256-70hZYCbjOYhPNdacUpiMQqyWb0vINRa/X3zyEyh8oic="
   },
-  "compose/runtime#runtime-saveable/1.9.4": {
-   "module": "sha256-exsm2uetyGKjS/vYPgoS5x3uI41Bp7pd42bOBVzaKPU=",
-   "pom": "sha256-I8fdOoHs474rqLTm7osX/Nkg3nRpADkkBW1Wltb9RP8="
+  "compose/runtime#runtime/1.11.0-rc01": {
+   "module": "sha256-9qoW/UKCWGMRau0MFAqIPj7KRSjihhCRTnqhFCIaMXE=",
+   "pom": "sha256-kQ9SBuUzbh/ekzZH/n/oxA/uWZ8CO47JZtfoxSzgWFg="
   },
-  "compose/runtime#runtime/1.10.5": {
-   "jar": "sha256-OTRR9TXSGU2ljqSzu9oNoJu8DeHQQVF2q+AdVnZKDOM=",
-   "module": "sha256-zw9E6oolRaUAMppCTFO/WRCIfUn/+yECLdAVYJbr35Q=",
-   "pom": "sha256-YYG0edX3JMzZfHHu6sXY4XHK6BJaz5wGV7SvWdRdjwk="
-  },
-  "compose/runtime#runtime/1.9.0": {
-   "module": "sha256-sR6bZBtlR39obhm0mdqkNbr0INE7t56Y2wXsAYktsi4=",
-   "pom": "sha256-0vrrNhehR8vOsH6B2tI8+wHi/QiJ3hO5kJWQChpe030="
-  },
-  "compose/runtime#runtime/1.9.4": {
-   "module": "sha256-f5pbcCKwprlNXD5LAOYS4Zbw2pkV1qs8Sd8dItFbb1o=",
-   "pom": "sha256-eVGpmylFQxFVtvqEwUoJh6pQXBevj6xvOz/zVQ9xcYw="
+  "compose/runtime#runtime/1.11.2": {
+   "jar": "sha256-EjyO2UUlDPUP+610tYV8s32u9aU/hTeHC1VFJbNkExw=",
+   "module": "sha256-aLriuaUArmOAm45H/xSZcnvBSkJASOBVMum55WOqoG0=",
+   "pom": "sha256-Zqsry2Myf6uC84jtBvgW/CIyfhdSEaibFIPN5CmLgAo="
   },
   "datastore#datastore-core-jvm/1.2.1": {
    "jar": "sha256-3S0ID8FusL6h4C5VUdQ0lvueUXeFXFtyxqr24WqxxcE=",
@@ -157,11 +148,6 @@
    "module": "sha256-k9kBazr9A2OaQH9RoRnVyk2umI3jdsOA8OUd2diOaG0=",
    "pom": "sha256-ygYrmrsCmLDUCuEMLRygbUEp9fYO/cXoxExsKzN10Vs="
   },
-  "lifecycle#lifecycle-common-jvm/2.9.2": {
-   "jar": "sha256-N9ibIQHwdKxsJgkX2rsYVgdkXuIAqjAYx8W95w7c8YQ=",
-   "module": "sha256-cjad+SZiA6QqezjE5J9n5ueWL55I4ihiftfvRmsFFIE=",
-   "pom": "sha256-jQ3Ks2SXw0q09G3Hm+cCWsQDWdDUK/SL1pqaa6FzQnI="
-  },
   "lifecycle#lifecycle-common-jvm/2.9.4": {
    "jar": "sha256-N9ibIQHwdKxsJgkX2rsYVgdkXuIAqjAYx8W95w7c8YQ=",
    "module": "sha256-HRg385QrM+owqiMB/c6iY5QIoP1v1DaMIkePqBU6678=",
@@ -171,10 +157,6 @@
    "jar": "sha256-nTqZgAlbdp3rTzKPfzJUObGIFHEk1m3ELt1V4+e+6jc=",
    "module": "sha256-XRJHse373J3e3L5SXJ0mKVZ7HFOMt6nGIM0EShJLXHM=",
    "pom": "sha256-EAT03wURixPCqQmEa63GZkbtJ3lEcGpgTk3YKE1TVIs="
-  },
-  "lifecycle#lifecycle-common/2.9.2": {
-   "module": "sha256-SDP4jjmhvSZO1eoYciAj6+UedLGaBBEkaqPXQOFukIE=",
-   "pom": "sha256-bLkiyxFc6PYeffjRkl4tHTDvPP0I2G7Tl66qc32V+S8="
   },
   "lifecycle#lifecycle-common/2.9.4": {
    "module": "sha256-xXi9dV6kbXp3gRMJo1OVOOLX+4agX8KtgcZV7Pff96Q=",
@@ -204,11 +186,6 @@
    "module": "sha256-Lu74CEz2cSnhmSJ6P6us+FBvV/ruywqrD3ZdXE5ZBAo=",
    "pom": "sha256-SQEy3ZcZUnyYf6pBMkaax+QcJXub5DU/Kc2rFcVS568="
   },
-  "lifecycle#lifecycle-runtime-desktop/2.9.2": {
-   "jar": "sha256-L7SfdtECF5L7NZ4KkkbBUJ8vW1VfCkZZHSTVjetovVw=",
-   "module": "sha256-LlSqpZmBsgH4wWFd8SOPcCXy/z82H+FNwOcJJhaJOu4=",
-   "pom": "sha256-mSJ0JPvUDXx17N+uiOXDVuDEuWVAtKui88RAyFnOU1s="
-  },
   "lifecycle#lifecycle-runtime-desktop/2.9.4": {
    "jar": "sha256-L7SfdtECF5L7NZ4KkkbBUJ8vW1VfCkZZHSTVjetovVw=",
    "module": "sha256-+VLq6Qa8BiePYEGvs8EzPp1rAL5DeIV7zWahulg2eQk=",
@@ -219,10 +196,6 @@
    "module": "sha256-2oBfoBekrM4T9QFGmnWj8wYkjuvFj1vMKAGbABXfumU=",
    "pom": "sha256-Sote7FTV7N8JnqU7Lk6fJNspZ+pdOTCXtqbFSe1pMI0="
   },
-  "lifecycle#lifecycle-runtime/2.9.2": {
-   "module": "sha256-Tt2F+xoXbKfoOxW0dltc7hqTSqMX5BcQ+grBM0HXODo=",
-   "pom": "sha256-C7WGx+arw98w0Xnqn72uhnREwnmoF6IQHAzJQ/ks79w="
-  },
   "lifecycle#lifecycle-runtime/2.9.4": {
    "module": "sha256-3LxbW1BmboQlinS/2OUUkYxZOk/87wwDWFYqAvvYDFg=",
    "pom": "sha256-1helGd2zajCCE/W5r5kWOwo6NznOA4G2yND6aBRhOgg="
@@ -231,11 +204,6 @@
    "jar": "sha256-58hqXlxm/UH9PMnJrTGimXEQsaY4DEQbo/e2sLBw4ys=",
    "module": "sha256-zaMZ18njJgKFmnK+gcACblbReX75umfpFz6QXT90d08=",
    "pom": "sha256-z5W8pQ/AIStIWGre/gQ9VF+B+/YeNF8LeR6tlrLnNuE="
-  },
-  "lifecycle#lifecycle-viewmodel-desktop/2.9.2": {
-   "jar": "sha256-mPgWvmhpQHyH1GBYdW+XeA+mxs9hrNupchb0E3Ma8V0=",
-   "module": "sha256-EDoC/VlNnhlqMQF7rZ69in05EOKKt5Shi2CvS4F18s8=",
-   "pom": "sha256-AZqq8EgWPVXoTyiQpYWpVQGn1KqbbhSByOWPcXsvDJ0="
   },
   "lifecycle#lifecycle-viewmodel-desktop/2.9.4": {
    "jar": "sha256-mPgWvmhpQHyH1GBYdW+XeA+mxs9hrNupchb0E3Ma8V0=",
@@ -247,11 +215,6 @@
    "module": "sha256-Wbc2f72Ct0pgUykaEnQ8rAws8f6WkpN4xR2Cv4/pqV0=",
    "pom": "sha256-i2wwG0UvOIUsD9VRfFFDl2uwLDaSHb+F3TDYiz9gOAE="
   },
-  "lifecycle#lifecycle-viewmodel-savedstate-desktop/2.9.2": {
-   "jar": "sha256-PgtE4lFOr91pONVFfZ9G5HhQd8RdO0NktcI8TcuT79M=",
-   "module": "sha256-lIcA/BG62P5o4na+85NOzf889H12tSMRrtMMunDB3Dw=",
-   "pom": "sha256-SB3uYNMEYo+2QdsKJ3dGBi4D0eIIefF5AgLQaydM6ws="
-  },
   "lifecycle#lifecycle-viewmodel-savedstate-desktop/2.9.4": {
    "jar": "sha256-PgtE4lFOr91pONVFfZ9G5HhQd8RdO0NktcI8TcuT79M=",
    "module": "sha256-Zz9dNS3D2hsaNY5aMO9+FjIZs6HXA27hjJNQxT8F8rE=",
@@ -262,10 +225,6 @@
    "module": "sha256-UIV3gePd+OOZBeTkpXowSWwkX5kB0bfT8XOCOCGINH0=",
    "pom": "sha256-WWVv/K4eDhRwQ7DW2JlmpflnUvBSkev6AoQG7ZRETdE="
   },
-  "lifecycle#lifecycle-viewmodel-savedstate/2.9.2": {
-   "module": "sha256-wXhdcTP8/hFpz0tPbxgER3wdpv/XmtVg9M7brfFsHo4=",
-   "pom": "sha256-8no6SPJjUb0t4pEq7j9zarJufDfXj4fz9VR18piHIKc="
-  },
   "lifecycle#lifecycle-viewmodel-savedstate/2.9.4": {
    "module": "sha256-Q4nMoKmoAace/664j4nwoD2Zwivgk8U5qcD5w5YpVBY=",
    "pom": "sha256-aRK1XHRcV57G/L6wBl1aF9i18G3QpYeIA31B5A21AgI="
@@ -275,65 +234,34 @@
    "module": "sha256-T9cd9zMkXEbkuI6FtKkLgsmvSjWe8x8r3yUPk6AsdFI=",
    "pom": "sha256-HYYK/wylmNSOjoPaP05naQeEmFdKGNO4iewrjECQsZg="
   },
-  "lifecycle#lifecycle-viewmodel/2.9.2": {
-   "module": "sha256-uBT8ApPfHqN+GfIGrRg3A/+bslTdbarvXl59H4V/4Yw=",
-   "pom": "sha256-qsFQVEEJtWQoOeo5u2P7e5B6jSK3wXEWmD7YpaI0unw="
-  },
   "lifecycle#lifecycle-viewmodel/2.9.4": {
    "module": "sha256-lk1p1rh3KW6Lead7uCbvX7GGrsqnoaf/d2+yJQyZMAY=",
    "pom": "sha256-BU22+S2SMBA7OsqLDavMDWPeJuRA/5jrWxmiVV0+sDc="
   },
-  "navigationevent#navigationevent-desktop/1.0.2": {
+  "navigationevent#navigationevent-desktop/1.0.1": {
    "jar": "sha256-Q97rV3T9c3+pReCaR/k7bxpQjRf6yPO2XxyGPn99BmA=",
-   "module": "sha256-GKJKvO+qQwHquqLVD8DiEABPmzRv4KZGYNlQGfNcU7E=",
-   "pom": "sha256-fy3dXDpWBCuV6pFFabqJpq5eP3KnBEpLF3OwQb/OGs8="
+   "module": "sha256-kJ46U7h2B1HXmu9YZfS/SRoWCV2eGvvfueSKxovR/Gg=",
+   "pom": "sha256-MluouGydEyyXeA53cbo8k51iLIfAxYcHlen0OCmd93E="
   },
-  "navigationevent#navigationevent/1.0.2": {
+  "navigationevent#navigationevent/1.0.1": {
    "jar": "sha256-PXBoRNxJYGyxqjzX1rJ/R/GA38TG1Le4DqR4/4jcvZM=",
-   "module": "sha256-hA2TsFuCeQbhZfcXoDeKDszN6z4NEUkOoU1atbEIJic=",
-   "pom": "sha256-GwQqB6oi1U8GaFw38JPepPJtnvrlsgEDlLDGWE6IgUM="
-  },
-  "savedstate#savedstate-compose-desktop/1.3.3": {
-   "jar": "sha256-SpR4em5bz+FDOQpPJzfUQl0uqGfys0qEfebNo8bMxYo=",
-   "module": "sha256-BqAgEkeEflkwPk/7RoyUGcYUcI9Wh4fgq9WpLG2trUA=",
-   "pom": "sha256-N8EU329XwI5xm1T4pK4DzIS1y3ODNiRIxULQmZ5XQTM="
+   "module": "sha256-NrRI1xJsSW2bEryrKNzWguxI7IP6x+VizS5LZSeB7xE=",
+   "pom": "sha256-h9uD3BBM9BeKnov3Wy44nbkXa1iDoTuNeiqEEGkG99k="
   },
   "savedstate#savedstate-compose-desktop/1.4.0": {
    "jar": "sha256-wCqYsMKzXN3iRcC/5uf/RTx7bQal64aB0lt/VLh06kg=",
    "module": "sha256-gI/3I6FTrM4WBImlvEtYyh1wM/6EqQYPUtF9sifqpM0=",
    "pom": "sha256-U+fXiRm8heHIjh5rDinQrjvGaT16jsVzGnJQRMdhdGE="
   },
-  "savedstate#savedstate-compose/1.3.3": {
-   "module": "sha256-BYxm9HOvIVVCltHOG+aNXV4FLt8GmOlYPENhqng4VEE=",
-   "pom": "sha256-4/ZHRdP91KBJQwX1Q0RbW5iYOnSLDnJMIuMkKtAZy+I="
-  },
   "savedstate#savedstate-compose/1.4.0": {
    "jar": "sha256-hk0ggwlx+wjC7Q/E+QKwX9AuOO8wvLZaQ7DJkQqsOIw=",
    "module": "sha256-cnUhGQGgfuOXPkCjRV6K0SlV0dI03CSJ+Ghvz8gguKg=",
    "pom": "sha256-sV9HtCWFRCybap1BavwweCxp2/mldgosNxdfACTw0X4="
   },
-  "savedstate#savedstate-desktop/1.3.1": {
-   "jar": "sha256-xciQYrqEArj4ZX79VNsf8ZL5HKlfrlnDtBj7xHfD4+o=",
-   "module": "sha256-ojpT27hho7dWpXwBrJXnD6zUEC9SbAIFFR8fJ+YeoaE=",
-   "pom": "sha256-kEAj2DEYw/jOLa5imbljIWCRTOjsZf7MS2lnZOTsPlU="
-  },
-  "savedstate#savedstate-desktop/1.3.3": {
-   "jar": "sha256-xciQYrqEArj4ZX79VNsf8ZL5HKlfrlnDtBj7xHfD4+o=",
-   "module": "sha256-lF88cTqx84ltshbRmfkkRBRTlh7iu9dLtHrokZ2691k=",
-   "pom": "sha256-LY28tvROMSS4n/WUGmZ9HRSLkOViPkfb9Rw5ve0L4j4="
-  },
   "savedstate#savedstate-desktop/1.4.0": {
    "jar": "sha256-6WXtegEb6DonGsfYIkmndjaEee46KweUjDRFtR1kCFY=",
    "module": "sha256-5z8s+IGOzjR9i13/mQ0Ntjmn37j8yF7uyyYYOD9+zvc=",
    "pom": "sha256-jxFKQnNTWta9y+0Zhs/dmNlV6804oyqP7k7n3I4hH14="
-  },
-  "savedstate#savedstate/1.3.1": {
-   "module": "sha256-f0RPZf6XnogYNnLa1arxvTn5HYDKyXFtPYTgZkyVkz4=",
-   "pom": "sha256-GhLo7FM8a1UtSX37R/rRo5zQuZY5e3S5YDeo4breW1k="
-  },
-  "savedstate#savedstate/1.3.3": {
-   "module": "sha256-qeIZivqGIswgPVx697gdUa8YVoM2Pv2xK5TnV2oNdP8=",
-   "pom": "sha256-arxTGFGx2bQG9tuXdMKWNT5rFN0oF60YFGPux//jO2Q="
   },
   "savedstate#savedstate/1.4.0": {
    "jar": "sha256-CYWWyN+6K+9EvgN/PT+JzdARWHUF7YL6Yl8qg6ItZBU=",
@@ -349,6 +277,14 @@
   },
   "com/github/ben-manes/versions#com.github.ben-manes.versions.gradle.plugin/0.54.0": {
    "pom": "sha256-o07zaR8ZggeMe8ef2fuJojK3xzxFpYuBEVH+m/dgb+I="
+  },
+  "com/github/jk1#gradle-license-report/3.1.2": {
+   "jar": "sha256-usYblgjaDRDRS+dHknUJ1xkjxQXLFunIBatR53gv2jg=",
+   "module": "sha256-g/wB/sH7gX2Zk3PDolzmr7HVCDGY28D9LOJwgdF6rBM=",
+   "pom": "sha256-PdcOs3qnhw3Lu3FhPsrJsQCf0gu5bZ6qnYbyyiUCGvc="
+  },
+  "com/github/jk1/dependency-license-report#com.github.jk1.dependency-license-report.gradle.plugin/3.1.2": {
+   "pom": "sha256-DtyZC8qthXD2Ek0T89Mzmyc8EUdsl9r0kiBNEKh9WMA="
   },
   "com/google/code/gson#gson-parent/2.8.9": {
    "pom": "sha256-sW4CbmNCfBlyrQ/GhwPsN5sVduQRuknDL6mjGrC7z/s="
@@ -663,10 +599,10 @@
    "module": "sha256-YH4iD/ghW5Kdgpu/VPMyiU8UWbTXlZea6vy8wc6lTPM=",
    "pom": "sha256-fHNwQKlBlSLnxQzAJ0FqcP58dinlKyGZNa3mtBGcfTg="
   },
-  "com/squareup/okio#okio-jvm/3.16.4": {
-   "jar": "sha256-IZa5k800272Rnn4B9XpHgbWL7oD4YQYWPih8IDQ6lqc=",
-   "module": "sha256-kAjVopVKBoxoSCdPbuvf9IsUpw28aT0zAuCMVwzKAy8=",
-   "pom": "sha256-ZnePTQWXvOY/kewADFdcwCmzIB990JLLgIh1FVs+hqE="
+  "com/squareup/okio#okio-jvm/3.17.0": {
+   "jar": "sha256-OxPcw+FXMEfC1Qf8T3/LC7DLzZ05XaIdIOCUBuLNanM=",
+   "module": "sha256-1GF9DfcfIC5ymUcYSOYl9PNtf6ZNRsNQP3Cs9IIaRd4=",
+   "pom": "sha256-5ORCN6ZvQJG8D1sdWiu+IorAFKs8D5GM1vwCujGZkDA="
   },
   "com/squareup/okio#okio-jvm/3.6.0": {
    "jar": "sha256-Z1Q/Bzb8QirpJ+0OUEuYvF4mn9oNNQBXkzfLcT2ihBI=",
@@ -677,10 +613,10 @@
    "module": "sha256-sK+pGSxC18Rj3jjWMlk2xpAdnjtxSXNf/RihHfMQNKs=",
    "pom": "sha256-VXZInO8kBTNoAPxt6VhUU18zVxpO/lpa0OybmwkNIdU="
   },
-  "com/squareup/okio#okio/3.16.4": {
-   "jar": "sha256-yZZPOUxM0yt5vzOK+/ovIpciHu4IMReHBhzqVfh91g4=",
-   "module": "sha256-yEQahybbGk+dTzngaOu0LfalnWR+MqnGHBW1OQ7VklI=",
-   "pom": "sha256-CPvpfh4ugVoUyvFv9ayHCFEb713ec51gwHE5UYdtomM="
+  "com/squareup/okio#okio/3.17.0": {
+   "jar": "sha256-iSiY/xOwz9pfC/aJ6zO3wAyFOyUx/NT+IP5TAtN5gdg=",
+   "module": "sha256-PYeNuf/U6VnDD5qDZqiMItAB6bMkN419vu2YVo5+xVk=",
+   "pom": "sha256-FbSDHoT1ylLdN8HW4XCaKQfi6bwqnD6hPyggMd4MATU="
   },
   "com/squareup/okio#okio/3.6.0": {
    "module": "sha256-akesUDZOZZhFlAH7hvm2z832N7mzowRbHMM8v0xAghg=",
@@ -704,88 +640,88 @@
    "jar": "sha256-8cwY8VldRBroOc2hRlwIsefbRrcsHX87NzIK4WQexys=",
    "pom": "sha256-tNgod+BwsV0dTmdrQV9qVCnw4i3U75gX2F5MWcU7yr8="
   },
-  "dev/zacsweers/metro#compiler/0.13.2": {
-   "jar": "sha256-IdUz86KNprcAl56j/gpWJAs9wgNfd6vXCdtjcuMAOhc=",
-   "module": "sha256-7vq4/l8cA0F1g0Kjha9JSHspskHKaPKl0IAIvQ3fhl0=",
-   "pom": "sha256-qi4IrMz+X212avx56aVPMd+G/gdY5BzmKW2GjJPi3SU="
+  "dev/zacsweers/metro#compiler/1.1.1": {
+   "jar": "sha256-MdND/GKbblD01JYxka2yau894e+iXYElBo596UheoSI=",
+   "module": "sha256-ddGfsqptq5lmPw8q3FAvy3yV3REOC+uYJZy7K8DQZks=",
+   "pom": "sha256-O2EQQfLfXlHKuw/Qyefz1u8HjR9oj2T7jeQ7i7zU5DQ="
   },
-  "dev/zacsweers/metro#dev.zacsweers.metro.gradle.plugin/0.13.2": {
-   "pom": "sha256-k2fumkPqfEGebbXa6Z+lo/ROV5NzDKY9rJkKIwztQOE="
+  "dev/zacsweers/metro#dev.zacsweers.metro.gradle.plugin/1.1.1": {
+   "pom": "sha256-HhMABm4TrgyLsUbMF/WzanV1zi0mSbU3t/+u5Sfxl7E="
   },
-  "dev/zacsweers/metro#gradle-plugin/0.13.2": {
-   "jar": "sha256-myYSaPXbrs7SgCyMZCah4kW4dRptO5j0ZigHFbwM1JM=",
-   "module": "sha256-5LShS1g4/Az5XPu/MVxRC2xNW5Svs1Yo/CrlxW0HAF8=",
-   "pom": "sha256-JhsorfMb1vnqusRTad35BwuSYQYVkdxlzeLzX4n0kGc="
+  "dev/zacsweers/metro#gradle-plugin/1.1.1": {
+   "jar": "sha256-mVgHMfSr7Hn8dGxCnQVMCXWiLHEZDXjvQguMDg18PuY=",
+   "module": "sha256-dnkR5xlz+f7fNRx2etacST+4hYO2E4ivTN6sJSAToEg=",
+   "pom": "sha256-DMa65DhfdVTon9W2pKjm98x5llcjCdX6h8jDpuppNNo="
   },
-  "dev/zacsweers/metro#runtime-jvm/0.13.2": {
-   "jar": "sha256-SGAYoNiyUJZTNovmq66J2VdPTMpDezLj8YCbDQQ71mc=",
-   "module": "sha256-AZfrajH8w+OZBjTJ9RF9ugRqwx5YO6ihBLuzRou6Y4A=",
-   "pom": "sha256-EscU+yycpYo7TLkic95F1FoFJ5yq/1UqJM4tQNsHPMI="
+  "dev/zacsweers/metro#runtime-jvm/1.1.1": {
+   "jar": "sha256-NFnWGIxNw8ycjgZ+I7gfO6Thll3tLXvG6L2CfSSy2LE=",
+   "module": "sha256-6VwmWgY+1Qbs7I4GXoZR1WMRDc9tYfOXcaQodrIk7Uc=",
+   "pom": "sha256-/Z9ZjxIc0SKldm5tCCEL01iDD/59+qw7vUahwkj69Hg="
   },
-  "dev/zacsweers/metro#runtime/0.13.2": {
-   "jar": "sha256-C+8WXCyr/5OO8KeZuG0ydEvoEq1VYxEwwWpDDW+p0z8=",
-   "module": "sha256-cMGrnK9MhwYUglD1vz11+aJSPMmTTR6gxAeB9LEabQs=",
-   "pom": "sha256-4bXRNr0avav92i/PAjWUEQJkylaKDgwDugqqUKvEBhk="
+  "dev/zacsweers/metro#runtime/1.1.1": {
+   "jar": "sha256-gZ/YKrOMEwFadi4jrHl1Z43h6IXBqvoRg+ESHGFosrw=",
+   "module": "sha256-d40CCk+mbG5vSblbLq4cErulW9nSuh0cKAwgSVrEMPM=",
+   "pom": "sha256-E+C5YR2XHcDzQFgtSGZ6L7bR/dyaGdtP/UOwvI2rlnc="
   },
-  "io/coil-kt/coil3#coil-compose-core-jvm/3.4.0": {
-   "jar": "sha256-UZpHGiZB7VJW052oUbF4qv8yfJ+iNQYi+utE7rGO05c=",
-   "module": "sha256-DHLibYVA/HN8kFHGhAVQhlM/UTmgcnutc3PWF4knYAg=",
-   "pom": "sha256-jtWVHvZARZs7JFnHxROoqAPg9n4FbZmMZEWJfgwKoLA="
+  "io/coil-kt/coil3#coil-compose-core-jvm/3.5.0-beta01": {
+   "jar": "sha256-1bggBh9BiCqQEFw6SNkDuyUktQq4Go+UBA3Eevj6qgw=",
+   "module": "sha256-zVJuXqo+bABuVTeD63YbhDQjkjR/KAY88vQIjcnOA0A=",
+   "pom": "sha256-rNxSvLVZq9EoHGB8R+UAbLv6PFzHenxaugkoJxdWMYU="
   },
-  "io/coil-kt/coil3#coil-compose-core/3.4.0": {
-   "jar": "sha256-xgS7FINNhN25VhbBQhMnNSkXyMFMtt8Wdi8fUv562KU=",
-   "module": "sha256-gJP4IwYSR/QTuhN1bF1kCpbXXqjldeHbVNuv0zCF5go=",
-   "pom": "sha256-Bi62HyYVqqmh82FTzVBVA7Z3Xc2ZxHTDAQ8t7+R4TDw="
+  "io/coil-kt/coil3#coil-compose-core/3.5.0-beta01": {
+   "jar": "sha256-3rpZ/T6+xD+OKMtNpu3h3Q9YC8ha8ZZPrsbmgixFph0=",
+   "module": "sha256-b0Nd6a280k3/3gVk5/sEXYkbRfG5rCO3zbziZpfhZOs=",
+   "pom": "sha256-v1yuxq2mNdhXu+/BYbk9Tiw56hiz0EPKQteb6plCBcI="
   },
-  "io/coil-kt/coil3#coil-compose-jvm/3.4.0": {
-   "jar": "sha256-HYlXkAM5FpVebMW4NXX5YozHN6KaVUhNfDzC86az7WU=",
-   "module": "sha256-6wKPSFt5vp9FXa/dnvnSROYCAhMn3Gk5feu9APpThYA=",
-   "pom": "sha256-qBb2n8Bu8PIG7xXGyrAde8L8nOp5Eikf1+izVYIELxo="
+  "io/coil-kt/coil3#coil-compose-jvm/3.5.0-beta01": {
+   "jar": "sha256-hEC1U8TWZ9Tqa4ocJdv+hXhl6h++7LHrmWX4Z/fRlus=",
+   "module": "sha256-dX1DXViMW4hbaHqyqzd3K6Upd5dzAOYoXC5L7muThTc=",
+   "pom": "sha256-HyIdVlQdF1TTCmLvR1hpxpfcKp9xU+c2GYEmMY/x4Ow="
   },
-  "io/coil-kt/coil3#coil-compose/3.4.0": {
-   "jar": "sha256-Iz+ZBSm9Ijm6AAockpas3oRMDQFyUGaQw6m6t8ZXByU=",
-   "module": "sha256-gUi96Mu3cTaN6vsPXopXMOjdqnuZd9K/Sa6oW9SZ5f8=",
-   "pom": "sha256-SHmLQ9l293aYHAgR54N279S/jf/aAzvUnh9BLgsHi18="
+  "io/coil-kt/coil3#coil-compose/3.5.0-beta01": {
+   "jar": "sha256-HW23bMsvhgjr/XGmRLFXlQ7+U1ALEzvcyO60iu5w6uM=",
+   "module": "sha256-ToGXqXT0kwOJhH9/KYq08tnXKcpuoF/lX4b+t+CyByo=",
+   "pom": "sha256-t6YNifKhjJE91ps6qjUHRo0AIbRBILgd/zetl7n6PCI="
   },
-  "io/coil-kt/coil3#coil-core-jvm/3.4.0": {
-   "jar": "sha256-VcqK14GHwpuZ4eJ9ZL1TSiXPU+ooz3hs1iIESiKqNXE=",
-   "module": "sha256-QubYdwaCSraBNwvlpF1hSbKJNb4rHJ1hEWIbSOYLVdI=",
-   "pom": "sha256-J/jri/iHdHvY3BTRifkdB4DLE8tkx5Emai5wDHoM3ME="
+  "io/coil-kt/coil3#coil-core-jvm/3.5.0-beta01": {
+   "jar": "sha256-p12Kp4UF9dNaTpxrBUxvWMMZQmIvLlyz9sVAKQO90oc=",
+   "module": "sha256-cDAPYSpXzEI3fLUXzChFIzY5kh/WJXUYh0A4onEDvZo=",
+   "pom": "sha256-meZ54pjrIfRZf2Ne25JSsfWFACxecyesYj3FE9udRNY="
   },
-  "io/coil-kt/coil3#coil-core/3.4.0": {
-   "jar": "sha256-ovFt0ldTnOQQ1G1W5lV6P8l/f1BPe/AVXPI4g234AfA=",
-   "module": "sha256-6iHg7xC2TxMmH8L6aAIU3tSJTjvp+YUy7fsUi1q8Hjc=",
-   "pom": "sha256-cFLwQJso91rDHXBWHDzsHwAMOm4GuITKz36N64nYnj4="
+  "io/coil-kt/coil3#coil-core/3.5.0-beta01": {
+   "jar": "sha256-11MYayv1c8q7UGRu4/AivT1ZrCc8kaRwzGZdGFxwloA=",
+   "module": "sha256-aPn/xzlxCbW0vYmDbfY7CP80pI7mW64NCRxprbUvSW0=",
+   "pom": "sha256-XacP9kPOGyJeYbxuS1SWPl/i+UoBYlPeJ8RW6/xWavk="
   },
-  "io/coil-kt/coil3#coil-jvm/3.4.0": {
+  "io/coil-kt/coil3#coil-jvm/3.5.0-beta01": {
    "jar": "sha256-FuRMFYG9fFczMNTIMUU9gdLKUGWtgZxFyuj/lkExepQ=",
-   "module": "sha256-29d1JoWn9q6dRZp8XGRUIcOc+R82E20DJdrk+6ssOWU=",
-   "pom": "sha256-hwcuI9DzN6vjUFVaW535RMfVn3735cW9meWIGr5BASc="
+   "module": "sha256-yeTTr2pkjU73aXVOCIk/jtQNqwUh7n9+aohRT52yoQY=",
+   "pom": "sha256-ixtB8PEPMIUR0r96/u46KmooBcB6dMfi13K/UMOUSFU="
   },
-  "io/coil-kt/coil3#coil-network-core-jvm/3.4.0": {
-   "jar": "sha256-pendnwlGa9qldwAiBk+9nAHP1nIpo1aLFmSpep0TG/8=",
-   "module": "sha256-0PBWjEA2kr76N0ardL4Zhpju247VS5A3JyYTYPKrgeY=",
-   "pom": "sha256-x+h8S7FnrR7QHy6ma+7UU0GrApk/Jzg2Uv57rHBA07w="
+  "io/coil-kt/coil3#coil-network-core-jvm/3.5.0-beta01": {
+   "jar": "sha256-FXEFoZjH0aZDC7ANpPfIXWhxfbpZOOuREmrsURg9B5Q=",
+   "module": "sha256-3WyJ/F6rgLIVqTzMehdzvxWCWN+5vzLlzUlzVXC+H8Y=",
+   "pom": "sha256-O+W2gdZA7BQfWYtOQTEYWinYk7Khwaniaf+je+c//Yo="
   },
-  "io/coil-kt/coil3#coil-network-core/3.4.0": {
-   "jar": "sha256-UvW4cp8b2QIjmvL3kzz7DHYRLwEO6GYH1EdnAJwrqyQ=",
-   "module": "sha256-HwXhOXxUXmlg9rIsBbP+S0uxWAk+5Zc+n5qu69sCSHU=",
-   "pom": "sha256-98udG+JA0nNXljQLujPmAV9QLxrla6eZXrL4gNCP5io="
+  "io/coil-kt/coil3#coil-network-core/3.5.0-beta01": {
+   "jar": "sha256-irMBKkLATfMmmw1MzoLTYLzc6PyIKy2Mc+ZGbcO0G5o=",
+   "module": "sha256-EdegVJkMBY5O5XrPhgc4GNCS88gsRzzj4/bkl15zw6M=",
+   "pom": "sha256-le7vs3offwSGSLB8h3RJKI87KUXp7M1zKEERSjKKotI="
   },
-  "io/coil-kt/coil3#coil-network-okhttp-jvm/3.4.0": {
-   "jar": "sha256-lpMYS6Nfve4MrGRNR1FBB2rXieNJ2SEmx63bx7ib3Cs=",
-   "module": "sha256-ANWexH86+CoVVLTaGpLmzcvWxrO6pgyQpfGQRFsakM4=",
-   "pom": "sha256-SgqzKTsP/0a3H3DvLTY4tsqvUXaRiJRBbO5qSS7jdsc="
+  "io/coil-kt/coil3#coil-network-okhttp-jvm/3.5.0-beta01": {
+   "jar": "sha256-wtJ1Oc/OHgyPiTQsSvPrxG2TtJlUP3MD2z4/OS9iAhY=",
+   "module": "sha256-YLRVEMmdUA+N7xrPN9AmpSe0lc/bhzYVrIhdm7iiLmk=",
+   "pom": "sha256-XseMXREdINV7/neMg2e3woD5Zx7EXLic9WXwYOleSf0="
   },
-  "io/coil-kt/coil3#coil-network-okhttp/3.4.0": {
+  "io/coil-kt/coil3#coil-network-okhttp/3.5.0-beta01": {
    "jar": "sha256-mUDHZn3QbRihsY0j0ktKlXvXEFif66VLUNlhiEUtHpY=",
-   "module": "sha256-2ob7y0O0kO8ZTUCr78U+bJd1Y8czkwGnaCFff16RvwU=",
-   "pom": "sha256-PLlSeecJZr5qjK4HdZcjKS8p28XbLX3c4K4oMV4a2GQ="
+   "module": "sha256-KwxxNAeN+iGBEapuqzQFbQy8vYzOf1k64YwPy0lXbk0=",
+   "pom": "sha256-gay9LyJJtLkzXC8650pAsNHInjls1XPOPiK7dmZVwGk="
   },
-  "io/coil-kt/coil3#coil/3.4.0": {
-   "jar": "sha256-gzU2f+hZSf1wwIaVbiEL3ZPj0o6+diXnjpkLUbBzq/8=",
-   "module": "sha256-0yJb8IXYbZ1kkfEDMEQ24MR7fnvOttkQicqZTvAjg3M=",
-   "pom": "sha256-ehSZzkBhq7uO5z7s7o+cjLpccy1kmMTVXDkrXkeefpY="
+  "io/coil-kt/coil3#coil/3.5.0-beta01": {
+   "jar": "sha256-fhq+PVgs1+kxFetX5ryjpCLDjtKHXRHnqfOfF1sJYF8=",
+   "module": "sha256-Y6u/NcatELbrNBNh0sgKcVJAqIrbu59JjywVhCCAdnk=",
+   "pom": "sha256-3zQRrqSTGs/PiqV8kLDjh3scJA+2K2hA3E51LY/TFDQ="
   },
   "io/github/java-diff-utils#java-diff-utils-parent/4.12": {
    "pom": "sha256-2BHPnxGMwsrRMMlCetVcF01MCm8aAKwa4cm8vsXESxk="
@@ -854,135 +790,117 @@
    "module": "sha256-kibzxBq0koDI2ICOdnCGJkvK6Wa2HjjhoZ/Z6DjS+d4=",
    "pom": "sha256-aOCPC4VPlpixFzpkVstualPzc65tzLv3XL/ag0TiRwA="
   },
-  "io/ktor#ktor-client-core-jvm/3.4.3": {
-   "jar": "sha256-85Jh6JTfw5LHOnyeTNnzpvIFOadSSdi5xMJJuAD9+PA=",
-   "module": "sha256-kBoGXtZEzRzJQNy40jS1nE28Q5md96Q752G2XVwWbMM=",
-   "pom": "sha256-nuva7qpaGilELP/LjGuARFMxOhfyzdc4lGTp1jd371Y="
+  "io/ktor#ktor-client-core-jvm/3.5.0": {
+   "jar": "sha256-VPHR8goaFXYdC0RaisGyb4WVOsNf4id2N3xbQWb7N34=",
+   "module": "sha256-M9wLAQXnJM5N3l37qyIws/FE+4czdSqHWXOQJ/q7YE0=",
+   "pom": "sha256-uN/og5qZl25LOIg+MEepXWbpjCICinGZvSuWtItGQmk="
   },
-  "io/ktor#ktor-client-core/3.4.3": {
-   "jar": "sha256-EVePpxQnYKfAjFglRs03SCsjaExmjGlpMvbBhwtvwJ8=",
-   "module": "sha256-nJaxhi3Dnw9oM9nALH3liAbWfZ3MYlBO4r7obaGSMB4=",
-   "pom": "sha256-f8THD5i9nQtzAQ+GRCNLXoi6xt1pRIgftFbFO+FT4n0="
+  "io/ktor#ktor-client-core/3.5.0": {
+   "jar": "sha256-MZOSBfhiEFwvY0YnKrtVSRRaFbRgJf5o3xrT6bXErPY=",
+   "module": "sha256-vSX44EwJcZ7txWV5aW5xjZxhLVypZMDp3oEVtCSwO/Y=",
+   "pom": "sha256-bihc2pmG1VOcBJNCwqftMRY1MYRKt/3JJQCwBSe9NHg="
   },
-  "io/ktor#ktor-events-jvm/3.4.3": {
-   "jar": "sha256-DwShuDgBMaFOlwW/HcvJ3yMvEkFTP8W40avYMHR93KQ=",
-   "module": "sha256-eeEIV/SWgUg1Pei+2HDfZqifPr8d6K4LaM9ff2T2+Gg=",
-   "pom": "sha256-9UhK45rMTWxivK2R+LbzroYqxrxoaemh8s8bo+7jalA="
+  "io/ktor#ktor-events-jvm/3.5.0": {
+   "jar": "sha256-jUm530dFrH4hOGTdQkmwmLTr0VZviwCHuL+3rM4CS1Q=",
+   "module": "sha256-VsG1N4ALdcgks1iZ+pBOkhjk5N9sGVi0j4FQXPLf1Kw=",
+   "pom": "sha256-pHpoFsDiyVauryyEiaxAxKGupz1fblmlvCyXVEkkHkI="
   },
-  "io/ktor#ktor-events/3.4.3": {
-   "jar": "sha256-AXH8Y+I+z47LsUcn42ohjtCQ13AmIaQGZjDmRa/DKnA=",
-   "module": "sha256-iFOMVNRUJlYsI/dtPg0Xh5dQu2dJla0gERa4UrAIhdU=",
-   "pom": "sha256-AMiqw04HLRxxjWn5e7Xaejg0YvaNiOoMHFp+3kd95+k="
+  "io/ktor#ktor-events/3.5.0": {
+   "jar": "sha256-y2t/GV/ZyDsXJxL7E2i7me5gHCM66+/7nt8XK2oQKkA=",
+   "module": "sha256-TgRkCpmobTazws8DxgNvhflbqbr1WQG6PBwR9XalVL0=",
+   "pom": "sha256-3tNQHKZZ/2hVayAfsiMfA2k/YgQ2pV3cu5t1xJPFfS4="
   },
-  "io/ktor#ktor-http-cio-jvm/3.4.3": {
-   "jar": "sha256-8ElYQSa29Nouk9fUMzYpYxLiqI1dUmPx0dJPG41m/zo=",
-   "module": "sha256-ySfYy+G12KCFyJRlS4rLwJoHkn0cGhxjW1VtN+NBTFQ=",
-   "pom": "sha256-JZ9NsLXMSaR1c0v3hIehFaGS6S/AmJHhHhlhqmiaDwM="
+  "io/ktor#ktor-http-cio-jvm/3.5.0": {
+   "jar": "sha256-j+H7Hlz5hJ74XAnqjxmrXXom90ZEEBytSZBMakkVR1s=",
+   "module": "sha256-Wd2hYUh8kz7gJbzdlrO3XpkrUAtvsfbkj6AUiMWGG+I=",
+   "pom": "sha256-fCxaKuXskgIU3hcoryjJnoicm37cOTnRjvoORroduao="
   },
-  "io/ktor#ktor-http-cio/3.4.3": {
-   "jar": "sha256-MlFo99aA+JBzl/87TR+WiNzJILJYyHSpE+OzRfJBYJk=",
-   "module": "sha256-bJGF/f35izzYbLpwez4NoUr7ihTePe20hccafwPMyuU=",
-   "pom": "sha256-62gfWQOGEvNs8oXWt6bpyuWDBCTwrPmaAWUUu8nYjp8="
+  "io/ktor#ktor-http-cio/3.5.0": {
+   "jar": "sha256-z+ZRVd4Smrx6O5bfYsizebK7Tj83ER+IQ8Fb8O+1Qc8=",
+   "module": "sha256-7fcPLn3Y5aGTqZ5NPdRaYw5DVCVAZNPk8ob2VIvHyec=",
+   "pom": "sha256-CL/Hjmc5tOE8F1/vRzI+wQaGN0Fh3U4Ug1isrlBAIzM="
   },
-  "io/ktor#ktor-http-jvm/3.4.3": {
-   "jar": "sha256-sxNMLGxJvMl0ekJCeNByPtuiSiU7NkUOq8x/pWLirak=",
-   "module": "sha256-gq5sIoutescyEwStMduZdvPP0zOPOazWtPNIKEAkvpo=",
-   "pom": "sha256-wdL9ezT+PT/mFSZXkZJvIBeAwfUHJk1uodKk3AHdmsU="
+  "io/ktor#ktor-http-jvm/3.5.0": {
+   "jar": "sha256-K6usNV3jZMRzsnsGDRyBD8L4PtbkSCLqvGw/Rq3xVaM=",
+   "module": "sha256-cH+4Jd5xPg8hcp4K1tQYSZC4PPtaYceUC55Ooaugx44=",
+   "pom": "sha256-9v8xXUJu/ovnQCiUykxI30j8xeM0TxJJnShri+q6Mmc="
   },
-  "io/ktor#ktor-http/3.4.3": {
-   "jar": "sha256-dELHB5CPgs4lZkz6B3CYx6l+qeuTbMKivhT6kp0XieE=",
-   "module": "sha256-N0VSChyPVCRmCovRJ34JlqH/Ehp1aVJmqR7PEti5/iM=",
-   "pom": "sha256-TRz1iMxd+vLlf1+yrnMjxA3pY22q2/5lLofqmPW8VkM="
+  "io/ktor#ktor-http/3.5.0": {
+   "jar": "sha256-Hf1GUk4bvz7XtPUjdlTYcY+RGGRYgoQlX7bLcv2FsnU=",
+   "module": "sha256-VkIoS3asAW2DnBwoySXAbiq09tFt+nN6H/iJZfHZN9Q=",
+   "pom": "sha256-OrhYDEYAvqGhTA9pgm1n5hHzEnhbsIpGRaZ91BAojkA="
   },
-  "io/ktor#ktor-io-jvm/3.4.3": {
-   "jar": "sha256-RdpGKS4cKwWAxIfrp2fX28tQRg3y1uiTf0PoddkrRN8=",
-   "module": "sha256-nc98up0ZHkVwxE1EP5TWCyhJiIkc40feWWBXocNsppE=",
-   "pom": "sha256-LtT6ft1CHFIGV2/wlOXwHodDjonSYqVOZZmSMlKGCWk="
+  "io/ktor#ktor-io-jvm/3.5.0": {
+   "jar": "sha256-yp+UQ0eSBP6XoAvVO8Pe5bBRTBoIjp3x4OTUzPxgXlE=",
+   "module": "sha256-/QxmE+yCfPCdICdT5sZj57OT92awmNPhAbUCtnfb26g=",
+   "pom": "sha256-xQyDA/OG6CX+fmdxIq4rnaAbJhr6Ph9woWwIiHcmbMU="
   },
-  "io/ktor#ktor-io/3.4.3": {
-   "jar": "sha256-bi8Bu1BC9U6yPX1vrm9S3FoD9rH3o2agu+m2606aiC0=",
-   "module": "sha256-//2lHn3hMeIpcl+0IVMSi++p5rkRNAmxD4gZ0ehhdi0=",
-   "pom": "sha256-vqyeo/zmS0cuMVI2afPLIX0xnqs8qd5LHq26ZBZV1Jo="
+  "io/ktor#ktor-io/3.5.0": {
+   "jar": "sha256-slbt/JjznwD8Ysjq1HCsrce7tuYoiJoOMcYX+a37kdM=",
+   "module": "sha256-y2FR4vesZcJwKLFt7jMqTbvMwVMFgM/T/o9PKwyKc0c=",
+   "pom": "sha256-biSVDcRyz1+8qGoFeC0ujT4QSi9kWPOb3d3m0bescrU="
   },
-  "io/ktor#ktor-network-jvm/3.4.3": {
-   "jar": "sha256-pro+Kta7OKI7CPCO3DLjpgBArZUsbDqeCIctXZbdi0U=",
-   "module": "sha256-3wYcaZ9FR9LhGCepP0+I/lEfDK6/hXNOAU32gIkiqKA=",
-   "pom": "sha256-T8kNVYjgG5tXc+5MG6C9r80a1mLksHtXWLBMTR38FZU="
+  "io/ktor#ktor-network-jvm/3.5.0": {
+   "jar": "sha256-IBWJCI8PIZom0S4B58TlszWP0okHXBt5nRXECEccGYU=",
+   "module": "sha256-Riu72moAj0JA7m2DHgUWgupy86GIvgbEE+a69pIHMt4=",
+   "pom": "sha256-9GIDluO2+pTy+F4KQasERQV8naRT4QJjASkDm+dLrZo="
   },
-  "io/ktor#ktor-network/3.4.3": {
-   "module": "sha256-Mo0KmmgMefqIDSvcGGBNuOB3U2sT/lb2KM/ILbRWAxw=",
-   "pom": "sha256-9HGimig98gDhJT/vCsw+yOMPGtSyFLFvWnQJy6zzZko="
+  "io/ktor#ktor-network/3.5.0": {
+   "module": "sha256-XodNKhs4VuDiisLzG+ACVCLTm/kX1lx7b9SGL4zipKs=",
+   "pom": "sha256-Ow70GRGvz0G0o4Rvch1GRWVZ0tE5h5QJuqgr0bRC1Y0="
   },
-  "io/ktor#ktor-serialization-jvm/3.4.3": {
-   "jar": "sha256-WH37qUYnL2W0El/QpoJCxC2E3jn/wrguN7q/N+QtaRk=",
-   "module": "sha256-1tWshNysj1H91xB5cm0Wec8XSUxIF9VEfmY68pGgIMU=",
-   "pom": "sha256-23rkKbgpGlRXi4djqD0LJItBM64l6HjibDUGIHbluCo="
+  "io/ktor#ktor-serialization-jvm/3.5.0": {
+   "jar": "sha256-0Ivvxng8T+n1wIV5mzLqcCf94eXQinrveVQTpjPGhjw=",
+   "module": "sha256-1DKnY8QrF4xkffgkVo1IT40yQb/fqYVaAhScI5eB02U=",
+   "pom": "sha256-NebJO0lWpFB2d54X4P5lzWBnuwa/Zg/C+KbHzuwWreY="
   },
-  "io/ktor#ktor-serialization/3.4.3": {
-   "jar": "sha256-tgY1K6fiKrmbRZjH3UGrk64P8YhvD4/93ZmnmBsyVA0=",
-   "module": "sha256-T+4wl1yw6S4NYqMkioF0sfB7uI62DF1laKNRJedWCPs=",
-   "pom": "sha256-4upPJ0roD+p5VYJDWkOJ1cmH15Uanb5aYJsUMWrmFGw="
+  "io/ktor#ktor-serialization/3.5.0": {
+   "jar": "sha256-/SrvFQlzPKSOhMeVPMdy52gWhCiVyTc6ctQqzPbBDlY=",
+   "module": "sha256-OPh4TdgVNYCecVoeMGxq88/TCW5N0IQbsTggOTuHQWo=",
+   "pom": "sha256-X8Lm5Daq0RuqQ4GowROk0wzQbmfU62ushXpFIs41q0Q="
   },
-  "io/ktor#ktor-sse-jvm/3.4.3": {
-   "jar": "sha256-qQaybsUziQFskuniSunXmXbj5YJncT0Muajyaj8/aQc=",
-   "module": "sha256-GAzZFl4HYVhbtTmjRTR9zKw8hqE8dMRnL0ytITfoGsw=",
-   "pom": "sha256-clI40vwgtKittZB6vTOQcUa2LJJG3UFp8Tp4pikskaA="
+  "io/ktor#ktor-sse-jvm/3.5.0": {
+   "jar": "sha256-lBhxZYxcm+1dFxKbB0chDphrCKV6R4+EzdmivNigCIQ=",
+   "module": "sha256-V7KFlTRixcTdg+oqatrF/hiEDxUVb3VUjGOSGPSGvns=",
+   "pom": "sha256-ZLF7TIWcMQKgCf2IMkFw7zNx2Oz95PpAIMuHj1lm2Kg="
   },
-  "io/ktor#ktor-sse/3.4.3": {
-   "jar": "sha256-CyJmwH4hDhfrJAsttWPnvpqcnC96WFdOqqZZOgtlX+0=",
-   "module": "sha256-44dTyTiU/6SGb2ftjhDjd9xwCdJPdsJ3aIsu6dEsTMs=",
-   "pom": "sha256-iZfzk4e1n8qxvvFcfuQ7eymDJOs5U+MXOfDJ7hDDn4Q="
+  "io/ktor#ktor-sse/3.5.0": {
+   "jar": "sha256-H0g43bfVfoS905E69LQGJ2Yqvbyi+6iSG4Z/GmLQv10=",
+   "module": "sha256-6Usv/TfLarDOwXQKxr+bE4PosmzLkIgMcAEh6xMpxgk=",
+   "pom": "sha256-wahVhBWICx1OHJ87tkivI+AzQiw8grjQqLNnk3nUCp8="
   },
-  "io/ktor#ktor-utils-jvm/3.4.3": {
-   "jar": "sha256-5Iuc5Rhw9BDHq1wEDI5tAmlIJ+v9/ForhPCGrQSbtWE=",
-   "module": "sha256-OxfQWvPm0mTnYqh9wor5ipRcvXIJtqbu0/KrXIH5Xx4=",
-   "pom": "sha256-M0ozEdk/iJ0R9D4Mt5/jq8TZjaYVTTt/z7oXbbmDS6w="
+  "io/ktor#ktor-utils-jvm/3.5.0": {
+   "jar": "sha256-IUIA8HSv6dS5FdNHOXtcH3aPvdEOrXGS6K39Zi3Upy8=",
+   "module": "sha256-lr8SZTPTjLiz8WkRw2mAwts+dGxkh4KIADoLbhk4WuM=",
+   "pom": "sha256-We88Ni2DBk8LBkx5SKzjixmfZxcYPgqtCOnoJ5Kbh2s="
   },
-  "io/ktor#ktor-utils/3.4.3": {
-   "jar": "sha256-YiCmt/pEy7dKg9Q4vtPpR7ou7VwQxoyeUA8fUv8wsXc=",
-   "module": "sha256-NRoL9TGXRIj0tH82hNfiMJK4+epGwWDw7TCl89NQgQE=",
-   "pom": "sha256-nKnA3GjHIk2iLx4uM7LvPmXLBOtL8SaJwZcLX3JIzbs="
+  "io/ktor#ktor-utils/3.5.0": {
+   "jar": "sha256-1syTBOx3QJllHiDG0y3kpn9t04FvkefJllN4PJKQ9Xo=",
+   "module": "sha256-KSPNpVwBptcAWoYPW4/9CHLucEuLKNFM6QWl6ma7qsg=",
+   "pom": "sha256-JJKBcvdfDHkHSo+9rgL0KNR2E/Dz9asyonz2mRHCDS4="
   },
-  "io/ktor#ktor-websocket-serialization-jvm/3.4.3": {
-   "jar": "sha256-2ZmnuQs9mtLvDRF8Ss5isQvXrBNFzRxqdoCkP/++DtA=",
-   "module": "sha256-aA7NoHNJxf+3FzVwVRd7fehIpu690bXIhvlzzzpwgDg=",
-   "pom": "sha256-uFOTESsUbe6LlrdxuoyiCjY9bmtO8W5T1ZP1bgXPcnU="
+  "io/ktor#ktor-websocket-serialization-jvm/3.5.0": {
+   "jar": "sha256-z5MerkR9y+dgKIkd0YW2ReEbbHoQhyv83k/kCoLTs0I=",
+   "module": "sha256-6D00HGh91ohvvbVie9stNXOGI8Iuth+ZY4lmF/O48bM=",
+   "pom": "sha256-Ib4S+MPSfGr5cxV9w2ruXETAKHi8aK+LdbXSSzXKkuI="
   },
-  "io/ktor#ktor-websocket-serialization/3.4.3": {
-   "jar": "sha256-PRUs4CTMJjFuJEU3HPhPr+JiECQc13vF58hD17/n0z8=",
-   "module": "sha256-13WjyEC6DDt9WOtQZ33kG0OtZbBsrVlBAhF+XlxRXZc=",
-   "pom": "sha256-QSPdZhKyV50uomw1TwhNJyxDkZw0ansWvUNedYK4hNA="
+  "io/ktor#ktor-websocket-serialization/3.5.0": {
+   "jar": "sha256-t0VVWddBP5wLMIiSCfgkQBokNNj1zF6grTiLSFQ7dTs=",
+   "module": "sha256-dZVABH5cT1DbmSd9ECsY+ItHAZ/mhKoti5QTYtw+fCg=",
+   "pom": "sha256-14Oaz68+KwRzJkmakT4JDSQJjP6fWs+9sIFub8Svx/s="
   },
-  "io/ktor#ktor-websockets-jvm/3.4.3": {
-   "jar": "sha256-7S+/uB0wKc8FpirHttRbOKhzoC+O5gsErmU0btUpnuQ=",
-   "module": "sha256-eXohs+3Xxgs6GiMKYbEfkoEAJVD9LwCnmB73XUblJkc=",
-   "pom": "sha256-k2UZSibMt2zh5QG+UngqZRULt0XdzUibgcFHwL6r44U="
+  "io/ktor#ktor-websockets-jvm/3.5.0": {
+   "jar": "sha256-7Ae0veE6PDrWFp1ix1owj9ERZ+q0qhqpuqJIRww5fOE=",
+   "module": "sha256-dl5OdlQONxCYC/z2xoQorvyypk4tq8R2JlkG73yIxOE=",
+   "pom": "sha256-oIc0oBdVRrwjZKFuQ6e5LjXxmmW9q9QTyLXB9dOhTyU="
   },
-  "io/ktor#ktor-websockets/3.4.3": {
-   "jar": "sha256-DlDrexsDI2CHmF/v+VmXsayEcuge4IoLzpRTnWL3ibc=",
-   "module": "sha256-xTwREBNT5YY31k9EevyRPGVUHbgDOeB+q7PeWiGD8BI=",
-   "pom": "sha256-UWoi9aLNpSqE9e4WFcfKtvKABy9GqYNY5bRjS2zh/mQ="
+  "io/ktor#ktor-websockets/3.5.0": {
+   "jar": "sha256-3vZ9V1vRQtHXXk8XWHlW9IPAlWJYapzAL5KaLyEcIEQ=",
+   "module": "sha256-kvvRwTkxxVqWGB8fM4CyiKpWiLPHdgtGzBN+4DybY80=",
+   "pom": "sha256-WhVJDgXGmEzUgY1OoHlzxnoz1TtUayJXOVdon5ytwcA="
   },
   "io/netty#netty-bom/4.2.12.Final": {
    "pom": "sha256-Sx6sh5HJMaM9ni+4wINDJVLPh0adtBm30kNBeONPBww="
-  },
-  "io/sellmair#evas-compose-jvm/1.3.0": {
-   "jar": "sha256-z0ANDakJZF+G1zUrr8Fll3ucyZ0KsPhm3Kj21x9D6oA=",
-   "module": "sha256-lPSPBmrTfJEdo1KiBwagvGctskRFg1qSc2gZ1H4gs+A=",
-   "pom": "sha256-a4ZqTh4vonYspaHatax8JWooP5jHa60GraVo/w1yl0Q="
-  },
-  "io/sellmair#evas-compose/1.3.0": {
-   "module": "sha256-tPb3Xfgpkqbcqtc37O0Q3xxlwrSEoLIghFPZDiom1e8=",
-   "pom": "sha256-ZJgX/ZaAWkx5mbqTvXk5t3lMYCQaDbm1suBAUGsExfM="
-  },
-  "io/sellmair#evas-jvm/1.3.0": {
-   "jar": "sha256-tjgzqY9CQUFitnTfPDi9G3AHiHJuYXM91Mz9gAb9w7Q=",
-   "module": "sha256-+GZCZ4GOhqRjyLLHux+R/Be7BfGxOlFbmvW2tw/9fyA=",
-   "pom": "sha256-FkeNhw1UmbLDzmAnDYLJR2DYswHDvcU1AM4U98SHgA8="
-  },
-  "io/sellmair#evas/1.3.0": {
-   "module": "sha256-IookviLFssr0kQ6Zi+W3nXKaYVzObAQYNBfByxE5XkI=",
-   "pom": "sha256-dNeLQjL3wIqiktIuxRH2KMhPAa7YMbNTT/DHGplDiTg="
   },
   "junit#junit/4.13.2": {
    "jar": "sha256-jklbY0Rp1k+4rPo0laBly6zIoP/1XOHjEAe+TBbcV9M=",
@@ -1019,10 +937,6 @@
   "org/hamcrest#hamcrest-parent/1.3": {
    "pom": "sha256-bVNflO+2Y722gsnyelAzU5RogAlkK6epZ3UEvBvkEps="
   },
-  "org/javassist#javassist/3.30.2-GA": {
-   "jar": "sha256-66NykJlLXkho86+Y/xE/YkSmsJk4XZrUaIEwfTywGq8=",
-   "pom": "sha256-QieFHLcOQ/c6zti//mkt465EEsSmLc3/BV5RPuPYAaM="
-  },
   "org/jetbrains#annotations/13.0": {
    "jar": "sha256-rOKhDcji1f00kl7KwD5JiLLA+FFlDJS4zvSbob0RFHg=",
    "pom": "sha256-llrrK+3/NpgZvd4b96CzuJuCR91pyIuGN112Fju4w5c="
@@ -1036,10 +950,6 @@
    "module": "sha256-Zg7q/+b69J/qIIOkNCqAsbhNK/yXYx9tfmeLSFsZm5o=",
    "pom": "sha256-4Fs07/GcQaRQesMEW7ngiVmInyRoRzuV1nhuhCjHgLQ="
   },
-  "org/jetbrains/androidx/lifecycle#lifecycle-common/2.9.4": {
-   "module": "sha256-S/WE5uBMORPf6cIMGIKiKZ3N3gMgR9YxpqsAZSpRnTM=",
-   "pom": "sha256-DRDzDh37izhO+dnYN5kDd+pecAijEujpEINo++ZR67g="
-  },
   "org/jetbrains/androidx/lifecycle#lifecycle-common/2.9.6": {
    "module": "sha256-gF5FIbAzeYEISMesMUzzyVT8jS3zSlsJEcRW1Djc2iY=",
    "pom": "sha256-0yUq74s29h2gYJD4T+URQCGCA0Tq0dZAw3NXohkYVBk="
@@ -1048,11 +958,6 @@
    "jar": "sha256-McPEtt6jjweMRoKd7ixDq7or+HV7fuig9mDzEhc2SJg=",
    "module": "sha256-FKEs03MDhyfssw91RF+H5sqf9DzwFcZm0HLr3U7PHBs=",
    "pom": "sha256-R/Y3Vq9c4hBRByM0+oBYjAPBZNo3HSTLTO362OGyglU="
-  },
-  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose-desktop/2.9.4": {
-   "jar": "sha256-oHi0QUV+wOEAB9zRY/+fLAQ3+bNfvJ7Gzq2C+OmFiU0=",
-   "module": "sha256-bzhY5UrLXgDNt5WBB1XNOo0YvhH5CA5Kq9NOW8fkAmk=",
-   "pom": "sha256-o4T7ZoTUHnwBpKhmOERe+s/bHJ2dzEwi5JIBV8T9Odc="
   },
   "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose-desktop/2.9.6": {
    "jar": "sha256-McPEtt6jjweMRoKd7ixDq7or+HV7fuig9mDzEhc2SJg=",
@@ -1064,10 +969,6 @@
    "module": "sha256-wsBsS6GmDvmIlIX2+lFVslfH6GTJo+tvN0M84N7xhvs=",
    "pom": "sha256-NaXwX5/pggJulEwaYuXV7Sp10zsOhJvwchSasMXYAxo="
   },
-  "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose/2.9.4": {
-   "module": "sha256-FOsoP3X55Qs7gDCWEi5xO7YX8LZkWntNkUYReBLzmzQ=",
-   "pom": "sha256-nTn31/uWEshmNaR9lkulaMrU+K6LD6JpwvNXUR4mC4E="
-  },
   "org/jetbrains/androidx/lifecycle#lifecycle-runtime-compose/2.9.6": {
    "module": "sha256-gAMMZAio8gsZVXh+GmE8tp8Fh26vW5GF++FZSAwPZyE=",
    "pom": "sha256-OFjDsK0gsHhobakHitFk7MbF5Y8wlvLS5vpmznPHg98="
@@ -1076,10 +977,6 @@
    "jar": "sha256-5JiBOn4qvorXEjnd0h4pUwmEX9aMSW2y+BOeDSACrpY=",
    "module": "sha256-9HuN0p6QQBl8OpMYzGkzHYOUwj7iYVLwO9IEe71NgAI=",
    "pom": "sha256-t2ghIp9UPorV8uaFgF5r4FE/sV7UHvS94IDTtezoYiU="
-  },
-  "org/jetbrains/androidx/lifecycle#lifecycle-runtime/2.9.4": {
-   "module": "sha256-bu2+0UiG5BVzBDUROa1LtNTvkBxn3AKyJ+6Yvkr2EXs=",
-   "pom": "sha256-maX6xqZWgAhsFHQuww5ChGeEiEOVfgUhKzfW+qhbBaw="
   },
   "org/jetbrains/androidx/lifecycle#lifecycle-runtime/2.9.6": {
    "module": "sha256-LSN78RA5ccVpZ6GVMbwI8QBuSZOoQxmpL04V+w+Qyhs=",
@@ -1100,10 +997,6 @@
    "module": "sha256-r4zVML1zj+GsH+Dg/IYhnyToE4yN4/lMGFzuwvqly/o=",
    "pom": "sha256-eZav2khVeVAQN+XFXVwE7omQ7RT2Y+T9PtN72jfaSZg="
   },
-  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-savedstate/2.9.4": {
-   "module": "sha256-BenXVkAXdWgEeEwxXpZxqASZXa3EHaolt/8g3OWJm2Q=",
-   "pom": "sha256-7bq4xQVmwkGOjCZUXViG+sbkExhgn4Xarhd1t/jM9FQ="
-  },
   "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel-savedstate/2.9.6": {
    "module": "sha256-rQ264j3Z3KujqV0dCCwb+0xASxe7kySQ9ASayTgl3E8=",
    "pom": "sha256-hC0AC7vnoGloZw6B/tCSr3gLhtbjCLaqGo+QwjsrZ2w="
@@ -1113,344 +1006,218 @@
    "module": "sha256-BeXmNx8kIzertlVRuq29uDTDF4auOuhH+BKSd1w9RcY=",
    "pom": "sha256-EF3rS+RhEND7iGT0o0Qr/b1Cw90jEUCzrOa5dMkZoXA="
   },
-  "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel/2.9.4": {
-   "module": "sha256-RQ5l1bXN5cWq6WwHPkOmA8k3xawekl2V1gX2zAmivoc=",
-   "pom": "sha256-jx+k87JIILrduKGJmb9NkMnF93g0BmL2lfYSrHOK09s="
-  },
   "org/jetbrains/androidx/lifecycle#lifecycle-viewmodel/2.9.6": {
    "module": "sha256-JMv8NlN1knXknL9Wl748L+fEpqHByk+CWAWk82EbYJU=",
    "pom": "sha256-oJpT4rFQ+ZKfyN33sZ0qhl1K8TRGnYFx5aiFhEA/zsM="
-  },
-  "org/jetbrains/androidx/savedstate#savedstate-compose-desktop/1.3.4": {
-   "jar": "sha256-UijQcyEoARdHyNVvZRVlBaCy0psADTmMbxl5vA70IRM=",
-   "module": "sha256-HMfdieaRvibyXww3A/+4qDCwl6v6vFRakNf6JOKkRec=",
-   "pom": "sha256-NbzmQ7VvI5UgjooZhxZkW0vCkLz6yXlaWv/8j/k3BmM="
   },
   "org/jetbrains/androidx/savedstate#savedstate-compose-desktop/1.3.6": {
    "jar": "sha256-Dz0EXF/X4TAatsOM0HeAZ7BITPOaysEjO+cacjpqgHU=",
    "module": "sha256-krjcB5kBhmwbUgx1DDHghRtQSZUkfa3yu1HPcLgO9pg=",
    "pom": "sha256-RJsKGtrBUXq3EzFIQN2vUqy/hz6shWCDsuLSGBPP0J8="
   },
-  "org/jetbrains/androidx/savedstate#savedstate-compose/1.3.4": {
-   "module": "sha256-A46PL+QVpysSdcURVYa94PKM445mUZqTaO2wvZMePTc=",
-   "pom": "sha256-WeXvwinjf4pQWaElb5mp1A1ayC2ms9YhQSNqyou8R50="
-  },
   "org/jetbrains/androidx/savedstate#savedstate-compose/1.3.6": {
    "jar": "sha256-Ybi1HQS02ZLo4bYYrUzxFzJDAeSSrQagWPyWzfhht4A=",
    "module": "sha256-r8PlvURgTqnKYQwjQFoJa0CJ1izTRnl9M5/14sig5bQ=",
    "pom": "sha256-uUeSNGwy0j9Md1UYlfi80RSbtbgPuncxu60qoR07zIc="
-  },
-  "org/jetbrains/androidx/savedstate#savedstate/1.3.4": {
-   "module": "sha256-nx47jPrw+5xq1VqY6u7M/fO6p3lTj0JynWSeQGWLd5A=",
-   "pom": "sha256-31rG2m1h5s9MeWq3dLxDiMztC4h8B50q5VbpwZrcYgo="
   },
   "org/jetbrains/androidx/savedstate#savedstate/1.3.6": {
    "jar": "sha256-B0GnUJQJeMfosWBfEXvmLjmf1Xp2Jasa6AooosoPNBU=",
    "module": "sha256-5Z+aDYcs4zt44W18XqY2lgRuYXKTSozo1Cdyawd5GTQ=",
    "pom": "sha256-+01/UV0FOzQ9G+gAao4Ehw3SFbi1L89/DJvIv+7WgMY="
   },
-  "org/jetbrains/compose#compose-gradle-plugin/1.10.3": {
-   "jar": "sha256-d48mgTMzNIhWDYG8zaVVA1uILv2eKCfWkcnGlJaPL2s=",
-   "module": "sha256-HwCtYh+cIyGWA2KtyrQrUq0ryIQ+8Qi56WfM03E2rfU=",
-   "pom": "sha256-5+ltaBasFiuUf4f3f9E1G52BMO9amENhClEF2qIyQ1M="
+  "org/jetbrains/compose#compose-gradle-plugin/1.11.1": {
+   "jar": "sha256-p4uEexWdXLcC0bYs+o8miX4A3coL2I4KVwNarvN0hqk=",
+   "module": "sha256-75q6+yrL5z/87yVmzsoI54hUZckPQO+RRJiRxS3FHHc=",
+   "pom": "sha256-tyr7g2O40X0i4s4hLZZqnPhSoOHkC/6EwYkRbgzHeUw="
   },
-  "org/jetbrains/compose#gradle-plugin-internal-jdk-version-probe/1.10.3": {
-   "jar": "sha256-k+cSRZy25+oodZxQdFuWufCpy9NuECpkUbpqMgLDRkM=",
-   "module": "sha256-MSf8sJgMd67/CVn8KKpeVITi1BA1yjueIpQguoLCLhY=",
-   "pom": "sha256-osvx2YU1apEBi21GF/QrNhs1Q01n675H3DArWbEt80A="
+  "org/jetbrains/compose#gradle-plugin-internal-jdk-version-probe/1.11.1": {
+   "jar": "sha256-wNLTPRbxdffJXv5W7gVMenf/ii2dpXFLvolDmbZIcpo=",
+   "module": "sha256-+0zIBUd6uqCMC2OcIMdldGVZ4HXGrNnu4X6AXRTkjnc=",
+   "pom": "sha256-2h+OFRyH5nAhrE/rBsQTWLHWfziNte/9b9dcz1d5mSk="
   },
-  "org/jetbrains/compose#org.jetbrains.compose.gradle.plugin/1.10.3": {
-   "pom": "sha256-0abWKYWWrm4rsGeAMbv4wl54KEBCalDJ4weoXLRXBsQ="
+  "org/jetbrains/compose#org.jetbrains.compose.gradle.plugin/1.11.1": {
+   "pom": "sha256-l0NsU/5PZQPKybETrkdAVuAE2UB4JfSgC+54Yitqm8w="
   },
-  "org/jetbrains/compose/animation#animation-core-desktop/1.10.3": {
-   "jar": "sha256-QcAiDdvFXLiX/rDVgWt0j5wRFiFx8SdDwEtQ0NhNtig=",
-   "module": "sha256-riRweG87PQrDeEJIz750J5XyILUhq9M/0Zh740fG5bc=",
-   "pom": "sha256-zdJX3Ppv5CRud5U41Fu3+pZ5Qgsc/bJcFMTWh3CsECw="
+  "org/jetbrains/compose/animation#animation-core-desktop/1.11.0-beta03": {
+   "jar": "sha256-Gzr40gYnsBEB2Cf3LibbrczI0hLA/8DAL/Km/JZ6bKg=",
+   "module": "sha256-dayy25cZPo48G46wRJnYupZ1wf2VqxCMWv/3ZRrUfY0=",
+   "pom": "sha256-EDNFH/5muRzTA9SPKwy1cJqfmtryCW9O/FPSCQuF0co="
   },
-  "org/jetbrains/compose/animation#animation-core-desktop/1.8.2": {
-   "module": "sha256-qxOVOtDhVv+Au9EXooS4EVYN46LMXQKvjWGDKM5xbIg=",
-   "pom": "sha256-5BZ9JA37PUEKkRee2wCWUkkSqkdZLOk/SqbirF0g6uY="
-  },
-  "org/jetbrains/compose/animation#animation-core-desktop/1.9.0": {
-   "jar": "sha256-ds9NCbUxL5qeRugKJwx2pxV6k4GUk/63B2+cjJhhBgU=",
-   "module": "sha256-HDYyn4gq6yRHC8JYRVpXevjwVGV+OeWjDsocxR9wBkE=",
-   "pom": "sha256-0AS32FEkDFzOaTFu02dVyOzygw2YpC16jsrytm8GOYI="
+  "org/jetbrains/compose/animation#animation-core-desktop/1.11.1": {
+   "jar": "sha256-Gzr40gYnsBEB2Cf3LibbrczI0hLA/8DAL/Km/JZ6bKg=",
+   "module": "sha256-RcYWgKu7S0Pjeu6AGADn+McNYQVsbhHNOAZhSiMEHmQ=",
+   "pom": "sha256-z3Gjr4mGYDoAyTVLm3Ql8zAfGfm4Q2C4xPsQCQ4NXW8="
   },
   "org/jetbrains/compose/animation#animation-core-desktop/1.9.1": {
    "module": "sha256-hgdAqi8Icj+Iq5y9pDwTI/0Dbvfdw11tURa0ZDnAROc=",
    "pom": "sha256-1VVL+PdDa479M8WdaENtV8T0woD2wK+oqBRDrGtGV78="
   },
-  "org/jetbrains/compose/animation#animation-core-desktop/1.9.3": {
-   "jar": "sha256-ds9NCbUxL5qeRugKJwx2pxV6k4GUk/63B2+cjJhhBgU=",
-   "module": "sha256-hNnSyX8aeeZyRZntDqAd1wQCURcArCGP9V79qZ6j2CE=",
-   "pom": "sha256-4y8Cfj983nDxLtkxt92SO9s6VuoYYKSZhmtAu3YEqiI="
+  "org/jetbrains/compose/animation#animation-core/1.11.0-beta03": {
+   "module": "sha256-Lyg8tBqEJe4z+el2WvpqpXHe32uUCt75Me1iTUV2pyE=",
+   "pom": "sha256-mzS3KMEUniUwiVW/tsQiy+opZdI24udDU1ZxhzrIRag="
   },
-  "org/jetbrains/compose/animation#animation-core/1.10.3": {
-   "jar": "sha256-v8T0PWZFdawQ22FkkhL0U5L5aCR/lq6R4ac+S9CiBPM=",
-   "module": "sha256-XYUVJC/1g+Ia9MMP3hSIUjAXjcqk902VAMeoJidUAnw=",
-   "pom": "sha256-gRpNAdnxMxbtseUzmc3bgZ2f3y9HWvpm4iSZG/NPVes="
-  },
-  "org/jetbrains/compose/animation#animation-core/1.8.2": {
-   "module": "sha256-tRGby7/TKMDcD8yKRynXk6g3vz4naSP1bRCtvifGSMk=",
-   "pom": "sha256-RSX5/0gQEwHIPf84HI+Hre+IYuIAdmLUQwgDBG8tOkA="
-  },
-  "org/jetbrains/compose/animation#animation-core/1.9.0": {
-   "module": "sha256-AyvygPprM79S8/PKNEQe2Ing2RdH+2ly4IgcEhagAu0=",
-   "pom": "sha256-QL8NFIA7IHhDz87+sllqcj1m35hwN3wNiQRjt2XRHns="
+  "org/jetbrains/compose/animation#animation-core/1.11.1": {
+   "jar": "sha256-yVDtLCc6sA4VznLQTqo4AYiNXVXkM18C1NACkAnffXo=",
+   "module": "sha256-PNhXR4ESEdkz69mwnAZ47QoTdEJUTUWXfH+0y7xpYeg=",
+   "pom": "sha256-WZd8s6w6nSmzcDTmf7HB0OpggME41inpqaQ3XzlBvio="
   },
   "org/jetbrains/compose/animation#animation-core/1.9.1": {
    "module": "sha256-sLNcaXIN2EWqMr9DTUyMalYOE4elIAh0jvlGeJSOoyQ=",
    "pom": "sha256-u3hZBa0EmVIiHZzNxcJFY5ri9TfiEICldU/YZ0UhvK0="
   },
-  "org/jetbrains/compose/animation#animation-core/1.9.3": {
-   "module": "sha256-//2Jmf4MeqLGL+F2pGRbxxslH4+JK8fBwcbZFV6vLLI=",
-   "pom": "sha256-HxktalvHdmP3EGHKkbD+RaiwF56b5c52GInkx5ics9c="
+  "org/jetbrains/compose/animation#animation-desktop/1.11.0-beta03": {
+   "jar": "sha256-u0HGxVCkccaMURhcO7BFhIKk6APuB0vyFa3Igy4gB+E=",
+   "module": "sha256-F82Km0qkV2AvXmzcFhzCrb28Z2reZM7IJcivacRPUzM=",
+   "pom": "sha256-rME5ZlLRuMsUTMcbPf9bOpKvXyhnTPPnIQ9J3ReapsE="
   },
-  "org/jetbrains/compose/animation#animation-desktop/1.10.3": {
-   "jar": "sha256-GIHFV1RABV1UpnlBj3rX6GwDSXQziTYL7Q9qNq8WujQ=",
-   "module": "sha256-YY744ccvBoP4cbTZWyhl9kxjgI87ZUIKB+8O7wzF0Rc=",
-   "pom": "sha256-tBYhxRzPb9oueqO44E2D8egLz7SfBLDojVVLif38DMc="
+  "org/jetbrains/compose/animation#animation-desktop/1.11.1": {
+   "jar": "sha256-u0HGxVCkccaMURhcO7BFhIKk6APuB0vyFa3Igy4gB+E=",
+   "module": "sha256-Xspxyb3gALsU4gUE5VfMPUzoVZdEpiowMTTdCyImKsU=",
+   "pom": "sha256-1cmnfoKnK6vZ+nAcHGdj76d5LFvxdIo2QCT9r8ooOXo="
   },
-  "org/jetbrains/compose/animation#animation-desktop/1.9.0": {
-   "jar": "sha256-+LkLWR0fjCyLVHzd2uo3CpmJsLLHG0IDi2f9so8SC30=",
-   "module": "sha256-GZi9Zn+D8JNWo5xob3hS7RVvjCqNuJKVo6w56UYkukM=",
-   "pom": "sha256-cdJ8weEaTONaDDWYjPFMHqDlygRz9hm+3augjRl0v8Y="
+  "org/jetbrains/compose/animation#animation/1.11.0-beta03": {
+   "module": "sha256-1fsd1sWN0y1qhTqpqOCYP0Gp390nBEXCF0D5aWOwuYQ=",
+   "pom": "sha256-tktWrhGVzsdcUIPKOA2q6jLhheB/fa2m9prDdiNUXoo="
   },
-  "org/jetbrains/compose/animation#animation-desktop/1.9.3": {
-   "jar": "sha256-u8XhmPe4FZ+nFwr/LvvJxhJKbamn+quIiekiQio7Ils=",
-   "module": "sha256-W9cMeWQRQOm3sLdHlW8yj2tiayvu/unikOy/OkJQ28w=",
-   "pom": "sha256-L99kHu+ToKOvR4Aslk0Wagvx6GZvd8yVUjW77jXxf6s="
+  "org/jetbrains/compose/animation#animation/1.11.1": {
+   "jar": "sha256-CzkZYHS7VWNHvRiSt32kT4nXysl4jRV70i5Ea2xwk64=",
+   "module": "sha256-hddIC1HSPOPPHTVqZMIzXWdXZxVOXvlsfzLq+o8OsIs=",
+   "pom": "sha256-d50b/Qi0HKFp+g7M4fRQthYgM7eAZ0vlgRfhgBxRqz0="
   },
-  "org/jetbrains/compose/animation#animation/1.10.3": {
-   "jar": "sha256-wk2FqQJHt64x7m5du+xicV7QRoEqSIhhQq/YjVaD9GQ=",
-   "module": "sha256-1duqOn4R7nbqmSCDCb+5RxIG8fgvzCjoe/Aui0ulccc=",
-   "pom": "sha256-LHgtDl0eauEvaJ0A+P+RnGM828uaE4F9x/AParksMt4="
-  },
-  "org/jetbrains/compose/animation#animation/1.9.0": {
-   "module": "sha256-RiS7LSOr9KRgyluQd1oG53UoTk2gnYOYl5hpjgVDM1g=",
-   "pom": "sha256-zNUgtBuPHxNkX8e2txcG0ochLUQ26E5L4ETRKGtKlIE="
-  },
-  "org/jetbrains/compose/animation#animation/1.9.3": {
-   "module": "sha256-qj5kBl1T2z8KenRJ/2HKb5QfXzKKddHldItIZ/8ElTE=",
-   "pom": "sha256-BYvPS8fjYOus8vHvLRoQu1XP+7cIMzfD81ZRKt1iFTM="
-  },
-  "org/jetbrains/compose/annotation-internal#annotation/1.10.3": {
+  "org/jetbrains/compose/annotation-internal#annotation/1.10.0": {
    "jar": "sha256-WaDpt3s+H2HT4/Dfj5ntKhKxaN7YCeo55v117v+UvhI=",
-   "module": "sha256-aIUGFrD2Kg1aSQSAxpD0hWa3Jez019L1Jt6pAnA2Voc=",
-   "pom": "sha256-ax6PA960/1/orq5MHbElj8lGDDmlNPPQI36a7Xx72dw="
+   "module": "sha256-HL+uQT2AyKFYOzNP9XnvvC8oDLcj2RHA4kFEfzS142w=",
+   "pom": "sha256-f+e1+/Oz3SH1HP3NSVXqto9Aug/BnVd5irryB3dZtDA="
   },
-  "org/jetbrains/compose/annotation-internal#annotation/1.8.2": {
-   "module": "sha256-6tQ9Tmx0RuQ3H8KpGRhBKUJXKCApYhbsE/hAOj0w9Ww=",
-   "pom": "sha256-GSS3emTUqvyOwlr6mUXq2MRmTSJGrKmU0vq60CxbsDE="
+  "org/jetbrains/compose/annotation-internal#annotation/1.9.1": {
+   "module": "sha256-RsknnlfVlOv57yHCfGM8wgy86ypFIIMrlOgaejaJCpg=",
+   "pom": "sha256-im42jvSXI4fcZZrftOgJkK9mi4q6k/ZPwURQM7byuR4="
   },
-  "org/jetbrains/compose/annotation-internal#annotation/1.9.0": {
-   "module": "sha256-wuNy4DRqo8B0a94IDEAFIb0zdicuXVTBc2pkuji8dZc=",
-   "pom": "sha256-hOGFqg90Z7GfToFxQY0FRr2MpJMIfhPFXoUWeHoq/V4="
-  },
-  "org/jetbrains/compose/annotation-internal#annotation/1.9.3": {
-   "module": "sha256-XJA8onJ3P/ZifQO8vgh0IwV+kKYfYpNxyYupGQ04DDA=",
-   "pom": "sha256-zC5CIiLwOdJa9TeVsBO6syHZG7HothhYNuG4sWbo9wk="
-  },
-  "org/jetbrains/compose/collection-internal#collection/1.10.3": {
+  "org/jetbrains/compose/collection-internal#collection/1.10.0": {
    "jar": "sha256-NnuOooSW3AJFMaD+l1dt12hkuwZv+gm6IUH3PHm/PD0=",
-   "module": "sha256-mZ/hZJwmRHaT2+XQFKgQeE1qiYjShwAkp0ecMxa/jlA=",
-   "pom": "sha256-Y9pqUxNa3hS5UFwL4pVXObOwZGkw7J2F7j5DcmLSRa4="
+   "module": "sha256-C6k3s06FAnNf+ds1y0RpAs8RooVgyGqmSDNlu9/548I=",
+   "pom": "sha256-5FdZGCjqC+2jhllNlNsB49nX3XcypgY4eZrlkxzyNqM="
   },
-  "org/jetbrains/compose/collection-internal#collection/1.8.2": {
-   "module": "sha256-et7z8txM7WiKbJz7YNYGu2K0A2nvic2yr+l2NCiuoYk=",
-   "pom": "sha256-N3c+CKLm/WF2YfGpQp10mEiujF5xq+kXntswRzl+c+w="
+  "org/jetbrains/compose/collection-internal#collection/1.9.1": {
+   "module": "sha256-Zr648cP02SBn/9YViufb8WeZlOB1RM6NNMSpD3fZsfA=",
+   "pom": "sha256-Pt165cmCi3TPEev8QyhpdWSiDIcELs9u+/SbSJfaVMc="
   },
-  "org/jetbrains/compose/collection-internal#collection/1.9.0": {
-   "module": "sha256-gDAK5xf3KEo4h5SKEX94kRnvukfy0fZIiwCv0Mt0rx8=",
-   "pom": "sha256-boJ19whECuea8VxYRdIUy2liiMRyyokyV3q7VsER5ic="
+  "org/jetbrains/compose/components#components-resources-desktop/1.11.1": {
+   "jar": "sha256-BeHK13yO3nkwrSEiO4GZMrcNetlp6/75fd8nL8GnvDk=",
+   "module": "sha256-wg/4XvLT1WWTJUY5RD+AXD3gGygz4nsWcZ35SwQzUXU=",
+   "pom": "sha256-B2F/aMr/i7Q5yzuD48EjjBSquPUmHsTDv7bPCE4Khzg="
   },
-  "org/jetbrains/compose/collection-internal#collection/1.9.3": {
-   "module": "sha256-DG395u8H/Lkr6q4j5SO4yLOBaYYd7HKyT3+urnVT6iA=",
-   "pom": "sha256-uMEk0N0L89C3jdKlGvWBtzsy20VZGtmbb/scmo9o1L4="
+  "org/jetbrains/compose/components#components-resources/1.11.1": {
+   "jar": "sha256-arSpUPBmPXY85qZsNn2f5Ud2VT9skrzrbOXTKNtEWI4=",
+   "module": "sha256-FY0UPT9BXVsn8nHRP4waqwbfl3ZeCTfyMO8H3Z1L8zo=",
+   "pom": "sha256-cSuuPBIodvYHy1kelwhZtLfoCscNiahBgimEPY7fv/c="
   },
-  "org/jetbrains/compose/components#components-resources-desktop/1.10.3": {
-   "jar": "sha256-fbvgZoO++oEQtKySanQyt+LuRG7RVq31WtF+nIaK4OI=",
-   "module": "sha256-qpgF01LVAd0nUt742l2vAAsY7ZCRbbnzN6Jbp9VHZm0=",
-   "pom": "sha256-XAMcVL/tWAgj790GKivUGNZELOaKIaVcr0GSSVkf1HE="
-  },
-  "org/jetbrains/compose/components#components-resources-desktop/1.9.0": {
-   "jar": "sha256-87jzMba7QxKnTtFte7NlRCfPpzcopYF63b/2TG533+w=",
-   "module": "sha256-OTHh694xwO+VJYKEJkOrT7yKQa3f8LMQN/y5HJnRjtE=",
-   "pom": "sha256-JiFTqaOp09D+2PS88PlLDk9Xzx31156V6JGGiUE3kA0="
-  },
-  "org/jetbrains/compose/components#components-resources/1.10.3": {
-   "jar": "sha256-w8pVlHgcoFydarBZbX9OvcZKdE63TXvCwQ5Yxo1E65Q=",
-   "module": "sha256-0TjBrJkvJVO3GY8CNllHUXaOJfSxxPt/hWJ57axdEG8=",
-   "pom": "sha256-Ta/7HsxYuoCPrJ3aes4bp4/I2iApbOJfpKQS+wEo8WQ="
-  },
-  "org/jetbrains/compose/components#components-resources/1.9.0": {
-   "module": "sha256-O/zJJv65jlZXAEXvnMLXKH+swiWJNEQlTENGSEM42P0=",
-   "pom": "sha256-4UJBU1Q55uEIKLERKX1Ot/9QIR+JR81kx0nKck4BmmE="
-  },
-  "org/jetbrains/compose/desktop#desktop-jvm-linux-x64/1.10.3": {
-   "pom": "sha256-WmNhwRJxW+ojNImOII7IJkCGPVkih8KCi57fVtXXM6k="
-  },
-  "org/jetbrains/compose/desktop#desktop-jvm-linux-x64/1.9.0": {
-   "pom": "sha256-ikrzKPIGw40cwII7kzDaHHM/HAY2dIVgzPk8T6u9JcM="
+  "org/jetbrains/compose/desktop#desktop-jvm-linux-x64/1.11.1": {
+   "pom": "sha256-H9Q2XorYZZKgFLJ/TF0JdLiY5dVwjf2tFwon3D74u2A="
   },
   "org/jetbrains/compose/desktop#desktop-jvm-macos-arm64/1.9.0": {
    "pom": "sha256-JiGp36CoFnnMhSVjEflgjoMQj5zRlDvQa1F/fblo1kw="
   },
-  "org/jetbrains/compose/desktop#desktop-jvm/1.10.3": {
-   "jar": "sha256-/bY95Mm9xlcMU1XusPAT1GNe/9pCkHwtCErMd+CNT4o=",
-   "module": "sha256-oFaLOfMJVCZFJVaI77Qx3u4JUJ8jXQiMJROx08LDFn8=",
-   "pom": "sha256-ZkN5IyKyUh5VqkxvaqVDNax0FDUSO7Z/WJ6JsAZ6bRQ="
+  "org/jetbrains/compose/desktop#desktop-jvm/1.11.1": {
+   "jar": "sha256-nz0iHhrM1sfGSsKg18gFNTe8f0lZLETXK3ZkNN/OdEA=",
+   "module": "sha256-L1zMciy73iVgOeMSEsAm9zGL5IU9/MnF3U4fwtxgOMU=",
+   "pom": "sha256-lfOCogMYZh6K4DpAdHjqUKaRYI0nQtOnEPxqeR7O1yk="
   },
-  "org/jetbrains/compose/desktop#desktop-jvm/1.9.0": {
-   "jar": "sha256-winFLJW0xNc5hMiPQPhHXAfRPSkI003wKeQktroambI=",
-   "module": "sha256-XZKFY3U+ZqsA1zpMgxAoYUt5SubNnt3BykvxdziQ2Eo=",
-   "pom": "sha256-Fa1qgZfJUB2LTvKsCnkU7SOK4KSU+Gq5dYdlaYjticc="
+  "org/jetbrains/compose/desktop#desktop/1.11.1": {
+   "jar": "sha256-uF4VUMzSz46+U78IHMv7PWmvYaXzVbj8sRsuin96ohQ=",
+   "module": "sha256-91Hc17faBt+lcbSQJQ5+johwxpmegVieo4OjjrWb300=",
+   "pom": "sha256-DTBaW5mD5ygF1YrGVHuDn4SkwIbC5cN2JvBQgz0rwD8="
   },
-  "org/jetbrains/compose/desktop#desktop/1.10.3": {
-   "jar": "sha256-CJ4kQXv59sNO7Fcg7rssvMguooVezvkBM+sX4QedWGg=",
-   "module": "sha256-amqqVt4c3fe9rFlNfuh/bpnUiQ2kmT25Yf5cOirS3OE=",
-   "pom": "sha256-NPi89983+I9us/8gN+7v7sjNFvlxzt0sqmupEgMvI4I="
+  "org/jetbrains/compose/foundation#foundation-desktop/1.11.0-beta03": {
+   "jar": "sha256-ex5Udj63UU5Mp4YzYREt9/8qiv/egSHkPo3Cf8GrktE=",
+   "module": "sha256-VmzkCAMY5fTL/kgMYzhW9Gu6lPBSlIshiveOqKTlANw=",
+   "pom": "sha256-XYILp7WmvQfTAsGzjBf739ENwPebmTQb4AuqJmsF6Kg="
   },
-  "org/jetbrains/compose/desktop#desktop/1.9.0": {
-   "module": "sha256-kiCLVt2h9QQPgOmufi3pZ9az1UY2gorrwFYVBa6weLk=",
-   "pom": "sha256-6pFZD1PxYbxeT/rjAVVXsG7zGcLme+lPiHuDPGEIPw8="
+  "org/jetbrains/compose/foundation#foundation-desktop/1.11.1": {
+   "jar": "sha256-MmAWU2N+R8xEL6d8nl3ZWlV6BTOlMEulIAzHLFZfB0o=",
+   "module": "sha256-MYn6H3Eb30h5ewnt7DbxxEYDG21s/HiULXJY3wFH7bI=",
+   "pom": "sha256-OkA9BQm/hR0p7LqSdJW1wmn+sQCYXBcfdjWF7uIAtWk="
   },
-  "org/jetbrains/compose/foundation#foundation-desktop/1.10.3": {
-   "jar": "sha256-Opt7+ucvGpKoEj0ykLt9f2HZLlzeh3r1Nzw+XCys6ys=",
-   "module": "sha256-97MIb0lTebZoHD7744z3D9z8fK9UzGM79rPQlpSnUiE=",
-   "pom": "sha256-ljQ4YfNGEdQrKvHOq8L45W5NpyTjp1fXOIqHlwHic/E="
+  "org/jetbrains/compose/foundation#foundation-layout-desktop/1.11.0-beta03": {
+   "jar": "sha256-iJ/2np/rLzUYaKUOPyGw6wA0gck1t9XBLMjFWPFVGqY=",
+   "module": "sha256-Me/vBdRVthRszjUOlLKixYPn8koMSGiNRjA3oZFm76s=",
+   "pom": "sha256-Acx9MixEYurLgudM+OVbDAeJSJOmfp1/WC8BF+bIbQU="
   },
-  "org/jetbrains/compose/foundation#foundation-desktop/1.9.0": {
-   "jar": "sha256-CzobXwhb5sDOlTVKRzmzXp6oLgD3kEl8H1PHLqUTQvk=",
-   "module": "sha256-vpZlZzRb+0wg8vNOWSVdBKRhvAXF4fia/qyOrD9kqro=",
-   "pom": "sha256-Dy5t7Bgcjq7IznOIHLJIaC+c9Z+rl/iuDFevTBkGyNY="
+  "org/jetbrains/compose/foundation#foundation-layout-desktop/1.11.1": {
+   "jar": "sha256-15kptFUh3/DHfTGEQSAHs7lpV1XIsZM9X/nk8ek/oTE=",
+   "module": "sha256-0o6VTq2HvE4cIg0Tm8FJVUHBjdEWbK9U7cj+Au/OeVk=",
+   "pom": "sha256-eQO2y+HHwzMm1B+6pWm5G60IKPCTeQNArkzQERkqhe0="
   },
-  "org/jetbrains/compose/foundation#foundation-desktop/1.9.3": {
-   "jar": "sha256-08V6qBjAEjNAju7wc09RsLwWh7ceTPhj3fkrk6fMhhI=",
-   "module": "sha256-/nKrfJWvH+8AgrxOYWlG4VBQ3gZRA/UA1FSweqM4Tpg=",
-   "pom": "sha256-+HCWU6qwkonNNgeG8mwcJ8+UL5g9Xkj0GhGREzdC2AU="
+  "org/jetbrains/compose/foundation#foundation-layout/1.11.0-beta03": {
+   "module": "sha256-tJfEXxA1kNcNo2cu6t2Zg6tsuFsFyxUG3hUx03YokKw=",
+   "pom": "sha256-+JMUlJ+eHNkat9VoJAP1E7N1shrauDcTEFq/8D31TQE="
   },
-  "org/jetbrains/compose/foundation#foundation-layout-desktop/1.10.3": {
-   "jar": "sha256-jY4ABiqDoUdAn0L5F5g5TDwiHSKHeVPv99CoF2e10Pw=",
-   "module": "sha256-NXX5ELMyQjwm+/DFQwPMeWQBmmH+yeC6OEyRiSgUF0k=",
-   "pom": "sha256-KftqG6ps/iBKzdfAlTytZ4PAPwecjt/5lDSwBXya9Rk="
+  "org/jetbrains/compose/foundation#foundation-layout/1.11.1": {
+   "jar": "sha256-sUYAI/yC0pioGhcNGPPnL+39QoRI0r5gUCPbFbg2xWo=",
+   "module": "sha256-QuPM5CdYs9tRHynzfhhoD0wsPKbY/Zr/Pbar2Z7BJQk=",
+   "pom": "sha256-1EJsKsBwAIzN/MPV/NGtBbC9xMu9+ysFRVWDnQHV9Kc="
   },
-  "org/jetbrains/compose/foundation#foundation-layout-desktop/1.8.2": {
-   "module": "sha256-FLYe6xVeaN7rIikWXb9OsXxYDoUZHVWAImCESRfwnrc=",
-   "pom": "sha256-Fed6HT2iHROf8shLGg6t+xGr5NZq+nMO47Tdbgm/9Yk="
+  "org/jetbrains/compose/foundation#foundation/1.11.0-beta03": {
+   "module": "sha256-j7CB2b1ZeLldP1JPOr3UHwaoGj40lbzRfiS8vzY3xWE=",
+   "pom": "sha256-2AxtwYrDqFx9D6M+dOdORh4w+UBwn/pzOsp+MhzsubM="
   },
-  "org/jetbrains/compose/foundation#foundation-layout-desktop/1.9.0": {
-   "jar": "sha256-WVDOHhAlmuIZikbhaB2Vnxa81k2LXQKJ4XxQhjrz+O0=",
-   "module": "sha256-5wXUw8YaJQC9BmkMhIGkjjl/PzyEaPEVYX1p6szzcTs=",
-   "pom": "sha256-KxoFyZeJ69iDa5wc73P09K6FUqWN5SvNu0iDlLy2ASM="
+  "org/jetbrains/compose/foundation#foundation/1.11.1": {
+   "jar": "sha256-TSDNftbAbktx+pCa7iY3wVEyDzgmvarzLZt6VVZJM7I=",
+   "module": "sha256-6/fS6fGq7hC1sUyJpTPIB/Di9YJl5mZlD3cq4eEM7JM=",
+   "pom": "sha256-M7AOmYx1WEw3v5OSfg45iXySV2LBNVoDl3T6+4Ly7dA="
   },
-  "org/jetbrains/compose/foundation#foundation-layout-desktop/1.9.3": {
-   "jar": "sha256-WVDOHhAlmuIZikbhaB2Vnxa81k2LXQKJ4XxQhjrz+O0=",
-   "module": "sha256-gtXkFCxeZpJWvZH2owJ7+crJKATmi9Rfdaj0dbysts4=",
-   "pom": "sha256-noSi2dPlxYmIFRKUkjFU1dyxh9oF1mM8Q8XtHD54Zgg="
-  },
-  "org/jetbrains/compose/foundation#foundation-layout/1.10.3": {
-   "jar": "sha256-XCmtk/BVfEeKvT/N/5wZXF6EvajJfwIu98WPSSMyFHU=",
-   "module": "sha256-gkovKnf9KkRJEfFeXQGELBpbJdOyYeDmJEvfoQ2Me1M=",
-   "pom": "sha256-v7wQ5yF+NgW+1e5f5G/kTFht7ZQRxo+50u4xaQ7MrkM="
-  },
-  "org/jetbrains/compose/foundation#foundation-layout/1.8.2": {
-   "module": "sha256-4ZO0QesgCnPcerN0hgMczkKibiznAPp53WsxZut6R5Q=",
-   "pom": "sha256-fWrcrn12qThawuLXFFl3HzGkFRLDgY+WLPm75d6nF1Q="
-  },
-  "org/jetbrains/compose/foundation#foundation-layout/1.9.0": {
-   "module": "sha256-YwrZaw97aT69sY9aXgKPZxaM4paL08yz8VflSqRjG7s=",
-   "pom": "sha256-Y0v0YLAjBNxJWl1pTxHeKYZeCdgHzZ7q1hPTxgXmkEc="
-  },
-  "org/jetbrains/compose/foundation#foundation-layout/1.9.3": {
-   "module": "sha256-BC1gYzk28D+86dvOi66DXG3mR/ZWaqtlUhmveApPB4o=",
-   "pom": "sha256-SGJ1Sxcpg8FGGKEesl328Sfx8gVXHKMa4CQ1NmDBbD0="
-  },
-  "org/jetbrains/compose/foundation#foundation/1.10.3": {
-   "jar": "sha256-4ZIu0qgQtBnlPztiGgnSJ4Ohu4U9b0J9qfMgEglxKx8=",
-   "module": "sha256-V66/3SNSe9U2Ix+hP28fFwP5I7RuTYeobXwW5T2x23c=",
-   "pom": "sha256-mHKS9jWEfIedR/5Og7/bmvcxVK6hb88+lz53+EdYkHA="
-  },
-  "org/jetbrains/compose/foundation#foundation/1.9.0": {
-   "module": "sha256-/6+3yasG25hJJDhAlTja6o9Y3Bydh0TsSgMCn6b4Ky0=",
-   "pom": "sha256-KdYEVx22XMXYrruz8VeeiDBr1SxG2dh203PpYauoQW8="
-  },
-  "org/jetbrains/compose/foundation#foundation/1.9.3": {
-   "module": "sha256-XMLCtU13nZlCjZcgjf9mclJe8PBY0b+3F7s8cNopVr4=",
-   "pom": "sha256-1uFzEB2DhAZQMlv2jdRpOdznvuXzPos6/j1fx3DgdEI="
-  },
-  "org/jetbrains/compose/hot-reload#hot-reload-agent/1.0.0": {
-   "jar": "sha256-MmtA0vfH40G4B2hGA7ji9XUMOdj5yfZ6ShjCJMjDGX0=",
-   "module": "sha256-WnI00tHPc0kArfE68JjMXNl9R4m1dM6hVF5b38U9J4A=",
-   "pom": "sha256-9idg8jL1hUnsbvIJUUCyeTjPVBPeJxjl5BJICFaRsTo="
-  },
-  "org/jetbrains/compose/hot-reload#hot-reload-analysis/1.0.0": {
-   "jar": "sha256-ubbR2SyC25+mVAgddK656uNlbh8U+T/EvMob1gWM7RU=",
-   "module": "sha256-mo+hE7NYpZLrGLOmePcjin4iFrHBhsdrVpYXvRx4FLo=",
-   "pom": "sha256-pZPc8QWIEVihx4CqVzcmgCYGP+4KRLNlbZxbXT/93h8="
-  },
-  "org/jetbrains/compose/hot-reload#hot-reload-annotations-jvm/1.0.0": {
+  "org/jetbrains/compose/hot-reload#hot-reload-annotations-jvm/1.1.1": {
    "jar": "sha256-9QbjmAxn+HbJUUvgIJW8rTvv969P3tu/WXlD2G3wcPM=",
-   "module": "sha256-V2zswUJwwpwX+cng/CEQecEo0MBPlAvMHdyP/A9HpYQ=",
-   "pom": "sha256-yKl2WannZXTliRSIwW0u8xMwzlTxynIgLrXiGstLKmc="
+   "module": "sha256-tzLbcqfMhTnByPNVYmMeq5aeADP3DU3mzYcXwS02bdI=",
+   "pom": "sha256-DT6Dj8VwSkIGkuTkxGFS0EmN/t9Mv9QnZqjnlBiJkW4="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-annotations/1.0.0": {
-   "jar": "sha256-3DgxgwlH4wbP7Dt/EKS5fN+VrMjntKMLnQUOaiOI6pU=",
-   "module": "sha256-kSBb9Jz0CWbbCc4CngfEUoRek7lzLpgOxcGjbt/z2WM=",
-   "pom": "sha256-3aWEn5RinN6jGfKxP9RUjIOw3EzJbOxSpxKf0FvNToI="
+  "org/jetbrains/compose/hot-reload#hot-reload-annotations/1.1.1": {
+   "jar": "sha256-FfTQYpKf6T46z2ri6laAfh0LKhWPmfiE3nva2vpvc5c=",
+   "module": "sha256-GzIidigY3IspcNtNmW9JALlqtg2ZGLO/BGdQYITYkQw=",
+   "pom": "sha256-4MJcqn8j1wZ+dQTsxY4OEK7eEzDWJk+iC17F9ZgORm8="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-core/1.0.0": {
-   "jar": "sha256-U0+7FSIvV1lLAzDPGTr0Q6cg7YouhXzFWHEwIrG0keA=",
-   "module": "sha256-IclZxt8H2/UDOPYsdFWvyPh1yDB5RFvK2BpPDglknoA=",
-   "pom": "sha256-s05XRwVr5YBCDQt4ahYc8gZfchGeAfCPiRTV3JvDB2s="
+  "org/jetbrains/compose/hot-reload#hot-reload-core/1.1.1": {
+   "jar": "sha256-DBLxjNb1mFr0Af8MOwMT4xaW8o6tsgBGgNoRx7AW1ps=",
+   "module": "sha256-EZ1rqh8S8A+yoh3ZX2kkD8UQ1qCH1FvPdB2gOnMkB3U=",
+   "pom": "sha256-F94xHE/mPK5mLl0PugrYdWWXRrkx0Pov+6C9HzRDEc0="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-devtools-api/1.0.0": {
-   "jar": "sha256-tXW6eZ2ynY1N5LK0aFhHxtKR4JpkfVstTM5D1v8c5cY=",
-   "module": "sha256-TgBuaOSX9omnvjg+MbmuqKBEoJCLtLavXltzAmdytNI=",
-   "pom": "sha256-3Ql9KAngMyEyvcYYBE+Iru3t++SVQ2uUgh8+JjzMI/s="
+  "org/jetbrains/compose/hot-reload#hot-reload-devtools-api/1.1.1": {
+   "jar": "sha256-X7Cqbk00kczz7GcdPLvx8rz88OBnbz4thWEs/ejfbVE=",
+   "module": "sha256-8iAegT/4RSdDHsV7j/q9dNQVV0TUZrucUhqPQHzdDFM=",
+   "pom": "sha256-M1JwjocZRXcOuwWb0ofxUOoO3xiMJVLJov+le5zvMPU="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-devtools/1.0.0": {
-   "jar": "sha256-aXlhIy7pOlRWq2EFTww12XnXsMnjcgK56kUMt6so1K8=",
-   "module": "sha256-FTy000ikm/fdBPAP1QNA6sr4Px+FK1+CWT2fvRqkp78=",
-   "pom": "sha256-HtbnvXf8IJLHuRXuOUbjLiGal0S0kgle8pZMny/jAnw="
+  "org/jetbrains/compose/hot-reload#hot-reload-gradle-plugin/1.1.1": {
+   "jar": "sha256-yErWizz55/HRj43qTlCXo86YYAIPpVA0JU8AnA3mndM=",
+   "module": "sha256-3rLhUP0khvjJMScGzQuIOfy5FqkKGihtQqn5JoWSlZs=",
+   "pom": "sha256-HzNyUqXvicvUGpsVOsmRRdK54K4u0mbGgEj0BUH8oGM="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-gradle-plugin/1.0.0": {
-   "jar": "sha256-NVGyox2E7Pla0UDP3FsEs7a1Br8VZhh63vm5GgXGawQ=",
-   "module": "sha256-BESHhjuIvcse0ymXqNij1sVogVgHfYUKmbNSihWuJWI=",
-   "pom": "sha256-KjpWO0MhAFxK+EbO3aCr2EA/avxtSdojD7q4EOrvB+k="
+  "org/jetbrains/compose/hot-reload#hot-reload-orchestration/1.1.1": {
+   "jar": "sha256-OJyfTOFdQIOjykh8+YIIWXxG4wn3DhXT2DXf4w/4mTk=",
+   "module": "sha256-zqLGhUYawKYlkdwPVxN5lbx/L0yWVhx+dh0vT8+0Q0E=",
+   "pom": "sha256-VzrjxEI1VHILRiii9ZWXH9d3r4c67Gfgor2SElu+JZg="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-orchestration/1.0.0": {
-   "jar": "sha256-nuw1Z76g9hI2An6AOOAD8BIAsOifEyydH6fDkByzS7I=",
-   "module": "sha256-0+mMw3hrwELMGWuFjctzdMODK4nKYakv17ywY4LIhyg=",
-   "pom": "sha256-ybUGOBTo1vIaeg09PKnfVnzz/oXj9kuQFiQzD8df8lo="
+  "org/jetbrains/compose/hot-reload#hot-reload-runtime-api-jvm/1.1.1": {
+   "jar": "sha256-AiGFq+fdw9i49lBnN/jFXKu+X8jUn+EoN3/3GEcl6vw=",
+   "module": "sha256-v3WtT4g84yZhqRttSMxcMLk10g7tGCAu3l8m4hddG+8=",
+   "pom": "sha256-D+FZhNuX0wiPA3CwQG0ON2GeawD7gNL/wklJWhO9Zhc="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-runtime-api-jvm/1.0.0": {
-   "jar": "sha256-456SOpwjDi5JyWmnuxs1M4s32+1erLLAOIkgto5uvDQ=",
-   "module": "sha256-tA3MSn42Q0jCXyE8IuTHFLRGhm1fNcn8iw9Aa2Vr21Q=",
-   "pom": "sha256-MJgt9tT/1aV0cKjAVceFOwxB76F+rl0pkAbpLz7pQ7I="
+  "org/jetbrains/compose/hot-reload#hot-reload-runtime-api/1.1.1": {
+   "jar": "sha256-DXwGz7KAihdDfKSLcuxjSljAmM9AhQdOALcc60fCmeQ=",
+   "module": "sha256-xMGOOQLn8bcY53511o1+PTr7KgDGYEFnpSdaGKkcK3M=",
+   "pom": "sha256-GOhkDldZzxqo5pcJmNTUZQBj+H877uBk4Sg8i4sreyU="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-runtime-api/1.0.0": {
-   "jar": "sha256-5M6NjBByySNtUkmu9DaPhKM1kr9wb1zDBk7HNObBatw=",
-   "module": "sha256-WFqlgVPJTyVhkXHMBy+CEVw5TYu+PsSa8KpUWHEgZjc=",
-   "pom": "sha256-3eyc3hN+JhsKtteccyrE7X9Ktk5xRTtqZ2wTsNnwbFY="
+  "org/jetbrains/compose/hot-reload#hot-reload-runtime-jvm/1.1.1": {
+   "jar": "sha256-9iQCE7NYXC82OI+MWXSqqVBw/QFxTkfqNbSPgob/70E=",
+   "module": "sha256-L0vVQf0Ofe0pESxWRwjHuhuVgGknUKy0uJVl7wtHX5U=",
+   "pom": "sha256-wcnX5pm7pTWgUtvw6sKXxn62zwN5X9AlUC8vnKHNA3s="
   },
-  "org/jetbrains/compose/hot-reload#hot-reload-runtime-jvm/1.0.0": {
-   "jar": "sha256-ehDmryszBytMfePjjI+Pq2VCr8UVz+8kLlOHj+x+EAI=",
-   "module": "sha256-z5SLFdUac4ebh8Zszk2JEyaTDdm9oRchZj1olHCDUmI=",
-   "pom": "sha256-UdKNSEj/eI45/WCFkJ/kEYH215u6xU92dJc8MNj92vc="
+  "org/jetbrains/compose/hot-reload#org.jetbrains.compose.hot-reload.gradle.plugin/1.1.1": {
+   "pom": "sha256-1MflNuUHav7FKqKagxvikzEz4dOY/TdHVttu5CP5Yd4="
   },
-  "org/jetbrains/compose/hot-reload#org.jetbrains.compose.hot-reload.gradle.plugin/1.0.0": {
-   "pom": "sha256-buCnhcd6o2l4sJSDyk0zJ68TS6ZjktF4Tr109dyD/NM="
-  },
-  "org/jetbrains/compose/material#material-desktop/1.10.3": {
-   "jar": "sha256-7kr6M6JBHgbPG+xolmd2f/uZH/AiaeBApO9k5245IRk=",
-   "module": "sha256-oHcuPnoXOyVEyrU0/XlYOi/wZA8VXM+cVW37+St6Uxs=",
-   "pom": "sha256-L3/X+0HcGuyjh8GZmv9K95xvYSiMBlfhl0eUF3VZoPM="
-  },
-  "org/jetbrains/compose/material#material-desktop/1.9.0": {
-   "jar": "sha256-WgTR4pWWAj/dXK/e20UQpKb6ZRIuhBm1ogSlFtyJR4c=",
-   "module": "sha256-TJ2trYhGh+FTYScKxPLbbAjX+xZQBm/bEJa5gBELA+0=",
-   "pom": "sha256-0+IE86ZZdTxVipwLnVnHoP4t+PmWHJdnMps6sxyFRqw="
+  "org/jetbrains/compose/material#material-desktop/1.11.1": {
+   "jar": "sha256-/NiBITYov1Cx4niSXbiS9VLCO9Y7x+25m5aHkMngl/g=",
+   "module": "sha256-eP9qdfrxc7Vef3T7jy78/lUf/yqcARZd4d7jXtkuPNw=",
+   "pom": "sha256-FHmRJK0j4aKzEb8bcDUhns561uU2w89JMnwMmc11fYk="
   },
   "org/jetbrains/compose/material#material-icons-core-desktop/1.7.3": {
    "jar": "sha256-vPbIU7bbL/FI0tOq07en6lTZP8e0Lgr9hA622vGhxoE=",
@@ -1472,389 +1239,237 @@
    "module": "sha256-sfqa12veAdmGn5uwxxKc0rByeU8jfgTRXj73yKZqSHI=",
    "pom": "sha256-3NyiJy7t6vlAZmO5s4zMl8cXnoWqHKeJMuxhIuVZlYw="
   },
-  "org/jetbrains/compose/material#material-ripple-desktop/1.10.3": {
-   "jar": "sha256-MldpehpYGI7D3DHzGGfxw4IJkAuH3xJh66yeahOH24M=",
-   "module": "sha256-pR3QR6gJYUVSE+M9RkwPbfuFYs1yUT5uHhm40Dky/ts=",
-   "pom": "sha256-cPnot28P5QBPa7xSCt74A6o6a3w5Wr8CEKxi/4sOqUI="
-  },
-  "org/jetbrains/compose/material#material-ripple-desktop/1.8.2": {
-   "module": "sha256-qonDHtpLPCdfECYdvgaC7a5j/N66IKNauEDsZIsQH7w=",
-   "pom": "sha256-TLDKRvyZMp5/EyBOXzVVjWKFl8f/LlpBFZKyPRiCmSs="
-  },
-  "org/jetbrains/compose/material#material-ripple-desktop/1.9.0": {
-   "jar": "sha256-JAfZ6Dxv2EuQsSPMeuYpH6ehi7QJOK0hD2deTIZCXIs=",
-   "module": "sha256-2zKNEcRG02g9UjTeSFKppIOPc7w2XCDglmFYre/lbAs=",
-   "pom": "sha256-KVdrVWPnpEioaL1EkUP4HGeC8yHC35pYERwvzdbZh9w="
+  "org/jetbrains/compose/material#material-ripple-desktop/1.11.1": {
+   "jar": "sha256-4k7Qp0BDhQjMg+s8sH3FXYOwouJfIz9I/8KgeCpy4Ac=",
+   "module": "sha256-VIlnE1bPlsJY+xLEmuYL33TtHYW3CxLpv+1ASkVLKhA=",
+   "pom": "sha256-9B1CZZeqEaa2HiYVkhzylupzSobj1mQnKTuAGzWMOZs="
   },
   "org/jetbrains/compose/material#material-ripple-desktop/1.9.1": {
    "module": "sha256-BlaiK1iKg5uADqwoWqPrTQNd89VSIccGxdNfpil+bYk=",
    "pom": "sha256-T5wpVlxWK/sQxbeoEGzHkuJZp2z3iJnemi71R4cADBM="
   },
-  "org/jetbrains/compose/material#material-ripple/1.10.3": {
-   "jar": "sha256-ce62zqnl/PPpPoRj4YjOseRIhxg6AgId0ML0JKWrHEo=",
-   "module": "sha256-WO35cU3AaVBDi8b89gCAtaSLq34IbsrQOHX5I+7CYp4=",
-   "pom": "sha256-c+E5j0QvD2h4PxOJIbmxBAis4y6Uv7h7H0YX0FiMwHo="
-  },
-  "org/jetbrains/compose/material#material-ripple/1.8.2": {
-   "module": "sha256-sPjhBmZdFZ5A5QpkLm/L4voyjv7tdZ073Js89SZ8nQk=",
-   "pom": "sha256-2Bnue2maiafpoGNneZA+WkB/M+IgBggHvkVGiFiMQqo="
-  },
-  "org/jetbrains/compose/material#material-ripple/1.9.0": {
-   "module": "sha256-WBIIy/NsxIRNry00g+nD3Dd2myRLnTdjDvhEx2fViss=",
-   "pom": "sha256-AXqwUq4lbqakhkdg6OQWCVHLKmEJXt7hiSW6XNOlE3U="
+  "org/jetbrains/compose/material#material-ripple/1.11.1": {
+   "jar": "sha256-aCKiJ1yYknuGNUbXdYUydrFZkhTkI02btHEHstpwdOM=",
+   "module": "sha256-4cXp8ji+k3PPrs17nYPvvpU/zFzheZYrr6PyIAWJIlg=",
+   "pom": "sha256-8S2WkwTwAJJVQoC6ah+0rpuZ9LAa5FjpI12aIEXXrJc="
   },
   "org/jetbrains/compose/material#material-ripple/1.9.1": {
    "jar": "sha256-KS0rP7u8wkuzJvP2QtrJqM1V4Y1bUYNlusbayiOlz3Q=",
    "module": "sha256-iY2+mg5iyco5GzdewaJ7SZZXQ7dKBq2F9ucQoLu0o9o=",
    "pom": "sha256-9S84Kui5GL5SNnYUELp9jdEuC2rJkjB5fFOyQLoaMeg="
   },
-  "org/jetbrains/compose/material#material/1.10.3": {
-   "jar": "sha256-LSEY93unibj6F5gDhWp64ex1P5/5ko70jyB3VAq4MgU=",
-   "module": "sha256-hUirZfmexDGhviU4aHlXl7pxYje0HOijrAHtc3pCqx8=",
-   "pom": "sha256-WHVX6+B9rZpj+5dUNl4GDp9OQrknZqMStPghVnEPEmY="
-  },
-  "org/jetbrains/compose/material#material/1.9.0": {
-   "module": "sha256-UyLG9xJ+ZTOuU8dQ+TmDz7ww6kiJTOc72bKqUIzby/g=",
-   "pom": "sha256-4sNTk4f+GRpSKz4DesH+9UYn5T2gpkgHr6Xbd/+rCKc="
-  },
-  "org/jetbrains/compose/material3#material3-desktop/1.8.2": {
-   "jar": "sha256-PgFota97rNusxB6dNv9PbTmouYn9Y7aOOzBftqTSq1g=",
-   "module": "sha256-00fR/8tIGIzQgLUdIaRbyTi7wRaKoFhXqmUvnujPoZY=",
-   "pom": "sha256-WdF4UbuYtEfu+CrRrR0TPSvNfAVqDlQ4SKcqqteSbH4="
+  "org/jetbrains/compose/material#material/1.11.1": {
+   "jar": "sha256-8pMkH9XVFXmeT3wbfOQrPghdIaSZoZVZH7Pq2UyZVXU=",
+   "module": "sha256-zRVOaYXpFUjuCLjIQBdJk3lFDotRHstXL1n4rMJASeQ=",
+   "pom": "sha256-L9p0J+ElR+kEUII0E6WGjo3SMSvmROY6pjPtojWn8WI="
   },
   "org/jetbrains/compose/material3#material3-desktop/1.9.0": {
    "jar": "sha256-ePB4ehxtIPmyRgo4f1Hs9VTiEdPIdLItZlMKVAOQuBE=",
    "module": "sha256-8k6gvUIXSQX9Mq+I84qKTRXYBlQ8qxiyT/5mnxjnWY0=",
    "pom": "sha256-2uS4gKerRfs4sPOijcOSbbWiOdGxfn6i5xY3+WMLtUw="
   },
-  "org/jetbrains/compose/material3#material3/1.8.2": {
-   "module": "sha256-ecEjW2d12MzzwJkrYDrBUPkMkmUyLAwg7rHCKTSCZVM=",
-   "pom": "sha256-BcrLqe9FofHCyT3MhTbmvl/p4Wo2s2PIqqpjraSZrWc="
-  },
   "org/jetbrains/compose/material3#material3/1.9.0": {
    "jar": "sha256-C+JrF0bluq5Dfb+CDa7+9+EHtkiEb5fntBHc0d5PZDM=",
    "module": "sha256-+np0XfkXBZHZjzdzMDvPU4KTE6z7Q8csGqT4+5m6RaQ=",
    "pom": "sha256-lyjwhwOCTgT6yPhOZuHn8obuQwiQ8yf/ix51Qx3fGto="
   },
-  "org/jetbrains/compose/runtime#runtime-desktop/1.10.3": {
-   "jar": "sha256-BfVXDAp+qK3db+lQenDyk++n8UUNi5sW3DyP7iHMYSc=",
-   "module": "sha256-AzcEvJYZP3j8+I8ZHWr+QThLXvohEKIb+sHSm78fKJA=",
-   "pom": "sha256-6XHhyRcUR2RQjFqRk98TVyU3eVTNemGrn0eSUCtufGA="
+  "org/jetbrains/compose/runtime#runtime-desktop/1.11.0-beta03": {
+   "jar": "sha256-vOssUG5CCZNL4BrA9FMysMEreIbuANw5DHu9+/WPQhc=",
+   "module": "sha256-8oK4GYgmtmdnQi3rdoCwW0S2XebRzccgUNWw0iW3Hnk=",
+   "pom": "sha256-vu8B5OdOsVfmWE5/8+Wkc14hAkHL//k0NRVObtFfFts="
   },
-  "org/jetbrains/compose/runtime#runtime-desktop/1.9.0": {
-   "jar": "sha256-BfVXDAp+qK3db+lQenDyk++n8UUNi5sW3DyP7iHMYSc=",
-   "module": "sha256-kszIipLLMPWv1OBsHU/jkKBCEDbOzUD7jL6ntnEp8Pc=",
-   "pom": "sha256-hRQIp7xApYgt3rUY0HU/c42x0birWJP3U1mmYfmArSk="
+  "org/jetbrains/compose/runtime#runtime-desktop/1.11.1": {
+   "jar": "sha256-vOssUG5CCZNL4BrA9FMysMEreIbuANw5DHu9+/WPQhc=",
+   "module": "sha256-IqGKlVggz4zIxmQPUf2+feRncV6suiXMU4aIPZQrzWo=",
+   "pom": "sha256-+B5PSD8GxVjXclg/KNig9bPrpZZw7phPluQOEf7lmOk="
   },
-  "org/jetbrains/compose/runtime#runtime-desktop/1.9.3": {
-   "jar": "sha256-BfVXDAp+qK3db+lQenDyk++n8UUNi5sW3DyP7iHMYSc=",
-   "module": "sha256-PTuLjN+aMF8bQuIKiUjw6NkHoyLbktmEmdCg4d18TyE=",
-   "pom": "sha256-r0eMxiql29JF+HIbQEpFZp7pk6zxaTXs7CGdq65uoZI="
+  "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.11.0-beta03": {
+   "jar": "sha256-dpbBXdI94BQNgVDxEV9Z0qIRMx47qiQ/QYR0R36Ylxw=",
+   "module": "sha256-vcQ6n/CC1Lt9SFdIEAYs6zSu+um1J1CcQVgtmUR1W4s=",
+   "pom": "sha256-o8WlwM47B3ND4gZFPtQPZeBjiP3fZVqltiUM8wKAFnA="
   },
-  "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.10.3": {
-   "jar": "sha256-63EytV3isJE3Nv3/RwUCKAPkVYEPAY7+zJ6zIwk2Ugo=",
-   "module": "sha256-JKUzujIzNXFcrGkEiFr8GQBMy/rbpZoFJcHFPI2kfwo=",
-   "pom": "sha256-D/UkSJQVoj7DPL88/+0k4uankfjwqvJNsQx/uGQylpE="
+  "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.11.1": {
+   "jar": "sha256-dpbBXdI94BQNgVDxEV9Z0qIRMx47qiQ/QYR0R36Ylxw=",
+   "module": "sha256-nT3r1HAKUl7E4JspOOwX/mkw+AccE0/FTVqmiOkHB5Q=",
+   "pom": "sha256-90MTqloWvsPZAbjYKYHNKgci/dwqxqji5Psne/hTTOI="
   },
-  "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.9.0": {
-   "jar": "sha256-lgpiL9h17cPFmPJpIQHm+STvePuvvpQR50nRhK+49i8=",
-   "module": "sha256-QT66RZ1ktkSR4mtYEPCXk5OX52278IvGKf2kYE+GR/w=",
-   "pom": "sha256-pIix1dT0+gTMEUVKX1YnmoDbgV5wv8poOu6gmovY0Wg="
+  "org/jetbrains/compose/runtime#runtime-saveable/1.11.0-beta03": {
+   "module": "sha256-fLfCEhxH1b+klQI+rs89V0ZXiIio7MWae+O2k+JABw4=",
+   "pom": "sha256-cqHT9I2uI002RzEiBL2X5HClq0KqtlPA0zkwDJsf8sM="
   },
-  "org/jetbrains/compose/runtime#runtime-saveable-desktop/1.9.3": {
-   "jar": "sha256-63EytV3isJE3Nv3/RwUCKAPkVYEPAY7+zJ6zIwk2Ugo=",
-   "module": "sha256-G9YdH5y8eupNKWgKQnuusT4/7swkssYyusJI/TqHL/k=",
-   "pom": "sha256-0WllLahBVRQ34G/mvsJ04QodSziMT40nQuehJF0re9k="
+  "org/jetbrains/compose/runtime#runtime-saveable/1.11.1": {
+   "jar": "sha256-aZ+/dGYW6ifIkD9QuV04BZDB8Hw5VaI7fAvwual51A0=",
+   "module": "sha256-cG31drzu1+6WQLpyHHWZwitc5Il23mW+vYXFaSfGtaU=",
+   "pom": "sha256-oE+rRUIsu/z5rnu8/DT4dIpbIev067rua1NAOQE5TnY="
   },
-  "org/jetbrains/compose/runtime#runtime-saveable/1.10.3": {
-   "jar": "sha256-3R9FlRnD00QOtXjsQSrQaRnJ02ucF+XNs5jWv7CMIvs=",
-   "module": "sha256-T/wCzyHJTDjKgSBPIRJtYzKeYIiD5r2PIEMua+5M6CM=",
-   "pom": "sha256-48qngqK2ebBKlYcLpy7WZJKAfxYJUOtRLgrmjynqFUo="
+  "org/jetbrains/compose/runtime#runtime/1.11.0-beta03": {
+   "module": "sha256-ppHzsuiouhmW3QExhh20VLnBSdBNwtCoyMGjB1Fhuew=",
+   "pom": "sha256-2oRUH9Bi3rS7cag6EvyJOVSETNIZusNG9p/jiWfvHn0="
   },
-  "org/jetbrains/compose/runtime#runtime-saveable/1.9.0": {
-   "module": "sha256-vND9YwqwZNKdv3HahqLATVX1lXiM+doOB8G+YZdAQlI=",
-   "pom": "sha256-0TBzcL6/xy7vRmUgeBvnPskoxvHzur2HfozlRl47Xb0="
+  "org/jetbrains/compose/runtime#runtime/1.11.1": {
+   "jar": "sha256-dJL4PPeRpyeIDFVcrCmLkd/S4MqSJK2vkiO9gj64wMw=",
+   "module": "sha256-K16b4y2ouXH+yhrdU/OfXGb/rKuBCzFfXmJzPe2wEF4=",
+   "pom": "sha256-ZiHJEdYlb9Em5YpDnSjnIWnD+XYJ2CGOeUbirgCf+Us="
   },
-  "org/jetbrains/compose/runtime#runtime-saveable/1.9.3": {
-   "module": "sha256-r8hC/ovdMqXOdBMrta6H9ziiCXUGkW0W4orbGIgFfpU=",
-   "pom": "sha256-8b9Fr9nQV0k5nvAqwnbC3LZWVz3USSdTD66/L7u7R7M="
+  "org/jetbrains/compose/ui#ui-backhandler-desktop/1.11.0-beta03": {
+   "jar": "sha256-AH+5qD+kBbi/4d2+/vPdkp3qK+QpU+ZRDORvhf9jXjA=",
+   "module": "sha256-st2Y3GD0GMpEgJVEPBABE8UHQU4R0fZTDPJAv8Cdq34=",
+   "pom": "sha256-ay4QcRVV5RVjKs11siDsbJ50qjHzKRpz6ajRNx9GGm4="
   },
-  "org/jetbrains/compose/runtime#runtime/1.10.3": {
-   "jar": "sha256-uj5+kVsZvOBaHnQzWlRijrzuRssjihu2hHrT+wRaVr0=",
-   "module": "sha256-Ma23If6jrpqbW5tS6gUY1+3NR/rricTBKuki2sFJcW0=",
-   "pom": "sha256-PzmzrJI8vG31+BwX9AYVdG3KL6DdxKIz9iawtvyhDOk="
+  "org/jetbrains/compose/ui#ui-backhandler-desktop/1.11.1": {
+   "jar": "sha256-AH+5qD+kBbi/4d2+/vPdkp3qK+QpU+ZRDORvhf9jXjA=",
+   "module": "sha256-0QGxD3yuXegOFJdTyNg7lRaSLm79BCJaM5wJvdrEVGk=",
+   "pom": "sha256-KopUqbkj11gjfd/ZXm57NxJ2gIYDJOWN0gjlqGGH+5Q="
   },
-  "org/jetbrains/compose/runtime#runtime/1.9.0": {
-   "module": "sha256-FuTMFfw9DaBRlitd4t2codlJqQ6TBF4nOCvdozGjiqM=",
-   "pom": "sha256-NYdEukMSFIl1/n0TqPnnQV1BRTdTSkFG2YDJSIBrSQA="
+  "org/jetbrains/compose/ui#ui-backhandler/1.11.0-beta03": {
+   "module": "sha256-pUJEbcbYQXGTbmYbkeiVuO12/3EGqrQub1U9e5kUowI=",
+   "pom": "sha256-UBu8+9vWLgsqdhasNuIxG8NsBM8dM3Pk2eqALZEgtg0="
   },
-  "org/jetbrains/compose/runtime#runtime/1.9.3": {
-   "module": "sha256-RoPOYaDjW2fnQuNTqNRlcXglAxwQgc+7+zojate9s9o=",
-   "pom": "sha256-4yJMwKXBCThxJVp+fmcbXoXsxKLloEg1Q7o3Tc9awq4="
-  },
-  "org/jetbrains/compose/ui#ui-backhandler-desktop/1.10.3": {
-   "jar": "sha256-G6v2j1oFy+G6jPk08OV1uw0LGEREUU5qp+wfgATJzjM=",
-   "module": "sha256-NLa5JVcTtJ2+Sb/Ny9qelSz80OnCJSBAi2I1PRN7+aE=",
-   "pom": "sha256-GckrfcqDBGLgeL8HGwQr1yRHrr5GCHbkac9nhq/h/Og="
-  },
-  "org/jetbrains/compose/ui#ui-backhandler-desktop/1.8.2": {
-   "module": "sha256-+oKZkW+3Mr9DcgP4srNf2cfIX64H4I6qh4bVYM4eo1w=",
-   "pom": "sha256-FyT0XKYO3FXhUT1ePE6xpveCcBRMREpO2aEB1Jxolpc="
-  },
-  "org/jetbrains/compose/ui#ui-backhandler-desktop/1.9.0": {
-   "jar": "sha256-N9Npc3xo770nsUuDXOKIzK5FaTzBUCy161gxo09Eo9A=",
-   "module": "sha256-9gHX8qF1m8UoF9XSmX62b7zXZWPAkHeWJzr/dTE0FAE=",
-   "pom": "sha256-qFojKagc8fJgF5STGQ9zxBByptHZJjn3MwFvCMJyAoQ="
-  },
-  "org/jetbrains/compose/ui#ui-backhandler-desktop/1.9.3": {
-   "jar": "sha256-N9Npc3xo770nsUuDXOKIzK5FaTzBUCy161gxo09Eo9A=",
-   "module": "sha256-dGExx/cfhC4n5QGSwyrcJeiH1EoLbCKVXP6787UpLPI=",
-   "pom": "sha256-wc4wH0ViEhDEOp9TSQ0itmQcRDVo+laE9LCzlKCt0iw="
-  },
-  "org/jetbrains/compose/ui#ui-backhandler/1.10.3": {
-   "jar": "sha256-oyMxtIaU52eRz0Gx4WGUfs1zscw29iksG7vHPMQRd2s=",
-   "module": "sha256-eWIJfSsQmDZ+jNRpQQU9g3U0B+Ze84aASiyu96EckmY=",
-   "pom": "sha256-IzfSkg0+wW6/WGVPDlC4wWO3cTea5aVv1WtDOzEkdA0="
-  },
-  "org/jetbrains/compose/ui#ui-backhandler/1.8.2": {
-   "module": "sha256-WR18EZK6Ag6G3DevzSi/QzFyT+bE+kfO2XWQkKrp6EU=",
-   "pom": "sha256-OfZ7iLon+G50hefUvexlDWzRkI66opCQKf7tMvxrjfI="
-  },
-  "org/jetbrains/compose/ui#ui-backhandler/1.9.0": {
-   "module": "sha256-P4hjF2qDOYRO2IuAerY9e6T/sE5FHQ2z3vOl5rike1w=",
-   "pom": "sha256-vQddtSeMju4iD5jf0PWJ1MQfVm4hcPGAPFB1e9q12+k="
+  "org/jetbrains/compose/ui#ui-backhandler/1.11.1": {
+   "jar": "sha256-ni/S+T5C4kpwidSx1VIpp2f1G1MspEqDDpjknWrd6DQ=",
+   "module": "sha256-TDymAUhUKkHYT5IkioExCUqgXOad7SLB4KkL5kIbGt4=",
+   "pom": "sha256-ro3VqyhA7HVN3PsFy4H4erLHf/NkFkA+7MWWr1PwDXQ="
   },
   "org/jetbrains/compose/ui#ui-backhandler/1.9.1": {
    "module": "sha256-Md+hhs1xs1XLG+eGB//VJW3Mg8/xFaJg6k1pdJIJJYI=",
    "pom": "sha256-jKkBhNsSyAgoKenTNle2BzBOI6o2nTbfy7sQjib+DuI="
   },
-  "org/jetbrains/compose/ui#ui-backhandler/1.9.3": {
-   "module": "sha256-dDCSIM9OhiXxSAUduWL3g+4E87ZCatgbEXKeaD8JcYE=",
-   "pom": "sha256-IRNOf+Gko/ke6PDfdCFGTa/zjLv32D1qx80oWvg+QjE="
+  "org/jetbrains/compose/ui#ui-desktop/1.11.0-beta03": {
+   "jar": "sha256-4X6Wgg+HXHKCVZwec/xE3hR2daQTEInVoOXUUJzck/0=",
+   "module": "sha256-KuTvIslxmIpC//n59gkez1naEgmMHDa19CSQgT+SX10=",
+   "pom": "sha256-VR+emWnI9fLOLHDLBdKPVQ55iabxhMleRk9bauK+NJo="
   },
-  "org/jetbrains/compose/ui#ui-desktop/1.10.3": {
-   "jar": "sha256-7IiHwDozP6N00LTEa7n7cAk3hX9AiOrqTEzA7INfdJg=",
-   "module": "sha256-QexVKoykIp1qXsMAxPIa2LVlzhBA1wRhfl0ktsMaOvE=",
-   "pom": "sha256-gtlnQ/oWPgzFcclgdyEGkmrWtR7j7zw88IGAF/MMouo="
+  "org/jetbrains/compose/ui#ui-desktop/1.11.1": {
+   "jar": "sha256-RC1KLw2VBURTtoGRME3KmVJn5y/Ny7wKY5l7/03N+Uk=",
+   "module": "sha256-J26MT45zVFyDgdA1SQcvu7hsO5j0fzqS5N3mO3hwGt4=",
+   "pom": "sha256-OBBx4nN56euSbGNATHbtIm+4+CEQ+PJkMANFYkzQwtQ="
   },
-  "org/jetbrains/compose/ui#ui-desktop/1.9.0": {
-   "jar": "sha256-c5clOZPo1RLGE7dyOeIOUFLaghj2sLZMzeLDexS1QNw=",
-   "module": "sha256-nShr23AMBOUQ6rfv8xcalPsS21In3UmIVjy2/JQAuCk=",
-   "pom": "sha256-N8qab9bThJ5l+UCCMjH05oycfYfAt19zSLSPIeU+NPw="
+  "org/jetbrains/compose/ui#ui-geometry-desktop/1.11.0-beta03": {
+   "jar": "sha256-rW1VV1cnCKzuvxqmJsWQDo/OYfBAptXZcbGtylhpq4w=",
+   "module": "sha256-7nOj5PCvwqleoDzoGQ24x2wT671Drj6TklydalfGzTE=",
+   "pom": "sha256-ZTY5x2xtRfUpFXrOe6cBbMjpD6FU2OyQjvkb4tqWZg8="
   },
-  "org/jetbrains/compose/ui#ui-desktop/1.9.3": {
-   "jar": "sha256-nJIUT23ylm1319Fmv4ktjF3ao1jAr47IJ2515CZgevQ=",
-   "module": "sha256-b7sxOjIcHw/GgZFKPgHUmydYgTTakLrXHrEsow0a5+0=",
-   "pom": "sha256-6ZxZIdDUmtwX6Xl4CPHoyT36g9Y09wef/nbT1XLGHB4="
+  "org/jetbrains/compose/ui#ui-geometry-desktop/1.11.1": {
+   "jar": "sha256-rW1VV1cnCKzuvxqmJsWQDo/OYfBAptXZcbGtylhpq4w=",
+   "module": "sha256-nkZ3Rd+KER895SD6pftnlFFEdTCrmbak58QnyEww0ig=",
+   "pom": "sha256-4TnWipls4mpydKoJrfPl9yGtjse0gnVzz7N6Bn8rMAs="
   },
-  "org/jetbrains/compose/ui#ui-geometry-desktop/1.10.3": {
-   "jar": "sha256-zb/avMrIq+8tm8BCDsDEvnqID20mstHMTiMXwNJS7ic=",
-   "module": "sha256-lgQU9dg6zOgoJoWEGcmyjj/x06R7vkEuMkXA5Y6OTjE=",
-   "pom": "sha256-SGFxRyZ0bKhvpFR5Sx+wx93SoWeVgrGlEPBmi3A4uLQ="
+  "org/jetbrains/compose/ui#ui-geometry/1.11.0-beta03": {
+   "module": "sha256-olopE+gEhIL/ohKUO1+CK/CjepWN4SEc7AG4a75IAO8=",
+   "pom": "sha256-OBu9zibKolLz+sAewF0yuJlDE0mYn9dQQCiMdgSI7MY="
   },
-  "org/jetbrains/compose/ui#ui-geometry-desktop/1.9.0": {
-   "jar": "sha256-3qD2dSTkNJY3yYXg+iIE/zVJIvOMZcyPgQZJ0Njp+uo=",
-   "module": "sha256-mZqXUb2oQ+LV/S6ZVq3Fd+FxVP5SrH6Q7LdaqTd+WUY=",
-   "pom": "sha256-ajUF56SiSisNnJqjxSFMQ5M0mQljcpLjvPjvjDR/9EM="
+  "org/jetbrains/compose/ui#ui-geometry/1.11.1": {
+   "jar": "sha256-+3sqZUb2gbwrjukuVlD83kKpHaBmnYG4g4VFISnj3eI=",
+   "module": "sha256-8frXRcmYYY5Tgm+iSVfYjhwKFueCs/ctNxYAA78MerQ=",
+   "pom": "sha256-uhc2rmi4+mQZMdUpkwXoPRCpzn0cZOWIbUyfou+AJEU="
   },
-  "org/jetbrains/compose/ui#ui-geometry-desktop/1.9.3": {
-   "jar": "sha256-3qD2dSTkNJY3yYXg+iIE/zVJIvOMZcyPgQZJ0Njp+uo=",
-   "module": "sha256-BR1eOV0OB305IVxbnXP3I+xEBjK2leBZD52i07kdnpk=",
-   "pom": "sha256-Vsnm4VvcVVQNaroiYKvRSwXw7AKbSeUvw/6EUkyAOqI="
+  "org/jetbrains/compose/ui#ui-graphics-desktop/1.11.0-beta03": {
+   "jar": "sha256-zpz6uzK04iaxG/sLU48FHu9McFAEkQzXf+KRkYnnyCo=",
+   "module": "sha256-XYAm9BcoLlhZ/01c4xnu32BMsizL+AZ+Mo8hnbEokiw=",
+   "pom": "sha256-b8ACQ2Kh20U+Af1u/RYUKEJGUZHDtWOrMjVwtE7C26o="
   },
-  "org/jetbrains/compose/ui#ui-geometry/1.10.3": {
-   "jar": "sha256-Fu6RG4s+UdacwImB2VcjoWgtV4/vr3+OilTVVVv4WSU=",
-   "module": "sha256-xH4Zjl1/zy+lNzDFORotQbkYnPbUy96nqc6lfwMaVLI=",
-   "pom": "sha256-59cSUyCMUcsEg4n9rXWoNHZ9NZmapWjP7FtPiOuuHK4="
+  "org/jetbrains/compose/ui#ui-graphics-desktop/1.11.1": {
+   "jar": "sha256-x9diDHjw5kBS8fKN9UqWmzbPSRjnlltWaHWFVWk0blk=",
+   "module": "sha256-eMKnTI0R9NfIxAE9ksmqkhML4wYloE7VvyK7UkziRcM=",
+   "pom": "sha256-sbg9CWCygnJssIXQPwsmx2CvmcQ1mgeuiIqmAOwZ+8U="
   },
-  "org/jetbrains/compose/ui#ui-geometry/1.9.0": {
-   "module": "sha256-MrCoE8bMfwFQv+MYCKP9uAm4g7Xp+yODOZ2OCbxzAvQ=",
-   "pom": "sha256-6D3wiP53lSdwbdxB5T6g/o+aE0fLCZ79FGskisUtbEc="
+  "org/jetbrains/compose/ui#ui-graphics/1.11.0-beta03": {
+   "module": "sha256-mYh8YwTbaYZyP1ghSQE/D1DGPGjl3r1rFa4KVaHxhCk=",
+   "pom": "sha256-zEM9waFzO+vESHmB5WxCeu2lbc1beO4ufZf4TOSEc2k="
   },
-  "org/jetbrains/compose/ui#ui-geometry/1.9.3": {
-   "module": "sha256-BjMaYYvV3QXSIEF7anPoQjtaluNNU4vZ9Cp80eVvl4M=",
-   "pom": "sha256-WBN7lJhIqew1/8/4sjM1kZTp19/c7GlpRY61KYllCYM="
-  },
-  "org/jetbrains/compose/ui#ui-graphics-desktop/1.10.3": {
-   "jar": "sha256-n6YENk3E3iPT+BAfL1lor6dC2EcQWl4sQbagqpEj8Rs=",
-   "module": "sha256-RFCY1FzyEXQXpn6X9Rtc7PUx6HxvYPF65DEjv92i+U0=",
-   "pom": "sha256-nFOUiy1/SAlltzXpSNgUjpl1lJ2+ILnBaZ3fDHFOPM4="
-  },
-  "org/jetbrains/compose/ui#ui-graphics-desktop/1.8.2": {
-   "module": "sha256-VKdWGvFbAenj1reymZfgvN5/VhMgTzwWaaYhBdZ5b4s=",
-   "pom": "sha256-Q8xiGyDTZPIimJ4bva2fkSoice/WjDX5SJlczGX6emo="
-  },
-  "org/jetbrains/compose/ui#ui-graphics-desktop/1.9.0": {
-   "jar": "sha256-D4vlJjaE3TrgPCPoIhoejmlypQjsmuzXd/iYR5jxUfg=",
-   "module": "sha256-zhOcM8R+fBaIL+Wg9x/ybsIgf0nbXkQs8dLsZjBYls8=",
-   "pom": "sha256-dnVmTZ/ahP6rPQ3AJn1nzNraBKiSlTzQsCY3BejgIsI="
-  },
-  "org/jetbrains/compose/ui#ui-graphics-desktop/1.9.3": {
-   "jar": "sha256-D4vlJjaE3TrgPCPoIhoejmlypQjsmuzXd/iYR5jxUfg=",
-   "module": "sha256-mTvTBodaBfZ31NpkMS0ryg+77/wTXstcr8HsORgVTho=",
-   "pom": "sha256-+OREs7Vl2nYYWQqdu8K9+EJFrtTSdhNjWfwEP7drSzc="
-  },
-  "org/jetbrains/compose/ui#ui-graphics/1.10.3": {
-   "jar": "sha256-F9QqULHO3TvO33td55ZYPt9z/SnNwgeVxeWA2x9/bgw=",
-   "module": "sha256-9828VRQnee5Xi8fP/n5xopYqaJFkXLnnbHu8h+Ie1/o=",
-   "pom": "sha256-O3KdDpbmdci9sYStwDrSU2nWlcarGhiToO5G1nQKExA="
-  },
-  "org/jetbrains/compose/ui#ui-graphics/1.8.2": {
-   "module": "sha256-ah9EbiXhhsXFXUOG42zKGnadejS0QSN6vWxmSrPrPiU=",
-   "pom": "sha256-x7BcaNcE2k5LXbxB9z2f17jwZRjHgjcQqHuohM20JU0="
-  },
-  "org/jetbrains/compose/ui#ui-graphics/1.9.0": {
-   "module": "sha256-Dvn6KFk5rYTtwfdsWt5TDFFg8GdE1PVnrZeGRui5AEY=",
-   "pom": "sha256-WTraj4T62MMvpRVLwqHpDRcjycZMCNhuvTfBsg80tp4="
+  "org/jetbrains/compose/ui#ui-graphics/1.11.1": {
+   "jar": "sha256-txpnyyuomXi00QvmmykNVvltxuCfahAgR+8S+YFB+Kc=",
+   "module": "sha256-26V/jt8uDPbelpKYFQXGi+Tnj+7yhS7c2s/JFfs68Sc=",
+   "pom": "sha256-d6XkNSQTllS293GgVBAofQEc7sjnq3roZCcE/Up5L2o="
   },
   "org/jetbrains/compose/ui#ui-graphics/1.9.1": {
    "module": "sha256-ttJkrI5cSN1PbxPZ/YGQeA8aOG5KEL2Qw7sFVlLUdAE=",
    "pom": "sha256-Fg1bjrRrnNaYMU32OM+sNDC5aC3fm1RAG3kWxjd7z6c="
   },
-  "org/jetbrains/compose/ui#ui-graphics/1.9.3": {
-   "module": "sha256-WZRUxCZS+cyjOPEzwWLfV8sOZ2EgroZFl0FrFHXmVyM=",
-   "pom": "sha256-kGv0hbcgzxNRbm4UTNyU/cVfIcF2UIfZeIWqXWWxrFA="
+  "org/jetbrains/compose/ui#ui-text-desktop/1.11.0-beta03": {
+   "jar": "sha256-wajOseh1xvG7LmfsqHePwEAn3WGPMaafiGNoy9017uw=",
+   "module": "sha256-EuEkZ75vI6v8ETW9ZK0jp0nh7z7zixrQ+XGf4IPfdyk=",
+   "pom": "sha256-AighDkf3GUAJU1iAE/VACFCsZqHNBbEGZ42PCHOA8eM="
   },
-  "org/jetbrains/compose/ui#ui-text-desktop/1.10.3": {
-   "jar": "sha256-+8pNuUW+KGuE91wMnHhCGEcL6++oMfc/CO37MpS2yOg=",
-   "module": "sha256-5gnsPt8KodhowgXbhOS4nqLaA4nCcrA0Ra7YrswPAY4=",
-   "pom": "sha256-Fd6V18ybuUy8U+g0DdryyEyq4hyID6NQ1YyYk1o+yBE="
+  "org/jetbrains/compose/ui#ui-text-desktop/1.11.1": {
+   "jar": "sha256-wajOseh1xvG7LmfsqHePwEAn3WGPMaafiGNoy9017uw=",
+   "module": "sha256-9scak1ko0uAWzsZveE52qtzUKhnXaKyBrXpFUXSgt1I=",
+   "pom": "sha256-hcEWmHvTA0hEYx1kLTP9goNcuZqc7J2bZ94s4wNDQNE="
   },
-  "org/jetbrains/compose/ui#ui-text-desktop/1.8.2": {
-   "module": "sha256-M/9uYPm7rQMunqnxIZir/MD5H0dLeclIh0NK//DE4xY=",
-   "pom": "sha256-rQhacC7enMbO4cCujRFRO1stHpu0BTJ52RjGvqZf5R0="
+  "org/jetbrains/compose/ui#ui-text/1.11.0-beta03": {
+   "module": "sha256-EJFByb8fbBTakvlbvuPKoDvbwTVJC44uv8VGzhkWS50=",
+   "pom": "sha256-KbvfF8yk+j4YokEW8GTX9AKu09BKnOmHe5tLC0MQ5X4="
   },
-  "org/jetbrains/compose/ui#ui-text-desktop/1.9.0": {
-   "jar": "sha256-M3cgBxAUajU1hOtz6/6t19ZBANNWuvW/hgh24Rgij0I=",
-   "module": "sha256-zVME5EaA/wXyqzYNOiRrCCIwhRfjAFfmYnBr15waBtk=",
-   "pom": "sha256-XEZdule7t8YccSEaS2jRBr/HRoguZBReio7Z3jwzix4="
-  },
-  "org/jetbrains/compose/ui#ui-text-desktop/1.9.3": {
-   "jar": "sha256-M3cgBxAUajU1hOtz6/6t19ZBANNWuvW/hgh24Rgij0I=",
-   "module": "sha256-UFCQKbJeoFDYbnL2wv9p3lp8j+INsjgkMs+0YVmam8A=",
-   "pom": "sha256-ltaW+gUBBy569mpdyzbuhhDyzDq0WOsCJviEuWD/ueA="
-  },
-  "org/jetbrains/compose/ui#ui-text/1.10.3": {
-   "jar": "sha256-tTfQs7sj7HlaGzVifeqpNwPP0HM7x7LcNGQV3wYkOpE=",
-   "module": "sha256-CPiJJvaVF0nsUM/1hDl4BqECAUznBWLmrje14JDCE/Y=",
-   "pom": "sha256-umj/mgjfC4sIdY/F4RQHd5CBhF2Sp3a1D2yleLqt0+c="
-  },
-  "org/jetbrains/compose/ui#ui-text/1.8.2": {
-   "module": "sha256-6MI81LMwHQAVpsgJYVty7dTJPCKarirtmfAVgJ6K56k=",
-   "pom": "sha256-gU42tOmeT+hYu07T+r4bYAfk85iqEbuFIuEKTqqgrNE="
-  },
-  "org/jetbrains/compose/ui#ui-text/1.9.0": {
-   "module": "sha256-oLAwD3XZxrvIN6sNSuRpo3WqoZwV/ZhY03BVJmJOsEc=",
-   "pom": "sha256-0l2bn0ISu2Xoqx4KsQaltKLVxIky3AAzeZ015cS+hwQ="
+  "org/jetbrains/compose/ui#ui-text/1.11.1": {
+   "jar": "sha256-XdkHaJyLQ6YQAFx/qGkYDCC2ozWhOnLM7Sw7w3di1ug=",
+   "module": "sha256-YymeOu/iaYtpeI/e/NDyz6C41ybk/Uxw0119qvexek0=",
+   "pom": "sha256-LoyJ7XELS9uTjWgqHFaY+ubFVMleMoRCAchw1mAEpNQ="
   },
   "org/jetbrains/compose/ui#ui-text/1.9.1": {
    "module": "sha256-lEvw4Xg0uVarRga3jgXG90MxqSVAcnYJ0Qq1cjd6F9k=",
    "pom": "sha256-jEFrj59tZfdBvaLWzwySOJjfJyA99Q2alHSiLNDhQig="
   },
-  "org/jetbrains/compose/ui#ui-text/1.9.3": {
-   "module": "sha256-ExDZIq34+r97g8qO6Z1bNCJnWSscNvjdANkDp/y8eUc=",
-   "pom": "sha256-7kAj5T1Z2i94hfKhuON4lhALRv/QHXrpQ9kqT10EmAo="
+  "org/jetbrains/compose/ui#ui-tooling-preview-desktop/1.11.1": {
+   "jar": "sha256-YNOpE+VQpAdiSNYhBc0Ki1xsgHzwnF3nLLr0KI3FKpA=",
+   "module": "sha256-EtH9xNyF1SIYoD3GzD4QHchll8+PW9APQvBYmUqHVXE=",
+   "pom": "sha256-tTgw2EyCDGaI3pFSDEL2l3dQ00gqJKLfOQWS86F3/9A="
   },
-  "org/jetbrains/compose/ui#ui-tooling-preview-desktop/1.10.3": {
-   "jar": "sha256-tfpvu+6l+JatKo53A71+tXTTobWrbUTb4KB1Nr1q9sQ=",
-   "module": "sha256-Bn2HL8VQfiVgupRjfTEUiVMrykfmHIa3R0FZ93SDHio=",
-   "pom": "sha256-1+SCuqTsTsJFzyvYs83q735LupSOU9C719SJXumMYb8="
+  "org/jetbrains/compose/ui#ui-tooling-preview/1.11.1": {
+   "jar": "sha256-LUfR7+TwgJksRPI+0u2ARq3O1XqneezIIW/8cA+qXjY=",
+   "module": "sha256-eI6dM0RECTpSX6AYmyTJak3yVxX5NhV11yxzuVAyttI=",
+   "pom": "sha256-n+vWaCE0Zl/E6ucbMa3AtpZcHO6nOaBH1PoovUdi06o="
   },
-  "org/jetbrains/compose/ui#ui-tooling-preview-desktop/1.9.0": {
-   "jar": "sha256-qyghEVDLh8RtZzfiyGyb9E2sZCqV7SbbLCAKDi2vJQ0=",
-   "module": "sha256-4tbglF3zQSeXbYCB7PrQm8Rja5mpceQbd1Z5xZXaWR4=",
-   "pom": "sha256-WhRl70I5MpG2qcNZ97Hkl///onhZKPDkvS8PI10diI0="
+  "org/jetbrains/compose/ui#ui-uikit/1.11.1": {
+   "jar": "sha256-axl+MetJAS/Qvc0HxVjrXVpXYkZoXpVBvD0rcTNa7ug=",
+   "module": "sha256-ITx8vB7IvSEct1kZ2OIl1uZ4/hn+llLYJFL/6D1yvFI=",
+   "pom": "sha256-vCeDFBSpwqrywW6XwY4uG3U8cWBPf87lo8Ws19SUBJg="
   },
-  "org/jetbrains/compose/ui#ui-tooling-preview/1.10.3": {
-   "jar": "sha256-YlyeD/k7ko5YYPEcUQiizVEXl7m0Om3MuznXydowUjM=",
-   "module": "sha256-eF5tJOCTxaLPQWCgX68MS5jC4myXWyduwIq6zpJEaAQ=",
-   "pom": "sha256-QfDdaCgaz0YMYwX0ybcp9t7xWBZsmPcHV7QCOxhg6g8="
+  "org/jetbrains/compose/ui#ui-unit-desktop/1.11.0-beta03": {
+   "jar": "sha256-nJGGiwvZZ9ZPcm7cMZyJXjWYcaRO9+ddxp/wytRqwNo=",
+   "module": "sha256-Nnw06UVjeFSGYuGy9kEPc7A1+NZHwCrvmbsO8knlhwQ=",
+   "pom": "sha256-ZrSIAeOXKPUA7zE6Y1kXAnCzxsMv13TuoFHjY8ZIdwU="
   },
-  "org/jetbrains/compose/ui#ui-tooling-preview/1.9.0": {
-   "module": "sha256-qLznna0FAdzZ4hCg0TrDGpiYtn0fDfJoNJuwP/RYgM0=",
-   "pom": "sha256-3Sx+EPRlVAIyJVl4J+n4B79+UEq30vkjp6C8pEffiD0="
+  "org/jetbrains/compose/ui#ui-unit-desktop/1.11.1": {
+   "jar": "sha256-nJGGiwvZZ9ZPcm7cMZyJXjWYcaRO9+ddxp/wytRqwNo=",
+   "module": "sha256-mmIUrNREcxfb9da5Xj7DopDK15Gca8W7p/n2ETT/LzY=",
+   "pom": "sha256-QWbnNxm2rjaMRwE8mTjZ032FOOmST2YhsxRj92gg83s="
   },
-  "org/jetbrains/compose/ui#ui-uikit/1.10.3": {
-   "jar": "sha256-GhOzmt860nZ/ln92S6Cg0u0qLQnu8xDyLSwDBNe9pss=",
-   "module": "sha256-+9+ULffd5/i7joGH1N33UVjQJcZ9RcJWtxKyN9o/dFw=",
-   "pom": "sha256-V+AYB3a8mq21KYxdlVEhooa122j6VOSEKdz9uHMCvGg="
+  "org/jetbrains/compose/ui#ui-unit/1.11.0-beta03": {
+   "module": "sha256-r6wiakOeSfF5efbRj/LLM03yB4qWoG+VMR0Og4uOApw=",
+   "pom": "sha256-SnhCIaTl54XVT1I+RUAFPaMkJF58mE4iPGNEl/jM66c="
   },
-  "org/jetbrains/compose/ui#ui-unit-desktop/1.10.3": {
-   "jar": "sha256-8PNDmSiz2RMvB8steoYJFpY3LryDVNFrSIMLbOFegWE=",
-   "module": "sha256-YK5I45ilQiP6fTG3IgkPicpZllR6Zw+nuCHM+4tqLPo=",
-   "pom": "sha256-kDqfw2cqSsSvdiNndU3GG9GGGJfzBwmOv4hs1Ue+bT8="
+  "org/jetbrains/compose/ui#ui-unit/1.11.1": {
+   "jar": "sha256-aoewfvoRvawJxaZZ9oLMjDc+DiwntHkWUwtzC0g9Jc4=",
+   "module": "sha256-zR8anUPkHHrlt9gVAEbd4BPjxlayx62fol4c3gI2gLg=",
+   "pom": "sha256-4CbxFkMTGn+jwtZzTgP4JX4+NS6eHxJpxDUh80EwiWs="
   },
-  "org/jetbrains/compose/ui#ui-unit-desktop/1.7.3": {
-   "module": "sha256-Tscp7nc71qd6x6bKCayPqPUFejgJjclUnYSm44ml7pw=",
-   "pom": "sha256-n/eV5ZtaFbFZMYar9pUyNlEbMkb6s9lAhURyUxTDcKs="
+  "org/jetbrains/compose/ui#ui-util-desktop/1.11.0-beta03": {
+   "jar": "sha256-c9BJMKkfuaIETywZjsbj8dphaWzLWaKI0f8KFbqwju0=",
+   "module": "sha256-TVAepThaSn0SGYWhzoQMX0kOLAiil4GTUHejKKIfwOc=",
+   "pom": "sha256-2z6lgDJyeS96EJqX/A2NOqxmLQP6DQSQlCXA7kC1rP0="
   },
-  "org/jetbrains/compose/ui#ui-unit-desktop/1.9.0": {
-   "jar": "sha256-EV99ATZ/4ddX9G8+WIJXzBLTmiIiprOXVIfKDuqGFuY=",
-   "module": "sha256-9LjQy4GaPPqID16h6LxxPe4439uRa8P1vdjd1Cp2TmY=",
-   "pom": "sha256-CwR/GlukxA3i2aels9nBgZ6rNW9kvNxUAqr8dvsiUwE="
+  "org/jetbrains/compose/ui#ui-util-desktop/1.11.1": {
+   "jar": "sha256-c9BJMKkfuaIETywZjsbj8dphaWzLWaKI0f8KFbqwju0=",
+   "module": "sha256-Y/eRvdSFrp2hu+mhKs192NlJRUi3rSxih7OCfgh99yM=",
+   "pom": "sha256-x1kLUwQm1IyRQ+KYivDfHuWzWuIPm5kjrILdiJw4L8w="
   },
-  "org/jetbrains/compose/ui#ui-unit-desktop/1.9.3": {
-   "jar": "sha256-EV99ATZ/4ddX9G8+WIJXzBLTmiIiprOXVIfKDuqGFuY=",
-   "module": "sha256-U1s9qLc15uzRKRSAOfr/FKJHar0D+kFCTObt1f7GI6w=",
-   "pom": "sha256-h/R7VdAMyoj2UW6FqESUCfBf63fPszdnoq7vYhYDJRI="
+  "org/jetbrains/compose/ui#ui-util/1.11.0-beta03": {
+   "module": "sha256-gn/7w7YxvAXdXY0D2z0Yh1+XHnNq6CrWoJFdlE2eTJU=",
+   "pom": "sha256-GyslM5cSbeSyHcleAspH9vDiXl/mtHOcVEse9hS9K5Q="
   },
-  "org/jetbrains/compose/ui#ui-unit/1.10.3": {
-   "jar": "sha256-khB/iX1tho/DPn5O3cPodMqa6yLYcSdkasjtK2drxHo=",
-   "module": "sha256-SJxKVMN8asZIn6hyu5GO9hkCQEdV6bBJ3LC3bLWBvUY=",
-   "pom": "sha256-YxwN1GEOak4O2ATvqRCf1FcfR//AHUa4T8nTI31ROXQ="
+  "org/jetbrains/compose/ui#ui-util/1.11.1": {
+   "jar": "sha256-zb1LEe9BZ7FIOHnExuxS0VLBtQfwyBdBuD+UNACoOvU=",
+   "module": "sha256-j488kSfdGBmN9aMoBH7vbum/UU9aMNo9MD8D52ryrQg=",
+   "pom": "sha256-adivGuv/w0tIRdaGyLuam1IJwDhhDFDDeBO6Az5dJhg="
   },
-  "org/jetbrains/compose/ui#ui-unit/1.7.3": {
-   "module": "sha256-12BSTnbgmCj0oa3tvG89ZGZ+g4GP9A2G8MXOANlIrWg=",
-   "pom": "sha256-DA7+AYbpUYP+JYBBmDJNLy8xdwSEV0qQlrmLrAzZ/9E="
+  "org/jetbrains/compose/ui#ui/1.11.0-beta03": {
+   "module": "sha256-dyfymNnS5zYkTMamtjeqjbHOLMLpFzNHgeSqgFuhfhc=",
+   "pom": "sha256-hRpdUDvAR5JKomYWUTCInuzTY4rXty8flov03x/TNbM="
   },
-  "org/jetbrains/compose/ui#ui-unit/1.9.0": {
-   "module": "sha256-swHbwckV5ClwaGLg09Q7DrG+0xkkd1Vns+7t2SH0g84=",
-   "pom": "sha256-xE2RKziWVTv7+ZXmf+uJZtpP1QNGm4j048Ea/KyS3HU="
-  },
-  "org/jetbrains/compose/ui#ui-unit/1.9.3": {
-   "module": "sha256-+rgCJR75HGHb76FqSNupF/yVt9sJzQohLXn6XdRCgts=",
-   "pom": "sha256-SvveVAHDpEDevrSvcszIknHUA9uL0Osi41xUW2ZhT84="
-  },
-  "org/jetbrains/compose/ui#ui-util-desktop/1.10.3": {
-   "jar": "sha256-e/yTqMrSl0zf1aLIF+MIPg48SO+Z5Nu6UeuYoUyS7S0=",
-   "module": "sha256-8IqyrOlYf+ysqau8JGl0ADCozk2vQ5Ia3vpUCjmmAnM=",
-   "pom": "sha256-UjW+9VVNVGNc5FXgzNKiUd9+aaqxNgH6OUUgsUqA69I="
-  },
-  "org/jetbrains/compose/ui#ui-util-desktop/1.9.0": {
-   "jar": "sha256-nLACuJI3L6IDCX6hHSFz3z4nEPZAzPeK2NBfPprx9xY=",
-   "module": "sha256-SUw37O+HE6n4UoBX6BbaPW3UD/kRcMZfygX7MlStozI=",
-   "pom": "sha256-6jmJnKSbL2BgJpcaZsbJcLNcpcyDNzWBssu7JcFaPtA="
-  },
-  "org/jetbrains/compose/ui#ui-util-desktop/1.9.3": {
-   "jar": "sha256-nLACuJI3L6IDCX6hHSFz3z4nEPZAzPeK2NBfPprx9xY=",
-   "module": "sha256-ouuTFJGMuOIn404uuvSTcRsPSv8nwZ+zGrr43b+8SU0=",
-   "pom": "sha256-PdzaSnSoiB1TJHwCG4oLRtpP+nnw3ISfCouvbedXCSI="
-  },
-  "org/jetbrains/compose/ui#ui-util/1.10.3": {
-   "jar": "sha256-8K3Lk6F/J7VUgxQgfbiq+Y+u1i49stIsqYxJnqK8I+0=",
-   "module": "sha256-iZWbbG68oTMcl5ZJ+xe6Gn3jJzenPyEdPCQSALsW2CE=",
-   "pom": "sha256-8CmGm5gA/E5wFJYuah+OXp6G8A8LgL0dWAGjlDSxtIo="
-  },
-  "org/jetbrains/compose/ui#ui-util/1.9.0": {
-   "module": "sha256-y6I6SuhwblUOxPj3BW225t4Q7oGB9ZEYtUGyzTWrP/g=",
-   "pom": "sha256-FXiSH0ZOLYUd47smQi7VTeiet5Tz/3Ufu4HmqbOxLW0="
-  },
-  "org/jetbrains/compose/ui#ui-util/1.9.3": {
-   "module": "sha256-vzxx0r1FrCKQFidq+zp/V58XWAUuNsv00DA7E9nb6zA=",
-   "pom": "sha256-Qko43+7YsGYRZPE8YgfwrFMJ/0zU4oSxOqJ4tqRvUvY="
-  },
-  "org/jetbrains/compose/ui#ui/1.10.3": {
-   "jar": "sha256-rKMrBWibtBFqwQ7usoOlfQy36h782XYh1GQ/XLRP7Gw=",
-   "module": "sha256-DEQJwWJayTiBvTHszB6bViPGaU+9+mFM01AP+wa9qKY=",
-   "pom": "sha256-h1fPGlIoZBUdQBf8nSGttA5ke+HIdJhbOJYvLrN4ju4="
-  },
-  "org/jetbrains/compose/ui#ui/1.9.0": {
-   "module": "sha256-M6lOgXRyk5JvQ5FMDB0G1LFrSfTKwX1geTXHLjD8yEc=",
-   "pom": "sha256-Pd5Fl2AoE2rkmsrdr7O6oWT8wpTv6sGqjaoRI0EdPPI="
-  },
-  "org/jetbrains/compose/ui#ui/1.9.3": {
-   "module": "sha256-g6n1tIgz3apLwOxywHUn9kIUMehcuMtKYjHt18kIhDE=",
-   "pom": "sha256-1BliLw4IiJAwNstVd/dor/6jEbk4+KjHNhcTfM7sqs4="
+  "org/jetbrains/compose/ui#ui/1.11.1": {
+   "jar": "sha256-Plv/lbmorLcTPvj87ENDgvcHDRyLWsPc5soSyAKlJRY=",
+   "module": "sha256-jOjNcE6cjIFg87/k3Ks2hqSNJUzQTMoyBHDn6HKifdI=",
+   "pom": "sha256-XcGk1dMXvlIA7gRZYzaxb75Jl8MDNPwhzxvfn0xDETw="
   },
   "org/jetbrains/intellij/deps#trove4j/1.0.20200330": {
    "jar": "sha256-xf1yW/+rUYRr88d9sTg8YKquv+G3/i8A0j/ht98KQ50=",
@@ -2079,16 +1694,13 @@
    "module": "sha256-b134r2M2AKa5z7D8x2SvPVEZ83Zndne5G2rugWsdMKs=",
    "pom": "sha256-X0As+413MZW5ZwUBJMnom1+EsXJGThiUkpeJv1xMLyk="
   },
-  "org/jetbrains/kotlin#kotlin-stdlib-common/2.1.21": {
-   "module": "sha256-pNj8FM7bN3mEOkf7zlIv0XPph1CRlk26wbjdeIT2wfk=",
-   "pom": "sha256-kk6Exb2AM5n2nFspYmsTKpSwBAL1X53lugGNyBHfo5M="
-  },
   "org/jetbrains/kotlin#kotlin-stdlib-common/2.3.21": {
    "module": "sha256-atL1eJGlTZamkiES91jflXzhq4o9WlchXLdPo+EF4lU=",
    "pom": "sha256-3kz/N522KFN9r20aYfAqIL8YVIDxIMq0IU/uPcMzo+g="
   },
-  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/1.8.0": {
-   "pom": "sha256-36lkSmrluJjuR1ux9X6DC6H3cK7mycFfgRKqOBGAGEo="
+  "org/jetbrains/kotlin#kotlin-stdlib-common/2.4.0": {
+   "module": "sha256-sDh/gRgDrxUU8aojhbRgw7gTxvQ861bPreavqiBpedg=",
+   "pom": "sha256-/RpljtvteICsPgoNvSCuGkbJh+QK9UTjprEQglu+/PU="
   },
   "org/jetbrains/kotlin#kotlin-stdlib-jdk7/1.8.21": {
    "jar": "sha256-M9FI2w4R3r0NkGd9KCQrztkH+cd3MAAP1ZeGcIkDnYY=",
@@ -2098,14 +1710,6 @@
    "jar": "sha256-cS9IB2Dt7uSKhDaea+ifarUjdUCLsso74U72Y/cr7jE=",
    "pom": "sha256-TXE+dTi5Kh15cX6nHPHQI1eoThFFDEbLkuMgee40224="
   },
-  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/2.1.21": {
-   "jar": "sha256-lmhGFy4QUstbNNezRkemR5mzP22oFlCfeCXFb1WJUjQ=",
-   "pom": "sha256-Dm8fi7CjxJxFYamSMAl0c4g/1bL121k5bQ5VGfJ2xDA="
-  },
-  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/2.2.20": {
-   "jar": "sha256-O9Juy20Sl4xcTgtB92yf9VH6wqXmJoQnqdKgzfilrZE=",
-   "pom": "sha256-Cukeav/wZg79os8CjFvbnnoehn4Z3CyOuuiaglcUOOI="
-  },
   "org/jetbrains/kotlin#kotlin-stdlib-jdk8/1.8.21": {
    "jar": "sha256-PbdSowB08G7mxXmEqm8n2kT00rvH9UQmUfaYjxyyt9c=",
    "pom": "sha256-ODnXKNfDCaXDaLAnC0S08ceHj/XKXTKpogT6o0kUWdg="
@@ -2113,14 +1717,6 @@
   "org/jetbrains/kotlin#kotlin-stdlib-jdk8/2.0.21": {
    "jar": "sha256-FcjArLMRSDwGjRaXUBllR0tw39gKx5WA7KOgPPUeSh0=",
    "pom": "sha256-MQ1tXGVBPjEQuUAr2AdfyuP0vlGdH9kHMTahj+cnvFc="
-  },
-  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/2.1.21": {
-   "jar": "sha256-h7T5Vt4nQBRGIn5HSsejGs/w0KgIcWDFQojB5vRqZ+Y=",
-   "pom": "sha256-9KkWH2LpUq9Q/WKhomCB8413f+zWlH/YQD8UR/hmnao="
-  },
-  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/2.2.20": {
-   "jar": "sha256-wxQXeTXY3C7ah5UHEX8l1t5W9sV+3plBaxTNYiu54J0=",
-   "pom": "sha256-NditbBnaV6t00h7YHdxYSZt8GwAlEbXoUgANuwxYq64="
   },
   "org/jetbrains/kotlin#kotlin-stdlib/2.0.21": {
    "jar": "sha256-8xzFPxBafkjAk2g7vVQ3Vh0SM5IFE3dLRwgFZBvtvAk=",
@@ -2142,6 +1738,11 @@
   },
   "org/jetbrains/kotlin#kotlin-stdlib/2.3.21/all": {
    "jar": "sha256-IZeuB3iLCdA9Xz8qLVIHOFnjUkgbtv60M145EJMRYnA="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/2.4.0": {
+   "jar": "sha256-zLFP+D+ryxFFi3mNvJgkdIzN/+7HnJq6eJ5u0c2oaxw=",
+   "module": "sha256-wkpH3L2Sldd29EO+Qdd6wkUwlgHtBTcR3uKwJUvgLbY=",
+   "pom": "sha256-gZT/eanuJKf6P3SmsXnAShhZ3ouYek8JgwVuWUUXId4="
   },
   "org/jetbrains/kotlin#kotlin-test-junit/2.3.21": {
    "jar": "sha256-VUc58oLqyhFIgq1+/82FI94mUettZRiWJEJREJkspM4=",
@@ -2184,19 +1785,20 @@
   "org/jetbrains/kotlin/plugin/serialization#org.jetbrains.kotlin.plugin.serialization.gradle.plugin/2.3.21": {
    "pom": "sha256-yIhTYIUUX6NyHzlWQ7PIDLYim9iayrC4etXTYuOd7Gk="
   },
-  "org/jetbrains/kotlinx#atomicfu-jvm/0.23.2": {
-   "jar": "sha256-EB/0P/Vj/KFnr1remMO2m/VpAQ6rdFATuE2JVQNNOzw=",
-   "module": "sha256-9frJHDc6AJjlzK5iIeibtxoUkM9qiUnuNI1G7hyo06Y=",
-   "pom": "sha256-WTrWZUvtuP1m4DrQfQxIZ6x3WjgPTiYOFI6p26pTRU4="
+  "org/jetbrains/kotlinx#atomicfu-jvm/0.28.0": {
+   "jar": "sha256-OVduxGuDQS/3opCdJMzLupBADpH5qmeyUDCbwIcuz1I=",
+   "module": "sha256-NLYjr5wlyn8uUkBvEElcRub0EINdegWMYLo2kj1oljU=",
+   "pom": "sha256-3X+tXV1LIcqdsHiHULCZe6HbaILe2G5SEvXIP8UfrOw="
   },
-  "org/jetbrains/kotlinx#atomicfu/0.23.2": {
-   "module": "sha256-UVMN4oSWehXiEcmFY8qdI1aJm4yzMXBFYLBkWt6sbcA=",
-   "pom": "sha256-QlA7zusRzeFIh3T7DE+chWM6juD6XSLTNyYMLfUKkrY="
+  "org/jetbrains/kotlinx#atomicfu/0.28.0": {
+   "jar": "sha256-09oifhoGwZVcEQFM3vpZlpqwygUHqB6ooP0Fq2xNvJw=",
+   "module": "sha256-U1VoySkaPadwXEtAU16s7fhrJI31cKxSZpyQfUu4VYs=",
+   "pom": "sha256-yboB7z5omdQs8HDVm6OdVy/FhjvylscpqZciwGR99so="
   },
-  "org/jetbrains/kotlinx#atomicfu/0.27.0": {
-   "jar": "sha256-oiN62Ro9NklP+yVW9MWYicgfeuO177RF0S7NCQs3xuk=",
-   "module": "sha256-umecB1fjmeaKmfl9c4QosvtwB3F93/Dx3uuoYrr0RpA=",
-   "pom": "sha256-e3Fbn9t9MTr8hRjV/Kv0LrSfzNbNf/RHNqEF6AmUBdg="
+  "org/jetbrains/kotlinx#kotlinx-browser/0.5.0": {
+   "jar": "sha256-pZr+a8slswkUsKLQrp7Zunrc+vmRG3MkpaW9mBUK8QI=",
+   "module": "sha256-x4N0GbmT1yzN0Te0FRZzh7l0qfbKRFDn9JuBQ+Za86Y=",
+   "pom": "sha256-ufuiXryFRH9SF9NHBll2ahP8/h2MXe3LJC6iKKEPTek="
   },
   "org/jetbrains/kotlinx#kotlinx-collections-immutable-jvm/0.4.0": {
    "jar": "sha256-12cBStDJon0n0m/Tjnr6AwruDRQTOPEIeB/wLs8v2rU=",
@@ -2211,6 +1813,9 @@
   "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.10.2": {
    "pom": "sha256-+vDGU45T3cBJmmNmTY52PCFlgLLhjnIsy98bQxpq/iY="
   },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.11.0": {
+   "pom": "sha256-9lhgvOWKK/rfBf3FFtODM0IfDjh/74fiREnAOUyA0lQ="
+  },
   "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.6.4": {
    "pom": "sha256-qyYUhV+6ZqqKQlFNvj1aiEMV/+HtY/WTLnEKgAYkXOE="
   },
@@ -2221,6 +1826,11 @@
    "jar": "sha256-XKF1s43zMf1kFVs1zYyuElH6nuNpcJs21C4KKIzM4/0=",
    "module": "sha256-6eSnS02/4PXr7tiNSfNUbD7DCJQZsg5SUEAxNcLGTFM=",
    "pom": "sha256-ZY9Xa5bIMuc4JAatsZfWTY4ul94Q6W36NwDez6KmDe8="
+  },
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.11.0": {
+   "jar": "sha256-0ddaoB3/u00cUg5n5MTn9fYXRxjny0YyQSUD8vDmBPo=",
+   "module": "sha256-WyVWU61rHyHgxGEIYF8SnjqlbtlBSEnMn1tDZEFRdSg=",
+   "pom": "sha256-3VS5eqP6uR/CT13ykWwivpQpoznS9Ft/8JIzL2wZ3Dk="
   },
   "org/jetbrains/kotlinx#kotlinx-coroutines-core-jvm/1.6.4": {
    "jar": "sha256-wkyLsnuzIMSpOHFQGn5eDGFgdjiQexl672dVE9TIIL4=",
@@ -2233,67 +1843,71 @@
    "pom": "sha256-pWM6vVNGfOuRYi2B8umCCAh3FF4LduG3V4hxVDSIXQs="
   },
   "org/jetbrains/kotlinx#kotlinx-coroutines-core/1.10.2": {
-   "jar": "sha256-MZtlMAnUnHCYL5jfKcyE/HAlsJLLBXHI51MuOtQ2ba4=",
    "module": "sha256-j+JUF35xGnzRijwG2CQvzpRfQcLMoT3BmzOuQqVDUBY=",
    "pom": "sha256-UZ2lQACW80YqTa6AeDrQUEE9S8gex65T+udq7wzL7Uw="
   },
-  "org/jetbrains/kotlinx#kotlinx-coroutines-slf4j/1.10.2": {
-   "jar": "sha256-1l3uPK+m97+u/ttJP8aLXGOr51BzT7ivkvrHoNMQFFc=",
-   "module": "sha256-B7xJACLGWAQpQfUrFxwPXOBkvWxjUikEMDmS5BegRbs=",
-   "pom": "sha256-xHdj+siNuwlDhJ0W4RucBdReYDhMfNExBe5xD7TdX7M="
+  "org/jetbrains/kotlinx#kotlinx-coroutines-core/1.11.0": {
+   "jar": "sha256-BOdzf7Fc9fOu2DqRFBpTA6CyrNiG9bvDXNvnka1j3+4=",
+   "module": "sha256-Hhl4XTRyi3Ul16d/8y6tRUfVHMekXUrETU3mCBabDA0=",
+   "pom": "sha256-QbbnjBsNEbyZ3nlTkN+eTs5k3BE/SC1uMI8bekIcHTA="
   },
-  "org/jetbrains/kotlinx#kotlinx-coroutines-swing/1.10.2": {
-   "jar": "sha256-Ar24XyDsCABEKav2iH6NDkDzq2N9dGL4F/D4q759HrU=",
-   "module": "sha256-kFK7SUS5FqUGX2GNfUb+EqTAxonQIbyYQ1v4l3WIsWQ=",
-   "pom": "sha256-zt+0Miu5cVkXrmmCCeoS3ziKuliVy7rRxWcith6EQ8A="
+  "org/jetbrains/kotlinx#kotlinx-coroutines-slf4j/1.11.0": {
+   "jar": "sha256-EENHHn1fmWgN86BWz3ZiduD+M55IAw3qUD/ByUwzdD4=",
+   "module": "sha256-eJRlqAo7YbMcJwBZ9nF42iYEXcLd85sBtFQ6YCrc9wY=",
+   "pom": "sha256-IIUKKt51yo8Ax5gblNZZ8oqyah4nuGZuS4oxAu59I40="
   },
-  "org/jetbrains/kotlinx#kotlinx-coroutines-test-jvm/1.10.2": {
-   "jar": "sha256-WQpUn4wdtZDJ2YqKIEJKH1gaNBYqNp5qa9iEzn0209c=",
-   "module": "sha256-VrIIF8xRrYi9tZwBIWsJiXzU+mmNUXu0d9kqlyp6Gq8=",
-   "pom": "sha256-Y96yqGiry+JIjrzrqnXnMbLvIQQQO4FzjnY3/JolpfM="
+  "org/jetbrains/kotlinx#kotlinx-coroutines-swing/1.11.0": {
+   "jar": "sha256-f2WP6VK1YXYRH6rYrCdSaJBGCJFdbHk3T6DID7KI+2A=",
+   "module": "sha256-I4V4NJwX/DTVylTRIi8v6VR+Yb6FgnRQ93kAFoeCcdo=",
+   "pom": "sha256-Xg1OSIf8gLFAcOMd62DIxY4lYRFvNro5rEuSAZP74Nk="
   },
-  "org/jetbrains/kotlinx#kotlinx-coroutines-test/1.10.2": {
-   "module": "sha256-QiByzuO2n2jVsVA7tmUb54lGsEw5KEocwCbM6L3x+AY=",
-   "pom": "sha256-vyXI3w7J8+rHu+5Tm2AbYBm36Z9fPzAR4ugXixQHUNs="
+  "org/jetbrains/kotlinx#kotlinx-coroutines-test-jvm/1.11.0": {
+   "jar": "sha256-1PfucdpwivRxnc620yAMj53FFG6hqBLLYo7VPGQZb5Y=",
+   "module": "sha256-g1U1kqRGrfki3Gavt1ZaOwDFKVhwjCEMKE53YdMdD4Y=",
+   "pom": "sha256-hNEZMm3mSWuPIKmFq+M9GOLSYrDPIEUwWpHrxX+x9bY="
   },
-  "org/jetbrains/kotlinx#kotlinx-datetime-jvm/0.7.1": {
-   "jar": "sha256-O4uYZXya/zvn9rS1denz+5o6H0UqgB2g9DiQFzSs2t4=",
-   "module": "sha256-2iG17aY2QqSURWXCqMhEzkj17+c0cDrFkYKglBusino=",
-   "pom": "sha256-inUEl+cFy/5Ljqu2IN1MG4woTs6taqjmMKWXefQ4l10="
+  "org/jetbrains/kotlinx#kotlinx-coroutines-test/1.11.0": {
+   "module": "sha256-uh54xTl6qTSnS555nSkOa3afYE2q2zBkD5Gub8r4HW0=",
+   "pom": "sha256-n+XNTGBseFzBT8RpLtHsbLQFPB9eZ/qLP6Ot8cca+ao="
   },
   "org/jetbrains/kotlinx#kotlinx-datetime-jvm/0.7.1-0.6.x-compat": {
    "jar": "sha256-z5zfezB0BEZXoagLwbtSgLWFRalnrH/kKxqjz5MwVxQ=",
    "module": "sha256-J/MbNeJ4XVidhYHTbJ+dZpK0S7Y3rBW2kcVGHdDF7Iw=",
    "pom": "sha256-HfcIy6EsD0qC/LdoyoPc9LgPrJ5i37QCvDYkhexE/PE="
   },
-  "org/jetbrains/kotlinx#kotlinx-datetime/0.7.1": {
-   "jar": "sha256-s9gJ0hpBtyrp3gsy3FqhlIV7F7Px7kEHv84zSE+gXQU=",
-   "module": "sha256-R0gD1qR3t8OV7otCw0zK52ZftdIx/bBa0I7TCFwk03o=",
-   "pom": "sha256-yiZ2PuBih00KtdOBzB0jBKjLm/VKUoI6wE7PA5oaMfw="
+  "org/jetbrains/kotlinx#kotlinx-datetime-jvm/0.8.0": {
+   "jar": "sha256-7kS1H4l3wvUdV1KZpPxngqs3AOukz8f61UjM7RVDk2o=",
+   "module": "sha256-X+Uto4d86+Pq52X53qh1gAmolNJEHN1uisb7pTjxcec=",
+   "pom": "sha256-ZqScb1N5kQZRonMqtzhY+IimhqVpybHL8vYAoDRYKCc="
   },
   "org/jetbrains/kotlinx#kotlinx-datetime/0.7.1-0.6.x-compat": {
    "module": "sha256-Z9HcRg78U5nv5IcpK32V8vIY4kmAamOO/FxJrqptU+I=",
    "pom": "sha256-iBoHz8YixkJPjy675W0bZLzLqjqLs43i5MCbTpcR/8g="
   },
-  "org/jetbrains/kotlinx#kotlinx-io-bytestring-jvm/0.8.2": {
-   "jar": "sha256-PagF6dov88sRn3RNzRHeahjjKluTNRjxdBi6V5XPp3U=",
-   "module": "sha256-zLwAxm9EwR025LLI3him8gFK409V2vIarbRpXuB5qjs=",
-   "pom": "sha256-FRY1+uo9dZloCkuDrXiLcAAmFtXFdnSdh+RNgxM3iQU="
+  "org/jetbrains/kotlinx#kotlinx-datetime/0.8.0": {
+   "jar": "sha256-GLd/BOpHaSZ0lwfh7LujQ2oMUJg0eAYmVTdPHxGRd6M=",
+   "module": "sha256-NHk8CZGv1NbNDfhzfVw4D7hNoJcUfHDs7BodaLBszGM=",
+   "pom": "sha256-80wfr0blQG5y5jyzjqPkPujf7THCv0FmDBLyW0Z4tak="
   },
-  "org/jetbrains/kotlinx#kotlinx-io-bytestring/0.8.2": {
-   "jar": "sha256-g0mATPWbsOhVOZ0C972+oRBKQo4zd36XG/MdG70lDT8=",
-   "module": "sha256-Rr6OR2rNrlReNYRmWuWDzEqYr8YU6Ms9DGTI1Puvk7o=",
-   "pom": "sha256-VNISwY3EmqVjNq7MgqP2u09ibxRiS0xZ3WQQifP15e0="
+  "org/jetbrains/kotlinx#kotlinx-io-bytestring-jvm/0.9.0": {
+   "jar": "sha256-Q6jJ18VGBiLE/+fnyUQ3Nq8aaRgzFrUy3nipqvqGtjY=",
+   "module": "sha256-0RrPnfTLjwsBXNARZici1ySQwIiZhCJOpW3+TCc0rqQ=",
+   "pom": "sha256-jQD25Qd/O76Bod8yi+te79AIzI+B//5srNUm8BXcnoQ="
   },
-  "org/jetbrains/kotlinx#kotlinx-io-core-jvm/0.8.2": {
-   "jar": "sha256-YQdwzIVe3xxX2fzXxp/QQK9Xra+INFBfkYBd5oB4PRM=",
-   "module": "sha256-CwPCv3wseY6naj73f/gPOYVNOFhBsefR/jbFxQpRXd0=",
-   "pom": "sha256-4gGfv0x3cnzBGQLazKfnHBBtW/ALFBrnUqYZjakVscg="
+  "org/jetbrains/kotlinx#kotlinx-io-bytestring/0.9.0": {
+   "jar": "sha256-Siu1X59CjfC/p3WsVAZAzA5tYz7Gb1IM0hV7/hC+L0g=",
+   "module": "sha256-hhg+j506LZqCiIN4+tb5V1hhk1nkXfty7K9sCwcmOFA=",
+   "pom": "sha256-1DAvY5qQe0AlwH89LuQ+3KC369+2rtWA2k0gdjQLIGc="
   },
-  "org/jetbrains/kotlinx#kotlinx-io-core/0.8.2": {
-   "jar": "sha256-KAA+vl98bQrGW53+o0RziH498p991fkEpF2WxCELZ8I=",
-   "module": "sha256-5HEw0i3rmVYcjoMa96o4FP0ZjjMKCm0RbFIVN2j9ocE=",
-   "pom": "sha256-yXvIo+dC1U/J2Vp2EfeXDYVTrM4zvhdfGnyCEK5sGiQ="
+  "org/jetbrains/kotlinx#kotlinx-io-core-jvm/0.9.0": {
+   "jar": "sha256-M4hyFI+qSkSsyb+pE0OBPVF4To1H8AWtRAZkcpf4UEE=",
+   "module": "sha256-GtjQ5PgKNhxWevWqkEYHYp5TAN7hU6RnPmUX+HayFDY=",
+   "pom": "sha256-fLkR4mPRz0Lm1zY+1WAaYaxYgZdo1SB9+RsPaeIqbOg="
+  },
+  "org/jetbrains/kotlinx#kotlinx-io-core/0.9.0": {
+   "jar": "sha256-7yi18O49Zm/1B49uGwjAjRCj/ioWkUHfx2PeluqvvK0=",
+   "module": "sha256-+QJWEkHN4gRxfh6u368DBumKuZZ5rLemY6rqgfFaNiA=",
+   "pom": "sha256-rYa7iYQNaLA2Wz0hnRACStrUxkZOBBNsakKeG7do/qY="
   },
   "org/jetbrains/kotlinx#kotlinx-serialization-bom/1.10.0": {
    "pom": "sha256-Lpc+Tfw7xjjdLmg9qVncK5eSMpe/O49gx/8A1h6sOwc="
@@ -2357,39 +1971,41 @@
    "pom": "sha256-PIUWIFu9DIjtNXCwnGS+f7WvEMGapgJFBu/Su7WSrMk="
   },
   "org/jetbrains/runtime#jbr-api/1.5.0": {
-   "jar": "sha256-ZX7efX+OF1yQmyPKoQ/NTUpREwT9k4qpzIRXtDeJUNU=",
    "pom": "sha256-/jziiqT0Ga0GcErRyoIzTQ6HFmfKWxE8UVfnUXzhMh4="
   },
-  "org/jetbrains/skiko#skiko-awt-runtime-linux-x64/0.9.22.2": {
-   "jar": "sha256-Szx19siqYLiDYsPf2Nc/hdkjc187Fb9nXEmBwm7+hdQ=",
-   "pom": "sha256-LmRnxRep8E1Z1YlRFkpMl/zMpRcs+/lXkNLF6AHzdt8="
+  "org/jetbrains/runtime#jbr-api/1.9.0": {
+   "jar": "sha256-fjcoTjO1swTuYXTcqpLblJslfMTImRyoZefa9RE9gnk=",
+   "pom": "sha256-M7lsUL7ccqirVffzfSN8X+MwugWvMRZHeKGpgP1N3E8="
   },
-  "org/jetbrains/skiko#skiko-awt-runtime-linux-x64/0.9.37.4": {
-   "jar": "sha256-7Hlt8TXZgLuxdA54n+hmioGE3yQ+TRw5mXdQMDx28Ts=",
-   "pom": "sha256-OdTTs4n7AZEljgICt7DeawkhBQm81haLJ3Slsk8u1qI="
+  "org/jetbrains/skiko#skiko-awt-runtime-linux-x64/0.144.6": {
+   "jar": "sha256-PtFr43PMu6f73Kms13R/8u09RBdkrAcKogaCyEdkpnE=",
+   "pom": "sha256-QnxTZkt/qBWscS6xKF/ZNrz2mxJE2vs0gqxm3+iSJhU="
+  },
+  "org/jetbrains/skiko#skiko-awt-runtime-macos-arm64/0.144.6": {
+   "jar": "sha256-rsN7ROjav03mIAaBRnaWVXSL45cb+GhhTl7GskCyrDU=",
+   "pom": "sha256-lL7LBJrdupIyi+3lgPP1V4sa0NAypqXWzGr/pj2Ko1Q="
   },
   "org/jetbrains/skiko#skiko-awt-runtime-macos-arm64/0.9.22.2": {
-   "jar": "sha256-iaMVIfr5mFu9SFjIYyg9HDjqXXjRd72zmqMgMoXy/QQ=",
    "pom": "sha256-sqCj8EKIL9aGPFpynw1S3TpVTWpxCYfW8PNVifDY3oY="
   },
-  "org/jetbrains/skiko#skiko-awt/0.9.22.2": {
-   "jar": "sha256-jMftbErik0zd9lAtF98w89HCNYmMggtQYrkw/qS51jw=",
-   "module": "sha256-LeiBcFkeTTs4BM1Mdr2I5XUGBjUyOyHCiXGqw9dkBk4=",
-   "pom": "sha256-GIPhVQyTdcCV4177wr2N/A1iBPddDw+KSBiRQwkzjeg="
+  "org/jetbrains/skiko#skiko-awt/0.144.5": {
+   "jar": "sha256-GeMozzmjOcDYDGSx6YbYI4B8391Eta0egJHEsDTy5S0=",
+   "module": "sha256-5omIIKF4zeZa1nb1xi92P615R/AA8U6DkATfr9VT4gI=",
+   "pom": "sha256-77/4J7kSusLfh23xkTpiyKhBVS+quOs9XoXCyik80YQ="
   },
-  "org/jetbrains/skiko#skiko-awt/0.9.37.4": {
-   "jar": "sha256-noWa65gmI/qxVrpmcceCVff14bczNPPeeTJED+1kVd8=",
-   "module": "sha256-GsTVhATzIPDdifbMoV+Bj048iehjiATfjgHtTYDFyHo=",
-   "pom": "sha256-jMcrhU+iv+z2j79TB66ZLxP+wxa6hQksYsiJswNopa8="
+  "org/jetbrains/skiko#skiko-awt/0.144.6": {
+   "jar": "sha256-V0IBIu0B/vBc20lBV2yY6mIlxSXzc4DCFqPARrK1Up0=",
+   "module": "sha256-+HxTqxf2SfK4U8c7UkTsyUMSimXTCRczRV5j3HXt1Gw=",
+   "pom": "sha256-hYumSDgVeq/Oe0lvNq3HPyLLjfk4W4Rw3G6UYp7Ckos="
   },
-  "org/jetbrains/skiko#skiko/0.9.22.2": {
-   "module": "sha256-++zojoxrB/L+lPgSKs9AfjnTsMFUzHf+OLZoPfNn9Ks=",
-   "pom": "sha256-FVBgFtv1/RvtYYDWpVe7dyeX1N2woKzKLu0OVkf69fw="
+  "org/jetbrains/skiko#skiko/0.144.5": {
+   "module": "sha256-664bLBc2v4iUWHH8gkyRG8p4KA+x2CpVkiqoyfvCVs0=",
+   "pom": "sha256-oUr6OtK+4DmVwrXu5DtCHrPNhINUuMQJIlSMhVZ5k0o="
   },
-  "org/jetbrains/skiko#skiko/0.9.37.4": {
-   "jar": "sha256-cnPbKwiENaMKptPPRl8cgtCR4cU43r13F6OXirP4l9o=",
-   "module": "sha256-cCCSHsd+yhXxDs3xbMt1fOUToR9e1KKHPh3FYJ4EYok=",
-   "pom": "sha256-yGEgoPxWVhXsdLgBnP65EnsqzDAgpx+qn3DdUswmtBk="
+  "org/jetbrains/skiko#skiko/0.144.6": {
+   "jar": "sha256-JwF75Q+DlQyJgm9TM/FkMYqcEfyA+CXTbyRL3cKTRvE=",
+   "module": "sha256-WERq+5TVVDcMFmDrn7aM1G0X3jlfrSyClHcXvU8H0q0=",
+   "pom": "sha256-VMhrNiyMumSLoJ0bRgaqgamX1hK+dnMVKeqMWkA4xzE="
   },
   "org/jsoup#jsoup/1.22.2": {
    "jar": "sha256-WWeFmW08bfFvVEwjLRCpodiHg7KkdAz1JRy2FvK+cE0=",
@@ -2404,46 +2020,45 @@
    "module": "sha256-6Vkoj94bGwUNm8CC/HhniRKNpdKFMJFGj8pQQQS99AA=",
    "pom": "sha256-16CKmbJQLwu2jNTh+YTwv2kySqogi9D3M2bAP8NUikI="
   },
-  "org/kodein/emoji#emoji-kt-jvm/2.3.0": {
-   "jar": "sha256-IrKGuhvU9tEgGWuxOSwULIZ+mPcSEVeAlIPwFKJTEwM=",
-   "module": "sha256-U6FTLaPEZpYp4Wv7eJgRyzF6zP7obk9xQLVndFt+yYs=",
-   "pom": "sha256-aoUosnvwZ46PIEyCxyS9MdGoPpBaXzAZe3rKH4HLy8U="
+  "org/kodein/emoji#emoji-kt-jvm/2.4.0": {
+   "jar": "sha256-jL2rOkWG0lnx6+ZGOy5xcp8lgjfPDgj2HRbTsnELPqI=",
+   "module": "sha256-/p9USod54adSeMfnwx/Xz1hD+oiVaAvpcFhCcjerF5k=",
+   "pom": "sha256-zqcDuPFZn7+anKB9V7ICkiIBgMw4bqKtZsvK3H3QZ2I="
   },
-  "org/kodein/emoji#emoji-kt/2.3.0": {
-   "jar": "sha256-ZIzPgkBjzdh1m/K6cnTiAvwi1LYr/S7Sr0itPRGZG3A=",
-   "module": "sha256-MNtVhttWit9Z9T3UrfKlD7DyKYbakUrrEFV7UYVfcRc=",
-   "pom": "sha256-eTDXZIhCKU7Ws7dBoXN6Q06DKRE4ZvcJ3m+wf3k4HnI="
-  },
-  "org/ow2#ow2/1.5.1": {
-   "pom": "sha256-Mh3bt+5v5PU96mtM1tt0FU1r+kI5HB92OzYbn0hazwU="
-  },
-  "org/ow2/asm#asm-tree/9.8": {
-   "jar": "sha256-FLeIDLfIXu0QHicQQy/D/7gydVMqaolNxMQJXUmtWfE=",
-   "pom": "sha256-cUnn+qDhkSlvh5ru2SCciULTmPBpjSzKGpxijy4qj3c="
-  },
-  "org/ow2/asm#asm/9.8": {
-   "jar": "sha256-h26raoPa7K1cpn65/KuwY8l7WuuM8fynqYns3hdSIFE=",
-   "pom": "sha256-wTZ8O7OD12Gef3l+ON91E4hfLu8ErntZCPaCImV7W6o="
+  "org/kodein/emoji#emoji-kt/2.4.0": {
+   "jar": "sha256-HIeMdjUt8RPRqLPckh0/r2Pg5oLsXy/Oq/yguvkL56A=",
+   "module": "sha256-hsBQw028DEH5wilvWN9qascAMhn99EHUpncrRNPyZyE=",
+   "pom": "sha256-Z36gCnKoilousQexig/VsSnPvFq9jUz1J/rfHQHpG3M="
   },
   "org/slf4j#slf4j-api/2.0.17": {
    "jar": "sha256-e3UdlSBhlU1av+1xgcH2RdM2CRtnmJFZHWMynGIuuDI=",
    "pom": "sha256-FQxAKH987NwhuTgMqsmOkoxPM8Aj22s0jfHFrJdwJr8="
   },
+  "org/slf4j#slf4j-api/2.0.18": {
+   "jar": "sha256-RFCP0VdlAGiMeQsZCs3Rb+xPjHmj4LkAr9cFA88FX1U=",
+   "pom": "sha256-bCx/LAJ3TMK3thn70t94c82tKXGJJuRHVLh/cNHrQ8s="
+  },
   "org/slf4j#slf4j-bom/2.0.17": {
    "pom": "sha256-940ntkK0uIbrg5/BArXNn+fzDzdZn/5oGFvk4WCQMek="
   },
+  "org/slf4j#slf4j-bom/2.0.18": {
+   "pom": "sha256-khmqtgFXUSbE5m4TMesrDGwXozCsTVoH480R1YCgwS0="
+  },
   "org/slf4j#slf4j-parent/2.0.17": {
    "pom": "sha256-lc1x6FLf2ykSbli3uTnVfsKy5gJDkYUuC1Rd7ggrvzs="
+  },
+  "org/slf4j#slf4j-parent/2.0.18": {
+   "pom": "sha256-CziWvtrSye2Wl+3L6h2gxUzSOKcjWDqBNYqDv7eC6fo="
   },
   "org/sonatype/oss#oss-parent/7": {
    "pom": "sha256-tR+IZ8kranIkmVV/w6H96ne9+e9XRyL+kM5DailVlFQ="
   }
  },
  "https://www.jitpack.io": {
-  "com/github/beeper/matrix-messageformat-compose#messageformat-jvm/10242add9dbeefe02c8d63e8392ffe5343becf93": {
-   "jar": "sha256-ckEsgRBqBAY9A6dQuw9nKtqFuN5n8FfCjUC7nhJa6Ho=",
-   "module": "sha256-LuZGtICVxnF4ynfHmbc7GW04Trm6/ge7eJJabMFfSEo=",
-   "pom": "sha256-PXECa+pwp7HvzEqJKWwntEFWTcZgWycta3sriIF8mFo="
+  "com/github/beeper/matrix-messageformat-compose#messageformat-jvm/5ac720dbe1a46f228df673cc2c554584731f932c": {
+   "jar": "sha256-XiHH93nwFIKa1kM6f3jhnohGGw2XRaZ7vNGt2QS8rfo=",
+   "module": "sha256-xFighI7x4M2UzBxhuUhqbY9/zMAH+9nbKnOmUxfCs5s=",
+   "pom": "sha256-Tgml1Kjr3pI9GWxuk+6llGmih5zkApnz2i/Ny4VTKUs="
   }
  }
 }

--- a/pkgs/by-name/sc/schildi-revenge/package.nix
+++ b/pkgs/by-name/sc/schildi-revenge/package.nix
@@ -14,20 +14,20 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "schildi-revenge";
-  version = "26.05.05";
+  version = "26.06.06";
 
   src = fetchFromGitHub {
     owner = "SchildiChat";
     repo = "schildi-revenge";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-B12OcryErrrFyKFweCFQWnbt/L8HvceAhBI51TlT3pg=";
+    hash = "sha256-bj2pSS+kUAs800c/OyK4fIrckB/hAWV3Iypwei8P/W4=";
     fetchSubmodules = true;
   };
 
   cargoRoot = "matrix-rust-sdk";
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src cargoRoot;
-    hash = "sha256-8HI7UtuO2eg3/Zb2PhX0jvTDaIOpCCY0EHkrsdzSEkc=";
+    hash = "sha256-ZUMX6Y2kT0CEUFVcn8fAlxoCnQT5ipAi5YqZ3Geet4A=";
   };
 
   nativeBuildInputs = [
@@ -59,14 +59,14 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    BUILD_DIR="composeApp/build/compose/binaries/main-release/app/SchildiChatRevenge"
+    BUILD_DIR="composeApp/build/compose/binaries/main-release/app/schildichat-revenge"
 
     mkdir -p $out/share/{applications,icons/scalable}
     cp -r $BUILD_DIR/bin $out/bin
     cp -r $BUILD_DIR/lib $out/lib
 
     cp -r graphics/ic_launcher_foreground.svg $out/share/icons/scalable/ic_launcher.svg
-    cp -r launcher/SchildiChatRevenge.desktop $out/share/applications
+    cp -r launcher/schildichat-revenge.desktop $out/share/applications
 
     runHook postInstall
   '';
@@ -80,7 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Matrix client for desktop written in Kotlin and using the Matrix Rust SDK";
-    mainProgram = "SchildiChatRevenge";
+    mainProgram = "schildichat-revenge";
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl3Only;
     homepage = "https://schildi.chat/revenge";


### PR DESCRIPTION
Output files in new release have other names.
New release changes user-config in way that is not backwards compatible with old releases


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
