### PR TITLE
erlang: 27.3.4.12 -> 27.3.4.13, 28.5.0.1 -> 28.5.0.2, 29.0.1 -> 29.0.2

### DIFF
--- a/pkgs/development/interpreters/erlang/27.nix
+++ b/pkgs/development/interpreters/erlang/27.nix
@@ -1,6 +1,6 @@
 genericBuilder:
 
 genericBuilder {
-  version = "27.3.4.12";
-  hash = "sha256-RnCBGuqEEJ+3kkbiVNLSb8sAh2i9SNyH9ixkqtAbjsk=";
+  version = "27.3.4.13";
+  hash = "sha256-2WF+EWq1S9IaDuUuG8IR09LjYvEq81E88oq6yFazkkM=";
 }

--- a/pkgs/development/interpreters/erlang/28.nix
+++ b/pkgs/development/interpreters/erlang/28.nix
@@ -1,6 +1,6 @@
 genericBuilder:
 
 genericBuilder {
-  version = "28.5.0.1";
-  hash = "sha256-tZQQCBDpDcrN9QX8Qwz6HqNVATck1+emGVOviEhqsLc=";
+  version = "28.5.0.2";
+  hash = "sha256-H25iMB+CvAd8yXv8jydBOCYfMm0LEwN1otRearNthYI=";
 }

--- a/pkgs/development/interpreters/erlang/29.nix
+++ b/pkgs/development/interpreters/erlang/29.nix
@@ -1,6 +1,6 @@
 genericBuilder:
 
 genericBuilder {
-  version = "29.0.1";
-  hash = "sha256-0I82VBCgA8KfdNYkNWyqcH+f0Kc6al11BAErtxfVDZo=";
+  version = "29.0.2";
+  hash = "sha256-6tpe+jCOC1V2SOPMH1J8DHVXQqR4pqEjIiAcSitn8Hc=";
 }

--- a/pkgs/development/interpreters/erlang/generic-builder.nix
+++ b/pkgs/development/interpreters/erlang/generic-builder.nix
@@ -21,7 +21,6 @@
   parallelBuild ? true,
 
   fetchFromGitHub,
-  fetchpatch2,
   gawk,
   gnum4,
   gnused,
@@ -111,15 +110,6 @@ stdenv.mkDerivation {
   ++ optionals odbcSupport [ unixodbc ]
   ++ optionals javacSupport [ openjdk11 ]
   ++ optionals enableSystemd [ systemd ];
-
-  patches = lib.optionals (!wxSupport && major == "27") [
-    # https://github.com/erlang/otp/pull/11162
-    (fetchpatch2 {
-      name = "otp-27-doc-target-fix.patch";
-      url = "https://github.com/erlang/otp/commit/7ce587b61a2557fca79f1c130794abf834f37ee1.patch?full_index=1";
-      hash = "sha256-Ce6tWUzeF6TQMxus7ultxG2piFllw/xa5IPLCxSd024=";
-    })
-  ];
 
   # disksup requires a shell
   postPatch = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The linked github and cve numbers don't appear to work, but this does in fact appear to be security releases.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
