### PR TITLE
nixos/xdg/autostart: actually disable generation of autostart units

### DIFF
--- a/nixos/modules/config/xdg/autostart.nix
+++ b/nixos/modules/config/xdg/autostart.nix
@@ -4,21 +4,33 @@
     teams = [ lib.teams.freedesktop ];
   };
 
-  options = {
-    xdg.autostart.enable = lib.mkOption {
-      type = lib.types.bool;
-      default = true;
-      description = ''
-        Whether to install files to support the
-        [XDG Autostart specification](https://specifications.freedesktop.org/autostart-spec/latest).
-      '';
-    };
+  options.xdg.autostart = {
+    enable =
+      lib.mkEnableOption "auto-starting of desktop applications according to the [XDG Autostart specification](https://specifications.freedesktop.org/autostart-spec/latest)."
+      // lib.mkOption {
+        default = true;
+      };
+    install =
+      lib.mkEnableOption ''
+        install desktop files following the [XDG Autostart specification](https://specifications.freedesktop.org/autostart-spec/latest) into `/etc/xdg/autostart/`.
+
+        These are handled by your desktop environment or [`systemd-xdg-autostart-generator`](https://www.freedesktop.org/software/systemd/man/latest/systemd-xdg-autostart-generator.html).
+      ''
+      // lib.mkOption {
+        default = true;
+      };
   };
 
-  config = lib.mkIf config.xdg.autostart.enable {
-    environment.pathsToLink = [
+  config = {
+    # FIXME this does not actually work because "/etc/xdg" is linked
+    # unconditionally in `nixos/modules/config/system-path.nix`
+    environment.pathsToLink = lib.mkIf config.xdg.autostart.install [
       "/etc/xdg/autostart"
     ];
-  };
 
+    # On by default
+    systemd.user.generators.systemd-xdg-autostart-generator = lib.mkIf (!config.xdg.autostart.enable) (
+      lib.mkDefault "/dev/null"
+    );
+  };
 }


### PR DESCRIPTION
This did not actually do anything when set to false.

Fixes https://github.com/NixOS/nixpkgs/issues/380166

I split this into two options that are independent of each other:

1. Whether to link the `systemPackages`' autostarts
2. Whether to enable their interpretation

(You can have interpretation of user-provided autostarts and the user could interpret the system-provided autostarts.)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
