### PR TITLE
blesh: build from source

### DIFF
--- a/pkgs/by-name/bl/blesh/fix-cache-invalidation.patch
+++ b/pkgs/by-name/bl/blesh/fix-cache-invalidation.patch
@@ -1,0 +1,11 @@
+--- a/ble.pp
++++ b/ble.pp
+@@ -2063,7 +2063,7 @@
+     return 1
+   fi
+ 
+-  local ver=${BLE_VERSINFO[0]}.${BLE_VERSINFO[1]}
++  local ver=$BLE_VERSION
+   ble/base/.create-user-directory _ble_base_cache "$cache_dir/blesh/$ver"
+ }
+ function ble/base/initialize-cache-directory {

--- a/pkgs/by-name/bl/blesh/package.nix
+++ b/pkgs/by-name/bl/blesh/package.nix
@@ -10,14 +10,14 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "blesh";
-  version = "0.4.0-devel3-unstable-2026-03-10";
+  version = "0.4.0-devel3-unstable-2026-05-28";
 
   src = fetchFromGitHub {
     owner = "akinomyoga";
     repo = "ble.sh";
-    rev = "b99cadb4520a1fdec0067fdc007b39cc905ecbad";
+    rev = "f38850cb0add16f110341a517ff7c849adb43e57";
     fetchSubmodules = true;
-    hash = "sha256-LXDow/4yv3V0Liy12bXQ1qwO5z4u0equRO9xeJaDaWo=";
+    hash = "sha256-EtOCZvUkzstXaT7N9qe+oT7+7ExlREsobzY+ylNy/7Y=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/bl/blesh/package.nix
+++ b/pkgs/by-name/bl/blesh/package.nix
@@ -1,36 +1,56 @@
 {
   lib,
   stdenvNoCC,
-  fetchzip,
-  runtimeShell,
+  fetchFromGitHub,
   bashInteractive,
-  glibcLocales,
+  gawk,
+  runtimeShell,
+  unstableGitUpdater,
 }:
 
-stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "blesh";
   version = "0.4.0-devel3-unstable-2026-03-10";
 
-  src = fetchzip {
-    url = "https://github.com/akinomyoga/ble.sh/releases/download/nightly/ble-nightly-20260310%2Bb99cadb.tar.xz";
-    name = "ble-nightly-20260310+b99cadb.tar.xz";
-    sha256 = "sha256-rJnSEY7J4wfy8dnL9Bg59u0epPe0HL1J7piPbkNyes0=";
+  src = fetchFromGitHub {
+    owner = "akinomyoga";
+    repo = "ble.sh";
+    rev = "b99cadb4520a1fdec0067fdc007b39cc905ecbad";
+    fetchSubmodules = true;
+    hash = "sha256-LXDow/4yv3V0Liy12bXQ1qwO5z4u0equRO9xeJaDaWo=";
   };
 
-  dontBuild = true;
+  nativeBuildInputs = [
+    gawk
+  ];
+
+  # Fix the cache invalidation not working; see
+  # https://github.com/NixOS/nixpkgs/pull/521218#issuecomment-4641313131
+  postPatch = ''
+    substituteInPlace ble.pp \
+      --replace-fail \
+        'local ver=''${BLE_VERSINFO[0]}.''${BLE_VERSINFO[1]}' \
+        'local ver=$BLE_VERSION'
+  '';
+
+  # ble.sh embeds the commit id, normally read from .git, which fetchFromGitHub omits.
+  makeFlags = [
+    "PREFIX=$(out)"
+    "BLE_GIT_COMMIT_ID=${builtins.substring 0 7 finalAttrs.src.rev}"
+    "BLE_GIT_BRANCH=master"
+  ];
 
   doCheck = true;
-  nativeCheckInputs = [
-    bashInteractive
-    glibcLocales
-  ];
-  preCheck = "export LC_ALL=en_US.UTF-8";
+  # auto-detection runs `make -n check` without makeFlags, which fails without BLE_GIT_COMMIT_ID
+  checkTarget = "check";
+  nativeCheckInputs = [ bashInteractive ];
+  preCheck = ''
+    export HOME=$TMPDIR
+    # upstream skips its flaky sleep-timing tests under GitHub CI
+    export CI=true GITHUB_ACTION=nix
+  '';
 
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p "$out/share/blesh/lib"
-
+  postInstall = ''
     cat <<EOF >"$out/share/blesh/lib/_package.sh"
     _ble_base_package_type=nix
 
@@ -40,12 +60,6 @@ stdenvNoCC.mkDerivation {
     }
     EOF
 
-    cp -rv $src/* $out/share/blesh
-
-    runHook postInstall
-  '';
-
-  postInstall = ''
     mkdir -p "$out/bin"
     cat <<EOF >"$out/bin/blesh-share"
     #!${runtimeShell}
@@ -54,7 +68,17 @@ stdenvNoCC.mkDerivation {
     echo "$out/share/blesh"
     EOF
     chmod +x "$out/bin/blesh-share"
+
+    rm -rf "$out/share/blesh/cache.d" "$out/share/blesh/run"
   '';
+
+  # tagFormat skips the "nightly"/"spike-*" tags; the newest tag is too far
+  # behind HEAD for shallow deepening, so clone fully.
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "v";
+    tagFormat = "v*";
+    shallowClone = false;
+  };
 
   meta = {
     homepage = "https://github.com/akinomyoga/ble.sh";
@@ -67,4 +91,4 @@ stdenvNoCC.mkDerivation {
     ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/bl/blesh/package.nix
+++ b/pkgs/by-name/bl/blesh/package.nix
@@ -24,14 +24,15 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     gawk
   ];
 
-  # Fix the cache invalidation not working; see
-  # https://github.com/NixOS/nixpkgs/pull/521218#issuecomment-4641313131
-  postPatch = ''
-    substituteInPlace ble.pp \
-      --replace-fail \
-        'local ver=''${BLE_VERSINFO[0]}.''${BLE_VERSINFO[1]}' \
-        'local ver=$BLE_VERSION'
-  '';
+  patches = [
+    # Fix the cache invalidation not working; see
+    # https://github.com/NixOS/nixpkgs/pull/521218#issuecomment-4641313131
+    ./fix-cache-invalidation.patch
+    # ble.sh reaches a runtime-dir fallback under the install base when the
+    # others are unusable (always on WSL); see
+    # https://github.com/NixOS/nixpkgs/pull/521218#issuecomment-4686973408
+    ./skip-readonly-runtime-dir.patch
+  ];
 
   # ble.sh embeds the commit id, normally read from .git, which fetchFromGitHub omits.
   makeFlags = [

--- a/pkgs/by-name/bl/blesh/skip-readonly-runtime-dir.patch
+++ b/pkgs/by-name/bl/blesh/skip-readonly-runtime-dir.patch
@@ -1,0 +1,10 @@
+--- a/ble.pp
++++ b/ble.pp
+@@ -1934,6 +1934,7 @@
+ function ble/base/initialize-runtime-directory/.base {
+   local tmp_dir=$_ble_base/run
+   if [[ ! -d $tmp_dir ]]; then
++    [[ -w $_ble_base ]] || return 1
+     ble/bin/mkdir -p "$tmp_dir" || return 1
+     ble/bin/chmod a+rwxt "$tmp_dir" || return 1
+   fi


### PR DESCRIPTION
Follow-up to #521218: switch `src` from the prebuilt nightly tarball to
`fetchFromGitHub` and build from source, wire up
`passthru.updateScript`, and fix the stale-cache issue reported after
that PR landed. I'm also adding myself as maintainer, deferred from
#521218 to this follow-up (see the discussion there).

This doesn't change which codebase the package follows: the nightly
tarball is itself a CI build of master, so building from master tracks
exactly what the package already shipped. Master-tracking also has
upstream precedent: the AUR `blesh-git` package, maintained by the
ble.sh author themself, builds from master the same way.

Building from source enables automated updates: the nightly tarball
embeds a date and commit hash in its filename, which update tooling
cannot predict, while `fetchFromGitHub` works mechanically with
`unstableGitUpdater`. The version-bump commit in this PR was produced
by running the update script, so the full flow (update, build, test)
is exercised here. I went with `unstableGitUpdater` rather than the
`nix-update-script` invocation I sketched in #521218, because its
`tagFormat` cleanly excludes the moving `nightly` and `spike-*` tags
and it produces the conventional `0.4.0-devel3-unstable-<date>`
version. `shallowClone = false` because the newest `v*` tag is years
behind HEAD, so progressive deepening would fetch full history anyway.

It also means the test suite actually runs now. The old
`doCheck = true` was silently a no-op: the tarball ships no Makefile,
so checkPhase printed "no Makefile or custom checkPhase, doing nothing"
and skipped everything. The new package runs upstream's suite on every
build; all 27 sections pass with 0 failures on aarch64-darwin and
aarch64-linux. `checkTarget = "check"` is required because stdenv's
auto-detection probes `make -n check` without makeFlags, and ble.sh's
GNUmakefile aborts at parse time when `BLE_GIT_COMMIT_ID` is missing.
Upstream's two timing-sensitive sleep tests are flaky in sandboxes;
upstream itself skips them on GitHub CI behind a
`CI=true && GITHUB_ACTION` guard, which `preCheck` reuses.

The `ble.pp` patch addresses the cursor disappearance reported in
https://github.com/NixOS/nixpkgs/pull/521218#issuecomment-4639643655
(analysis in
https://github.com/NixOS/nixpkgs/pull/521218#issuecomment-4641313131):
ble.sh invalidates caches by mtime comparison and keys the cache
directory by MAJOR.MINOR only. Nix normalizes store mtimes to 1970, so
invalidation never fires, and old and new packages share
`~/.cache/blesh/0.4/`. A terminal cache from 0.4.0-devel3 (predating
`_ble_term_rmcivis`) survives the upgrade and the new code hides the
cursor without restoring it. The patch keys the cache by the full
version string (commit id included), so every update gets a fresh
directory. Stale per-version directories accumulate (~100 kB each).

User-visible changes: docs move from `share/blesh/doc/` to
`share/doc/blesh/` (the standard location used by `make install`);
`ble --version` reports `0.4.0-devel4+<short rev>` while the package
version stays tag-based per the `-unstable` convention; the empty
`cache.d/` and `run/` directories are no longer shipped (at runtime
ble.sh prefers the XDG paths; the in-store fallbacks are read-only and
unusable anyway). `share/blesh/ble.sh`, `contrib/`, and `blesh-share`
are unchanged.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
