### PR TITLE
python3Packages.nptyping: migrate to pyproject, enable __structuredAttrs, use finalAttrs

### DIFF
--- a/pkgs/development/python-modules/nptyping/default.nix
+++ b/pkgs/development/python-modules/nptyping/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   pytestCheckHook,
+  setuptools,
   beartype,
   invoke,
   numpy,
@@ -13,7 +14,7 @@
 buildPythonPackage (finalAttrs: {
   pname = "nptyping";
   version = "2.5.0";
-  format = "setuptools";
+  pyproject = true;
 
   __structuredAttrs = true;
 
@@ -28,7 +29,9 @@ buildPythonPackage (finalAttrs: {
     ./numpy-2.0-compat.patch
   ];
 
-  propagatedBuildInputs = [ numpy ];
+  build-system = [ setuptools ];
+
+  dependencies = [ numpy ];
 
   nativeCheckInputs = [
     beartype

--- a/pkgs/development/python-modules/nptyping/default.nix
+++ b/pkgs/development/python-modules/nptyping/default.nix
@@ -10,7 +10,7 @@
   feedparser,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "nptyping";
   version = "2.5.0";
   format = "setuptools";
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "ramonhagenaars";
     repo = "nptyping";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-hz4YrcvARCAA7TXapmneIwle/F4pzcIYLPSmiFHC0VQ=";
   };
 
@@ -63,11 +63,11 @@ buildPythonPackage rec {
   meta = {
     description = "Type hints for numpy";
     homepage = "https://github.com/ramonhagenaars/nptyping";
-    changelog = "https://github.com/ramonhagenaars/nptyping/blob/v${version}/HISTORY.md";
+    changelog = "https://github.com/ramonhagenaars/nptyping/blob/v${finalAttrs.version}/HISTORY.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       bcdarwin
       pandapip1
     ];
   };
-}
+})

--- a/pkgs/development/python-modules/nptyping/default.nix
+++ b/pkgs/development/python-modules/nptyping/default.nix
@@ -15,6 +15,8 @@ buildPythonPackage (finalAttrs: {
   version = "2.5.0";
   format = "setuptools";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "ramonhagenaars";
     repo = "nptyping";


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974
- use `finalAttrs`
- enable `__structuredAttrs`
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
