### PR TITLE
nixos/system-path: don't link `/etc/xdg/` uncoditionally

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -10,6 +10,7 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- Paths under `/etc/xdg/` from packages in `environment.systemPackages` are no longer linked into the global `/etc/` by default. Modules depending on such directories must declare them explicitly using `environment.pathsToLink`.
 - `databricks-cli` has been updated from `0.290.2` to `1.x.x`, the first major release. OAuth tokens for interactive logins (`auth_type = databricks-cli`) are now stored in the OS-native secure store by default (Secret Service on Linux) instead of `~/.databricks/token-cache.json`; cached tokens from older versions are not migrated, so run `databricks auth login` once per profile after upgrading. To keep the previous file-backed storage, set `DATABRICKS_AUTH_STORAGE=plaintext` or add `auth_storage = plaintext` under `[__settings__]` in `~/.databrickscfg`. Additionally, the `vector_search_endpoints` DABs resource renamed `min_qps` to `target_qps` (and the `vector-search-endpoints` command renamed `--min-qps` to `--target-qps`). See the [upstream changelog](https://github.com/databricks/cli/blob/main/CHANGELOG.md) for details.
 
 - `hurl` has been updated to `8.x.x` which has some breaking changes. See [upstream changelog](https://github.com/Orange-OpenSource/hurl/releases/tag/8.0.0) for details.
@@ -63,4 +64,3 @@
 ### Additions and Improvements {#sec-nixpkgs-release-26.11-lib-additions-improvements}
 
 - Create the first release note entry in this section!
-

--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -187,7 +187,6 @@ in
 
     environment.pathsToLink = [
       "/bin"
-      "/etc/xdg"
       "/etc/gtk-2.0"
       "/etc/gtk-3.0"
       "/lib" # FIXME: remove and update debug-info.nix

--- a/nixos/modules/config/xdg/autostart.nix
+++ b/nixos/modules/config/xdg/autostart.nix
@@ -4,21 +4,33 @@
     teams = [ lib.teams.freedesktop ];
   };
 
-  options = {
-    xdg.autostart.enable = lib.mkOption {
-      type = lib.types.bool;
-      default = true;
-      description = ''
-        Whether to install files to support the
-        [XDG Autostart specification](https://specifications.freedesktop.org/autostart-spec/latest).
-      '';
-    };
+  options.xdg.autostart = {
+    enable =
+      lib.mkEnableOption "auto-starting of desktop applications according to the [XDG Autostart specification](https://specifications.freedesktop.org/autostart-spec/latest)."
+      // lib.mkOption {
+        default = true;
+      };
+    install =
+      lib.mkEnableOption ''
+        install desktop files following the [XDG Autostart specification](https://specifications.freedesktop.org/autostart-spec/latest) into `/etc/xdg/autostart/`.
+
+        These are handled by your desktop environment or [`systemd-xdg-autostart-generator`](https://www.freedesktop.org/software/systemd/man/latest/systemd-xdg-autostart-generator.html).
+      ''
+      // lib.mkOption {
+        default = true;
+      };
   };
 
-  config = lib.mkIf config.xdg.autostart.enable {
-    environment.pathsToLink = [
+  config = {
+    # FIXME this does not actually work because "/etc/xdg" is linked
+    # unconditionally in `nixos/modules/config/system-path.nix`
+    environment.pathsToLink = lib.mkIf config.xdg.autostart.install [
       "/etc/xdg/autostart"
     ];
-  };
 
+    # On by default
+    systemd.user.generators.systemd-xdg-autostart-generator = lib.mkIf (!config.xdg.autostart.enable) (
+      lib.mkDefault "/dev/null"
+    );
+  };
 }

--- a/nixos/modules/config/xdg/autostart.nix
+++ b/nixos/modules/config/xdg/autostart.nix
@@ -22,8 +22,6 @@
   };
 
   config = {
-    # FIXME this does not actually work because "/etc/xdg" is linked
-    # unconditionally in `nixos/modules/config/system-path.nix`
     environment.pathsToLink = lib.mkIf config.xdg.autostart.install [
       "/etc/xdg/autostart"
     ];


### PR DESCRIPTION
This is the root cause of https://github.com/NixOS/nixpkgs/issues/380166

This was added in 825923a051366cb44fbe9e65869bd2dfea9dfac8 which does not look
correct to me. I checked my system and all relevant sub-directories of
`/etc/xdg/` are explicitly declared to be linked.

Since then people may have started depending on this, so this is
a breaking change.

(Depends on https://github.com/NixOS/nixpkgs/pull/530372.)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
