### PR TITLE
termtekst: migrate to pyproject; use tag, hash and --replace-fail

### DIFF
--- a/pkgs/by-name/te/termtekst/package.nix
+++ b/pkgs/by-name/te/termtekst/package.nix
@@ -15,8 +15,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
   src = fetchFromGitHub {
     owner = "zevv";
     repo = "termtekst";
-    rev = "v${finalAttrs.version}";
-    sha256 = "1gm7j5d49a60wm7px82b76f610i8pl8ccz4r6qsz90z4mp3lyw9b";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-K3FPx63kg/Q1Npl8xhC9KIJgnDlLoH5P5cCoRFqRp74=";
   };
 
   dependencies = with python3Packages; [

--- a/pkgs/by-name/te/termtekst/package.nix
+++ b/pkgs/by-name/te/termtekst/package.nix
@@ -8,7 +8,9 @@
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "termtekst";
   version = "1.0";
-  format = "setuptools";
+  pyproject = true;
+
+  build-system = with python3Packages; [ setuptools ];
 
   src = fetchFromGitHub {
     owner = "zevv";
@@ -17,7 +19,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     sha256 = "1gm7j5d49a60wm7px82b76f610i8pl8ccz4r6qsz90z4mp3lyw9b";
   };
 
-  propagatedBuildInputs = with python3Packages; [
+  dependencies = with python3Packages; [
     ncurses
     requests
   ];

--- a/pkgs/by-name/te/termtekst/package.nix
+++ b/pkgs/by-name/te/termtekst/package.nix
@@ -26,9 +26,9 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   patchPhase = ''
     substituteInPlace setup.py \
-      --replace "assert" "assert 1==1 #"
+      --replace-fail "assert" "assert 1==1 #"
     substituteInPlace src/tt \
-      --replace "locale.setlocale" "#locale.setlocale"
+      --replace-fail "locale.setlocale" "#locale.setlocale"
   '';
 
   meta = {


### PR DESCRIPTION
Part of #515974
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
