### PR TITLE
macaulay2: 1.26.05->1.26.06

### DIFF
--- a/pkgs/by-name/ma/macaulay2/package.nix
+++ b/pkgs/by-name/ma/macaulay2/package.nix
@@ -64,19 +64,19 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "macaulay2";
-  version = "1.26.05";
+  version = "1.26.06";
 
   src = fetchFromGitHub {
     owner = "Macaulay2";
     repo = "M2";
     tag = "release-${finalAttrs.version}";
-    hash = "sha256-UiPLownaFtuYFUlZhBl+Nl/sRZRhG9OUwepZtFTkTqc";
+    hash = "sha256-2e39qzBO63Ft+yw+tJChLsupeinalTkDwXp3WBF2wms=";
     fetchSubmodules = true;
   };
 
   docs = fetchurl {
     url = "https://macaulay2.com/Downloads/OtherSourceCode/Macaulay2-docs-${finalAttrs.version}.tar.gz";
-    hash = "sha256-rz9b7HvxfxI978yM9wE7XvLu7DO38i/amokXBU0RjSg=";
+    hash = "sha256-0+ilvDh87Gmwzx0bLhT6nnadcPwgU3uB6pKhP9VqW0Q=";
   };
 
   buildInputs = [
@@ -152,16 +152,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     sed -i 's/AC_SUBST(REL,.*uname -r.*)/AC_SUBST(REL,"")/' configure.ac
-    substituteInPlace Macaulay2/packages/DeterminantalRepresentations.m2 \
-      --replace-fail "eps = 1e-15" "eps = 1e-14"
-  ''
-  # TODO remove in v1.26.06 (see https://github.com/Macaulay2/M2/pull/4334)
-  # ForeignFunctions.m2 uses `brew --prefix` to discover potential library paths,
-  # which fails when Homebrew is not installed.
-  # We patch it to return an empty path instead, which should be harmless
-  + ''
-    substituteInPlace Macaulay2/packages/ForeignFunctions.m2 \
-      --replace-fail 'get "!brew --prefix"' 'try get "!brew --prefix" else ""'
+    substituteInPlace configure.ac \
+      --replace-fail "[\$gfan_version], [ge], [0.8]" "[\$gfan_version], [ge], [0.6]"
+    substituteInPlace Macaulay2/packages/gfanInterface.m2 \
+      --replace-fail 'MinimumVersion => ("0.8"' 'MinimumVersion => ("0.6"'
   '';
 
   preConfigure = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
This is just a simple version upgrade.  There were a couple removals of things fixed (by nixpkgs people) in upstream and we now have to force Macaulay2 to accept non-beta `gfan` (Debian is doing the same thing).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
