### PR TITLE
maintainers: remove berce

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3438,12 +3438,6 @@
     githubId = 20448408;
     keys = [ { fingerprint = "D446 E58D 87A0 31C7 EC15  88D7 B461 2924 45C6 E696"; } ];
   };
-  berce = {
-    email = "bert.moens@gmail.com";
-    github = "berce";
-    githubId = 10439709;
-    name = "Bert Moens";
-  };
   bergey = {
     email = "bergey@teallabs.org";
     github = "bergey";

--- a/pkgs/by-name/li/libacr38u/package.nix
+++ b/pkgs/by-name/li/libacr38u/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation {
     '';
     homepage = "https://www.acs.com.hk";
     license = lib.licenses.lgpl2Plus;
-    maintainers = with lib.maintainers; [ berce ];
+    maintainers = [ ];
     platforms = with lib.platforms; unix;
   };
 }

--- a/pkgs/by-name/or/orca/package.nix
+++ b/pkgs/by-name/or/orca/package.nix
@@ -128,7 +128,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
       Needs `services.gnome.at-spi2-core.enable = true;` in `configuration.nix`.
     '';
-    maintainers = with lib.maintainers; [ berce ];
     teams = [ lib.teams.gnome ];
     license = lib.licenses.lgpl21;
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/rh/rhvoice/package.nix
+++ b/pkgs/by-name/rh/rhvoice/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Free and open source speech synthesizer for Russian language and others";
     homepage = "https://github.com/Olga-Yakovleva/RHVoice/wiki";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ berce ];
+    maintainers = [ ];
     platforms = with lib.platforms; all;
     mainProgram = "RHVoice-test";
   };

--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -157,10 +157,7 @@ stdenv.mkDerivation (finalAttrs: {
       "Common interface to speech synthesis" + lib.optionalString libsOnly " - client libraries only";
     homepage = "https://devel.freebsoft.org/speechd";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [
-      berce
-      jtojnar
-    ];
+    maintainers = with lib.maintainers; [ jtojnar ];
     # TODO: remove checks for `withPico` once PR #375450 is merged
     platforms = if withAlsa || withPico then lib.platforms.linux else lib.platforms.unix;
     mainProgram = "speech-dispatcher";


### PR DESCRIPTION
## Reasons

- Last commented in [December 2017](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Aberce)
- Hasn't created any PRs / Issues since [December 2017](https://github.com/NixOS/nixpkgs/issues?q=author%3Aberce)
- About 100 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Aberce%20-commenter%3Aberce%20-author%3Aberce%20-reviewed-by%3Aberce) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] libacr38u
- [ ] rhvoice