### PR TITLE
xtb: init at 6.7.1

### DIFF
--- a/pkgs/by-name/cp/cpcm-x/cmake-config-find-numsa.patch
+++ b/pkgs/by-name/cp/cpcm-x/cmake-config-find-numsa.patch
@@ -1,0 +1,15 @@
+diff --git a/config/config.cmake.in b/config/config.cmake.in
+index e5e4f6b..d41c070 100644
+--- a/config/config.cmake.in
++++ b/config/config.cmake.in
+@@ -23,6 +23,10 @@ if(NOT TARGET "@PROJECT_NAME@::@PROJECT_NAME@")
+ 
+   include(CMakeFindDependencyMacro)
+ 
++  if(NOT TARGET "numsa::numsa")
++    find_dependency("numsa" REQUIRED)
++  endif()
++
+   if(NOT TARGET "mctc-lib::mctc-lib")
+     find_dependency("mctc-lib" REQUIRED)
+   endif()

--- a/pkgs/by-name/cp/cpcm-x/package.nix
+++ b/pkgs/by-name/cp/cpcm-x/package.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  buildType ? "meson",
+
+  gfortran,
+  pkg-config,
+  python3,
+  meson,
+  ninja,
+  cmake,
+
+  # buildInputs
+  blas,
+  lapack,
+  test-drive,
+
+  # propagatedBuildInputs
+  mctc-lib,
+  numsa,
+  toml-f,
+
+  nix-update-script,
+}:
+
+assert (
+  builtins.elem buildType [
+    "meson"
+    "cmake"
+  ]
+);
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cpcm-x";
+  version = "1.1.0";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "grimme-lab";
+    repo = "CPCM-X";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-FyPUECbcqUHoGq1LASvPF4qSUKQ5N/y1itq8e2wGliE=";
+  };
+
+  patches = [
+    # The installed CMake package config links numsa::numsa transitively but
+    # never re-discovers it, so consumers fail with "target numsa::numsa not
+    # found". Add the missing find_dependency call.
+    ./cmake-config-find-numsa.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace config/install-mod.py \
+      --replace-fail "/usr/bin/env python" "${lib.getExe python3}"
+  '';
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  nativeBuildInputs = [
+    gfortran
+    pkg-config
+    python3
+  ]
+  ++ lib.optionals (buildType == "meson") [
+    meson
+    ninja
+  ]
+  ++ lib.optionals (buildType == "cmake") [
+    cmake
+  ];
+
+  buildInputs = [
+    blas
+    lapack
+    # only needed to build the bundled test suite
+    test-drive
+  ];
+
+  propagatedBuildInputs = [
+    mctc-lib
+    numsa
+    toml-f
+  ];
+
+  doCheck = true;
+
+  preCheck = ''
+    export OMP_NUM_THREADS=2
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Extended conductor-like polarizable continuum solvation model";
+    homepage = "https://github.com/grimme-lab/CPCM-X";
+    changelog = "https://github.com/grimme-lab/CPCM-X/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.lgpl3;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    mainProgram = "cpx";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/df/dftd4/package.nix
+++ b/pkgs/by-name/df/dftd4/package.nix
@@ -27,11 +27,13 @@ assert (
 stdenv.mkDerivation (finalAttrs: {
   pname = "dftd4";
   version = "4.2.0";
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "dftd4";
     repo = "dftd4";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-uKjNOIza3/I0oREp88oFESoNqEdumo1AztIjcrVb1O8=";
   };
 
@@ -85,6 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Generally Applicable Atomic-Charge Dependent London Dispersion Correction";
+    changelog = "https://github.com/dftd4/dftd4/releases/tag/${finalAttrs.src.tag}";
     mainProgram = "dftd4";
     license = with lib.licenses; [
       lgpl3Plus

--- a/pkgs/by-name/mu/multicharge/package.nix
+++ b/pkgs/by-name/mu/multicharge/package.nix
@@ -26,11 +26,13 @@ assert (
 stdenv.mkDerivation (finalAttrs: {
   pname = "multicharge";
   version = "0.5.0";
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "grimme-lab";
     repo = "multicharge";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-hswqC+fvC6tuxDpuUgowyqm72ubVikzpR4EzXtTM5cs=";
   };
 
@@ -48,7 +50,9 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
   ]
-  ++ lib.optional (buildType == "cmake") cmake;
+  ++ lib.optionals (buildType == "cmake") [
+    cmake
+  ];
 
   buildInputs = [
     blas
@@ -85,6 +89,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "multicharge";
     license = lib.licenses.asl20;
     homepage = "https://github.com/grimme-lab/multicharge";
+    changelog = "https://github.com/grimme-lab/multicharge/releases/tag/${finalAttrs.src.tag}";
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.sheepforce ];
   };

--- a/pkgs/by-name/nu/numsa/package.nix
+++ b/pkgs/by-name/nu/numsa/package.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  buildType ? "meson",
+
+  # nativeBuildInputs
+  asciidoctor,
+  gfortran,
+  pkg-config,
+  python3,
+  # meson:
+  meson,
+  ninja,
+  # cmake:
+  cmake,
+
+  # buildInputs
+  mstore,
+  test-drive,
+  blas,
+  lapack,
+
+  # propagatedBuildInputs
+  mctc-lib,
+
+  # passthru
+  nix-update-script,
+}:
+
+assert (
+  builtins.elem buildType [
+    "meson"
+    "cmake"
+  ]
+);
+stdenv.mkDerivation (finalAttrs: {
+  pname = "numsa";
+  version = "0.2.0";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "grimme-lab";
+    repo = "numsa";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-PAzxeYyg/9P/3YFxKzM4ZFm2xT0AGap6q8/ei8jD/3M=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  patches = [
+    # Use nixpkgs' mstore instead of building it from source
+    ./use-external-mstore.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace config/install-mod.py \
+      --replace-fail "/usr/bin/env python" "${lib.getExe python3}"
+  '';
+
+  nativeBuildInputs = [
+    asciidoctor
+    gfortran
+    pkg-config
+    python3
+  ]
+  ++ lib.optionals (buildType == "meson") [
+    meson
+    ninja
+  ]
+  ++ lib.optionals (buildType == "cmake") [
+    cmake
+  ];
+
+  buildInputs = [
+    blas
+    lapack
+    mstore # only needed to build the bundled test suite
+    test-drive
+  ];
+
+  propagatedBuildInputs = [
+    mctc-lib
+  ];
+
+  doCheck = true;
+
+  preCheck = ''
+    export OMP_NUM_THREADS=2
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Solvent accessible surface area calculation";
+    homepage = "https://github.com/grimme-lab/numsa";
+    changelog = "https://github.com/grimme-lab/numsa/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/nu/numsa/use-external-mstore.patch
+++ b/pkgs/by-name/nu/numsa/use-external-mstore.patch
@@ -1,0 +1,30 @@
+diff --git a/test/meson.build b/test/meson.build
+index c60e4a4..7da0216 100644
+--- a/test/meson.build
++++ b/test/meson.build
+@@ -14,20 +14,21 @@
+ # You should have received a copy of the GNU Lesser General Public License
+ # along with numsa.  If not, see <https://www.gnu.org/licenses/>.
+ 
+-# Create mstore as subproject for testing
+-mstore_prj = subproject(
++# Find the molecular structure store, preferring an external installation
++# (e.g. via pkg-config) and falling back to building it as a subproject
++mstore_dep = dependency(
+   'mstore',
+   version: '>=0.1',
++  fallback: ['mstore', 'mstore_dep'],
+   required: not meson.is_subproject(),
+   default_options: [
+     'default_library=static',
+   ],
+ )
+ # If we do not find mstore and are a subproject, we just skip testing
+-if not mstore_prj.found()
++if not mstore_dep.found()
+    subdir_done()
+ endif
+-mstore_dep = mstore_prj.get_variable('mstore_dep')
+ 
+ tests = [
+   'surface',

--- a/pkgs/by-name/to/toml-f/package.nix
+++ b/pkgs/by-name/to/toml-f/package.nix
@@ -21,11 +21,13 @@ assert (
 stdenv.mkDerivation (finalAttrs: {
   pname = "toml-f";
   version = "0.5.1";
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "toml-f";
     repo = "toml-f";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-lReez2rSAJVnLFngjUYgGkm+HUDH8VsCC2m9zYOOr4A=";
   };
 
@@ -42,7 +44,9 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
   ]
-  ++ lib.optional (buildType == "cmake") cmake;
+  ++ lib.optionals (buildType == "cmake") [
+    cmake
+  ];
 
   buildInputs = [ test-drive ];
 
@@ -65,6 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
       mit
     ];
     homepage = "https://github.com/toml-f/toml-f";
+    changelog = "https://github.com/toml-f/toml-f/releases/tag/${finalAttrs.src.tag}";
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.sheepforce ];
   };

--- a/pkgs/by-name/xt/xtb/package.nix
+++ b/pkgs/by-name/xt/xtb/package.nix
@@ -1,0 +1,112 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  # nativeBuildInputs
+  gfortran,
+  meson,
+  ninja,
+  pkg-config,
+
+  # buildInputs
+  blas,
+  lapack,
+  cpcm-x,
+  dftd4,
+  mctc-lib,
+  multicharge,
+  numsa,
+  simple-dftd3,
+  tblite,
+  test-drive,
+  toml-f,
+
+  # passthru
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xtb";
+  # No tagged release supports the tblite 0.6 / dftd4 4.2 API; the latest tag (6.7.1) targets
+  # tblite 0.3. Track master, which builds against the current grimme-lab stack packaged in nixpkgs
+  version = "6.7.1-unstable-2026-05-16";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "grimme-lab";
+    repo = "xtb";
+    rev = "2b5cd4829290775e575807daee21560f851ff7e1";
+    hash = "sha256-dnpmbjLG6xKSLXEUdwndsA0ADTEyaTY9fJiOSXI7jD4=";
+  };
+
+  # The `solve`/`solve4` eigensolvers size the DSYGVD workspace from a `LWORK = -1` query.
+  # OpenBLAS leaves `aux(1)` as a denormal/garbage value on that query, so `int(aux(1))` falls
+  # below DSYGVD's documented minimum and the real call aborts with `DSYGVD parameter number 11 had
+  # an illegal value` (it works against reference LAPACK, which fills the query correctly).
+  # This surfaces as failures in the `gfn0` and `peeq` unit tests. Clamp the workspace sizes to the
+  # LAPACK minima so the query result can only ever grow them.
+  postPatch = ''
+    substituteInPlace src/scc_core.f90 \
+      --replace-fail "lwork=int(aux(1))"  "lwork=max(int(aux(1)),1+6*ndim+2*ndim**2)" \
+      --replace-fail "lwork=int(aux4(1))" "lwork=max(int(aux4(1)),1+6*ndim+2*ndim**2)" \
+      --replace-fail "liwork=iwork(1)"    "liwork=max(iwork(1),3+5*ndim)"
+  '';
+
+  nativeBuildInputs = [
+    gfortran
+    meson
+    ninja
+    pkg-config
+  ];
+
+  mesonFlags = [
+    # Require the optional backends rather than letting the `auto` features
+    # silently disable themselves if a dependency is not found.
+    (lib.mesonEnable "tblite" true)
+    (lib.mesonEnable "cpcmx" true)
+  ];
+
+  # Serialize the build: ninja otherwise compiles xtb's program/library objects before the
+  # library's Fortran modules are generated.
+  # `enableParallel` only controls the explicit -j flag and ninja parallelizes regardless, so the
+  # race has to be killed with an explicit -j1.
+  ninjaFlags = [ "-j1" ];
+
+  buildInputs = [
+    blas
+    cpcm-x
+    dftd4
+    lapack
+    mctc-lib
+    multicharge
+    numsa
+    simple-dftd3
+    tblite
+    test-drive
+    toml-f
+  ];
+
+  doCheck = true;
+  preCheck = ''
+    export OMP_NUM_THREADS=2
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "Semiempirical Extended Tight-Binding Program Package";
+    homepage = "https://github.com/grimme-lab/xtb";
+    # changelog = "https://github.com/grimme-lab/xtb/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+      sheepforce
+    ];
+    mainProgram = "xtb";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/development/libraries/science/chemistry/tblite/default.nix
+++ b/pkgs/development/libraries/science/chemistry/tblite/default.nix
@@ -27,14 +27,16 @@ assert (
   ]
 );
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tblite";
   version = "0.6.0";
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "tblite";
     repo = "tblite";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-z0g+bf6APqNLB9mDE49FelitQ9ptZXdFQuYeXIT0NIw=";
   };
 
@@ -86,7 +88,9 @@ stdenv.mkDerivation rec {
     "dev"
   ];
 
-  checkInputs = [
+  nativeCheckInputs = [
+    # Runs python test drivers (test/*/tester.py) during checkPhase, so it must be available on the
+    # build host (strictDeps)
     python3
   ];
 
@@ -108,7 +112,8 @@ stdenv.mkDerivation rec {
       lgpl3Plus
     ];
     homepage = "https://github.com/tblite/tblite";
+    changelog = "https://github.com/tblite/tblite/releases/tag/${finalAttrs.src.tag}";
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.sheepforce ];
   };
-}
+})


### PR DESCRIPTION
## Things done

- **toml-f: cleanup**
- **multicharge: cleanup**
- **tblite: cleanup**
- **dftd4: cleanup**
- **numsa: init at 0.2.0**
- **cpcm-x: init at 1.1.0**
- **xtb: init at 6.7.1**

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
