### PR TITLE
python3Packages.uefi-firmware-parser: add setuptools-scm to build dependencies

### DIFF
--- a/pkgs/development/python-modules/uefi-firmware-parser/default.nix
+++ b/pkgs/development/python-modules/uefi-firmware-parser/default.nix
@@ -4,7 +4,7 @@
   buildPythonPackage,
   nix-update-script,
   setuptools,
-  wheel,
+  setuptools-scm,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -21,7 +21,7 @@ buildPythonPackage (finalAttrs: {
 
   build-system = [
     setuptools
-    wheel
+    setuptools-scm
   ];
 
   pythonRemoveDeps = [ "future" ];


### PR DESCRIPTION
## Things done

It looks like uefi-firmware-parser was updated to add setuptools-scm as a build dependency. This PR adds that to the build dependencies to fix the build issue:

```
* Getting build dependencies for wheel...
/nix/store/25rr86lli13limp2np2xfqhq0x8lwjgv-python3.13-setuptools-80.10.1/lib/python3.13/site-packages/setuptools/_distutils/dist.py:289: UserWarning: Unknown distribution option: 'use_scm_version'
  warnings.warn(msg)
running egg_info
creating uefi_firmware.egg-info
writing uefi_firmware.egg-info/PKG-INFO
writing dependency_links to uefi_firmware.egg-info/dependency_links.txt
writing requirements to uefi_firmware.egg-info/requires.txt
writing top-level names to uefi_firmware.egg-info/top_level.txt
writing manifest file 'uefi_firmware.egg-info/SOURCES.txt'
reading manifest file 'uefi_firmware.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no files found matching 'uefi_firmware/compression/*/*/*.h'
adding license file 'LICENSE'
adding license file 'AUTHORS'
writing manifest file 'uefi_firmware.egg-info/SOURCES.txt'

ERROR Missing dependencies:
        setuptools-scm>=8.0
```

### Testing

**Before**

```
nix build .#uefi-firmware-parser
error: Cannot build '/nix/store/6zsy0867a0ipv34rplgq80r6b7f1bjb3-python3.13-uefi-firmware-parser-1.16.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/a5khaai6akz27fcrsz3lqds0zszi38lk-python3.13-uefi-firmware-parser-1.16-dist
         /nix/store/jllpgc2y2523sd5pdzlr5n1v32qm8349-python3.13-uefi-firmware-parser-1.16
       Last 25 log lines:
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > Executing pypaBuildPhase
       > Creating a wheel...
       > pypa build flags: --no-isolation --outdir dist/ --wheel
       > * Getting build dependencies for wheel...
       > /nix/store/25rr86lli13limp2np2xfqhq0x8lwjgv-python3.13-setuptools-80.10.1/lib/python3.13/site-packages/setuptools/_distutils/dist.py:289: UserWarning: Unknown distribution option: 'use_scm_version'
       >   warnings.warn(msg)
       > running egg_info
       > creating uefi_firmware.egg-info
       > writing uefi_firmware.egg-info/PKG-INFO
       > writing dependency_links to uefi_firmware.egg-info/dependency_links.txt
       > writing requirements to uefi_firmware.egg-info/requires.txt
       > writing top-level names to uefi_firmware.egg-info/top_level.txt
       > writing manifest file 'uefi_firmware.egg-info/SOURCES.txt'
       > reading manifest file 'uefi_firmware.egg-info/SOURCES.txt'
       > reading manifest template 'MANIFEST.in'
       > warning: no files found matching 'uefi_firmware/compression/*/*/*.h'
       > adding license file 'LICENSE'
       > adding license file 'AUTHORS'
       > writing manifest file 'uefi_firmware.egg-info/SOURCES.txt'
       >
       > ERROR Missing dependencies:
       >  setuptools-scm>=8.0
       For full logs, run:
         nix log /nix/store/6zsy0867a0ipv34rplgq80r6b7f1bjb3-python3.13-uefi-firmware-parser-1.16.drv
```

**After**

```
nix build .#uefi-firmware-parser
# no errors
```

```
./result/bin/uefi-firmware-parser --help
usage: uefi-firmware-parser [-h] [-b] [--superbrute] [--depex] [-q] [--color {always,never,auto}] [-p] [-o OUTPUT] [-O] [-c] [-e] [-g GENERATE] [-j] [--test] [--verbose]
                            file [file ...]

Parse, and optionally output, details and data on UEFI-related firmware.

positional arguments:
  file                  The file(s) to work on

options:
  -h, --help            show this help message and exit
  -b, --brute           The input is a blob and may contain FV headers.
  --superbrute          The input is a blob and may contain any sort of firmware object
  --depex               The input is a DEPEX blob
  -q, --quiet           Do not show info.
  --color {always,never,auto}
                        Control the use of ANSI colors in the output. (auto is default)
  -p, --nocolor         Plain text output. Do not use ANSI colors. (Alias for --color=never)
  -o, --output OUTPUT   Dump firmware objects to this folder.
  -O, --outputfolder    Dump firmware objects to a folder based on filename ${FILENAME}_output/
  -c, --echo            Echo the filename before parsing or extracting.
  -e, --extract         Extract all files/sections/volumes.
  -g, --generate GENERATE
                        Generate a FDF, implies extraction (volumes only)
  -j, --json            Output in JSON format
  --test                Test file parsing, output name/success.
  --verbose             Enable verbose logging while parsing
```

Source:

https://github.com/theopolis/uefi-firmware-parser/blame/master/pyproject.toml#L2

This should also be backported to 26.05.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
