### PR TITLE
python3Packages.torchmd-net: init at 3.0.3

### DIFF
--- a/pkgs/development/python-modules/torchmd-net/default.nix
+++ b/pkgs/development/python-modules/torchmd-net/default.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  ase,
+  h5py,
+  lightning,
+  numpy,
+  torch,
+  torch-geometric,
+  tqdm,
+  warp-lang,
+
+  # tests
+  pytest-xdist,
+  pytestCheckHook,
+  writableTmpDirAsHomeHook,
+  llvmPackages,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "torchmd-net";
+  version = "3.0.3";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "torchmd";
+    repo = "torchmd-net";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-FBeeNkc7mJQYmMwlsW3Un+3RHvErJM7rWKUqSCYYUCM=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  pythonRemoveDeps = [
+    # Not a runtime dependency
+    "setuptools"
+  ];
+  dependencies = [
+    ase
+    h5py
+    lightning
+    numpy
+    torch
+    torch-geometric
+    tqdm
+    warp-lang
+  ];
+
+  pythonImportsCheck = [ "torchmdnet" ];
+
+  nativeCheckInputs = [
+    pytest-xdist
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  checkInputs = lib.optionals stdenv.cc.isClang [
+    # torch._inductor.exc.InductorError: CppCompileError: C++ compile error
+    # fatal error: 'omp.h' file not found
+    llvmPackages.openmp
+  ];
+
+  disabledTests = [
+    # Require internet access
+    "test_dataset_s66x8"
+
+    # Failed: torch.compile failed on TorchScripted tensornet model:
+    # torch.compile does not support compiling torch.jit.script or torch.jit.freeze models directly.
+    "test_torchscript_then_compile"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # torch._inductor.exc.InductorError: ImportError: ...
+    # symbol not found in flat namespace '___kmpc_barrier'
+    "test_ase_calculator"
+    "test_torch_export_then_compile"
+  ];
+
+  meta = {
+    description = "Library to train state-of-the-art neural networks potentials (NNPs)";
+    homepage = "https://github.com/torchmd/torchmd-net";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19946,6 +19946,8 @@ self: super: with self; {
 
   torchlibrosa = callPackage ../development/python-modules/torchlibrosa { };
 
+  torchmd-net = callPackage ../development/python-modules/torchmd-net { };
+
   torchmetrics = callPackage ../development/python-modules/torchmetrics { };
 
   torchprofile = callPackage ../development/python-modules/torchprofile { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add [torchmd-net](https://github.com/torchmd/torchmd-net), a library to train state-of-the-art neural networks potentials (NNPs).

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
