### PR TITLE
[26.05] ifstate: 2.3.0 -> 2.4.1

### DIFF
--- a/pkgs/by-name/if/ifstate/package.nix
+++ b/pkgs/by-name/if/ifstate/package.nix
@@ -13,12 +13,12 @@
 }:
 
 let
-  version = "2.3.0";
+  version = "2.4.1";
   src = fetchFromCodeberg {
     owner = "routerkit";
     repo = "ifstate";
     tag = version;
-    hash = "sha256-qJdWoe9hbLMmyaaK7m+NzU3415KavbBkHJdFPhmlOnY=";
+    hash = "sha256-/kibcWSGg7AqkjvQAzhSs+aoRHE/YoYhTqVjw4NWNgA=";
   };
   docs = stdenv.mkDerivation {
     pname = "ifstate-docs";


### PR DESCRIPTION
Backport of #529289

PR creation failed probably due to https://www.githubstatus.com/incidents/fcj3088jg1wx (see https://github.com/NixOS/nixpkgs/pull/529289#issuecomment-4671992750 and https://github.com/NixOS/nixpkgs/actions/runs/27288479838/job/80602204830)