### PR TITLE
bobby: init at 50.0.2

### DIFF
--- a/pkgs/by-name/bo/bobby/package.nix
+++ b/pkgs/by-name/bo/bobby/package.nix
@@ -1,0 +1,84 @@
+{
+  cargo,
+  desktop-file-utils,
+  fetchFromGitHub,
+  glib,
+  gtk4,
+  lib,
+  libadwaita,
+  meson,
+  ninja,
+  nix-update-script,
+  pkg-config,
+  rustc,
+  rustPlatform,
+  sqlite,
+  stdenv,
+  wrapGAppsHook4,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bobby";
+  version = "50.0.2";
+
+  src = fetchFromGitHub {
+    owner = "hbons";
+    repo = "bobby";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/N7CmzPwUdGkHIZujCGW3LvsGM6DdXrcm2kH6XlVGDA=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-TT3ceAy44sfyKZ7wmH3C4nj5TyfiJlu4vBWAaGs+pGg=";
+  };
+
+  buildInputs = [
+    glib
+    gtk4
+    libadwaita
+    sqlite
+  ];
+
+  # favor sqlite from nixpkgs instead of a vendored variant in rusqlite
+  postPatch = ''
+    substituteInPlace Cargo.toml \
+      --replace-fail ', features = ["bundled"]' ""
+  '';
+
+  nativeBuildInputs = [
+    cargo
+    desktop-file-utils # for `update-desktop-database`
+    gtk4 # for `gtk-update-icon-cache`
+    meson
+    ninja
+    pkg-config
+    rustc
+    rustPlatform.cargoSetupHook
+    wrapGAppsHook4 # fix error: GLib-GIO-ERROR **: No GSettings schemas are installed on the system
+  ];
+
+  mesonCheckFlags = [
+    "--print-errorlogs"
+  ];
+
+  doCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  meta = {
+    changelog = "https://github.com/hbons/Bobby/blob/${finalAttrs.src.tag}/data/studio.planetpeanut.Bobby.metainfo.xml";
+    description = "Browse SQLite files";
+    donationPage = "https://planetpeanut.studio/sponsors";
+    homepage = "https://apps.gnome.org/Bobby/";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      aiyion
+    ];
+    teams = [ lib.teams.gnome-circle ];
+    mainProgram = "bobby";
+  };
+})


### PR DESCRIPTION
`bobby: init at 50.0.2`

https://github.com/hbons/Bobby
https://apps.gnome.org/Bobby/

This is the first time I packaged something relying on dconf to store its configuration.
Is there something one should enable/mark which warns if `programs.dconf.enable` has not been set on the current system?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - ~Package update: when the change is major or breaking.~
- NixOS Release Notes
  - ~Module addition: when adding a new NixOS module.~
  - ~Module update: when the change is significant.~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
- [x] get rid of bundled sqlite in favor of system sqlite
- [x] run tests
- [x] GSettings


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
