### PR TITLE
python3Packages.pysail: init at 0.6.4

### DIFF
--- a/pkgs/development/python-modules/pysail/default.nix
+++ b/pkgs/development/python-modules/pysail/default.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  rustPlatform,
+  nix-update-script,
+  testers,
+  pysail,
+
+  protoc,
+  protobuf,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pysail";
+  version = "0.6.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "lakehq";
+    repo = "sail";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-EX8cDed32uF7NSreViKBn7RQeWIG7C7sI6O0c+hVf4M=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname src version;
+    hash = "sha256-ouNXKPpwKTLfI+Gcp393r7oHZAjUFQL9225+AuFzdoo=";
+  };
+
+  # The `generate-import-lib` PyO3 feature only matters when building Windows
+  # import libraries; on other platforms it just pulls in the `python3-dll-a`
+  # crate, which is not vendored. Drop it so the offline maturin build resolves.
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail '"pyo3/generate-import-lib",' ""
+  '';
+
+  nativeBuildInputs = with rustPlatform; [
+    cargoSetupHook
+    maturinBuildHook
+    protoc
+  ];
+
+  buildInputs = [
+    protobuf
+  ];
+
+  pythonImportsCheck = [
+    "pysail"
+    "pysail._native"
+  ];
+
+  # The test suite requires a running Spark Connect server and many
+  # heavyweight optional dependencies (pyspark-client, duckdb, ...).
+  doCheck = false;
+
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      package = pysail;
+    };
+  };
+
+  meta = {
+    description = "Python bindings for Sail, a Spark-compatible compute engine on Apache Arrow and DataFusion";
+    homepage = "https://github.com/lakehq/sail";
+    changelog = "https://github.com/lakehq/sail/blob/${finalAttrs.src.tag}/docs/reference/changelog/index.md";
+    license = lib.licenses.asl20;
+    mainProgram = "sail";
+    maintainers = [ lib.maintainers.davidlghellin ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15182,6 +15182,10 @@ self: super: with self; {
 
   pysabnzbd = callPackage ../development/python-modules/pysabnzbd { };
 
+  pysail = callPackage ../development/python-modules/pysail {
+    protoc = pkgs.protobuf;
+  };
+
   pysaj = callPackage ../development/python-modules/pysaj { };
 
   pysam = callPackage ../development/python-modules/pysam { };


### PR DESCRIPTION
Changelog: https://github.com/lakehq/sail/releases/tag/v0.6.4

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
