### PR TITLE
python3Packages.readme-renderer: 44.0 -> 45.0

### DIFF
--- a/pkgs/development/python-modules/readme-renderer/default.nix
+++ b/pkgs/development/python-modules/readme-renderer/default.nix
@@ -10,14 +10,14 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "readme-renderer";
   version = "45.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "readme_renderer";
-    inherit version;
+    inherit (finalAttrs) version;
     hash = "sha256-AwqPrHSQT4+6Ea0btpZOP3boltx+XnHxavGQyQVmltE=";
   };
 
@@ -29,9 +29,14 @@ buildPythonPackage rec {
     pygments
   ];
 
-  optional-dependencies.md = [ cmarkgfm ];
+  optional-dependencies = {
+    md = [ cmarkgfm ];
+  };
 
-  nativeCheckInputs = [ pytestCheckHook ] ++ optional-dependencies.md;
+  nativeCheckInputs = [
+    pytestCheckHook
+  ]
+  ++ lib.flatten (builtins.attrValues finalAttrs.passthru.optional-dependencies);
 
   disabledTests = [
     "test_rst_fixtures"
@@ -43,8 +48,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python library for rendering readme descriptions";
     homepage = "https://github.com/pypa/readme_renderer";
-    changelog = "https://github.com/pypa/readme_renderer/releases/tag/${version}";
+    changelog = "https://github.com/pypa/readme_renderer/releases/tag/${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/readme-renderer/default.nix
+++ b/pkgs/development/python-modules/readme-renderer/default.nix
@@ -4,7 +4,6 @@
   cmarkgfm,
   docutils,
   fetchPypi,
-  fetchpatch2,
   nh3,
   pygments,
   pytestCheckHook,
@@ -13,28 +12,14 @@
 
 buildPythonPackage rec {
   pname = "readme-renderer";
-  version = "44.0";
+  version = "45.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "readme_renderer";
     inherit version;
-    hash = "sha256-hxIDTqu/poBcrPFAK07rKnMCj3LRFm1vXLf5wEfF0eE=";
+    hash = "sha256-AwqPrHSQT4+6Ea0btpZOP3boltx+XnHxavGQyQVmltE=";
   };
-
-  patches = [
-    # https://github.com/pypa/readme_renderer/pull/325
-    (fetchpatch2 {
-      name = "pygment-2_19-compatibility.patch";
-      url = "https://github.com/pypa/readme_renderer/commit/04d5cfe76850192364eff344be7fe27730af8484.patch";
-      hash = "sha256-QBU3zL3DB8gYYwtKrIC8+H8798pU9Sz3T9e/Q/dXksw=";
-    })
-    (fetchpatch2 {
-      name = "docutils-0.22-compat.patch";
-      url = "https://github.com/pypa/readme_renderer/commit/d047a29755a204afca8873a6ecf30e686ccf6a27.patch";
-      hash = "sha256-GHTfRuOZr5c4mwu4s8K5IpvG1ZP1o/qd0U4H09BzhE8=";
-    })
-  ];
 
   build-system = [ setuptools ];
 
@@ -59,7 +44,7 @@ buildPythonPackage rec {
     description = "Python library for rendering readme descriptions";
     homepage = "https://github.com/pypa/readme_renderer";
     changelog = "https://github.com/pypa/readme_renderer/releases/tag/${version}";
-    license = with lib.licenses; [ asl20 ];
+    license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
   };
 }


### PR DESCRIPTION
Changelog: https://github.com/pypa/readme_renderer/releases/tag/45.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
