### PR TITLE
restish: 2.0.0 -> 2.2.0

### DIFF
--- a/pkgs/by-name/re/restish/package.nix
+++ b/pkgs/by-name/re/restish/package.nix
@@ -14,16 +14,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "restish";
-  version = "2.0.0";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "danielgtaylor";
     repo = "restish";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-4piN0W/9y2NTsTuZ2B4Czhr9RQNb4eT9ZIX9MYzfMLI=";
+    hash = "sha256-wGchbKSEbzr1vQlYWgUTubA1xQVcxq7iyRUIuWqVL0Y=";
   };
 
-  vendorHash = "sha256-ZRyGCdmPenOeLtFuj0howJH0rah05sPUuD7RH/c0LKI=";
+  vendorHash = "sha256-Y0GwgrkD09WAlmyI6Oe3Kw6L62E7QRTCIThZGXbbn74=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     libx11
@@ -37,6 +37,11 @@ buildGoModule (finalAttrs: {
     "-s"
     "-w"
     "-X=main.version=${finalAttrs.version}"
+  ];
+
+  checkFlags = [
+    # Test requires network access  
+    "-skip=TestAPISyncDiscoveryDoesNotSendAuthToCrossOriginLinkSpec"
   ];
 
   preCheck = ''

--- a/pkgs/by-name/re/restish/package.nix
+++ b/pkgs/by-name/re/restish/package.nix
@@ -9,6 +9,7 @@
   libxinerama,
   libxrandr,
   versionCheckHook,
+  writableTmpDirAsHomeHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -32,7 +33,10 @@ buildGoModule (finalAttrs: {
     libxrandr
   ];
 
-  nativeInstallCheckInputs = [ versionCheckHook ];
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
 
   ldflags = [
     "-s"
@@ -44,10 +48,6 @@ buildGoModule (finalAttrs: {
     # Test requires network access and test with hard-coded version '2.0.0'
     "-skip=TestAPISyncDiscoveryDoesNotSendAuthToCrossOriginLinkSpec|TestVersion$|TestVersionCommand"
   ];
-
-  preCheck = ''
-    export HOME=$(mktemp -d)
-  '';
 
   doInstallCheck = true;
 

--- a/pkgs/by-name/re/restish/package.nix
+++ b/pkgs/by-name/re/restish/package.nix
@@ -3,13 +3,12 @@
   stdenv,
   buildGoModule,
   fetchFromGitHub,
-  restish,
-  testers,
-  libxrandr,
+  libx11,
+  libxcursor,
   libxi,
   libxinerama,
-  libxcursor,
-  libx11,
+  libxrandr,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -33,25 +32,24 @@ buildGoModule (finalAttrs: {
     libxrandr
   ];
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
   ldflags = [
     "-s"
     "-w"
-    "-X=main.version=${finalAttrs.version}"
+    "-X=github.com/rest-sh/restish/v2/internal/cli.Version=${finalAttrs.version}"
   ];
 
   checkFlags = [
-    # Test requires network access  
-    "-skip=TestAPISyncDiscoveryDoesNotSendAuthToCrossOriginLinkSpec"
+    # Test requires network access and test with hard-coded version '2.0.0'
+    "-skip=TestAPISyncDiscoveryDoesNotSendAuthToCrossOriginLinkSpec|TestVersion$|TestVersionCommand"
   ];
 
   preCheck = ''
     export HOME=$(mktemp -d)
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = restish;
-    command = "HOME=$(mktemp -d) restish --version";
-  };
+  doInstallCheck = true;
 
   meta = {
     description = "CLI tool for interacting with REST-ish HTTP APIs";

--- a/pkgs/by-name/re/restish/package.nix
+++ b/pkgs/by-name/re/restish/package.nix
@@ -16,6 +16,8 @@ buildGoModule (finalAttrs: {
   pname = "restish";
   version = "2.2.0";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "danielgtaylor";
     repo = "restish";
@@ -40,7 +42,6 @@ buildGoModule (finalAttrs: {
 
   ldflags = [
     "-s"
-    "-w"
     "-X=github.com/rest-sh/restish/v2/internal/cli.Version=${finalAttrs.version}"
   ];
 
@@ -54,7 +55,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "CLI tool for interacting with REST-ish HTTP APIs";
     homepage = "https://rest.sh/";
-    changelog = "https://github.com/danielgtaylor/restish/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/danielgtaylor/restish/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "restish";


### PR DESCRIPTION
Changelog: https://github.com/danielgtaylor/restish/releases/tag/v2.2.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
