### PR TITLE
gbenchmark: fix eval and build on musl

### DIFF
--- a/pkgs/by-name/gb/gbenchmark/package.nix
+++ b/pkgs/by-name/gb/gbenchmark/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   ninja,
   gtest,
@@ -20,6 +21,14 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Mm4pG7zMB00iof32CxreoNBFnduPZTMp3reHMCIAFPQ=";
   };
 
+  patches = [
+    (fetchpatch {
+      name = "portability.patch";
+      url = "https://github.com/google/benchmark/commit/b5ba9bab85d80f29a161dd634b7d234cf3722f90.patch";
+      hash = "sha256-/X01AWXK0eJ59F8oSREZ7V5Cpw1y35n9uFB1mCvMOus=";
+    })
+  ];
+
   nativeBuildInputs = [
     cmake
     ninja
@@ -27,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ gtest ];
 
-  nativeCheckInputs = lib.optionals stdenv.hostPlatform.isLinux [ glibcLocales ];
+  nativeCheckInputs = lib.optionals (glibcLocales != null) [ glibcLocales ];
 
   cmakeFlags = [
     (lib.cmakeBool "BENCHMARK_USE_BUNDLED_GTEST" false)
@@ -45,10 +54,12 @@ stdenv.mkDerivation (finalAttrs: {
     # with Xcode, but we just work around it by silencing the warning.
     NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-c++17-attribute-extensions";
   }
-  // lib.optionalAttrs stdenv.hostPlatform.isLinux {
+  // lib.optionalAttrs stdenv.hostPlatform.isGnu {
     # For test:locale_impermeability_test
     LANG = "en_US.UTF-8";
     LC_ALL = "en_US.UTF-8";
+  }
+  // lib.optionalAttrs (glibcLocales != null) {
     LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
   };
 


### PR DESCRIPTION
glibcLocales is only non-null when stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isGnu, so when it was added it broke eval of this package on musl.  Fix the platform checks to be more accurate, and backport an upstream fix for more accurate platform checks on their side, to get building on musl again.

Fixes: f6da9198396a ("gbenchmark: 1.9.4 -> 1.9.5")


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
