### PR TITLE
hooksmith: init at 1.13.0

### DIFF
--- a/pkgs/by-name/ho/hooksmith/package.nix
+++ b/pkgs/by-name/ho/hooksmith/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "hooksmith";
+  version = "1.13.0";
+
+  src = fetchFromGitHub {
+    owner = "TomPlanche";
+    repo = "hooksmith";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-03EXvJctt/Ro27rna7DrCR1IdxIH2kFEQobSbK84p0s=";
+  };
+
+  cargoHash = "sha256-h0kzRDC5W6L/oLllTneKlGbmXxA0tQjmLNdNUesbpHw=";
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Trivial git hook management tool";
+    homepage = "https://github.com/TomPlanche/hooksmith";
+    changelog = "https://github.com/TomPlanche/hooksmith/releases/tag/${finalAttrs.src.tag}";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [ ilya-epifanov ];
+    mainProgram = "hooksmith";
+  };
+})


### PR DESCRIPTION
https://github.com/TomPlanche/hooksmith

Hooksmith is a lightweight, easy-to-use tool that simplifies Git hook management. Define your hooks in a simple YAML file and let Hooksmith handle the rest.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


