### PR TITLE
pmd: 6.55.0 -> 7.25.0

### DIFF
--- a/pkgs/by-name/pm/pmd/package.nix
+++ b/pkgs/by-name/pm/pmd/package.nix
@@ -4,16 +4,19 @@
   fetchurl,
   unzip,
   makeWrapper,
-  jdk8,
+  jdk17,
 }:
 
+let
+  jdk = jdk17.override { enableJavaFX = true; };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "pmd";
-  version = "6.55.0";
+  version = "7.25.0";
 
   src = fetchurl {
-    url = "https://github.com/pmd/pmd/releases/download/pmd_releases/${finalAttrs.version}/pmd-bin-${finalAttrs.version}.zip";
-    hash = "sha256-Iaz5bUPLQNWRyszMHCCmb8eW6t32nqYYEllER7rHoR0=";
+    url = "https://github.com/pmd/pmd/releases/download/pmd_releases%2F${finalAttrs.version}/pmd-dist-${finalAttrs.version}-bin.zip";
+    hash = "sha256-H86zAF6/1YDMmvpSQuB990gm7t6yJfI59QMIOEXXf8I=";
   };
 
   nativeBuildInputs = [
@@ -27,16 +30,20 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    install -Dm755 bin/run.sh $out/libexec/pmd
+    install -Dm755 bin/pmd $out/libexec/pmd
     install -Dm644 lib/*.jar -t $out/lib/pmd
+    cp -r conf $out/lib/pmd-conf
 
     wrapProgram $out/libexec/pmd \
-        --prefix PATH : ${jdk8.jre}/bin \
-        --set LIB_DIR $out/lib/pmd
+        --prefix PATH : ${jdk}/bin \
+        --set LIB_DIR $out/lib/pmd \
+        --set CONF_DIR $out/lib/pmd-conf
 
-    for app in pmd cpd cpdgui designer bgastviewer designerold ast-dump; do
-        makeWrapper $out/libexec/pmd $out/bin/$app --argv0 $app --add-flags $app
-    done
+    makeWrapper $out/libexec/pmd $out/bin/pmd --argv0 pmd
+    makeWrapper $out/libexec/pmd $out/bin/cpd --argv0 cpd --add-flags cpd
+    makeWrapper $out/libexec/pmd $out/bin/cpdgui --argv0 cpdgui --add-flags cpd-gui
+    makeWrapper $out/libexec/pmd $out/bin/designer --argv0 designer --add-flags designer
+    makeWrapper $out/libexec/pmd $out/bin/ast-dump --argv0 ast-dump --add-flags ast-dump
 
     runHook postInstall
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://pmd.github.io/pmd/pmd_release_notes_pmd7.html

Removed `bgastviewer`, `designerold` as they're no longer available in 7.x.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

