### PR TITLE
wikidesk: init at 0.1.2

### DIFF
--- a/pkgs/by-name/wi/wikidesk/package.nix
+++ b/pkgs/by-name/wi/wikidesk/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "wikidesk";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "ilya-epifanov";
+    repo = "wikidesk";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-QAAO1duiYYkU1gl0Jq0EjCSe0Rd/l7er1NdQMM69BKk=";
+  };
+
+  cargoHash = "sha256-ISf+v34hBJ7Kizqch82PFzy7+epkOtllyZVbdgh/xBE=";
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Shared knowledge service for LLM-wiki repositories";
+    homepage = "https://github.com/ilya-epifanov/wikidesk";
+    changelog = "https://github.com/ilya-epifanov/wikidesk/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [ ilya-epifanov ];
+    mainProgram = "wikidesk";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/ilya-epifanov/wikidesk
A companion server for [LLM-wiki](https://github.com/karpathy/LLM-wiki) that turns any existing wiki repo into a shared knowledge service for multiple AI coding agents.

# I need your advice here

The tool is written by me (AI assisted but fully reviewed at the time).
In the world of AI and especially AI-related tools themselves, this might become obsolete in 3 months.
Is there a place for such software in nixpkgs?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
