### PR TITLE
dune: 3.22.2 → 3.23.1

### DIFF
--- a/pkgs/by-name/du/dune/package.nix
+++ b/pkgs/by-name/du/dune/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   buildPackages,
-  version ? "3.22.2",
+  version ? "3.23.1",
 }:
 let
   # needed for pkgsStatic
@@ -21,6 +21,7 @@ stdenv.mkDerivation {
       "https://github.com/ocaml/dune/releases/download/${version}/dune-${sfx}${version}.tbz";
     hash =
       {
+        "3.23.1" = "sha256-k7TnFX9rqP62HPxfhgCO/SxZA3unigF9krSr8wYyNI8=";
         "3.22.2" = "sha256-wsz4vGsXr6R8RQKXNXSWMDqnyGgOMpt52Yxo41AToRg=";
         "3.21.1" = "sha256-hPeoLG2ApxJPOEfppInoDPvq+3vtNXOsAShu9W/QjZQ=";
         "2.9.3" = "sha256:1ml8bxym8sdfz25bx947al7cvsi2zg5lcv7x9w6xb01cmdryqr9y";

--- a/pkgs/development/ocaml-modules/dune-configurator/default.nix
+++ b/pkgs/development/ocaml-modules/dune-configurator/default.nix
@@ -1,14 +1,17 @@
 {
   lib,
   buildDunePackage,
+  ocaml,
   dune,
   csexp,
+  version ? if lib.versionAtLeast ocaml.version "4.13" then dune.version else "3.22.2",
 }:
 
 buildDunePackage {
   pname = "dune-configurator";
+  inherit version;
 
-  inherit (dune) src version;
+  inherit (dune.override { inherit version; }) src;
 
   dontAddPrefix = true;
 

--- a/pkgs/development/ocaml-modules/stdune/default.nix
+++ b/pkgs/development/ocaml-modules/stdune/default.nix
@@ -1,5 +1,7 @@
 {
+  lib,
   buildDunePackage,
+  ocaml,
   dune,
   dyn,
   ordering,
@@ -7,11 +9,14 @@
   csexp,
   fs-io,
   top-closure,
+  version ? if lib.versionAtLeast ocaml.version "4.13" then dune.version else "3.22.2",
 }:
 
 buildDunePackage {
   pname = "stdune";
-  inherit (dune) version src;
+  inherit version;
+
+  inherit (dune.override { inherit version; }) src;
 
   dontAddPrefix = true;
 


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
