### PR TITLE
python3Packages.genai-prices: 0.0.65 -> 0.0.66; python3Packages.pydantic-{ai-slim,graph}: 1.106.0 -> 1.107.0

### DIFF
--- a/pkgs/development/python-modules/genai-prices/default.nix
+++ b/pkgs/development/python-modules/genai-prices/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "genai-prices";
-  version = "0.0.65";
+  version = "0.0.66";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pydantic";
     repo = "genai-prices";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-3iqHpJpEdCfBObdcbS0MlVrPNqAAvN4ymCD6JDeb+LE=";
+    hash = "sha256-bvAAdlijxRzgjEeZEibuywJXhxKBWWQVPzO8gr6dWzo=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/packages/python";

--- a/pkgs/development/python-modules/pydantic-ai-slim/default.nix
+++ b/pkgs/development/python-modules/pydantic-ai-slim/default.nix
@@ -20,14 +20,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pydantic-ai-slim";
-  version = "1.106.0";
+  version = "1.107.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pydantic";
     repo = "pydantic-ai";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-D7fCBhGJjcBeIoddIFobfZBUocgQW2R0vhTGdvd/Dew=";
+    hash = "sha256-++tAI+KRCscDWqPQx5oswrjDq2txpzdI1ls/O/aAClE=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/pydantic_ai_slim";

--- a/pkgs/development/python-modules/pydantic-graph/default.nix
+++ b/pkgs/development/python-modules/pydantic-graph/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pydantic-graph";
-  version = "1.106.0";
+  version = "1.107.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pydantic";
     repo = "pydantic-ai";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-D7fCBhGJjcBeIoddIFobfZBUocgQW2R0vhTGdvd/Dew=";
+    hash = "sha256-++tAI+KRCscDWqPQx5oswrjDq2txpzdI1ls/O/aAClE=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/pydantic_graph";


### PR DESCRIPTION
https://github.com/pydantic/pydantic-ai/compare/v1.106.0...v1.107.0
https://github.com/pydantic/genai-prices/compare/v0.0.65...v0.0.66

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. (lasuite-docs)
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
