### PR TITLE
python3Packages.splitzip, splitzip: init at 0.3.0

### DIFF
--- a/pkgs/by-name/sp/splitzip/package.nix
+++ b/pkgs/by-name/sp/splitzip/package.nix
@@ -1,0 +1,2 @@
+{ python3Packages }:
+python3Packages.toPythonApplication python3Packages.splitzip

--- a/pkgs/development/python-modules/splitzip/default.nix
+++ b/pkgs/development/python-modules/splitzip/default.nix
@@ -30,14 +30,6 @@ buildPythonPackage (finalAttrs: {
     hatchling
   ];
 
-  optional-dependencies = {
-    dev = [
-      mypy
-      pytest
-      pytest-cov
-      ruff
-    ];
-  };
 
   postPatch = ''
     # See upstream issue https://github.com/twwat/splitzip/issues/1

--- a/pkgs/development/python-modules/splitzip/default.nix
+++ b/pkgs/development/python-modules/splitzip/default.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  pytestCheckHook,
+  versionCheckHook,
+  which,
+  mypy,
+  pytest,
+  pytest-cov,
+  ruff,
+  nix-update-script,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "splitzip";
+  version = "0.3.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "twwat";
+    repo = "splitzip";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OwC31MyTuHAcGX81WYnUKVNa6nKQKmr7M8Vlx2jkzCE=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  optional-dependencies = {
+    dev = [
+      mypy
+      pytest
+      pytest-cov
+      ruff
+    ];
+  };
+
+  postPatch = ''
+    # See upstream issue https://github.com/twwat/splitzip/issues/1
+    sed -i 's/^__version__ = .*$/__version__ = __import__("importlib.metadata", globals(), locals()).metadata.version("splitzip")/' src/splitzip/__init__.py
+  '';
+
+  pythonImportsCheck = [
+    "splitzip"
+  ];
+
+  nativeInstallCheckInputs = [
+    pytestCheckHook
+    versionCheckHook
+    which
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Pure Python library/utility to create split ZIP archives compatible with Windows Explorer, 7-Zip, and standard unzip";
+    homepage = "https://github.com/twwat/splitzip";
+    changelog = "https://github.com/twwat/splitzip/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      ShamrockLee
+    ];
+    mainProgram = "splitzip";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18658,6 +18658,8 @@ self: super: with self; {
 
   splinter = callPackage ../development/python-modules/splinter { };
 
+  splitzip = callPackage ../development/python-modules/splitzip { };
+
   splunk-sdk = callPackage ../development/python-modules/splunk-sdk { };
 
   spotapi = callPackage ../development/python-modules/spotapi { };


### PR DESCRIPTION
Package splitzip, a Python library and command-line utility that creates split ZIP archives with vanilla Python.

Assisted-by: nix-init

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
