### PR TITLE
[Backport staging-26.05] libtpms: fix building with `-march=x86-64-v4`

### DIFF
--- a/pkgs/by-name/li/libtpms/0001-fix-march-x86-64-v4.patch
+++ b/pkgs/by-name/li/libtpms/0001-fix-march-x86-64-v4.patch
@@ -1,0 +1,17 @@
+https://github.com/stefanberger/libtpms/pull/588
+
+diff --git a/src/tpm2/AlgorithmTests.c b/src/tpm2/AlgorithmTests.c
+index eca917d0..8cbc749b 100644
+--- a/src/tpm2/AlgorithmTests.c
++++ b/src/tpm2/AlgorithmTests.c
+@@ -197,8 +197,8 @@ TestSMAC(
+ //*** MakeIv()
+ // Internal function to make the appropriate IV depending on the mode.
+ static UINT32 MakeIv(TPM_ALG_ID mode,  // IN: symmetric mode
+-		     UINT32     size,  // IN: block size of the algorithm
+-		     BYTE*      iv     // OUT: IV to fill in
++		     UINT32             size,  // IN: block size of the algorithm
++		     volatile BYTE*     iv     // OUT: IV to fill in; 'volatile' for gcc15
+ 		     )
+ {
+     BYTE i;

--- a/pkgs/by-name/li/libtpms/package.nix
+++ b/pkgs/by-name/li/libtpms/package.nix
@@ -19,6 +19,8 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-UhEpq5f/FT5DmtzQBe/Si414mOq+D4glikgRNK60GKQ=";
   };
 
+  patches = [ ./0001-fix-march-x86-64-v4.patch ];
+
   hardeningDisable = [ "strictflexarrays3" ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/530222

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
