### PR TITLE
musescore-evolution: 3.7.0-unstable-2026-03-03 -> 3.7.0-unstable-2026-06-10

### DIFF
--- a/pkgs/by-name/mu/musescore-evolution/package.nix
+++ b/pkgs/by-name/mu/musescore-evolution/package.nix
@@ -22,33 +22,30 @@
   libopus,
   tinyxml-2,
   qt5, # Needed for musescore 3.X
-  fetchpatch,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+
   pname = "musescore-evolution";
-  version = "3.7.0-unstable-2026-03-03";
+  version = "3.7.0-unstable-2026-06-10";
 
   src = fetchFromGitHub {
     owner = "Jojo-Schmitz";
     repo = "MuseScore";
-    rev = "67504236fa073783f6616545185ec8bde6c22647";
-    hash = "sha256-QUUvUkdrJ4iL6cgDob+PdVRZp44kzHeoOi2N0Xb51To=";
+    rev = "ec719c0152fbb0fb57758a14a3754ad08d31dfc7";
+    hash = "sha256-yXVKjaY/utXA3617ik4misxeOVFp+0oo0RSU3yPUA00=";
   };
 
   patches = [
     ./musescore-evolution-pch-fix.patch
-    (fetchpatch {
-      url = "https://github.com/Jojo-Schmitz/MuseScore/commit/bbaa38ba2babb339043f87d50cec3240ca49fe0b.patch";
-      hash = "sha256-TbbrBo4uWCHeAs0Er3eYL+i0JWafI0zhetLpFjN0xg8=";
-    })
   ];
 
   # From top-level CMakeLists.txt:
   # - DOWNLOAD_SOUNDFONT defaults ON and tries to fetch from the network.
   # Download manually at Help > Manage Resources
   cmakeFlags = [
-    "-DDOWNLOAD_SOUNDFONT=OFF"
+    (lib.cmakeBool "DOWNLOAD_SOUNDFONT" false)
   ];
 
   qtWrapperArgs = [
@@ -57,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
       lib.makeLibraryPath [ libjack2 ]
     }"
   ]
-  ++ lib.optionals (stdenv.hostPlatform.isLinux) [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     "--set ALSA_PLUGIN_DIR ${alsa-plugins}/lib/alsa-lib"
   ]
   ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
@@ -68,21 +65,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   preFixup = ''
     qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
-
-    # Recreate correct symlinks (let fixupPhase handle compression)
-    if [ -e "$manDir/mscore-evo.1" ]; then
-      ln -sf "mscore-evo.1" "$manDir/musescore-evo.1"
-    fi
   '';
 
   dontWrapGApps = true;
 
   nativeBuildInputs = [
-    qt5.wrapQtAppsHook
     cmake
-    qt5.qttools
-    pkg-config
     ninja
+    pkg-config
+    qt5.qttools
+    qt5.wrapQtAppsHook
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     # Since https://github.com/musescore/MuseScore/pull/13847/commits/685ac998
@@ -91,25 +83,25 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    libjack2
+    flac
     freetype
     lame
+    libjack2
     libogg
+    libopus
+    libopusenc
     libpulseaudio
     libsndfile
     libvorbis
     portaudio
     portmidi
-    flac
-    libopusenc
-    libopus
-    tinyxml-2
     qt5.qtbase
     qt5.qtdeclarative
+    qt5.qtgraphicaleffects
+    qt5.qtquickcontrols2
     qt5.qtsvg
     qt5.qtxmlpatterns
-    qt5.qtquickcontrols2
-    qt5.qtgraphicaleffects
+    tinyxml-2
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     alsa-lib
@@ -145,14 +137,18 @@ stdenv.mkDerivation (finalAttrs: {
   # On Linux, let CMake + wrapQtAppsHook install/wrap "mscore", then rename it
   # and adjust the .desktop file so it doesn't clash with the main musescore package.
   postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    # 1) Rename the binaries
     mv "$out/bin/mscore" "$out/bin/mscore-evo"
+    rm "$out/bin/musescore"
+    ln -s "$out/bin/mscore-evo" "$out/bin/musescore-evolution"
 
     # 2) Fix desktop entry to point to mscore-evo and avoid ID clash
     desktop="$out/share/applications/mscore.desktop"
     substitute "$desktop" "$out/share/applications/mscore-evo.desktop" \
-      --replace "Exec=mscore" "Exec=mscore-evo" \
-      --replace "Name=MuseScore 3.7" "Name=MuseScore 3.7 (Evolution)" \
-      --replace "Icon=mscore" "Icon=mscore-evo"
+      --replace-fail "Exec=mscore" "Exec=mscore-evo" \
+      --replace-fail "Name=MuseScore 3.7" "Name=MuseScore 3.7 (Evolution)" \
+      --replace-fail "Icon=mscore" "Icon=mscore-evo" \
+      --replace-fail "StartupWMClass=mscore" "StartupWMClass=MuseScore3"
     rm $desktop
 
     # 3) Rename app icons (apps/)
@@ -169,33 +165,29 @@ stdenv.mkDerivation (finalAttrs: {
                 "$out"/share/icons/hicolor/*/mimetypes/application-x-musescore+xml.*; do
       dir="''${icon%/*}"; base="''${icon##*/}"; ext="''${base##*.}"
       case "$base" in
-        application-x-musescore.*) mv "$icon" "$dir/application-x-musescore-evo.$ext" ;;
-        application-x-musescore+xml.*) mv "$icon" "$dir/application-x-musescore-evo+xml.$ext" ;;
+        application-x-musescore.*) mv "$icon" "$dir/application-x-musescore-evolution.$ext" ;;
+        application-x-musescore+xml.*) mv "$icon" "$dir/application-x-musescore-evolution+xml.$ext" ;;
       esac
     done
 
     # 4) Rename MIME XML and point icons to the new names
-    mv "$out/share/mime/packages/musescore.xml" "$out/share/mime/packages/musescore-evo.xml"
+    mv "$out/share/mime/packages/musescore.xml" "$out/share/mime/packages/musescore-evolution.xml"
     sed -i \
-      -e 's|<icon>application-x-musescore\(\+xml\)\?</icon>|<icon>application-x-musescore-evo\1</icon>|g' \
+      -e 's|<icon>application-x-musescore\(\+xml\)\?</icon>|<icon>application-x-musescore-evolution\1</icon>|g' \
       -e 's|<icon>musescore</icon>|<icon>mscore-evo</icon>|g' \
-      "$out/share/mime/packages/musescore-evo.xml"
+      "$out/share/mime/packages/musescore-evolution.xml"
 
     # 5) Rename man pages to match mscore-evo and remove legacy symlinks
     manDir="$out/share/man/man1"
 
-    # Remove all old musescore/mscore symlinks first (gzip may have created them)
-    find "$manDir" -type l \
-      \( -name 'mscore.1*' -o -name 'musescore.1*' \) \
-      -exec rm -f {} +
+    # Fix existing dangling aliases
+    if [ -f "$manDir/mscore.1.gz" ]; then
+      mv "$manDir/mscore.1.gz" "$manDir/mscore-evo.1.gz"
+    fi
 
-    # Rename real files
-    find "$manDir" \( -name 'mscore.1*' -o -name 'musescore.1*' \) -type f |
-    while IFS= read -r man; do
-      base="$(basename "$man")"
-      newname=$(echo "$base" | sed -e 's/^mscore/mscore-evo/' -e 's/^musescore/mscore-evo/')
-      mv "$man" "$manDir/$newname"
-    done
+    # Replace old musescore.1.gz alias
+    rm -f "$manDir/musescore.1.gz"
+    ln -s "$manDir/mscore-evo.1.gz" "$manDir/musescore-evolution.1.gz"
 
     # 6) Rename AppStream metadata and its IDs
     meta="$out/share/metainfo/org.musescore.MuseScore.appdata.xml"


### PR DESCRIPTION
- Updated package
- Removed patch (fixed in upstream Musescore Evolution now)-
- Fixed binary name conflict with `musescore` (resolves #530246)
- Made renaming scheme more consistent


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
