### PR TITLE
aws-iam-language-server: init at 0.0.38

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17427,6 +17427,12 @@
     githubId = 613740;
     name = "Martin Baillie";
   };
+  mbarneyjr = {
+    email = "mbarneyme@gmail.com";
+    github = "mbarneyjr";
+    githubId = 11701776;
+    name = "Michael Barney";
+  };
   mbe = {
     email = "brandonedens@gmail.com";
     github = "brandonedens";

--- a/pkgs/by-name/aw/aws-iam-language-server/package.nix
+++ b/pkgs/by-name/aw/aws-iam-language-server/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "aws-iam-language-server";
+  version = "0.0.35";
+
+  src = fetchFromGitHub {
+    owner = "mbarneyjr";
+    repo = "aws-iam-language-server";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-EcaJitilBgLzQGRLgfWnk/mrOF1ncpD3UZETh58/V+w=";
+  };
+
+  npmDepsHash = "sha256-AptI7QS7uDYekklZ4tP0QyuGfhDn75W0bCQxdxx+gME=";
+
+  doCheck = true;
+  checkPhase = ''
+    npm test
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "AWS IAM Policy Language Server";
+    mainProgram = "aws-iam-language-server";
+    homepage = "https://github.com/mbarneyjr/aws-iam-language-server";
+    license = lib.licenses.mit;
+    platforms = with lib.platforms; linux ++ darwin;
+    maintainers = with lib.maintainers; [
+      mbarneyjr
+    ];
+  };
+})

--- a/pkgs/by-name/aw/aws-iam-language-server/package.nix
+++ b/pkgs/by-name/aw/aws-iam-language-server/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "aws-iam-language-server";
+  version = "0.0.38";
+
+  src = fetchFromGitHub {
+    owner = "mbarneyjr";
+    repo = "aws-iam-language-server";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-GypV7Ey4ZVYJKszt2kX0xMH+V8LLYv6msDJIOeID4tk=";
+  };
+
+  npmDepsHash = "sha256-MvqbZR2GLCzmijCdGi4A58ZxbZjzCYom5uF/BT2iAKw=";
+
+  doCheck = true;
+  checkPhase = ''
+    npm test
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "AWS IAM Policy Language Server";
+    mainProgram = "aws-iam-language-server";
+    homepage = "https://github.com/mbarneyjr/aws-iam-language-server";
+    license = lib.licenses.mit;
+    platforms = with lib.platforms; linux ++ darwin;
+    maintainers = with lib.maintainers; [
+      mbarneyjr
+    ];
+  };
+})


### PR DESCRIPTION
This inits [aws-iam-language-server](https://github.com/mbarneyjr/aws-iam-language-server) at version 0.0.34 (latest as of creating this PR).

The AWS IAM Language Server is an LSP server that works on CloudFormation/Terraform/Tofu/YAML/JSON files to provide autocomplete, hover information, diagnostic tooltips, and document links for the AWS IAM policy language (actions, resources, conditions, etc), even embedded within sections of a CloudFormation template or Terraform module.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
