### PR TITLE
[25.11] percona-server_8_0: 8.0.45-36 -> 8.0.46-37

### DIFF
--- a/pkgs/servers/sql/percona-server/8_0.nix
+++ b/pkgs/servers/sql/percona-server/8_0.nix
@@ -43,11 +43,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "percona-server";
-  version = "8.0.45-36";
+  version = "8.0.46-37";
 
   src = fetchurl {
     url = "https://downloads.percona.com/downloads/Percona-Server-8.0/Percona-Server-${finalAttrs.version}/source/tarball/percona-server-${finalAttrs.version}.tar.gz";
-    hash = "sha256-E3zbJKH1uK+9H+84RXuY6tjXPjzHPCKjxvrMlKs4cd4=";
+    hash = "sha256-zt/zwZH/Fg38DOHFdEQBZfPyv+emIWmRcK300dxVZhc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/tools/backup/percona-xtrabackup/8_0.nix
+++ b/pkgs/tools/backup/percona-xtrabackup/8_0.nix
@@ -3,8 +3,8 @@
 callPackage ./generic.nix (
   args
   // {
-    version = "8.0.35-34";
-    hash = "sha256-DqjDBLSQqlWazWJjdb+n7RwqSe/OMlZI2ca/JNTX2W8=";
+    version = "8.0.35-36";
+    hash = "sha256-5PCIsQMx5xMdI1CwbcaPWZd8HEd1tsFVSKy6+xTWdSI=";
 
     # includes https://github.com/Percona-Lab/libkmip.git
     fetchSubmodules = true;


### PR DESCRIPTION
https://docs.percona.com/percona-server/8.0/release-notes/8.0.46-37.html

.. and percona-xtrabackup_8_0: 8.0.35-34 -> 8.0.35-36

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
