### PR TITLE
python3Packages.manuel: migrate to pyproject, enable __structuredAttrs, use finalAttrs, add changelog, enable tests

### DIFF
--- a/pkgs/development/python-modules/manuel/default.nix
+++ b/pkgs/development/python-modules/manuel/default.nix
@@ -25,6 +25,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Documentation builder";
     homepage = "https://pypi.org/project/manuel/";
+    changelog = "https://github.com/benji-york/manuel/blob/${finalAttrs.version}/CHANGES.rst";
     license = lib.licenses.zpl20;
   };
 })

--- a/pkgs/development/python-modules/manuel/default.nix
+++ b/pkgs/development/python-modules/manuel/default.nix
@@ -4,6 +4,7 @@
   fetchPypi,
   fetchpatch,
   python,
+  setuptools,
   six,
   zope-testing,
 }:
@@ -11,7 +12,7 @@
 buildPythonPackage (finalAttrs: {
   pname = "manuel";
   version = "1.13.0";
-  format = "setuptools";
+  pyproject = true;
 
   __structuredAttrs = true;
 
@@ -30,7 +31,10 @@ buildPythonPackage (finalAttrs: {
     })
   ];
 
-  propagatedBuildInputs = [ six ];
+  build-system = [ setuptools ];
+
+  dependencies = [ six ];
+
   nativeCheckInputs = [ zope-testing ];
 
   meta = {

--- a/pkgs/development/python-modules/manuel/default.nix
+++ b/pkgs/development/python-modules/manuel/default.nix
@@ -8,13 +8,13 @@
   zope-testing,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "manuel";
   version = "1.13.0";
   format = "setuptools";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-XWMSDej6bZJ3gLaa4oqj6dFmmxCvPTJ4Xz+6EaW+iFo=";
   };
 
@@ -36,4 +36,4 @@ buildPythonPackage rec {
     homepage = "https://pypi.org/project/manuel/";
     license = lib.licenses.zpl20;
   };
-}
+})

--- a/pkgs/development/python-modules/manuel/default.nix
+++ b/pkgs/development/python-modules/manuel/default.nix
@@ -13,6 +13,8 @@ buildPythonPackage (finalAttrs: {
   version = "1.13.0";
   format = "setuptools";
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
     inherit (finalAttrs) pname version;
     hash = "sha256-XWMSDej6bZJ3gLaa4oqj6dFmmxCvPTJ4Xz+6EaW+iFo=";

--- a/pkgs/development/python-modules/manuel/default.nix
+++ b/pkgs/development/python-modules/manuel/default.nix
@@ -2,10 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  fetchpatch,
-  python,
   setuptools,
-  six,
   zope-testing,
 }:
 
@@ -21,19 +18,7 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-XWMSDej6bZJ3gLaa4oqj6dFmmxCvPTJ4Xz+6EaW+iFo=";
   };
 
-  patches = lib.optionals (lib.versionAtLeast python.version "3.11") [
-    # https://github.com/benji-york/manuel/pull/32
-    # Applying conditionally until upstream arrives at some general solution.
-    (fetchpatch {
-      name = "TextTestResult-python311.patch";
-      url = "https://github.com/benji-york/manuel/commit/d9f12d03e39bb76e4bb3ba43ad51af6d3e9d45c0.diff";
-      hash = "sha256-k0vBtxEixoI1INiKtc7Js3Ai00iGAcCvCFI1ZIBRPvQ=";
-    })
-  ];
-
   build-system = [ setuptools ];
-
-  dependencies = [ six ];
 
   nativeCheckInputs = [ zope-testing ];
 

--- a/pkgs/development/python-modules/manuel/default.nix
+++ b/pkgs/development/python-modules/manuel/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  python,
   setuptools,
   zope-testing,
 }:
@@ -21,6 +22,13 @@ buildPythonPackage (finalAttrs: {
   build-system = [ setuptools ];
 
   nativeCheckInputs = [ zope-testing ];
+
+  # https://github.com/benji-york/manuel/issues/34#issuecomment-2016443027
+  checkPhase = ''
+    ${python.interpreter} -m unittest -vv manuel.tests.test_suite
+  '';
+
+  pythonImportsCheck = [ "manuel" ];
 
   meta = {
     description = "Documentation builder";


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974
- use `finalAttrs`
- enable `__structuredAttrs`
- add changelog
- remove unused `six` dependency and patch, both made unnecessary by 1.13.0
- enable tests

I couldn't get `pytestCheckHook` or `unittestCheckHook` to pick up the tests correctly, hence the manual invocation. 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
