### PR TITLE
testers.testEqualEvalSet: init from `tests.overriding`'s implementation

### DIFF
--- a/lib/debug.nix
+++ b/lib/debug.nix
@@ -533,7 +533,7 @@ rec {
             ]
           else
             [ ]
-        ) tests
+        ) (removeAttrs tests [ "tests" ])
       )
     );
 

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -158,6 +158,54 @@ in
 
 runTests {
 
+  # DEBUG
+
+  testRunTest =
+    let
+      test-cases = {
+        foo-false = {
+          expr = 2;
+          expected = 3;
+        };
+        foo-true = {
+          expr = 1;
+          expected = 1;
+        };
+        test-bar-false = {
+          expr = 2;
+          expected = 3;
+        };
+        test-bar-true = {
+          expr = 1;
+          expected = 1;
+        };
+      };
+      test-cases-without-prefixed = lib.filterAttrs (n: v: lib.hasPrefix "foo-" n) test-cases;
+      toResult =
+        testCases:
+        lib.attrValues (
+          lib.mapAttrs (testName: testCase: {
+            name = testName;
+            inherit (testCase) expected;
+            result = testCase.expr;
+          }) testCases
+        );
+    in
+    {
+      expr = {
+        empty = runTests { };
+        testlist-unspecified-without-prefixed = runTests test-cases-without-prefixed;
+        testlist-unspecified-with-prefixed = runTests test-cases;
+        testlist-nonempty = runTests (test-cases // { tests = lib.attrNames test-cases-without-prefixed; });
+      };
+      expected = {
+        empty = [ ];
+        testlist-unspecified-without-prefixed = [ ];
+        testlist-unspecified-with-prefixed = toResult { inherit (test-cases) test-bar-false; };
+        testlist-nonempty = toResult { inherit (test-cases) foo-false; };
+      };
+    };
+
   # CUSTOMIZATION
 
   testFunctionArgsMakeOverridable = {

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -196,12 +196,16 @@ runTests {
         empty = runTests { };
         testlist-unspecified-without-prefixed = runTests test-cases-without-prefixed;
         testlist-unspecified-with-prefixed = runTests test-cases;
+        testlist-empty-without-prefixed = runTests (test-cases-without-prefixed // { tests = [ ]; });
+        testlist-empty-with-prefixed = runTests (test-cases // { tests = [ ]; });
         testlist-nonempty = runTests (test-cases // { tests = lib.attrNames test-cases-without-prefixed; });
       };
       expected = {
         empty = [ ];
         testlist-unspecified-without-prefixed = [ ];
         testlist-unspecified-with-prefixed = toResult { inherit (test-cases) test-bar-false; };
+        testlist-empty-without-prefixed = [ ];
+        testlist-empty-with-prefixed = toResult { inherit (test-cases) test-bar-false; };
         testlist-nonempty = toResult { inherit (test-cases) foo-false; };
       };
     };

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -96,6 +96,68 @@
   # or doc/build-helpers/testers.chapter.md
   testEqualArrayOrMap = callPackage ./testEqualArrayOrMap { };
 
+  testEqualEvalSet = lib.extendMkDerivation {
+    constructDrv = stdenvNoCC.mkDerivation;
+    excludeDrvArgNames = [
+      "tests"
+    ];
+    extendDrvArgs =
+      finalAttrs:
+      {
+        name,
+        tests,
+        literalPackage ? "",
+        # Name attributes handled by mkDerivation
+      }:
+      let
+        genPassthruHint =
+          attrName:
+          if finalAttrs.literalPackage != "" then
+            finalAttrs.literalPackage + "." + attrName
+          else
+            "the test package's passthru." + attrName;
+      in
+      {
+        __structuredAttrs = true;
+        preferLocalBuild = true;
+        inherit
+          name
+          literalPackage
+          ;
+        nTests = lib.length (lib.attrNames finalAttrs.passthru.all-tests);
+        nFailures = lib.length finalAttrs.passthru.failures;
+        testResultsText = lib.concatMapAttrsStringSep "\n" (
+          n: v: "[${if v.expr == v.expected then "PASS" else "FAIL"}] ${n}"
+        ) finalAttrs.passthru.all-tests;
+        testFailuresText = lib.concatLines (map (t: "- " + t.name) finalAttrs.passthru.failures);
+        testAccessText = ''
+          The tests can be found in ${genPassthruHint "all-tests"}
+          The failures in ${genPassthruHint "failures"}
+        '';
+        buildCommand = ''
+          echo "''${literalPackage:-$name} has $nTests tests, $nFailures failed."
+          echo "$testResultsText"
+          if [[ -n "$testFailuresText" ]]; then
+            echo "ERROR: ''${literalPackage:-name}: $nFailures failed tests encountered."
+            echo "$testFailuresText"
+            echo "$testAccessText"
+            exit 1
+          fi
+          echo "''${literalPackage:-name}: All tests passed."
+          touch "$out"
+        '';
+        passthru = {
+          all-tests = tests;
+          failures = lib.runTests (
+            {
+              tests = lib.attrNames finalAttrs.passthru.all-tests;
+            }
+            // finalAttrs.passthru.all-tests
+          );
+        };
+      };
+  };
+
   # See https://nixos.org/manual/nixpkgs/unstable/#tester-testVersion
   # or doc/build-helpers/testers.chapter.md
   testVersion =

--- a/pkgs/build-support/testers/test/default.nix
+++ b/pkgs/build-support/testers/test/default.nix
@@ -401,4 +401,110 @@ lib.recurseIntoAttrs {
   };
 
   testEqualArrayOrMap = pkgs.callPackages ../testEqualArrayOrMap/tests.nix { };
+
+  testEqualEvalSet =
+    let
+      sample-single-failed = testers.testEqualEvalSet {
+        name = "testEqualEvalSet-sample-single-failed";
+        tests = {
+          test-ab-failed = {
+            expr = "ab";
+            expected = "c";
+          };
+        };
+      };
+
+      sample-build-failure = stdenvNoCC.mkDerivation {
+        name = "testEqualEvalSet-sample-build-failure";
+        buildCommand = ''
+          echo "ERROR: $name is only meant to be evaluated without building."
+          false
+        '';
+      };
+    in
+    lib.recurseIntoAttrs rec {
+      empty = testers.testEqualEvalSet {
+        name = "testEqualEvalSet-empty";
+        literalPackage = "tests.testers.testEqualEvalSet.empty";
+        tests = { };
+      };
+
+      single = testers.testEqualEvalSet {
+        name = "testEqualEvalSet-single";
+        tests = {
+          test-ab = {
+            expr = "a" + "b";
+            expected = "ab";
+          };
+        };
+      };
+
+      single-literalPackage = single.overrideAttrs {
+        name = "testEqualEvalSet-single-literalPackage";
+        literalPackage = "tests.testers.testEqualEvalSet.single-literalPackage";
+      };
+
+      single-failed = testers.testBuildFailure sample-single-failed;
+
+      single-failed-literalPackage = testers.testBuildFailure (
+        sample-single-failed.overrideAttrs {
+          name = "testEqualEvalSet-single-failed-literalPackage";
+          literalPackage = "tests.testers.testEqualEvalSet.single-failed-literalPackage";
+        }
+      );
+
+      multiple-types = testers.testEqualEvalSet {
+        name = "testEqualEvalSet-multiple-types";
+        literalPackage = "tests.testers.testEqualEvalSet.multiple-types";
+        tests = {
+          null = {
+            expr = null;
+            expected = null;
+          };
+          int = {
+            expr = 1;
+            expected = 1;
+          };
+          float = {
+            expr = 1.0;
+            expected = 1.0;
+          };
+          string = {
+            expr = "hi";
+            expected = "hi";
+          };
+          derivation = {
+            expr = emptyFile;
+            expected = emptyFile;
+          };
+          drv-path = {
+            expr = emptyFile.drvPath;
+            expected = emptyFile.drvPath;
+          };
+          out-path = {
+            expr = emptyFile.outPath;
+            expected = emptyFile.outPath;
+          };
+        };
+      };
+
+      no-build-expr = testers.testEqualEvalSet {
+        name = "testEqualEvalSet-no-build-expr";
+        literalPackage = "tests.testers.testEqualEvalSet.no-build-expr";
+        tests = {
+          derivation = {
+            expr = sample-build-failure;
+            expected = sample-build-failure;
+          };
+          drv-path = {
+            expr = sample-build-failure.drvPath;
+            expected = sample-build-failure.drvPath;
+          };
+          out-path = {
+            expr = sample-build-failure.outPath;
+            expected = sample-build-failure.outPath;
+          };
+        };
+      };
+    };
 }

--- a/pkgs/test/overriding.nix
+++ b/pkgs/test/overriding.nix
@@ -2,6 +2,7 @@
   lib,
   pkgs,
   stdenvNoCC,
+  testers,
 }:
 
 let
@@ -523,35 +524,8 @@ let
 
 in
 
-stdenvNoCC.mkDerivation (finalAttrs: {
-  __structuredAttrs = true;
+testers.testEqualEvalSet {
   name = "test-overriding";
-  passthru = {
-    inherit tests;
-    failures = lib.runTests (finalAttrs.passthru.tests // { tests = lib.attrNames tests; });
-  };
-  testResults = lib.mapAttrs (testName: test: test.expr == test.expected) finalAttrs.passthru.tests;
-  buildCommand = ''
-    touch $out
-    for testName in "''${!testResults[@]}"; do
-      if [[ -n "''${testResults[$testName]}" ]]; then
-        echo "$testName success"
-      else
-        echo "$testName fail"
-      fi
-    done
-  ''
-  + lib.optionalString (lib.any (v: !v) (lib.attrValues finalAttrs.testResults)) ''
-    {
-      echo "ERROR: tests.overriding: Encountering failed tests."
-      for testName in "''${!testResults[@]}"; do
-        if [[ -z "''${testResults[$testName]}" ]]; then
-          echo "- $testName"
-        fi
-      done
-      echo "To inspect the expected and actual result, "
-      echo '  evaluate `tests.overriding.tests.''${testName}`.'
-    } >&2
-    exit 1
-  '';
-})
+  literalPackage = "tests.overriding";
+  inherit tests;
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR abstracts the implementation of `tests.overriding` into a tester `testers.testEqualEvalSet`, so that we could construct similar evaluation package tests outside `tests.overriding`, with some refactoring to enhance build log readability.

This PR depends on:
- #529236

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
