### PR TITLE
python3Packages.beets-filetote: 1.1.1 -> 1.3.5, add returntoreality as maintainer

### DIFF
--- a/pkgs/development/python-modules/beets-filetote/default.nix
+++ b/pkgs/development/python-modules/beets-filetote/default.nix
@@ -81,7 +81,10 @@ buildPythonPackage (finalAttrs: {
     description = "Beets plugin to move non-music files during the import process";
     homepage = "https://github.com/gtronset/beets-filetote";
     changelog = "https://github.com/gtronset/beets-filetote/blob/${finalAttrs.src.tag}/CHANGELOG.md";
-    maintainers = with lib.maintainers; [ dansbandit ];
+    maintainers = with lib.maintainers; [
+      dansbandit
+      returntoreality
+    ];
     license = lib.licenses.mit;
     inherit (beets-minimal.meta) platforms;
   };

--- a/pkgs/development/python-modules/beets-filetote/default.nix
+++ b/pkgs/development/python-modules/beets-filetote/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  fetchpatch2,
   buildPythonPackage,
 
   # build-system
@@ -20,17 +21,26 @@
   writableTmpDirAsHomeHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "beets-filetote";
-  version = "1.1.1";
+  version = "1.3.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "gtronset";
     repo = "beets-filetote";
-    tag = "v${version}";
-    hash = "sha256-NsYBsP60SiCfQ63C4WMkshyreFqOSmx3LP5Gwq6ECF0=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qMHjcBrXkVG7U5a1E0yRwNgmg7XinRnK3gnV7jAZLTk=";
   };
+  # needed to keep beetsplug a namespace package, othwise other plugins will not be found
+  # can be removed with next version
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/gtronset/beets-filetote/commit/762cf0c4b60b8f6b38cf39b027de4241f12cef37.patch?full_index=1";
+      hash = "sha256-c7qIECcqwoV4ZOaA/8JYsM6Aym34peWPh7ZLWUxIYSI=";
+      excludes = [ "CHANGELOG.md" ];
+    })
+  ];
 
   postPatch = ''
     substituteInPlace pyproject.toml --replace-fail "poetry-core<2.0.0" "poetry-core"
@@ -67,20 +77,12 @@ buildPythonPackage rec {
     "-rfEs"
   ];
 
-  disabledTestPaths = [
-    "tests/test_cli_operation.py"
-    "tests/test_pruning.py"
-    "tests/test_version.py"
-  ];
-
   meta = {
     description = "Beets plugin to move non-music files during the import process";
     homepage = "https://github.com/gtronset/beets-filetote";
-    changelog = "https://github.com/gtronset/beets-filetote/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/gtronset/beets-filetote/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     maintainers = with lib.maintainers; [ dansbandit ];
     license = lib.licenses.mit;
     inherit (beets-minimal.meta) platforms;
-    # https://github.com/gtronset/beets-filetote/issues/211
-    broken = true;
   };
-}
+})


### PR DESCRIPTION
Updated to latest release, removed broken, added myself to maintainers

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
