### PR TITLE
nemo: 6.6.4 -> 6.7.2, nemo-{emblems,fileroller,preview,python,seahorse}: 6.6.0 -> 6.7.0

### DIFF
--- a/pkgs/by-name/ne/nemo-emblems/package.nix
+++ b/pkgs/by-name/ne/nemo-emblems/package.nix
@@ -7,15 +7,15 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "nemo-emblems";
-  version = "6.6.0";
+  version = "6.7.0";
   pyproject = true;
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "nemo-extensions";
-    rev = finalAttrs.version;
-    hash = "sha256-tXeMkaCYnWzg+6ng8Tyg4Ms1aUeE3xiEkQ3tKEX6Vv8=";
+    rev = "${finalAttrs.version}-unstable";
+    hash = "sha256-msmy//e15B6lYLfsqqUhPAYt/PK+c4k6piY7pw4eqkI=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/nemo-emblems";

--- a/pkgs/by-name/ne/nemo-fileroller/package.nix
+++ b/pkgs/by-name/ne/nemo-fileroller/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nemo-fileroller";
-  version = "6.6.0";
+  version = "6.7.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "nemo-extensions";
-    rev = finalAttrs.version;
-    hash = "sha256-tXeMkaCYnWzg+6ng8Tyg4Ms1aUeE3xiEkQ3tKEX6Vv8=";
+    rev = "${finalAttrs.version}-unstable";
+    hash = "sha256-msmy//e15B6lYLfsqqUhPAYt/PK+c4k6piY7pw4eqkI=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/nemo-fileroller";
@@ -39,8 +39,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace src/nemo-fileroller.c \
-      --replace "file-roller" "${lib.getExe file-roller}" \
-      --replace "GNOMELOCALEDIR" "${cinnamon-translations}/share/locale"
+      --replace-fail "file-roller" "${lib.getExe file-roller}"
+
+    substituteInPlace meson.build \
+      --replace-fail "config.set_quoted('GNOMELOCALEDIR', get_option('prefix')/get_option('datadir')/'locale')" \
+        "config.set_quoted('GNOMELOCALEDIR', '${cinnamon-translations}/share/locale')"
   '';
 
   env.PKG_CONFIG_LIBNEMO_EXTENSION_EXTENSIONDIR = "${placeholder "out"}/${nemo.extensiondir}";

--- a/pkgs/by-name/ne/nemo-preview/package.nix
+++ b/pkgs/by-name/ne/nemo-preview/package.nix
@@ -21,13 +21,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nemo-preview";
-  version = "6.6.0";
+  version = "6.7.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "nemo-extensions";
-    tag = finalAttrs.version;
-    hash = "sha256-tXeMkaCYnWzg+6ng8Tyg4Ms1aUeE3xiEkQ3tKEX6Vv8=";
+    tag = "${finalAttrs.version}-unstable";
+    hash = "sha256-msmy//e15B6lYLfsqqUhPAYt/PK+c4k6piY7pw4eqkI=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/nemo-preview";

--- a/pkgs/by-name/ne/nemo-python/package.nix
+++ b/pkgs/by-name/ne/nemo-python/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nemo-python";
-  version = "6.6.0";
+  version = "6.7.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "nemo-extensions";
-    rev = finalAttrs.version;
-    hash = "sha256-tXeMkaCYnWzg+6ng8Tyg4Ms1aUeE3xiEkQ3tKEX6Vv8=";
+    rev = "${finalAttrs.version}-unstable";
+    hash = "sha256-msmy//e15B6lYLfsqqUhPAYt/PK+c4k6piY7pw4eqkI=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/nemo-python";
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     # Tries to load libpython3.so via g_module_open ().
     substituteInPlace meson.build \
-      --replace "get_option('prefix'), get_option('libdir')" "'${python3}/lib'"
+      --replace-fail "get_option('prefix'), get_option('libdir')" "'${python3}/lib'"
   '';
 
   env.PKG_CONFIG_LIBNEMO_EXTENSION_EXTENSIONDIR = "${placeholder "out"}/${nemo.extensiondir}";

--- a/pkgs/by-name/ne/nemo-seahorse/package.nix
+++ b/pkgs/by-name/ne/nemo-seahorse/package.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nemo-seahorse";
-  version = "6.6.0";
+  version = "6.7.0";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "nemo-extensions";
-    tag = finalAttrs.version;
-    hash = "sha256-tXeMkaCYnWzg+6ng8Tyg4Ms1aUeE3xiEkQ3tKEX6Vv8=";
+    tag = "${finalAttrs.version}-unstable";
+    hash = "sha256-msmy//e15B6lYLfsqqUhPAYt/PK+c4k6piY7pw4eqkI=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/nemo-seahorse";

--- a/pkgs/by-name/ne/nemo-with-extensions/package.nix
+++ b/pkgs/by-name/ne/nemo-with-extensions/package.nix
@@ -51,7 +51,7 @@ symlinkJoin {
     do
       rm "$out/$file"
       substitute "${nemo}/$file" "$out/$file" \
-        --replace "${nemo}" "$out"
+        --replace-fail "${nemo}" "$out"
     done
   '';
 

--- a/pkgs/by-name/ne/nemo/package.nix
+++ b/pkgs/by-name/ne/nemo/package.nix
@@ -37,13 +37,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "nemo";
-  version = "6.6.4";
+  version = "6.7.2";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
     repo = "nemo";
-    rev = finalAttrs.version;
-    hash = "sha256-HYrpq22rWScdweDQQlrQbOShYFH4FjZWQKBnvKIsOAI=";
+    rev = "${finalAttrs.version}-unstable";
+    hash = "sha256-MkMbX3XCONHdE+WznUmHlP1HUFnaIHpoTIvVPQmV/vM=";
   };
 
   patches = [


### PR DESCRIPTION
Updates Nemo and the packaged Nemo extension set that is used by `nemo-with-extensions`.

Changes:
- `nemo`: 6.6.4 -> 6.7.2. Upstream tag `6.7.2-unstable` reports project version `6.7.2`.
- `nemo-emblems`: 6.6.0 -> 6.7.0.
- `nemo-fileroller`: 6.6.0 -> 6.7.0.
- `nemo-preview`: 6.6.0 -> 6.7.0.
- `nemo-python`: 6.6.0 -> 6.7.0.
- `nemo-seahorse`: 6.6.0 -> 6.7.0.

The extension packages above are sourced from `linuxmint/nemo-extensions`. Upstream tag `6.7.0-unstable` carries those subproject versions.

`nemo-with-extensions` has no independent version. It now resolves to `nemo-with-extensions-6.7.2` through `nemo.version`; this also switches its service-file substitution to `--replace-fail` so future upstream drift fails during the build instead of silently missing the replacement.

`nemo-fileroller` now patches `GNOMELOCALEDIR` in `meson.build` because the 6.7.0 source no longer has that token in `src/nemo-fileroller.c`.

`folder-color-switcher` is also part of the default `nemo-with-extensions` input set. It is unchanged because nixpkgs already pins upstream `HEAD` (`856f6f27dfa48ee1ac8d7ec40333e3f892458067`), version = `1.7.1`.

Upstream references:
- https://github.com/linuxmint/nemo/tree/6.7.2-unstable
- https://github.com/linuxmint/nemo-extensions/tree/6.7.0-unstable
- https://github.com/linuxmint/folder-color-switcher/commit/856f6f27dfa48ee1ac8d7ec40333e3f892458067

Validation (x86_64-linux):
- `nixfmt pkgs/by-name/ne/nemo/package.nix pkgs/by-name/ne/nemo-emblems/package.nix pkgs/by-name/ne/nemo-fileroller/package.nix pkgs/by-name/ne/nemo-python/package.nix pkgs/by-name/ne/nemo-preview/package.nix pkgs/by-name/ne/nemo-seahorse/package.nix pkgs/by-name/ne/nemo-with-extensions/package.nix`
- `git diff --check`
- `nix eval --impure --json --expr ...`
- `nix-build -A nemo -A nemo-with-extensions -A nemo-emblems -A nemo-fileroller -A nemo-python -A nemo-preview -A nemo-seahorse --no-out-link`
- `nix-build -A folder-color-switcher --no-out-link`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test