### PR TITLE
wgpu-native: 27.0.4.0 -> 29.0.0.0

### DIFF
--- a/pkgs/by-name/wg/wgpu-native/package.nix
+++ b/pkgs/by-name/wg/wgpu-native/package.nix
@@ -7,17 +7,18 @@
   vulkan-loader,
   nix-update-script,
   callPackage,
+  makePkgconfigItem,
+  copyPkgconfigItems,
 }:
-
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "wgpu-native";
-  version = "27.0.4.0";
+  version = "29.0.0.0";
 
   src = fetchFromGitHub {
     owner = "gfx-rs";
     repo = "wgpu-native";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-XOT6Wx5TfbFzwcSjoyqUwv7mbN0RShaMf99qADmCKxg=";
+    hash = "sha256-XaNNqQ7YcAuINSrG0Ri8qRA7b5iJPTbTKlFutKw2MQU=";
     fetchSubmodules = true;
   };
 
@@ -26,10 +27,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "dev"
   ];
 
-  cargoHash = "sha256-PZHS2lUX6PbIG1xF6jhreGjdtCbS/GWeY1pHhRPo2aU=";
+  cargoHash = "sha256-M0yQhKqs1ifOlh5yDsajMH3P2Qj2rUIqrhUhyl1FKV4=";
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook
+    copyPkgconfigItems
   ]
   ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
 
@@ -37,7 +39,29 @@ rustPlatform.buildRustPackage (finalAttrs: {
     vulkan-loader
   ];
 
-  env.WGPU_NATIVE_VERSION = finalAttrs.version;
+  pkgconfigItems = [
+    (makePkgconfigItem {
+      name = "wgpu-native";
+      inherit (finalAttrs) version;
+      inherit (finalAttrs.meta) description;
+      libs = [
+        "-L\${libdir}"
+        "-lwgpu_native"
+      ];
+      cflags = [ "-I\${includedir}" ];
+      variables = {
+        includedir = "@includedir@";
+        libdir = "@libdir@";
+      };
+    })
+  ];
+
+  env = {
+    WGPU_NATIVE_VERSION = finalAttrs.version;
+    # copyPkgconfigItems will substitute these in the pkg-config file
+    includedir = "${placeholder "dev"}/include";
+    libdir = "${placeholder "out"}/lib";
+  };
 
   postInstall = ''
     rm $out/lib/libwgpu_native.a


### PR DESCRIPTION
Numerous API changes and new features in webgpu.h spec.
https://github.com/gfx-rs/wgpu-native/blob/trunk/CHANGELOG.md
https://github.com/gfx-rs/wgpu-native/releases/tag/v29.0.0.0

Added pkg-config item. (Its useful for build scripts. This can be removed if not wanted.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
