### PR TITLE
python3Packages.httpx: only unset $SSL_CERT_FILE if path doesn't exist

### DIFF
--- a/pkgs/development/python-modules/httpx/setup-hook.sh
+++ b/pkgs/development/python-modules/httpx/setup-hook.sh
@@ -1,5 +1,7 @@
 httpxSslCertFileUnset() {
+  if [ ! -e "${SSL_CERT_FILE-}" ]; then
     unset SSL_CERT_FILE
+  fi
 }
 
 postHooks+=(httpxSslCertFileUnset)

--- a/pkgs/development/python-modules/prowlpy/default.nix
+++ b/pkgs/development/python-modules/prowlpy/default.nix
@@ -43,18 +43,13 @@ buildPythonPackage (finalAttrs: {
   pythonImportsCheck = [ "prowlpy" ];
 
   nativeCheckInputs = [
+    cacert
     pytest-asyncio
     pytest-cov-stub
     pytestCheckHook
     respx
   ]
   ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
-
-  preCheck = ''
-    # Without this pyreqwest fails with
-    #     unexpected error: No CA certificates were loaded from the system
-    export SSL_CERT_FILE="${cacert}/etc/ssl/certs/ca-bundle.crt"
-  '';
 
   # tests fail without this
   pytestFlags = [ "-v" ];

--- a/pkgs/development/python-modules/pyreqwest/default.nix
+++ b/pkgs/development/python-modules/pyreqwest/default.nix
@@ -43,6 +43,7 @@ buildPythonPackage (finalAttrs: {
   pythonImportsCheck = [ "pyreqwest" ];
 
   nativeCheckInputs = [
+    cacert
     dirty-equals
     docker
     granian
@@ -56,12 +57,6 @@ buildPythonPackage (finalAttrs: {
     trustme
     yarl
   ];
-
-  preCheck = ''
-    # Without this tests fails with
-    #     unexpected error: No CA certificates were loaded from the system
-    export SSL_CERT_FILE="${cacert}/etc/ssl/certs/ca-bundle.crt"
-  '';
 
   disabledTestPaths = [
     # requires a running Docker daemon


### PR DESCRIPTION
see https://github.com/NixOS/nixpkgs/pull/518879

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
