### PR TITLE
beamPackages.buildMix: fix install hooks not running

### DIFF
--- a/pkgs/development/beam-modules/hooks/beam-module-install-hook.sh
+++ b/pkgs/development/beam-modules/hooks/beam-module-install-hook.sh
@@ -7,6 +7,8 @@
 beamModuleInstallHook() {
   echo "Executing beamModuleInstallHook"
 
+  runHook preInstall
+
   mkdir -p "$out/lib/erlang/lib/${beamModuleName}-${version}"
 
   # default to rebar3
@@ -24,6 +26,8 @@ beamModuleInstallHook() {
       cp -vHrt "$out/lib/erlang/lib/${beamModuleName}-${version}" "$reldir"
     fi
   done
+
+  runHook postInstall
 
   echo "Finished beamModuleInstallHook"
 }


### PR DESCRIPTION
When I updated to NixOS 26.05 I noticed a `postInstall` hook for `beamPackages.buildMix` didn't run. With some AI-assisted debugging I tracked it down to the refactor in https://github.com/NixOS/nixpkgs/pull/475224, which added `beamModuleInstallHook`. Since it overrides the `installPhase` it needs to call the hooks, similarly to `mixCompileHook` in the same PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
