### PR TITLE
mandoc: modernize

### DIFF
--- a/pkgs/by-name/ma/mandoc/package.nix
+++ b/pkgs/by-name/ma/mandoc/package.nix
@@ -26,6 +26,10 @@ stdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
   strictDeps = true;
   enableParallelBuilding = true;
+  outputs = [
+    "out"
+    "man"
+  ];
 
   buildInputs = [ zlib ];
 

--- a/pkgs/by-name/ma/mandoc/package.nix
+++ b/pkgs/by-name/ma/mandoc/package.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "8bf0d570f01e70a6e124884088870cbed7537f36328d512909eb10cd53179d9c";
   };
 
+  __structuredAttrs = true;
+
   buildInputs = [ zlib ];
 
   configureLocal = ''

--- a/pkgs/by-name/ma/mandoc/package.nix
+++ b/pkgs/by-name/ma/mandoc/package.nix
@@ -24,6 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   __structuredAttrs = true;
+  strictDeps = true;
+  enableParallelBuilding = true;
 
   buildInputs = [ zlib ];
 


### PR DESCRIPTION
Set `__structuredAttrs`, `strictDeps`, `enableParallelBuilding`. These changes did not affect the output (i.e. `nix store make-content-addressed` still gives the same output), but on my machine (6 core / 12 thread Ryzen 5 4600H) it sped up the compilation from `26s` down to `14s`.

Then also split out the `man` output (i.e. man pages about mandoc itself).
This resulted in the following output size changes:
- `out`: `1044K` -> `908K`
- `man`: `0K` -> `136K`

cc:
- https://github.com/NixOS/nixpkgs/issues/205690
- https://github.com/NixOS/nixpkgs/issues/515268
- https://github.com/NixOS/nixpkgs/issues/178468


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
