### PR TITLE
libcanberra: fix build failure on musl

### DIFF
--- a/pkgs/by-name/li/libcanberra/package.nix
+++ b/pkgs/by-name/li/libcanberra/package.nix
@@ -70,6 +70,18 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
+  # musl doesn't provide ldconfig, so we bypass it
+  #
+  # We also bypass relinking as we dont need to do so and it causes
+  # a build failure when libcanberra-gtk3-module relinks against
+  # libcanberra-gtk3
+  postConfigure = lib.optionalString (stdenv.hostPlatform.isMusl) ''
+    substituteInPlace libtool \
+      --replace-fail 'ldconfig' 'true'
+    substituteInPlace libtool \
+      --replace-fail 'relink_command=' 'true; relink_command='
+  '';
+
   postInstall = ''
     for f in $out/lib/*.la; do
       sed 's|-lltdl|-L${libtool.lib}/lib -lltdl|' -i $f


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes `libcanberra` build on musl. The approach is... idk it's fine, would love opinions if anyone has any! The relinking specifically is a bit blunt, while technically correct. Also would appreciate corrections on the comment, not sure if I explained myself well.

Also gonna mark as draft for now as I test it a *teensy* bit more.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
