### PR TITLE
python3Packages.pipdeptree: 2.30.0 -> 3.1.0

### DIFF
--- a/pkgs/development/python-modules/pipdeptree/default.nix
+++ b/pkgs/development/python-modules/pipdeptree/default.nix
@@ -14,7 +14,7 @@
   virtualenv,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pipdeptree";
   version = "3.1.0";
   pyproject = true;
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "tox-dev";
     repo = "pipdeptree";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-poUults9ev+5aryrZPxnxF/X9u0iivnlc1ceLxB7dys=";
   };
 
@@ -49,7 +49,7 @@ buildPythonPackage rec {
     pytestCheckHook
     virtualenv
   ]
-  ++ lib.concatAttrValues optional-dependencies;
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 
   pythonImportsCheck = [ "pipdeptree" ];
 
@@ -61,7 +61,7 @@ buildPythonPackage rec {
   meta = {
     description = "Command line utility to show dependency tree of packages";
     homepage = "https://github.com/tox-dev/pipdeptree";
-    changelog = "https://github.com/tox-dev/pipdeptree/releases/tag/${src.tag}";
+    changelog = "https://github.com/tox-dev/pipdeptree/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       charlesbaynham
@@ -69,4 +69,4 @@ buildPythonPackage rec {
     ];
     mainProgram = "pipdeptree";
   };
-}
+})

--- a/pkgs/development/python-modules/pipdeptree/default.nix
+++ b/pkgs/development/python-modules/pipdeptree/default.nix
@@ -2,27 +2,28 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  diff-cover,
   graphviz,
   hatchling,
   hatch-vcs,
   packaging,
-  pytest-mock,
+  pip-requirements-parser,
   pytestCheckHook,
-  pip,
+  pytest-mock,
+  pytest-subprocess,
+  rich,
   virtualenv,
 }:
 
 buildPythonPackage rec {
   pname = "pipdeptree";
-  version = "2.30.0";
+  version = "3.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tox-dev";
     repo = "pipdeptree";
     tag = version;
-    hash = "sha256-nDCd4Bk5P65+fnFM/kC3cbfPanj5P35/bta86/E65i0=";
+    hash = "sha256-poUults9ev+5aryrZPxnxF/X9u0iivnlc1ceLxB7dys=";
   };
 
   build-system = [
@@ -30,18 +31,21 @@ buildPythonPackage rec {
     hatch-vcs
   ];
 
-  dependencies = [
-    pip
-    packaging
-  ];
+  dependencies = [ packaging ];
 
   optional-dependencies = {
     graphviz = [ graphviz ];
+    index = [
+      # nab-index # Unstable + not packaged yet
+      # nab-python # Same
+      pip-requirements-parser
+    ];
+    rich = [ rich ];
   };
 
   nativeCheckInputs = [
-    diff-cover
     pytest-mock
+    pytest-subprocess
     pytestCheckHook
     virtualenv
   ]


### PR DESCRIPTION
- **python3Packages.pipdeptree: 2.30.0 -> 3.1.0**
  Diff: https://github.com/tox-dev/pipdeptree/compare/2.30.0...3.1.0
  Includes major update https://github.com/tox-dev/pipdeptree/releases/tag/3.0.0
- **python3Packages.pipdeptree: rec -> finalAttrs**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
