### PR TITLE
emmet-language-server: migrate to pnpm_11, add test, refactor

### DIFF
--- a/pkgs/by-name/em/emmet-language-server/package.nix
+++ b/pkgs/by-name/em/emmet-language-server/package.nix
@@ -5,6 +5,7 @@
   pnpm_9,
   fetchPnpmDeps,
   pnpmConfigHook,
+  pnpmBuildHook,
   fetchFromGitHub,
   nix-update-script,
 }:
@@ -29,17 +30,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
+    pnpmBuildHook
     pnpm_9
   ];
-
-  buildPhase = ''
-    runHook preBuild
-
-    # TODO: use deploy after resolved https://github.com/pnpm/pnpm/issues/5315
-    pnpm build
-
-    runHook postBuild
-  '';
 
   # remove unnecessary and non-deterministic files
   preInstall = ''

--- a/pkgs/by-name/em/emmet-language-server/package.nix
+++ b/pkgs/by-name/em/emmet-language-server/package.nix
@@ -2,13 +2,16 @@
   lib,
   stdenvNoCC,
   nodejs,
-  pnpm_9,
+  pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
   pnpmBuildHook,
   fetchFromGitHub,
   nix-update-script,
 }:
+let
+  pnpm = pnpm_11;
+in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "emmet-language-server";
   version = "2.8.0";
@@ -22,16 +25,16 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-livnY/iwd7gqy6SKFBMF2MSIs7LVFec4BFqMBVasGWE=";
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-FbwciSGn/W8xQhTU2rHdYIX01wUAqcgY67za8n5AMcM=";
   };
 
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
     pnpmBuildHook
-    pnpm_9
+    pnpm
   ];
 
   # remove unnecessary and non-deterministic files

--- a/pkgs/by-name/em/emmet-language-server/package.nix
+++ b/pkgs/by-name/em/emmet-language-server/package.nix
@@ -8,6 +8,8 @@
   pnpmBuildHook,
   fetchFromGitHub,
   nix-update-script,
+  runCommand,
+  emmet-language-server,
 }:
 let
   pnpm = pnpm_11;
@@ -60,7 +62,24 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+
+    tests.smoke = runCommand "emmet-language-server-smoke-test" { } ''
+      INIT_REQUEST='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":null,"rootUri":"file:///tmp","workspaceFolders":[{"uri":"file:///tmp","name":"test"}],"capabilities":{}}}'
+      CONTENT_LENGTH=''${#INIT_REQUEST}
+
+      RESPONSE=$(
+        {
+          printf "Content-Length: %d\r\n\r\n%s" "$CONTENT_LENGTH" "$INIT_REQUEST"
+          sleep 1
+        } | timeout 3  ${lib.getExe emmet-language-server} --stdio 2>&1 | head -c 1000
+      ) || true
+
+      echo "$RESPONSE" | grep -q '"capabilities"'
+      touch $out
+    '';
+  };
 
   meta = {
     description = "Language server for emmet.io";

--- a/pkgs/by-name/em/emmet-language-server/package.nix
+++ b/pkgs/by-name/em/emmet-language-server/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenvNoCC,
-  nodejs,
+  nodejs-slim,
   pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
@@ -31,7 +31,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    nodejs
+    nodejs-slim
     pnpmConfigHook
     pnpmBuildHook
     pnpm


### PR DESCRIPTION
Part of https://github.com/NixOS/nixpkgs/issues/529285


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
