### PR TITLE
stylelint-lsp: migrate from pnpm_9 to pnpm_11

### DIFF
--- a/pkgs/by-name/st/stylelint-lsp/package.nix
+++ b/pkgs/by-name/st/stylelint-lsp/package.nix
@@ -1,7 +1,7 @@
 {
   fetchFromGitHub,
   lib,
-  nodejs,
+  nodejs-slim,
   pnpm_9,
   fetchPnpmDeps,
   pnpmConfigHook,
@@ -22,11 +22,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-LUX/H7yY8Dl44vgpf7vOgtMdY7h//m5BAfrK5RRH9DM=";
   };
 
-  buildInputs = [
-    nodejs
-  ];
-
   nativeBuildInputs = [
+    nodejs-slim
     pnpmConfigHook
     pnpmBuildHook
     pnpm_9
@@ -53,7 +50,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     mkdir -p $out/{bin,lib/stylelint-lsp}
     mv {dist,node_modules} $out/lib/stylelint-lsp
+
     chmod a+x $out/lib/stylelint-lsp/dist/index.js
+    patchShebangs $out/lib/stylelint-lsp/dist/index.js
     ln -s $out/lib/stylelint-lsp/dist/index.js $out/bin/stylelint-lsp
 
     runHook postInstall

--- a/pkgs/by-name/st/stylelint-lsp/package.nix
+++ b/pkgs/by-name/st/stylelint-lsp/package.nix
@@ -5,6 +5,7 @@
   pnpm_9,
   fetchPnpmDeps,
   pnpmConfigHook,
+  pnpmBuildHook,
   stdenvNoCC,
   nix-update-script,
 }:
@@ -25,6 +26,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     pnpmConfigHook
+    pnpmBuildHook
     pnpm_9
   ];
 
@@ -34,14 +36,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     fetcherVersion = 3;
     hash = "sha256-qzUvA00ujnIibQAONOPlp5BsXcwQb/gQvOPp83hMT5A=";
   };
-
-  buildPhase = ''
-    runHook preBuild
-
-    pnpm build
-
-    runHook postBuild
-  '';
 
   preInstall = ''
     # remove unnecessary files

--- a/pkgs/by-name/st/stylelint-lsp/package.nix
+++ b/pkgs/by-name/st/stylelint-lsp/package.nix
@@ -8,6 +8,8 @@
   pnpmBuildHook,
   stdenvNoCC,
   nix-update-script,
+  runCommand,
+  stylelint-lsp,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "stylelint-lsp";
@@ -57,7 +59,24 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+
+    tests.smoke = runCommand "stylelint-lsp-smoke-test" { } ''
+      INIT_REQUEST='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":null,"rootUri":"file:///tmp","workspaceFolders":[{"uri":"file:///tmp","name":"test"}],"capabilities":{}}}'
+      CONTENT_LENGTH=''${#INIT_REQUEST}
+
+      RESPONSE=$(
+        {
+          printf "Content-Length: %d\r\n\r\n%s" "$CONTENT_LENGTH" "$INIT_REQUEST"
+          sleep 1
+        } | timeout 3  ${lib.getExe stylelint-lsp} --stdio 2>&1 | head -c 1000
+      ) || true
+
+      echo "$RESPONSE" | grep -q '"capabilities"'
+      touch $out
+    '';
+  };
 
   meta = {
     description = "Stylelint Language Server";

--- a/pkgs/by-name/st/stylelint-lsp/package.nix
+++ b/pkgs/by-name/st/stylelint-lsp/package.nix
@@ -2,7 +2,7 @@
   fetchFromGitHub,
   lib,
   nodejs-slim,
-  pnpm_9,
+  pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
   pnpmBuildHook,
@@ -11,29 +11,32 @@
   runCommand,
   stylelint-lsp,
 }:
+let
+  pnpm = pnpm_11;
+in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "stylelint-lsp";
-  version = "2.0.1";
+  version = "2.0.1-unstable-2026-07-19";
 
   src = fetchFromGitHub {
     owner = "bmatcuk";
     repo = "stylelint-lsp";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-LUX/H7yY8Dl44vgpf7vOgtMdY7h//m5BAfrK5RRH9DM=";
+    rev = "0362a26ffaf1879b9ec02e2a52a11792a2d4f8d4";
+    hash = "sha256-qRc67tvgncERh6FDJdydN6aL/a5bVSsQQir3KPp1cFk=";
   };
 
   nativeBuildInputs = [
     nodejs-slim
     pnpmConfigHook
     pnpmBuildHook
-    pnpm_9
+    pnpm
   ];
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = "sha256-qzUvA00ujnIibQAONOPlp5BsXcwQb/gQvOPp83hMT5A=";
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-EuCvuErydwe2LGG62VHcZtN/51Gv1uhhBN3/sEiqzME=";
   };
 
   preInstall = ''
@@ -59,7 +62,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    updateScript = nix-update-script { };
+    updateScript = nix-update-script {
+      extraArgs = [ "--version=branch" ];
+    };
 
     tests.smoke = runCommand "stylelint-lsp-smoke-test" { } ''
       INIT_REQUEST='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":null,"rootUri":"file:///tmp","workspaceFolders":[{"uri":"file:///tmp","name":"test"}],"capabilities":{}}}'


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Part of https://github.com/NixOS/nixpkgs/issues/529285

This package uses `lockfileVersion: 6` which is rejected by `pnpm_10` and `pnpm_11` with this error:
```console
stylelint-lsp-pnpm-deps> [WARN] Ignoring not compatible lockfile at /build/source/pnpm-lock.yaml
stylelint-lsp-pnpm-deps> [ERR_PNPM_NO_LOCKFILE] Cannot install with "frozen-lockfile" because pnpm-lock.yaml is absent
```

~~Including this big of a patch into nixpkgs is a bad idea: https://github.com/NixOS/nixpkgs/issues/327064.
I've submitted an [upstream PR](https://github.com/bmatcuk/stylelint-lsp/pull/54), in case it would block the removal of `pnpm_9`, I'll most likely fork but maybe drop it.~~
The big patch is now redundant as upstream updated the lockfile.

The enhancements and refactors are also separated into https://github.com/NixOS/nixpkgs/pull/530550 which can be merged before making the final decision on how to migrate away from `pnpm_9`, this PR focuses only on the `pnpm_9` stuff.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
