### PR TITLE
python3Packages.uarray: 0.9.3 -> 0.9.4

### DIFF
--- a/pkgs/development/python-modules/uarray/default.nix
+++ b/pkgs/development/python-modules/uarray/default.nix
@@ -2,56 +2,41 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  scikit-build-core,
-  setuptools,
-  setuptools-scm,
-  cmake,
-  ninja,
-  matchpy,
-  numpy,
-  typing-extensions,
+  meson-python,
+  versioningit,
+  pkg-config,
   nix-update-script,
   pytestCheckHook,
-  pytest-cov-stub,
 }:
 
 buildPythonPackage rec {
   pname = "uarray";
-  version = "0.9.3";
+  version = "0.9.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Quansight-Labs";
     repo = "uarray";
     tag = version;
-    hash = "sha256-Nog7jvRG/EFf3n3W2DWC7UML5NyrlaaS0ECis5rtCSk=";
+    hash = "sha256-gCoSpyFPQTIi86y+4xtRb+vsRkjZ2O6KcCj8mj8tcTQ=";
   };
 
+  preBuild = ''
+    echo "__version__ = '$version'" > src/uarray/_version.py
+  '';
+
   build-system = [
-    scikit-build-core
-    setuptools
-    setuptools-scm
-    cmake
-    ninja
+    meson-python
+    versioningit
   ];
 
-  dontUseCmakeConfigure = true;
-
-  dependencies = [
-    matchpy
-    numpy
-    typing-extensions
+  nativeBuildInputs = [
+    pkg-config
   ];
 
   nativeCheckInputs = [
     pytestCheckHook
-    pytest-cov-stub
   ];
-
-  # Tests must be run from outside the source directory
-  preCheck = ''
-    cd $TMP
-  '';
 
   pytestFlags = [
     "--pyargs"


### PR DESCRIPTION
Changelog: https://github.com/Quansight-Labs/uarray/releases/tag/0.9.4


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
