### PR TITLE
libcamera: 0.7.0 -> 0.7.2

### DIFF
--- a/pkgs/by-name/li/libcamera/package.nix
+++ b/pkgs/by-name/li/libcamera/package.nix
@@ -10,6 +10,7 @@
   libdrm,
   libevent,
   libyaml,
+  libyuv,
   gst_all_1,
   gtest,
   graphviz,
@@ -32,12 +33,12 @@
 
 stdenv.mkDerivation rec {
   pname = "libcamera";
-  version = "0.7.1";
+  version = "0.7.2";
 
   src = fetchgit {
     url = "https://git.libcamera.org/libcamera/libcamera.git";
     rev = "v${version}";
-    hash = "sha256-JE0OuhsCL9DAYrVC0/6RlvgOdy+ehO6Bv9M8NtgolkI=";
+    hash = "sha256-vhFkeT1j2KKm+CVvGrtH5BEYJSEdaX7N7DRdA0a9EWk=";
   };
 
   outputs = [
@@ -84,6 +85,8 @@ stdenv.mkDerivation rec {
 
     # pycamera
     python3Packages.pybind11
+
+    libyuv
 
     # yamlparser
     libyaml

--- a/pkgs/by-name/li/libcamera/package.nix
+++ b/pkgs/by-name/li/libcamera/package.nix
@@ -18,21 +18,26 @@
   python3Packages,
   udev,
   libpisp,
+  libglvnd,
   withTracing ? lib.meta.availableOn stdenv.hostPlatform lttng-ust,
   lttng-ust, # withTracing
-  withQcam ? false,
-  qt6, # withQcam
-  libtiff, # withQcam
+  withSoftispGPU ? true, # software ISP GPU acceleration
+  withQcam ? false, # cannot be enabled per default as it causes infinite recursion
+  # withQcam
+  qt6,
+  libjpeg,
+  libtiff,
+  SDL2,
 }:
 
 stdenv.mkDerivation rec {
   pname = "libcamera";
-  version = "0.7.0";
+  version = "0.7.1";
 
   src = fetchgit {
     url = "https://git.libcamera.org/libcamera/libcamera.git";
     rev = "v${version}";
-    hash = "sha256-W9pRE8/0Cf2EEP5bbvy4FsDSeKKSklfJb6T48ZN4dzE=";
+    hash = "sha256-JE0OuhsCL9DAYrVC0/6RlvgOdy+ehO6Bv9M8NtgolkI=";
   };
 
   outputs = [
@@ -87,10 +92,13 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optionals stdenv.hostPlatform.isAarch [ libpisp ]
   ++ lib.optionals withTracing [ lttng-ust ]
+  ++ lib.optionals withSoftispGPU [ libglvnd ]
   ++ lib.optionals withQcam [
+    libjpeg
     libtiff
     qt6.qtbase
     qt6.qttools
+    SDL2
   ];
 
   nativeBuildInputs = [
@@ -109,22 +117,27 @@ stdenv.mkDerivation rec {
   ++ lib.optional withQcam qt6.wrapQtAppsHook;
 
   mesonFlags = [
-    "-Dv4l2=true"
+    (lib.mesonEnable "v4l2" true)
     (lib.mesonEnable "tracing" withTracing)
     (lib.mesonEnable "qcam" withQcam)
-    "-Dlibunwind=disabled"
-    "-Dlc-compliance=disabled" # tries unconditionally to download gtest when enabled
+    (lib.mesonEnable "apps-output-dng" withQcam)
+    (lib.mesonEnable "cam-output-sdl2" withQcam)
+    (lib.mesonEnable "cam-jpeg" withQcam)
+    (lib.mesonEnable "softisp-gpu" withSoftispGPU)
+    (lib.mesonEnable "libunwind" false)
+    (lib.mesonEnable "libdw" false)
+    (lib.mesonEnable "lc-compliance" false) # tries unconditionally to download gtest when enabled
     # Avoid blanket -Werror to evade build failures on less
     # tested compilers.
-    "-Dwerror=false"
+    (lib.mesonBool "werror" false)
     # Documentation breaks binary compatibility.
     # Given that upstream also provides public documentation,
     # we can disable it here.
-    "-Ddocumentation=disabled"
+    (lib.mesonEnable "documentation" false)
   ]
   ++ lib.optionals stdenv.hostPlatform.isAarch [
     # we don't have tensorflow-lite to build this
-    "-Drpi-awb-nn=disabled"
+    (lib.mesonEnable "rpi-awb-nn" false)
   ];
 
   env = {


### PR DESCRIPTION
Release notes:
https://gitlab.freedesktop.org/camera/libcamera/-/releases/v0.7.2
https://gitlab.freedesktop.org/camera/libcamera/-/releases/v0.7.1

Lots of new features which require changes to the meson configuration.

In particular, SDL2 depends on libcamera, so that option is currently gated behind the qcam option (even though it applies to the cam app as well) to break the cycle. Since jpeg is dependent on SDL2, it's gated the same way.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
