### PR TITLE
sif: 0-unstable-2026-06-09 -> 0-unstable-2026-06-11

### DIFF
--- a/pkgs/by-name/si/sif/package.nix
+++ b/pkgs/by-name/si/sif/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule {
   pname = "sif";
-  version = "0-unstable-2026-06-09";
+  version = "0-unstable-2026-06-11";
 
   src = fetchFromGitHub {
     owner = "vmfunc";
     repo = "sif";
-    rev = "83ac92a4b82a0ab92257c580c9b6a3b82ab66af9";
-    hash = "sha256-VeURSRwvuh+VJd94mG2F8wQWD6NIitxqwRQr3IJ0QzU=";
+    rev = "d62919523abfecd06e07ba6528b15e9861bd747c";
+    hash = "sha256-T/HIvcXG3OpSK7xhZpYnCWv4KsRn0bnLhyouPjgwUoE=";
   };
 
-  vendorHash = "sha256-fR63/dStMsZon22vancuLWIAvZiEYMLjMwY1kmRDNgM=";
+  vendorHash = "sha256-rOAubGbeDPl0LJovksKRfYJmUvU6hmx3Ht12M7eLiOA=";
 
   subPackages = [ "cmd/sif" ];
 

--- a/pkgs/by-name/si/sif/package.nix
+++ b/pkgs/by-name/si/sif/package.nix
@@ -2,10 +2,11 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  installShellFiles,
   nix-update-script,
 }:
 
-buildGoModule {
+buildGoModule (finalAttrs: {
   pname = "sif";
   version = "0-unstable-2026-06-11";
 
@@ -20,15 +21,23 @@ buildGoModule {
 
   subPackages = [ "cmd/sif" ];
 
+  nativeBuildInputs = [ installShellFiles ];
+
   env.CGO_ENABLED = 0;
 
   ldflags = [
     "-s"
     "-w"
+    # upstream stamps the lowercase main.version, see cmd/sif/main.go
+    "-X main.version=${finalAttrs.version}"
   ];
 
   # network-dependent tests
   doCheck = false;
+
+  postInstall = ''
+    installManPage man/sif.1
+  '';
 
   passthru.updateScript = nix-update-script {
     extraArgs = [
@@ -44,4 +53,4 @@ buildGoModule {
     maintainers = with lib.maintainers; [ vmfunc ];
     mainProgram = "sif";
   };
-}
+})


### PR DESCRIPTION
bumps sif to the latest commit on main. r-ryantm's been lagging so i'm doing it by hand, i maintain this package.

rev + hash + vendorHash refreshed with nix-update.

###### things done

- built it locally (`nix-build -A sif`) and ran the binary
- doCheck stays off, the test suite needs network
