### PR TITLE
openscad: override glew to disable EGL fixing build failure

### DIFF
--- a/pkgs/by-name/op/openscad/package.nix
+++ b/pkgs/by-name/op/openscad/package.nix
@@ -127,7 +127,9 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     eigen
     boost
-    glew
+    # OpenSCAD's GLX offscreen renderer needs GLEW's GLXEW symbols (`__GLXEW_SGIX_pbuffer`, `__GLXEW_SGIX_fbconfig`)
+    # which are not found in the default EGL-enabled glew and causes the build failure in https://github.com/NixOS/nixpkgs/issues/530529
+    (glew.override { enableEGL = false; })
     opencsg
     cgal_5
     mpfr


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes https://github.com/NixOS/nixpkgs/issues/530529

The default glew is built with GLEW_EGL=ON, after a recent bump that dropped the egl+glx.patch, the EGL build no longer provides the GLXEW symbols (__GLXEW_SGIX_pbuffer, __GLXEW_SGIX_fbconfig) that OpenSCAD's GLX offscreen renderer links against, causing the build failure in the issue

<img width="1912" height="1080" alt="image" src="https://github.com/user-attachments/assets/0caa7470-8af0-49e7-a8b9-62b8df0004a0" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
