### PR TITLE
fetchgit: disable git background maintenance during clean_git

### DIFF
--- a/pkgs/build-support/fetchgit/nix-prefetch-git
+++ b/pkgs/build-support/fetchgit/nix-prefetch-git
@@ -515,13 +515,25 @@ unset XDG_CONFIG_HOME
 export GIT_CONFIG_NOSYSTEM=1
 
 
-# Disable maintenance: it's not useful for a short-lived clone, and
-# background maintenance causes non-deterministic builds.
+# Append a config entry via the GIT_CONFIG_* environment variables. Unlike
+# `git config` (writes a single repo) or `git -c` (one invocation), these
+# propagate to every git invocation *and* its children, including (nested)
+# submodule fetches. Done additively so it composes with any GIT_CONFIG_* the
+# caller passes via `impureEnvVars`.
+git_config_env(){
+    export GIT_CONFIG_COUNT=$(( ${GIT_CONFIG_COUNT:-0} + 1 ))
+    export "GIT_CONFIG_KEY_$(( GIT_CONFIG_COUNT - 1 ))=$1"
+    export "GIT_CONFIG_VALUE_$(( GIT_CONFIG_COUNT - 1 ))=$2"
+}
+
+# Disable maintenance and auto-gc: they're not useful for a short-lived clone,
+# and their background/detached processes race the later `.git` removal,
+# producing non-deterministic output (and outright failures with nested
+# submodules, where the legacy gc.auto path still fires).
 # https://github.com/NixOS/nixpkgs/issues/524215
-export GIT_CONFIG_COUNT=$(( ${GIT_CONFIG_COUNT:-0} + 1 ))
-# Not the best but generic enough that it will work with `impureEnvVars`
-export "GIT_CONFIG_KEY_$(( GIT_CONFIG_COUNT - 1 ))=maintenance.auto"
-export "GIT_CONFIG_VALUE_$(( GIT_CONFIG_COUNT - 1 ))=false"
+git_config_env maintenance.auto false
+git_config_env gc.auto 0
+git_config_env gc.autoDetach false
 
 if test -n "$builder"; then
     test -n "$out" -a -n "$url" -a -n "$rev" || usage


### PR DESCRIPTION
`nix-prefetch-git` (used by `fetchgit`) can intermittently **fail** or produce a
**non-deterministic output hash** when fetching a repository whose submodules are
themselves fetched with submodules.

### Symptom

Building such a fixed-output derivation fails non-deterministically with:

```
> Submodule path 'zlib/csources': checked out '...'
> removing `.git'...
> rm: cannot remove '.../<name>/.git/modules/<sub>/objects/pack': Directory not empty
builder failed with exit code 123
```

…or it "succeeds" but yields a **different `got:` hash on different runs** (i.e. a
hash mismatch against the pinned `sha256`, with the mismatching hash varying
between attempts).

### Root cause

`clean_git` runs `git submodule update --init --recursive -j ${NIX_BUILD_CORES:-1}`.
With parallelism, git triggers **background auto-maintenance**
(`git maintenance run --auto`, on by default; and legacy auto-gc via
`gc.autoDetach`). That maintenance process **detaches and keeps repacking**
`.git/modules/<sub>/objects` *after* the submodule reports "checked out". It then
races the fetcher's later `rm -rf .git`:

- `rm` empties `objects/pack`, the detached maintenance drops a fresh pack file
  in, and `rmdir` fails with `Directory not empty` (exit 123); or
- removal partially completes, leaving varying `.git` remnants in the output → a
  non-deterministic NAR hash.

This is why it is flaky and effectively Linux-only in practice (depends on git
auto-maintenance thresholds and core count).

### Fix

Disable git auto-maintenance/gc for every git invocation in `clean_git`. The `-c`
options propagate to child git processes (including the submodule fetches) via
`GIT_CONFIG_PARAMETERS`, so nothing detaches to write into `.git` while it is
being removed:

```sh
clean_git(){
    git -c gc.auto=0 -c maintenance.auto=false "$@" >&2
}
```

### Why this is safe (no mass rebuild)

In the success case the produced output is **identical** — `.git` is removed
either way — so existing pinned `sha256`/`hash` values for `fetchgit` sources
remain valid. The change only makes the removal step deterministic; it does not
alter fetched outputs, so it should not trigger rebuilds beyond
`nix-prefetch-git` itself.

### Reproducer

Fetch a repo with a nested submodule, e.g.
[`status-im/nim-zlib`](https://github.com/status-im/nim-zlib) (submodule `zlib/csources` → `madler/zlib`):

```nix
fetchgit {
  url = "https://github.com/status-im/nim-zlib";
  rev = "e680f269fb01af2c34a2ba879ff281795a5258fe";
  hash = "sha256-Ze5V9pdiYmsYjIMmu0W3b1rFA1ZrtnlegxE/LV9wifc=";
  fetchSubmodules = true;
}
```

On `master` this intermittently fails with `Directory not empty` or a varying
hash under load (`NIX_BUILD_CORES > 1`); with the patch it fetches
deterministically.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin <!-- adjust to your actual arch -->
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. <!-- verified `nix build` of the nim-zlib fetchgit FOD reproduces the pinned hash with the patched nix-prefetch-git -->
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
