### PR TITLE
discord: recreate module symlinks on every launch

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -153,14 +153,13 @@ let
   stageModules = writeShellScript "discord-stage-modules" ''
     store_modules="$1"
     modules_dir="''${XDG_CONFIG_HOME:-$HOME/.config}/${lib.toLower binaryName}/${version}/modules"
-    if [ ! -f "$modules_dir/installed.json" ]; then
-      mkdir -p "$modules_dir"
-      for m in ${lib.concatStringsSep " " (lib.attrNames moduleSrcs)}; do
-        ln -sfn "$store_modules/$m" "$modules_dir/$m"
-      done
-      echo '${builtins.toJSON (lib.mapAttrs (_: mod: { installedVersion = mod; }) moduleVersions)}' \
-        > "$modules_dir/installed.json"
-    fi
+    rm -rf "$modules_dir"
+    mkdir -p "$modules_dir"
+    for m in ${lib.concatStringsSep " " (lib.attrNames moduleSrcs)}; do
+      ln -sn "$store_modules/$m" "$modules_dir/$m"
+    done
+    echo '${builtins.toJSON (lib.mapAttrs (_: mod: { installedVersion = mod; }) moduleVersions)}' \
+      > "$modules_dir/installed.json"
   '';
 
   disableBreakingUpdates =


### PR DESCRIPTION
As of #515876, Discord's launch script runs a `discord-stage-modules` script defined in `linux.nix`, which creates symlinks from `~/.config/discord/<version>/modules/<module_name>` to the corresponding Nix store paths so Discord can find them. It checks whether this has already been done by looking for `installed.json` in the same dir, which it also creates, and skips link creation if so. However, since the dir is indexed by Discord version number, the links are not refreshed when opening a new build of Discord with the same version number as an older build. If the old build is then GC'd, the links break and Discord fails to start with an error such as `Cannot find module 'discord_desktop_core'`. Deleting the module folder entirely allows for it to be recreated and for Discord to start without issue. This problem and solution are [attested](https://wiki.nixos.org/wiki/Discord#Crash_on_start-up) on the wiki, albeit with less explanation; Claude Fable 5 figured out the details.
The package fix is to delete and recreate the `modules` folder on each launch, as it is small and does not contain any data meant to persist between launches: it has only the module links, `installed.json`, and a `pending/` download directory recreated by Discord's updater on startup. The fix ensures that the links always point to the Nix store of the build of Discord being run, so they will not be broken by GC.
CC @FlameFlag to confirm that the change doesn't break any of the script's intended functionality?

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
