### PR TITLE
gp-saml-gui: migrate to pyproject; use finalAttrs

### DIFF
--- a/pkgs/by-name/gp/gp-saml-gui/package.nix
+++ b/pkgs/by-name/gp/gp-saml-gui/package.nix
@@ -9,9 +9,9 @@
   gobject-introspection,
   openconnect,
 }:
-python3Packages.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "gp-saml-gui";
-  version = "0.1+20240731-${lib.strings.substring 0 7 src.rev}";
+  version = "0.1+20240731-${lib.strings.substring 0 7 finalAttrs.src.rev}";
   format = "setuptools";
 
   src = fetchFromGitHub {
@@ -53,4 +53,4 @@ python3Packages.buildPythonPackage rec {
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ pallix ];
   };
-}
+})

--- a/pkgs/by-name/gp/gp-saml-gui/package.nix
+++ b/pkgs/by-name/gp/gp-saml-gui/package.nix
@@ -12,7 +12,9 @@
 python3Packages.buildPythonPackage (finalAttrs: {
   pname = "gp-saml-gui";
   version = "0.1+20240731-${lib.strings.substring 0 7 finalAttrs.src.rev}";
-  format = "setuptools";
+  pyproject = true;
+
+  build-system = with python3Packages; [ setuptools ];
 
   src = fetchFromGitHub {
     owner = "dlenski";

--- a/pkgs/by-name/gp/gp-saml-gui/package.nix
+++ b/pkgs/by-name/gp/gp-saml-gui/package.nix
@@ -11,7 +11,7 @@
 }:
 python3Packages.buildPythonPackage (finalAttrs: {
   pname = "gp-saml-gui";
-  version = "0.1+20240731-${lib.strings.substring 0 7 finalAttrs.src.rev}";
+  version = "0.1-unstable-2024-07-31";
   pyproject = true;
 
   build-system = with python3Packages; [ setuptools ];


### PR DESCRIPTION
Part of #515974
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
