### PR TITLE
gscreenshot: migrate to pyproject; use hash; doCheck

### DIFF
--- a/pkgs/by-name/gs/gscreenshot/package.nix
+++ b/pkgs/by-name/gs/gscreenshot/package.nix
@@ -20,7 +20,9 @@
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "gscreenshot";
   version = "3.11.1";
-  format = "setuptools";
+  pyproject = true;
+
+  build-system = with python3Packages; [ setuptools ];
 
   src = fetchFromGitHub {
     owner = "thenaterhood";
@@ -35,7 +37,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   doCheck = false;
 
   nativeBuildInputs = [ wrapGAppsHook3 ];
-  propagatedBuildInputs = [
+  dependencies = [
     gettext
     gobject-introspection
     gtk3

--- a/pkgs/by-name/gs/gscreenshot/package.nix
+++ b/pkgs/by-name/gs/gscreenshot/package.nix
@@ -26,7 +26,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     owner = "thenaterhood";
     repo = "gscreenshot";
     tag = "v${finalAttrs.version}";
-    sha256 = "sha256-24eo4ihWM/sJXj7Dp3hSp0FEP1uYzvCON2emuMiONSc=";
+    hash = "sha256-24eo4ihWM/sJXj7Dp3hSp0FEP1uYzvCON2emuMiONSc=";
   };
 
   # needed for wrapGAppsHook3 to function

--- a/pkgs/by-name/gs/gscreenshot/package.nix
+++ b/pkgs/by-name/gs/gscreenshot/package.nix
@@ -33,8 +33,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   # needed for wrapGAppsHook3 to function
   strictDeps = false;
-  # tests require a display and fail
-  doCheck = false;
 
   nativeBuildInputs = [ wrapGAppsHook3 ];
   dependencies = [

--- a/pkgs/by-name/gs/gscreenshot/package.nix
+++ b/pkgs/by-name/gs/gscreenshot/package.nix
@@ -57,7 +57,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
   ++ (with python3Packages; [
     pillow
     pygobject3
-    setuptools
   ]);
 
   patches = [ ./0001-Changing-paths-to-be-nix-compatible.patch ];


### PR DESCRIPTION
Part of #515974

I reactivate the checks as they all passed when I tested them.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
