### PR TITLE
[25.11]: Backport 530639

### DIFF
--- a/pkgs/by-name/kd/kdash/package.nix
+++ b/pkgs/by-name/kd/kdash/package.nix
@@ -6,7 +6,7 @@
   perl,
   python3,
   openssl,
-  xorg,
+  libxcb-util,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [
     openssl
-    xorg.xcbutil
+    libxcb-util
   ];
 
   # Fix for build failure with gcc15

--- a/pkgs/by-name/kd/kdash/package.nix
+++ b/pkgs/by-name/kd/kdash/package.nix
@@ -9,14 +9,14 @@
   libxcb-util,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "kdash";
   version = "0.6.2";
 
   src = fetchFromGitHub {
     owner = "kdash-rs";
     repo = "kdash";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-fFpdWVoeWycnp/hRw2S+hYpnXYmCs+rLqcZdmSSMGwI=";
   };
 
@@ -43,4 +43,4 @@ rustPlatform.buildRustPackage rec {
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [ matthiasbeyer ];
   };
-}
+})

--- a/pkgs/by-name/kd/kdash/package.nix
+++ b/pkgs/by-name/kd/kdash/package.nix
@@ -31,6 +31,9 @@ rustPlatform.buildRustPackage rec {
     xorg.xcbutil
   ];
 
+  # Fix for build failure with gcc15
+  env.NIX_CFLAGS_COMPILE = "-std=gnu17";
+
   cargoHash = "sha256-72DuM64wj8WW6soagodOFIeHvVn1CPpb1T3Y7GQYsbs=";
 
   meta = {

--- a/pkgs/by-name/kd/kdash/package.nix
+++ b/pkgs/by-name/kd/kdash/package.nix
@@ -11,13 +11,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "kdash";
-  version = "1.0.0";
+  version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "kdash-rs";
     repo = "kdash";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-1ZG0u4k95tm+k/cvLIzWD/pvVrdP3+ivTqtKr3Pniqw=";
+    sha256 = "sha256-yIBBWtdIvx9lMU9hoh0bsqYqXkSSBtfOMmUxM5UR+IQ=";
   };
 
   nativeBuildInputs = [
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # Fix for build failure with gcc15
   env.NIX_CFLAGS_COMPILE = "-std=gnu17";
 
-  cargoHash = "sha256-zcvlR7BDkeTcwhGi2Fyz2VdfZH4+JOMRTIjIXkTAHOU=";
+  cargoHash = "sha256-eRXW3EBkNMClxLUKufhrz9WJVBY5UTA/JnabGJvAvF4=";
 
   meta = {
     description = "Simple and fast dashboard for Kubernetes";

--- a/pkgs/by-name/kd/kdash/package.nix
+++ b/pkgs/by-name/kd/kdash/package.nix
@@ -11,13 +11,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "kdash";
-  version = "0.6.2";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "kdash-rs";
     repo = "kdash";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-fFpdWVoeWycnp/hRw2S+hYpnXYmCs+rLqcZdmSSMGwI=";
+    sha256 = "sha256-1ZG0u4k95tm+k/cvLIzWD/pvVrdP3+ivTqtKr3Pniqw=";
   };
 
   nativeBuildInputs = [
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # Fix for build failure with gcc15
   env.NIX_CFLAGS_COMPILE = "-std=gnu17";
 
-  cargoHash = "sha256-72DuM64wj8WW6soagodOFIeHvVn1CPpb1T3Y7GQYsbs=";
+  cargoHash = "sha256-zcvlR7BDkeTcwhGi2Fyz2VdfZH4+JOMRTIjIXkTAHOU=";
 
   meta = {
     description = "Simple and fast dashboard for Kubernetes";

--- a/pkgs/by-name/kd/kdash/package.nix
+++ b/pkgs/by-name/kd/kdash/package.nix
@@ -11,13 +11,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "kdash";
-  version = "1.1.1";
+  version = "1.1.2";
 
   src = fetchFromGitHub {
     owner = "kdash-rs";
     repo = "kdash";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-yIBBWtdIvx9lMU9hoh0bsqYqXkSSBtfOMmUxM5UR+IQ=";
+    sha256 = "sha256-xc2vNPQWg6P+FWxKekvOTW3QHxgmkD6t/jgYGdoaMeI=";
   };
 
   nativeBuildInputs = [
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # Fix for build failure with gcc15
   env.NIX_CFLAGS_COMPILE = "-std=gnu17";
 
-  cargoHash = "sha256-eRXW3EBkNMClxLUKufhrz9WJVBY5UTA/JnabGJvAvF4=";
+  cargoHash = "sha256-aEVV5E0GvskhSRwwPD8at4xwkn2Q6k5SO1fyFrsDbFM=";
 
   meta = {
     description = "Simple and fast dashboard for Kubernetes";

--- a/pkgs/by-name/kd/kdash/package.nix
+++ b/pkgs/by-name/kd/kdash/package.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "kdash-rs";
     repo = "kdash";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-CFGZIRZgOUiB/evCDUQFB+w5PJCJNtrWqYzx2yRQKpE=";
   };
 
@@ -40,6 +40,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Simple and fast dashboard for Kubernetes";
     mainProgram = "kdash";
     homepage = "https://github.com/kdash-rs/kdash";
+    changelog = "https://github.com/kdash-rs/kdash/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [ matthiasbeyer ];
   };

--- a/pkgs/by-name/kd/kdash/package.nix
+++ b/pkgs/by-name/kd/kdash/package.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "kdash-rs";
     repo = "kdash";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-xc2vNPQWg6P+FWxKekvOTW3QHxgmkD6t/jgYGdoaMeI=";
+    hash = "sha256-CFGZIRZgOUiB/evCDUQFB+w5PJCJNtrWqYzx2yRQKpE=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
This is a backport of #530639 to release-25.11, but also includes patches from other PRs that updated the package and some manual backports of treewide changes that affected the `kdash` package.

I know release-25.11 is almost EOL, I would still like to see this backported.

@jopejoe1 (release maintainer of 25.11) should decide.

I will run a nixpkgs-review within a minute.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
