### PR TITLE
xwpe: init at 1.6.3

### DIFF
--- a/pkgs/by-name/xw/xwpe/package.nix
+++ b/pkgs/by-name/xw/xwpe/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitea,
+  autoreconfHook,
+  pkg-config,
+  texinfo,
+  ncurses,
+  json_c,
+  zlib,
+  libx11,
+  libxft,
+  fontconfig,
+  cairo,
+  pango,
+  gpm,
+  libvterm,
+  librsvg,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xwpe";
+  version = "1.6.3";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "mendezr";
+    repo = "xwpe";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-VpXQL583bnoJKFBiKSCk09xOx6958RAewZ7S7VS+LXA=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    texinfo
+    librsvg
+  ];
+
+  buildInputs = [
+    ncurses
+    json_c
+    zlib
+    libx11
+    libxft
+    fontconfig
+    cairo
+    pango
+    gpm
+    libvterm
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Code editor inspired by Borland C and Pascal family";
+    homepage = "https://codeberg.org/mendezr/xwpe";
+    changelog = "https://codeberg.org/mendezr/xwpe/releases/tag/v${finalAttrs.version}";
+    mainProgram = "xwpe";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ castorNova2 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add [xwpe](https://codeberg.org/mendezr/xwpe) which is a IDE for unix terminal and X11.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
