### PR TITLE
hifiscan: migrate to pyproject; use finalAttrs

### DIFF
--- a/pkgs/by-name/hi/hifiscan/package.nix
+++ b/pkgs/by-name/hi/hifiscan/package.nix
@@ -7,9 +7,11 @@
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "hifiscan";
   version = "1.5.2";
-  format = "setuptools";
+  pyproject = true;
 
-  pythonPath = with python3Packages; [
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
     eventkit
     numpy
     sounddevice

--- a/pkgs/by-name/hi/hifiscan/package.nix
+++ b/pkgs/by-name/hi/hifiscan/package.nix
@@ -3,14 +3,11 @@
   python3Packages,
   fetchPypi,
 }:
-let
+
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "hifiscan";
   version = "1.5.2";
-  hash = "sha256-8eystqjNdDP2X9beogRcsa+Wqu50uMHZv59jdc5GjUc=";
-in
-python3Packages.buildPythonApplication {
   format = "setuptools";
-  inherit pname version;
 
   pythonPath = with python3Packages; [
     eventkit
@@ -22,7 +19,8 @@ python3Packages.buildPythonApplication {
   ];
 
   src = fetchPypi {
-    inherit pname version hash;
+    inherit (finalAttrs) pname version;
+    hash = "sha256-8eystqjNdDP2X9beogRcsa+Wqu50uMHZv59jdc5GjUc=";
   };
 
   meta = {
@@ -32,4 +30,4 @@ python3Packages.buildPythonApplication {
     maintainers = with lib.maintainers; [ cab404 ];
     mainProgram = "hifiscan";
   };
-}
+})


### PR DESCRIPTION
Part of #515974

Replaced by #555352
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
