### PR TITLE
hue-plus: migrate to pyproject; use finalAttrs, tag, hash and mainProgram; doCheck

### DIFF
--- a/pkgs/by-name/hu/hue-plus/package.nix
+++ b/pkgs/by-name/hu/hue-plus/package.nix
@@ -8,7 +8,9 @@
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "hue-plus";
   version = "1.4.5";
-  format = "setuptools";
+  pyproject = true;
+
+  build-system = with python3Packages; [ setuptools ];
 
   src = fetchFromGitHub {
     owner = "kusti8";

--- a/pkgs/by-name/hu/hue-plus/package.nix
+++ b/pkgs/by-name/hu/hue-plus/package.nix
@@ -44,5 +44,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     '';
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ garaiza-93 ];
+    mainProgram = "hue";
   };
 })

--- a/pkgs/by-name/hu/hue-plus/package.nix
+++ b/pkgs/by-name/hu/hue-plus/package.nix
@@ -31,7 +31,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     setuptools
   ];
 
-  doCheck = false;
   dontWrapQtApps = true;
 
   makeWrapperArgs = [

--- a/pkgs/by-name/hu/hue-plus/package.nix
+++ b/pkgs/by-name/hu/hue-plus/package.nix
@@ -5,7 +5,7 @@
   libsForQt5,
 }:
 
-python3Packages.buildPythonApplication {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "hue-plus";
   version = "1.4.5";
   format = "setuptools";
@@ -13,8 +13,8 @@ python3Packages.buildPythonApplication {
   src = fetchFromGitHub {
     owner = "kusti8";
     repo = "hue-plus";
-    rev = "7ce7c4603c6d0ab1da29b0d4080aa05f57bd1760";
-    sha256 = "sha256-dDIJXhB3rmKnawOYJHE7WK38b0M5722zA+yLgpEjDyI=";
+    tag = "v.${finalAttrs.version}"; # Only the latest tag uses a . between v and 1.
+    hash = "sha256-dDIJXhB3rmKnawOYJHE7WK38b0M5722zA+yLgpEjDyI=";
   };
 
   buildInputs = [ libsForQt5.qtbase ];
@@ -45,4 +45,4 @@ python3Packages.buildPythonApplication {
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ garaiza-93 ];
   };
-}
+})


### PR DESCRIPTION
Part of #515974

I removed doCheck = false; because it didnt gave me an error.
It build on my machine, but I can't run or test it as I don't have the hardware. It would be really cool if @garaiza-93 could test it.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
