### PR TITLE
Fix eval warning for pkgs.python3.tests.condaExamplePackage

### DIFF
--- a/pkgs/development/interpreters/python/tests.nix
+++ b/pkgs/development/interpreters/python/tests.nix
@@ -261,9 +261,7 @@ let
             condaUnpackHook
             condaInstallHook
           ]);
-          buildInputs = [
-            pythonCondaPackages.condaPatchelfLibs
-          ];
+          buildInputs = pythonCondaPackages.condaPatchelfLibs;
           propagatedBuildInputs = with python.pkgs; [
             chardet
             idna


### PR DESCRIPTION
before:
```
nix-repl> legacyPackages.x86_64-linux.python3.tests.condaExamplePackage            
evaluation warning: Dependency of package 'python3.13-requests-2.24.0' uses a nested list in attribute 'buildInputs'.
                    This is deprecated as of Nixpkgs release 26.05, and support will
                    be removed in a future nixpkgs release.
«derivation /nix/store/7m75r239aj4332qd4r7p4hirxz2ry0gm-import-requests.drv»`
```
after:
```
nix-repl> legacyPackages.x86_64-linux.python3.tests.condaExamplePackage
«derivation /nix/store/g56vnj1k1rn19ax0xsr1h74hbaw8ajjx-import-requests.drv»
```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
