### PR TITLE
python3Packages.pycifrw: init at 5.0.1

### DIFF
--- a/pkgs/development/python-modules/pycifrw/default.nix
+++ b/pkgs/development/python-modules/pycifrw/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  nix-update-script,
+  numpy,
+  ply,
+  prettytable,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pycifrw";
+  version = "5.0.1";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "jamesrhester";
+    repo = "pycifrw";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-b55+Vb2H/ADl586o5ch0X4HurwsbbgDg5XS5/8QhFZM=";
+  };
+
+  preBuild = ''
+    make -C src Parsers
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    numpy
+    prettytable
+    ply
+  ];
+
+  # Requires external dictionaries (dics/DDLm/cif_mag.dic) which are not available
+  doCheck = false;
+
+  pythonImportsCheck = [ "CifFile" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Python library for reading and writing CIF files";
+    homepage = "https://github.com/jamesrhester/pycifrw";
+    changelog = "https://github.com/jamesrhester/pycifrw/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.psfl;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13742,6 +13742,8 @@ self: super: with self; {
 
   pychromecast = callPackage ../development/python-modules/pychromecast { };
 
+  pycifrw = callPackage ../development/python-modules/pycifrw { };
+
   pycketcasts = callPackage ../development/python-modules/pycketcasts { };
 
   pyclibrary = callPackage ../development/python-modules/pyclibrary { };


### PR DESCRIPTION
Python library for reading and writing CIF files

https://github.com/jamesrhester/pycifrw


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
