### PR TITLE
Revert "replaceVarsWith: properly set pname, version"

### DIFF
--- a/pkgs/build-support/replace-vars/replace-vars-with.nix
+++ b/pkgs/build-support/replace-vars/replace-vars-with.nix
@@ -122,8 +122,7 @@ in
 
 stdenvNoCC.mkDerivation (
   {
-    pname = optionalAttrs.pname or optionalAttrs.name or (baseNameOf src);
-    version = "26.11pre-git";
+    name = baseNameOf src;
   }
   // optionalAttrs
   // forcedAttrs


### PR DESCRIPTION
Reverts NixOS/nixpkgs#528305

Breaks stdenv, e.g. python3Minimal, where the build fails with

```
find: ‘nuke-refs’: No such file or directory
```

Feel free to requeue, after fixing the now obvious regressions.