### PR TITLE
prometheus-xray-exporter: init at 1.0.0

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -133,6 +133,7 @@ let
         "v2ray"
         "varnish"
         "wireguard"
+        "xray"
         "zfs-siebenmann"
         "zfs"
       ]

--- a/nixos/modules/services/monitoring/prometheus/exporters/xray.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/xray.nix
@@ -58,6 +58,14 @@ in
         Time window in minutes for user metrics.
       '';
     };
+
+    withUserMetrics = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Collect user metrics from the Xray access log.
+      '';
+    };
   };
 
   serviceOpts = {
@@ -70,6 +78,7 @@ in
           --scrape-timeout ${toString cfg.scrapeTimeout} \
           ${optionalString (cfg.logPath != "") "--log-path ${cfg.logPath}"} \
           --log-time-window ${toString cfg.logTimeWindow} \
+          ${optionalString cfg.withUserMetrics "--with-user-metrics"} \
           ${concatStringsSep " \\\n  " cfg.extraFlags}
       '';
     };

--- a/nixos/modules/services/monitoring/prometheus/exporters/xray.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/xray.nix
@@ -1,0 +1,77 @@
+{
+  config,
+  lib,
+  pkgs,
+  options,
+  ...
+}:
+
+let
+  cfg = config.services.prometheus.exporters.xray;
+  inherit (lib)
+    mkOption
+    types
+    concatStringsSep
+    optionalString
+    ;
+in
+{
+  port = 9550;
+
+  extraOpts = {
+    xrayEndpoint = mkOption {
+      type = types.str;
+      default = "127.0.0.1:8080";
+      description = ''
+        Xray gRPC API endpoint.
+      '';
+    };
+
+    metricsPath = mkOption {
+      type = types.str;
+      default = "/scrape";
+      description = ''
+        Path under which to expose metrics.
+      '';
+    };
+
+    scrapeTimeout = mkOption {
+      type = types.int;
+      default = 5;
+      description = ''
+        Timeout in seconds for every individual scrape.
+      '';
+    };
+
+    logPath = mkOption {
+      type = types.str;
+      default = "/var/log/xray/access.log";
+      description = ''
+        Path to Xray access log file. Set to empty string to disable user metrics.
+      '';
+    };
+
+    logTimeWindow = mkOption {
+      type = types.int;
+      default = 5;
+      description = ''
+        Time window in minutes for user metrics.
+      '';
+    };
+  };
+
+  serviceOpts = {
+    serviceConfig = {
+      ExecStart = ''
+        ${pkgs.prometheus-xray-exporter}/bin/xray-exporter \
+          --listen ${cfg.listenAddress}:${toString cfg.port} \
+          --metrics-path ${cfg.metricsPath} \
+          --xray-endpoint ${cfg.xrayEndpoint} \
+          --scrape-timeout ${toString cfg.scrapeTimeout} \
+          ${optionalString (cfg.logPath != "") "--log-path ${cfg.logPath}"} \
+          --log-time-window ${toString cfg.logTimeWindow} \
+          ${concatStringsSep " \\\n  " cfg.extraFlags}
+      '';
+    };
+  };
+}

--- a/pkgs/by-name/pr/prometheus-xray-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-xray-exporter/package.nix
@@ -7,13 +7,13 @@
 buildGoModule (finalAttrs: {
   __structuredAttrs = true;
   pname = "prometheus-xray-exporter";
-  version = "0.2.0";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
-    owner = "compassvpn";
+    owner = "podocarp";
     repo = "xray-exporter";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-GP0CFphMgSS8ezSuRoHQJMuehCND4glrXE9fye0PhTE=";
+    hash = "sha256-Ocex/D1OYOlQ2BZ835qrlXaEuMdXaglIPpVzfo0OZ5g=";
   };
 
   vendorHash = "sha256-yRxy44SnEFa7yOJyiOgFTk+Z4s5HOJ4cMjcf8VTTfQk=";
@@ -21,7 +21,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Prometheus exporter for Xray-core metrics";
     mainProgram = "xray-exporter";
-    homepage = "https://github.com/compassvpn/xray-exporter";
+    homepage = "https://github.com/podocarp/xray-exporter";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ podocarp ];
   };

--- a/pkgs/by-name/pr/prometheus-xray-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-xray-exporter/package.nix
@@ -1,0 +1,28 @@
+{
+  buildGoModule,
+  lib,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "prometheus-xray-exporter";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "compassvpn";
+    repo = "xray-exporter";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-GP0CFphMgSS8ezSuRoHQJMuehCND4glrXE9fye0PhTE=";
+  };
+
+  vendorHash = "sha256-yRxy44SnEFa7yOJyiOgFTk+Z4s5HOJ4cMjcf8VTTfQk=";
+
+  meta = {
+    description = "Prometheus exporter for Xray-core metrics";
+    mainProgram = "xray-exporter";
+    homepage = "https://github.com/compassvpn/xray-exporter";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ podocarp ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

We have a v2ray exporter for `services.v2ray`. We have `services.xray` but no xray exporter! (xray is a fork of v2ray)
This PR adds [this exporter](https://github.com/podocarp/xray-exporter) for xray and a module to configure it. This repo is my fork which merges some older PRs and also some extra changes I made. Tested on a deploy and working fine.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
