### PR TITLE
openclaw: 2026.6.1 -> 2026.6.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19808,6 +19808,11 @@
     github = "nigelgbanks";
     githubId = 487373;
   };
+  nikhilmaddirala = {
+    name = "Nikhil Maddirala";
+    github = "nikhilmaddirala";
+    githubId = 4138581;
+  };
   nikitavoloboev = {
     email = "nikita.voloboev@gmail.com";
     github = "nikivdev";

--- a/pkgs/by-name/op/openclaw/package.nix
+++ b/pkgs/by-name/op/openclaw/package.nix
@@ -11,7 +11,7 @@
   versionCheckHook,
   rolldown,
   installShellFiles,
-  version ? "2026.6.1",
+  version ? "2026.6.5",
 }:
 let
   pnpm = pnpm_11.override { nodejs-slim = nodejs-slim_22; };
@@ -24,7 +24,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "openclaw";
     repo = "openclaw";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-FjxiI7YHkt6fTzJD7G5A3/wsbcWgpO44IHMOwymDxpg=";
+    hash = "sha256-hiYbIhE13XMFIeB0zmb6AHlfw8le6vpJgCqN81YWGsE=";
   };
 
   pnpmDepsHash = "sha256-7RQJAVWqhauG8JrF8AD1VU1IJRM+SH05aHAfmFaXraU=";
@@ -134,6 +134,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       chrisportela
       mkg20001
+      nikhilmaddirala
     ];
     platforms = with lib.platforms; linux ++ darwin;
     knownVulnerabilities = [


### PR DESCRIPTION
Update OpenClaw from 2026.6.1 to 2026.6.5.

Adding myself as a maintainer, because I've contributed to this package in the past and intend to continue contributing to it.

## Things done

- Built on platform:
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] Ran nixpkgs-review on this PR. See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).
  - [x] aarch64-darwin
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Verified locally:
  - `./result/bin/openclaw --version`
  - `git diff --check`
