### PR TITLE
amnezia-vpn: fix VLESS

### DIFF
--- a/nixos/modules/programs/amnezia-vpn.nix
+++ b/nixos/modules/programs/amnezia-vpn.nix
@@ -17,7 +17,8 @@ in
     environment.systemPackages = [ cfg.package ];
     services.dbus.packages = [ cfg.package ];
     services.resolved.enable = true;
-
+    networking.firewall.checkReversePath = "loose";
+    
     systemd = {
       packages = [ cfg.package ];
       services."AmneziaVPN" = {


### PR DESCRIPTION
This is the only way I managed to make VLESS in Amnezia VPN work.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].