### PR TITLE
nixos/accounts-daemon: conditionally disable using systemd-homed backend

### DIFF
--- a/nixos/modules/services/desktops/accountsservice.nix
+++ b/nixos/modules/services/desktops/accountsservice.nix
@@ -5,6 +5,17 @@
   pkgs,
   ...
 }:
+let
+  cfg = config.services.accounts-daemon;
+
+  package =
+    if (cfg.useHomed || config.services.homed.enable) then
+      pkgs.accountsservice
+    else
+      pkgs.accountsservice.override {
+        useHomed = false;
+      };
+in
 {
   meta = {
     teams = [ lib.teams.freedesktop ];
@@ -24,21 +35,28 @@
         '';
       };
 
+      useHomed = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Whether to use systemd-homed as a backend for account metedata discovery.
+        '';
+      };
     };
 
   };
 
   ###### implementation
-  config = lib.mkIf config.services.accounts-daemon.enable {
+  config = lib.mkIf cfg.enable {
 
-    environment.systemPackages = [ pkgs.accountsservice ];
+    environment.systemPackages = [ package ];
 
     # Accounts daemon looks for dbus interfaces in $XDG_DATA_DIRS/accountsservice
     environment.pathsToLink = [ "/share/accountsservice" ];
 
-    services.dbus.packages = [ pkgs.accountsservice ];
+    services.dbus.packages = [ package ];
 
-    systemd.packages = [ pkgs.accountsservice ];
+    systemd.packages = [ package ];
 
     systemd.services.accounts-daemon =
       lib.recursiveUpdate

--- a/pkgs/by-name/ac/accountsservice/disable-homed.patch
+++ b/pkgs/by-name/ac/accountsservice/disable-homed.patch
@@ -1,0 +1,137 @@
+diff --git a/meson.build b/meson.build
+index 44f8b85..9d2b79f 100644
+--- a/meson.build
++++ b/meson.build
+@@ -234,8 +234,10 @@ config_h.set_quoted('PATH_LIGHTDM_CONF', lightdm_conf_file)
+ 
+ create_homed = get_option('create_homed')
+ config_h.set10('CREATE_HOMED', create_homed)
++homed = get_option('homed')
++config_h.set10('HAVE_HOMED', homed)
+ 
+ if get_option('elogind')
+   logind_dep = dependency('libelogind', version: '>= 229.4')
+ else
+   logind_dep = dependency('libsystemd', version: '>= 186', required: false)
+@@ -276,4 +278,5 @@ output += '** LightDM configuration: ' + lightdm_conf_file + '\n'
+ output += '        cflags: ' + ' '.join(get_option('c_args')) + ' ' + ' '.join(get_option('c_link_args')) + '\n'
+ output += '        Maintainer mode: ' + get_option('maintainer_mode').to_string() + '\n'
+-output += '** Create homed users: ' + create_homed.to_string()
++output += '** Create homed users: ' + create_homed.to_string() + '\n'
++output += '** Support homed users: ' + homed.to_string()
+ message(output)
+diff --git a/meson_options.txt b/meson_options.txt
+index f657ec6..3d31108 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -18,4 +18,5 @@ option('docbook', type: 'boolean', value: false, description: 'build documentati
+ option('gtk_doc', type: 'boolean', value: false, description: 'use gtk-doc to build documentation')
+ option('tests',   type: 'boolean', value: true, description: 'run accountservice tests if possible')
+ 
+ option('create_homed', type: 'boolean', value: false, description: 'Use systemd-homed to create new user accounts')
++option('homed', type: 'boolean', value: true, description: 'Use systemd-homed as an account source')
+diff --git a/src/daemon.c b/src/daemon.c
+index d97f60e..b58c22d 100644
+--- a/src/daemon.c
++++ b/src/daemon.c
+@@ -569,6 +569,7 @@ bus_get_homed_user_record (GDBusConnection *bus,
+                            uid_t            uid,
+                            GError         **error)
+ {
++#if HAVE_HOMED
+         g_autofree char *json = NULL;
+ 
+         g_autoptr (GVariant) retval = NULL;
+@@ -613,6 +614,13 @@ bus_get_homed_user_record (GDBusConnection *bus,
+         }
+ 
+         return g_steal_pointer (&json);
++#else
++        if (error != NULL)
++                g_set_error (error, ERROR, ERROR_USER_DOES_NOT_EXIST,
++                             "systemd-homed support is disabled");
++
++        return NULL;
++#endif
+ }
+ 
+ static char *
+@@ -644,6 +652,7 @@ entry_generator_homed (Daemon         *daemon,
+                        struct spwd   **spent,
+                        char          **json)
+ {
++#if HAVE_HOMED
+         DaemonPrivate *priv = daemon_get_instance_private (daemon);
+ 
+         g_autoptr (GError) error = NULL;
+@@ -724,3 +733,6 @@ finished:
+-}
++#else
++        return;
++#endif
++}
+ 
+ static void
+@@ -1167,6 +1179,7 @@ static guint
+ setup_homed_monitor (Daemon *daemon)
+ {
+-        DaemonPrivate *priv = daemon_get_instance_private (daemon);
++#if HAVE_HOMED
++        DaemonPrivate *priv = daemon_get_instance_private (daemon);
+ 
+         if (!ensure_system_bus (daemon)) {
+                 g_warning ("Failed to init system bus to set up homed monitor!");
+@@ -1180,6 +1193,9 @@ setup_homed_monitor (Daemon *daemon)
+                                                    on_homed_users_monitor_changed,
+                                                    daemon,
+                                                    NULL);
++#else
++        return 0;
++#endif
+ }
+ 
+ static void
+@@ -2059,6 +2075,7 @@ daemon_delete_homed_user (Daemon  *daemon,
+                           User    *user,
+                           GError **error)
+ {
++#if HAVE_HOMED
+         DaemonPrivate *priv = daemon_get_instance_private (daemon);
+         const char *username = accounts_user_get_user_name (ACCOUNTS_USER (user));
+ 
+@@ -2075,6 +2092,11 @@ daemon_delete_homed_user (Daemon  *daemon,
+                                      HOMED_BUS_LONG_TIMEOUT,
+                                      NULL,
+                                      error);
++#else
++        if (error != NULL)
++                g_set_error (error, ERROR, ERROR_FAILED,
++                             "systemd-homed support is disabled");
++#endif
+ }
+ 
+ static void
+diff --git a/src/user.c b/src/user.c
+index 5f5a766..f26127f 100644
+--- a/src/user.c
++++ b/src/user.c
+@@ -1225,6 +1225,7 @@ homed_update (GDBusConnection *bus,
+               GHashTable      *blobs_map,
+               GError         **error)
+ {
++#if HAVE_HOMED
+         g_autoptr (GVariant) blobs = NULL;
+         g_autoptr (GUnixFDList) blob_fds = NULL;
+ 
+@@ -1284,6 +1285,11 @@ homed_update (GDBusConnection *bus,
+                 g_clear_error (&inner_error);
+                 flags |= HOMED_UPDATE_FLAGS_OFFLINE;
+         }
++#else
++        if (error != NULL)
++                g_set_error (error, ERROR, ERROR_FAILED,
++                             "systemd-homed support is disabled");
++#endif
+ }
+ 
+ static void

--- a/pkgs/by-name/ac/accountsservice/package.nix
+++ b/pkgs/by-name/ac/accountsservice/package.nix
@@ -19,6 +19,7 @@
   vala,
   gettext,
   libxcrypt,
+  useHomed ? true,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -40,9 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     # Hardcode dependency paths.
-    (replaceVars ./fix-paths.patch {
-      inherit shadow coreutils;
-    })
+    (replaceVars ./fix-paths.patch { inherit shadow coreutils; })
 
     # Do not try to create directories in /var, that will not work in Nix sandbox.
     ./no-create-dirs.patch
@@ -57,7 +56,13 @@ stdenv.mkDerivation (finalAttrs: {
     # Detect DM type from config file.
     # `readlink display-manager.service` won't return any of the candidates.
     ./get-dm-type-from-config.patch
-  ];
+
+  ]
+  ++ (lib.optionals (!useHomed) [
+    # Allow disabling systemd-homed support to avoid probing org.freedesktop.home1
+    # on systems that do not enable systemd-homed.
+    ./disable-homed.patch
+  ]);
 
   nativeBuildInputs = [
     gettext
@@ -97,7 +102,8 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dadmin_group=wheel"
     "-Dlocalstatedir=/var"
     "-Dsystemdsystemunitdir=${placeholder "out"}/etc/systemd/system"
-  ];
+  ]
+  ++ (lib.optionals (!useHomed) [ (lib.mesonBool "homed" useHomed) ]);
 
   postPatch = ''
     chmod +x meson_post_install.py


### PR DESCRIPTION
Currently AccountsService sends activation requests for `org.freedesktop.home1` over DBus. This unit is provided by `systemd-homed`. If `systemd-homed` is not used, journald is flooded with error messages from both AccountsService and DBus.

This adds:
- a patch that disables the use of `systemd-homed` by AccountsService. The patch is enabled conditionally, depending on `useHomed ? true` option and is disabled by default.
- an option to use the patched AccountsService package that can disable the use of `systemd-homed` by AccountsService. The option is true by default, that is the default behaviour is untouched and the fix is only enabled by user intentionally.



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
