### PR TITLE
zen-browser: init at 1.19.5b

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16298,6 +16298,12 @@
     githubId = 30468956;
     name = "Lukas Heiligenbrunner";
   };
+  lukas-sgx = {
+    email = "lukas.soigneux@epitech.eu";
+    github = "lukas-sgx";
+    githubId = 68616614;
+    name = "Lukas Soigneux";
+  };
   lukaslihotzki = {
     email = "lukas@lihotzki.de";
     github = "lukaslihotzki";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1851,6 +1851,10 @@ in
   yggdrasil = runTest ./yggdrasil.nix;
   your_spotify = runTest ./your_spotify.nix;
   zammad = runTest ./zammad.nix;
+  zen-browser = runTest {
+    imports = [ ./firefox.nix ];
+    _module.args.firefoxPackage = pkgs.zen-browser;
+  };
   zenohd = runTest ./zenohd.nix;
   zeronet-conservancy = runTest ./zeronet-conservancy.nix;
   zfs = import ./zfs.nix { inherit system pkgs runTest; };

--- a/pkgs/by-name/ze/zen-browser-unwrapped/assets.nix
+++ b/pkgs/by-name/ze/zen-browser-unwrapped/assets.nix
@@ -1,0 +1,193 @@
+{
+  branding,
+  surfer-config,
+  writeText,
+}:
+{
+  # https://github.com/zen-browser/surfer/blob/main/template/branding.optional/locales/en-US/brand.dtd
+  brandDtd = writeText "brand.dtd" ''
+    <!-- This Source Code Form is subject to the terms of the Mozilla Public
+       - License, v. 2.0. If a copy of the MPL was not distributed with this
+       - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+    <!ENTITY  brandShorterName      "${surfer-config.brands.${branding}.brandShorterName}">
+    <!ENTITY  brandShortName        "${surfer-config.brands.${branding}.brandShortName}">
+    <!ENTITY  brandFullName         "${surfer-config.brands.${branding}.brandFullName}">
+  '';
+
+  # https://github.com/zen-browser/surfer/blob/main/template/branding.optional/locales/en-US/brand.ftl
+  brandFtl = writeText "brand.ftl" ''
+    # This Source Code Form is subject to the terms of the Mozilla Public
+    # License, v. 2.0. If a copy of the MPL was not distributed with this
+    # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+    ## Firefox and Mozilla Brand
+    ##
+    ## Firefox and Mozilla must be treated as a brand.
+    ##
+    ## They cannot be:
+    ## - Transliterated.
+    ## - Translated.
+    ##
+    ## Declension should be avoided where possible, leaving the original
+    ## brand unaltered in prominent UI positions.
+    ##
+    ## For further details, consult:
+    ## https://mozilla-l10n.github.io/styleguides/mozilla_general/#brands-copyright-and-trademark
+
+    -brand-shorter-name = ${surfer-config.brands.${branding}.brandShorterName}
+    -brand-short-name = ${surfer-config.brands.${branding}.brandShortName}
+    -brand-full-name = ${surfer-config.brands.${branding}.brandFullName}
+    # This brand name can be used in messages where the product name needs to
+    # remain unchanged across different versions (Nightly, Beta, etc.).
+    -brand-product-name = ${surfer-config.name}
+    -vendor-short-name = ${surfer-config.vendor}
+    trademarkInfo = { " " }
+  '';
+
+  # https://github.com/zen-browser/surfer/blob/main/template/branding.optional/locales/en-US/brand.properties
+  brandProperties = writeText "brand.properties" ''
+    # This Source Code Form is subject to the terms of the Mozilla Public
+    # License, v. 2.0. If a copy of the MPL was not distributed with this
+    # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+    brandShorterName=${surfer-config.brands.${branding}.brandShorterName}
+    brandShortName=${surfer-config.brands.${branding}.brandShortName}
+    brandFullName=${surfer-config.brands.${branding}.brandFullName}
+    vendorShortName=${surfer-config.vendor}
+  '';
+
+  # https://github.com/zen-browser/surfer/blob/main/src/commands/patches/branding-patch.ts
+  brandingNsi = writeText "branding.nsi" ''
+    # This Source Code Form is subject to the terms of the Mozilla Public
+    # License, v. 2.0. If a copy of the MPL was not distributed with this
+    # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+    # NSIS branding defines for official release builds.
+    # The nightly build branding.nsi is located in browser/installer/windows/nsis/
+    # The unofficial build branding.nsi is located in browser/branding/unofficial/
+
+    # BrandFullNameInternal is used for some registry and file system values
+    # instead of BrandFullName and typically should not be modified.
+    !define BrandFullNameInternal "${surfer-config.brands.${branding}.brandFullName}"
+    !define BrandFullName         "${surfer-config.brands.${branding}.brandFullName}"
+    !define CompanyName           "${surfer-config.vendor}"
+    !define URLInfoAbout          "https://zen-browser.app"
+    !define URLUpdateInfo         "https://zen-browser.app/release-notes/''${AppVersion}"
+    !define HelpLink              "https://github.com/zen-browser/desktop/issues"
+
+    ; The OFFICIAL define is a workaround to support different urls for Release and
+    ; Stable since they share the same branding when building with other branches that
+    ; set the update channel to stable.
+    !define OFFICIAL
+    !define URLStubDownloadX86 "https://download.mozilla.org/?os=win&lang=''${AB_CD}&product=firefox-latest"
+    !define URLStubDownloadAMD64 "https://download.mozilla.org/?os=win64&lang=''${AB_CD}&product=firefox-latest"
+    !define URLStubDownloadAArch64 "https://download.mozilla.org/?os=win64-aarch64&lang=''${AB_CD}&product=firefox-latest"
+    !define URLManualDownload "https://zen-browser.app/download"
+    !define URLSystemRequirements "https://www.mozilla.org/firefox/system-requirements/"
+    !define Channel "stable"
+
+    # The installer's certificate name and issuer expected by the stub installer
+    !define CertNameDownload   "${surfer-config.brands.${branding}.brandFullName}"
+    !define CertIssuerDownload "DigiCert SHA2 Assured ID Code Signing CA"
+
+    # Dialog units are used so the UI displays correctly with the system's DPI
+    # settings. These are tweaked to look good with the en-US strings; ideally
+    # we would customize them for each locale but we don't really have a way to
+    # implement that and it would be a ton of work for the localizers.
+    !define PROFILE_CLEANUP_LABEL_TOP "50u"
+    !define PROFILE_CLEANUP_LABEL_LEFT "22u"
+    !define PROFILE_CLEANUP_LABEL_WIDTH "175u"
+    !define PROFILE_CLEANUP_LABEL_HEIGHT "100u"
+    !define PROFILE_CLEANUP_LABEL_ALIGN "left"
+    !define PROFILE_CLEANUP_CHECKBOX_LEFT "22u"
+    !define PROFILE_CLEANUP_CHECKBOX_WIDTH "175u"
+    !define PROFILE_CLEANUP_BUTTON_LEFT "22u"
+    !define INSTALL_HEADER_TOP "70u"
+    !define INSTALL_HEADER_LEFT "22u"
+    !define INSTALL_HEADER_WIDTH "180u"
+    !define INSTALL_HEADER_HEIGHT "100u"
+    !define INSTALL_BODY_LEFT "22u"
+    !define INSTALL_BODY_WIDTH "180u"
+    !define INSTALL_INSTALLING_TOP "115u"
+    !define INSTALL_INSTALLING_LEFT "270u"
+    !define INSTALL_INSTALLING_WIDTH "150u"
+    !define INSTALL_PROGRESS_BAR_TOP "100u"
+    !define INSTALL_PROGRESS_BAR_LEFT "270u"
+    !define INSTALL_PROGRESS_BAR_WIDTH "150u"
+    !define INSTALL_PROGRESS_BAR_HEIGHT "12u"
+
+    !define PROFILE_CLEANUP_CHECKBOX_TOP_MARGIN "12u"
+    !define PROFILE_CLEANUP_BUTTON_TOP_MARGIN "12u"
+    !define PROFILE_CLEANUP_BUTTON_X_PADDING "80u"
+    !define PROFILE_CLEANUP_BUTTON_Y_PADDING "8u"
+    !define INSTALL_BODY_TOP_MARGIN "20u"
+
+    # Font settings that can be customized for each channel
+    !define INSTALL_HEADER_FONT_SIZE 20
+    !define INSTALL_HEADER_FONT_WEIGHT 600
+    !define INSTALL_INSTALLING_FONT_SIZE 15
+    !define INSTALL_INSTALLING_FONT_WEIGHT 600
+
+    # UI Colors that can be customized for each channel
+    !define COMMON_TEXT_COLOR 0x000000
+    !define COMMON_BACKGROUND_COLOR 0xFFFFFF
+    !define INSTALL_INSTALLING_TEXT_COLOR 0xFFFFFF
+    # This color is written as 0x00BBGGRR because it's actually a COLORREF value.
+    !define PROGRESS_BAR_BACKGROUND_COLOR 0xFFAA00
+  '';
+
+  # https://github.com/zen-browser/surfer/blob/main/template/branding.optional/configure.sh
+  configureSh = writeText "configure.sh" ''
+    # This Source Code Form is subject to the terms of the Mozilla Public
+    # License, v. 2.0. If a copy of the MPL was not distributed with this
+    # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+    MOZ_APP_DISPLAYNAME="${surfer-config.brands.${branding}.brandShortName}"
+    MOZ_MACBUNDLE_ID="${surfer-config.appId}"
+
+    # if test "$DEVELOPER_OPTIONS"; then
+    #   if test "$MOZ_DEBUG"; then
+    #     # Local debug builds
+    #     MOZ_HANDLER_CLSID="398ffd8d-5382-48f7-9e3b-19012762d39a"
+    #     MOZ_IHANDLERCONTROL_IID="a218497e-8b10-460b-b668-a92b7ee39ff2"
+    #     MOZ_ASYNCIHANDLERCONTROL_IID="ca18b9ab-04b6-41be-87f7-d99913d6a2e8"
+    #     MOZ_IGECKOBACKCHANNEL_IID="231c4946-4479-4c8e-aadc-8a0e48fc4c51"
+    #   else
+    #     # Local non-debug builds
+    #     MOZ_HANDLER_CLSID="ce573faf-7815-4fc2-a031-b092268ace9e"
+    #     MOZ_IHANDLERCONTROL_IID="2b715cce-1790-4fe1-aef5-48bb5acdf3a1"
+    #     MOZ_ASYNCIHANDLERCONTROL_IID="8e089670-4f57-41a7-89c0-37f17482fa6f"
+    #     MOZ_IGECKOBACKCHANNEL_IID="18e2488d-310f-400f-8339-0e50b513e801"
+    #   fi
+    # fi
+  '';
+
+  # https://github.com/zen-browser/surfer/blob/main/src/commands/patches/branding-patch.ts
+  firefox-brandingJs = writeText "firefox-branding.js" ''
+    /* This Source Code Form is subject to the terms of the Mozilla Public
+     * License, v. 2.0. If a copy of the MPL was not distributed with this
+     * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+    pref("startup.homepage_override_url", "https://zen-browser.app/whatsnew?v=%VERSION%");
+    pref("startup.homepage_welcome_url", "https://zen-browser.app/welcome/");
+    pref("startup.homepage_welcome_url.additional", "https://zen-browser.app/privacy-policy/");
+
+    // Give the user x seconds to react before showing the big UI. default=192 hours
+    pref("app.update.promptWaitTime", 691200);
+    // app.update.url.manual: URL user can browse to manually if for some reason
+    // all update installation attempts fail.
+    // app.update.url.details: a default value for the "More information about this
+    // update" link supplied in the "An update is available" page of the update
+    // wizard.
+    pref("app.update.url.manual", "https://zen-browser.app/download/");
+    pref("app.update.url.details", "https://zen-browser.app/release-notes/latest/");
+    pref("app.releaseNotesURL", "https://zen-browser.app/whatsnew/");
+    pref("app.releaseNotesURL.aboutDialog", "https://www.zen-browser.app/release-notes/%VERSION%/");
+    pref("app.releaseNotesURL.prompt", "https://zen-browser.app/release-notes/%VERSION%/");
+
+    // Number of usages of the web console.
+    // If this is less than 5, then pasting code into the web console is disabled
+    pref("devtools.selfxss.count", 5);
+  '';
+}

--- a/pkgs/by-name/ze/zen-browser-unwrapped/package.nix
+++ b/pkgs/by-name/ze/zen-browser-unwrapped/package.nix
@@ -1,0 +1,49 @@
+{
+  buildMozillaMach,
+  callPackage,
+  lib,
+  nixosTests,
+  stdenv,
+}:
+let
+  zen-browser-src = callPackage ./zen-browser.nix { };
+in
+(buildMozillaMach {
+  inherit (zen-browser-src) extraNativeBuildInputs extraPostPatch;
+  pname = "zen-browser";
+  allowAddonSideload = true;
+  applicationName = "Zen";
+  binaryName = "zen";
+  branding = "browser/branding/release";
+  extraPassthru = {
+    inherit (zen-browser-src) ffprefs;
+    inherit zen-browser-src;
+  };
+  packageVersion = zen-browser-src.zen-version;
+  requireSigning = false;
+  src = zen-browser-src.firefox-src;
+  version = zen-browser-src.firefox-version;
+
+  meta = {
+    # since Firefox 60, build on 32-bit platforms fails with "out of memory".
+    # not in `badPlatforms` because cross-compilation on 64-bit machine might work.
+    broken = stdenv.buildPlatform.is32bit;
+    description = "Firefox fork with a focus on looks and privacy";
+    homepage = "https://zen-browser.app";
+    license = lib.licenses.mpl20;
+    mainProgram = "zen";
+    maintainers = with lib.maintainers; [ lukas-sgx ];
+    maxSilent = 14400; # 4h, double the default of 7200s (c.f. #129212, #129115)
+    platforms = lib.platforms.unix;
+  };
+  tests = { inherit (nixosTests) zen-browser; };
+  updateScript = ./update.sh;
+}).override
+  {
+    crashreporterSupport = false;
+    enableOfficialBranding = false;
+  }
+// {
+  strictDeps = true;
+  __structuredAttrs = true;
+}

--- a/pkgs/by-name/ze/zen-browser-unwrapped/update.sh
+++ b/pkgs/by-name/ze/zen-browser-unwrapped/update.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash common-updater-scripts curl gawk jq nix-prefetch-git
+
+set -exuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_NIX="$SCRIPT_DIR/zen-browser.nix"
+
+setKey () {
+  sed -i "s|$1 = \".*\"|$1 = \"${2:-}\"|" "${SRC_NIX}"
+}
+
+latestVersion=$(curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} "https://api.github.com/repos/zen-browser/desktop/releases/latest" | jq -r .tag_name)
+currentVersion=$(nix eval --raw -f . zen-browser-unwrapped.version)
+
+echo "latest  version: $latestVersion"
+echo "current version: $currentVersion"
+
+if [[ "$latestVersion" == "$currentVersion" ]]; then
+   echo "package is up-to-date"
+   exit 0
+fi
+
+# Retrieving firefox version
+currentFirefoxVersion=$(nix eval --raw -f . zen-browser-unwrapped.zen-browser-src.firefox-version)
+
+prefetchOut=$(mktemp)
+nix-prefetch-git "https://github.com/zen-browser/desktop.git" --quiet --rev $latestVersion > $prefetchOut
+srcDir=$(jq -r .path < $prefetchOut)
+srcHash=$(nix --extra-experimental-features nix-command hash convert --to sri --hash-algo sha256 $(jq -r .sha256 < $prefetchOut))
+firefoxVersion=$(cat $srcDir/surfer.json | jq -r .version.version)
+echo "firefox version: $firefoxVersion"
+
+# Retrieving firefox source hash
+HOME=$(mktemp -d)
+export GNUPGHOME=$(mktemp -d)
+gpg --receive-keys 14F26682D0916CDD81E37B6D61B7B526D98F0353
+
+mozillaUrl=https://archive.mozilla.org/pub/firefox/releases/
+
+curl --silent --show-error -o "$HOME"/shasums "$mozillaUrl$firefoxVersion/SHA512SUMS"
+curl --silent --show-error -o "$HOME"/shasums.asc "$mozillaUrl$firefoxVersion/SHA512SUMS.asc"
+gpgv --keyring="$GNUPGHOME"/pubring.kbx "$HOME"/shasums.asc "$HOME"/shasums
+
+firefoxHash=$(nix --extra-experimental-features nix-command hash convert --from base16 --to sri --hash-algo sha512 $(grep '\.source\.tar\.xz$' "$HOME"/shasums | grep '^[^ ]*' -o))
+echo "firefoxHash=$firefoxHash"
+
+# Updating the firefox and zen source hash and version
+awk -v currentFirefoxVersion="$currentFirefoxVersion" -v firefoxVersion="$firefoxVersion" -v firefoxHash="$firefoxHash" \
+    -v currentZenVersion="$currentVersion" -v zenVersion="$latestVersion" -v srcHash="$srcHash" '
+  /firefox-version = "/ { gsub(currentFirefoxVersion, firefoxVersion) }
+  /hash = "sha512-/ { gsub(/sha512-[^"]*/, firefoxHash)}
+  /zen-version = "/ { gsub(currentZenVersion, zenVersion) }
+  /hash = "sha256-/ { gsub(/sha256-[^"]*/, srcHash)}
+  { print }
+' "$SRC_NIX" > "$SRC_NIX.tmp" && mv "$SRC_NIX.tmp" "$SRC_NIX"
+
+# Update ffprefs
+setKey cargoHash "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+set +e
+cargoSha256=$(nix build .#zen-browser-unwrapped.passthru.ffprefs 2>&1 >/dev/null | grep "got:" | cut -d':' -f2 | sed 's| ||g')
+cargoHash=$(nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri "$cargoSha256")
+set -e
+
+if [ -n "${cargoHash:-}" ]; then
+    setKey cargoHash "${cargoHash}"
+else
+    echo "Update failed. cargo_hash is empty."
+    exit 1
+fi

--- a/pkgs/by-name/ze/zen-browser-unwrapped/zen-browser.nix
+++ b/pkgs/by-name/ze/zen-browser-unwrapped/zen-browser.nix
@@ -1,0 +1,125 @@
+{
+  branding ? "release",
+  fetchFromGitHub,
+  fetchurl,
+  rsync,
+  rustPlatform,
+  writeText,
+}:
+let
+  assets = import ./assets.nix { inherit branding surfer-config writeText; };
+
+  ffprefs = rustPlatform.buildRustPackage {
+    cargoHash = "sha256-DZMwxeulQiIiSATU0MoyqiUMA0USZq6umhkr67hZH1Q=";
+    pname = "ffprefs";
+    postPatch = ''
+      substituteInPlace src/main.rs \
+        --replace-fail "../engine/" "../"
+    '';
+    src = "${zen-src}/tools/ffprefs";
+    version = zen-version;
+  };
+
+  firefox-src = fetchurl {
+    url = "mirror://mozilla/firefox/releases/${firefox-version}/source/firefox-${firefox-version}.source.tar.xz";
+    hash = "sha512-zdhxp3OPtw2FpwPonEh00b9EGEtMmyiQGQKty/olwZlnXnRjBrtZ1mgh5uzRfgfJm2akjYJ/OazKbDsBK5U3Gg==";
+  };
+
+  firefox-version = "149.0";
+
+  surfer-config = {
+    name = "Zen Browser";
+    vendor = "Zen OSS Team";
+    appId = "zen";
+    brands = {
+      release = {
+        backgroundColor = "#282A33";
+        brandShorterName = "Zen";
+        brandShortName = "Zen";
+        brandFullName = "Zen Browser";
+      };
+      twilight = {
+        backgroundColor = "#282A33";
+        brandShorterName = "Zen";
+        brandShortName = "Twilight";
+        brandFullName = "Zen Twilight";
+      };
+    };
+  };
+
+  zen-src = fetchFromGitHub {
+    owner = "zen-browser";
+    repo = "desktop";
+    tag = zen-version;
+    hash = "sha256-UQATOPDahwaxoWQcawnT/d5go6YJPjIVud9Bow8BfRg=";
+  };
+
+  zen-version = "1.19.5b";
+in
+{
+  inherit
+    ffprefs
+    firefox-src
+    firefox-version
+    zen-version
+    ;
+
+  extraNativeBuildInputs = [
+    rsync
+  ];
+
+  extraPostPatch = ''
+    rsync -r ${zen-src}/prefs/ prefs
+    ${ffprefs}/bin/ffprefs .
+
+    rsync -r --exclude "*.patch" "${zen-src}/src/" .
+
+    find "${zen-src}/src" -type f -name "*.patch" ! -name "fix_macos_crash_on_shutdown_firefox_149.patch" | while read -r patch_name; do
+      patch -p1 < $patch_name
+    done
+
+    rsync -r "${zen-src}/locales/en-US/browser/" browser/locales/en-US/
+    for language in $(cat ${zen-src}/locales/supported-languages); do
+      loc="$(grep -m1 "^$language:" "${zen-src}/locales/language-maps" | cut -d: -f2 || true)"
+      loc="''${loc:-$language}"
+      rsync -r "${zen-src}/locales/$language/." browser/locales/$loc
+    done
+
+    rsync -r --exclude='branding.nsi' browser/branding/unofficial/. browser/branding/${branding}
+
+    cp -r ${zen-src}/configs/branding/${branding} browser/branding
+    for size in 16 22 24 32 48 64 128 256 512; do
+      cp ${zen-src}/configs/branding/${branding}/logo"$size".png browser/branding/${branding}/default"$size".png
+    done
+
+    rsync ${assets.brandDtd} browser/branding/${branding}/locales/en-US/brand.dtd
+    rsync ${assets.brandFtl} browser/branding/${branding}/locales/en-US/brand.ftl
+    rsync ${assets.brandProperties} browser/branding/${branding}/locales/en-US/brand.properties
+    rsync ${assets.brandingNsi} browser/branding/${branding}/branding.nsi
+    rsync ${assets.configureSh} browser/branding/${branding}/configure.sh
+    rsync ${assets.firefox-brandingJs} browser/branding/${branding}/pref/firefox-branding.js
+
+    find "browser/branding/${branding}" -type f -name "*.css" | while read -r style; do
+      echo ":root { --theme-bg: ${surfer-config.brands.${branding}.backgroundColor} }" >> $style
+      sed -i -E 's/#130829|hsla\(235, 43%, 10%, 0\.5\)/var(--theme-bg)/g' $style
+    done
+
+    substituteInPlace build/application.ini.in \
+      --replace-fail 'URL=https://@MOZ_APPUPDATE_HOST@/update/6/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%SYSTEM_CAPABILITIES%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/update.xml' 'URL=https://@MOZ_APPUPDATE_HOST@/updates/browser/%BUILD_TARGET%/%CHANNEL%/update.xml'
+
+    substituteInPlace browser/installer/windows/nsis/shared.nsh  \
+      --replace-fail '"Publisher" "Mozilla"' '"Publisher" "${surfer-config.vendor}"'
+
+    scripts="$(mktemp -d)"
+    cp -r "${zen-src}/scripts/." "$scripts"
+    sed -i '9,15c\
+    DUMPS_FOLDER = "${zen-src}/configs/dumps"\
+    ENGINE_DUMPS_FOLDER = "services/settings/dumps/main"' $scripts/update_service_dumps.py
+
+    python $scripts/update_service_dumps.py
+
+    for file in browser/config/version.txt browser/config/version_display.txt; do
+      echo "${zen-version}" > $file
+    done
+  '';
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10159,6 +10159,10 @@ with pkgs;
 
   zed-editor-fhs = zed-editor.fhs;
 
+  zen-browser = (wrapFirefox zen-browser-unwrapped { }) // {
+    strictDeps = true;
+  };
+
   zynaddsubfx-fltk = zynaddsubfx.override {
     guiModule = "fltk";
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Initial implementation of Zen Browser. 

Zen Browser is a privacy-focused, open-source web browser built on top of Firefox, featuring a highly customizable user interface, built-in vertical tabs, workspaces, and optimized performance.

This PR resolves preceding evaluation bugs and conflicts encountered in #496647 and #363992, offering a clean setup that adheres to current Nixpkgs guidelines.

### Changes:

- Added `zen-browser-unwrapped` under `pkgs/by-name/` following modern nixpkgs structure.
- Exposed the wrapped version `zen-browser` in `pkgs/top-level/all-packages.nix` utilizing `wrapFirefox`.
- Added myself to `maintainers/maintainer-list.nix`.

Homepage: https://zen-browser.app/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
