### PR TITLE
python3Packages.lime: migrate to pyproject, enable __structuredAttrs, use finalAttrs

### DIFF
--- a/pkgs/development/python-modules/lime/default.nix
+++ b/pkgs/development/python-modules/lime/default.nix
@@ -13,13 +13,13 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "lime";
   version = "0.2.0.1";
   format = "setuptools";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-dpYOTwVf61Pom1AiODuvyHtj8lusYmWYSwozPRpX94E=";
   };
 
@@ -55,8 +55,8 @@ buildPythonPackage rec {
   meta = {
     description = "Local Interpretable Model-Agnostic Explanations for machine learning classifiers";
     homepage = "https://github.com/marcotcr/lime";
-    changelog = "https://github.com/marcotcr/lime/releases/tag/${version}";
+    changelog = "https://github.com/marcotcr/lime/releases/tag/${finalAttrs.version}";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ khaser ];
   };
-}
+})

--- a/pkgs/development/python-modules/lime/default.nix
+++ b/pkgs/development/python-modules/lime/default.nix
@@ -3,6 +3,8 @@
   fetchPypi,
   buildPythonPackage,
 
+  setuptools,
+
   matplotlib,
   numpy,
   scipy,
@@ -16,7 +18,7 @@
 buildPythonPackage (finalAttrs: {
   pname = "lime";
   version = "0.2.0.1";
-  format = "setuptools";
+  pyproject = true;
 
   __structuredAttrs = true;
 
@@ -30,7 +32,9 @@ buildPythonPackage (finalAttrs: {
       --replace-fail "random_seed" "rng"
   '';
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     matplotlib
     numpy
     scipy

--- a/pkgs/development/python-modules/lime/default.nix
+++ b/pkgs/development/python-modules/lime/default.nix
@@ -48,6 +48,8 @@ buildPythonPackage (finalAttrs: {
   disabledTestPaths = [
     # touches network
     "lime/tests/test_lime_text.py"
+    # slightly flaky
+    "lime/tests/test_lime_tabular.py::TestLimeTabular::test_lime_explainer_entropy_discretizer"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/lime/default.nix
+++ b/pkgs/development/python-modules/lime/default.nix
@@ -18,6 +18,8 @@ buildPythonPackage (finalAttrs: {
   version = "0.2.0.1";
   format = "setuptools";
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
     inherit (finalAttrs) pname version;
     hash = "sha256-dpYOTwVf61Pom1AiODuvyHtj8lusYmWYSwozPRpX94E=";


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974
- use `finalAttrs`
- enable `__structuredAttrs`
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
