### PR TITLE
maintainers: remove anmonteiro

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1893,12 +1893,6 @@
     githubId = 750786;
     name = "Justin Wood";
   };
-  anmonteiro = {
-    email = "anmonteiro@gmail.com";
-    github = "anmonteiro";
-    githubId = 661909;
-    name = "Antonio Nuno Monteiro";
-  };
   anna328p = {
     email = "anna328p@gmail.com";
     github = "anna328p";

--- a/pkgs/by-name/sq/sqlite-vec/package.nix
+++ b/pkgs/by-name/sq/sqlite-vec/package.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/asg017/sqlite-vec/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      anmonteiro
       sarahec
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/development/ocaml-modules/alcotest/mirage.nix
+++ b/pkgs/development/ocaml-modules/alcotest/mirage.nix
@@ -29,7 +29,6 @@ buildDunePackage {
     description = "Mirage implementation for Alcotest";
     maintainers = with lib.maintainers; [
       ulrikstrid
-      anmonteiro
     ];
   };
 }

--- a/pkgs/development/ocaml-modules/gluten/default.nix
+++ b/pkgs/development/ocaml-modules/gluten/default.nix
@@ -28,6 +28,6 @@ buildDunePackage (finalAttrs: {
     description = "Implementation of a platform specific runtime code for driving network libraries based on state machines, such as http/af, h2 and websocketaf";
     license = lib.licenses.bsd3;
     homepage = "https://github.com/anmonteiro/gluten";
-    maintainers = with lib.maintainers; [ anmonteiro ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/development/ocaml-modules/hpack/default.nix
+++ b/pkgs/development/ocaml-modules/hpack/default.nix
@@ -31,7 +31,6 @@ buildDunePackage (finalAttrs: {
     homepage = "https://github.com/anmonteiro/ocaml-h2";
     maintainers = with lib.maintainers; [
       sternenseemann
-      anmonteiro
     ];
   };
 })

--- a/pkgs/development/ocaml-modules/piaf/default.nix
+++ b/pkgs/development/ocaml-modules/piaf/default.nix
@@ -58,6 +58,6 @@ buildDunePackage (finalAttrs: {
     description = "HTTP library with HTTP/2 support written entirely in OCaml";
     homepage = "https://github.com/anmonteiro/piaf";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ anmonteiro ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/development/ocaml-modules/routes/default.nix
+++ b/pkgs/development/ocaml-modules/routes/default.nix
@@ -22,7 +22,6 @@ buildDunePackage (finalAttrs: {
     homepage = "https://anuragsoni.github.io/routes";
     maintainers = with lib.maintainers; [
       ulrikstrid
-      anmonteiro
     ];
   };
 })

--- a/pkgs/development/ocaml-modules/ssl/default.nix
+++ b/pkgs/development/ocaml-modules/ssl/default.nix
@@ -42,7 +42,6 @@ buildDunePackage rec {
       ocamlLgplLinkingException
     ];
     maintainers = with lib.maintainers; [
-      anmonteiro
       dandellion
     ];
   };


### PR DESCRIPTION
## Reasons

- Last commented in [December 2024](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Aanmonteiro)
- Hasn't created any PRs / Issues since [November 2024](https://github.com/NixOS/nixpkgs/issues?q=author%3Aanmonteiro)
- About 36 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Aanmonteiro%20-commenter%3Aanmonteiro%20-author%3Aanmonteiro%20-reviewed-by%3Aanmonteiro) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] ocamlPackages.gluten
- [ ] ocamlPackages.piaf