### PR TITLE
maintainers: remove cmars

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5279,13 +5279,6 @@
     githubId = 3392199;
     name = "Calum MacRae";
   };
-  cmars = {
-    email = "nix@cmars.tech";
-    github = "cmars";
-    githubId = 23741;
-    name = "Casey Marshall";
-    keys = [ { fingerprint = "6B78 7E5F B493 FA4F D009  5D10 6DEC 2758 ACD5 A973"; } ];
-  };
   cmcdragonkai = {
     email = "roger.qiu@matrix.ai";
     github = "CMCDragonkai";

--- a/pkgs/by-name/ku/kubebuilder/package.nix
+++ b/pkgs/by-name/ku/kubebuilder/package.nix
@@ -69,6 +69,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/kubernetes-sigs/kubebuilder";
     changelog = "https://github.com/kubernetes-sigs/kubebuilder/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ cmars ];
+    maintainers = [ ];
   };
 })


### PR DESCRIPTION
## Reasons

- Last commented in [August 2024](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Acmars)
- Hasn't created any PRs / Issues since [June 2022](https://github.com/NixOS/nixpkgs/issues?q=author%3Acmars)
- About 36 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Acmars%20-commenter%3Acmars%20-author%3Acmars%20-reviewed-by%3Acmars) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] kubebuilder