### PR TITLE
maintainers: remove ToxicFrog

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28288,12 +28288,6 @@
     github = "toXel";
     githubId = 2300709;
   };
-  ToxicFrog = {
-    email = "toxicfrog@ancilla.ca";
-    github = "ToxicFrog";
-    githubId = 90456;
-    name = "Rebecca (Bex) Kelly";
-  };
   toyboot4e = {
     email = "toyboot4e@gmail.com";
     github = "toyboot4e";

--- a/pkgs/by-name/bl/blitz/package.nix
+++ b/pkgs/by-name/bl/blitz/package.nix
@@ -87,7 +87,7 @@ stdenv.mkDerivation rec {
       lgpl3Plus
     ];
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ ToxicFrog ];
+    maintainers = [ ];
     longDescription = ''
       Blitz++ is a C++ class library for scientific computing which provides
       performance on par with Fortran 77/90. It uses template techniques to

--- a/pkgs/by-name/cr/crossfire-arch/package.nix
+++ b/pkgs/by-name/cr/crossfire-arch/package.nix
@@ -29,6 +29,6 @@ stdenv.mkDerivation {
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
     hydraPlatforms = [ ];
-    maintainers = with lib.maintainers; [ ToxicFrog ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/cr/crossfire-client/package.nix
+++ b/pkgs/by-name/cr/crossfire-client/package.nix
@@ -68,6 +68,6 @@ stdenv.mkDerivation {
     homepage = "http://crossfire.real-time.com/";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ ToxicFrog ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/cr/crossfire-gridarta/package.nix
+++ b/pkgs/by-name/cr/crossfire-gridarta/package.nix
@@ -48,6 +48,6 @@ stdenv.mkDerivation {
     homepage = "http://crossfire.real-time.com/";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ ToxicFrog ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/cr/crossfire-jxclient/package.nix
+++ b/pkgs/by-name/cr/crossfire-jxclient/package.nix
@@ -68,6 +68,6 @@ stdenv.mkDerivation rec {
     homepage = "http://crossfire.real-time.com/";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ ToxicFrog ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/cr/crossfire-maps/package.nix
+++ b/pkgs/by-name/cr/crossfire-maps/package.nix
@@ -29,6 +29,6 @@ stdenv.mkDerivation {
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
     hydraPlatforms = [ ];
-    maintainers = with lib.maintainers; [ ToxicFrog ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/cr/crossfire-server/package.nix
+++ b/pkgs/by-name/cr/crossfire-server/package.nix
@@ -55,6 +55,6 @@ stdenv.mkDerivation {
     homepage = "http://crossfire.real-time.com/";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ ToxicFrog ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/op/openttd-grfcodec/package.nix
+++ b/pkgs/by-name/op/openttd-grfcodec/package.nix
@@ -47,6 +47,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Low-level (dis)assembler and linter for OpenTTD GRF files";
     homepage = "http://openttd.org/";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ ToxicFrog ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/op/openttd-nml/package.nix
+++ b/pkgs/by-name/op/openttd-nml/package.nix
@@ -34,6 +34,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     description = "Compiler for OpenTTD NML files";
     mainProgram = "nmlc";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ ToxicFrog ];
+    maintainers = [ ];
   };
 })


### PR DESCRIPTION
## Reasons

- Last commented in [November 2025](https://github.com/NixOS/nixpkgs/issues?q=commenter%3AToxicFrog)
- Hasn't created any PRs / Issues since [August 2025](https://github.com/NixOS/nixpkgs/issues?q=author%3AToxicFrog)
- About 29 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3AToxicFrog%20-commenter%3AToxicFrog%20-author%3AToxicFrog%20-reviewed-by%3AToxicFrog) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] blitz
- [ ] crossfire-arch
- [ ] crossfire-client
- [ ] crossfire-gridarta
- [ ] crossfire-maps
- [ ] crossfire-server
- [ ] openttd-grfcodec
- [ ] openttd-nml