### PR TITLE
python3Packages.ble-reticulum: init at 0.2.2-unstable-2026-01-18

### DIFF
--- a/pkgs/development/python-modules/ble-reticulum/default.nix
+++ b/pkgs/development/python-modules/ble-reticulum/default.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytest,
+  pytest-asyncio,
+  pytest-cov,
+  pytest-timeout,
+  pytestCheckHook,
+  rns,
+  bleak,
+  bluezero,
+  dbus-fast,
+  dbus-python,
+  nix-update-script,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "ble-reticulum";
+  version = "0.2.2-unstable-2026-01-18";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "torlando-tech";
+    repo = "ble-reticulum";
+    rev = "07d941304c9a1dc3a8e58087b3b974ff3d229e56";
+    hash = "sha256-qtNn2OEcBbjAJprHDRBE4f8HyOavr5mzQrtMkxh1oxE=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    bleak
+    bluezero
+    dbus-fast
+    dbus-python
+  ];
+
+  pythonImportsCheck = [
+    "ble_reticulum"
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    rns
+    pytestCheckHook
+    pytest
+    pytest-asyncio
+    pytest-cov
+    pytest-timeout
+  ];
+
+  disabledTestPaths = [
+    # AttributeError: 'NoneType' object has no attribute '_default_ic_max_held_announces'
+    "tests/test_v2_2_identity_handshake.py"
+    "tests/test_v2_2_mac_sorting.py"
+    "tests/test_v2_2_race_conditions.py"
+    "tests/test_zombie_connection_detection.py"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "BLE Interface for Reticulum Network";
+    homepage = "https://github.com/torlando-tech/ble-reticulum";
+    changelog = "https://github.com/torlando-tech/ble-reticulum/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ drupol ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2142,6 +2142,8 @@ self: super: with self; {
 
   blake3 = callPackage ../development/python-modules/blake3 { };
 
+  ble-reticulum = callPackage ../development/python-modules/ble-reticulum { };
+
   ble-serial = callPackage ../development/python-modules/ble-serial { };
 
   bleach = callPackage ../development/python-modules/bleach { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
