### PR TITLE
maintainers: remove vrthra

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29411,12 +29411,6 @@
     name = "Vince Rose";
     githubId = 9831420;
   };
-  vrthra = {
-    email = "rahul@gopinath.org";
-    github = "vrthra";
-    githubId = 70410;
-    name = "Rahul Gopinath";
-  };
   vsharathchandra = {
     email = "chandrasharath.v@gmail.com";
     github = "vsharathchandra";

--- a/pkgs/development/compilers/factor-lang/unwrapped.nix
+++ b/pkgs/development/compilers/factor-lang/unwrapped.nix
@@ -108,7 +108,6 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [
-      vrthra
       spacefrogg
     ];
     platforms = [ "x86_64-linux" ];


### PR DESCRIPTION
## Reasons

- Last commented in [September 2025](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Avrthra)
- Hasn't created any PRs / Issues since [May 2017](https://github.com/NixOS/nixpkgs/issues?q=author%3Avrthra)
- About 8 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Avrthra%20-commenter%3Avrthra%20-author%3Avrthra%20-reviewed-by%3Avrthra%20created%3A%3E2025-01-01) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.