### PR TITLE
python3Packages.roadlib: 1.6.0 -> 1.7.0, python3Packages.roadrecon: 1.7.4 -> 2.0.0, python3Packages.roadtx: 1.21.1 -> 1.22.0, python3Packages.selenium-wire-roadtx: init at 0-unstable-2026-05-20 

### DIFF
--- a/pkgs/by-name/ro/roadtools/package.nix
+++ b/pkgs/by-name/ro/roadtools/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: with python3Packages; toPythonApplication roadtools

--- a/pkgs/development/python-modules/roadlib/default.nix
+++ b/pkgs/development/python-modules/roadlib/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   aiohttp,
+  cbor2,
   cryptography,
   buildPythonPackage,
   fetchPypi,
@@ -10,19 +11,22 @@
   sqlalchemy,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "roadlib";
-  version = "1.6.0";
+  version = "1.7.0";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-WKlbYTIw7A5d4UCxeFgtQ1/dTecqQVzSheImnrb2Hmw=";
+    inherit (finalAttrs) pname version;
+    hash = "sha256-al1FnLcKAFWRY43weXtsS8DN5pXCO1qFUw1vwLfZvGM=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [
+    cbor2
     cryptography
     pyjwt
     requests
@@ -44,4 +48,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/roadrecon/default.nix
+++ b/pkgs/development/python-modules/roadrecon/default.nix
@@ -17,12 +17,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "roadrecon";
-  version = "1.7.4";
+  version = "2.0.0";
   pyproject = true;
+
+  __structuredAttrs = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-V/McstT+2LAlNe4HHQ0xNfAIM0ExFstyEL3qQrEfkoQ=";
+    hash = "sha256-wzr0J6tGhsZdjTDeIeSzCRTquiw4iZ8FxqFEl1fC2iU=";
   };
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/roadtools/default.nix
+++ b/pkgs/development/python-modules/roadtools/default.nix
@@ -8,19 +8,21 @@
   roadtx,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "roadtools";
   version = "0.0.2";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-RxRbcT9uhQBYRDqq1asYDIwqrji14zi7dwRuQLXJiyQ=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     roadrecon
     roadlib
     roadtx
@@ -34,4 +36,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/roadtools/default.nix
+++ b/pkgs/development/python-modules/roadtools/default.nix
@@ -35,5 +35,6 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/dirkjanm/ROADtools";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "roadtools";
   };
 })

--- a/pkgs/development/python-modules/roadtx/default.nix
+++ b/pkgs/development/python-modules/roadtx/default.nix
@@ -7,19 +7,21 @@
   requests,
   roadlib,
   selenium,
-  selenium-wire,
+  selenium-wire-roadtx,
   setuptools,
   signxml,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "roadtx";
-  version = "1.21.1";
+  version = "1.22.0";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-UxyyvVWuRE/Uh7zUtSN6GdRdintNpFAHVQ+ufc+uFjU=";
+    inherit (finalAttrs) pname version;
+    hash = "sha256-2GIJAjLxOqy3E+5j1gnby8F5IAvdnChMT4Lfq5I5zeE=";
   };
 
   build-system = [ setuptools ];
@@ -30,7 +32,7 @@ buildPythonPackage rec {
     requests
     roadlib
     selenium
-    selenium-wire
+    selenium-wire-roadtx
     signxml
   ];
 
@@ -42,4 +44,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/selenium-wire-roadtx/default.nix
+++ b/pkgs/development/python-modules/selenium-wire-roadtx/default.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  blinker,
+  brotli,
+  buildPythonPackage,
+  certifi,
+  cryptography,
+  fetchFromGitHub,
+  gunicorn,
+  h2,
+  httpbin,
+  hyperframe,
+  kaitaistruct,
+  nix-update-script,
+  pyasn1,
+  pyopenssl,
+  pyparsing,
+  pysocks,
+  pytestCheckHook,
+  ruamel-yaml,
+  selenium,
+  setuptools,
+  wsproto,
+  zstandard,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "selenium-wire-roadtx";
+  version = "0-unstable-2026-05-20";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "dirkjanm";
+    repo = "selenium-wire-roadtx";
+    rev = "98e91ea9e2472902d19b4a328a2ea08539b488b9";
+    hash = "sha256-WhGsgIuJrbc6Emq9B0uin7FUKc/qPH9E1DUjt/FIVZs=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    blinker
+    brotli
+    certifi
+    cryptography
+    h2
+    hyperframe
+    kaitaistruct
+    pyasn1
+    pyopenssl
+    pyparsing
+    pysocks
+    ruamel-yaml
+    selenium
+    wsproto
+    zstandard
+  ];
+
+  nativeCheckInputs = [
+    gunicorn
+    httpbin
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "seleniumwire" ];
+
+  disabledTestPaths = [
+    # Don't run End2End tests
+    "tests/end2end/test_end2end.py"
+    # Don't run MitM tests
+    "tests/seleniumwire/test_server.py"
+  ];
+
+  disabledTests = [
+    # Tests require setup
+    "BackendIntegrationTest"
+    # AssertionError
+    "test_save_response"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Extends Selenium's Python bindings to give you the ability to inspect requests made by the browser";
+    homepage = "https://github.com/dirkjanm/selenium-wire-roadtx";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -17810,6 +17810,8 @@ self: super: with self; {
 
   selenium-wire = callPackage ../development/python-modules/selenium-wire { };
 
+  selenium-wire-roadtx = callPackage ../development/python-modules/selenium-wire-roadtx { };
+
   semantic-version = callPackage ../development/python-modules/semantic-version { };
 
   semaphore-bot = callPackage ../development/python-modules/semaphore-bot { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
