### PR TITLE
python3Packages.syslog-rfc5424-formatter: migrate to pyproject, enable __structuredAttrs, use finalAttrs, add changelog

### DIFF
--- a/pkgs/development/python-modules/syslog-rfc5424-formatter/default.nix
+++ b/pkgs/development/python-modules/syslog-rfc5424-formatter/default.nix
@@ -31,6 +31,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Python logging formatter for emitting RFC5424 Syslog messages";
     homepage = "https://github.com/easypost/syslog-rfc5424-formatter";
+    changelog = "https://github.com/EasyPost/syslog-rfc5424-formatter/blob/v${finalAttrs.version}/CHANGES.md";
     license = with lib.licenses; [ isc ];
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/syslog-rfc5424-formatter/default.nix
+++ b/pkgs/development/python-modules/syslog-rfc5424-formatter/default.nix
@@ -9,6 +9,8 @@ buildPythonPackage (finalAttrs: {
   version = "1.2.3";
   format = "setuptools";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "easypost";
     repo = "syslog-rfc5424-formatter";

--- a/pkgs/development/python-modules/syslog-rfc5424-formatter/default.nix
+++ b/pkgs/development/python-modules/syslog-rfc5424-formatter/default.nix
@@ -2,12 +2,13 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "syslog-rfc5424-formatter";
   version = "1.2.3";
-  format = "setuptools";
+  pyproject = true;
 
   __structuredAttrs = true;
 
@@ -18,7 +19,11 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-dvRSOMXRmZf0vEEyX6H7OBSfo/PgyOLKuDS8X6g4qe0=";
   };
 
-  # Tests are not picked up, review later again
+  build-system = [
+    setuptools
+  ];
+
+  # Tests depend on syslog_rfc5424_parser, which we don't package
   doCheck = false;
 
   pythonImportsCheck = [ "syslog_rfc5424_formatter" ];

--- a/pkgs/development/python-modules/syslog-rfc5424-formatter/default.nix
+++ b/pkgs/development/python-modules/syslog-rfc5424-formatter/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "syslog-rfc5424-formatter";
   version = "1.2.3";
   format = "setuptools";
@@ -12,7 +12,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "easypost";
     repo = "syslog-rfc5424-formatter";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-dvRSOMXRmZf0vEEyX6H7OBSfo/PgyOLKuDS8X6g4qe0=";
   };
 
@@ -27,4 +27,4 @@ buildPythonPackage rec {
     license = with lib.licenses; [ isc ];
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974
- use `finalAttrs`
- enable `__structuredAttrs`
- add changelog
- The tests can't be enabled because they depend on `syslog_rfc5424_parser` which we do not have in nixpkgs.   
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
