### PR TITLE
python3Packages.mace-torch: init at 0.3.16

### DIFF
--- a/pkgs/development/python-modules/e3nn/default.nix
+++ b/pkgs/development/python-modules/e3nn/default.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  opt-einsum-fx,
+  scipy,
+  sympy,
+  torch,
+
+  # tests
+  pytestCheckHook,
+  llvmPackages,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "e3nn";
+  version = "0.6.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "e3nn";
+    repo = "e3nn";
+    tag = finalAttrs.version;
+    hash = "sha256-gGl0DiLU8w0jqGWA/ZzvkxdZdZCvtXqtmEEZ2dIwZ2o=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    opt-einsum-fx
+    scipy
+    sympy
+    torch
+  ];
+
+  pythonImportsCheck = [ "e3nn" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # RuntimeError: torch.compile does not support compiling torch.jit.script or
+    # torch.jit.freeze models directly
+    "test_identity"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # symbol not found in flat namespace '___kmpc_barrier'
+    "test_activation"
+    "test_input_weights_jit"
+    "test_variance"
+  ];
+
+  propagatedBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    # Otherwise, torch will fail to include `omp.h`:
+    # torch._inductor.exc.InductorError: CppCompileError: C++ compile error OpenMP support not found
+    llvmPackages.openmp
+  ];
+
+  meta = {
+    description = "Modular framework for neural networks with Euclidean symmetry";
+    homepage = "https://github.com/e3nn/e3nn";
+    changelog = "https://github.com/e3nn/e3nn/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/development/python-modules/mace-torch/default.nix
+++ b/pkgs/development/python-modules/mace-torch/default.nix
@@ -1,0 +1,138 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  ase,
+  configargparse,
+  e3nn,
+  gitpython,
+  h5py,
+  lmdb,
+  matplotlib,
+  matscipy,
+  numpy,
+  opt-einsum,
+  orjson,
+  pandas,
+  prettytable,
+  python-hostlist,
+  pyyaml,
+  torch,
+  torch-ema,
+  torchmetrics,
+  tqdm,
+
+  # tests
+  pytestCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "mace-torch";
+  version = "0.3.16";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "acesuit";
+    repo = "mace";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-sJ/3c7kPe99vkliixUMqqQi2OiL3CCUdlcgpDZ/PUHA=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  pythonRelaxDeps = [
+    "e3nn"
+  ];
+  dependencies = [
+    ase
+    configargparse
+    e3nn
+    gitpython
+    h5py
+    lmdb
+    matplotlib
+    matscipy
+    numpy
+    opt-einsum
+    orjson
+    pandas
+    prettytable
+    python-hostlist
+    pyyaml
+    torch
+    torch-ema
+    torchmetrics
+    tqdm
+  ];
+
+  pythonImportsCheck = [ "mace" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  disabledTests = [
+    # _pickle.PickleError: ScriptFunction cannot be pickled
+    "test_run_eval_fail_with_wrong_model"
+
+    # ValueError: too many values to unpack (expected 2)
+    "test_mace_mp"
+
+    # AssertionError (tensors not close)
+    "test_run_train_dipole"
+    "test_run_train_dipole_polar"
+
+    # RuntimeError: Model download failed and no local model found
+    "test_calculator_descriptor"
+    "test_compile_foundation"
+    "test_extract_config"
+    "test_finite_difference_hessian"
+    "test_foundations"
+    "test_initial_metrics_replay_head_mh0"
+    "test_initial_metrics_replay_head_mh1"
+    "test_initial_metrics_replay_head_omol"
+    "test_mace_mh_1_elements_subset_reproduces_energy_forces"
+    "test_mace_mp_energies"
+    "test_mace_mp_stresses"
+    "test_mace_off"
+    "test_mace_omol_elements_subset_reproduces_energy_forces"
+    "test_multi_reference"
+    "test_multihead_finetuning_different_formats"
+    "test_multihead_finetuning_does_not_modify_default_keyspec"
+    "test_potential_energy_and_hessian"
+    "test_remove_pt_head_omol_multihead"
+    "test_run_train_foundation"
+    "test_run_train_foundation_elements"
+    "test_run_train_foundation_elements_multihead"
+    "test_run_train_foundation_multihead"
+    "test_run_train_foundation_multihead_json"
+    "test_run_train_foundation_multihead_pseudolabeling"
+    "test_run_train_freeze"
+    "test_run_train_mh_foundation"
+    "test_run_train_soft_freeze"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # symbol not found in flat namespace '___kmpc_barrier'
+    "test_mace"
+    "test_mace_compile_stress"
+  ];
+
+  meta = {
+    description = "Fast and accurate machine learning interatomic potentials with higher order equivariant message passing";
+    homepage = "https://github.com/acesuit/mace";
+    changelog = "https://github.com/acesuit/mace/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/development/python-modules/matscipy/default.nix
+++ b/pkgs/development/python-modules/matscipy/default.nix
@@ -1,0 +1,186 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonAtLeast,
+
+  fetchpatch,
+
+  # build-system
+  meson-python,
+  ninja,
+  numpy,
+
+  # dependencies
+  ase,
+  packaging,
+  scipy,
+
+  # optional-dependencies
+  # cli:
+  argcomplete,
+  # dislocation:
+  atomman,
+  nglview,
+  ovito,
+  # docs:
+  jupytext,
+  myst-nb,
+  numpydoc,
+  pydata-sphinx-theme,
+  sphinx,
+  sphinx-copybutton,
+  sphinx-rtd-theme,
+  sphinxcontrib-spelling,
+
+  # tests
+  pytest-subtests,
+  pytest-timeout,
+  pytest-xdist,
+  sympy,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "matscipy";
+  version = "1.2.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "libAtoms";
+    repo = "matscipy";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XmY13B5S8tXYiUaec9gL6e0E3bSnbaMteHHiX2ij2sw=";
+  };
+
+  patches = [
+    # API: Fix compatibility with ASE 3.27.0
+    # https://github.com/libAtoms/matscipy/pull/301
+    (fetchpatch {
+      url = "https://github.com/libAtoms/matscipy/commit/6a91a4646e30796abe51ef3efa4b479d4471aae0.patch";
+      hash = "sha256-PH9I+7+nN6fSkugVbxPCs3LqjhP/fQ5NZjiNQ7F70YU=";
+    })
+    (fetchpatch {
+      url = "https://github.com/libAtoms/matscipy/commit/f6478347bbceeab8ec177042b6ed1243e742d55f.patch";
+      hash = "sha256-DKk+1TlP+OngcmycsCIE+7s2h/7wa7Gxv9APbuIAoZg=";
+    })
+  ];
+
+  postPatch =
+    # Otherwise the script fails as it can't resolve the version with git
+    ''
+      substituteInPlace discover_version.py \
+        --replace-fail \
+          "version = get_version_from_git()" \
+          "version = '${finalAttrs.version}'"
+    ''
+    # Failed: [pytest] section in setup.cfg files is no longer supported, change to [tool:pytest] instead.
+    + ''
+      substituteInPlace setup.cfg \
+        --replace-fail \
+          "[pytest]" \
+          "[tool:pytest]"
+    '';
+
+  build-system = [
+    # meson
+    meson-python
+    ninja
+    numpy
+  ];
+
+  dependencies = [
+    ase
+    numpy
+    packaging
+    scipy
+  ];
+
+  optional-dependencies = {
+    cli = [
+      argcomplete
+    ];
+    dislocation = [
+      atomman
+      nglview
+      ovito
+    ];
+    docs = [
+      jupytext
+      # matscipy
+      myst-nb
+      numpydoc
+      pydata-sphinx-theme
+      sphinx
+      sphinx-copybutton
+      sphinx-rtd-theme
+      sphinxcontrib-spelling
+    ];
+  };
+
+  pythonImportsCheck = [ "matscipy" ];
+
+  nativeCheckInputs = [
+    pytest-subtests
+    pytest-timeout
+    pytest-xdist
+    pytestCheckHook
+    sympy
+  ];
+
+  preCheck = ''
+    rm -rf matscipy
+  '';
+
+  disabledTestPaths = [
+    # The CLI tests look for the source scripts under `../matscipy/cli` relative to the test
+    # directory, which we remove in `preCheck` so that tests run against the installed package.
+    "tests/test_electrochemistry_cli.py"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # ValueError: cannot resize an array that may be referenced by another object
+    "tests/manybody/test_newmb.py"
+    "tests/test_neighbours.py"
+  ];
+
+  disabledTests = [
+    # Numerical assertion failure
+    "test_birch_constants"
+
+    # numpy 2 / ase 3.28 incompatibilities in matscipy 1.2.0
+    # `ase.phonons` finite-difference reference no longer matches
+    "test_hessian_monoatomic"
+    "test_hessian_amorphous_alloy"
+    "test_hessian_crystalline_alloy"
+
+    # TypeError: only 0-dimensional arrays can be converted to Python scalars
+    "test_eam_read_write"
+
+    # AttributeError: 'Log' object has no attribute 'close'
+    "test_logger"
+    "test_usage"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+    # AssertionError: assert np.False (numerical precision)
+    "test_fixed_line_atoms"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # ValueError: cannot resize an array that may be referenced by another object
+    "test_harmonic_bond"
+    "test_read_molecules_from_atoms"
+    "test_read_molecules_from_lammps_data"
+    "test_read_write_lammps_data"
+  ];
+
+  meta = {
+    description = "Materials science with Python at the atomic-scale";
+    homepage = "https://github.com/libAtoms/matscipy";
+    changelog = "https://github.com/libAtoms/matscipy/blob/${finalAttrs.src.tag}/ChangeLog.md";
+    license = lib.licenses.lgpl21Only;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/development/python-modules/opt-einsum-fx/default.nix
+++ b/pkgs/development/python-modules/opt-einsum-fx/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  opt-einsum,
+  torch,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "opt-einsum-fx";
+  version = "0.1.4";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Linux-cpp-lisp";
+    repo = "opt_einsum_fx";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-HamDghqmdX4Q+4zXQvCly588p3TaYFCSnzgEKLVMXSo=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    opt-einsum
+    torch
+  ];
+
+  pythonImportsCheck = [ "opt_einsum_fx" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Einsum optimization using opt_einsum and PyTorch FX graph rewriting";
+    homepage = "https://github.com/Linux-cpp-lisp/opt_einsum_fx";
+    changelog = "https://github.com/Linux-cpp-lisp/opt_einsum_fx/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/development/python-modules/pytest-subtests/default.nix
+++ b/pkgs/development/python-modules/pytest-subtests/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  attrs,
+  pytest,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pytest-subtests";
+  version = "0.15.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "pytest-dev";
+    repo = "pytest-subtests";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KJbTxhheEkvH/Xnje45dSb57526bVoi8N6GSKfUfCYA=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    attrs
+    pytest
+  ];
+
+  pythonImportsCheck = [ "pytest_subtests" ];
+
+  # The self-tests assert on exact pytest terminal output. pytest 9 ships its
+  # own bundled subtests support and changed how subtest failures are reported,
+  # so these output-matching tests no longer match. The plugin itself works.
+  doCheck = false;
+
+  meta = {
+    description = "Unittest subTest() support and subtests fixture";
+    homepage = "https://github.com/pytest-dev/pytest-subtests";
+    changelog = "https://github.com/pytest-dev/pytest-subtests/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/development/python-modules/python-hostlist/default.nix
+++ b/pkgs/development/python-modules/python-hostlist/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchurl,
+
+  # build-system
+  setuptools,
+
+  # tests
+  pytestCheckHook,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "python-hostlist";
+  version = "2.3.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchurl {
+    url = "https://www.nsc.liu.se/~kent/python-hostlist/python_hostlist-${finalAttrs.version}.tar.gz";
+    hash = "sha256-4aCxjlJaX8pXPLmGJ5nxGz8r07p67HDE7Ni5U0G7ceo=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  pythonImportsCheck = [ "hostlist" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Python module for hostlist handling";
+    homepage = "https://www.nsc.liu.se/~kent/python-hostlist/";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/development/python-modules/torch-ema/default.nix
+++ b/pkgs/development/python-modules/torch-ema/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  torch,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "torch-ema";
+  version = "0.3.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "fadel";
+    repo = "pytorch_ema";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OOF5Lb3HEIBXc1WXoUp7y44pheDc5oX/7L1vTrwNS2o=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    torch
+  ];
+
+  pythonImportsCheck = [ "torch_ema" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTests = lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+    # aarch64-linux fails cpuinfo test, because /sys/devices/system/cpu/ does not exist in the sandbox:
+    # RuntimeError: Failed to initialize cpuinfo!
+    "test_state_dict_types"
+    "test_to"
+  ];
+
+  meta = {
+    description = "Tiny PyTorch library for maintaining a moving average of a collection of parameters";
+    homepage = "https://github.com/fadel/pytorch_ema";
+    changelog = "https://github.com/fadel/pytorch_ema/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19913,6 +19913,8 @@ self: super: with self; {
 
   torch-einops-utils = callPackage ../development/python-modules/torch-einops-utils { };
 
+  torch-ema = callPackage ../development/python-modules/torch-ema { };
+
   torch-geometric = callPackage ../development/python-modules/torch-geometric { };
 
   torch-memory-saver = callPackage ../development/python-modules/torch-memory-saver { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16029,6 +16029,8 @@ self: super: with self; {
 
   python-homewizard-energy = callPackage ../development/python-modules/python-homewizard-energy { };
 
+  python-hostlist = callPackage ../development/python-modules/python-hostlist { };
+
   python-hosts = callPackage ../development/python-modules/python-hosts { };
 
   python-hpilo = callPackage ../development/python-modules/python-hpilo { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4905,6 +4905,8 @@ self: super: with self; {
 
   e3-testsuite = callPackage ../development/python-modules/e3-testsuite { };
 
+  e3nn = callPackage ../development/python-modules/e3nn { };
+
   eagle100 = callPackage ../development/python-modules/eagle100 { };
 
   earn-e-p1 = callPackage ../development/python-modules/earn-e-p1 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12052,6 +12052,8 @@ self: super: with self; {
 
   opt-einsum = callPackage ../development/python-modules/opt-einsum { };
 
+  opt-einsum-fx = callPackage ../development/python-modules/opt-einsum-fx { };
+
   optax = callPackage ../development/python-modules/optax { };
 
   optiland = callPackage ../development/python-modules/optiland { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9578,6 +9578,8 @@ self: super: with self; {
 
   macaddress = callPackage ../development/python-modules/macaddress { };
 
+  mace-torch = callPackage ../development/python-modules/mace-torch { };
+
   macfsevents = callPackage ../development/python-modules/macfsevents { };
 
   macholib = callPackage ../development/python-modules/macholib { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9752,6 +9752,8 @@ self: super: with self; {
 
   matrix-nio = callPackage ../development/python-modules/matrix-nio { };
 
+  matscipy = callPackage ../development/python-modules/matscipy { };
+
   matter-ble-proxy = callPackage ../development/python-modules/matter-ble-proxy { };
 
   matter-python-client = callPackage ../development/python-modules/matter-python-client { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15797,6 +15797,8 @@ self: super: with self; {
 
   pytest-subtesthack = callPackage ../development/python-modules/pytest-subtesthack { };
 
+  pytest-subtests = callPackage ../development/python-modules/pytest-subtests { };
+
   pytest-sugar = callPackage ../development/python-modules/pytest-sugar { };
 
   pytest-tap = callPackage ../development/python-modules/pytest-tap { };


### PR DESCRIPTION
## Things done

Add [mace-torch](https://github.com/acesuit/mace), fast and accurate machine learning interatomic potentials with higher order equivariant message passing.

- **python3Packages.opt-einsum-fx: init at 0.1.4**
- **python3Packages.e3nn: init at 0.6.0**
- **python3Packages.pytest-subtests: init at 0.15.0**
- **python3Packages.matscipy: init at 1.2.0**
- **python3Packages.torch-ema: init at 0.3.0**
- **python3Packages.python-hostlist: init at 2.3.0**
- **python3Packages.mace-torch: init at 0.3.16**

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
