### PR TITLE
vmTools: fix `img` collision with pkgs.img, add `kernelModules` arg

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -26,6 +26,10 @@
   - `linux-kernel.DTB` is available as the `buildDTBs` parameter and passthru attribute on the kernel builders.
   - `linux-kernel.{autoModules,preferBuiltin,extraConfig}` were already available as kernel builder parameters.
 
+- The `img` argument of `vmTools` has been renamed to `kernelImage`, as it collided with the top-level `img` package.
+  Additionally, the kernel module tree used inside the VM has been split out of the `kernel` argument into a new `kernelModules` argument (defaulting to `kernel`).
+  Callers that overrode `kernel` with a module tree (e.g. from `pkgs.aggregateModules`) to make extra modules available must now pass it via `kernelModules` instead, keeping `kernel` pointing at a bootable kernel derivation.
+
 - The ARMv5 Linux kernel build now uses a standard configuration and generates a standard compressed image instead of the deprecated legacy U‐Boot image format.
   `lib.systems.{examples,platforms}.{sheevaplug,pogoplug4}` have been unified into `lib.systems.examples.armv5tel-multiplatform`.
   Note that there is no official support for ARMv5 and it is not possible to build even a simple NixOS configuration out of the box.

--- a/nixos/lib/make-multi-disk-zfs-image.nix
+++ b/nixos/lib/make-multi-disk-zfs-image.nix
@@ -262,7 +262,8 @@ let
         "virtiofs"
         "zfs"
       ];
-      kernel = modulesTree;
+      kernel = config.boot.kernelPackages.kernel;
+      kernelModules = modulesTree;
     }).runInLinuxVM
       (
         pkgs.runCommand name

--- a/nixos/lib/make-single-disk-zfs-image.nix
+++ b/nixos/lib/make-single-disk-zfs-image.nix
@@ -250,7 +250,8 @@ let
         "virtiofs"
         "zfs"
       ];
-      kernel = modulesTree;
+      kernel = config.boot.kernelPackages.kernel;
+      kernelModules = modulesTree;
     }).runInLinuxVM
       (
         pkgs.runCommand name

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -30,7 +30,22 @@
   # ----------------------------
   customQemu ? null,
   kernel ? linux,
-  img ? kernel.target,
+  # Name of the kernel image file inside the `kernel` output.
+  kernelImage ?
+    kernel.target or (throw ''
+      vmTools: the `kernel` argument (${kernel.name or "<unknown>"}) has no
+      `target` attribute, so the kernel image filename cannot be determined.
+
+      If you are passing a module tree (e.g. from `pkgs.aggregateModules`) to
+      make extra modules available, pass it via `kernelModules` instead and
+      keep `kernel` pointing at a real kernel derivation. Alternatively, pass
+      `kernelImage` explicitly with the path of the bootable image relative
+      to the `kernel` derivation output (e.g. "bzImage" or "Image").
+    ''),
+  # Package providing `lib/modules` for the VM initrd. Override this (e.g.
+  # with `pkgs.aggregateModules [ ... ]`) to make extra kernel modules
+  # available inside the VM without replacing the boot kernel.
+  kernelModules ? kernel,
   storeDir ? builtins.storeDir,
   rootModules ? [
     "virtio_pci"
@@ -50,9 +65,9 @@ let
   qemu = buildPackages.qemu_kvm;
 
   modulesClosure = makeModulesClosure {
-    kernel = lib.getOutput "modules" kernel;
+    kernel = lib.getOutput "modules" kernelModules;
     inherit rootModules;
-    firmware = kernel;
+    firmware = kernelModules;
   };
 
   hd = "vda"; # either "sda" or "vda"
@@ -260,7 +275,7 @@ let
       -chardev socket,id=xchg,path=virtio-xchg.sock \
       -device vhost-user-fs-pci,chardev=xchg,tag=xchg \
       ''${diskImage:+-drive file=$diskImage,if=virtio,cache=unsafe,werror=report} \
-      -kernel ${kernel}/${img} \
+      -kernel ${kernel}/${kernelImage} \
       -initrd ${initrd}/initrd \
       -append "console=${qemu-common.qemuSerialDevice} panic=1 command=${stage2Init} mountDisk=$mountDisk loglevel=4" \
       $QEMU_OPTS

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -235,7 +235,7 @@ let
     fi
 
     # Set up automatic kernel module loading.
-    export MODULE_DIR=${lib.getOutput "modules" kernel}/lib/modules/
+    export MODULE_DIR=${lib.getOutput "modules" kernelModules}/lib/modules/
     ${coreutils}/bin/cat <<EOF > /run/modprobe
     #! ${bash}/bin/sh
     export MODULE_DIR=$MODULE_DIR
@@ -432,7 +432,7 @@ let
         name = "extract-file";
         buildInputs = [ util-linux ];
         buildCommand = ''
-          ln -s ${kernel}/lib /lib
+          ln -s ${kernelModules}/lib /lib
           ${kmod}/bin/modprobe loop
           ${kmod}/bin/modprobe ext4
           ${kmod}/bin/modprobe hfs
@@ -464,7 +464,7 @@ let
           mtdutils
         ];
         buildCommand = ''
-          ln -s ${kernel}/lib /lib
+          ln -s ${kernelModules}/lib /lib
           ${kmod}/bin/modprobe mtd
           ${kmod}/bin/modprobe mtdram total_size=131072
           ${kmod}/bin/modprobe mtdchar


### PR DESCRIPTION
#530133 changed all-packages.nix from

```nix
vmTools = callPackage ../build-support/vm {
  img = stdenv.hostPlatform.linux-kernel.target;
};
```

to

```nix
vmTools = callPackage ../build-support/vm { };
```

and changed the function default to `img ? kernel.target`. Since `pkgs.img` exists, `callPackage` now auto-fills the `img` argument with that attribute and the default is never used. Anything going through `runInLinuxVM` (make-disk-image, `nixosTests.bootspec.*`, etc.) then fails with:

```
qemu: could not open kernel file
'/nix/store/...-linux-.../...-img-0.5.11': No such file or directory
```

Rename `img` to `kernelImage` so it no longer collides with a top-level package.

The same commit also broke callers that override `kernel` with an `aggregateModules` tree (the in-tree zfs image builders, disko), since that has no `.target`. The single `kernel` argument was being used for two unrelated things: the boot image for `qemu -kernel` and the module tree for the initrd. Split the latter out into a new `kernelModules` argument (defaulting to `kernel`), point the zfs image builders at it, and throw a clear error explaining the migration when `kernel.target` is missing.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
