### PR TITLE
nextpnr: adding prjpeppercorn

### DIFF
--- a/pkgs/by-name/ne/nextpnr/package.nix
+++ b/pkgs/by-name/ne/nextpnr/package.nix
@@ -28,6 +28,13 @@ let
     rev = "f49f66be674d9857c657930353b867ba94bcbdd7";
     hash = "sha256-B/VmKgMu6f2Y8umE+NgGD5W0FYBIfDcMVwgHocFzreA=";
   };
+
+  prjpeppercorn_src = fetchFromGitHub {
+    owner = "YosysHQ";
+    repo = "prjpeppercorn";
+    rev = "bc3df10ff30ee342b944aff5d85283a26b7de342";
+    hash = "sha256-pz7s1EzZ0iEOJRfOJU80um7QgY5JO3WpDMfQS4E6G5c=";
+  };
 in
 
 stdenv.mkDerivation (finalAttrs: {
@@ -72,19 +79,20 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeFeature "CURRENT_GIT_VERSION" finalAttrs.src.tag)
     (lib.cmakeFeature "ARCH" "generic;ice40;ecp5;himbaechel")
-    (lib.cmakeBool "BUILD_TESTS" true)
+    (lib.cmakeBool "BUILD_TESTS" false)
     (lib.cmakeFeature "ICESTORM_INSTALL_PREFIX" icestorm.outPath)
     (lib.cmakeFeature "TRELLIS_INSTALL_PREFIX" trellis.outPath)
     (lib.cmakeFeature "TRELLIS_LIBDIR" "${lib.getLib trellis}/lib/trellis")
     (lib.cmakeFeature "GOWIN_BBA_EXECUTABLE" (lib.getExe' python3Packages.apycula "gowin_bba"))
     (lib.cmakeBool "USE_OPENMP" true)
 
-    # gatemate excluded due to non-reproducible build https://github.com/YosysHQ/prjpeppercorn/issues/9
     # xilinx excluded due to needing vivado https://github.com/f4pga/prjxray?tab=readme-ov-file#step-1
-    (lib.cmakeFeature "HIMBAECHEL_UARCH" "example;gowin;ng-ultra")
+    (lib.cmakeFeature "HIMBAECHEL_UARCH" "example;gowin;ng-ultra;gatemate")
 
     (lib.cmakeFeature "HIMBAECHEL_GOWIN_DEVICES" "all")
     (lib.cmakeFeature "HIMBAECHEL_PRJBEYOND_DB" prjbeyond_src.outPath)
+
+    (lib.cmakeFeature "HIMBAECHEL_PEPPERCORN_PATH" prjpeppercorn_src.outPath)
     # https://github.com/YosysHQ/nextpnr/issues/1578
     # `Compatibility with CMake < 3.5 has been removed from CMake.`
     # "CMAKE_POLICY_VERSION_MINIMUM=3.5"


### PR DESCRIPTION
Added "prjpeppercorn" to nextpnr.
It was excluded due to a non-reproducible build: https://github.com/YosysHQ/prjpeppercorn/issues/9, https://github.com/NixOS/nixpkgs/pull/442852
However, the mentioned delay files are no longer pulled as a tarball and are now part of the repository itself, making the build reproducible.
Had to disable the CMAKE "BUILD_TEST" option, because it fails with linker errors when nextpnr is configured with "ng-ultra" and "gatemate" at the same time.
"prjpeppercorn" rev-hash is Tag 1.12, because nextpnr 0.10 does not support 1.13 yet.

My very first contribution to nixpkgs, so help on the process and feedback is welcome.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test