### PR TITLE
python3Packages.uvloop: fix riscv64-linux build

### DIFF
--- a/pkgs/development/python-modules/uvloop/default.nix
+++ b/pkgs/development/python-modules/uvloop/default.nix
@@ -73,11 +73,18 @@ buildPythonPackage rec {
     # https://github.com/MagicStack/uvloop/issues/709
     "tests/test_process.py::TestAsyncio_AIO_Process::test_cancel_post_init"
   ]
-  ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # Segmentation fault
     "tests/test_fs_event.py::Test_UV_FS_EVENT_RENAME::test_fs_event_rename"
     # Broken: https://github.com/NixOS/nixpkgs/issues/160904
     "tests/test_context.py::Test_UV_Context::test_create_ssl_server_manual_connection_lost"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isRiscV64 [
+    # SSL record layer failures & ConnectionResetError
+    "tests/test_tcp.py::Test_AIO_TCPSSL"
+    "tests/test_tcp.py::Test_UV_TCPSSL"
+    "tests/test_unix.py::Test_AIO_UnixSSL"
+    "tests/test_unix.py::Test_UV_UnixSSL"
   ];
 
   preCheck = ''


### PR DESCRIPTION
Fix this issue :

```
tests/test_tcp.py ..........................................................Unexpected calls to loop.call_exception_handler():
[{'exception': SSLError(1, '[SSL] record layer failure (_ssl.c:2658)'),
  'message': 'Unhandled exception in client_connected_cb',
  'transport': <uvloop.loop._SSLProtocolTransport object at 0x3ff45eacc0>},
 {'exception': SSLError(1, '[SSL] record layer failure (_ssl.c:2658)'),
  'message': 'Unhandled exception in client_connected_cb',
  'transport': <uvloop.loop._SSLProtocolTransport object at 0x3ff4439600>},
 {'exception': IncompleteReadError('1015808 bytes read on a total of 1048576 expected bytes'),
  'message': 'Unhandled exception in client_connected_cb',
  'transport': <uvloop.loop._SSLProtocolTransport object at 0x3ff4439bc0>},
 {'exception': IncompleteReadError('0 bytes read on a total of 1048576 expected bytes'),
  'message': 'Unhandled exception in client_connected_cb',
  'transport': <uvloop.loop._SSLProtocolTransport object at 0x3ff443bec0>},
 {'exception': IncompleteReadError('0 bytes read on a total of 1048576 expected bytes'),
  'message': 'Unhandled exception in client_connected_cb',
  'transport': <uvloop.loop._SSLProtocolTransport object at 0x3ff44f46c0>},
 {'exception': IncompleteReadError('802816 bytes read on a total of 1048576 expected bytes'),
  'message': 'Unhandled exception in client_connected_cb',
  'transport': <uvloop.loop._SSLProtocolTransport object at 0x3ff44f4dc0>},
 {'exception': IncompleteReadError('1015808 bytes read on a total of 1048576 expected bytes'),
  'message': 'Unhandled exception in client_connected_cb',
  'transport': <uvloop.loop._SSLProtocolTransport object at 0x3ff443a340>},
 {'exception': IncompleteReadError('802816 bytes read on a total of 1048576 expected bytes'),
  'message': 'Unhandled exception in client_connected_cb',
  'transport': <uvloop.loop._SSLProtocolTransport object at 0x3ff44f54c0>},
 {'exception': IncompleteReadError('1015808 bytes read on a total of 1048576 expected bytes'),
  'message': 'Unhandled exception in client_connected_cb',
  'transport': <uvloop.loop._SSLProtocolTransport object at 0x3ff443a9c0>},
 {'exception': IncompleteReadError('1015808 bytes read on a total of 1048576 expected bytes'),
  'message': 'Unhandled exception in client_connected_cb',
  'transport': <uvloop.loop._SSLProtocolTransport object at 0x3ff443b080>},
 {'exception': IncompleteReadError('1015808 bytes read on a total of 1048576 expected bytes'),
  'message': 'Unhandled exception in client_connected_cb',
  'transport': <uvloop.loop._SSLProtocolTransport object at 0x3ff443b7c0>}]

```

```
=========================== short test summary info ============================
FAILED tests/test_tcp.py::Test_UV_TCPSSL::test_create_server_ssl_1 - ConnectionResetError: [Errno 104] Connection reset by peer
FAILED tests/test_tcp.py::Test_UV_TCPSSL::test_renegotiation - ssl.SSLError: [SSL] record layer failure (_ssl.c:2658)
FAILED tests/test_tcp.py::Test_UV_TCPSSL::test_shutdown_timeout - ConnectionResetError: [Errno 104] Connection reset by peer
FAILED tests/test_unix.py::Test_AIO_UnixSSL::test_create_unix_connection_ssl_1 - RuntimeError: Event loop stopped before Future completed.
ERROR tests/test_tcp.py::Test_UV_TCPSSL::test_create_server_ssl_1 - AssertionError: unexpected calls to loop.call_exception_handler()
ERROR tests/test_tcp.py::Test_UV_TCPSSL::test_shutdown_timeout - AssertionError: unexpected calls to loop.call_exception_handler()
= 4 failed, 410 passed, 32 skipped, 7 deselected, 69 warnings, 2 errors in 246.44s (0:04:06) =
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
