### PR TITLE
cockpit-zfs: fix build by pinning nodejs to 22

### DIFF
--- a/pkgs/by-name/co/cockpit-zfs/package.nix
+++ b/pkgs/by-name/co/cockpit-zfs/package.nix
@@ -15,7 +15,7 @@
   mbuffer,
   msmtp,
   nix-update-script,
-  nodejs,
+  nodejs_22,
   openssh,
   samba,
   shadow,
@@ -27,6 +27,22 @@
   yarn-berry,
   zfs,
 }:
+let
+  # Pin to Node <24.15.0: Yarn Berry's PnP linker breaks `require.cache` on
+  # newer Node, which crashes tailwindcss mid-build (and ESLint, per
+  # yarnpkg/berry#7106). See NixOS/nixpkgs#530137.
+  #
+  # `nodejs` is rebound here (rather than touched at every call site below)
+  # so the rest of this file is unaffected.
+  #
+  # yarn-berry's own `yarn` binary gets patchShebang'd against whatever
+  # `nodejs` *it* was built with, so overriding nativeBuildInputs alone does
+  # nothing - we have to rebuild yarn-berry itself against nodejs_22, for
+  # both the host and build-platform (cross-compilation) variants.
+  nodejs = nodejs_22;
+  yarnBerry = yarn-berry.override { inherit nodejs; };
+  yarnBerryForBuild = buildPackages.yarn-berry.override { nodejs = buildPackages.nodejs_22; };
+in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cockpit-zfs";
@@ -49,17 +65,17 @@ stdenv.mkDerivation (finalAttrs: {
   missingHashes = ./missing-hashes.json;
 
   # Use buildPackages for cross-compilation support
-  offlineCache = buildPackages.yarn-berry.fetchYarnBerryDeps {
+  offlineCache = yarnBerryForBuild.fetchYarnBerryDeps {
     inherit (finalAttrs) src missingHashes patches;
     hash = "sha256-Tdxe5bXN9psSrnUXL1f+1nh4WPzuvOI7j0I+VPU2/1s=";
   };
 
   nativeBuildInputs = [
     makeWrapper
-    nodejs
+    nodejs_22
     jq
-    yarn-berry
-    buildPackages.yarn-berry.yarnBerryConfigHook
+    yarnBerry
+    yarnBerryForBuild.yarnBerryConfigHook
   ];
 
   disallowedRequisites = [ finalAttrs.offlineCache ];
@@ -76,7 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
     lsscsi
     mbuffer
     msmtp
-    nodejs
+    nodejs_22
     openssh
     samba
     shadow


### PR DESCRIPTION
Fixes: #530137

## Things done

I bisected, and commit 00e16e88fac47cb8da7d0ba82fdc6f3e169c3354 is the first failing.
This is a staging commit that contains a Node.js update from 25 to 26 and an update from Node.js 24.14.1 to 24.15.0
This is probably linked to https://github.com/yarnpkg/berry/issues/7106.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
