### PR TITLE
patch(`julia-modules`): add `pythonSupport` for optional Python

### DIFF
--- a/pkgs/development/julia-modules/default.nix
+++ b/pkgs/development/julia-modules/default.nix
@@ -27,6 +27,7 @@
   extraLibs ? [ ],
   juliaCpuTarget ? null,
   makeTransitiveDependenciesImportable ? false, # Used to support symbol indexing
+  pythonSupport ? true,
   makeWrapperArgs ? "",
   packageOverrides ? { },
   precompile ? true,
@@ -66,9 +67,10 @@ let
         makeWrapper ${julia}/bin/julia $out/bin/julia \
           --suffix LD_LIBRARY_PATH : "${lib.makeLibraryPath extraLibs}" \
           --set FONTCONFIG_FILE ${fontconfig.out}/etc/fonts/fonts.conf \
-          --set PYTHONHOME "${pythonToUse}" \
-          --prefix PYTHONPATH : "${pythonToUse}/${pythonToUse.sitePackages}" \
-          --set PYTHON ${pythonToUse}/bin/python $makeWrapperArgs \
+          ${lib.optionalString pythonSupport "--set PYTHONHOME ${pythonToUse}"} \
+          ${lib.optionalString pythonSupport "--prefix PYTHONPATH : ${pythonToUse}/${pythonToUse.sitePackages}"} \
+          ${lib.optionalString pythonSupport "--set PYTHON ${pythonToUse}/bin/python"} \
+          $makeWrapperArgs \
           --set JULIA_CONDAPKG_OFFLINE yes \
           --set JULIA_CONDAPKG_BACKEND Null \
           --set JULIA_PYTHONCALL_EXE "@PyCall"


### PR DESCRIPTION
`julia.withPackages` unconditionally wraps the resulting Julia with a full `python3` (via `PYTHON{,HOME,PATH}`) -- so that packages bridging to Python (e.g., `PyCall`, `PythonCall`, `CondaPkg`, etc.) find the interpreter at runtime.

For common cases of pure-Julia closures, this is dead weight. e.g., on Darwin, this is especially true: `python3`'s runtime closure pulls in the Apple SDK plus `clang`/`llvm` toolchains (~1.3GB), via the compiler reference kept in Python's `sysconfig`. For example, `julia-bin.withPackages [ "JuliaFormatter" ]` is ~2.4GB on `aarch64-darwin`, of which ~1.3GB is reachable *only* through the Python wrapper. (`nix why-depends --all` shows a single edge: `env -> julia-wrapped -> python3`.) The depot itself (in this instance) is Python-free at runtime.

Since auto-detecting "needs no Python" could result in silent breakages (including for transitive users), I opted for an explicit flag. (e.g., consider that `extraPythonPackages` only covers packages needing *extra* `pip` deps (`matplotlib`, `sympy`, `xlrd`, etc.) – anyone using `PyCall`/`PythonCall` still requires an interpreter even though it could yield an empty list.

The explicit, overridable, `pythonSupport` defaults to `true` to retain existing behavior, but if a downstream knows their closure doesn't need Python, they can now opt-out:

```nix
julia.withPackages.override { pythonSupport = false; } [
"JuliaFormatter" ];
```

This is partially driven by what I discovered while trying to submit https://github.com/numtide/treefmt-nix/pull/515.

> [!NOTE]
> **re: `nixpkgs-review`**
>
> `nixpkgs-review rev 421d7d2` reports 0 rebuilt packages on aarch64-darwin. This is expected rather than a miss: since `julia.withPackages` is a builder function, and nothing in tree consumes it — every caller lives downstream of `nixpkgs`, so there are no reverse-dependencies whose out-paths shift. (Additionally, since the builder's own outputs are IFD-gated and never surface as top-level attrs, they shouldn't enter the rebuild diff either.)
> 
> Since the reverse-dep sweep can't exercise a consumer-less function, I verified the change directly by building `julia-bin.withPackages [ "JuliaFormatter" ]` on `aarch64-darwin` under both flag values:
>   - `pythonSupport = true` (default) — closure is 2.3G; `nix why-depends --all` still shows the lone `env -> julia-wrapped -> python3` edge, i.e., behavior is byte-for-byte the existing wrapper.
>   - `pythonSupport = false` — closure drops to ~1.0G (−1.3G); the `python3` edge is gone entirely (`PYTHON{,HOME,PATH}` unset at runtime), and a pure-Julia workload still runs(`format_text("x=  1+2") → x = 1+2`).

<details>

<summary> Differences in closures because of Python. </summary>

```shell
$ nix-build -E 'with import ./. {}; julia-bin.withPackages [ "JuliaFormatter" ]' -o result-python
/nix/store/cwxcmab7qkbz0hgnkz8f999pdf5lwd51-julia-1.12.6-env

$ nix path-info -Sh ./result-python
/nix/store/cwxcmab7qkbz0hgnkz8f999pdf5lwd51-julia-1.12.6-env	   2.3G

$ nix-build -E 'with import ./. {}; julia-bin.withPackages.override { pythonSupport = false; } [ "JuliaFormatter" ]' -o result-nopython
/nix/store/99j1ng2gf3xj1j02a6jyx1ag1gji690y-julia-1.12.6-env

$ nix path-info -Sh ./result-nopython
/nix/store/99j1ng2gf3xj1j02a6jyx1ag1gji690y-julia-1.12.6-env	1012.2M
```

</details>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
