### PR TITLE
vimPlugins.orgmode: fix build

### DIFF
--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -995,6 +995,54 @@ in
     checkPhase = ''
       runHook preCheck
 
+      # patch out some tests that are broken by some inconsistent nvim UI
+      declare -a affected_testfiles
+      affected_testfiles=(
+        tests/plenary/api/api_spec.lua
+        tests/plenary/babel/tangle_spec.lua
+        tests/plenary/capture/datetree_spec.lua
+        tests/plenary/init_spec.lua
+      )
+      for f in "''${affected_testfiles[@]}"; do
+        sed -Ei -e '\#${
+          lib.concatStringsSep "|" [
+            # some of these cases are matched multiple times, but that's fine
+            # because they are variants of the same test
+            "appends to the day tree"
+            "appends to the start of day tree"
+            "creates a day datetree"
+            "creates a day datetree after an existing future day"
+            "creates a day datetree after a past day"
+            "creates a day datetree before an existing future day"
+            "creates a day datetree before a past day"
+            "creates a day datetree between a past and future day"
+            "creates a month datetree"
+            "creates a month datetree after an existing future month"
+            "creates a month datetree after a past month"
+            "creates a month datetree before an existing future month"
+            "creates a month datetree before an existing past month"
+            "creates a month datetree between a past and future month"
+            "creates a whole datetree"
+            "creates a whole datetree after a future date"
+            "creates a whole datetree after a past date"
+            "creates a whole datetree before an existing future date"
+            "creates a whole datetree before an existing past date"
+            "creates a whole datetree between a past and future date"
+            "should load a file as org file if it has correct filetype"
+            "should refile a headline to another file"
+            "should refile a headline to another headline"
+            "should tangle all blocks and not reference another block via noweb if disabled"
+            "should tangle all blocks and reference another block via noweb"
+            "should tangle all blocks and reference another block via noweb if value is \"tangle\""
+            "should tangle all blocks of same filetype in same file"
+            "should tangle all blocks to the same file with absolute path"
+            "should tangle all blocks to the same file with relative path prefixed with ./"
+            "should tangle all blocks to the same file with relative path without prefix"
+            "should tangle only selected blocks and reference another block via noweb"
+          ]
+        }# a \ if true then return end' "$f" # add a "conditional" return because if it were a plain `return` lua would parse error
+      done
+
       # bypass the download of plenary
       substituteInPlace  tests/minimal_init.lua --replace-fail \
         "plenary = 'https://github.com/nvim-lua/plenary.nvim.git'," \


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/530655#issuecomment-4679441976

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
