### PR TITLE
xfstests: 2023.05.14 -> 2026.05.17

### DIFF
--- a/pkgs/by-name/xf/xfstests/package.nix
+++ b/pkgs/by-name/xf/xfstests/package.nix
@@ -4,6 +4,7 @@
   attr,
   autoconf,
   automake,
+  pkg-config,
   bash,
   bc,
   coreutils,
@@ -29,22 +30,24 @@
   which,
   writeScript,
   xfsprogs,
+  nix-update-script,
   runtimeShell,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xfstests";
-  version = "2023.05.14";
+  version = "2026.05.17";
 
   src = fetchzip {
     url = "https://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git/snapshot/xfstests-dev-v${finalAttrs.version}.tar.gz";
-    hash = "sha256-yyjY9Q3eUH+q+o15zFUjOcNz1HpXPCwdcxWXoycOx98=";
+    hash = "sha256-vfK4PcPdd1121lcjhjP63RyS6YdFfgZ6Nsauv02b1S8=";
   };
 
   nativeBuildInputs = [
     autoconf
     automake
     libtool
+    pkg-config
   ];
   buildInputs = [
     acl
@@ -62,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patchPhase = ''
     substituteInPlace Makefile \
-      --replace "cp include/install-sh ." "cp -f include/install-sh ."
+      --replace-fail "cp include/install-sh ." "cp -f include/install-sh ."
 
     # Patch the destination directory
     sed -i include/builddefs.in -e "s|^PKG_LIB_DIR\s*=.*|PKG_LIB_DIR=$out/lib/xfstests|"
@@ -154,6 +157,7 @@ stdenv.mkDerivation (finalAttrs: {
     }:$PATH
     exec ./check "$@"
   '';
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Torture test suite for filesystems";


### PR DESCRIPTION

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
