### PR TITLE
sessiongrep: init at 0-unstable-2026-06-03

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10388,6 +10388,11 @@
     githubId = 95086304;
     name = "Guilherme Lima";
   };
+  guilhermeprokisch = {
+    github = "guilhermeprokisch";
+    githubId = 12011070;
+    name = "Guilherme Prokisch";
+  };
   guillaumekoenig = {
     email = "guillaume.edward.koenig@gmail.com";
     github = "guillaumekoenig";

--- a/pkgs/by-name/se/sessiongrep/package.nix
+++ b/pkgs/by-name/se/sessiongrep/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "sessiongrep";
+  version = "0-unstable-2026-06-03";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "braincompany";
+    repo = "sessiongrep";
+    rev = "76e08a0a338a0e7b6f666c171d15bf275c9916cb";
+    hash = "sha256-hNMvHD7bgWII30+ySHzTGRzAb/InFBtkjiqNukEh61U=";
+  };
+
+  cargoHash = "sha256-Xvhux42slDfXN1h+JkJj+0tKYoLMNUD/TaMJm5r0d3k=";
+
+  meta = {
+    description = "Local-first search, inspection, export, and resume for Claude Code, Codex CLI, and Cursor sessions, with an MCP server for agent-driven recall";
+    homepage = "https://github.com/braincompany/sessiongrep";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ guilhermeprokisch ];
+    mainProgram = "sessiongrep";
+  };
+})


### PR DESCRIPTION
## Description

Adds [`sessiongrep`](https://github.com/braincompany/sessiongrep): a local-first CLI to search, inspect, export, and resume Claude Code, Codex CLI, and Cursor sessions, plus an MCP server (`sessiongrep-mcp`) for agent-driven recall.

Upstream has no tagged release yet, so this packages the latest commit using the `unstable` versioning convention (`0-unstable-<date>`), fetched by `rev`.

- Built with `rustPlatform.buildRustPackage` from the committed `Cargo.lock`.
- Produces two binaries: `sessiongrep` (set as `meta.mainProgram`) and `sessiongrep-mcp`.
- `rusqlite` is built with the `bundled` feature (SQLite compiled from C); builds cleanly under the standard stdenv with no extra inputs.

I'm packaging this and listing myself as maintainer. The package is not platform-restricted; I verified both Darwin targets locally and rely on OfBorg for the Linux builders.

## Things done

- Built on platform(s)
  - [x] aarch64-darwin
  - [x] x86_64-darwin
  - [ ] aarch64-linux (left to OfBorg — no Linux builder available locally)
  - [ ] x86_64-linux (left to OfBorg — no Linux builder available locally)
- [x] For new packages: there is a maintainer entry and I am listed as a maintainer.
- [x] Ran `nixfmt` on the changed files.
- [x] Tested execution of all binary files (`sessiongrep --version` -> `0.1.0`; `sessiongrep-mcp` starts its MCP server).
- [x] `meta.description`, `meta.homepage`, `meta.license`, `meta.maintainers`, and `meta.mainProgram` are set.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc