### PR TITLE
fwupd: 2.1.4 -> 2.1.5

### DIFF
--- a/pkgs/by-name/fw/fwupd/0001-Install-fwupdplugin-to-out.patch
+++ b/pkgs/by-name/fw/fwupd/0001-Install-fwupdplugin-to-out.patch
@@ -3,6 +3,8 @@ From: r-vdp <ramses@well-founded.dev>
 Date: Mon, 28 Oct 2024 12:07:51 +0100
 Subject: [PATCH] Install fwupdplugin to out
 
+Install plug-ins and libfwupdplugin to $out output, they are not really
+part of the library.
 ---
  meson.build | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/pkgs/by-name/fw/fwupd/0002-Add-output-for-installed-tests.patch
+++ b/pkgs/by-name/fw/fwupd/0002-Add-output-for-installed-tests.patch
@@ -3,6 +3,8 @@ From: r-vdp <ramses@well-founded.dev>
 Date: Tue, 15 Oct 2024 14:49:53 +0200
 Subject: [PATCH] Add output for installed tests
 
+Installed tests are installed to different output we also cannot have
+fwupd-tests.conf in $out/etc since it would form a cycle.
 ---
  data/tests/meson.build             | 2 +-
  meson.build                        | 5 +++--

--- a/pkgs/by-name/fw/fwupd/0003-Add-option-for-installation-sysconfdir.patch
+++ b/pkgs/by-name/fw/fwupd/0003-Add-option-for-installation-sysconfdir.patch
@@ -3,6 +3,10 @@ From: r-vdp <ramses@well-founded.dev>
 Date: Tue, 15 Oct 2024 11:46:38 +0200
 Subject: [PATCH] Add option for installation sysconfdir
 
+Since /etc is the domain of NixOS, not Nix, we cannot install files
+there. Let's install the files to $prefix/etc while still reading them
+from /etc. NixOS module for fwupd will take care of copying the files
+appropriately.
 ---
  data/bios-settings.d/meson.build |  2 +-
  data/meson.build                 |  2 +-

--- a/pkgs/by-name/fw/fwupd/0004-Get-the-efi-app-from-fwupd-efi.patch
+++ b/pkgs/by-name/fw/fwupd/0004-Get-the-efi-app-from-fwupd-efi.patch
@@ -3,6 +3,7 @@ From: r-vdp <ramses@well-founded.dev>
 Date: Mon, 28 Oct 2024 12:08:49 +0100
 Subject: [PATCH] Get the efi app from fwupd-efi
 
+EFI capsule is located in fwupd-efi now.
 ---
  meson.build | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/pkgs/by-name/fw/fwupd/package.nix
+++ b/pkgs/by-name/fw/fwupd/package.nix
@@ -122,7 +122,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "fwupd";
-  version = "2.1.4";
+  version = "2.1.5";
 
   # libfwupd goes to lib
   # daemon, plug-ins and libfwupdplugin go to out
@@ -140,7 +140,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "fwupd";
     repo = "fwupd";
     tag = finalAttrs.version;
-    hash = "sha256-bKBEZR7Wzi9nZYH+KAzh1q+sh2t2Gl3puQmeogNdIsE=";
+    hash = "sha256-DzQ+N99ZmFRqZc2rN6PSqmoIMXUyrE8Kkn+KnT/AWPc=";
   };
 
   patches = [

--- a/pkgs/by-name/fw/fwupd/package.nix
+++ b/pkgs/by-name/fw/fwupd/package.nix
@@ -144,22 +144,9 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
-    # Install plug-ins and libfwupdplugin to $out output,
-    # they are not really part of the library.
     ./0001-Install-fwupdplugin-to-out.patch
-
-    # Installed tests are installed to different output
-    # we also cannot have fwupd-tests.conf in $out/etc since it would form a cycle.
     ./0002-Add-output-for-installed-tests.patch
-
-    # Since /etc is the domain of NixOS, not Nix,
-    # we cannot install files there.
-    # Let’s install the files to $prefix/etc
-    # while still reading them from /etc.
-    # NixOS module for fwupd will take take care of copying the files appropriately.
     ./0003-Add-option-for-installation-sysconfdir.patch
-
-    # EFI capsule is located in fwupd-efi now.
     ./0004-Get-the-efi-app-from-fwupd-efi.patch
   ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
