### PR TITLE
openrsync: unstable-2025-01-27 -> 0.5.0-unstable-2026-05-31, modernize

### DIFF
--- a/pkgs/by-name/op/openrsync/package.nix
+++ b/pkgs/by-name/op/openrsync/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation {
   pname = "openrsync";
-  version = "unstable-2025-01-27";
+  version = "0.5.0-unstable-2026-05-31";
 
   src = fetchFromGitHub {
     owner = "kristapsdz";
     repo = "openrsync";
-    rev = "a257c0f495af2b5ee6b41efc6724850a445f87ed";
-    hash = "sha256-pc1lo8d5FY8/1K2qUWzSlrSnA7jnRg4FQRyHqC8I38k=";
+    rev = "48070e68d73f67d6922b2ffc8c2dee9754e659c6";
+    hash = "sha256-9ApkHIak1/XQn1nMwdC0iiZEzZI2gHCOIj8P6bQPFyA=";
   };
 
   # Uses oconfigure

--- a/pkgs/by-name/op/openrsync/package.nix
+++ b/pkgs/by-name/op/openrsync/package.nix
@@ -16,8 +16,12 @@ stdenv.mkDerivation {
     hash = "sha256-9ApkHIak1/XQn1nMwdC0iiZEzZI2gHCOIj8P6bQPFyA=";
   };
 
+  strictDeps = true;
+  __structuredAttrs = true;
+  enableParallelBuilding = true;
+
   # Uses oconfigure
-  prefixKey = "PREFIX=";
+  env.prefixKey = "PREFIX=";
 
   passthru.updateScript = nix-update-script {
     extraArgs = [

--- a/pkgs/by-name/op/openrsync/package.nix
+++ b/pkgs/by-name/op/openrsync/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation {
@@ -17,6 +18,13 @@ stdenv.mkDerivation {
 
   # Uses oconfigure
   prefixKey = "PREFIX=";
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex=^VERSION_(\\d+)_(\\d+)_(\\d+.*)"
+      "--version=branch"
+    ];
+  };
 
   meta = {
     homepage = "https://www.openrsync.org/";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
