### PR TITLE
noctalia: init at 4.7.7-unstable-2026-06-11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14889,6 +14889,14 @@
     github = "krovuxdev";
     githubId = 62192487;
   };
+  kruemmelspalter = {
+    github = "kruemmelspalter";
+    githubId = 54735589;
+    name = "kruemmelspalter";
+    email = "kruemmelspalter@kruemmelspalter.org";
+    matrix = "@kruemmelsplater:kruemmelspalter.org";
+    keys = [ { fingerprint = "28F5 4BD4 73F1 7495 24BF  F4BD 4F4A 2EFA E386 71C8"; } ];
+  };
   krupkat = {
     github = "krupkat";
     githubId = 6817216;

--- a/pkgs/by-name/no/noctalia/package.nix
+++ b/pkgs/by-name/no/noctalia/package.nix
@@ -1,0 +1,105 @@
+### adapted from upstream at <https://github.com/noctalia-dev/noctalia/blob/d967ed5f5484e57866350106be8bfe3b50f90cfd/nix/package.nix> (licensed MIT)
+{
+  lib,
+  config,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  wayland-scanner,
+  wayland,
+  wayland-protocols,
+  libGL,
+  libglvnd,
+  freetype,
+  fontconfig,
+  cairo,
+  pango,
+  harfbuzz,
+  libxkbcommon,
+  sdbus-cpp_2,
+  systemdLibs,
+  pipewire,
+  pam,
+  curl,
+  libwebp,
+  glib,
+  polkit,
+  librsvg,
+  libqalculate,
+  libxml2,
+  jemalloc,
+  autoAddDriverRunpath,
+  cudaSupport ? config.cudaSupport,
+}:
+
+stdenv.mkDerivation {
+  pname = "noctalia";
+  version = "4.7.7-unstable-2026-06-11";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "noctalia-dev";
+    repo = "noctalia";
+    rev = "7421f80b041e81d6e202a25ade6bfc59d716dd43";
+    hash = "sha256-H+uwJBulU/0Qt+BGUvlyrTPgcdOfojSalklpEuKKD2c=";
+  };
+
+  postPatch = ''
+    # Remove -march=native and -mtune=native for reproducible builds
+    substituteInPlace meson.build --replace-fail "'-march=native', '-mtune=native'," ""
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wayland-scanner
+  ]
+  ++ lib.optional cudaSupport autoAddDriverRunpath;
+
+  buildInputs = [
+    wayland
+    wayland-protocols
+    libGL
+    libglvnd
+    freetype
+    fontconfig
+    cairo
+    pango
+    harfbuzz
+    libxkbcommon
+    sdbus-cpp_2
+    systemdLibs
+    pipewire
+    pam
+    curl
+    libwebp
+    glib
+    polkit
+    librsvg
+    libqalculate
+    libxml2
+    jemalloc
+  ];
+
+  mesonBuildType = "release";
+
+  ninjaFlags = [ "-v" ];
+
+  meta = {
+    description = "Sleek and minimal desktop shell thoughtfully crafted for Wayland";
+    homepage = "https://github.com/noctalia-dev/noctalia";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      spacedentist
+      kruemmelspalter
+      dtomvan
+    ];
+    mainProgram = "noctalia";
+  };
+}


### PR DESCRIPTION
add noctalia v5 (alpha) as unstable

this is the upcoming version of the noctalia-shell package (the project got renamed from noctalia-shell to noctalia)

this is not updating the old package because v4 is still being supported and v5 is still in alpha and has breaking configuration changes

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
