### PR TITLE
python3Packages.flash-attn: 2.8.3 -> 2.8.3.post1

### DIFF
--- a/pkgs/development/python-modules/flash-attn/default.nix
+++ b/pkgs/development/python-modules/flash-attn/default.nix
@@ -31,7 +31,7 @@ let
 
   self = buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
     pname = "flash-attention";
-    version = "2.8.3";
+    version = "2.8.3.post1";
     pyproject = true;
     __structuredAttrs = true;
 
@@ -40,7 +40,7 @@ let
       repo = "flash-attention";
       tag = "v${finalAttrs.version}";
       fetchSubmodules = true;
-      hash = "sha256-6I1O4E5K5IdbpzrXFHK06QVcOE8zuVkFE338ffk6N8M=";
+      hash = "sha256-IgK517JorAf9ERcimusF20HgnuETBNKgnGaOxWBuV/M=";
     };
 
     patches = [


### PR DESCRIPTION
## Things done

Diff: https://github.com/Dao-AILab/flash-attention/compare/v2.8.3...v2.8.3.post1
Changelog: https://github.com/Dao-AILab/flash-attention/releases/tag/v2.8.3.post1

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
