### PR TITLE
python3Packages.flash-attn-3: 3.0.0-unstable-2026-06-02 -> 3.0.0-unstable-2026-06-10

### DIFF
--- a/pkgs/development/python-modules/flash-attn-3/default.nix
+++ b/pkgs/development/python-modules/flash-attn-3/default.nix
@@ -11,8 +11,8 @@
   # dependencies
   einops,
 
-  # tests
-  pytestCheckHook,
+  # passthru
+  nix-update-script,
 }:
 
 let
@@ -20,7 +20,7 @@ let
 in
 buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
   pname = "flash-attn-3";
-  version = "3.0.0-unstable-2026-06-02";
+  version = "3.0.0-unstable-2026-06-10";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -33,8 +33,8 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
   src = fetchFromGitHub {
     owner = "Dao-AILab";
     repo = "flash-attention";
-    rev = "b02b07e1a10238fe12831b80a8937ed59b1353a5";
-    hash = "sha256-LALX4lYioJLYssoQ0rJCC5M2Ij28wtP7ucpGkKIzmmg=";
+    rev = "fc8cbad6b6b90220cf6ef8121c29e299a3ba7d9a";
+    hash = "sha256-6HxeLAahkWO5pghszfLS6i8Ju67sAxjWnDk0RYRuY88=";
     fetchSubmodules = true;
   };
 
@@ -95,6 +95,13 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
 
   # Tests require access to a physical GPU
   doCheck = false;
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version=branch"
+      "--version-regex=v(3.*)"
+    ];
+  };
 
   meta = {
     description = "Official implementation of FlashAttention-3";


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
