### PR TITLE
semble: init at 0.3.3 

### DIFF
--- a/pkgs/by-name/se/semble/package.nix
+++ b/pkgs/by-name/se/semble/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  fetchFromGitHub,
+  git,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "semble";
+  version = "0.3.3";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "MinishLab";
+    repo = "semble";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-AZJYGrYrvAa+qm95lU8Dz1Gq+bHUgrGay8chgZzhs68=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+    setuptools-scm
+  ];
+
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
+
+  dependencies =
+    with python3Packages;
+    [
+      bm25s
+      model2vec
+      numpy
+      orjson
+      pathspec
+      questionary
+      tree-sitter
+      tree-sitter-language-pack
+      vicinity
+    ]
+    ++ finalAttrs.passthru.optional-dependencies.mcp;
+
+  passthru.optional-dependencies = with python3Packages; {
+    mcp = [
+      mcp
+      watchfiles
+    ];
+  };
+
+  nativeCheckInputs = [
+    git
+  ]
+  ++ (with python3Packages; [
+    pytestCheckHook
+    pytest-cov
+  ]);
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  disabledTestPaths = [
+    # Downloads a tree-sitter JSON5 grammar at runtime (requires network)
+    "tests/test_installer.py"
+  ];
+
+  pythonImportsCheck = [ "semble" ];
+
+  meta = {
+    description = "Fast and accurate code search for agents";
+    homepage = "https://github.com/MinishLab/semble";
+    changelog = "https://github.com/MinishLab/semble/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.gdifolco ];
+    mainProgram = "semble";
+  };
+})

--- a/pkgs/development/python-modules/bm25s/default.nix
+++ b/pkgs/development/python-modules/bm25s/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  setuptools,
+  numpy,
+  orjson,
+  tqdm,
+  pystemmer,
+  huggingface-hub,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "bm25s";
+  version = "0.3.9";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "xhluca";
+    repo = "bm25s";
+    tag = finalAttrs.version;
+    hash = "sha256-/aIQCJnOInjaxRTbAJgYMs20zEayWLz+uBKGhqX5ULM=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  env.BM25S_VERSION = finalAttrs.version;
+
+  dependencies = [
+    numpy
+  ];
+
+  pythonImportsCheck = [ "bm25s" ];
+
+  passthru.optional-dependencies = {
+    core = [
+      orjson
+      tqdm
+    ];
+    stem = [ pystemmer ];
+    hf = [ huggingface-hub ];
+  };
+
+  meta = {
+    description = "Ultrafast implementation of BM25 in pure Python, powered by Numpy";
+    homepage = "https://github.com/xhluca/bm25s";
+    changelog = "https://github.com/xhluca/bm25s/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.gdifolco ];
+  };
+})

--- a/pkgs/development/python-modules/model2vec/default.nix
+++ b/pkgs/development/python-modules/model2vec/default.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  setuptools,
+  setuptools-scm,
+  jinja2,
+  joblib,
+  numpy,
+  safetensors,
+  tokenizers,
+  tqdm,
+  torch,
+  transformers,
+  scikit-learn,
+  onnx,
+  skops,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "model2vec";
+  version = "0.8.2";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "MinishLab";
+    repo = "model2vec";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hDNDvx2kbvJE3eR8UDgWIQYa7ZUWbtuzX76i+kpDJx4=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
+
+  dependencies = [
+    jinja2
+    joblib
+    numpy
+    safetensors
+    tokenizers
+    tqdm
+  ];
+
+  pythonImportsCheck = [ "model2vec" ];
+
+  passthru.optional-dependencies = {
+    distill = [
+      torch
+      transformers
+      scikit-learn
+    ];
+    onnx = [
+      onnx
+      torch
+    ];
+    inference = [
+      scikit-learn
+      skops
+    ];
+    quantization = [ scikit-learn ];
+  };
+
+  meta = {
+    description = "Fast State-of-the-Art Static Embeddings";
+    homepage = "https://github.com/MinishLab/model2vec";
+    changelog = "https://github.com/MinishLab/model2vec/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.gdifolco ];
+  };
+})

--- a/pkgs/development/python-modules/vicinity/default.nix
+++ b/pkgs/development/python-modules/vicinity/default.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  setuptools,
+  setuptools-scm,
+  numpy,
+  orjson,
+  tqdm,
+  datasets,
+  hnswlib,
+  pynndescent,
+  annoy,
+  faiss,
+  usearch,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "vicinity";
+  version = "0.4.4";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "MinishLab";
+    repo = "vicinity";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-VRDCtPjuuEXeiJ2r4PqCDGnTyYlb3OVeemsN9VrS6Wc=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = finalAttrs.version;
+
+  dependencies = [
+    numpy
+    orjson
+    tqdm
+  ];
+
+  pythonImportsCheck = [ "vicinity" ];
+
+  passthru.optional-dependencies = {
+    huggingface = [ datasets ];
+    hnsw = [ hnswlib ];
+    pynndescent = [ pynndescent ];
+    annoy = [ annoy ];
+    faiss = [ faiss ];
+    usearch = [ usearch ];
+  };
+
+  meta = {
+    description = "Lightweight Nearest Neighbors with Flexible Backends";
+    homepage = "https://github.com/MinishLab/vicinity";
+    changelog = "https://github.com/MinishLab/vicinity/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.gdifolco ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2292,6 +2292,8 @@ self: super: with self; {
 
   blurhash-python = callPackage ../development/python-modules/blurhash-python { };
 
+  bm25s = callPackage ../development/python-modules/bm25s { };
+
   bme280spi = callPackage ../development/python-modules/bme280spi { };
 
   bme680 = callPackage ../development/python-modules/bme680 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10459,6 +10459,8 @@ self: super: with self; {
 
   model-signing = callPackage ../development/python-modules/model-signing { };
 
+  model2vec = callPackage ../development/python-modules/model2vec { };
+
   modelcif = callPackage ../development/python-modules/modelcif { };
 
   modelscope = callPackage ../development/python-modules/modelscope { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21456,6 +21456,8 @@ self: super: with self; {
 
   viaggiatreno-ha = callPackage ../development/python-modules/viaggiatreno-ha { };
 
+  vicinity = callPackage ../development/python-modules/vicinity { };
+
   victron-ble = callPackage ../development/python-modules/victron-ble { };
 
   victron-ble-ha-parser = callPackage ../development/python-modules/victron-ble-ha-parser { };


### PR DESCRIPTION
I know, I'm supposed to make one PR By package, but it will add a lot of delay.

I'll do it if asked.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
