### PR TITLE
discord: fix hardware-accelerated and DMABUF screen sharing

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -261,6 +261,7 @@ stdenv.mkDerivation (finalAttrs: {
         ${lib.strings.optionalString enableAutoscroll "--add-flags \"--enable-blink-features=MiddleClickAutoscroll\""} \
         --prefix XDG_DATA_DIRS : "${gtk3}/share/gsettings-schemas/${gtk3.name}/" \
         --prefix LD_LIBRARY_PATH : ${finalAttrs.libPath}:$out/opt/${binaryName}:${addDriverRunpath.driverLink}/lib \
+        --suffix VK_ADD_DRIVER_FILES : "${addDriverRunpath.driverLink}/share/vulkan/icd.d" \
         ${lib.strings.optionalString disableUpdates "--run ${lib.getExe disableBreakingUpdates}"} \
         --run "${stageModules} $out/opt/${binaryName}/modules" \
         --add-flags ${lib.escapeShellArg commandLineArgs}


### PR DESCRIPTION
Adds `--suffix VK_ADD_DRIVER_FILES : "${addDriverRunpath.driverLink}/share/vulkan/icd.d"` to Discord's Linux wrapper, fixing DMABUF screensharing and enabling hardware-accelerated video encoding. This should not affect non-NixOS systems without `/run/opengl-driver`.

---

Discord recently added Vulkan-powered [hardware-accelerated video encoding support](https://www.youtube.com/watch?v=BwNfmazmU4o) to Linux, being now deployed to all users. With this new update, DMABUF screen-sharing now requires a valid Vulkan GPU device to be able to access DMABUFs. In my NixOS system, for example, with the current package:

```
(lib.rs:24): WARN [linux_gpu_prober] Failed to initialize GPU prober: Failed to create Vulkan instance
```

While with a valid Vulkan configuration paths:

```
(lib.rs:201): INFO [linux_gpu_prober] Probing 2 H.264-capable GPU(s) for DMABUF import (format: DrmFourcc(BX24), modifier: I915_Y_TILED, stride: 10240)
(lib.rs:220): INFO [linux_gpu_prober] Successfully selected GPU for DMABUF: Intel(R) UHD Graphics (ADL-S GT1) (Some(Intel), /dev/dri/renderD128)
```

Without the DMABUF support, Discord fallbacks to SHM, which makes the screencast instantly fail in compositors such as niri that doesn't support SHM screenshare, besides DMABUFs being better performance-wise. Besides, this patch also makes hardware-accelerated video encoding work.

<img width="334" height="56" alt="image" src="https://github.com/user-attachments/assets/fd69d6dd-00aa-4321-83bf-797475d11a7b" />

On my system, having in my config only `config.hardware.graphics.extraPackages` with the proper packages, without the Vulkan env variable, didn't work. It was only by adding the variable `VK_ADD_DRIVER_FILES` (or similar such as `VK_ICD_FILENAMES`) to `/run/opengl-driver/share/vulkan/icd.d` that it got fixed, hence why this PR. I've chosen `VK_ADD_DRIVER_FILES` because it can be overriden by `VK_DRIVER_FILES` or `VK_ICD_FILENAMES`. 

Other places where a similar fix was needed:
- #517594 
-  #182539

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
