### PR TITLE
nixosTests.accountsservice: init

### DIFF
--- a/nixos/tests/accountsservice.nix
+++ b/nixos/tests/accountsservice.nix
@@ -1,0 +1,26 @@
+{ ... }:
+
+{
+  name = "accountsservice";
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      environment.systemPackages = with pkgs; [ jq ];
+
+      services.accounts-daemon.enable = true;
+
+      users.users.alice = {
+        isNormalUser = true;
+        description = "Alice";
+      };
+    };
+
+  testScript = ''
+    machine.start_job("accounts-daemon.service")
+    machine.wait_for_unit("accounts-daemon.service")
+    user = machine.succeed("busctl call -j org.freedesktop.Accounts /org/freedesktop/Accounts org.freedesktop.Accounts FindUserByName s alice | jq -j '.data[]'")
+    name = machine.succeed(f"busctl get-property -j org.freedesktop.Accounts {user} org.freedesktop.Accounts.User RealName | jq -j .data")
+    t.assertEqual(name, "Alice")
+  '';
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -174,6 +174,7 @@ in
   # keep-sorted start case=no numeric=no block=yes
   _3proxy = runTest ./3proxy.nix;
   aaaaxy = runTest ./aaaaxy.nix;
+  accountsservice = runTest ./accountsservice.nix;
   acl = pkgs.callPackage ./acl.nix { };
   acme = import ./acme/default.nix {
     inherit runTest;

--- a/pkgs/by-name/ac/accountsservice/package.nix
+++ b/pkgs/by-name/ac/accountsservice/package.nix
@@ -19,6 +19,7 @@
   vala,
   gettext,
   libxcrypt,
+  nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -106,6 +107,8 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace meson.build \
       --replace-fail "run_command(['./generate-version.sh'], check: true).stdout().strip()" "'${finalAttrs.version}'"
   '';
+
+  passthru.tests = { inherit (nixosTests) accountsservice; };
 
   meta = {
     changelog = "https://gitlab.freedesktop.org/accountsservice/accountsservice/-/releases/${finalAttrs.src.tag}";


### PR DESCRIPTION
It's not much, but it was useful to me to have a basic test.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
