### PR TITLE
silver-searcher-ng: Bring back silver-searcher with PCRE2 support

### DIFF
--- a/pkgs/by-name/si/silver-searcher-ng/bash-completion.patch
+++ b/pkgs/by-name/si/silver-searcher-ng/bash-completion.patch
@@ -1,0 +1,5 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -9 +9 @@
+-bashcompdir = $(pkgdatadir)/completions
++bashcompdir = $(datadir)/bash-completion/completions

--- a/pkgs/by-name/si/silver-searcher-ng/package.nix
+++ b/pkgs/by-name/si/silver-searcher-ng/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  pcre,
+  zlib,
+  xz,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "silver-searcher-ng";
+  version = "2.2.0";
+
+  src = fetchFromGitHub {
+    owner = "silver-searcher";
+    repo = "silver-searcher-ng";
+    rev = finalAttrs.version;
+    sha256 = "0cyazh7a66pgcabijd27xnk1alhsccywivv6yihw378dqxb22i1p";
+  };
+
+  patches = [ ./bash-completion.patch ];
+
+  env = {
+    # Workaround build failure on -fno-common toolchains like upstream
+    # gcc-10. Otherwise build fails as:
+    #   ld: src/zfile.o:/build/source/src/log.h:12: multiple definition of
+    #     `print_mtx'; src/ignore.o:/build/source/src/log.h:12: first defined here
+    # TODO: remove once next release has https://github.com/ggreer/the_silver_searcher/pull/1377
+    NIX_CFLAGS_COMPILE = "-fcommon";
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isLinux {
+    NIX_LDFLAGS = "-lgcc_s";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+  buildInputs = [
+    pcre
+    zlib
+    xz
+  ];
+
+  meta = {
+    homepage = "https://github.com/silver-searcher/silver-searcher-ng";
+    description = "Code-searching tool similar to ack, but faster";
+    maintainers = with lib.maintainers; [ timschumi ];
+    mainProgram = "ag";
+    platforms = lib.platforms.all;
+    license = lib.licenses.asl20;
+  };
+})

--- a/pkgs/by-name/si/silver-searcher-ng/package.nix
+++ b/pkgs/by-name/si/silver-searcher-ng/package.nix
@@ -4,33 +4,25 @@
   fetchFromGitHub,
   autoreconfHook,
   pkg-config,
-  pcre,
+  pcre2,
   zlib,
   xz,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "silver-searcher-ng";
-  version = "2.2.0";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "silver-searcher";
     repo = "silver-searcher-ng";
     rev = finalAttrs.version;
-    sha256 = "0cyazh7a66pgcabijd27xnk1alhsccywivv6yihw378dqxb22i1p";
+    hash = "sha256-IiVFbS9XGmqcGN4NRXFC07cV6bGKDs9C2y5XxJKdvFk=";
   };
 
   patches = [ ./bash-completion.patch ];
 
-  env = {
-    # Workaround build failure on -fno-common toolchains like upstream
-    # gcc-10. Otherwise build fails as:
-    #   ld: src/zfile.o:/build/source/src/log.h:12: multiple definition of
-    #     `print_mtx'; src/ignore.o:/build/source/src/log.h:12: first defined here
-    # TODO: remove once next release has https://github.com/ggreer/the_silver_searcher/pull/1377
-    NIX_CFLAGS_COMPILE = "-fcommon";
-  }
-  // lib.optionalAttrs stdenv.hostPlatform.isLinux {
+  env = lib.optionalAttrs stdenv.hostPlatform.isLinux {
     NIX_LDFLAGS = "-lgcc_s";
   };
 
@@ -39,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
   buildInputs = [
-    pcre
+    pcre2
     zlib
     xz
   ];

--- a/pkgs/by-name/si/silver-searcher-ng/package.nix
+++ b/pkgs/by-name/si/silver-searcher-ng/package.nix
@@ -52,6 +52,9 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postCheck
   '';
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   meta = {
     homepage = "https://github.com/silver-searcher/silver-searcher-ng";
     description = "Code-searching tool similar to ack, but faster";

--- a/pkgs/by-name/si/silver-searcher-ng/package.nix
+++ b/pkgs/by-name/si/silver-searcher-ng/package.nix
@@ -3,8 +3,10 @@
   stdenv,
   fetchFromGitHub,
   autoreconfHook,
+  git,
   pkg-config,
   pcre2,
+  python3Packages,
   zlib,
   xz,
 }:
@@ -30,11 +32,25 @@ stdenv.mkDerivation (finalAttrs: {
     autoreconfHook
     pkg-config
   ];
+
   buildInputs = [
     pcre2
     zlib
     xz
   ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    python3Packages.cram
+    git
+  ];
+  checkPhase = ''
+    runHook preCheck
+
+    make test
+
+    runHook postCheck
+  '';
 
   meta = {
     homepage = "https://github.com/silver-searcher/silver-searcher-ng";

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1974,7 +1974,7 @@ mapAliases {
   sierra-breeze-enhanced = throw "'sierra-breeze-enhanced' has been removed, as it is only compatible with Plasma 5, which is EOL"; # Added 2025-08-20
   signal-desktop-bin = throw "'signal-desktop-bin' has been replaced by 'signal-desktop' which is built from source"; # Added 2026-03-02
   signal-desktop-source = throw "'signal-desktop-source' has been renamed to/replaced by 'signal-desktop'"; # Converted to throw 2025-10-27
-  silver-searcher = throw "'silver-searcher' has been removed as it has seen no development since 2020 and is stuck on the obsolete pcre library";
+  silver-searcher = throw "'silver-searcher' has been removed as it has seen no development since 2020 and is stuck on the obsolete pcre library. Consider using 'silver-searcher-ng', which is a fork with support for PCRE2.";
   simpleBluez = warnAlias "'simpleBluez' has been renamed to 'simplebluez'" simplebluez; # Added 2026-02-18
   simpleDBus = warnAlias "'simpleDBus' has been renamed to 'simpledbus'" simpledbus; # Added 2026-02-12
   simplesamlphp = throw "'simplesamlphp' was removed because it was unmaintained in nixpkgs"; # Added 2025-10-17


### PR DESCRIPTION
I ended up forking silver-searcher and adding in PCRE2 support myself. Not sure if we will ever see [the matching PR](https://github.com/ggreer/the_silver_searcher/pull/1562) being merged upstream.

Not sure what the rules around bringing back packages same-cycle are, or whether it has any effect on "please don't immediately package overly new software", but putting this up for discussion still.

[This](https://github.com/timschumi/ag/compare/2.2.0...3.0.0?expand=1) is the full changelog between the former version of 2.2.0 and what I have now dubbed 3.0.0.

@madjar I ended up putting myself as the new maintainer, let me know if you want to be on the list as well.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
