### PR TITLE
varlpenis: init at 3.0.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26355,6 +26355,12 @@
     githubId = 6362238;
     name = "Christoph Honal";
   };
+  starhaze = {
+    email = "starhazze@proton.me";
+    github = "starhazze";
+    githubId = 239991650;
+    name = "starhaze";
+  };
   starius = {
     email = "bnagaev@gmail.com";
     github = "starius";

--- a/pkgs/by-name/va/varlpenis/package.nix
+++ b/pkgs/by-name/va/varlpenis/package.nix
@@ -1,0 +1,38 @@
+{
+  stdenv,
+  lib,
+  fetchFromCodeberg,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "varlpenis";
+  version = "3.0.4";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "ssterling";
+    repo = "varlpenis";
+    tag = "v${version}";
+    hash = "sha256-XfdflE+IsJSWgjafruVyC8KagQ+RC84A5PGYI6Fjni4=";
+  };
+
+  # fixes upstream typo in configure script ("$cd_pwd" instead of "$cs_pwd", causing the working directory check to fail)
+  postPatch = ''
+    substituteInPlace configure \
+      --replace-fail 'cd "$cd_pwd"' 'cd "$cs_pwd"'
+  '';
+
+  # upstream defaults to BSD make options (ifndef_guards="yes")
+  configureFlags = [ "--no-ifndef-guards" ];
+
+  meta = {
+    description = "Generate an ASCII-art penis of arbitrary length";
+    homepage = "https://codeberg.org/ssterling/varlpenis";
+    license = lib.licenses.mit;
+    mainProgram = "varlpenis";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ starhaze ];
+  };
+}


### PR DESCRIPTION
add [varlpenis](https://codeberg.org/ssterling/varlpenis), a program that flawlessly generates penis ASCII arts
AI was only partially used for debugging build errors, the rest of the package is human-made

<img height="288" alt="Pasted image (7)" src="https://github.com/user-attachments/assets/dde22fba-b99f-40f5-b184-44f553b2e696" />

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
