### PR TITLE
stalwart-vandelay: init at 1.0.2

### DIFF
--- a/pkgs/by-name/st/stalwart-vandelay/package.nix
+++ b/pkgs/by-name/st/stalwart-vandelay/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  cacert,
+  fetchFromGitHub,
+  rustPlatform,
+  versionCheckHook,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "vandelay";
+  version = "1.0.2";
+  src = fetchFromGitHub {
+    owner = "stalwartlabs";
+    repo = "vandelay";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RwcSwgzAqagm4JpNXptnXbHhtl7KoyPoiuSf2kBwzt8=";
+  };
+  cargoHash = "sha256-hxnnBy7YpwYhxw1jtGckNt0zU/6sdsXC8geFuwIJjWE=";
+  __structuredAttrs = true;
+  __darwinAllowLocalNetworking = true;
+  # called `Result::unwrap()` on an `Err` value: Tls("rustls platform verifier: unexpected error: No CA certificates were loaded from the system")
+  nativeCheckInputs = [
+    cacert
+  ];
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  meta = {
+    description = "JMAP importer-exporter (and backup tool)";
+    longDescription = ''
+      One-shot account migration and backup across JMAP, IMAP, CalDAV, CardDAV, WebDAV, ManageSieve, Maildir, Google Takeout and Microsoft Exchange.
+    '';
+    homepage = "https://github.com/stalwartlabs/vandelay";
+    changelog = "https://github.com/stalwartlabs/vandelay/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.OR [
+      lib.licenses.mit
+      lib.licenses.apsl20
+    ];
+    mainProgram = "vandelay";
+    maintainers = with lib.maintainers; [
+      debtquity
+    ];
+  };
+})


### PR DESCRIPTION
add jmap import and export tool which may aid in planned refactor work for stalwart NixOS module

* changelog: https://github.com/stalwartlabs/vandelay/releases/tag/v1.0.2

Related to: #511880


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
