### PR TITLE
zennotes: init at 2.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -591,6 +591,12 @@
       { fingerprint = "CE85 54F7 B9BC AC0D D648  5661 AB5F C04C 3C94 443F"; }
     ];
   };
+  ad030 = {
+    github = "ad030";
+    githubId = 68517956;
+    name = "Alex Dam";
+    email = "work.a.dam.030@proton.me";
+  };
   adam-tj = {
     github = "adam-tj";
     githubId = 9314405;

--- a/pkgs/by-name/ze/zennotes/package.nix
+++ b/pkgs/by-name/ze/zennotes/package.nix
@@ -1,0 +1,129 @@
+# https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/sp/sparkle/package.nix used as a base
+
+{
+  lib,
+  stdenv,
+
+  fetchFromGitHub,
+
+  nodejs,
+  electron_41,
+  fetchNpmDeps,
+  npmHooks,
+
+  makeWrapper,
+  makeDesktopItem,
+  copyDesktopItems,
+
+  nix-update-script,
+}:
+let
+  pname = "zennotes";
+  version = "2.2.0";
+
+  src = fetchFromGitHub {
+    owner = "ZenNotes";
+    repo = "zennotes";
+    tag = "v${version}";
+    hash = "sha256-ipS/G0rcMciMQSLvhIcjlChg9BdpRKabGwuvm7ldKAc=";
+  };
+
+  npmDeps = fetchNpmDeps {
+    inherit src pname version;
+    hash = "sha256-9YO5YfCmAENVsfOz5jClWRtQwIS5du6wz35P3FELsWM=";
+  };
+
+  electron = electron_41;
+in
+stdenv.mkDerivation (finalAttrs: {
+  inherit
+    src
+    pname
+    version
+    npmDeps
+    ;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    nodejs
+    npmHooks.npmConfigHook
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+  };
+
+  buildPhase = ''
+    runHook preBuild
+    pushd apps/desktop
+
+    npm exec electron-vite -- build
+    npm exec electron-builder -- \
+      --dir \
+      -c.electronDist=${electron.dist} \
+      -c.electronVersion=${electron.version}
+
+    popd
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/zennotes
+    cp -r dist/*-unpacked/{locales,resources{,.pak}} $out/lib/zennotes/
+
+    install -D apps/desktop/build/icon.png $out/share/icons/hicolor/512x512/apps/zennotes.png
+
+    # electron app
+    makeWrapper '${lib.getExe electron}' $out/bin/zennotes \
+      --add-flags $out/lib/zennotes/resources/app.asar \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true --wayland-text-input-version=3}}" \
+      --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
+      --set-default ELECTRON_IS_DEV 0 \
+      --inherit-argv0
+
+    # cli tool
+    makeWrapper '${lib.getExe nodejs}' $out/bin/zen \
+      --add-flags $out/lib/zennotes/resources/cli.js
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "zennotes";
+      desktopName = "ZenNotes";
+      exec = "zennotes %U";
+      terminal = false;
+
+      type = "Application";
+      icon = "zennotes";
+      startupWMClass = "ZenNotes";
+      comment = "ZenNotes desktop shell";
+
+      categories = [ "Office" ];
+      mimeTypes = [
+        "text/markdown"
+        "x-scheme-handler/zennotes"
+      ];
+
+    })
+  ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };
+
+  meta = {
+    description = "Keyboard-based Markdown notes app";
+    homepage = "https://zennotes.org/";
+    license = lib.licenses.mit;
+    mainProgram = "zennotes";
+    changelog = "https://github.com/ZenNotes/zennotes/releases/tag/v${version}";
+    maintainers = with lib.maintainers; [ ad030 ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Added package for ZenNotes, a local Markdown-based notetaking app similar to Obsidian. 
Homepage link: https://zennotes.org/
GitHub link: https://github.com/ZenNotes/zennotes


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
