### PR TITLE
sox_ng: 14.7.1.2 -> 14.8.0.1

### DIFF
--- a/pkgs/by-name/so/sox_ng/package.nix
+++ b/pkgs/by-name/so/sox_ng/package.nix
@@ -48,13 +48,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sox";
-  version = "14.7.1.2";
+  version = "14.8.0.1";
 
   src = fetchFromCodeberg {
     owner = "sox_ng";
     repo = "sox_ng";
     tag = "sox_ng-${finalAttrs.version}";
-    hash = "sha256-yIebX0a/fbpr/NMgiK+gjDPNValf3gITpxDSJAc6eAw=";
+    hash = "sha256-dHyDbMYvydC7ayG0n+RXK59w1vMTsi6y9jsYHBppC9k=";
   };
 
   strictDeps = true;
@@ -78,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional enableAMR opencore-amr
     ++ lib.optional enableFLAC flac
     ++ lib.optional enableFFTW fftw
-    ++ lib.optional enableLadspa ladspa-sdk
+    ++ lib.optional (enableLadspa && stdenv.hostPlatform.isLinux) ladspa-sdk
     ++ lib.optional enableLame lame
     ++ lib.optional enableLibao libao
     ++ lib.optional enableLibid3tag libid3tag


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Updated to latest version. Also fixed `ladspa-sdk-1.17` unsupported error on darwin systems.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
