### PR TITLE
golazo: derivation improvements

### DIFF
--- a/pkgs/by-name/go/golazo/0001-disable-update-flag.patch
+++ b/pkgs/by-name/go/golazo/0001-disable-update-flag.patch
@@ -1,0 +1,17 @@
+diff --git i/cmd/root.go w/cmd/root.go
+index 7b42feb..c5d01f7 100644
+--- i/cmd/root.go
++++ w/cmd/root.go
+@@ -124,10 +124,10 @@ func decideUpdate(current, latest string, fetchErr error) (proceed bool, message
+ 		return false, "Running a dev build; skipping update."
+ 	}
+ 	if fetchErr != nil || latest == "" {
+-		return true, ""
++		return false, "The update flag is unsupported for the nixpkgs package."
+ 	}
+ 	if version.IsOlder(current, latest) {
+-		return true, ""
++		return false, "The update flag is unsupported for the nixpkgs package."
+ 	}
+ 	return false, fmt.Sprintf("Already on the latest version (%s).", current)
+ }

--- a/pkgs/by-name/go/golazo/package.nix
+++ b/pkgs/by-name/go/golazo/package.nix
@@ -28,6 +28,7 @@ buildGoModule (finalAttrs: {
   ];
 
   __structuredAttrs = true;
+  strictDeps = true;
 
   passthru.updateScript = gitUpdater {
     rev-prefix = "v";

--- a/pkgs/by-name/go/golazo/package.nix
+++ b/pkgs/by-name/go/golazo/package.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   gitUpdater,
   libnotify,
+  makeWrapper,
 }:
 buildGoModule (finalAttrs: {
   pname = "golazo";
@@ -21,11 +22,20 @@ buildGoModule (finalAttrs: {
 
   subPackages = [ "." ];
 
-  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ libnotify ];
-
   ldflags = [
     "-X github.com/0xjuanma/golazo/cmd.Version=v${finalAttrs.version}"
   ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
+    wrapProgram $out/bin/golazo \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          libnotify
+        ]
+      }
+  '';
 
   __structuredAttrs = true;
   strictDeps = true;

--- a/pkgs/by-name/go/golazo/package.nix
+++ b/pkgs/by-name/go/golazo/package.nix
@@ -20,6 +20,8 @@ buildGoModule (finalAttrs: {
 
   vendorHash = "sha256-M2gfqU5rOfuiVSZnH/Dr8OVmDhyU2jYkgW7RuIUTd+E=";
 
+  patches = [ ./0001-disable-update-flag.patch ];
+
   subPackages = [ "." ];
 
   ldflags = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Some improvements to the existing derivation:
- Add `strictDeps = true`.
- Fix `libnotify` dependency. The program does not link to the lib itself, but depends on the `notify-send` binary.
- Patch the program so that the `--update` flag is removed, as it's incompatible with nix.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
