### PR TITLE
bumpver: 2021.1110 -> 2026.1143

### DIFF
--- a/pkgs/by-name/bu/bumpver/package.nix
+++ b/pkgs/by-name/bu/bumpver/package.nix
@@ -8,12 +8,12 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "bumpver";
-  version = "2021.1110";
+  version = "2026.1132";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    sha256 = "b6a0ddb78db7e00ae7ffe895bf8ef97f91e6310dfc1c4721896bdfd044b1cb03";
+    sha256 = "sha256-gLIjwj/Km8ndVpt6RGgJSdNL7iOnOIYNmps28avjsOA=";
   };
 
   prePatch = ''
@@ -21,6 +21,8 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       --replace-fail "if any(arg.startswith(\"bdist\") for arg in sys.argv):" ""\
       --replace-fail "import lib3to6" ""\
       --replace-fail "package_dir = lib3to6.fix(package_dir)" ""
+
+    patchShebangs test/fixtures/hooks
   '';
 
   build-system = with python3.pkgs; [
@@ -28,23 +30,16 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   ];
 
   dependencies = with python3.pkgs; [
-    pathlib2
     click
     toml
     lexid
     colorama
-    setuptools
   ];
 
   nativeCheckInputs = [
     python3.pkgs.pytestCheckHook
     git
     mercurial
-  ];
-
-  disabledTests = [
-    # fails due to more aggressive setuptools version specifier validation
-    "test_parse_default_pattern"
   ];
 
   meta = {


### PR DESCRIPTION
Update bumpver and clean up.
- Remove now unnecessary deps.
- Previous failing test now works.
- Fix shebangs in hooks. These are required for some tests.

Seems to me like there are no breaking changes. Mainly additions and fixes.
https://github.com/mbarkhau/bumpver/blob/master/CHANGELOG.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
