### PR TITLE
python3Packages.zict: disable one test

### DIFF
--- a/pkgs/development/python-modules/zict/default.nix
+++ b/pkgs/development/python-modules/zict/default.nix
@@ -28,6 +28,11 @@ buildPythonPackage (finalAttrs: {
     pytest-timeout
   ];
 
+  disabledTests = [
+    # timeout
+    "test_stress_different_keys_threadsafe"
+  ];
+
   meta = {
     description = "Mutable mapping tools";
     homepage = "https://github.com/dask/zict";


### PR DESCRIPTION
Hi,

I got this issue with this test a few times, when trying to rebuild other things on staging:

```python
zict/tests/test_lru.py::test_stress_different_keys_threadsafe +++++++++++++++++++++++++++++++++++ Timeout ++++++++++++++++++++++++++++++++++++
~~~~~~~~~~~~~ Stack of ThreadPoolExecutor-174_1 (140737295558336) ~~~~~~~~~~~~~~
  File "/nix/store/vwd42kbgdh01iyl9bxv5hy537lhmicps-python3-3.14.5/lib/python3.14/threading.py", line 1044, in _bootstrap
    self._bootstrap_inner()
  File "/nix/store/vwd42kbgdh01iyl9bxv5hy537lhmicps-python3-3.14.5/lib/python3.14/threading.py", line 1082, in _bootstrap_inner
    self._context.run(self.run)
  File "/nix/store/vwd42kbgdh01iyl9bxv5hy537lhmicps-python3-3.14.5/lib/python3.14/threading.py", line 1024, in run
    self._target(*self._args, **self._kwargs)
  File "/nix/store/vwd42kbgdh01iyl9bxv5hy537lhmicps-python3-3.14.5/lib/python3.14/concurrent/futures/thread.py", line 119, in _worker
    work_item.run(ctx)
  File "/nix/store/vwd42kbgdh01iyl9bxv5hy537lhmicps-python3-3.14.5/lib/python3.14/concurrent/futures/thread.py", line 86, in run
    result = ctx.run(self.task)
  File "/nix/store/vwd42kbgdh01iyl9bxv5hy537lhmicps-python3-3.14.5/lib/python3.14/concurrent/futures/thread.py", line 73, in run
    return fn(*args, **kwargs)
  File "/build/zict-3.0.0/zict/tests/utils_test.py", line 173, in worker
    z[key] = value
  File "/build/zict-3.0.0/zict/lru.py", line 138, in __setitem__
    self.evict_until_below_target()
  File "/build/zict-3.0.0/zict/lru.py", line 180, in evict_until_below_target
    self.evict()
  File "/build/zict-3.0.0/zict/common.py", line 126, in wrapper
    with self.lock:
~~~~~~~~~~~~~ Stack of ThreadPoolExecutor-174_0 (140737211524800) ~~~~~~~~~~~~~~
  File "/nix/store/vwd42kbgdh01iyl9bxv5hy537lhmicps-python3-3.14.5/lib/python3.14/threading.py", line 1044, in _bootstrap
    self._bootstrap_inner()
  File "/nix/store/vwd42kbgdh01iyl9bxv5hy537lhmicps-python3-3.14.5/lib/python3.14/threading.py", line 1082, in _bootstrap_inner
    self._context.run(self.run)
  File "/nix/store/vwd42kbgdh01iyl9bxv5hy537lhmicps-python3-3.14.5/lib/python3.14/threading.py", line 1024, in run
    self._target(*self._args, **self._kwargs)
  File "/nix/store/vwd42kbgdh01iyl9bxv5hy537lhmicps-python3-3.14.5/lib/python3.14/concurrent/futures/thread.py", line 119, in _worker
    work_item.run(ctx)
  File "/nix/store/vwd42kbgdh01iyl9bxv5hy537lhmicps-python3-3.14.5/lib/python3.14/concurrent/futures/thread.py", line 86, in run
    result = ctx.run(self.task)
  File "/nix/store/vwd42kbgdh01iyl9bxv5hy537lhmicps-python3-3.14.5/lib/python3.14/concurrent/futures/thread.py", line 73, in run
    return fn(*args, **kwargs)
  File "/build/zict-3.0.0/zict/tests/utils_test.py", line 173, in worker
    z[key] = value
  File "/build/zict-3.0.0/zict/lru.py", line 138, in __setitem__
    self.evict_until_below_target()
  File "/build/zict-3.0.0/zict/lru.py", line 178, in evict_until_below_target
    while self.total_weight + self.offset > n and not self.closed:
  File "/build/zict-3.0.0/zict/common.py", line 126, in wrapper
    with self.lock:
  File "/build/zict-3.0.0/zict/lru.py", line 241, in evict
    return key, value, weight
  File "/build/zict-3.0.0/zict/tests/test_lru.py", line 424, in slow_cb
    time.sleep(0.01)
~~~~~~~~~~~~~~~~~~~~ Stack of MainThread (140737353635712) ~~~~~~~~~~~~~~~~~~~~~
  File "<frozen runpy>", line 203, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/nix/store/mn6w6kly3rfvy8c8l4ajvjvda9kqgz01-python3.14-pytest-9.0.3/lib/python3.14/site-packages/pytest/__main__.py", line 9, in <module>
    raise SystemExit(pytest.console_main())
  File "/nix/store/mn6w6kly3rfvy8c8l4ajvjvda9kqgz01-python3.14-pytest-9.0.3/lib/python3.14/site-packages/_pytest/config/__init__.py", line 223, in console_main
    code = main()
  File "/nix/store/mn6w6kly3rfvy8c8l4ajvjvda9kqgz01-python3.14-pytest-9.0.3/lib/python3.14/site-packages/_pytest/config/__init__.py", line 199, in main
    ret: ExitCode | int = config.hook.pytest_cmdline_main(config=config)
  File "/nix/store/7w7lw1hq2k1an4splvy7azh7whr9wcpx-python3.14-pluggy-1.6.0/lib/python3.14/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/nix/store/7w7lw1hq2k1an4splvy7azh7whr9wcpx-python3.14-pluggy-1.6.0/lib/python3.14/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/nix/store/7w7lw1hq2k1an4splvy7azh7whr9wcpx-python3.14-pluggy-1.6.0/lib/python3.14/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/nix/store/mn6w6kly3rfvy8c8l4ajvjvda9kqgz01-python3.14-pytest-9.0.3/lib/python3.14/site-packages/_pytest/main.py", line 365, in pytest_cmdline_main
    return wrap_session(config, _main)
  File "/nix/store/mn6w6kly3rfvy8c8l4ajvjvda9kqgz01-python3.14-pytest-9.0.3/lib/python3.14/site-packages/_pytest/main.py", line 318, in wrap_session
    session.exitstatus = doit(config, session) or 0
  File "/nix/store/mn6w6kly3rfvy8c8l4ajvjvda9kqgz01-python3.14-pytest-9.0.3/lib/python3.14/site-packages/_pytest/main.py", line 372, in _main
    config.hook.pytest_runtestloop(session=session)
  File "/nix/store/7w7lw1hq2k1an4splvy7azh7whr9wcpx-python3.14-pluggy-1.6.0/lib/python3.14/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/nix/store/7w7lw1hq2k1an4splvy7azh7whr9wcpx-python3.14-pluggy-1.6.0/lib/python3.14/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/nix/store/7w7lw1hq2k1an4splvy7azh7whr9wcpx-python3.14-pluggy-1.6.0/lib/python3.14/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/nix/store/mn6w6kly3rfvy8c8l4ajvjvda9kqgz01-python3.14-pytest-9.0.3/lib/python3.14/site-packages/_pytest/main.py", line 396, in pytest_runtestloop
    item.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
  File "/nix/store/7w7lw1hq2k1an4splvy7azh7whr9wcpx-python3.14-pluggy-1.6.0/lib/python3.14/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/nix/store/7w7lw1hq2k1an4splvy7azh7whr9wcpx-python3.14-pluggy-1.6.0/lib/python3.14/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/nix/store/7w7lw1hq2k1an4splvy7azh7whr9wcpx-python3.14-pluggy-1.6.0/lib/python3.14/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/nix/store/mn6w6kly3rfvy8c8l4ajvjvda9kqgz01-python3.14-pytest-9.0.3/lib/python3.14/site-packages/_pytest/runner.py", line 118, in pytest_runtest_protocol
    runtestprotocol(item, nextitem=nextitem)
  File "/nix/store/mn6w6kly3rfvy8c8l4ajvjvda9kqgz01-python3.14-pytest-9.0.3/lib/python3.14/site-packages/_pytest/runner.py", line 137, in runtestprotocol
    reports.append(call_and_report(item, "call", log))
  File "/nix/store/mn6w6kly3rfvy8c8l4ajvjvda9kqgz01-python3.14-pytest-9.0.3/lib/python3.14/site-packages/_pytest/runner.py", line 244, in call_and_report
    call = CallInfo.from_call(
  File "/nix/store/mn6w6kly3rfvy8c8l4ajvjvda9kqgz01-python3.14-pytest-9.0.3/lib/python3.14/site-packages/_pytest/runner.py", line 353, in from_call
    result: TResult | None = func()
  File "/nix/store/mn6w6kly3rfvy8c8l4ajvjvda9kqgz01-python3.14-pytest-9.0.3/lib/python3.14/site-packages/_pytest/runner.py", line 245, in <lambda>
    lambda: runtest_hook(item=item, **kwds),
  File "/nix/store/7w7lw1hq2k1an4splvy7azh7whr9wcpx-python3.14-pluggy-1.6.0/lib/python3.14/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/nix/store/7w7lw1hq2k1an4splvy7azh7whr9wcpx-python3.14-pluggy-1.6.0/lib/python3.14/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/nix/store/7w7lw1hq2k1an4splvy7azh7whr9wcpx-python3.14-pluggy-1.6.0/lib/python3.14/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/nix/store/mn6w6kly3rfvy8c8l4ajvjvda9kqgz01-python3.14-pytest-9.0.3/lib/python3.14/site-packages/_pytest/runner.py", line 179, in pytest_runtest_call
    item.runtest()
  File "/nix/store/mn6w6kly3rfvy8c8l4ajvjvda9kqgz01-python3.14-pytest-9.0.3/lib/python3.14/site-packages/_pytest/python.py", line 1720, in runtest
    self.ihook.pytest_pyfunc_call(pyfuncitem=self)
  File "/nix/store/7w7lw1hq2k1an4splvy7azh7whr9wcpx-python3.14-pluggy-1.6.0/lib/python3.14/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/nix/store/7w7lw1hq2k1an4splvy7azh7whr9wcpx-python3.14-pluggy-1.6.0/lib/python3.14/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/nix/store/7w7lw1hq2k1an4splvy7azh7whr9wcpx-python3.14-pluggy-1.6.0/lib/python3.14/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
  File "/nix/store/mn6w6kly3rfvy8c8l4ajvjvda9kqgz01-python3.14-pytest-9.0.3/lib/python3.14/site-packages/_pytest/python.py", line 166, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/build/zict-3.0.0/zict/tests/test_lru.py", line 440, in test_stress_different_keys_threadsafe
    utils_test.check_different_keys_threadsafe(lru, allow_keyerror=True)
  File "/build/zict-3.0.0/zict/tests/utils_test.py", line 193, in check_different_keys_threadsafe
    f1.result()
  File "/nix/store/vwd42kbgdh01iyl9bxv5hy537lhmicps-python3-3.14.5/lib/python3.14/concurrent/futures/_base.py", line 445, in result
    self._condition.wait(timeout)
  File "/nix/store/vwd42kbgdh01iyl9bxv5hy537lhmicps-python3-3.14.5/lib/python3.14/threading.py", line 369, in wait
    waiter.acquire()
+++++++++++++++++++++++++++++++++++ Timeout ++++++++++++++++++++++++++++++++++++
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
