### PR TITLE
ungoogled-chromium: 149.0.7827.53-1 -> 149.0.7827.102-1

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -823,7 +823,7 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "149.0.7827.53",
+    "version": "149.0.7827.102",
     "deps": {
       "depot_tools": {
         "rev": "45dedc4c3b87c982fd846b3dc599b233ed3aff90",
@@ -835,16 +835,16 @@
         "hash": "sha256-oFs7fZAZEs/gQ7X1A4uigo9+Y+iEN9sMMQYwAjEuD04="
       },
       "ungoogled-patches": {
-        "rev": "149.0.7827.53-1",
-        "hash": "sha256-j4maEZiU38tqs57cTmg8OhIAAQcT+liWU0fDA7GMZHM="
+        "rev": "149.0.7827.102-1",
+        "hash": "sha256-I2yrFav9r+vfkKfCpa71F8amzApGViVT8Enlmukwe7s="
       },
       "npmHash": "sha256-pF0JtwFpPC4/fodbhSJnQKkczA9WlDg4VqEAy9aDVLg="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "9d2c8156a72129edca4785abb98866fad60ea338",
-        "hash": "sha256-RPFeHTWAeJUzbWU7QyRPmT3sqf3bAEuJ7/IJ3TP40pA=",
+        "rev": "112f665d98a2fe84b156c74fbea2aed742f16c15",
+        "hash": "sha256-75PYsss5Qob493WCc28XHncjFIlvUr2HQx79w5UmK/k=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -914,8 +914,8 @@
       },
       "src/third_party/angle": {
         "url": "https://chromium.googlesource.com/angle/angle.git",
-        "rev": "ded782bca9d5f165d1c4a70124cdc5384043a8b3",
-        "hash": "sha256-7+Hhx/V554hO3zzGuIZswkaRVDElz7ost7vbnf2wyZc="
+        "rev": "4b8c7f0f321952bba4f81056b4aa57d0d6428642",
+        "hash": "sha256-ADG0WfkeFRq4NF0m+s3a/N5+u3q4ApExuWUnV3m5uAI="
       },
       "src/third_party/angle/third_party/glmark2/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glmark2/glmark2",
@@ -954,8 +954,8 @@
       },
       "src/third_party/dawn": {
         "url": "https://dawn.googlesource.com/dawn.git",
-        "rev": "1815a06195d9c74ac737a96f87c05111926e04f8",
-        "hash": "sha256-71KbW0w60VB67+HM48WpOo18hrVId4/4QBDl+xl5pgo="
+        "rev": "c1179de12ec3ed8feb91e922f12a90ae33f4a8cf",
+        "hash": "sha256-VFEBqbSsn/3jqRGJgTM/r5DEtfhvTOIfS9fGIKzYo9I="
       },
       "src/third_party/dawn/third_party/glfw3/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glfw/glfw",
@@ -1374,8 +1374,8 @@
       },
       "src/third_party/libyuv": {
         "url": "https://chromium.googlesource.com/libyuv/libyuv.git",
-        "rev": "a7849e8a5e9c996bef2332efae897e7301055a20",
-        "hash": "sha256-ftOTwWULKNplqjQQ9oM9t+PU3S6/ySDOBoE5E/HWuHg="
+        "rev": "644251f252a84bf8ce91ff0aca86a9b16b069ab8",
+        "hash": "sha256-DsoOY8bg0sPOF8tF67Gk7fRqdQzG1hc9fVMlZVjKWU4="
       },
       "src/third_party/lss": {
         "url": "https://chromium.googlesource.com/linux-syscall-support.git",
@@ -1429,8 +1429,8 @@
       },
       "src/third_party/perfetto": {
         "url": "https://chromium.googlesource.com/external/github.com/google/perfetto.git",
-        "rev": "846203c4b3b25f834a0bebc101fa8e1b8f9d0ca9",
-        "hash": "sha256-YOgOau9vNrOOqyUf6WylI/oQ2drCxoW7jnrHt7fAfQM="
+        "rev": "97c58a94bb6495c4e202467fb1c55eaa22b5670f",
+        "hash": "sha256-qtClkWAluLDRZn7yrHLU7qp9szP+/WsiG5JZZzRKd38="
       },
       "src/third_party/protobuf-javascript/src": {
         "url": "https://chromium.googlesource.com/external/github.com/protocolbuffers/protobuf-javascript",
@@ -1474,8 +1474,8 @@
       },
       "src/third_party/skia": {
         "url": "https://skia.googlesource.com/skia.git",
-        "rev": "53348aa333da02b77c4b5797e2de722f5abde7d0",
-        "hash": "sha256-Qh0ytA45zP67VQE417iUtjPcJmJmDzcu4BAatyh6p0w="
+        "rev": "92a56ebeef43061f4878aa869aa1f2160265c24c",
+        "hash": "sha256-QEY9Wy2guRuS4CXeXHUhUNigCJWWndnNCbWQmaSYJ/A="
       },
       "src/third_party/smhasher/src": {
         "url": "https://chromium.googlesource.com/external/smhasher.git",
@@ -1609,8 +1609,8 @@
       },
       "src/third_party/webrtc": {
         "url": "https://webrtc.googlesource.com/src.git",
-        "rev": "5a7e0ff57a52e12f834d64c57d040d1105ea17f2",
-        "hash": "sha256-V1accCSU6LV5Ixhd+HBOvqZ7GxT57ALsvaF8ABLIXxM="
+        "rev": "e8b4d4c5952a8fb7b35c2a6cba4e8c3de2ea2e1e",
+        "hash": "sha256-94U9URlFGLYe94KCFU0giY9bBbrHNDCBr9GEwbRbOK4="
       },
       "src/third_party/wuffs/src": {
         "url": "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git",
@@ -1639,8 +1639,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "5a39b146dd810a52812202fae891281d5dc4db7d",
-        "hash": "sha256-UbX88nE4VyWUm4PvFTOy3mC04MzSdgC006ZpQrEY8cQ="
+        "rev": "16ef80c1f5d3cfade812bd1743952a4cfd480a31",
+        "hash": "sha256-GI0NWA0XYGocxZp3+lPen6BkwaG7X3EDaEWM9rejgkI="
       }
     }
   }

--- a/pkgs/applications/networking/browsers/chromium/ungoogled-flags.toml
+++ b/pkgs/applications/networking/browsers/chromium/ungoogled-flags.toml
@@ -16,4 +16,3 @@ treat_warnings_as_errors=false
 use_official_google_api_keys=false
 use_unofficial_version_number=false
 v8_drumbrake_bounds_checks=true
-v8_enable_drumbrake=true


### PR DESCRIPTION
Same underlying changes as #529892

https://chromereleases.googleblog.com/2026/06/stable-channel-update-for-desktop_0153744567.html

This update includes 74 security fixes. Google is aware that an exploit for CVE-2026-11645 exists in the wild.

CVEs:
CVE-2026-11628 CVE-2026-11629 CVE-2026-11630 CVE-2026-11631
CVE-2026-11632 CVE-2026-11633 CVE-2026-11634 CVE-2026-11635
CVE-2026-11636 CVE-2026-11637 CVE-2026-11638 CVE-2026-11639
CVE-2026-11640 CVE-2026-11641 CVE-2026-11642 CVE-2026-11643
CVE-2026-11644 CVE-2026-11645 CVE-2026-11646 CVE-2026-11647
CVE-2026-11648 CVE-2026-11649 CVE-2026-11650 CVE-2026-11651
CVE-2026-11652 CVE-2026-11653 CVE-2026-11654 CVE-2026-11655
CVE-2026-11656 CVE-2026-11657 CVE-2026-11658 CVE-2026-11659
CVE-2026-11660 CVE-2026-11661 CVE-2026-11662 CVE-2026-11663
CVE-2026-11664 CVE-2026-11665 CVE-2026-11666 CVE-2026-11667
CVE-2026-11668 CVE-2026-11669 CVE-2026-11670 CVE-2026-11671
CVE-2026-11672 CVE-2026-11673 CVE-2026-11674 CVE-2026-11675
CVE-2026-11676 CVE-2026-11677 CVE-2026-11678 CVE-2026-11679
CVE-2026-11680 CVE-2026-11681 CVE-2026-11682 CVE-2026-11683
CVE-2026-11684 CVE-2026-11685 CVE-2026-11686 CVE-2026-11687
CVE-2026-11688 CVE-2026-11689 CVE-2026-11690 CVE-2026-11691
CVE-2026-11692 CVE-2026-11693 CVE-2026-11694 CVE-2026-11695
CVE-2026-11696 CVE-2026-11697 CVE-2026-11698 CVE-2026-11699
CVE-2026-11700 CVE-2026-11701

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
