### PR TITLE
[25.11] electron_{40,41,42}: updates

### DIFF
--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -56,13 +56,13 @@
     },
     "42": {
         "hashes": {
-            "aarch64-darwin": "19f4b0a4fcc3574e79befb53495cca8de02a126210d04363cf76f67099d128ef",
-            "aarch64-linux": "2a375ff973fb7bddc538a4f67b2141947e9d72513a1baa2beabec2a7f65cd0f0",
-            "armv7l-linux": "5d15e602d978d53772ec0c58af4ef02d1ba514dc3d6752ffe79c0ad21804c38c",
-            "headers": "1jh4r2ivgrgwq3bvw3a89lic97xmr9r37y5xfy2sqzqlss6sq2c7",
-            "x86_64-darwin": "92bc6bc82cbfe4c855e9b8c55cf48c32f0448553bb74defe8cc436da9588a73e",
-            "x86_64-linux": "487a667ca6a734b958c16cff1df74d9d44d2c18a6cccdb4dd51f6301a356c420"
+            "aarch64-darwin": "3ce55988c9998bcd1e9c69478dd26887b90e8f8010441172e520e94ba575e520",
+            "aarch64-linux": "d3bf612de0b651302fb46e50ed3282b609ea9d4d99bb296f7c9bb8ffd92fd69b",
+            "armv7l-linux": "83f9017f9a77bfdc8628b05237336c319da45f75974c37c68c82687a18106a92",
+            "headers": "1jim5dw909wzczdlcrajn03j4v8gsvq6zpk85nl3713b3rx0pjyz",
+            "x86_64-darwin": "0f141809eebe3f3f8c8f8377c10c93f21a39433f71526598de5e989f452cae29",
+            "x86_64-linux": "9a8194635548490a56099cc4c2b116738ae56834dee4472506d5a8b262bcbda4"
         },
-        "version": "42.3.0"
+        "version": "42.4.0"
     }
 }

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -45,14 +45,14 @@
     },
     "41": {
         "hashes": {
-            "aarch64-darwin": "a092f0c1aa722037fa07d3256d5bf4aef2833d990bf4d09fe907d588c35b341d",
-            "aarch64-linux": "8a8bc763406ad19954432922347ca7c3c8db130f966871687cfb8b4ddccfa28e",
-            "armv7l-linux": "895ecc3b61321699c24d3554272d116113c5dc2bf72df9b94ade87957cb8c9b3",
-            "headers": "1n1w2ngk44w9khbh4bnw6kfakawdxh3wii3hkynbjzj21swvqzrb",
-            "x86_64-darwin": "4e8ab5beb895c9fe29cd46090034b214e6b404868bf5e0a5f6eb92e5c8633cc4",
-            "x86_64-linux": "0165fc68656f49ad7ae0c4254b1ff3af1718c114b6007a2aeef5211e0562f174"
+            "aarch64-darwin": "f48986fa0d60b88eee78fd95c1a36e7fac9ab606c63fdabc28adec916b8f12d1",
+            "aarch64-linux": "d94b0231b05063e5cd959cda2bdb8ec7c94ab86f59698bfba4522343eb48d50e",
+            "armv7l-linux": "e3d04ffa4e020857a2a2554f7f5e41e746fa692c91c51575199473ddb264e551",
+            "headers": "0j9gvjjq9qdvjj33h2xh6qdxxr29aj96y2qs3p0xvy1bc3li9hzn",
+            "x86_64-darwin": "6b561462a94fd02837a525d0bca786a0b4345b61e2e3109c4bf13792235db90d",
+            "x86_64-linux": "a04bb66fd83c516c8b3adc5fb47f8307fe54704f5b1cd7c8ec9be8285d2989b3"
         },
-        "version": "41.7.1"
+        "version": "41.7.2"
     },
     "42": {
         "hashes": {

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -34,14 +34,14 @@
     },
     "40": {
         "hashes": {
-            "aarch64-darwin": "e889b35e399f374f5dca932195287b373c4b43f8bf242e50c35f88a751511a13",
-            "aarch64-linux": "b9725dd7a387960e778b66700836d178528ba2235c6b14135fb57ce4d3826257",
-            "armv7l-linux": "dd3bc8b27e905d7ac1f2d312b795e9f0f7491022aae5719ed5adf8ab4b203ef7",
+            "aarch64-darwin": "dfb6a853acdc547b6eedc97fa4a30693dba0bd310ab673e436b08b890772b529",
+            "aarch64-linux": "7a53169a16775f2b62f9434058c2c0e1cdf3f1718800b80712856f4766cf6043",
+            "armv7l-linux": "ef6ba9eb2e79721f7b1b9957fa71e55fcdbb9b6d1793daf61cd839f48cd1e86b",
             "headers": "0f9c09vk9kn3c7phw3dm8k1iaf8gw3g2s37r3qdycf9akirprpf2",
-            "x86_64-darwin": "5d171014187fb737f34c70b09ea886215e3d88a1b79cb5370a0815c34dd15668",
-            "x86_64-linux": "0246201400600ac089c51a36f15a8045b5db723ba42b864f732a9b4e48731e97"
+            "x86_64-darwin": "27a4e372ca19394fefedabbf4da0341cfb87c1fa9f5b9cf9b22e8cd8deb4f566",
+            "x86_64-linux": "d2593a23cc1c080b7333381579a65ecaf9628a70efbc466ddb545141257105a3"
         },
-        "version": "40.10.2"
+        "version": "40.10.3"
     },
     "41": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -56,13 +56,13 @@
     },
     "42": {
         "hashes": {
-            "aarch64-darwin": "caaf3fe945de448b908aec28eb2012eebd091dd7604d586ccba9d8dcde570564",
-            "aarch64-linux": "140bac763a2793c82782eef9c27272027a1aace5b02ad2dda99a1bb342063d35",
-            "armv7l-linux": "e4ddb1ff88404ca0c189a54466924eba6c67e0bd67aeeefe4f894ef09eff7423",
-            "headers": "1jh4r2ivgrgwq3bvw3a89lic97xmr9r37y5xfy2sqzqlss6sq2c7",
-            "x86_64-darwin": "c50daf833921ce7c9c4628d8fb8d9b294394cd4202a3dd4cd3a750dec6656ba9",
-            "x86_64-linux": "3c29fef7bf4873a57318fc25e77bc57bec1758e40ec8c56b4717f8dac2decc71"
+            "aarch64-darwin": "0ad0294171f61678036771f0a9e9de84b79a063d6781f166991d52d21d41a31f",
+            "aarch64-linux": "22fc9f5566d3a701965ae2cc77b0625644e827d67a80dfa86fbfd8076354a447",
+            "armv7l-linux": "b1ec1b8aec371b3b13303074739ddcd006a08060150f10a6c7a364c4b1bfd40c",
+            "headers": "1jim5dw909wzczdlcrajn03j4v8gsvq6zpk85nl3713b3rx0pjyz",
+            "x86_64-darwin": "2a736793968997a9f312156a7cb6575b23479ae4f23539d2b0fd1774589576eb",
+            "x86_64-linux": "09b69da1569f2d0bbf2015a976a314cefa212243cbfcfb32dcb82ef263c52942"
         },
-        "version": "42.3.0"
+        "version": "42.4.0"
     }
 }

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -45,14 +45,14 @@
     },
     "41": {
         "hashes": {
-            "aarch64-darwin": "adbc1b646cbd2cb6d9e9b6c71bab2caa7c00b05faaa699585f52decd0e89dfa8",
-            "aarch64-linux": "336f67cce0d702066c9d42fbc1221a2ab136193b85c5ca102dafc4050ebb3a02",
-            "armv7l-linux": "c7d42966f343703353e1b14a37ac7724f3661f6f11095f845149cafbf3e90941",
-            "headers": "1n1w2ngk44w9khbh4bnw6kfakawdxh3wii3hkynbjzj21swvqzrb",
-            "x86_64-darwin": "c01e23366b2e51b2c57669831cb57333cc78d6db94b8be500db3347c5425c0a1",
-            "x86_64-linux": "15abcca021cd649a03aa73c058cdbb3a32bf9cb882191c4930073458de496189"
+            "aarch64-darwin": "3b820eba3a2ec3805fa437e1d1557cd57634f22960a3232cdfdbadb197df0926",
+            "aarch64-linux": "187c6bd8dd6339c9f3558bd4f0dab5a71713da6fe7146e18160481045124d39e",
+            "armv7l-linux": "187df82834a49211c6cdf55f95c6eacfa94c83a95e84965a4cce8ba04075cd0b",
+            "headers": "0j9gvjjq9qdvjj33h2xh6qdxxr29aj96y2qs3p0xvy1bc3li9hzn",
+            "x86_64-darwin": "24a7018009ea46cc466f09504824379c430f8b4eb8f5cfc7f5235b81e1fa6def",
+            "x86_64-linux": "2af603975c4ee6bbd5332d49ec5bf2ded27db818db398b10a620f5ce0e719af7"
         },
-        "version": "41.7.1"
+        "version": "41.7.2"
     },
     "42": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -34,14 +34,14 @@
     },
     "40": {
         "hashes": {
-            "aarch64-darwin": "d54eec731e52b9daa25c80f8c5461928a5c8132e3af8f7dc9ecddde3e6da98d6",
-            "aarch64-linux": "f7cba7e899daae46e4dfaf292425dd61a97edfc6820d16d6ea6a600a8e968390",
-            "armv7l-linux": "a987bb7b31ed153ac304bc4dbcbfaa48139b60f3d33888ca1bbedb869dd74564",
+            "aarch64-darwin": "8f19ad2223292532b90e1ee4aa0f6f59e1cf0343055610bac3c0b0bdebc0dc1c",
+            "aarch64-linux": "6ce2b44eb560e5d305bef4c5886844ccd025d1edf0b7fe758a4fdf46beb8a0e3",
+            "armv7l-linux": "d2493fa2a16c3dddaccd7b846645ef5b3acd740fb0a206e5b54f9cbc8b288a31",
             "headers": "0f9c09vk9kn3c7phw3dm8k1iaf8gw3g2s37r3qdycf9akirprpf2",
-            "x86_64-darwin": "1928d63140157ede242d5111e2a5327abd01f2f9ae23e1a6bf1eb82a53029847",
-            "x86_64-linux": "e1dd0e162e248ca11aeca1485ccae8d813c7c7a6ef2959c42f1f8f486dad3963"
+            "x86_64-darwin": "9eb305ea485e72bd01d8d9d45e258a3b6708bb480caad048819141f420373c20",
+            "x86_64-linux": "494cd1ddfc0745032223a4995360ed5ab65ea1e2fe88612e1ae32398d13b3470"
         },
-        "version": "40.10.2"
+        "version": "40.10.3"
     },
     "41": {
         "hashes": {

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -1446,10 +1446,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-8I/3aDZgi5iIwujKnUQ/Uxx2VeFAuwvCPXgPl04HQdg=",
+                    "hash": "sha256-Bvm6S7otVUmGjRWOA53ua/7EdyIImHJMbDtVH3Xa4wo=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v41.7.1"
+                    "tag": "v41.7.2"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -2793,7 +2793,7 @@
         },
         "modules": "145",
         "node": "24.15.0",
-        "version": "41.7.1"
+        "version": "41.7.2"
     },
     "42": {
         "chrome": "148.0.7778.254",

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -2796,7 +2796,7 @@
         "version": "41.7.1"
     },
     "42": {
-        "chrome": "148.0.7778.180",
+        "chrome": "148.0.7778.254",
         "chromium": {
             "deps": {
                 "gn": {
@@ -2805,15 +2805,15 @@
                     "version": "0-unstable-2026-04-01"
                 }
             },
-            "version": "148.0.7778.180"
+            "version": "148.0.7778.254"
         },
         "chromium_npm_hash": "sha256-JuVcY8iFRDWcPcP4Pg+qm5rnTXkiVfNsqSkXbDWqsE8=",
         "deps": {
             "src": {
                 "args": {
-                    "hash": "sha256-Cjna6Z4uzdyuqZCacu01f1p2DoNl/x7NaZmU/NoiD3k=",
+                    "hash": "sha256-anHfDRQGlmW1CsH4T1KSLoGdoYvSBJBNBXebMxdXMHE=",
                     "postFetch": "rm -rf $(find $out/third_party/blink/web_tests ! -name BUILD.gn -mindepth 1 -maxdepth 1); rm -r $out/content/test/data; rm -rf $out/courgette/testdata; rm -r $out/extensions/test/data; rm -r $out/media/test/data; ",
-                    "tag": "148.0.7778.180",
+                    "tag": "148.0.7778.254",
                     "url": "https://chromium.googlesource.com/chromium/src.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -2852,10 +2852,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-HwfRacBv+em/gF+eEm+hAX+k/ZUBzj9DP30aPpydWXk=",
+                    "hash": "sha256-ce/7NTD85RlZtuuYNiuvECxtcLyPHNXAzWwHVdJEqP8=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v42.3.0"
+                    "tag": "v42.4.0"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -2885,8 +2885,8 @@
             },
             "src/third_party/angle": {
                 "args": {
-                    "hash": "sha256-HcfKm7UQmg3wMDOytmaYzm7Z7gRdOrRoqAKaE0ZdI4E=",
-                    "rev": "50fd896fb21cca91f325812d01d1e971593efc73",
+                    "hash": "sha256-P5KpTB/jaUR8MjrEccc1di5u9dvD/YiVw8/QlkdKZcE=",
+                    "rev": "007b92d82773d7a868a6dce85359232921903959",
                     "url": "https://chromium.googlesource.com/angle/angle.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -3085,8 +3085,8 @@
             },
             "src/third_party/dawn": {
                 "args": {
-                    "hash": "sha256-ihnVPCk9412UzCmoABWVUhiGaIdIYxiYMkk43KDqpg8=",
-                    "rev": "19696dd088b8ed5804e2f02a8f83f5afdb3e99e3",
+                    "hash": "sha256-LM5Z57mbH1u7XFnHF/p4fN/D9mO6504S0k8gqO6z3HI=",
+                    "rev": "c7de5291f0edba5398383d5592adcc78ba745bff",
                     "url": "https://dawn.googlesource.com/dawn.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -3165,8 +3165,8 @@
             },
             "src/third_party/devtools-frontend/src": {
                 "args": {
-                    "hash": "sha256-1pr3+RK519m+wtcacJB3PcDTL+qSHlOn1ctxpoLzTf8=",
-                    "rev": "6efd6eb1d85fd67fdcc2385c54fa56c524bec3f7",
+                    "hash": "sha256-S6agM7HMZ2g2W6e9tYdLSXr0Lc6zeQF9hAYLIeImAYQ=",
+                    "rev": "1fb83ff123c44ab59a480056c8c1ba3d33c2caf0",
                     "url": "https://chromium.googlesource.com/devtools/devtools-frontend"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -3205,10 +3205,10 @@
             },
             "src/third_party/electron_node": {
                 "args": {
-                    "hash": "sha256-Y4FP+AstENp1uTYBo8HeTRDwvKClTdrZ4RztLeHNP3k=",
+                    "hash": "sha256-LE2x6lkDk2r977zRRApdTTWId/vXql2uOob7aEsnncI=",
                     "owner": "nodejs",
                     "repo": "node",
-                    "tag": "v24.15.0"
+                    "tag": "v24.16.0"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -3303,8 +3303,8 @@
             },
             "src/third_party/freetype/src": {
                 "args": {
-                    "hash": "sha256-H5RzBFYWIp/QYKyeBM2wfuX7FvXHPbhCAp7qne5Zvhw=",
-                    "rev": "99b479dc34728936b006679a31e12b8cf432fc55",
+                    "hash": "sha256-A21ONLz8HxoBkOL/jHfs5YwePmOnFyNdlNYSJa9wers=",
+                    "rev": "6d9fc45fc4bca8aef0b8f65592520673638c3334",
                     "url": "https://chromium.googlesource.com/chromium/src/third_party/freetype2.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -3359,8 +3359,8 @@
             },
             "src/third_party/harfbuzz/src": {
                 "args": {
-                    "hash": "sha256-HWb3QbPl+RE2oI/Jwv5BjKwv9UnJ8VcJvk+uGy9cAqM=",
-                    "rev": "f027b8e9039f73bf803eae684fee2eb2d30e4180",
+                    "hash": "sha256-WCPEkbiiU8dENM+ik0KokW9Uxmz0xlsRFVVPPOEOZXw=",
+                    "rev": "67bb413f586f36ba44d740319cb7a28b3d283ea6",
                     "url": "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -3463,8 +3463,8 @@
             },
             "src/third_party/libaom/source/libaom": {
                 "args": {
-                    "hash": "sha256-LaBEcVcSB8WB9ZNRgPSiGaKdQL5f3wll2sPb9OhN5SE=",
-                    "rev": "b63f30b6d30028a3d7d9c5223def8f3ad97dcc4c",
+                    "hash": "sha256-H8Eu3BiUIiZcyReGDyFq9UvjdMJOX00ERjru8+I0zL8=",
+                    "rev": "343cee0a952f8c7d329e59ff3ac2c8bdbe70ec6a",
                     "url": "https://aomedia.googlesource.com/aom.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -3607,8 +3607,8 @@
             },
             "src/third_party/libyuv": {
                 "args": {
-                    "hash": "sha256-DW7PuRqA1x0K8/uJbxBJ4Cn9YEPFhZ9vhuGVVyGKK98=",
-                    "rev": "30809ff64a9ca5e45f86439c0d474c2d3eef3d05",
+                    "hash": "sha256-ZONwYhTD5/tPk5cm9Dmz59QB+rVxv1l/7lOhBOCMCf4=",
+                    "rev": "957f295ea946cbbd13fcfc46e7066f2efa801233",
                     "url": "https://chromium.googlesource.com/libyuv/libyuv.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -3744,8 +3744,8 @@
             },
             "src/third_party/pdfium": {
                 "args": {
-                    "hash": "sha256-qd3Oa/JFzoI5hKDY2/OQAzdr2z9srUj0H6oKz0R516U=",
-                    "rev": "a78c62d93a8f514ea2cd98a70bd1d21226be9d93",
+                    "hash": "sha256-0VgmDPyF5k81nBXdo88CcIIbz6XRhaiADnG8gwDGZZk=",
+                    "rev": "72ea487e4399c44c3a53a48b104f9612ca772008",
                     "url": "https://pdfium.googlesource.com/pdfium.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -3840,8 +3840,8 @@
             },
             "src/third_party/skia": {
                 "args": {
-                    "hash": "sha256-eOjFuMmXr9YtZ0e4yDB8JMjTrNWEg5OlTkAMGuHZIWE=",
-                    "rev": "a2888b27a98e4ff30085d4d2dba8a1a99baf6dfb",
+                    "hash": "sha256-3yGenYm9OO63FP53odWv6vfy0fOKsXNpygb4vT8HRQM=",
+                    "rev": "2ac66cfda097720cd8d3e481c45b68b4ba096ef7",
                     "url": "https://skia.googlesource.com/skia.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -4115,8 +4115,8 @@
             },
             "src/third_party/webrtc": {
                 "args": {
-                    "hash": "sha256-k5cHE4XURJQrPURmXk4MMNV5k8+ryKfjmsVTzARRro4=",
-                    "rev": "9a7f650bcd14f241d20f88f4e1ea3b7300de72ac",
+                    "hash": "sha256-n39HENOXmatsZLF6jdYRsb+wl2cM0i6ngT4Zbyu5ayE=",
+                    "rev": "e3ee86921c57b9f8921045e77f098604803cb66c",
                     "url": "https://webrtc.googlesource.com/src.git"
                 },
                 "fetcher": "fetchFromGitiles"
@@ -4155,15 +4155,15 @@
             },
             "src/v8": {
                 "args": {
-                    "hash": "sha256-+cQdsWTgIohd3yOCsNCprSr4Ctes77fWGdmPxN2tQlM=",
-                    "rev": "ad6e4525c418a92147c8247ef9d144ce4c242a38",
+                    "hash": "sha256-5wkfQsD5pWMAgsXSGTzMYwBADqJpWqSoJEfIyGYkAno=",
+                    "rev": "0b1a7b33935f88a225ca32de62a13478f329b625",
                     "url": "https://chromium.googlesource.com/v8/v8.git"
                 },
                 "fetcher": "fetchFromGitiles"
             }
         },
         "electron_yarn_data": {
-            "hash": "sha256-jNlIaaXY6CMDkmA+4a9HFJhHBOw0KkLhn16ysSYVyk8=",
+            "hash": "sha256-D3DtMWfDt8tg12J/AlrCjX6rYkMGMVqHgJQZ+qf+zrk=",
             "missing_hashes": {
                 "@oxfmt/binding-android-arm-eabi@npm:0.42.0": "42c08d87ce491086843070241f8777fa2cb968f4a08f67b3f6c33a8f67e0b3eac50eae146daede743e90e3bc32326951c5188814eea02e9c3e4a9764a4b492ba",
                 "@oxfmt/binding-android-arm64@npm:0.42.0": "73e6609498d05c655c6a435af9f3e4f341137c260c7ae27fbb0377573574ca5200bd9f187aa90d442879733bbd0c4e91ae023c3b4579c9a57413a0b2922c023a",
@@ -4206,7 +4206,7 @@
             }
         },
         "modules": "146",
-        "node": "24.15.0",
-        "version": "42.3.0"
+        "node": "24.16.0",
+        "version": "42.4.0"
     }
 }

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -56,10 +56,10 @@
             },
             "src/electron": {
                 "args": {
-                    "hash": "sha256-zpM+4Jok6FGaSKH4JxHKf9xrWNbdEVUBvgvd3Q9JnlU=",
+                    "hash": "sha256-fLk+Vs7u/mZFb4mLmytRPez4Fur5e0QugmuD58fulIs=",
                     "owner": "electron",
                     "repo": "electron",
-                    "tag": "v40.10.2"
+                    "tag": "v40.10.3"
                 },
                 "fetcher": "fetchFromGitHub"
             },
@@ -1387,7 +1387,7 @@
         },
         "modules": "143",
         "node": "24.15.0",
-        "version": "40.10.2"
+        "version": "40.10.3"
     },
     "41": {
         "chrome": "146.0.7680.216",


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Manual backport of #529205. Merge conflict is caused by yarn-berry version difference on master vs. 25.11, which generate different hashes for lockfiles.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
