### PR TITLE
musescore: 4.7.2 -> 4.7.3

### DIFF
--- a/pkgs/by-name/mu/musescore/package.nix
+++ b/pkgs/by-name/mu/musescore/package.nix
@@ -55,13 +55,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "musescore";
-  version = "4.7.2";
+  version = "4.7.3";
 
   src = fetchFromGitHub {
     owner = "musescore";
     repo = "MuseScore";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7oA+cC5/nOEM2zpFgM13zlBIoc3AB//Ovc+dU1c1r6M=";
+    hash = "sha256-wWqFJkXLRi3JtnEW3STTG/jBBIQK1dIYPZdKCiBn0m0=";
   };
 
   cmakeFlags = [

--- a/pkgs/by-name/mu/musescore/package.nix
+++ b/pkgs/by-name/mu/musescore/package.nix
@@ -16,7 +16,7 @@
   ffmpeg,
   flac,
   freetype,
-  kdePackages,
+  qt6,
   lame,
   libjack2,
   libogg,
@@ -36,36 +36,7 @@
 }:
 
 let
-  # TODO(@doronbehar): Contribute this one day to lib/? See:
-  # https://discourse.nixos.org/t/rfc-nix-function-that-overrides-a-scope-with-automatic-inheritance-propagation/78025
-  overrideScopeFully =
-    s: scopeOverrideFunc:
-    let
-      partiallyOverriddenScope = s.overrideScope scopeOverrideFunc;
-      directlyOverriddenAttrs = builtins.attrNames (scopeOverrideFunc partiallyOverriddenScope s);
-    in
-    builtins.mapAttrs (
-      attrName: pkg:
-      pkg.override (
-        lib.pipe directlyOverriddenAttrs [
-          (builtins.filter (
-            oAttr:
-            # Don't include in this filter the attribute `attrName` from the
-            # full scope, if it is already part of the _directly_ overridden
-            # attributes.
-            !(builtins.elem attrName directlyOverriddenAttrs)
-            && pkg ? override
-            # Continue with the creation of the `.override` arguments only for
-            # overridden attributes (`oAttr`) which are possible arguments to the
-            # `.override` function of the `pkg` at hand.
-            && pkg.override.__functionArgs ? ${oAttr}
-          ))
-          # Generate the `.override` argument using the attribute names `aNames`
-          (aNames: lib.genAttrs aNames (oAttr: partiallyOverriddenScope.${oAttr}))
-        ]
-      )
-    ) partiallyOverriddenScope;
-  kdePackages' = overrideScopeFully kdePackages (
+  qt6' = qt6.overrideScope (
     self: super: {
       # Fix for: https://github.com/NixOS/nixpkgs/issues/526825
       # reported upstream at: https://github.com/musescore/MuseScore/issues/33015
@@ -143,8 +114,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    kdePackages'.qttools
-    kdePackages'.wrapQtAppsHook
+    qt6'.qttools
+    qt6'.wrapQtAppsHook
     ninja
     pkg-config
   ]
@@ -157,12 +128,12 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     flac
     freetype
-    kdePackages'.qt5compat
-    kdePackages'.qtbase
-    kdePackages'.qtdeclarative
-    kdePackages'.qtnetworkauth
-    kdePackages'.qtscxml
-    kdePackages'.qtsvg
+    qt6'.qt5compat
+    qt6'.qtbase
+    qt6'.qtdeclarative
+    qt6'.qtnetworkauth
+    qt6'.qtscxml
+    qt6'.qtsvg
     lame
     libjack2
     libogg
@@ -179,7 +150,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     alsa-lib
-    kdePackages'.qtwayland
+    qt6'.qtwayland
   ];
 
   # Put the default, `$prefix/lib` directory to look for ffmpeg shared objects,


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test