### PR TITLE
nixpkgs manual: document version testing of the current package with finalAttrs

### DIFF
--- a/doc/build-helpers/testers.chapter.md
+++ b/doc/build-helpers/testers.chapter.md
@@ -308,6 +308,26 @@ A common usage of the `version` attribute is to specify `version = "v${version}"
 
 :::
 
+:::{.example #ex-testversion-finalAttrs}
+
+# Check a program in its own derivation with `finalAttrs`
+
+In a package.nix, the current package can be referenced using [the `finalAttrs` pattern](#mkderivation-recursive-attributes):
+
+```nix
+{
+  stdenv,
+  # ...
+}:
+stdenv.mkDerivation (finalAttrs: {
+  #...
+  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
+  #...
+})
+```
+
+:::
+
 ## `testBuildFailure` {#tester-testBuildFailure}
 
 Make sure that a build does not succeed. This is useful for testing testers.

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -2255,6 +2255,9 @@
   "ex-testversion-hello": [
     "index.html#ex-testversion-hello"
   ],
+  "ex-testversion-finalAttrs": [
+    "index.html#ex-testversion-finalAttrs"
+  ],
   "ex-testversion-different-commandversion": [
     "index.html#ex-testversion-different-commandversion"
   ],


### PR DESCRIPTION



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add a bit of documentation when you want to self reference the current package. I encountered this case while using `testVersion`, and found it non trivial that the final package is exposed that way. I propose to document it there, because it's imo the most common case of `testVersion` usage.


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
