### PR TITLE
kip: init at 0.15.0

### DIFF
--- a/pkgs/by-name/ki/kip/package.nix
+++ b/pkgs/by-name/ki/kip/package.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  arpa2cm,
+  arpa2common,
+  bison,
+  cacert,
+  cmake,
+  cyrus_sasl,
+  e2fsprogs,
+  flex,
+  freediameter,
+  gnutls,
+  json_c,
+  libev,
+  libkrb5,
+  libressl,
+  openssl,
+  pkg-config,
+  python3,
+  quick-sasl,
+  quickder,
+  quickmem,
+  unbound,
+  nix-update-script,
+}:
+let
+  python-with-packages = python3.withPackages (
+    ps: with ps; [
+      asn1ate
+      colored
+      pyparsing
+      setuptools
+      six
+    ]
+  );
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "kip";
+  version = "0.15.0";
+
+  src = fetchFromGitLab {
+    owner = "arpa2";
+    repo = "kip";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-A+tPaImjd9j1Vq69Dgh3j86xI/OcovwTZSULLkOVZaI=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    bison
+    cacert
+    cmake
+    cyrus_sasl
+    flex
+    libkrb5
+    openssl
+    pkg-config
+  ];
+
+  buildInputs = [
+    arpa2cm
+    arpa2common
+    cyrus_sasl
+    e2fsprogs
+    freediameter
+    gnutls
+    json_c
+    libev
+    libkrb5
+    libressl
+    python-with-packages
+    quick-sasl
+    quickder
+    quickmem
+    unbound
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "freeDiameter_EXTENSION_DIR" "${placeholder "out"}/lib/freeDiameter")
+  ];
+
+  preBuild = ''
+    patchShebangs test
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Keyful Identity Protocol — symmetric-key encryption and signing via an online KIP Service";
+    homepage = "https://gitlab.com/arpa2/kip";
+    license = lib.licenses.bsd2;
+    teams = with lib.teams; [ ngi ];
+  };
+})


### PR DESCRIPTION
Migrated from NGIpkgs.

closes https://github.com/ngi-nix/projects/issues/1066

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
