### PR TITLE
python3Packages.matplotlib: 3.10.9 -> 3.11.0

### DIFF
--- a/pkgs/by-name/fr/freetype/package.nix
+++ b/pkgs/by-name/fr/freetype/package.nix
@@ -41,14 +41,10 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "freetype";
   version = "2.14.3";
 
-  src =
-    let
-      inherit (finalAttrs) pname version;
-    in
-    fetchurl {
-      url = "mirror://savannah/freetype/freetype-${version}.tar.xz";
-      sha256 = "sha256-NrxPHMQTM1No7mVsQq/KZcWjmH6HaMwozxG6d154Wl8=";
-    };
+  src = fetchurl {
+    url = "mirror://savannah/freetype/freetype-${finalAttrs.version}.tar.xz";
+    hash = "sha256-NrxPHMQTM1No7mVsQq/KZcWjmH6HaMwozxG6d154Wl8=";
+  };
 
   propagatedBuildInputs = [
     zlib

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -75,13 +75,13 @@ let
   interactive = enableTk || enableGtk3 || enableQt;
 in
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   version = "3.10.9";
   pname = "matplotlib";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-/WZQjoxod9mOWGZUtgigRW241+ilRuseJgDv2VcwI1g=";
   };
 
@@ -199,7 +199,7 @@ buildPythonPackage rec {
   meta = {
     description = "Python plotting library, making publication quality plots";
     homepage = "https://matplotlib.org/";
-    changelog = "https://github.com/matplotlib/matplotlib/releases/tag/v${version}";
+    changelog = "https://github.com/matplotlib/matplotlib/releases/tag/v${finalAttrs.version}";
     license = with lib.licenses; [
       psfl
       bsd0
@@ -209,4 +209,4 @@ buildPythonPackage rec {
       doronbehar
     ];
   };
-}
+})

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -19,13 +19,8 @@
   # native libraries
   ffmpeg-headless,
   freetype,
-  # By default, almost all tests fail due to the fact we use our version of
-  # freetype. We still use this argument to define the overridden
-  # derivation `matplotlib.passthru.tests.withoutOutdatedFreetype` - which
-  # builds matplotlib with the freetype version they default to, with which all
-  # tests should pass.
-  doCheck ? false,
   qhull,
+  libraqm,
 
   # propagates
   contourpy,
@@ -76,13 +71,13 @@ let
 in
 
 buildPythonPackage (finalAttrs: {
-  version = "3.10.9";
+  version = "3.11.0";
   pname = "matplotlib";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-/WZQjoxod9mOWGZUtgigRW241+ilRuseJgDv2VcwI1g=";
+    hash = "sha256-aMDHvgGzDcyjY4k09/WR33NAEjXL2/DRqxxx59t/i1c=";
   };
 
   env.XDG_RUNTIME_DIR = "/tmp";
@@ -99,10 +94,6 @@ buildPythonPackage (finalAttrs: {
         --replace-fail "/usr/bin/env python3" "/usr/bin/env pypy3"
     ''
     + ''
-      substituteInPlace pyproject.toml \
-        --replace-fail "meson-python>=0.13.1,<0.17.0" meson-python \
-        --replace-fail "setuptools_scm>=7,<10" setuptools_scm
-
       patchShebangs tools
     ''
     + lib.optionalString (stdenv.hostPlatform.isLinux && interactive) ''
@@ -118,6 +109,7 @@ buildPythonPackage (finalAttrs: {
     ffmpeg-headless
     freetype
     qhull
+    libraqm
   ]
   ++ lib.optionals enableGtk3 [
     cairo
@@ -159,6 +151,7 @@ buildPythonPackage (finalAttrs: {
   mesonFlags = lib.mapAttrsToList lib.mesonBool {
     system-freetype = true;
     system-qhull = true;
+    system-libraqm = true;
     # Otherwise GNU's `ar` binary fails to put symbols from libagg into the
     # matplotlib shared objects. See:
     # -https://github.com/matplotlib/matplotlib/issues/28260#issuecomment-2146243663
@@ -168,20 +161,14 @@ buildPythonPackage (finalAttrs: {
 
   passthru.tests = {
     inherit sage;
-    withOutdatedFreetype = matplotlib.override {
-      doCheck = true;
-      freetype = freetype.overrideAttrs (_: {
-        src = fetchurl {
-          url = "mirror://savannah/freetype/freetype-old/freetype-2.6.1.tar.gz";
-          hash = "sha256-Cjx9+9ptoej84pIy6OltmHq6u79x68jHVlnkEyw2cBQ=";
-        };
-        patches = [ ];
-      });
-    };
   };
 
   pythonImportsCheck = [ "matplotlib" ];
-  inherit doCheck;
+  # Running the tests requires a specific freetype version, so pixel-to-pixel
+  # comparisons will pass. Since matplotlib depends directly & indirectly on
+  # freetype, this would be too expensive to even test this (correctly) in
+  # `passthru.tests`.
+  doCheck = false;
   nativeCheckInputs = [ pytestCheckHook ];
   preCheck = ''
     # https://matplotlib.org/devdocs/devel/testing.html#obtain-the-reference-images

--- a/pkgs/development/python-modules/matplotlib/default.nix
+++ b/pkgs/development/python-modules/matplotlib/default.nix
@@ -206,6 +206,7 @@ buildPythonPackage rec {
     ];
     maintainers = with lib.maintainers; [
       veprbl
+      doronbehar
     ];
   };
 }


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test