### PR TITLE
transmission_4-gtk: bump build dep GTK3→GTK4

### DIFF
--- a/pkgs/by-name/tr/transmission_4-gtk/package.nix
+++ b/pkgs/by-name/tr/transmission_4-gtk/package.nix
@@ -1,3 +1,3 @@
 { transmission_4 }:
 
-transmission_4.override { enableGTK3 = true; }
+transmission_4.override { enableGTK4 = true; }

--- a/pkgs/by-name/tr/transmission_4/package.nix
+++ b/pkgs/by-name/tr/transmission_4/package.nix
@@ -24,11 +24,11 @@
   dht,
   libnatpmp,
   # Build options
-  enableGTK3 ? false,
-  gtkmm3,
+  enableGTK4 ? false,
+  gtkmm4,
   libpthread-stubs,
   libayatana-appindicator,
-  wrapGAppsHook3,
+  wrapGAppsHook4,
   enableQt5 ? false,
   enableQt6 ? false,
   enableMac ? false,
@@ -98,7 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (cmakeBool "ENABLE_CLI" enableCli)
     (cmakeBool "ENABLE_DAEMON" enableDaemon)
-    (cmakeBool "ENABLE_GTK" enableGTK3)
+    (cmakeBool "ENABLE_GTK" enableGTK4)
     (cmakeBool "ENABLE_MAC" enableMac)
     (cmakeBool "ENABLE_QT" (enableQt5 || enableQt6))
     (cmakeBool "INSTALL_LIB" installLib)
@@ -144,7 +144,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     python3
   ]
-  ++ optionals enableGTK3 [ wrapGAppsHook3 ]
+  ++ optionals enableGTK4 [ wrapGAppsHook4 ]
   ++ optionals enableQt5 [ qt5.wrapQtAppsHook ]
   ++ optionals enableQt6 [ qt6Packages.wrapQtAppsHook ]
   ++ optionals enableMac [
@@ -186,8 +186,8 @@ stdenv.mkDerivation (finalAttrs: {
       qtsvg
     ]
   )
-  ++ optionals enableGTK3 [
-    gtkmm3
+  ++ optionals enableGTK4 [
+    gtkmm4
     libpthread-stubs
     libayatana-appindicator
   ]
@@ -232,7 +232,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram =
       if (enableQt5 || enableQt6) then
         "transmission-qt"
-      else if enableGTK3 then
+      else if enableGTK4 then
         "transmission-gtk"
       else if enableMac then
         "transmission-mac"


### PR DESCRIPTION
Bonjour !

I noticed that Transmission [supported GTK4](https://github.com/transmission/transmission/blob/4.1.2/docs/Building-Transmission.md#building-the-gtk-app-with-cmake) as well, and unlike the GTK3 variant (See #529356), it builds and runs without issues at the moment.

Fixes: #529356
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


