### PR TITLE
clipqr: 1.3.0 -> 1.4.0

### DIFF
--- a/pkgs/by-name/cl/clipqr/package.nix
+++ b/pkgs/by-name/cl/clipqr/package.nix
@@ -4,31 +4,37 @@
   fetchFromGitLab,
   lib,
   libGL,
+  libdecor,
+  libgbm,
   libx11,
   libxcursor,
   libxext,
   libxi,
   libxinerama,
+  libxkbcommon,
   libxrandr,
   libxxf86vm,
   makeDesktopItem,
-  libgbm,
+  makeWrapper,
   pkg-config,
-  stdenv,
+  wayland,
+  wl-clipboard,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "clipqr";
-  version = "1.3.0";
+  version = "1.4.0";
 
   src = fetchFromGitLab {
     owner = "imatt-foss";
     repo = "clipqr";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-iuA6RqclMm1CWaiM1kpOpgfYvKaYGOIwFQkLr/nCL5M=";
+    hash = "sha256-DC6zc1Qe/z7ihuvdawb8bj5MefYGgt7HAV5dWTjeHZc=";
   };
 
-  vendorHash = null;
+  vendorHash = "sha256-MrXMbavff6CEKVbL+Mx8hICYB9sZQcvAhnu2X4sVvVw=";
+
+  tags = [ "wayland" ];
 
   ldflags = [
     "-s"
@@ -37,23 +43,30 @@ buildGoModule (finalAttrs: {
 
   buildInputs = [
     libGL
+    libgbm
     libx11
     libxcursor
     libxext
     libxi
     libxinerama
+    libxkbcommon
     libxrandr
     libxxf86vm
-    libgbm
+    wayland
   ];
 
   nativeBuildInputs = [
     copyDesktopItems
+    makeWrapper
     pkg-config
   ];
 
   postInstall = ''
     install -Dm644 icon.svg $out/share/icons/hicolor/scalable/apps/clipqr.svg
+
+    wrapProgram $out/bin/clipqr \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libdecor ]} \
+      --prefix PATH : ${lib.makeBinPath [ wl-clipboard ]}
   '';
 
   desktopItems = [
@@ -73,7 +86,7 @@ buildGoModule (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ MatthieuBarthel ];
     homepage = "https://gitlab.com/imatt-foss/clipqr";
-    broken = stdenv.hostPlatform.isDarwin;
+    platforms = lib.platforms.linux;
     mainProgram = "clipqr";
   };
 })


### PR DESCRIPTION
https://gitlab.com/imatt-foss/clipqr/-/blob/master/CHANGELOG.md?ref_type=heads

## Things done

App is now wayland native and requires wl-clipboard at runtime.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
