### PR TITLE
ocamlPackages.aeneas: init at 2026.06.12

### DIFF
--- a/pkgs/development/ocaml-modules/aeneas/default.nix
+++ b/pkgs/development/ocaml-modules/aeneas/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  buildDunePackage,
+  fetchFromGitHub,
+
+  # propagatedBuildInputs,
+  charon,
+  core_unix,
+  domainslib,
+  ocamlgraph,
+  progress,
+  visitors,
+
+  nix-update-script,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "aeneas";
+  version = "2026.06.12";
+  __structuredAttrs = true;
+
+  minimalOCamlVersion = "5.1";
+
+  src = fetchFromGitHub {
+    owner = "AeneasVerif";
+    repo = "aeneas";
+    tag = "nightly-${finalAttrs.version}";
+    hash = "sha256-loTnCy4lNJki+dSShZ35jKyOWIh1XcPwN7oY7CyFa04=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/src";
+
+  propagatedBuildInputs = [
+    charon
+    core_unix
+    domainslib
+    ocamlgraph
+    progress
+    visitors
+  ];
+
+  # The test suite consists of heavy integration tests that require the full
+  # toolchain (Rust, charon and the F*/Coq/Lean backends), so it is not run here.
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=unstable" ];
+  };
+
+  meta = {
+    description = "Verification toolchain for Rust programs";
+    homepage = "https://github.com/AeneasVerif/aeneas";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    mainProgram = "aeneas";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/ocaml-modules/charon/default.nix
+++ b/pkgs/development/ocaml-modules/charon/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildDunePackage,
+  fetchFromGitHub,
+
+  # propagatedBuildInputs,
+  easy_logging,
+  name_matcher_parser,
+  ppx_deriving,
+  unionFind,
+  visitors,
+  yojson,
+
+  nix-update-script,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "charon";
+  version = "2026.06.12";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "AeneasVerif";
+    repo = "charon";
+    tag = "nightly-${finalAttrs.version}";
+    hash = "sha256-XCNDFJ8HakRBQ68rWB29R5RF7zhmqmNMna098SvXDE0=";
+  };
+
+  propagatedBuildInputs = [
+    easy_logging
+    name_matcher_parser
+    ppx_deriving
+    unionFind
+    visitors
+    yojson
+  ];
+
+  # The charon-ml test suite requires pre-generated `.llbc` fixtures produced by
+  # running the (Rust) charon binary, which are not part of the OCaml source
+  # distribution, so the tests cannot run here.
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=unstable" ];
+  };
+
+  meta = {
+    description = "Analyze Rust crates without touching compiler internals";
+    homepage = "https://github.com/AeneasVerif/charon";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/ocaml-modules/easy_logging/default.nix
+++ b/pkgs/development/ocaml-modules/easy_logging/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildDunePackage,
+  fetchFromGitHub,
+
+  # propagatedBuildInputs,
+  calendar,
+
+  nix-update-script,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "easy_logging";
+  version = "0.8.2";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "sapristi";
+    repo = "easy_logging";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Xy6Rfef7r2K8DTok7AYa/9m3ZEV07LlUeMQSRayLBco=";
+  };
+
+  propagatedBuildInputs = [
+    calendar
+  ];
+
+  doCheck = true;
+  # Only run the tests for the `easy_logging` package itself.
+  # The other directories belong to the separate `easy_logging_yojson` package, which is not built
+  # here and pulls in additional dependencies.
+  checkPhase = ''
+    runHook preCheck
+
+    dune runtest easy_logging ''${enableParallelBuilding:+-j $NIX_BUILD_CORES}
+
+    runHook postCheck
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Logging module for OCaml";
+    homepage = "https://github.com/sapristi/easy_logging";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/ocaml-modules/name_matcher_parser/default.nix
+++ b/pkgs/development/ocaml-modules/name_matcher_parser/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildDunePackage,
+  charon,
+
+  # nativeBuildInputs,
+  menhir,
+
+  # propagatedBuildInputs,
+  menhirLib,
+  ppx_deriving,
+  visitors,
+  zarith,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "name_matcher_parser";
+  inherit (charon) version;
+  __structuredAttrs = true;
+
+  inherit (charon) src;
+
+  nativeBuildInputs = [ menhir ];
+
+  propagatedBuildInputs = [
+    menhirLib
+    ppx_deriving
+    visitors
+    zarith
+  ];
+
+  # No test suite is defined for this package.
+  doCheck = false;
+
+  meta = {
+    description = "Parser to define name matchers";
+    homepage = "https://github.com/AeneasVerif/charon";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -247,6 +247,8 @@ let
 
         checkseum = callPackage ../development/ocaml-modules/checkseum { };
 
+        charon = callPackage ../development/ocaml-modules/charon { };
+
         chrome-trace = callPackage ../development/ocaml-modules/chrome-trace { };
 
         cil = callPackage ../development/ocaml-modules/cil { };
@@ -1422,6 +1424,8 @@ let
         mustache = callPackage ../development/ocaml-modules/mustache { };
 
         ### N ###
+
+        name_matcher_parser = callPackage ../development/ocaml-modules/name_matcher_parser { };
 
         nbd = pkgs.libnbd.override {
           ocamlPackages = self;

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -541,6 +541,8 @@ let
 
         easy-format = callPackage ../development/ocaml-modules/easy-format { };
 
+        easy_logging = callPackage ../development/ocaml-modules/easy_logging { };
+
         eigen = callPackage ../development/ocaml-modules/eigen {
           stdenv = pkgs.gcc14Stdenv;
         };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -22,6 +22,8 @@ let
 
         afl-persistent = callPackage ../development/ocaml-modules/afl-persistent { };
 
+        aeneas = callPackage ../development/ocaml-modules/aeneas { };
+
         alcotest = callPackage ../development/ocaml-modules/alcotest { };
 
         alcotest-lwt = callPackage ../development/ocaml-modules/alcotest/lwt.nix { };


### PR DESCRIPTION
## Things done

Add [aeneas](https://github.com/AeneasVerif/aeneas), a verification toolchain for Rust programs.

- **ocamlPackages.easy_logging: init at 0.8.2**
- **ocamlPackages.charon: init at 2026.06.12**
- **ocamlPackages.aeneas: init at 2026.06.12**

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
