### PR TITLE
rustical: 0.12.15 -> 0.13.1

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -24,6 +24,8 @@
 
 - Support for the legacy U‐Boot image format has been removed from the initrd generators, as it is deprecated upstream and no longer used by any platform in Nixpkgs.
 
+- Rustical migrates from `settings.http.host` and `settings.http.port` to `settings.http.bind` to support UNIX domain sockets as well as TCP sockets in one setting.
+
 - `services.llama-cpp` is now configured using structured `services.llama-cpp.settings` attribute.
 
 - Python 2 has been removed from the top-level package set, as it is long past end-of-life. The `python2`, `python27`, `python2Full`, `python27Full`, `python2Packages`, and `python27Packages` attributes, along with the legacy `python`, `pythonFull`, and `pythonPackages` aliases, now throw an error directing you to `python3`. The `isPy2` and `isPy27` package flags have been removed accordingly. The only remaining Python 2 interpreter is vendored inside the `resholve` package for its `oil` dependency and is not exposed for general use.

--- a/nixos/modules/services/web-apps/rustical.nix
+++ b/nixos/modules/services/web-apps/rustical.nix
@@ -55,26 +55,18 @@ in
           };
 
           http = {
-            host = mkOption {
+            bind = mkOption {
               type = types.str;
-              default = "[::1]";
-              example = "[::]";
+              default = "unix:/run/rustical/sock";
+              example = "[::]:4000";
               description = ''
-                Host address to bind the HTTP service to.
+                Address and port or UNIX socket path to bind the HTTP service to.
 
                 :::{.note}
                 Rustical expects to be hosted behind a reverse proxy that
                 provides HTTPS. Without HTTPS, the web frontend and some clients
                 (e.g. Apple Calendar) may not work.
                 :::
-              '';
-            };
-
-            port = mkOption {
-              type = types.port;
-              default = 4000;
-              description = ''
-                Port to bind the HTTP service to.
               '';
             };
           };
@@ -126,6 +118,19 @@ in
   };
 
   config = mkIf cfg.enable {
+    warnings = lib.optionals (cfg.settings.http ? host || cfg.settings.http ? port) [
+      ''
+        Rustical 0.13 deprecations
+
+        The following options are now deprecated and will be removed in a
+        future release:
+        - `services.rustical.settings.http.host`
+        - `services.rustical.settings.http.port`
+
+        Migrate to `services.rustical.settings.http.bind` instead.
+      ''
+    ];
+
     # install the config at a path where the cli will find it
     environment.etc."rustical/config.toml".source = configFile;
 

--- a/nixos/tests/web-apps/rustical.nix
+++ b/nixos/tests/web-apps/rustical.nix
@@ -13,7 +13,7 @@ in
 
   meta.maintainers = pkgs.rustical.meta.maintainers;
 
-  nodes.machine =
+  containers.machine =
     {
       pkgs,
       ...
@@ -28,7 +28,7 @@ in
 
   testScript =
     {
-      nodes,
+      containers,
       ...
     }:
     let

--- a/nixos/tests/web-apps/rustical.nix
+++ b/nixos/tests/web-apps/rustical.nix
@@ -3,6 +3,11 @@
   lib,
   ...
 }:
+
+let
+  port = "4000";
+in
+
 {
   name = "rustical";
 
@@ -14,7 +19,10 @@
       ...
     }:
     {
-      services.rustical.enable = true;
+      services.rustical = {
+        enable = true;
+        settings.http.bind = "[::]:${port}";
+      };
       environment.systemPackages = with pkgs; [ calendar-cli ];
     };
 
@@ -24,7 +32,6 @@
       ...
     }:
     let
-      port = toString nodes.machine.services.rustical.settings.http.port;
       url = "http://localhost:${toString port}";
 
       createPrincipalScript = pkgs.writeScript "rustical-create-principal" ''

--- a/pkgs/by-name/ru/rustical/package.nix
+++ b/pkgs/by-name/ru/rustical/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rustical";
-  version = "0.12.15";
+  version = "0.13.1";
 
   src = fetchFromGitHub {
     owner = "lennart-k";
     repo = "rustical";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ll7CFxYpzseYstBLe60VhYgvCYtobWeZ9/trBPTCSMg=";
+    hash = "sha256-DNwxQq2QKPQ6gzIxBJUhdMNbmHNYnt+MSFJ28PLzunQ=";
   };
 
-  cargoHash = "sha256-eqY5xzlPOlGSqqegTWTHeLR+YJb9l52Ku2yGVfflQkk=";
+  cargoHash = "sha256-bIbDohCkSlV7uBi+lyylLE/gSqjzlp+xwxQRS9zBiio=";
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
https://github.com/lennart-k/rustical/releases/tag/v0.12.16
https://github.com/lennart-k/rustical/releases/tag/v0.12.17
https://github.com/lennart-k/rustical/releases/tag/v0.13.0
https://github.com/lennart-k/rustical/releases/tag/v0.13.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
