### PR TITLE
Revert "litestar: 2.21.1 -> 2.23.0"

### DIFF
--- a/pkgs/development/python-modules/litestar/default.nix
+++ b/pkgs/development/python-modules/litestar/default.nix
@@ -60,14 +60,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "litestar";
-  version = "2.23.0";
+  version = "2.21.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "litestar-org";
     repo = "litestar";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-EKCQQElL4pq5Li52RUP68UKJQ+NyuCdEh7zz15ugP2s=";
+    hash = "sha256-dH51GecYwVTnOO+F1FJnFR2VO3IvLbpKWbxK7jssak8=";
   };
 
   build-system = [ hatchling ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#526578

broke `python3Packages.cross-web` and therefore `netbox` in combination with a update of `cross-web`. As the package is primarily used for this dependency chain, I think reverting is the best option.