### PR TITLE
nixos/systemd-boot: defer boot file garbage collection

### DIFF
--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -567,14 +567,16 @@ def install_bootloader(args: argparse.Namespace) -> None:
                 default_entry_id = new_bootctl_id
                 critical_paths.update(bf.path for bf in new_boot_files)
 
-    # Garbage-collect stale kernels/initrds/entries before re-populating extra
-    # files, so that user-supplied extraEntries (which may also live under
-    # loader/entries and start with `nixos-`) are not removed again.
-    garbage_collect(boot_files)
-
     write_boot_files(boot_files, critical_paths)
 
     write_loader_conf(default_entry_id)
+
+    # Garbage-collect stale kernels/initrds/entries only after the new boot
+    # files and loader configuration are in place. Keep this before
+    # re-populating extra files so that user-supplied extraEntries (which may
+    # also live under loader/entries and start with `nixos-`) are not removed
+    # again.
+    garbage_collect(boot_files)
 
     remove_extra_files()
     run([COPY_EXTRA_FILES])


### PR DESCRIPTION
## Summary

Mitigates #418157.

`systemd-boot-builder.py` currently garbage-collects stale NixOS kernels, initrds, and boot entries before writing the new boot files. If writing or fsyncing a new file fails partway through the update, the old boot files may already be gone, which matches the corruption pattern described in the issue.

This moves garbage collection until after `write_boot_files()` and `write_loader_conf()` have completed, while still keeping GC before extra files are re-populated so `extraEntries` are not removed again.

This does not diagnose the underlying block-device `EIO`, but it should make that failure mode less destructive.

## Things done

- [x] Tested the change locally
- [ ] Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S before and after`)
- [ ] Ensured that relevant documentation is up to date
- [ ] Fits CONTRIBUTING.md

Local checks run without Nix installed on this machine:

- `git diff --check`
- Static call-order check: `write_boot_files` -> `write_loader_conf` -> `garbage_collect` -> `remove_extra_files`
- `uv run --python 3.12 python -c "ast.parse(...)"` on `systemd-boot-builder.py`

Written by an agent for Federicorao (GPT-5).
