### PR TITLE
[25.11] redis: 8.6.3 -> 8.6.4

### DIFF
--- a/pkgs/by-name/re/redis/package.nix
+++ b/pkgs/by-name/re/redis/package.nix
@@ -27,13 +27,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "redis";
-  version = "8.6.3";
+  version = "8.6.4";
 
   src = fetchFromGitHub {
     owner = "redis";
     repo = "redis";
     tag = finalAttrs.version;
-    hash = "sha256-Zg2bghU4uExwI1SWplYIGCeGRhgRxdh3Oy9k1DZPado=";
+    hash = "sha256-w8LOcWTe0AT1qYrNDN3OAzQz8v3Im4/TzJok1CFMdiY=";
   };
 
   patches = lib.optional useSystemJemalloc (fetchpatch2 {
@@ -41,13 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-A9qp+PWQRuNy/xmv9KLM7/XAyL7Tzkyn0scpVCGngcc=";
   });
 
-  postPatch = ''
-    # Using `yes` seems to be an invalid value and causes the test to fail. See
-    # https://github.com/redis/redis/blob/bd3b38d41070b478c58bc8b72d2af89cbccd1a40/redis.conf#L674-L688
-    substituteInPlace tests/integration/replication.tcl \
-      --replace-fail 'repl-diskless-load yes' ' repl-diskless-load on-empty-db'
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
     # The path `/Library/...` isn't available in the build sandbox. The package `apple-sdk`
     # can provide that functionality for us.
     substituteInPlace src/modules/Makefile modules/vector-sets/Makefile tests/modules/Makefile \


### PR DESCRIPTION
changelog: https://github.com/redis/redis/releases/tag/8.6.4
diff: https://github.com/redis/redis/compare/8.6.3...8.6.4

Not a cherry-pick since master is already on `8.8.0`.

<details>
<summary>nixpkgs-review-gha</summary>

## `nixpkgs-review` result

Generated using [`nixpkgs-review-gha`](https://github.com/Defelo/nixpkgs-review-gha)

Command: `nixpkgs-review pr 531015`
Commit: [`427b192becafc58ad339ef74aee1c0d7a7ed74be`](https://github.com/NixOS/nixpkgs/commit/427b192becafc58ad339ef74aee1c0d7a7ed74be) ([subsequent changes](https://github.com/NixOS/nixpkgs/compare/427b192becafc58ad339ef74aee1c0d7a7ed74be..pull/531015/head))
Merge: [`4cf7b0705be1e2fd4f029f1cecf4b1469719911c`](https://github.com/NixOS/nixpkgs/commit/4cf7b0705be1e2fd4f029f1cecf4b1469719911c)

Logs: https://github.com/Hythera/nixpkgs-review-gha/actions/runs/27414330819


---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 3 packages built:</summary>
  <ul>
    <li>discourse</li>
    <li>discourseAllPlugins</li>
    <li>redis</li>
  </ul>
</details>

---
### `aarch64-linux`
<details>
  <summary>:white_check_mark: 3 packages built:</summary>
  <ul>
    <li>discourse</li>
    <li>discourseAllPlugins</li>
    <li>redis</li>
  </ul>
</details>

---
### `x86_64-darwin` (sandbox = relaxed)
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>redis</li>
  </ul>
</details>

---
### `aarch64-darwin` (sandbox = relaxed)
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>redis</li>
  </ul>
</details>
</details>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
