### PR TITLE
update scipopt-{soplex,gcg,zimpl}, fix changelogs

### DIFF
--- a/pkgs/by-name/sc/scipopt-gcg/package.nix
+++ b/pkgs/by-name/sc/scipopt-gcg/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "scipopt-gcg";
-  version = "4.0.1";
+  version = "4.0.2";
 
   src = fetchFromGitHub {
     owner = "scipopt";
     repo = "gcg";
     tag = "v${version}";
-    hash = "sha256-eu7JHtG10/4rzr4xSdoFJjGQ+X5OeWelkEWJOO7QQmE=";
+    hash = "sha256-Nzv4T4R6hxbKCKhpZF4w8N2smYVCmAIXCPaOB4mT+PQ=";
   };
 
   nativeBuildInputs = [
@@ -53,10 +53,10 @@ stdenv.mkDerivation rec {
 
   meta = {
     maintainers = with lib.maintainers; [ pmeinhold ];
-    changelog = "https://gcg.or.rwth-aachen.de/doc-3.5.0/RN${lib.versions.major version}${lib.versions.minor version}.html";
+    changelog = "https://github.com/scipopt/gcg/blob/master/CHANGELOG";
     description = "Branch-and-Price & Column Generation for Everyone";
     license = lib.licenses.lgpl3Plus;
-    homepage = "https://gcg.zib.de";
+    homepage = "https://gcg.or.rwth-aachen.de";
     mainProgram = "gcg";
   };
 }

--- a/pkgs/by-name/sc/scipopt-soplex/package.nix
+++ b/pkgs/by-name/sc/scipopt-soplex/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "scipopt-soplex";
-  version = "8.0.1";
+  version = "8.0.2";
 
   src = fetchFromGitHub {
     owner = "scipopt";
     repo = "soplex";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-NN1UwwvLPfRIpL49UV8f2G4glUmTEywKNXK3m1LFHcg=";
+    hash = "sha256-TW3OSBw8ok64kZedsXYjkO2eFqr0LH8uvrOsi3bwQC4=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/sc/scipopt-ug/package.nix
+++ b/pkgs/by-name/sc/scipopt-ug/package.nix
@@ -14,12 +14,12 @@ stdenv.mkDerivation rec {
   version = "1.0.1";
 
   # To correlate scipVersion and version, check: https://scipopt.org/#news
-  scipVersion = "10.0.1";
+  scipVersion = "10.0.2";
 
   # Take the SCIPOptSuite source since no other source exists publicly.
   src = fetchzip {
     url = "https://github.com/scipopt/scip/releases/download/v${scipVersion}/scipoptsuite-${scipVersion}.tgz";
-    hash = "sha256-U5tbgGCzUkDL/22RwQLQmvCjSAhxehJe0P5rwNupW6Q=";
+    hash = "sha256-y2u/mAbIELAGHXcwF3UQCuzUTmYXgoINxq3wkvZ8imc=";
   };
 
   sourceRoot = "${src.name}/ug";
@@ -37,7 +37,6 @@ stdenv.mkDerivation rec {
 
   meta = {
     maintainers = with lib.maintainers; [ pmeinhold ];
-    changelog = "https://scipopt.org/doc-${scipVersion}/html/RN${lib.versions.major scipVersion}.php";
     description = "Ubiquity Generator framework to parallelize branch-and-bound based solvers";
     license = lib.licenses.lgpl3Plus;
     homepage = "https://ug.zib.de";

--- a/pkgs/by-name/sc/scipopt-zimpl/package.nix
+++ b/pkgs/by-name/sc/scipopt-zimpl/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "scipopt-zimpl";
-  version = "3.7.0";
+  version = "3.7.1";
 
   src = fetchFromGitHub {
     owner = "scipopt";
     repo = "zimpl";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ataepqBfdA7CgqPhbw+Xy7PC3VZTLcSrF2/xnFyx+YI=";
+    hash = "sha256-CUWLI12rH+NggQph+qWmWCTtbQubnhFKanuMlADLiHs=";
   };
 
   postPatch = ''
@@ -50,22 +50,10 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://zimpl.zib.de/download/CHANGELOG.txt";
     description = "Zuse Institute Mathematical Programming Language";
     longDescription = ''
-      ZIMPL is a little language to translate the mathematical model of a
-      problem into a linear or (mixed-)integer mathematical program
-      expressed in .lp or .mps file format which can be read by a LP or MIP
-      solver.
-
-      If you use Zimpl for research and publish results, the best way
-      to refer to Zimpl is to cite my Ph.d. thesis:
-
-      @PHDTHESIS{Koch2004,
-         author      = "Thorsten Koch",
-         title       = "Rapid Mathematical Programming",
-         year        = "2004",
-         school      = "Technische {Universit\"at} Berlin",
-         url         = "http://www.zib.de/Publications/abstracts/ZR-04-58/",
-         note        = "ZIB-Report 04-58",
-      }
+      Zimpl is a little language to translate the mathematical model of a
+      problem into a linear or nonlinear (mixed-)integer mathematical
+      program expressed in .lp or .mps file format which can be read and
+      (hopefully) solved by a LP or MIP solver.
     '';
     license = lib.licenses.lgpl3Plus;
     homepage = "https://zimpl.zib.de";


### PR DESCRIPTION
- updated the packages `scipopt-{soplex,gcg,zimpl}` to the most recent version
- removed the misleading changelog url of `scipopt-ug`
- also fixes the 404 changelog issue for `scipopt-gcg`
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
