### PR TITLE
shen-sbcl: 41 -> 41.1

### DIFF
--- a/pkgs/by-name/sh/shen-sbcl/package.nix
+++ b/pkgs/by-name/sh/shen-sbcl/package.nix
@@ -4,16 +4,20 @@
   fetchzip,
   sbcl,
   installStandardLibrary ? true,
+  installConcurrency ? true,
+  installThorn ? true,
+  installLogicLab ? true,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "shen-sbcl";
-  version = "41";
+  version = "41.1";
 
   src = fetchzip {
     url = "https://www.shenlanguage.org/Download/S${finalAttrs.version}.zip";
-    hash = "sha256-uWGMET1zjGbI/+yM1zeMfhVYBgrGawafAEBBGXANXGE=";
+    hash = "sha256-v/hlP23yfpkpFEDCTKYoxeMJbfR2qVF9LFUkqsFwo6g=";
   };
 
+  sourceRoot = "${finalAttrs.src.name}/S41";
   nativeBuildInputs = [ sbcl ];
   dontStrip = true; # necessary to prevent runtime errors with sbcl
 
@@ -38,11 +42,18 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     substituteInPlace Primitives/globals.lsp \
       --replace-fail '"2.0.0"' '(LISP-IMPLEMENTATION-VERSION)'
 
-    # remove interactive prompt during image creation
-    substituteInPlace install.lsp \
-      --replace-fail '(Y-OR-N-P "Load Shen Standard Library? ")' '${
-        if installStandardLibrary then "T" else "NIL"
-      }'
+    # remove interactive prompts during image creation
+    # shen/tk requires further configuration and isn't supported by default
+    substituteInPlace Lib/install.shen \
+      --replace-fail '(y-or-n? "install standard library?")' '${
+        if installStandardLibrary then "true" else "false"
+      }' \
+      --replace-fail '(y-or-n? "install concurrency? (required for Shen/tk)")' '${
+        if installConcurrency then "true" else "false"
+      }' \
+      --replace-fail '(y-or-n? "install Shen/tk + IDE?")' 'false' \
+      --replace-fail '(y-or-n? "install THORN?")' '${if installThorn then "true" else "false"}' \
+      --replace-fail '(y-or-n? "install Logic Lab?")' '${if installLogicLab then "true" else "false"}'
   '';
 
   meta = {


### PR DESCRIPTION
Like it says on the tin. Now supports installing concurrency, THORN, and Logic Lab libraries into the default image.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
