### PR TITLE
Module system types.attrTag implement declaration info in options

### DIFF
--- a/lib/tests/modules/types-attrTag.nix
+++ b/lib/tests/modules/types-attrTag.nix
@@ -120,7 +120,17 @@ in
       assert config.merged.positive == { yay = 100; };
       assert config.merged.extensi-foo == { extensible = "foo"; };
       assert config.merged.extensi-bar == { extensible = "bar"; };
+      assert config.docs."submodules.<name>.foo.bar".declarations == [ __curPos.file ];
       assert config.docs."submodules.<name>.foo.bar".type == "signed integer";
+      assert
+        lib.length
+          (options.submodules.type.nestedTypes.elemType.nestedTypes.foo.type.getSubOptions [ ])
+          .bar.declarationPositions == 1;
+      assert
+        (lib.head
+          (options.submodules.type.nestedTypes.elemType.nestedTypes.foo.type.getSubOptions [ ])
+          .bar.declarationPositions
+        ).file == __curPos.file;
       assert config.docs."submodules.<name>.qux".type == "string";
       assert config.docs."submodules.<name>.qux".declarations == [ __curPos.file ];
       assert
@@ -133,8 +143,11 @@ in
       assert config.docs."submodules.<name>.qux".description == "A qux for when you don't want a foo";
       assert config.docs."submodules.<name>.qux".readOnly == false;
       assert config.docs."submodules.<name>.qux".visible == true;
-      # Not available (yet?)
-      # assert config.docs."submodules.<name>.qux".declarationsWithPositions == [ ... ];
+      assert
+        lib.length options.submodules.type.nestedTypes.elemType.nestedTypes.qux.declarationPositions == 1;
+      assert
+        (lib.head options.submodules.type.nestedTypes.elemType.nestedTypes.qux.declarationPositions).file
+        == __curPos.file;
       assert options.submodules.declarations == [ __curPos.file ];
       assert lib.length options.submodules.declarationPositions == 1;
       assert (lib.head options.submodules.declarationPositions).file == __curPos.file;

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1140,6 +1140,27 @@ rec {
         else
           throw "The option `${showOption loc}` is defined as ${lib.strings.escapeNixIdentifier choice}, but ${lib.strings.escapeNixIdentifier choice} is not among the valid choices (${choicesStr}). Value ${choice} was defined in ${showFiles (getFiles defs)}.";
       nestedTypes = tags;
+      getSubModules =
+        let
+          tagsWithSubModules = filterAttrs (_: mods: mods != null) (
+            mapAttrs (_: opt: opt.type.getSubModules) tags
+          );
+        in
+        if tagsWithSubModules == { } then null else [ tagsWithSubModules ];
+      substSubModules =
+        allWrappedModules:
+        let
+          tagsWithNewTypes = zipAttrsWith (tag: tags.${tag}.type.substSubModules) (
+            concatMap (
+              { _file, imports }: map (mapAttrs (_: imports: { inherit _file imports; })) imports
+            ) allWrappedModules
+          );
+        in
+        attrTag (
+          mapAttrs (
+            tag: opt: opt // (optionalAttrs (tagsWithNewTypes ? ${tag}) { type = tagsWithNewTypes.${tag}; })
+          ) tags
+        );
       functor = defaultFunctor "attrTag" // {
         type = { tags, ... }: lib.types.attrTag tags;
         payload = { inherit tags; };


### PR DESCRIPTION
It is about time that `types.attrTag` will have declaration information in the documentation.
Implemented `getSubModules` and `substSubModule` for `types.attrTag`.
Added asserts in the relevant tests.

Previous PR #531021 closed because of Merge commits issues.

Fixes https://github.com/NixOS/nixpkgs/issues/303082

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
