### PR TITLE
ifcopenshell,python3Packages.ifcopenshell: 0.8.3 -> 0.8.5 and split package in 2

### DIFF
--- a/pkgs/by-name/if/ifcopenshell/boost_components_system.patch
+++ b/pkgs/by-name/if/ifcopenshell/boost_components_system.patch
@@ -1,0 +1,12 @@
+diff --git i/cmake/CMakeLists.txt w/cmake/CMakeLists.txt
+index af28df300..34561da6b 100644
+--- i/cmake/CMakeLists.txt
++++ w/cmake/CMakeLists.txt
+@@ -310,7 +310,6 @@ else()
+     # @todo review this, shouldn't this be all possible header-only now?
+     # ... or rewritten using C++17 features?
+     set(BOOST_COMPONENTS
+-        system
+         program_options
+         regex
+         thread

--- a/pkgs/by-name/if/ifcopenshell/package.nix
+++ b/pkgs/by-name/if/ifcopenshell/package.nix
@@ -1,0 +1,160 @@
+{
+  lib,
+  stdenv,
+  testers,
+  # fetchers
+  fetchFromGitHub,
+  gitUpdater,
+  # build tools
+  autoPatchelfHook,
+  cmake,
+  swig,
+  # native dependencies
+  boost,
+  cgal_5,
+  eigen,
+  gmp,
+  hdf5,
+  icu,
+  libaec,
+  libxml2,
+  mpfr,
+  nlohmann_json,
+  opencascade-occt,
+  proj,
+  sqlite,
+  zlib,
+  withPython ? false,
+  python3,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ifcopenshell";
+  version = "0.8.5";
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "IfcOpenShell";
+    repo = "IfcOpenShell";
+    # NOTE: every part of the ifcopenshell source trees lives their life independently from each other
+    # The bin utilities uses `ifcconvert-*` releases
+    # but the python bindings points on a specific ifcopenshell commits (wich is *not* necessarily a tag)
+    # same thing for the blender extensions etc...
+    # Be careful when using this derivation to build other tools from ifcopenshell org ;-)
+    tag = "ifcconvert-${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-QL+b46tOqoaN8XhxM02B2LWeAdu4OhhbCCVe7bMohBI=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    # c++
+    cmake
+    swig
+  ]
+  ++ lib.optionals withPython [ python3 ];
+
+  buildInputs = [
+    # ifcopenshell needs stdc++
+    (lib.getLib stdenv.cc.cc)
+    boost
+    cgal_5
+    eigen
+    gmp
+    hdf5
+    icu
+    libaec
+    libxml2
+    mpfr
+    nlohmann_json
+    opencascade-occt
+    proj
+    sqlite
+  ];
+
+  patches = [
+    ./boost_components_system.patch
+  ];
+
+  # we need to explicitly install python bindings
+  postBuild = lib.optional withPython ''
+    echo "current dir $(pwd)"
+    ls -al .
+    ls -al ../
+    mkdir -p $lib/${python3.sitePackages}/ifcwrap
+    install -m 0755 ./ifcwrap/_ifcopenshell_wrapper.cpython-${
+      lib.versions.major python3.version + lib.versions.minor python3.version
+    }-${stdenv.targetPlatform.system}-gnu.so $lib/${python3.sitePackages}/ifcwrap
+    install -m 0755 ./ifcwrap/ifcopenshell_wrapper.py $lib/${python3.sitePackages}/ifcwrap
+  '';
+
+  # for some reason, when building ifcwrap, the RPATH is an absolute path to the build folder
+  # we need to patch that because nix-build refuses to continue otherwise
+  # autopatchelfhook doesn't work because it is executed later in the build process
+  preFixup = lib.optional withPython ''
+    patchelf --shrink-rpath --allowed-rpath-prefixes /nix/store $lib/${python3.sitePackages}/ifcwrap/_ifcopenshell_wrapper.cpython-${
+      lib.versions.major python3.version + lib.versions.minor python3.version
+    }-${stdenv.targetPlatform.system}-gnu.so
+  '';
+
+  # We still build with python to generate ifcopenshell_wrapper.py and ifcopenshell_wrapper.so
+  cmakeFlags = [
+    "-DVERSION_OVERRIDE=ON" # I really don't know why it's not the default...
+    "-DENABLE_BUILD_OPTIMIZATIONS=ON"
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DBUILD_IFCGEOM=ON"
+    # TODO for man pages ?
+    # option(BUILD_DOCUMENTATION "Build IfcOpenShell Documentation." OFF)
+    "-DBUILD_EXAMPLES=OFF"
+    # TODO add qt6
+    # "-DBUILD_QTVIEWER=ON"
+    "-DGLTF_SUPPORT=ON"
+    "-DCOLLADA_SUPPORT=OFF"
+    "-DWITH_PROJ=ON"
+    "-DEIGEN_DIR=${eigen}/include/eigen3"
+    "-DJSON_INCLUDE_DIR=${nlohmann_json}/include/"
+    "-DOCC_INCLUDE_DIR=${opencascade-occt}/include/opencascade"
+    "-DOCC_LIBRARY_DIR=${lib.getLib opencascade-occt}/lib"
+    "-DLIBXML2_INCLUDE_DIR=${libxml2.dev}/include/libxml2"
+    "-DLIBXML2_LIBRARIES=${lib.getLib libxml2}/lib/libxml2${stdenv.hostPlatform.extensions.sharedLibrary}"
+    "-DHDF5_SUPPORT=ON"
+    "-DHDF5_INCLUDE_DIR=${hdf5.dev}/include/"
+    "-DHDF5_LIBRARIES=${lib.getLib hdf5}/lib/libhdf5_cpp.so;${lib.getLib hdf5}/lib/libhdf5.so;${lib.getLib zlib}/lib/libz.so;${lib.getLib libaec}/lib/libaec.so;"
+  ]
+  # BUILD_IFCPYTHON=ON is the default
+  ++ lib.optional (!withPython) "-DBUILD_IFCPYTHON=OFF"
+  ++ lib.optionals withPython [
+    "-DPYTHON_MODULE_INSTALL_DIR=${python3.sitePackages}/ifcopenshell"
+  ];
+
+  preConfigure = ''
+    cd cmake
+  '';
+
+  outputs = [
+    "out"
+    "dev"
+    "lib"
+  ];
+  passthru = {
+    updateScript = gitUpdater { rev-prefix = "ifcconvert-"; };
+    # We'd love to do that, but unfortunately, IfcConvert still reports 0.8.0 even in 0.8.4.
+    # see https://github.com/IfcOpenShell/IfcOpenShell/issues/8164
+    # tests = {
+    #   version = testers.testVersion {
+    #     command = "IfcConvert --version";
+    #     package = finalAttrs.finalPackage;
+    #   };
+    # };
+  };
+
+  meta = {
+    broken = stdenv.hostPlatform.isDarwin;
+    mainProgram = "IfcConvert";
+    description = "Open source IFC library and geometry engine";
+    homepage = "https://ifcopenshell.org/";
+    license = lib.licenses.lgpl3;
+    maintainers = with lib.maintainers; [ autra ];
+  };
+})

--- a/pkgs/development/python-modules/ifcopenshell/default.nix
+++ b/pkgs/development/python-modules/ifcopenshell/default.nix
@@ -1,4 +1,5 @@
 {
+  callPackage,
   lib,
   stdenv,
   testers,
@@ -7,28 +8,14 @@
   pytestCheckHook,
   # fetchers
   fetchFromGitHub,
-  fetchpatch,
   gitUpdater,
-  # build tools
-  cmake,
-  swig,
   # native dependencies
-  eigen,
-  boost,
-  cgal_5,
-  gmp,
-  hdf5,
-  icu,
-  libaec,
-  libxml2,
-  mpfr,
-  nlohmann_json,
-  opencascade-occt_7_6,
-  zlib,
+  ifcopenshell,
 
   # python deps
   ## tools
   setuptools,
+  setuptools-scm,
   build,
   pytest,
   ## dependencies
@@ -39,68 +26,54 @@
   shapely,
   typing-extensions,
   ## additional deps for tests
-  ifcopenshell,
+  toposort,
+  requests,
   lxml,
-  mathutils,
   networkx,
   tabulate,
   xmlschema,
   xsdata,
 }:
 let
-  opencascade-occt = opencascade-occt_7_6;
+  # ifcopenshell-python build againts a specific native commit, which used to not be
+  # the same as the ifcconvert release.
+  # However upstream should now garantee that:
+  # see https://github.com/IfcOpenShell/IfcOpenShell/issues/6974#issuecomment-5017442743
+  # and https://github.com/IfcOpenShell/IfcOpenShell/blob/ifcopenshell-python-0.8.5/src/ifcopenshell-python/Makefile#L58
+  ifcopenshellNative = ifcopenshell.override {
+    python3 = python;
+    withPython = true;
+  };
 in
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "ifcopenshell";
-  version = "0.8.0";
-  pyproject = false;
+  version = "0.8.5";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "IfcOpenShell";
     repo = "IfcOpenShell";
-    tag = "ifcopenshell-python-${version}";
+    tag = "ifcopenshell-python-${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-tnj14lBEkUZNDM9J1sRhNA7OkWTWa5JPTSF8hui3q7k=";
+    hash = "sha256-QL+b46tOqoaN8XhxM02B2LWeAdu4OhhbCCVe7bMohBI=";
   };
 
-  patches = [
-    (fetchpatch {
-      name = "ifcopenshell-boost-1.86-mt19937.patch";
-      url = "https://github.com/IfcOpenShell/IfcOpenShell/commit/1fe168d331123920eeb9a96e542fcc1453de57fe.patch";
-      hash = "sha256-oZDEL8cPcEu83lW+qSvCbmDGYpaNNRrptW9MLu2pN70=";
-    })
+  strictDeps = true;
+  __structuredAttrs = true;
 
-    (fetchpatch {
-      name = "ifcopenshell-boost-1.86-json.patch";
-      url = "https://github.com/IfcOpenShell/IfcOpenShell/commit/88b861737c7c206d0e7307f90d37467e9585515c.patch";
-      hash = "sha256-zMoQcBWRdtavL0xdsr53SqyG6CZoeon8/mmJhrw85lc=";
-    })
-  ];
-
-  nativeBuildInputs = [
-    # c++
-    cmake
-    swig
-    # python
-    build
+  build-system = [
     setuptools
+    setuptools-scm
   ];
 
-  buildInputs = [
-    # ifcopenshell needs stdc++
-    (lib.getLib stdenv.cc.cc)
-    boost
-    cgal_5
-    eigen
-    gmp
-    hdf5
-    icu
-    libaec
-    libxml2
-    mpfr
-    nlohmann_json
-    opencascade-occt
-  ];
+  # copy the native part
+  preConfigure = ''
+    cd src/ifcopenshell-python
+    cp -v ${lib.getLib ifcopenshellNative}/${python.sitePackages}/ifcwrap/ifcopenshell_wrapper.py ./ifcopenshell
+    cp ${lib.getLib ifcopenshellNative}/${python.sitePackages}/ifcwrap/_ifcopenshell_wrapper.cpython-${
+      lib.versions.major python.version + lib.versions.minor python.version
+    }-${stdenv.targetPlatform.system}-gnu.so ./ifcopenshell
+  '';
 
   propagatedBuildInputs = [
     isodate
@@ -111,96 +84,27 @@ buildPythonPackage rec {
     typing-extensions
   ];
 
-  # list taken from .github/workflows/ci.yml:49
-  nativeCheckInputs = [
-    lxml
-    mathutils
-    networkx
-    pytest
-    tabulate
-    xmlschema
-    xsdata
-
-    pytestCheckHook
-  ];
-
   pythonImportsCheck = [ "ifcopenshell" ];
 
   env.PYTHONUSERBASE = ".";
 
-  # We still build with python to generate ifcopenshell_wrapper.py and ifcopenshell_wrapper.so
-  cmakeFlags = [
-    "-DUSERSPACE_PYTHON_PREFIX=ON"
-    "-DBUILD_SHARED_LIBS=ON"
-    "-DBUILD_IFCPYTHON=ON"
-    "-DCITYJSON_SUPPORT=OFF"
-    "-DCOLLADA_SUPPORT=OFF"
-    "-DEIGEN_DIR=${eigen}/include/eigen3"
-    "-DJSON_INCLUDE_DIR=${nlohmann_json}/include/"
-    "-DOCC_INCLUDE_DIR=${opencascade-occt}/include/opencascade"
-    "-DOCC_LIBRARY_DIR=${lib.getLib opencascade-occt}/lib"
-    "-DSWIG_EXECUTABLE=${swig}/bin/swig"
-    "-DLIBXML2_INCLUDE_DIR=${libxml2.dev}/include/libxml2"
-    "-DLIBXML2_LIBRARIES=${lib.getLib libxml2}/lib/libxml2${stdenv.hostPlatform.extensions.sharedLibrary}"
-    "-DGMP_LIBRARY_DIR=${lib.getLib gmp}/lib/"
-    "-DMPFR_LIBRARY_DIR=${lib.getLib mpfr}/lib/"
-    # HDF5 support is currently not optional, see https://github.com/IfcOpenShell/IfcOpenShell/issues/1815
-    "-DHDF5_SUPPORT=ON"
-    "-DHDF5_INCLUDE_DIR=${hdf5.dev}/include/"
-    "-DHDF5_LIBRARIES=${lib.getLib hdf5}/lib/libhdf5_cpp.so;${lib.getLib hdf5}/lib/libhdf5.so;${lib.getLib zlib}/lib/libz.so;${lib.getLib libaec}/lib/libaec.so;"
-  ];
-
   postPatch = ''
     pushd src/ifcopenshell-python
-    # The build process is here: https://github.com/IfcOpenShell/IfcOpenShell/blob/v0.8.0/src/ifcopenshell-python/Makefile#L131
-    # NOTE: it has changed a *lot* between 0.7.0 and 0.8.0, it *may* change again (look for mathutils and basically all the things this Makefile does manually)
-    substituteInPlace pyproject.toml --replace-fail "0.0.0" "${version}"
-    # NOTE: the following is directly inspired by https://github.com/IfcOpenShell/IfcOpenShell/blob/v0.8.0/src/ifcopenshell-python/Makefile#L123
+    # The build process is here: https://github.com/IfcOpenShell/IfcOpenShell/blob/ifcopenshell-python-0.8.5/src/ifcopenshell-python/Makefile#L126
+    # NOTE: it has changed a *lot* between 0.7.0 and 0.8.0, it *may* change again
+    substituteInPlace pyproject.toml --replace-fail "0.0.0" "${finalAttrs.version}"
+    # NOTE: the following is directly inspired by https://github.com/IfcOpenShell/IfcOpenShell/blob/ifcopenshell-python-0.8.5/src/ifcopenshell-python/Makefile#L143
     cp ../../README.md README.md
     popd
-
-    # boost189 compatibility; see https://www.boost.org/releases/1.89.0/
-    substituteInPlace cmake/CMakeLists.txt \
-      --replace-fail 'set(BOOST_COMPONENTS system' 'set(BOOST_COMPONENTS'
   '';
 
-  preConfigure = ''
-    cd cmake
-  '';
-
-  preCheck = ''
-    pushd ../../src/ifcopenshell-python
-    # let's test like done in .github/workflows/ci.yml
-    # installing the python wrapper and the .so, both are needed to be able to test
-    cp -v $out/${python.sitePackages}/ifcopenshell/ifcopenshell_wrapper.py ./ifcopenshell
-    cp $out/${python.sitePackages}/ifcopenshell/_ifcopenshell_wrapper.cpython-${
-      lib.versions.major python.version + lib.versions.minor python.version
-    }-${stdenv.targetPlatform.system}-gnu.so ./ifcopenshell
-    pushd ../../test
-    PYTHONPATH=../src/ifcopenshell-python/ python tests.py
-    popd
-  '';
-
-  pytestFlags = [
-    "-pno:pytest-blender"
-  ];
-
-  disabledTestPaths = [
-    "test/test_open.py"
-  ];
-
-  postCheck = ''
-    popd
-  '';
+  # NOTE: activating tests is difficult:
+  # - tests depends on some python packages that are not packaged
+  # - they are inside ifcopenshell source tree (look for bcf, ifcpatch, ...)
+  # - at least bcf itself depends on ifcopenshell itself
 
   passthru = {
     updateScript = gitUpdater { rev-prefix = "ifcopenshell-python-"; };
-    tests = {
-      version = testers.testVersion {
-        command = "IfcConvert --version";
-        package = ifcopenshell;
-      };
-    };
   };
 
   meta = {
@@ -210,4 +114,4 @@ buildPythonPackage rec {
     license = lib.licenses.lgpl3;
     teams = [ lib.teams.geospatial ];
   };
-}
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7896,7 +7896,7 @@ self: super: with self; {
   ifconfig-parser = callPackage ../development/python-modules/ifconfig-parser { };
 
   ifcopenshell = callPackage ../development/python-modules/ifcopenshell {
-    inherit (pkgs) cgal_5 libxml2;
+    inherit (pkgs) ifcopenshell;
   };
 
   iglo = callPackage ../development/python-modules/iglo { };


### PR DESCRIPTION
Updates the python3Packages.ifcopenshell package. Also split the native part from the python part.

First, the native part (both bin and lib outputs) is useful in itself.

Last, although this is not currently supported by upstream, I'd like to be able to build the native part only once for every python version. Currently, we have to build it each time, which is quite long. Upstream tracking issue: https://github.com/IfcOpenShell/IfcOpenShell/issues/8165


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
