### PR TITLE
fractal: 13 -> 14

### DIFF
--- a/pkgs/by-name/fr/fractal/package.nix
+++ b/pkgs/by-name/fr/fractal/package.nix
@@ -26,26 +26,26 @@
   sqlite,
   xdg-desktop-portal,
   libseccomp,
-  libglycin,
+  libglycin-gtk4,
   glycin-loaders,
   libwebp,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fractal";
-  version = "13";
+  version = "14";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "fractal";
     tag = finalAttrs.version;
-    hash = "sha256-zIB04OIhMSm6OWHalnLO9Ng87dsvsmYurrro3hKwoYU=";
+    hash = "sha256-pgu+O9fRyZiRYkxRTlPgnd5jaGPL1nN0agMR+x6+oGg=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
-    hash = "sha256-5wI74sKytewbRs0T/IQZFEaRTgJcF6HyDEK0mpjy0LU=";
+    hash = "sha256-Fsw0hIAYiF+31PNuC5a9SatRatY7A8OwABhlyHIl1Lc=";
   };
 
   patches = [
@@ -58,13 +58,14 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace src/meson.build --replace-fail \
       "target_dir / rust_target / meson.project_name()" \
       "target_dir / '${stdenv.hostPlatform.rust.cargoShortTarget}' / rust_target / meson.project_name()"
+
+    patchShebangs ./build-aux/compile-blueprints.sh
   '';
 
   nativeBuildInputs = [
     glib
     grass-sass
     gtk4
-    libglycin.patchVendorHook
     meson
     ninja
     pkg-config
@@ -80,12 +81,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     glib
-    libglycin.setupHook
     glycin-loaders
     gtk4
     gtksourceview5
     lcms2
     libadwaita
+    libglycin-gtk4
     openssl
     pipewire
     libshumate


### PR DESCRIPTION
Release Notes: https://gitlab.gnome.org/World/fractal/-/releases/14
Changes: https://gitlab.gnome.org/World/fractal/-/compare/fractal-13...fractal-14?from_project_id=147

Migrating stuff to libglycin-gtk4 as I encountered
```
executing libglycinPatchVendorHook
error: glycin was not found within the cargo dependencies at '/build/cargo-deps-vendor'.
are you sure libglycin.patchVendorHook is still required?
```

Tested locally and image viewing still works.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
