### PR TITLE
run0-sudo-shim: init at 1.3.1

### DIFF
--- a/pkgs/by-name/ru/run0-sudo-shim/package.nix
+++ b/pkgs/by-name/ru/run0-sudo-shim/package.nix
@@ -39,6 +39,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [
       zimward
+      kuflierl
+      grimmauld
     ];
   };
 })

--- a/pkgs/by-name/ru/run0-sudo-shim/package.nix
+++ b/pkgs/by-name/ru/run0-sudo-shim/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  coreutils,
+  polkit-stdin-agent,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "run0-sudo-shim";
+  version = "1.3.1";
+
+  src = fetchFromGitHub {
+    owner = "LordGrimmauld";
+    repo = "run0-sudo-shim";
+    tag = finalAttrs.version;
+    hash = "sha256-QkDoEBgcWh/eKX8jxctMNEy08Sf8kpxXFhWbsygTWz8=";
+  };
+
+  cargoHash = "sha256-ly2e2x1Z1XEXblGqWi+/r5q2FmvpekVfzGVGm+S1xio=";
+
+  __structuredAttrs = true;
+
+  env = {
+    POLKIT_STDIN_AGENT = lib.getExe polkit-stdin-agent;
+    TRUE = lib.getExe' coreutils "true";
+  };
+
+  postInstall = ''
+    ln -s $out/bin/run0-sudo-shim $out/bin/sudo
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Shim for the sudo command that utilizes run0";
+    changelog = "https://github.com/LordGrimmauld/run0-sudo-shim/releases/tag/${finalAttrs.version}";
+    mainProgram = "sudo";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [
+      zimward
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I added @LordGrimmauld as a co-author as most of this package is based on the existent drv in the upstream flake. 

This is probably significant enough to be added in the nixpkgs changelog, though i am not sure if i should just write "added run0-sudo-shim" or wait for the module and such be finished.

I also want to add a VM test, though i am not sure if i have the time for that this weekend.

CC @arcayr @kuflierl offered to also maintain this. ig either just give me a notice that's its fine to actually add you or open up a separate PR later

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
