### PR TITLE
github-runner: 2.334.0 -> 2.335.1

### DIFF
--- a/pkgs/by-name/gi/github-runner/deps.json
+++ b/pkgs/by-name/gi/github-runner/deps.json
@@ -36,8 +36,8 @@
   },
   {
     "pname": "Microsoft.Bcl.Cryptography",
-    "version": "10.0.6",
-    "hash": "sha256-6VaDedxTljDNE+a4ao4xSG3rzZ6lbmCShtgMgHe9aH4="
+    "version": "10.0.7",
+    "hash": "sha256-5hOu8j2jLhCj9m7MlBoCjq3Qo0ST+b8n6oG2lLHL24s="
   },
   {
     "pname": "Microsoft.CodeCoverage",
@@ -46,18 +46,18 @@
   },
   {
     "pname": "Microsoft.DevTunnels.Connections",
-    "version": "1.3.39",
-    "hash": "sha256-aJBUNv1n7b64EBrAa04+Gw1MLYC315xANCRdK3RnWlA="
+    "version": "1.3.48",
+    "hash": "sha256-/E7ik2riVOMUyPt/1pxU7laDHG1pG5JpLIf5cQ7x7K4="
   },
   {
     "pname": "Microsoft.DevTunnels.Contracts",
-    "version": "1.3.39",
-    "hash": "sha256-lREgEhQhgQJyLoMYS/N5w+i6iX0s3Ppnl0T71KhG2u8="
+    "version": "1.3.48",
+    "hash": "sha256-YYmyZWmKv03BnOKAwbAeLrKqYDbBQ4ZS26jn92QkLSc="
   },
   {
     "pname": "Microsoft.DevTunnels.Management",
-    "version": "1.3.39",
-    "hash": "sha256-twyduZ89fY69k5onUihezBwdiu3BxdOMBLIXq4aQvY0="
+    "version": "1.3.48",
+    "hash": "sha256-DyDPqIwQkKJESx5K9Y4nKtw05cHrTlTp56rg/JXuVag="
   },
   {
     "pname": "Microsoft.DevTunnels.Ssh",
@@ -536,8 +536,8 @@
   },
   {
     "pname": "System.Diagnostics.EventLog",
-    "version": "10.0.6",
-    "hash": "sha256-MpXUz1TiiFkD1ngApC7HKqW+i37zi5V2ApOmqZwDqiI="
+    "version": "10.0.7",
+    "hash": "sha256-fV+2RcEzBV/JUnPDOLce3VBQKqvo32zcTWMZeJcAAJg="
   },
   {
     "pname": "System.Diagnostics.EventLog",
@@ -561,8 +561,8 @@
   },
   {
     "pname": "System.Formats.Asn1",
-    "version": "10.0.6",
-    "hash": "sha256-h5f9iYBUHgG9kOV7jlVQ8HqBQ0DQJt+wy3R/FbB1kaQ="
+    "version": "10.0.7",
+    "hash": "sha256-s48DCef2td3qUMdsRRGFfzkZ/wl/kUaVseQBDDfWUzM="
   },
   {
     "pname": "System.Globalization",
@@ -856,8 +856,8 @@
   },
   {
     "pname": "System.Security.Cryptography.Pkcs",
-    "version": "10.0.6",
-    "hash": "sha256-7T34t/DoxxMWUGRPSnLV1l5ScAxcDnK9iYKstRvLJuA="
+    "version": "10.0.7",
+    "hash": "sha256-+3RdvoSme0k3FoutPdJLkbWPWsmqPVo80hMgpuH3FP0="
   },
   {
     "pname": "System.Security.Cryptography.Primitives",
@@ -896,8 +896,8 @@
   },
   {
     "pname": "System.ServiceProcess.ServiceController",
-    "version": "10.0.6",
-    "hash": "sha256-Lvkb2mzQT/tcJ2yxkQDmKKFpEyaUbQ75qU51FwD1dzY="
+    "version": "10.0.7",
+    "hash": "sha256-koSlZI43JaCrG3ultJ6Sj7Ic9D9N878L+6HtRRGyJSA="
   },
   {
     "pname": "System.Text.Encoding",

--- a/pkgs/by-name/gi/github-runner/package.nix
+++ b/pkgs/by-name/gi/github-runner/package.nix
@@ -35,13 +35,13 @@ assert builtins.all (
 
 buildDotnetModule (finalAttrs: {
   pname = "github-runner";
-  version = "2.334.0";
+  version = "2.335.1";
 
   src = fetchFromGitHub {
     owner = "actions";
     repo = "runner";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-KSfzWwIf8Vpc8H0XM1tIqdZhdY/noZCeYLBvdWjqmLA=";
+    hash = "sha256-mFwWhpFzp0pT7WaMpF/N6PGw0IJt3I6/e7GDgw9wA2U=";
     leaveDotGit = true;
     postFetch = ''
       git -C $out rev-parse --short HEAD > $out/.git-revision
@@ -210,6 +210,10 @@ buildDotnetModule (finalAttrs: {
     "RepositoryActionWithDockerfilePrepareActions_Repository"
     "RepositoryActionWithInvalidWrapperActionfile_Node"
     "RepositoryActionWithWrapperActionfile_PreSteps"
+  ]
+  ++ [
+    "GitHub.Runner.Common.Tests.Worker.ActionManagerL0.GetDownloadInfoAsync_OmitsDependencies_WhenEmpty"
+    "GitHub.Runner.Common.Tests.Worker.ActionManagerL0.GetDownloadInfoAsync_PropagatesDependencies_WhenPresent"
   ]
   ++ map (x: "GitHub.Runner.Common.Tests.DotnetsdkDownloadScriptL0.${x}") [
     "EnsureDotnetsdkBashDownloadScriptUpToDate"


### PR DESCRIPTION
2 additional tests needed to be disabled due to network access within the sandbox.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
