### PR TITLE
scarlett2: 0-unstable-2024-04-06 -> 1.0

### DIFF
--- a/pkgs/by-name/sc/scarlett2/package.nix
+++ b/pkgs/by-name/sc/scarlett2/package.nix
@@ -13,8 +13,8 @@ let
   firmwareSrc = fetchFromGitHub {
     owner = "geoffreybennett";
     repo = "scarlett2-firmware";
-    rev = "f628dfb4d2e874b2078dbb43e8c1d59dd6553dd1";
-    hash = "sha256-s61eyS47SuIbK9KR59XxHpybvl9tHFWPLkpHmdqwO24=";
+    rev = "a81d62812903cddde15f6d84d07152802cab10b2";
+    hash = "sha256-r1Wj9cq8+HwXOrC5OIsC8D0XuN8WpqvZPdPWAH1Ohfs=";
   };
 
 in
@@ -22,13 +22,13 @@ stdenv.mkDerivation {
 
   pname = "scarlett2";
 
-  version = "0-unstable-2024-04-06";
+  version = "1.0";
 
   src = fetchFromGitHub {
     owner = "geoffreybennett";
     repo = "scarlett2";
-    rev = "1c262bcac11bceb6da8334b8f5b56d3c9331bfc8";
-    hash = "sha256-yhmXVfys300NwZ8UJ7WvOyNkGP3OkIVoRaToF+SenQA=";
+    rev = "1.0";
+    hash = "sha256-GfWfIOQfH5SoBdExIT1p/OHXJG2pwzTW/RS8Rs4QSGQ=";
   };
 
   buildInputs = [


### PR DESCRIPTION
This bumps `scarlett2` forward considerably, opening the door to new firmware revisions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
