### PR TITLE
maintainers: remove ivan-tkatchev

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11906,12 +11906,6 @@
     github = "ivan-timokhin";
     githubId = 9802104;
   };
-  ivan-tkatchev = {
-    email = "tkatchev@gmail.com";
-    github = "ivan-tkatchev";
-    githubId = 650601;
-    name = "Ivan Tkatchev";
-  };
   ivan770 = {
     email = "ivan@ivan770.me";
     github = "ivan770";

--- a/pkgs/by-name/bo/boost-build/package.nix
+++ b/pkgs/by-name/bo/boost-build/package.nix
@@ -78,6 +78,6 @@ stdenv.mkDerivation {
     homepage = "https://www.boost.org/build/";
     license = lib.licenses.boost;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ ivan-tkatchev ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/gt/gtest/package.nix
+++ b/pkgs/by-name/gt/gtest/package.nix
@@ -69,6 +69,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/google/googletest";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ ivan-tkatchev ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/ma/makerpm/package.nix
+++ b/pkgs/by-name/ma/makerpm/package.nix
@@ -35,6 +35,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "makerpm";
     license = lib.licenses.free;
     platforms = lib.platforms.all;
-    maintainers = [ lib.maintainers.ivan-tkatchev ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/development/python-modules/marshmallow-oneofschema/default.nix
+++ b/pkgs/development/python-modules/marshmallow-oneofschema/default.nix
@@ -32,6 +32,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/marshmallow-code/marshmallow-oneofschema/blob/${version}/CHANGELOG.rst";
     homepage = "https://github.com/marshmallow-code/marshmallow-oneofschema";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ivan-tkatchev ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/python-nvd3/default.nix
+++ b/pkgs/development/python-modules/python-nvd3/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/areski/python-nvd3";
     changelog = "https://github.com/areski/python-nvd3/releases/tag/${src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ivan-tkatchev ];
+    maintainers = [ ];
     mainProgram = "nvd3";
   };
 }

--- a/pkgs/development/python-modules/sqlalchemy-jsonfield/default.nix
+++ b/pkgs/development/python-modules/sqlalchemy-jsonfield/default.nix
@@ -44,6 +44,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/penguinolog/sqlalchemy_jsonfield";
     changelog = "https://github.com/penguinolog/sqlalchemy_jsonfield/releases/tag/${version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ ivan-tkatchev ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
## Reasons

- Last commented in [May 2023](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Aivan-tkatchev)
- Hasn't created any PRs / Issues since [July 2021](https://github.com/NixOS/nixpkgs/issues?q=author%3Aivan-tkatchev)
- About 26 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Aivan-tkatchev%20-commenter%3Aivan-tkatchev%20-author%3Aivan-tkatchev%20-reviewed-by%3Aivan-tkatchev) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] boost-build
- [ ] gtest 
- [ ] makerpm
- [ ] python3Packages.marshmallow-oneofschema
- [ ] python3Packages.python-nvd3
- [ ] python3Packages.sqlalchemy-jsonfield