### PR TITLE
{ungoogled-,}chromium,chromedriver: 149.0.7827.102 -> 149.0.7827.114

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -823,7 +823,7 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "149.0.7827.102",
+    "version": "149.0.7827.114",
     "deps": {
       "depot_tools": {
         "rev": "45dedc4c3b87c982fd846b3dc599b233ed3aff90",
@@ -835,16 +835,16 @@
         "hash": "sha256-oFs7fZAZEs/gQ7X1A4uigo9+Y+iEN9sMMQYwAjEuD04="
       },
       "ungoogled-patches": {
-        "rev": "149.0.7827.102-1",
-        "hash": "sha256-I2yrFav9r+vfkKfCpa71F8amzApGViVT8Enlmukwe7s="
+        "rev": "149.0.7827.114-1",
+        "hash": "sha256-F0pIlZM/EBPLIZxD8jyLX7HWe0vFn2HXs2vkM5+Xplg="
       },
       "npmHash": "sha256-pF0JtwFpPC4/fodbhSJnQKkczA9WlDg4VqEAy9aDVLg="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "112f665d98a2fe84b156c74fbea2aed742f16c15",
-        "hash": "sha256-75PYsss5Qob493WCc28XHncjFIlvUr2HQx79w5UmK/k=",
+        "rev": "5be7af702aa73ed64f47858cecc86290e42f2a20",
+        "hash": "sha256-R2vnW3Wa+REar23OhyFWzOo44F8NN9IqH7GjWJ1g1lo=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {

--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,10 +1,10 @@
 {
   "chromium": {
-    "version": "149.0.7827.102",
+    "version": "149.0.7827.114",
     "chromedriver": {
-      "version": "149.0.7827.103",
-      "hash_darwin": "sha256-3ws6RyF5SwjRcdo4IY+MzqcaZ6214dCVV3YB4YL+h6k=",
-      "hash_darwin_aarch64": "sha256-S8/dGAlipcYXzZIEJEGAnvsu3ilqjnBb8IdXUxGrp2o="
+      "version": "149.0.7827.115",
+      "hash_darwin": "sha256-DOhM1knKphvLNyrkf0uvb9NZ3kBwSuVN5hkQLqAZR1Y=",
+      "hash_darwin_aarch64": "sha256-HXWvAjMdMMbeF8DsgFKNM+S0ZEYr2M8Wj0uUZC7tmxY="
     },
     "deps": {
       "depot_tools": {
@@ -21,8 +21,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "112f665d98a2fe84b156c74fbea2aed742f16c15",
-        "hash": "sha256-75PYsss5Qob493WCc28XHncjFIlvUr2HQx79w5UmK/k=",
+        "rev": "5be7af702aa73ed64f47858cecc86290e42f2a20",
+        "hash": "sha256-R2vnW3Wa+REar23OhyFWzOo44F8NN9IqH7GjWJ1g1lo=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {


### PR DESCRIPTION
https://chromereleases.googleblog.com/2026/06/stable-channel-update-for-desktop_01962725236.html

This update includes 28 security fixes.

CVEs:
CVE-2026-12007 CVE-2026-12008 CVE-2026-12009 CVE-2026-12010 CVE-2026-12011 CVE-2026-12012 CVE-2026-12013 CVE-2026-12014 CVE-2026-12015 CVE-2026-12016 CVE-2026-12017 CVE-2026-12018 CVE-2026-12019 CVE-2026-12020 CVE-2026-12022 CVE-2026-12023 CVE-2026-12024 CVE-2026-12025 CVE-2026-12026 CVE-2026-12027 CVE-2026-12028 CVE-2026-12029 CVE-2026-12030 CVE-2026-12031 CVE-2026-12032 CVE-2026-12033 CVE-2026-12034 CVE-2026-12035

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
