### PR TITLE
python3Packages.openmm-torch: init at 1.5.1

### DIFF
--- a/pkgs/development/python-modules/openmm-torch/default.nix
+++ b/pkgs/development/python-modules/openmm-torch/default.nix
@@ -1,0 +1,120 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+
+  # nativeBuildInputs
+  cmake,
+  pip,
+  setuptools,
+  swig,
+  wheel,
+  autoAddDriverRunpath,
+
+  # dependencies
+  openmm,
+  torch,
+}:
+let
+  inherit (torch) cudaSupport cudaPackages;
+in
+buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
+  pname = "openmm-torch";
+  version = "1.5.1";
+  pyproject = false;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "openmm";
+    repo = "openmm-torch";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-z9aw1ye9zcDTiS/2eBBoxqSjds+eB2aMeO04GzsH3aw=";
+  };
+
+  # Ensure pip will not try to query an online index + install to the output store path
+  postPatch = ''
+    substituteInPlace python/CMakeLists.txt \
+      --replace-fail \
+        '-m pip install .' \
+        '-m pip install --no-index --no-build-isolation --no-deps --prefix=$ENV{out} .'
+  '';
+
+  cmakeFlags = [
+    (lib.cmakeFeature "OPENMM_DIR" "${openmm}")
+
+    # Upstream's CMakeLists.txt registers OPENMM_DIR's lib directories as the build RPATH. CMake then
+    # fails trying to rewrite the install RPATH because Nix's cc-wrapper has already baked the correct
+    # RUNPATH (torch, openmm, ...) into the library at link time. Disable CMake's RPATH handling and
+    # keep the Nix-set RUNPATH.
+    (lib.cmakeBool "CMAKE_SKIP_RPATH" true)
+
+    (lib.cmakeBool "NN_BUILD_CUDA_LIB" cudaSupport)
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pip
+    setuptools
+    swig
+    wheel
+  ]
+  ++ lib.optionals cudaSupport [
+    cudaPackages.cuda_nvcc
+    autoAddDriverRunpath
+  ];
+
+  env.NIX_LDFLAGS = toString (
+    lib.optionals cudaSupport [
+      # The CUDA platform references driver API (libcuda) symbols.
+      # Upstream's CMake only links the driver library on Windows; on Linux it relies on it being on the
+      # link path, which fails in the sandbox (the openmm CUDA libs point their RUNPATH at the impure
+      # /run/opengl-driver/lib).
+
+      # Link the driver stub explicitly so the symbols resolve; the real driver is found at runtime via
+      # autoAddDriverRunpath, and removeStubsFromRunpath strips the stub path from the output.
+      "-L${lib.getOutput "stubs" cudaPackages.cuda_cudart}/lib/stubs"
+
+      "-lcuda"
+    ]
+  );
+
+  buildInputs = [
+    openmm
+    torch
+  ]
+  ++ lib.optionals cudaSupport [
+    cudaPackages.cuda_cudart
+    cudaPackages.cuda_nvrtc
+  ];
+
+  dependencies = [
+    openmm
+    torch
+  ];
+
+  # Install the python bindings
+  postInstall = ''
+    ${lib.optionalString cudaSupport ''
+      # The Python extension only wraps the core TorchForce API; it must not link the CUDA driver
+      # stub, otherwise importing it would require libcuda.so.1 at load time (absent in the sandbox
+      # and on CPU-only hosts).
+      export NIX_LDFLAGS="''${NIX_LDFLAGS//-lcuda/}"
+    ''}
+    make PythonInstall
+  '';
+
+  pythonImportsCheck = [ "openmmtorch" ];
+
+  # No tests
+  doCheck = false;
+
+  meta = {
+    description = "OpenMM plugin to define forces with neural networks";
+    homepage = "https://github.com/openmm/openmm-torch";
+    changelog = "https://github.com/openmm/openmm-torch/releases/tag/${finalAttrs.src.tag}";
+    # https://github.com/openmm/openmm-torch/tree/master#license
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11841,6 +11841,8 @@ self: super: with self; {
     }
   );
 
+  openmm-torch = callPackage ../development/python-modules/openmm-torch { };
+
   openpaperwork-core = callPackage ../applications/office/paperwork/openpaperwork-core.nix { };
 
   openpaperwork-gtk = callPackage ../applications/office/paperwork/openpaperwork-gtk.nix { };


### PR DESCRIPTION
## Things done

Add [openmm-torch](https://github.com/openmm/openmm-torch), an OpenMM plugin to define forces with neural networks.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
