### PR TITLE
python3Packages.chex: 0.1.91 -> 0.1.92

### DIFF
--- a/pkgs/development/python-modules/chex/default.nix
+++ b/pkgs/development/python-modules/chex/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
 
   # build-system
   flit-core,
@@ -23,28 +22,16 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "chex";
-  version = "0.1.91";
+  version = "0.1.92";
   pyproject = true;
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
-    owner = "deepmind";
+    owner = "google-deepmind";
     repo = "chex";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-lJ9+kvG7dRtfDVgvkcJ9/jtnX0lMfxY4mmZ290y/74U=";
+    hash = "sha256-PM76Q72Bgyms7dROJkmlpPuDvtqjHLPTDkUYqo08T74=";
   };
-
-  patches = [
-    # jax.device_put_replicated is removed in jax 0.10.0
-    # This fix was merged upstream -> remove when updating to the next release
-    (fetchpatch {
-      url = "https://github.com/google-deepmind/chex/commit/5fbd2c9a9936799daf92354e0307b9e88b9cc163.patch";
-      excludes = [
-        "chex/_src/variants.py"
-      ];
-      hash = "sha256-ZTimSq7/yt2UEiWmLcfFBadX8+VcaxuPhkQJEyiEZlE=";
-    })
-  ];
 
   build-system = [
     flit-core
@@ -67,19 +54,9 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ];
 
-  disabledTests = [
-    # Jax 0.8.2 incompatibility (reported at https://github.com/google-deepmind/chex/issues/422)
-    # AssertionError: AssertionError not raised
-    "test_assert_tree_is_on_device"
-    # AssertionError: "\[Chex\]\ [\s\S]*sharded arrays are disallowed" does not match ...
-    "test_assert_tree_is_on_host"
-    # AssertionError: [Chex] Assertion assert_tree_is_sharded failed: ...
-    "test_assert_tree_is_sharded"
-  ];
-
   meta = {
     description = "Library of utilities for helping to write reliable JAX code";
-    homepage = "https://github.com/deepmind/chex";
+    homepage = "https://github.com/google-deepmind/chex";
     changelog = "https://github.com/google-deepmind/chex/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ ndl ];


### PR DESCRIPTION


## Things done

Diff: https://github.com/google-deepmind/chex/compare/v0.1.91...v0.1.92
Changelog: https://github.com/google-deepmind/chex/releases/tag/v0.1.92

cc @ndl

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test