### PR TITLE
wivrn: 26.2.3 -> 26.6.1

### DIFF
--- a/pkgs/by-name/wi/wivrn/package.nix
+++ b/pkgs/by-name/wi/wivrn/package.nix
@@ -21,6 +21,7 @@
   glm,
   glslang,
   harfbuzz,
+  hexdump,
   kdePackages,
   libarchive,
   libdrm,
@@ -55,13 +56,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "wivrn";
-  version = "26.2.3";
+  version = "26.6.1";
 
   src = fetchFromGitHub {
     owner = "wivrn";
     repo = "wivrn";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-pU7FYPp5wa0MK0ut/BfFlnUai8yMcylpWC0CoAExAio=";
+    hash = "sha256-eXU7hYLYchAb6AbCyINfTmOp0NdxK35Kg9tcid2ucg4=";
   };
 
   monado = applyPatches {
@@ -69,8 +70,8 @@ stdenv.mkDerivation (finalAttrs: {
       domain = "gitlab.freedesktop.org";
       owner = "monado";
       repo = "monado";
-      rev = "723652b545a79609f9f04cb89fcbf807d9d6451a";
-      hash = "sha256-wGqvTI/X22apc8XCN3GCGQClHfBW5xk73mZnwWvHtyI=";
+      rev = "1b526bb3a0ff326ecd05af4c2c541407f53c6d4b";
+      hash = "sha256-SzuCQ1uX15vFGwGt3gswlVF2Su8sIND4R3tsTJ4T1LY=";
     };
 
     postPatch = ''
@@ -97,6 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
     git
     glib
     glslang
+    hexdump
     librsvg
     pkg-config
     python3
@@ -133,6 +135,7 @@ stdenv.mkDerivation (finalAttrs: {
     kdePackages.ki18n
     kdePackages.kiconthemes
     kdePackages.kirigami
+    kdePackages.kirigami-addons
     kdePackages.qcoro
     kdePackages.qqc2-desktop-style
     libarchive
@@ -162,6 +165,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "WIVRN_OPENXR_MANIFEST_TYPE" "absolute")
     (lib.cmakeBool "WIVRN_OPENXR_MANIFEST_ABI" clientLibOnly)
     (lib.cmakeFeature "GIT_DESC" "v${finalAttrs.version}")
+    (lib.cmakeFeature "GIT_COMMIT" "v${finalAttrs.version}")
     (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_MONADO" "${finalAttrs.monado}")
   ]
   ++ lib.optionals (!clientLibOnly) [

--- a/pkgs/by-name/wi/wivrn/package.nix
+++ b/pkgs/by-name/wi/wivrn/package.nix
@@ -11,8 +11,6 @@
   boost,
   cli11,
   cmake,
-  cudaPackages ? { },
-  cudaSupport ? config.cudaSupport,
   eigen,
   ffmpeg,
   freetype,
@@ -37,7 +35,6 @@
   nlohmann_json,
   opencomposite,
   openxr-loader,
-  ovrCompatSearchPaths ? "${xrizer}/lib/xrizer:${opencomposite}/lib/opencomposite",
   pipewire,
   pkg-config,
   python3,
@@ -50,6 +47,9 @@
   vulkan-loader,
   x264,
   xrizer,
+  cudaSupport ? config.cudaSupport,
+  # WiVRn defaults to the first path but the others can be manually selected
+  ovrCompatSearchPaths ? "${xrizer}/lib/xrizer:${opencomposite}/lib/opencomposite",
   # Only build the OpenXR client library. Useful for building the client library for a different architecture,
   # e.g. 32-bit library while running 64-bit service on host, so 32-bit apps can connect to the runtime
   clientLibOnly ? false,
@@ -150,9 +150,6 @@ stdenv.mkDerivation (finalAttrs: {
     qt6.qtsvg
     qt6.qttools
     x264
-  ]
-  ++ lib.optionals (cudaSupport && !clientLibOnly) [
-    cudaPackages.cudatoolkit
   ];
 
   cmakeFlags = [
@@ -177,9 +174,6 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "WIVRN_USE_PULSEAUDIO" true)
     (lib.cmakeBool "WIVRN_FEATURE_STEAMVR_LIGHTHOUSE" true)
     (lib.cmakeFeature "OVR_COMPAT_SEARCH_PATH" ovrCompatSearchPaths)
-  ]
-  ++ lib.optionals (cudaSupport && !clientLibOnly) [
-    (lib.cmakeFeature "CUDA_TOOLKIT_ROOT_DIR" "${cudaPackages.cudatoolkit}")
   ];
 
   dontWrapQtApps = true;


### PR DESCRIPTION
Bumped WiVRn version and added necessary dependencies

<strike>Something to note is the `GIT_COMMIT` and `GIT_DESC` cmake flags. They expect the full commit hash and the short (8 char long) respectively and normally these would be automatically determined from the cmake file [here](https://github.com/WiVRn/WiVRn/blob/master/cmake/GitVersion.cmake) but I tested with git in both nativeBuildInputs and buildInputs but neither was able to resolve the commit hashes.

I've got it to build by just plugging in our release version but I'm unsure of any potential side-effects to this and I have not tested the server because I would like to figure out what we want to do about this before then. Do we want to hard-code a commit hash and fill these flags with the expected information? Maybe there's a different way to automatically get the hashes?</strike>

<strike>Another thing we might be able to include in this PR is https://github.com/NixOS/nixpkgs/issues/514926. I had tested it and didn't encounter any issues but I didn't experience the issues that prompted adding the toolkit in the first place.</strike>

Fixes https://github.com/NixOS/nixpkgs/issues/514926

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
