### PR TITLE
albyhub: 1.22.2 -> 1.23.0

### DIFF
--- a/pkgs/by-name/al/albyhub/bark-ffi-go/default.nix
+++ b/pkgs/by-name/al/albyhub/bark-ffi-go/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitLab,
+  protobuf,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "bark-ffi-go";
+  version = "0.2.3";
+
+  src = fetchFromGitLab {
+    owner = "ark-bitcoin";
+    repo = "bark-ffi-bindings";
+    rev = "3c626a43d7523c4d19e867bd453ec80c541780c7";
+    hash = "sha256-PbGTbVMO2L+gQpZQewkR0uo6fxqrVUjT/eAsnz2o/u4=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/golang/rust";
+
+  cargoHash = "sha256-OED+NqNt71771UDZ1M8Ks/Yfx8YNjfL246FKMeLFfLg=";
+
+  cargoBuildFlags = [ "--lib" ];
+
+  doCheck = false;
+
+  nativeBuildInputs = [
+    protobuf
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 target/*/release/libbark_ffi_go.a \
+      $out/lib/libbark_ffi_go.a
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Go bindings static library for Bark";
+    homepage = "https://gitlab.com/ark-bitcoin/bark-ffi-bindings";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ bleetube ];
+  };
+})

--- a/pkgs/by-name/al/albyhub/ldk-node-go/default.nix
+++ b/pkgs/by-name/al/albyhub/ldk-node-go/default.nix
@@ -7,13 +7,13 @@
 
 buildGoModule {
   pname = "ldk-node-go";
-  version = "0-unstable-2026-04-24";
+  version = "0-unstable-2026-06-08";
 
   src = fetchFromGitHub {
     owner = "getAlby";
     repo = "ldk-node-go";
-    rev = "3690cdb3031c75f0ee0a67222c2db3c69fea8f2c";
-    hash = "sha256-OlJGHhal5fkR0r0FtsVbG1aILZSTLsSRcqrZ84pIRLU=";
+    rev = "5ba22268f000c78baa5cf57329eb0b1c07bd91d7";
+    hash = "sha256-+fuCvc2SuxBLXiacfc+0oNzAsBgFjUJgZ0+5B4Sy4vs=";
   };
 
   vendorHash = null;

--- a/pkgs/by-name/al/albyhub/ldk-node/default.nix
+++ b/pkgs/by-name/al/albyhub/ldk-node/default.nix
@@ -8,13 +8,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ldk-node";
-  version = "0-unstable-2026-04-24";
+  version = "0-unstable-2026-06-08";
 
   src = fetchFromGitHub {
     owner = "getAlby";
     repo = "ldk-node";
-    rev = "6d5546ec5fff10d4e560188cfcff6f294944c16e";
-    hash = "sha256-k3AZ1k/hV4Bh+RfOqmpo22wRQ5sdDaFR4bcnw58iwNI=";
+    rev = "549107b4d731bc9af06b81fbcd65463e3055df16";
+    hash = "sha256-7S/+po+a6DkUCnfCrwBMfMnsHzbLcvSiPxEmQc2Hzr0=";
   };
 
   buildFeatures = [ "uniffi" ];

--- a/pkgs/by-name/al/albyhub/package.nix
+++ b/pkgs/by-name/al/albyhub/package.nix
@@ -8,6 +8,7 @@
   yarn,
   stdenv,
   makeWrapper,
+  runCommand,
   callPackage,
 }:
 
@@ -96,6 +97,41 @@ buildGoModule (finalAttrs: {
         (lib.getLib stdenv.cc.cc)
       ]
     } $out/bin/albyhub
+  '';
+
+  passthru.tests.startup = runCommand "${finalAttrs.pname}-startup-test" { } ''
+    export HOME="$TMPDIR"
+    export AUTO_LINK_ALBY_ACCOUNT=false
+    export WORK_DIR="$TMPDIR/albyhub"
+    export DATABASE_URI="$WORK_DIR/nwc.db"
+    export PORT=8099
+    export LDK_LOG_LEVEL=2
+    export LOG_LEVEL=5
+
+    mkdir -p "$WORK_DIR"
+
+    ${lib.getExe finalAttrs.finalPackage} > "$TMPDIR/albyhub.log" 2>&1 &
+    pid=$!
+    trap 'kill "$pid" 2>/dev/null || true' EXIT
+
+    for _ in $(seq 1 30); do
+      if grep -q "http server started" "$TMPDIR/albyhub.log"; then
+        touch "$out"
+        exit 0
+      fi
+
+      if ! kill -0 "$pid" 2>/dev/null; then
+        echo "albyhub exited before startup" >&2
+        cat "$TMPDIR/albyhub.log" >&2
+        exit 1
+      fi
+
+      sleep 1
+    done
+
+    echo "timed out waiting for albyhub to start" >&2
+    cat "$TMPDIR/albyhub.log" >&2
+    exit 1
   '';
 
   meta = {

--- a/pkgs/by-name/al/albyhub/package.nix
+++ b/pkgs/by-name/al/albyhub/package.nix
@@ -12,6 +12,7 @@
 }:
 
 let
+  barkFfiGo = callPackage ./bark-ffi-go { };
   ldkNode = callPackage ./ldk-node { };
   ldkNodeGo = callPackage ./ldk-node-go {
     inherit ldkNode;
@@ -21,17 +22,24 @@ in
 
 buildGoModule (finalAttrs: {
   pname = "albyhub";
-  version = "1.22.2";
+  version = "1.23.0";
 
   src = fetchFromGitHub {
     owner = "getAlby";
     repo = "hub";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-xP/J9zdh4sZ1x+JUpOf12ft8f2II2Mn1Q7/gnMuFzy8=";
+    hash = "sha256-1mdpsctrQN012+HAWSgorzlN2UBA5D4+sZIIVYCq8k8=";
   };
 
-  vendorHash = "sha256-nzdHXY14o4D8NrcXu2JvDagvIfemfVAaGU3IDifhyW0=";
+  vendorHash = "sha256-xQkQIWBrbrXzU9/5BMD3/+KKR847gh4XQrwj/CDoml0=";
   proxyVendor = true; # needed for secp256k1-zkp CGO bindings
+
+  postPatch = ''
+    cp -r ${barkFfiGo.src}/golang bark-ffi-bindings-golang
+    chmod -R u+w bark-ffi-bindings-golang
+    rm -r bark-ffi-bindings-golang/lib
+    go mod edit -replace gitlab.com/ark-bitcoin/bark-ffi-bindings/golang=./bark-ffi-bindings-golang
+  '';
 
   nativeBuildInputs = [
     fixup-yarn-lock
@@ -41,16 +49,21 @@ buildGoModule (finalAttrs: {
   ];
 
   buildInputs = [
+    barkFfiGo
     ldkNodeGo
     (lib.getLib stdenv.cc.cc)
   ];
 
   frontendYarnOfflineCache = fetchYarnDeps {
     yarnLock = finalAttrs.src + "/frontend/yarn.lock";
-    hash = "sha256-BeuTBLJ/Iakd4jhIkI2+oHc4MFy6DSn8QcygTHEMmQo=";
+    hash = "sha256-VI4FRe1kzVMqqcZ68nZmZqmXW7FOQMbJ0z8QqZoLYEA=";
   };
 
   preBuild = ''
+    mkdir -p bark-ffi-bindings-golang/lib/linux_${stdenv.hostPlatform.go.GOARCH}
+    cp ${barkFfiGo}/lib/libbark_ffi_go.a \
+      bark-ffi-bindings-golang/lib/linux_${stdenv.hostPlatform.go.GOARCH}/libbark_ffi_go.a
+
     export HOME=$TMPDIR
     pushd frontend
       fixup-yarn-lock yarn.lock


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added `bark-ffi-go` as a new source-built subpackage so the Ark/Bark backend links against a Nix-built `libbark_ffi_go.a` instead of the prebuilt static libraries bundled in the upstream Go module.

Release notes: https://github.com/getAlby/hub/releases/tag/v1.23.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
