### PR TITLE
rcp: 0.32.0 -> 0.35.0

### DIFF
--- a/pkgs/by-name/rc/rcp/package.nix
+++ b/pkgs/by-name/rc/rcp/package.nix
@@ -6,16 +6,16 @@
 
 pkgsStatic.rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rcp";
-  version = "0.32.0";
+  version = "0.35.0";
 
   src = fetchFromGitHub {
     owner = "wykurz";
     repo = "rcp";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-ZMp1ZMuHdTcJ7iORq9a62pGQo5cGRueuAQy+AjSOY5g=";
+    hash = "sha256-toO+gVPHfc/drP9Xj0vJOJvOxsH/0VqXKSwfYvkZfnE=";
   };
 
-  cargoHash = "sha256-ZXPG429qgiAaxZxnDNiMIXiP1d0pkdWEblZuRU8+BSU=";
+  cargoHash = "sha256-lbS67Hiv0ay0DzzoZsFRxc9EKl9sw+pYJwn9FmXquos=";
 
   env.RUSTFLAGS = "--cfg tokio_unstable";
 
@@ -41,6 +41,17 @@ pkgsStatic.rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=version::tests::test_current_version"
     "--skip=test_protocol_version_has_git_info"
     "--skip=test_rcpd_protocol_version_has_git_info"
+    # these tests shell out to `getent` to resolve real user/group names, which isn't available in the sandbox
+    "--skip=chmod::tests::getent_real_resolves_root"
+    "--skip=chmod::tests::getent_real_option_like_name_fails_closed_no_injection"
+    "--skip=rejects_unknown_group"
+    # these tests change ownership and set setuid/setgid bits (fchown / chmod / chgrp),
+    # which the unprivileged sandbox build user isn't permitted to do (EPERM)
+    "--skip=safedir::tests::set_dir_metadata_fd_applies"
+    "--skip=safedir::tests::set_file_metadata_fd_ordering_preserves_setuid"
+    "--skip=applies_per_type_modes_recursively"
+    "--skip=group_change_preserves_setgid_across_chgrp"
+    "--skip=preserves_setgid_through_mode_change"
   ];
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
