### PR TITLE
hid-tools: 0.7 -> 0.12

### DIFF
--- a/pkgs/by-name/hi/hid-tools/package.nix
+++ b/pkgs/by-name/hi/hid-tools/package.nix
@@ -6,7 +6,7 @@
 
 python3.pkgs.buildPythonPackage rec {
   pname = "hid-tools";
-  version = "0.7";
+  version = "0.12";
 
   pyproject = true;
 
@@ -15,7 +15,7 @@ python3.pkgs.buildPythonPackage rec {
     owner = "libevdev";
     repo = "hid-tools";
     rev = version;
-    hash = "sha256-h880jJcZDc9pIPf+nr30wu2i9y3saAKFZpooJ4MF67E=";
+    hash = "sha256-00Vsnjio8LEcuCfvNVEbFpJ2JabmMZqwXli1My5SVWs=";
   };
 
   nativeBuildInputs = with python3.pkgs; [
@@ -28,6 +28,7 @@ python3.pkgs.buildPythonPackage rec {
     parse
     pyyaml
     click
+    pyroute2
     pyudev
     typing-extensions
   ];

--- a/pkgs/by-name/hi/hid-tools/package.nix
+++ b/pkgs/by-name/hi/hid-tools/package.nix
@@ -1,10 +1,10 @@
 {
-  python3,
+  python3Packages,
   lib,
   fetchFromGitLab,
 }:
 
-python3.pkgs.buildPythonPackage rec {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "hid-tools";
   version = "0.12";
 
@@ -14,16 +14,16 @@ python3.pkgs.buildPythonPackage rec {
     domain = "gitlab.freedesktop.org";
     owner = "libevdev";
     repo = "hid-tools";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-00Vsnjio8LEcuCfvNVEbFpJ2JabmMZqwXli1My5SVWs=";
   };
 
-  nativeBuildInputs = with python3.pkgs; [
+  build-system = with python3Packages; [
     hatchling
     pypandoc
   ];
 
-  propagatedBuildInputs = with python3.pkgs; [
+  dependencies = with python3Packages; [
     libevdev
     parse
     pyyaml
@@ -33,7 +33,7 @@ python3.pkgs.buildPythonPackage rec {
     typing-extensions
   ];
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with python3Packages; [
     pytestCheckHook
   ];
 
@@ -52,4 +52,4 @@ python3.pkgs.buildPythonPackage rec {
     license = lib.licenses.mit;
     teams = [ lib.teams.freedesktop ];
   };
-}
+})

--- a/pkgs/by-name/hi/hid-tools/package.nix
+++ b/pkgs/by-name/hi/hid-tools/package.nix
@@ -49,7 +49,7 @@ python3Packages.buildPythonPackage (finalAttrs: {
   meta = {
     description = "Python scripts to manipulate HID data";
     homepage = "https://gitlab.freedesktop.org/libevdev/hid-tools";
-    license = lib.licenses.mit;
+    license = lib.licenses.gpl2Plus;
     teams = [ lib.teams.freedesktop ];
   };
 })


### PR DESCRIPTION
diff: https://gitlab.freedesktop.org/libevdev/hid-tools/-/compare/0.7...0.12

License always seems to have been incorrect, see https://gitlab.freedesktop.org/libevdev/hid-tools/-/blob/master/COPYING.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
