### PR TITLE
libqrtr-glib: 1.2.2 -> 1.4.0

### DIFF
--- a/pkgs/by-name/li/libqrtr-glib/package.nix
+++ b/pkgs/by-name/li/libqrtr-glib/package.nix
@@ -15,12 +15,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libqrtr-glib";
-  version = "1.2.2";
+  version = "1.4.0";
 
   outputs = [
     "out"
     "dev"
-    "devdoc"
   ];
 
   src = fetchFromGitLab {
@@ -28,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "mobile-broadband";
     repo = "libqrtr-glib";
     rev = finalAttrs.version;
-    sha256 = "kHLrOXN6wgBrHqipo2KfAM5YejS0/bp7ziBSpt0s1i0=";
+    sha256 = "sha256-1zsGwZogsI0QvIvvQy5FhcRSq2Q75/J724OcM+K/QBo=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
diff: https://gitlab.freedesktop.org/mobile-broadband/libqrtr-glib/-/compare/1.2.2...1.4.0

`gtk_doc` has been disabled by default and doesn't seem to be too important.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
