### PR TITLE
nixos/hyprland: migrate Systemd user settings to RFC 42-style attrs

### DIFF
--- a/nixos/modules/programs/wayland/hyprland.nix
+++ b/nixos/modules/programs/wayland/hyprland.nix
@@ -107,9 +107,9 @@ in
         services.displayManager.sessionPackages = [ cfg.package ];
 
         systemd = lib.mkIf cfg.systemd.setPath.enable {
-          user.extraConfig = ''
-            DefaultEnvironment="PATH=/run/wrappers/bin:/etc/profiles/per-user/%u/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:$PATH"
-          '';
+          user.settings.Manager = {
+            DefaultEnvironment = "PATH=/run/wrappers/bin:/etc/profiles/per-user/%u/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:$PATH";
+          };
         };
       }
 


### PR DESCRIPTION
My system fails to build otherwise :(

This PR reflects the changes to Systemd user settings made in #516329.


Change-Id: I6f9330373d89a24ccc191104deaa7236a6a6964