### PR TITLE
Revert "rr: enable 32bit support"

### DIFF
--- a/pkgs/development/tools/analysis/rr/default.nix
+++ b/pkgs/development/tools/analysis/rr/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  gccMultiStdenv,
+  stdenv,
   fetchFromGitHub,
   fetchpatch,
   bash,
@@ -18,7 +18,7 @@
   zstd,
 }:
 
-gccMultiStdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   version = "5.9.0";
   pname = "rr";
 
@@ -77,7 +77,7 @@ gccMultiStdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
-    (lib.cmakeBool "disable32bit" false)
+    (lib.cmakeBool "disable32bit" true)
     (lib.cmakeBool "BUILD_TESTS" finalAttrs.finalPackage.doCheck)
   ];
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#486928

@aij reports:

```
$ nom build .#rr
error:
       … while calling the 'derivationStrict' builtin
         at «nix-internal»/derivation-internal.nix:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'rr-5.9.0'
         whose name attribute is located at /home/ivan/nixos/aij/unstable/pkgs/stdenv/generic/make-derivation.nix:651:11

       … while evaluating attribute 'NIX_HARDENING_ENABLE' of derivation 'rr-5.9.0'
         at /home/ivan/nixos/aij/unstable/pkgs/stdenv/generic/make-derivation.nix:762:11:
          761|
          762|           ${
             |           ^
          763|             if (hardeningDisable != [ ] || hardeningEnable != [ ] || isMusl) then

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: i686 Linux package set can only be used with the x86 family.
┏━ 1 Errors: 
┃ error:
┃        … while calling the 'derivationStrict' builtin
┃          at «nix-internal»/derivation-internal.nix:37:12:
┃            36|
┃            37|   strict = derivationStrict drvAttrs;
┃              |            ^
┃            38|
┃ 
┃        … while evaluating derivation 'rr-5.9.0'
┃          whose name attribute is located at /home/ivan/nixos/aij/unstable/pkgs/stdenv/generic/make-derivation.nix:651:11
┃ 
┃        … while evaluating attribute 'NIX_HARDENING_ENABLE' of derivation 'rr-5.9.0'
┃          at /home/ivan/nixos/aij/unstable/pkgs/stdenv/generic/make-derivation.nix:762:11:
┃           761|
┃           762|           ${
┃              |           ^
┃           763|             if (hardeningDisable != [ ] || hardeningEnable != [ ] || isMusl) then
┃ 
┃        (stack trace truncated; use '--show-trace' to show the full, detailed trace)
┃ 
┃        error: i686 Linux package set can only be used with the x86 family.
┣━━━                                                             
┗━ ∑ ⚠ Exited with 1 errors reported by nix at 22:03:57 after 22s
```