### PR TITLE
Init iou-cli at 0.3.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29486,6 +29486,12 @@
     github = "w1lldu";
     githubId = 70287641;
   };
+  w4tsn = {
+    email = "w4tsn@221b.uk";
+    name = "Alexander Wellbrock";
+    github = "w4tsn";
+    githubId = 2271467;
+  };
   waelwindows = {
     email = "waelwindows9922@gmail.com";
     github = "Waelwindows";

--- a/pkgs/by-name/io/iou-cli/package.nix
+++ b/pkgs/by-name/io/iou-cli/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitLab,
+  versionCheckHook,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "iou-cli";
+  version = "0.3.5";
+  pyproject = true;
+
+  src = fetchFromGitLab {
+    domain = "git.221b.uk";
+    owner = "iou";
+    repo = "cli-client";
+    rev = "24e2ba4a08a89b3101e76258f14334cba52c4493";
+    hash = "sha256-89pRwX3xYI4+FopsJut8+YdX2tbz/dzgX8MMlTtborA=";
+  };
+
+  build-system = with python3Packages; [
+    hatchling
+    hatch-vcs
+  ];
+
+  dependencies = with python3Packages; [
+    authlib
+    click
+    cloup
+    questionary
+    requests
+    rich
+  ];
+
+  nativeCheckInputs = [
+    versionCheckHook
+  ]
+  ++ (with python3Packages; [
+    pytest
+    pytest-cov
+    pytestCheckHook
+    mock
+  ]);
+
+  versionCheckProgramArg = "--version";
+
+  pythonImportsCheck = [
+    "iou_cli"
+  ];
+
+  meta = {
+    description = "Shared expense tracking and splitting. Client application.";
+    homepage = "https://git.221b.uk/iou/cli-client";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      w4tsn
+    ];
+    mainProgram = "iou";
+  };
+}


### PR DESCRIPTION
Init the IOU CLI client (python based) package.

This currently pulls the sources from my private gitlab instance on git.221b.uk. I intend on moving this to codeberg in a fully maintained fashion for broader access and a more stable platform with higher uptime though,

IOU is a new expense tracking / splitting client-server application. The current user-base is small, but a public instance is available on darmstadt.social using auth.darmstadt.social as IdP.

Note that I'm the upstream maintainer / developer of the server, cli- and android clients.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
