### PR TITLE
home-assistant: 2026.6.2 -> 2026.6.3

### DIFF
--- a/pkgs/development/python-modules/aioamazondevices/default.nix
+++ b/pkgs/development/python-modules/aioamazondevices/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "aioamazondevices";
-  version = "14.0.0";
+  version = "14.0.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "chemelli74";
     repo = "aioamazondevices";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ZF3w5lg6NijVBkJKoItmblay90VzUsDqPVxk712sXRU=";
+    hash = "sha256-C0cwPtAiA63DXqs8x0zlJ+y1BXgVe87Q56WKER/cmnk=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/bthome-ble/default.nix
+++ b/pkgs/development/python-modules/bthome-ble/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "bthome-ble";
-  version = "3.23.2";
+  version = "3.23.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Bluetooth-Devices";
     repo = "bthome-ble";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-t8AOz1riqwXAoovN/DXBzfQ/btCZqzgC72U9OBdSPHU=";
+    hash = "sha256-ZXCqwadNWl2Yct+rlZViFO2pFV4ZY0glKvD3xElY3Mg=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/hassil/default.nix
+++ b/pkgs/development/python-modules/hassil/default.nix
@@ -16,7 +16,7 @@
 
 let
   pname = "hassil";
-  version = "3.5.0";
+  version = "3.7.0";
 in
 buildPythonPackage rec {
   inherit pname version;
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     owner = "home-assistant";
     repo = "hassil";
     tag = "v${version}";
-    hash = "sha256-ei4+eGNCzBZQYghgVuQIPgFA2Y1kf8aNtl6ZjwzxIEE=";
+    hash = "sha256-C3nx8w0y4RsHq9txwdSfgS9BMcY4TyZiBOq4QIq5w+0=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/pytrydan/default.nix
+++ b/pkgs/development/python-modules/pytrydan/default.nix
@@ -17,14 +17,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pytrydan";
-  version = "1.0.1";
+  version = "1.0.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "dgomes";
     repo = "pytrydan";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-oXnTDwCY2Z/K7YwWNTwbbB0W47bZD+W6uFxZQRF3KgQ=";
+    hash = "sha256-vxIY+BCo3o4FBI1otiMx3swWTxtmEgYfVCWQAq2OuUM=";
   };
 
   pythonRelaxDeps = [ "tenacity" ];

--- a/pkgs/development/python-modules/reolink-aio/default.nix
+++ b/pkgs/development/python-modules/reolink-aio/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "reolink-aio";
-  version = "0.20.1";
+  version = "0.21.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "starkillerOG";
     repo = "reolink_aio";
     tag = finalAttrs.version;
-    hash = "sha256-0uJ1iGWbGy6sFhWVxUwLhkR9U1MtqF+82AYU0/gHhdU=";
+    hash = "sha256-MbIU4Hk/9b491EBzNktZiZU5UJddAIx3wVeS0mCk6No=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2026.6.2";
+  version = "2026.6.3";
   components = {
     "3_day_blinds" =
       ps: with ps; [

--- a/pkgs/servers/home-assistant/custom-components/better_thermostat/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/better_thermostat/package.nix
@@ -8,13 +8,13 @@
 buildHomeAssistantComponent rec {
   owner = "KartoffelToby";
   domain = "better_thermostat";
-  version = "1.8.0";
+  version = "1.8.1";
 
   src = fetchFromGitHub {
     owner = "KartoffelToby";
     repo = "better_thermostat";
     tag = version;
-    hash = "sha256-jxC8Xxhr1OjcAREggNaiB89TMFSdQyDr4QfdWGcmeU4=";
+    hash = "sha256-VSTGYs97ro65rrV80D6b3/XEeGi86FzXwU5nPabS5gE=";
   };
 
   passthru.updateScript = gitUpdater {

--- a/pkgs/servers/home-assistant/custom-components/blueprints-updater/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/blueprints-updater/package.nix
@@ -13,13 +13,13 @@
 buildHomeAssistantComponent rec {
   owner = "luuquangvu";
   domain = "blueprints_updater";
-  version = "2.7.3";
+  version = "2.7.4";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "blueprints-updater";
     tag = version;
-    hash = "sha256-Sb4ZUuOw4S8kh8N3fSgE35lD38LyvLW2oouot2zIWYg=";
+    hash = "sha256-8vq/tU9a0faioSmy9CdJerIx1ry67B+gqdlnSNiEFGU=";
   };
 
   patches = [

--- a/pkgs/servers/home-assistant/custom-components/dreo/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/dreo/package.nix
@@ -12,13 +12,13 @@
 buildHomeAssistantComponent rec {
   owner = "JeffSteinbok";
   domain = "dreo";
-  version = "1.9.12";
+  version = "1.9.13";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "hass-dreo";
     tag = "v${version}";
-    hash = "sha256-CMp3UIpLSpqTL0EGH6z5bvqOd68Ay8o7bDDdjNMawWg=";
+    hash = "sha256-45O21kF/gq49Dbz1Za0le++a90qz+mQnZvRD45Jzxpo=";
   };
 
   dependencies = [ websockets ];

--- a/pkgs/servers/home-assistant/custom-components/polaris-mqtt/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/polaris-mqtt/package.nix
@@ -7,13 +7,13 @@
 buildHomeAssistantComponent rec {
   owner = "samoswall";
   domain = "polaris";
-  version = "1.1.4";
+  version = "1.1.5";
 
   src = fetchFromGitHub {
     owner = "samoswall";
     repo = "polaris-mqtt";
     tag = "v${version}";
-    hash = "sha256-G0DWgDLS62yKXE6gktb8z2xKFeH7Cu2zssQhEiuhwD0=";
+    hash = "sha256-NViyBWTN18DQV3WywD6AXdoOw6W+PgMIV5tuKyRgN2w=";
   };
 
   meta = {

--- a/pkgs/servers/home-assistant/custom-components/yandex-station/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/yandex-station/package.nix
@@ -10,13 +10,13 @@
 buildHomeAssistantComponent rec {
   owner = "AlexxIT";
   domain = "yandex_station";
-  version = "3.21.1";
+  version = "3.21.2";
 
   src = fetchFromGitHub {
     owner = "AlexxIT";
     repo = "YandexStation";
     tag = "v${version}";
-    hash = "sha256-5a+631Gu7xaPq8EF+34bybm40YVTXPA/ylq6k8LPBNU=";
+    hash = "sha256-TjrBb7MatydixSEEAcM7ezQ8hDGKxTapD2h40c/0AxQ=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/auto-entities/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/auto-entities/package.nix
@@ -6,16 +6,16 @@
 
 buildNpmPackage rec {
   pname = "auto-entities";
-  version = "2.3.1";
+  version = "2.4.0";
 
   src = fetchFromGitHub {
     owner = "Lint-Free-Technology";
     repo = "lovelace-auto-entities";
     tag = "v${version}";
-    hash = "sha256-l6bg68PP+d9AiTAkT7MtuyIeSl9dmi9bMEaV+eByOIs=";
+    hash = "sha256-2uZtL2w/KntBReF//3WTrHAQrYJO24jJYWJZ8/mpsIY=";
   };
 
-  npmDepsHash = "sha256-1rJeyYn4QzYGxztFwJ812RjCApHlqnvrnFe69CUKCzM=";
+  npmDepsHash = "sha256-UYpkIKr4/lAfvf+H09uZ8tksnucjpHWiWvWvPKfva2I=";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -265,7 +265,7 @@ let
   extraBuildInputs = extraPackages python3Packages;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2026.6.2";
+  hassVersion = "2026.6.3";
 
 in
 python3Packages.buildPythonApplication rec {
@@ -286,13 +286,13 @@ python3Packages.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     tag = version;
-    hash = "sha256-wDGXJoo1R2YX2qNRsMYNHm94WCsSHsC7ihCW6w8YAD8=";
+    hash = "sha256-I9vmwlCoxEK3o04e1x5LissX3u0fgxVOu6Uzq88e9kI=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-XpFnxxa1liRUm8KEoI73t9wAfnsLKC3G56vrgkcIqR0=";
+    hash = "sha256-23tqASXXrhYh1x7Qy+ZR4T7z+XKkhW0Qn6YGM2iNJOk=";
   };
 
   build-system = with python3Packages; [

--- a/pkgs/servers/home-assistant/frontend.nix
+++ b/pkgs/servers/home-assistant/frontend.nix
@@ -8,7 +8,7 @@ buildPythonPackage (finalAttrs: {
   # the frontend version corresponding to a specific home-assistant version can be found here
   # https://github.com/home-assistant/home-assistant/blob/master/homeassistant/components/frontend/manifest.json
   pname = "home-assistant-frontend";
-  version = "20260527.5";
+  version = "20260527.6";
   format = "wheel";
 
   src = fetchPypi {
@@ -17,7 +17,7 @@ buildPythonPackage (finalAttrs: {
     pname = "home_assistant_frontend";
     dist = "py3";
     python = "py3";
-    hash = "sha256-DLuwjy3Gyqp8Y2N7Vbv4AbhFbFwaMOEvDzvkRncqmQE=";
+    hash = "sha256-tvJXB+lFrlDA3eUnE5NPQwXbWn8XGggPJ9I1f9U1ddk=";
   };
 
   # there is nothing to strip in this package

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-homeassistant-custom-component";
-  version = "0.13.338";
+  version = "0.13.339";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     owner = "MatthewFlamm";
     repo = "pytest-homeassistant-custom-component";
     tag = version;
-    hash = "sha256-O4h8vHjYo/cIBOqd+ag8jIoje9j1/zyBfuQq6IIFa3w=";
+    hash = "sha256-4BmtdmQyeYaOPPMDnnBNCvB0EgWcw9umC5hV4rFRTLA=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2026.6.2";
+  version = "2026.6.3";
   pyproject = true;
 
   disabled = python.version != home-assistant.python3Packages.python.version;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     tag = version;
-    hash = "sha256-Rf5HHXNJR6TJnB0Gtg6mwlqteMUf2Yw7stonsoO2EHE=";
+    hash = "sha256-YJT0/2NJiuh7Do3gik2Rr2a1A2rMJYVEjrV6xrxF9Ww=";
   };
 
   build-system = [

--- a/pkgs/servers/home-assistant/update-component-packages.py
+++ b/pkgs/servers/home-assistant/update-component-packages.py
@@ -73,6 +73,7 @@ EXTRA_COMPONENT_DEPS = {
 OUR_VERSION_IS_NEWER_THAN = {
     "blinkstick": "1.2.0",
     "gps3": "0.33.3",
+    "ouman-eh-800-api": "0.5.0",
     "proxmoxer": "2.2.0",
     "py-cpuinfo": "9.0.0",
     "pybluez": "0.22",


### PR DESCRIPTION
Diff: https://github.com/home-assistant/core/compare/2026.6.2...2026.6.3

Changelog: https://github.com/home-assistant/core/releases/tag/2026.6.3

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
