### PR TITLE
cloudquery: init at 6.36.1

### DIFF
--- a/pkgs/by-name/cl/cloudquery/package.nix
+++ b/pkgs/by-name/cl/cloudquery/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  installShellFiles,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "cloudquery";
+  version = "6.36.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "cloudquery";
+    repo = "cloudquery";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-D0gciTH5OwYXBPabOmn6bMHyWZwS6y5uAQIdNS+WugE=";
+  };
+
+  modRoot = "cli";
+
+  vendorHash = "sha256-gY/FQ71Nwk9i7QXgMmOVlJe9lEW9ViPZ3Eh1NusIizE=";
+
+  subPackages = [
+    "."
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/cloudquery/cloudquery/cli/v${lib.versions.major finalAttrs.version}/cmd.Version=${finalAttrs.version}"
+  ];
+
+  doInstallCheck = true;
+
+  nativeBuildInputs = [
+    installShellFiles
+    versionCheckHook
+  ];
+
+  postInstall = ''
+    mv $out/bin/cli $out/bin/cloudquery
+
+    installShellCompletion --cmd cloudquery \
+       --bash <($out/bin/cloudquery completion bash) \
+       --fish <($out/bin/cloudquery completion fish) \
+       --zsh <($out/bin/cloudquery completion zsh)
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Data pipelines for cloud config and security data";
+    homepage = "https://github.com/cloudquery/cloudquery";
+    changelog = "https://github.com/cloudquery/cloudquery/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ jlesquembre ];
+    mainProgram = "cloudquery";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is a fresh attempt to add [cloudquery](https://github.com/cloudquery/cloudquery) to nixpkgs, superseding a previous PR: #357718.

Since the original PR appears to be abandoned (last activity in 2024) and nixpkgs has evolved significantly since then, I decided to open this new PR with the necessary updates.

That said, if @mrgiles would prefer to revive their PR, I am more than happy to close this one.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
