### PR TITLE
fakeroot: fix build failure

### DIFF
--- a/pkgs/by-name/fa/fakeroot/add-missing-wrapawk.patch
+++ b/pkgs/by-name/fa/fakeroot/add-missing-wrapawk.patch
@@ -1,0 +1,98 @@
+--- /dev/null	2026-06-10 18:10:25.546025717 +0200
++++ b/wrapawk	1970-01-01 01:00:01.000000000 +0100
+@@ -0,0 +1,95 @@
++#Saluton Emacson! Bonvolu elekti -*- mode: awk; -*-. Dankon.
++
++BEGIN{
++  headerfile="wrapped.h";
++  deffile="wrapdef.h";
++  structfile="wrapstruct.h";
++  tmpffile="wraptmpf.h";
++  FS=";";
++  WARNING="/* Automatically generated file. Do not edit. Edit wrapawk/wrapfunc.inp. */";
++  print WARNING > headerfile;
++  print "#ifndef WRAPPED_H" > headerfile;
++  print "#define WRAPPED_H" > headerfile;
++  print WARNING > deffile;
++  print "#ifndef WRAPDEF_H" > deffile;
++  print "#define WRAPDEF_H" > deffile;
++  print WARNING > tmpffile;
++  print "#ifndef WRAPTMPF_H" > tmpffile;
++  print "#define WRAPTMPF_H" > tmpffile;
++  print WARNING > structfile;
++  print "#ifndef WRAPSTRUCT_H" > structfile;
++  print "#define WRAPSTRUCT_H" > structfile;
++  print "struct next_wrap_st next_wrap[]= {" > structfile;
++}
++
++/\/\*/{
++}
++/^(\#)/{
++  print $0 > structfile;
++  print $0 > tmpffile;
++  print $0 > deffile;
++  print $0 > headerfile;
++
++}
++/^[^\/].*;.*;.*;/{
++  name=$1;
++  ret=$2;
++  argtype=$3;
++  argname=$4;
++  MACRO=$5;
++  openat_extra=$6;
++  if(openat_extra){
++    print "  {(void(*))&next_" name ", \"" name "\"},"  > structfile;
++    print "extern " ret " (*next_" name ")" openat_extra ";" > headerfile;
++    print ret " (*next_" name ")" openat_extra "=tmp_" name ";"> deffile;
++
++    print ret " tmp_" name,  openat_extra "{"           > tmpffile;
++    print "  mode_t mode = 0;"                          > tmpffile;
++    print "  if (flags & O_CREAT) {"                    > tmpffile;
++    print "    va_list args;"                           > tmpffile;
++    print "    va_start(args, flags);"                  > tmpffile;
++    print "    mode = va_arg(args, int);"               > tmpffile;
++    print "    va_end(args);"                           > tmpffile;
++    print "  }"                                         > tmpffile;
++    print "  load_library_symbols();"                   > tmpffile;
++    print "  return  next_" name,  argname ";"          > tmpffile;
++    print "}"                                           > tmpffile;
++    print ""                                            > tmpffile;
++  } else if(MACRO){
++    print "  {(void(*))&NEXT_" MACRO "_NOARG, " name "_QUOTE},"  > structfile;
++    print "extern " ret " (*NEXT_" MACRO "_NOARG)" argtype ";" > headerfile;
++    print ret " (*NEXT_" MACRO "_NOARG)" argtype "=TMP_" MACRO ";"> deffile;
++    
++    print ret " TMP_" MACRO,  argtype "{"                 > tmpffile;
++    print "  load_library_symbols();"                   > tmpffile;
++    print "  return  NEXT_" MACRO "_NOARG "  argname ";"           > tmpffile;
++    print "}"                                           > tmpffile;
++    print ""                                            > tmpffile;
++  } else {
++    print "  {(void(*))&next_" name ", \"" name "\"},"  > structfile;
++    print "extern " ret " (*next_" name ")" argtype ";" > headerfile;
++    print ret " (*next_" name ")" argtype "=tmp_" name ";"> deffile;
++    
++    print ret " tmp_" name,  argtype "{"                 > tmpffile;
++    print "  load_library_symbols();"                   > tmpffile;
++    print "  return  next_" name,  argname ";"           > tmpffile;
++    print "}"                                           > tmpffile;
++    print ""                                            > tmpffile;
++  }
++}
++
++/^ *$/{
++  print > structfile;
++  print > headerfile;
++  print > deffile;  
++  print > tmpffile;
++}
++
++END{
++  print "  {NULL, NULL}," > structfile;
++  print "};"              > structfile;
++  print "#endif"          > structfile;
++  print "#endif"          > tmpffile;
++  print "#endif"          > deffile;
++  print "#endif"          > headerfile;
++}

--- a/pkgs/by-name/fa/fakeroot/package.nix
+++ b/pkgs/by-name/fa/fakeroot/package.nix
@@ -22,10 +22,11 @@ stdenv.mkDerivation (finalAttrs: {
     repo = "fakeroot";
     rev = "upstream/${finalAttrs.version}";
     domain = "salsa.debian.org";
-    hash = "sha256-1Xmb8OPZSVP4xtSBGuwwKwdVQXixEugMgQfvAJueJAg=";
+    hash = "sha256-sAzXeONjDT753lbu7amQY6yXpaTNCa4wFOzB01SRbCs=";
   };
 
   patches = lib.optionals stdenv.hostPlatform.isLinux [
+    ./add-missing-wrapawk.patch
     ./einval.patch
   ];
 


### PR DESCRIPTION
## Things done

* update hash

* add patch for missing wrapawk

* Resolves #531118

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
