### PR TITLE
{vectorscan,python3Packages.pyperscan,oniux}: make use of compund licenses

### DIFF
--- a/pkgs/by-name/on/oniux/package.nix
+++ b/pkgs/by-name/on/oniux/package.nix
@@ -30,10 +30,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Isolate Applications over Tor using Linux Namespaces";
     maintainers = with lib.maintainers; [ tnias ];
     platforms = lib.platforms.linux;
-    license = with lib.licenses; [
-      asl20
-      mit
-    ];
+    license =
+      with lib.licenses;
+      OR [
+        asl20
+        mit
+      ];
     mainProgram = "oniux";
   };
 })

--- a/pkgs/by-name/ve/vectorscan/package.nix
+++ b/pkgs/by-name/ve/vectorscan/package.nix
@@ -116,11 +116,13 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.vectorcamp.gr/vectorscan/";
     changelog = "https://github.com/VectorCamp/vectorscan/blob/${finalAttrs.src.rev}/CHANGELOG-vectorscan.md";
     platforms = lib.platforms.unix;
-    license = with lib.licenses; [
-      bsd3 # and
-      bsd2 # and
-      lib.licenses.boost
-    ];
+    license =
+      with lib.licenses;
+      AND [
+        bsd3
+        bsd2
+        lib.licenses.boost
+      ];
     maintainers = with lib.maintainers; [
       tnias
       vlaci

--- a/pkgs/development/python-modules/pyperscan/default.nix
+++ b/pkgs/development/python-modules/pyperscan/default.nix
@@ -43,10 +43,12 @@ buildPythonPackage rec {
     homepage = "https://vlaci.github.io/pyperscan/";
     changelog = "https://github.com/vlaci/pyperscan/releases/tag/${src.rev}";
     platforms = lib.platforms.unix;
-    license = with lib.licenses; [
-      asl20 # or
-      mit
-    ];
+    license =
+      with lib.licenses;
+      OR [
+        asl20
+        mit
+      ];
     maintainers = with lib.maintainers; [
       tnias
       vlaci


### PR DESCRIPTION
Apply https://github.com/NixOS/nixpkgs/pull/468378 for some packages I maintain.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

CC: @jopejoe1