### PR TITLE
thokr: adopt

### DIFF
--- a/pkgs/by-name/th/thokr/package.nix
+++ b/pkgs/by-name/th/thokr/package.nix
@@ -8,8 +8,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "thokr";
   version = "0.4.1";
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   src = fetchFromGitHub {
-    owner = "thatvegandev";
+    owner = "jrnxf";
     repo = "thokr";
     rev = "v${finalAttrs.version}";
     sha256 = "0aryfx9qlnjdq3iq2d823c82fhkafvibmbz58g48b8ah5x5fv3ir";
@@ -19,7 +22,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Typing tui with visualized results and historical logging";
-    homepage = "https://github.com/thatvegandev/thokr";
+    homepage = "https://github.com/jrnxf/thokr";
     license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "thokr";

--- a/pkgs/by-name/th/thokr/package.nix
+++ b/pkgs/by-name/th/thokr/package.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     description = "Typing tui with visualized results and historical logging";
     homepage = "https://github.com/jrnxf/thokr";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ aiyion ];
     mainProgram = "thokr";
   };
 })


### PR DESCRIPTION
Following #531114, I'd like to adopt thokr.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - ~Package update: when the change is major or breaking.~
- NixOS Release Notes
  - ~Module addition: when adding a new NixOS module.~
  - ~Module update: when the change is significant.~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
