### PR TITLE
vlc: libaacs repair and convention update

### DIFF
--- a/pkgs/by-name/vl/vlc/package.nix
+++ b/pkgs/by-name/vl/vlc/package.nix
@@ -26,6 +26,7 @@
   libxinerama,
   libxpm,
   libarchive,
+  libaacs,
   libass,
   libbluray-full,
   libcaca,
@@ -152,6 +153,7 @@ stdenv.mkDerivation (finalAttrs: {
     libGL
     libsm
     libarchive
+    libaacs
     libass
     libbluray-full
     libcaca
@@ -299,6 +301,7 @@ stdenv.mkDerivation (finalAttrs: {
   # depends on a qt5.qttranslations that doesn't build, even though it
   # should be the same as pkgsBuildBuild.qt5.qttranslations.
   postFixup = ''
+    patchelf --add-rpath ${libaacs}/lib "$out/lib/vlc/plugins/access/liblibbluray_plugin.so"
     patchelf --add-rpath ${libv4l}/lib "$out/lib/vlc/plugins/access/libv4l2_plugin.so"
     find $out/lib/vlc/plugins -exec touch -d @1 '{}' ';'
     ${

--- a/pkgs/by-name/vl/vlc/package.nix
+++ b/pkgs/by-name/vl/vlc/package.nix
@@ -5,7 +5,6 @@
   avahi,
   bison,
   cairo,
-  curl,
   dbus,
   faad2,
   fetchFromGitLab,
@@ -83,10 +82,8 @@
   wayland-protocols,
   wayland-scanner,
   wrapGAppsHook3,
-  writeShellScript,
   libxcb-keysyms,
   zlib,
-
   chromecastSupport ? true,
   jackSupport ? false,
   onlyLibVLC ? false,
@@ -248,7 +245,7 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     echo "$version" > src/revision.txt
     substituteInPlace modules/text_renderer/freetype/platform_fonts.h \
-      --replace \
+      --replace-fail \
         /usr/share/fonts/truetype/freefont \
         ${freefont_ttf}/share/fonts/truetype
   ''
@@ -257,7 +254,7 @@ stdenv.mkDerivation (finalAttrs: {
   # https://www.lua.org/wshop13/Jericke.pdf#page=39
   + lib.optionalString (!stdenv.hostPlatform.canExecute stdenv.buildPlatform) ''
     substituteInPlace share/Makefile.am \
-      --replace $'.luac \\\n' $'.lua \\\n'
+      --replace-fail $'.luac \\\n' $'.lua \\\n'
   '';
 
   enableParallelBuilding = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
## Summary
VLC Depends on libbluray-full to use codecs needed to play Blu-Ray discs due to the change here: #370686 libaacs was propagating through libbluray-full but was not being added to the rpath of the Blu-ray plugin, causing runtime issues this PR adds libaacs to top level attrset and buildInputs then uses patchelf to set the rpath. Furthermore there were 2 instances of the old --replace convention that have been updated to --replace-fail and 2 unused variables in the top level attrset have been dropped. Built VLC and checked that libaacs was in the build and rpath set correctly

Resolves #491989 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
