### PR TITLE
netboxPlugins: add passthru.pluginName

### DIFF
--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-attachments/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-attachments/package.nix
@@ -37,6 +37,8 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "netbox_attachments" ];
 
+  passthru.pluginName = "netbox_attachments";
+
   meta = {
     description = "Plugin to manage attachments for any model";
     homepage = "https://github.com/Kani999/netbox-attachments";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-bgp/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-bgp/package.nix
@@ -33,6 +33,8 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "netbox_bgp" ];
 
+  passthru.pluginName = "netbox_bgp";
+
   meta = {
     description = "NetBox plugin for BGP related objects documentation";
     homepage = "https://github.com/netbox-community/netbox-bgp";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-config-backup/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-config-backup/package.nix
@@ -42,6 +42,8 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "netbox_config_backup" ];
 
+  passthru.pluginName = "netbox_config_backup";
+
   meta = {
     description = "NetBox plugin for configuration backups using napalm";
     homepage = "https://github.com/DanSheps/netbox-config-backup";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-contract/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-contract/package.nix
@@ -43,6 +43,8 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "netbox_contract" ];
 
+  passthru.pluginName = "netbox_contract";
+
   meta = {
     description = "Contract plugin for netbox";
     homepage = "https://github.com/mlebreuil/netbox-contract";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-custom-objects/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-custom-objects/package.nix
@@ -32,6 +32,8 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "netbox_custom_objects" ];
 
+  passthru.pluginName = "netbox_custom_objects";
+
   meta = {
     description = "NetBox plugin to create new object types";
     homepage = "https://github.com/netboxlabs/netbox-custom-objects";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-data-flows/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-data-flows/package.nix
@@ -32,6 +32,8 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "netbox_data_flows" ];
 
+  passthru.pluginName = "netbox_data_flows";
+
   meta = {
     description = "NetBox plugin to document data flows between systems and applications";
     homepage = "https://github.com/Alef-Burzmali/netbox-data-flows";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-documents/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-documents/package.nix
@@ -34,6 +34,8 @@ buildPythonPackage (finalAttrs: {
   dontUsePythonImportsCheck = python.pythonVersion != netbox.python.pythonVersion;
   pythonImportsCheck = [ "netbox_documents" ];
 
+  passthru.pluginName = "netbox_documents";
+
   meta = {
     description = "Plugin designed to faciliate the storage of site, circuit, device type and device specific documents within NetBox";
     homepage = "https://github.com/jasonyates/netbox-documents";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-floorplan-plugin/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-floorplan-plugin/package.nix
@@ -37,6 +37,8 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "netbox_floorplan" ];
 
+  passthru.pluginName = "netbox_floorplan";
+
   meta = {
     description = "Netbox plugin providing floorplan mapping capability for locations and sites";
     homepage = "https://github.com/netbox-community/netbox-floorplan-plugin";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-interface-synchronization/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-interface-synchronization/package.nix
@@ -49,6 +49,8 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "netbox_interface_synchronization" ];
 
+  passthru.pluginName = "netbox_interface_synchronization";
+
   meta = {
     description = "Netbox plugin to compare and synchronize interfaces between devices and device types";
     homepage = "https://github.com/NetTech2001/netbox-interface-synchronization";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-inventory/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-inventory/package.nix
@@ -32,6 +32,8 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "netbox_inventory" ];
 
+  passthru.pluginName = "netbox_inventory";
+
   meta = {
     description = "NetBox plugin to manage hardware inventory";
     homepage = "https://github.com/ArnesSI/netbox-inventory";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-lifecycle/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-lifecycle/package.nix
@@ -34,6 +34,8 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "netbox_lifecycle" ];
 
+  passthru.pluginName = "netbox_lifecycle";
+
   dependencies = [ django-polymorphic ];
 
   meta = {

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-lists/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-lists/package.nix
@@ -34,6 +34,8 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "netbox_lists" ];
 
+  passthru.pluginName = "netbox_lists";
+
   meta = {
     description = "NetBox plugin to generate IP and prefix lists. Integrates with Ansible, Terraform, Prometheus, Oxidized and more";
     homepage = "https://github.com/devon-mar/netbox-lists";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-napalm-plugin/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-napalm-plugin/package.nix
@@ -43,6 +43,8 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "netbox_napalm_plugin" ];
 
+  passthru.pluginName = "netbox_napalm_plugin";
+
   meta = {
     description = "Netbox plugin for Napalm integration";
     homepage = "https://github.com/netbox-community/netbox-napalm-plugin";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-plugin-prometheus-sd/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-plugin-prometheus-sd/package.nix
@@ -47,6 +47,8 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "netbox_prometheus_sd" ];
 
+  passthru.pluginName = "netbox_prometheus_sd";
+
   meta = {
     description = "Netbox plugin to provide Netbox entires to Prometheus HTTP service discovery";
     homepage = "https://github.com/FlxPeters/netbox-plugin-prometheus-sd";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-qrcode/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-qrcode/package.nix
@@ -52,6 +52,8 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "netbox_qrcode" ];
 
+  passthru.pluginName = "netbox_qrcode";
+
   passthru.updateScript = nix-update-script {
     extraArgs = [
       "--version-regex"

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-reorder-rack/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-reorder-rack/package.nix
@@ -33,6 +33,8 @@ buildPythonPackage (finalAttrs: {
   dontUsePythonImportsCheck = python.pythonVersion != netbox.python.pythonVersion;
   pythonImportsCheck = [ "netbox_reorder_rack" ];
 
+  passthru.pluginName = "netbox_reorder_rack";
+
   meta = {
     description = "NetBox plugin to allow users to reorder devices within a rack using a drag and drop UI";
     homepage = "https://github.com/netbox-community/netbox-reorder-rack";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-routing/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-routing/package.nix
@@ -34,6 +34,8 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "netbox_routing" ];
 
+  passthru.pluginName = "netbox_routing";
+
   dependencies = [ django-polymorphic ];
 
   meta = {

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-secrets/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-secrets/package.nix
@@ -35,6 +35,8 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "netbox_secrets" ];
 
+  passthru.pluginName = "netbox_secrets";
+
   meta = {
     description = "NetBox plugin to enhance secret management with encrypted storage and flexible, user-friendly features";
     homepage = "https://github.com/Onemind-Services-LLC/netbox-secrets";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-security/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-security/package.nix
@@ -34,6 +34,8 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "netbox_security" ];
 
+  passthru.pluginName = "netbox_security";
+
   meta = {
     description = "NetBox plugin covering various security and NAT related models";
     homepage = "https://github.com/andy-shady-org/netbox-security";

--- a/pkgs/by-name/ne/netbox_4_5/plugins/netbox-topology-views/package.nix
+++ b/pkgs/by-name/ne/netbox_4_5/plugins/netbox-topology-views/package.nix
@@ -37,6 +37,8 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "netbox_topology_views" ];
 
+  passthru.pluginName = "netbox_topology_views";
+
   meta = {
     description = "Netbox plugin for generate topology views/maps from your devices";
     homepage = "https://github.com/netbox-community/netbox-topology-views";


### PR DESCRIPTION
As suggested in https://github.com/NixOS/nixpkgs/issues/261522 I'd like to introduce a pluginName parameter, for the plugin identifier (which is slightly different from the package name). This identifier is required to enable the plugin in netbox using the option `services.netbox.settings.PLUGINS`. In the future we might even extend the nixos module for netbox to allow the activation of plugins using mkEnableOptions.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
