### PR TITLE
libfaketime: modernize

### DIFF
--- a/pkgs/by-name/li/libfaketime/package.nix
+++ b/pkgs/by-name/li/libfaketime/package.nix
@@ -26,6 +26,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = hashes.${finalAttrs.version};
   };
 
+  outputs = [
+    "out"
+    "doc"
+    "man"
+  ];
+
   patches = [
     ./nix-store-date.patch
   ]

--- a/pkgs/by-name/li/libfaketime/package.nix
+++ b/pkgs/by-name/li/libfaketime/package.nix
@@ -72,6 +72,8 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
 
   __structuredAttrs = true;
+  structDeps = true;
+  enableParallelBuilding = true;
 
   meta = {
     description = "Report faked system time to programs without having to change the system-wide time";

--- a/pkgs/by-name/li/libfaketime/package.nix
+++ b/pkgs/by-name/li/libfaketime/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
   env = {
     PREFIX = placeholder "out";
     LIBDIRNAME = "/lib";
-    NIX_CFLAGS_COMPILE = toString (
+    CFLAGS = toString (
       lib.optionals stdenv.cc.isClang [
         "-Wno-error=cast-function-type"
         "-Wno-error=format-truncation"


### PR DESCRIPTION
Set `strictDeps` & `enableParallelBuilding` (`__structuredAttrs` was already set, yay).
This did not change the output (modulo input-addressed output paths).

Change `NIX_CFLAGS_COMPILE` to `CFLAGS`. Built for loongarch64, output remained the same (modulo paths).

Finally, split `doc` & `man` into separate outputs. Output size changes:
- `out`: `232K` -> `180K`
- `man`: `0` -> `4K`
- `doc:` `0` -> `48K`


cc:
- https://github.com/NixOS/nixpkgs/issues/79303
- https://github.com/NixOS/nixpkgs/issues/515268


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-linux -> loongarch64-linux
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
