### PR TITLE
acl: modernize

### DIFF
--- a/pkgs/development/libraries/acl/default.nix
+++ b/pkgs/development/libraries/acl/default.nix
@@ -11,12 +11,12 @@
 # cgit) that are needed here should be included directly in Nixpkgs as
 # files.
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "acl";
   version = "2.3.2";
 
   src = fetchurl {
-    url = "mirror://savannah/acl/acl-${version}.tar.gz";
+    url = "mirror://savannah/acl/acl-${finalAttrs.version}.tar.gz";
     hash = "sha256-XyvbrWKXB6p9hcYj+ZSqih0t7FWnPeUgW6wL9gWKL3w=";
   };
 
@@ -41,6 +41,6 @@ stdenv.mkDerivation rec {
     description = "Library and tools for manipulating access control lists";
     license = lib.licenses.gpl2Plus;
     teams = [ lib.teams.security-review ];
-    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "acl_project" version;
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "acl_project" finalAttrs.version;
   };
-}
+})

--- a/pkgs/development/libraries/acl/default.nix
+++ b/pkgs/development/libraries/acl/default.nix
@@ -28,6 +28,10 @@ stdenv.mkDerivation (finalAttrs: {
     "doc"
   ];
 
+  strictDeps = true;
+  __structuredAttrs = true;
+  enableParallelBuilding = true;
+
   nativeBuildInputs = [ gettext ];
   buildInputs = [ attr ];
 


### PR DESCRIPTION
- `finalAttrs` (no eval changes here)
- `strictDeps`, `__structuredAttrs`, `enableParallelBuilding`  (the last one sped it up for me from `15s` to `8s` on my 12-thread 6-core Ryzen 5 4600H) (output remained the same, modulo the path)
- cc https://github.com/NixOS/nixpkgs/issues/178468
- cc https://github.com/NixOS/nixpkgs/issues/205690


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
