### PR TITLE
rust-cbindgen: 0.29.3 -> 0.29.4

### DIFF
--- a/pkgs/build-support/build-mozilla-mach/153-cbindgen-0.29.4-compat.patch
+++ b/pkgs/build-support/build-mozilla-mach/153-cbindgen-0.29.4-compat.patch
@@ -1,0 +1,36 @@
+commit c4aab1ba6aadd6985fcd271679d2118f094ec876
+Author: Emilio Cobos Álvarez <emilio@crisal.io>
+Date:   Tue Jun 9 22:04:44 2026 +0000
+
+    Bug 2046162 - Remove some redundant pub qualifiers. r=gfx-reviewers,aosmond
+    
+    The enum is not public so this doesn't change behavior but a patch I'm
+    working on in cbindgen gets a bit confused with this.
+    
+    Differential Revision: https://phabricator.services.mozilla.com/D305678
+
+diff --git a/gfx/wr/webrender/src/texture_cache.rs b/gfx/wr/webrender/src/texture_cache.rs
+index e14c26bd3190..77e1f3a312ac 100644
+--- a/gfx/wr/webrender/src/texture_cache.rs
++++ b/gfx/wr/webrender/src/texture_cache.rs
+@@ -273,9 +273,9 @@ enum BudgetType {
+ }
+ 
+ impl BudgetType {
+-    pub const COUNT: usize = 7;
++    const COUNT: usize = 7;
+ 
+-    pub const VALUES: [BudgetType; BudgetType::COUNT] = [
++    const VALUES: [BudgetType; BudgetType::COUNT] = [
+         BudgetType::SharedColor8Linear,
+         BudgetType::SharedColor8Nearest,
+         BudgetType::SharedColor8Glyphs,
+@@ -285,7 +285,7 @@ impl BudgetType {
+         BudgetType::Standalone,
+     ];
+ 
+-    pub const PRESSURE_COUNTERS: [usize; BudgetType::COUNT] = [
++    const PRESSURE_COUNTERS: [usize; BudgetType::COUNT] = [
+         profiler::ATLAS_COLOR8_LINEAR_PRESSURE,
+         profiler::ATLAS_COLOR8_NEAREST_PRESSURE,
+         profiler::ATLAS_COLOR8_GLYPHS_PRESSURE,

--- a/pkgs/build-support/build-mozilla-mach/default.nix
+++ b/pkgs/build-support/build-mozilla-mach/default.nix
@@ -341,6 +341,11 @@ buildStdenv.mkDerivation {
       # https://bugzilla.mozilla.org/show_bug.cgi?id=1985509
       ./140-bindgen-string-view.patch
     ]
+    ++ lib.optionals (lib.versionAtLeast version "140" && lib.versionOlder version "140.13") [
+      # https://github.com/mozilla/cbindgen/issues/1165
+      # https://bugzilla.mozilla.org/show_bug.cgi?id=2046162
+      ./153-cbindgen-0.29.4-compat.patch
+    ]
     ++ extraPatches;
 
   postPatch = ''

--- a/pkgs/by-name/ru/rust-cbindgen/package.nix
+++ b/pkgs/by-name/ru/rust-cbindgen/package.nix
@@ -14,16 +14,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rust-cbindgen";
-  version = "0.29.3";
+  version = "0.29.4";
 
   src = fetchFromGitHub {
     owner = "mozilla";
     repo = "cbindgen";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-d0rY7Sk37s8HEZlQq9Sbjj1P+DgygD0Yjx8cXlFKEIA=";
+    hash = "sha256-leeHOwpzXuzg2cTjXehBnCsS+dvU4eIIFtWKeCee20U=";
   };
 
-  cargoHash = "sha256-UeierkQpfCiB5ES9ZW9hO+0AcI9Ip8qSJ/Nd+I1xrmQ=";
+  cargoHash = "sha256-f6YoDoiVoh0BVPYHFO1FsdI4OCsF+LY72QaD57StdIQ=";
 
   nativeCheckInputs = [
     cmake


### PR DESCRIPTION
https://github.com/mozilla/cbindgen/blob/v0.29.4/CHANGES


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
