### PR TITLE
plex-desktop: enable egl

### DIFF
--- a/pkgs/by-name/pl/plex-desktop/package.nix
+++ b/pkgs/by-name/pl/plex-desktop/package.nix
@@ -177,6 +177,9 @@ buildFHSEnv {
     # These environment variables sometimes silently cause plex to crash.
     unset QT_QPA_PLATFORM QT_STYLE_OVERRIDE
 
+    # Use EGL for Qt's XCB GL integration so libmpv can use direct VAAPI
+    export QT_XCB_GL_INTEGRATION=xcb_egl
+
     set -o allexport
     ${lib.toShellVars extraEnv}
     exec ${plex-desktop}/Plex.sh


### PR DESCRIPTION
I added an env variable that forces qt xcb to use egl over glx for gl integration which enables  vaapi direct playback, eliminating stuttering effect when using hardware decoding.

Before patch in my mpv logs (accessible through ~/.local/share/plex/mpv.conf) i saw that vaapi-copy is used because vaapi fails. This causes significant stuttering and audio desync. After the patch, vaapi succeeds and playback is normal.

Following this issue:
https://github.com/plexinc/plex-media-player/issues/1067

Relates to my investigation in the comments of my earlier PR #528535

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
