### PR TITLE
nixos/gitlab: Add support for enterprise edition licensing

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -62,6 +62,21 @@
   "module-boot-plymouth-tpm2-totp-quick-start-enable": [
     "index.html#module-boot-plymouth-tpm2-totp-quick-start-enable"
   ],
+  "module-services-gitlab-enterprise": [
+    "index.html#module-services-gitlab-enterprise"
+  ],
+  "module-services-gitlab-enterprise-activation-code": [
+    "index.html#module-services-gitlab-enterprise-activation-code"
+  ],
+  "module-services-gitlab-enterprise-enabling": [
+    "index.html#module-services-gitlab-enterprise-enabling"
+  ],
+  "module-services-gitlab-enterprise-license-file": [
+    "index.html#module-services-gitlab-enterprise-license-file"
+  ],
+  "module-services-gitlab-enterprise-portal-url": [
+    "index.html#module-services-gitlab-enterprise-portal-url"
+  ],
   "module-services-keycloak-unix-socket": [
     "index.html#module-services-keycloak-unix-socket"
   ],

--- a/nixos/modules/services/misc/gitlab.md
+++ b/nixos/modules/services/misc/gitlab.md
@@ -124,6 +124,93 @@ A list of all available rake tasks can be obtained by running:
 $ sudo -u git -H gitlab-rake -T
 ```
 
+## Enterprise Edition {#module-services-gitlab-enterprise}
+
+GitLab Enterprise Edition (EE) includes proprietary features that require a valid
+license. Configure it through the `services.gitlab.enterprise` option group.
+
+### Enabling EE {#module-services-gitlab-enterprise-enabling}
+
+`gitlab-ee` carries an unfree license, so you'll need to allow unfree packages:
+
+```nix
+{
+  nixpkgs.config.allowUnfree = true;
+
+  services.gitlab = {
+    enable = true;
+    enterprise.enable = true;
+  };
+}
+```
+
+This switches `services.gitlab.packages.gitlab` to `pkgs.gitlab-ee`. Without a
+valid license the instance runs EE binaries but only Community Edition features
+are available.
+
+### Offline license file {#module-services-gitlab-enterprise-license-file}
+
+For air-gapped instances, request an offline `.gitlab-license` file from GitLab
+Sales. It is recommended a secrets management tool is used to keep the license
+secure.
+
+```nix
+{
+  services.gitlab.enterprise = {
+    enable = true;
+    licenseFile = "/var/keys/gitlab/gitlab.gitlab-license";
+  };
+}
+```
+
+The file is loaded during `gitlab-db-config.service`. A sha256 sentinel prevents
+duplicate database entries across reboots, replacing the secret and running
+`nixos-rebuild switch` will invalidate this and apply a renewed license.
+If loading fails, the unit retries and holds back all GitLab services until
+a valid license is provided, and activation succeeds.
+
+### Cloud activation code {#module-services-gitlab-enterprise-activation-code}
+
+For instances with internet access, use the 24-character activation code from the
+GitLab customer portal:
+
+```nix
+{
+  services.gitlab.enterprise = {
+    enable = true;
+    activationCodeFile = "/var/keys/gitlab/activation_code";
+  };
+}
+```
+
+The activation code should be kept private, so it is recommended a secrets
+management tool is used to store and supply it at runtime.
+
+This contacts `https://customers.gitlab.com` on every boot to sync the license.
+If the portal is unreachable, `gitlab-db-config.service` retries and holds back
+all GitLab services until activation succeeds.
+
+`licenseFile` and `activationCodeFile` cannot be used at the same time.
+
+### Customer Portal URL {#module-services-gitlab-enterprise-portal-url}
+
+Override the portal URL, for example when using the staging portal:
+
+```nix
+{
+  services.gitlab.enterprise = {
+    enable = true;
+    customerPortalUrl = "https://customers.staging.gitlab.com";
+    licenseMode = "test"; # required for staging-issued licenses
+  };
+}
+```
+
+`licenseMode = "test"` selects the staging license decryption key. Leave it unset
+for production licenses.
+
+Most installs will not need to customize this and should use the production portal.
+
 ## Runner {#module-services-gitlab-runner}
 
 GitLab Runner is a CI runner which is an executable which you can host yourself.

--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -207,6 +207,12 @@ let
       # rather than version listed in Gemfile.lock
       BUNDLER_VERSION = pkgs.bundler.version;
     }
+    // optionalAttrs (cfg.enterprise.customerPortalUrl != null) {
+      CUSTOMER_PORTAL_URL = cfg.enterprise.customerPortalUrl;
+    }
+    // optionalAttrs (cfg.enterprise.licenseMode != null) {
+      GITLAB_LICENSE_MODE = cfg.enterprise.licenseMode;
+    }
     // cfg.extraEnv;
 
   runtimeDeps = [
@@ -305,8 +311,16 @@ in
         '';
       };
 
-      packages.gitlab = mkPackageOption pkgs "gitlab" {
-        example = "gitlab-ee";
+      packages.gitlab = mkOption {
+        type = types.package;
+        default = if cfg.enterprise.enable then pkgs.gitlab-ee else pkgs.gitlab;
+        defaultText = literalExpression "if config.services.gitlab.enterprise.enable then pkgs.gitlab-ee else pkgs.gitlab";
+        example = literalExpression "pkgs.gitlab-ee";
+        description = ''
+          The GitLab package to use. Defaults to `pkgs.gitlab-ee` when
+          {option}`services.gitlab.enterprise.enable` is set, otherwise
+          `pkgs.gitlab` (Community Edition).
+        '';
       };
 
       packages.gitlab-shell = mkPackageOption pkgs "gitlab-shell" { };
@@ -316,6 +330,72 @@ in
       packages.gitaly = mkPackageOption pkgs "gitaly" { };
 
       packages.pages = mkPackageOption pkgs "gitlab-pages" { };
+
+      enterprise = {
+        enable = mkEnableOption "GitLab Enterprise Edition (EE). Requires `nixpkgs.config.allowUnfree = true`. Without a valid license the instance runs EE binaries but only Community Edition features are available";
+
+        licenseFile = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          example = "/var/keys/gitlab/gitlab.gitlab-license";
+          description = ''
+            Path to an offline `.gitlab-license` file from GitLab Sales. Use this for
+            air-gapped instances that cannot reach the Customers Portal. A sha256 sentinel
+            ensures the file is only loaded when it changes, so renewing a license is just
+            a `nixos-rebuild switch` away.
+
+            Keep the file outside the Nix store (use agenix or sops-nix).
+
+            Mutually exclusive with {option}`services.gitlab.enterprise.activationCodeFile`.
+          '';
+        };
+
+        activationCodeFile = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          example = "/var/keys/gitlab/activation_code";
+          description = ''
+            Path to a file containing a 24-character GitLab EE cloud activation code from
+            the Customers Portal. Requires outbound HTTPS to the portal on every boot
+            (default `https://customers.gitlab.com`, or
+            {option}`services.gitlab.enterprise.customerPortalUrl`). Handles renewals
+            automatically. If the portal is unreachable, `gitlab-db-config.service` will
+            retry and hold back all GitLab services until it succeeds.
+
+            For air-gapped instances use
+            {option}`services.gitlab.enterprise.licenseFile` instead.
+
+            Mutually exclusive with {option}`services.gitlab.enterprise.licenseFile`.
+          '';
+        };
+
+        customerPortalUrl = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          example = "https://customers.gitlab.com";
+          description = ''
+            Override the GitLab Customers Portal URL (`CUSTOMER_PORTAL_URL`). Controls all
+            outbound traffic to the portal: activation, seat-link sync, Cloud Connector
+            token refresh, and Admin Area subscription links. Does not affect service ping
+            (`https://version.gitlab.com`); disable that separately via
+            `services.gitlab.extraConfig.usage_ping_enabled = false`.
+
+            Defaults to `https://customers.gitlab.com`. Override for the staging portal
+            (`https://customers.staging.gitlab.com`) or a custom endpoint.
+          '';
+        };
+
+        licenseMode = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          example = "test";
+          description = ''
+            Sets `GITLAB_LICENSE_MODE` on all GitLab services. Set to `"test"` when the
+            license or activation code was issued by the staging Customers Portal
+            (`https://customers.staging.gitlab.com`). Leave unset for production licenses.
+          '';
+        };
+      };
 
       statePath = mkOption {
         type = types.str;
@@ -1241,6 +1321,20 @@ in
         assertion = versionAtLeast postgresqlPackage.version "16";
         message = "PostgreSQL >= 16 is required to run GitLab 18. Follow the instructions in the manual section for upgrading PostgreSQL here: https://nixos.org/manual/nixos/stable/index.html#module-services-postgres-upgrading";
       }
+      {
+        assertion = !(cfg.enterprise.licenseFile != null && cfg.enterprise.activationCodeFile != null);
+        message = "services.gitlab.enterprise.licenseFile and services.gitlab.enterprise.activationCodeFile are mutually exclusive. Set only one.";
+      }
+      {
+        assertion =
+          (cfg.enterprise.licenseFile != null || cfg.enterprise.activationCodeFile != null)
+          -> (cfg.packages.gitlab.passthru.gitlabEnv.FOSS_ONLY or "true") == "false";
+        message = ''
+          services.gitlab.enterprise.licenseFile / activationCodeFile require an Enterprise
+          Edition package. Set services.gitlab.enterprise.enable = true, or set
+          services.gitlab.packages.gitlab = pkgs.gitlab-ee explicitly.
+        '';
+      }
     ];
 
     environment.systemPackages = [
@@ -1590,6 +1684,24 @@ in
           initial_root_password="$(<'${cfg.initialRootPasswordFile}')"
           ${gitlab-rake}/bin/gitlab-rake gitlab:db:configure GITLAB_ROOT_PASSWORD="$initial_root_password" \
                                                              GITLAB_ROOT_EMAIL='${cfg.initialRootEmail}' > /dev/null
+          ${optionalString (cfg.enterprise.enable && cfg.enterprise.licenseFile != null) ''
+            # License.create! inserts a new row on every call; use a sha256 sentinel to
+            # skip loading when the file hasn't changed.
+            _lic_hash=$(${pkgs.coreutils}/bin/sha256sum '${cfg.enterprise.licenseFile}' \
+                          | ${pkgs.coreutils}/bin/cut -c1-64)
+            _lic_sentinel='${cfg.statePath}/.license_loaded_'"$_lic_hash"
+            if [ ! -f "$_lic_sentinel" ]; then
+              export GITLAB_LICENSE_FILE='${cfg.enterprise.licenseFile}'
+              ${gitlab-rake}/bin/gitlab-rake gitlab:license:load > /dev/null
+              # If we crash before this touch, the duplicate row on next boot is harmless.
+              ${pkgs.coreutils}/bin/touch "$_lic_sentinel"
+            fi
+          ''}
+          ${optionalString (cfg.enterprise.enable && cfg.enterprise.activationCodeFile != null) ''
+            GITLAB_ACTIVATION_CODE="$(<'${cfg.enterprise.activationCodeFile}')"
+            export GITLAB_ACTIVATION_CODE
+            ${gitlab-rake}/bin/gitlab-rake gitlab:license:load > /dev/null
+          ''}
         '';
       };
     };

--- a/nixos/tests/gitlab/default.nix
+++ b/nixos/tests/gitlab/default.nix
@@ -1,5 +1,7 @@
 { runTest }:
 {
   gitlab = runTest ./gitlab.nix;
+  gitlab-ee = runTest ./ee.nix;
+  gitlab-ee-activation = runTest ./ee-activation.nix;
   runner = runTest ./runner.nix;
 }

--- a/nixos/tests/gitlab/ee-activation.nix
+++ b/nixos/tests/gitlab/ee-activation.nix
@@ -1,0 +1,122 @@
+# NixOS integration test for GitLab Enterprise Edition (EE) cloud activation
+# (services.gitlab.enterprise.activationCodeFile).
+#
+# Proves the full cloud-activation path: the module reads the activation code and
+# sends it to customerPortalUrl during gitlab-db-config, and the license returned
+# by the portal ends up in the database. A mock Customers Portal stands in for
+# customers.gitlab.com, returning a license blob signed by a throwaway keypair that
+# GitLab is made to trust (see ee-lib.nix), so no real activation code is needed.
+#
+# The EE package is unfree and large, so this test needs NIXPKGS_ALLOW_UNFREE=1 and
+# won't run in Hydra CI unless allowUnfree is set in the evaluation context.
+#
+# Run with:
+#   [nixpkgs]$ NIXPKGS_ALLOW_UNFREE=1 nix-build -A nixosTests.gitlab.gitlab-ee-activation
+
+{ pkgs, lib, ... }:
+
+let
+  eeLib = import ./ee-lib.nix { inherit pkgs lib; };
+in
+{
+  name = "gitlab-ee-activation";
+
+  meta = {
+    maintainers = with lib.maintainers; [ rane ];
+  };
+
+  nodes.gitlab =
+    { ... }:
+    lib.mkMerge [
+      eeLib.commonNode
+      {
+        systemd.tmpfiles.rules = [
+          "d /var/keys 0755 root root -"
+          "f /var/keys/activation-code 0400 gitlab gitlab - TESTACTIVATIONCODE123456"
+        ];
+
+        # Mock of the Customers Portal GraphQL endpoint. Records the request body and
+        # returns the fixture blob as cloudActivationActivate.licenseKey.
+        systemd.services.mock-portal = {
+          description = "Mock GitLab Customers Portal";
+          wantedBy = [ "multi-user.target" ];
+          before = [ "gitlab-db-config.service" ];
+          serviceConfig = {
+            Type = "simple";
+            ExecStart = pkgs.writeShellScript "mock-portal" ''
+              ${pkgs.python3}/bin/python3 ${pkgs.writeText "mock-portal.py" ''
+                import http.server, json
+
+                with open("${eeLib.licenseFixture}/license-blob") as f:
+                    BLOB = f.read()
+
+                class Handler(http.server.BaseHTTPRequestHandler):
+                    def do_POST(self):
+                        n = int(self.headers.get("Content-Length", 0))
+                        # Append every request: GitLab makes follow-up POSTs (seat-link,
+                        # cloud connector) after activation, so we must not overwrite.
+                        with open("/tmp/portal-requests.log", "ab") as out:
+                            out.write(self.rfile.read(n) + b"\n")
+                        resp = json.dumps({
+                            "data": {
+                                "cloudActivationActivate": {
+                                    "licenseKey": BLOB,
+                                    "futureSubscriptions": [],
+                                    "newSubscription": None,
+                                    "errors": []
+                                }
+                            }
+                        }).encode()
+                        self.send_response(200)
+                        self.send_header("Content-Type", "application/json")
+                        self.send_header("Content-Length", str(len(resp)))
+                        self.end_headers()
+                        self.wfile.write(resp)
+                    def log_message(self, *_):
+                        pass
+
+                http.server.HTTPServer(("127.0.0.1", 9999), Handler).serve_forever()
+              ''}
+            '';
+          };
+        };
+
+        systemd.services.gitlab-db-config = {
+          after = [ "mock-portal.service" ];
+          wants = [ "mock-portal.service" ];
+        };
+
+        services.gitlab = eeLib.commonGitlab // {
+          extraGitlabRb = eeLib.encryptionKeyOverride + eeLib.allowLocalRequestsOverride;
+          enterprise = {
+            enable = true;
+            activationCodeFile = "/var/keys/activation-code";
+            customerPortalUrl = "http://127.0.0.1:9999";
+          };
+        };
+      }
+    ];
+
+  testScript =
+    { ... }:
+    eeLib.helpers
+    + ''
+      gitlab.start()
+      gitlab.wait_for_unit("multi-user.target")
+
+      with subtest("activationCodeFile is wired into db-config"):
+          script = db_config_script(gitlab)
+          assert "GITLAB_ACTIVATION_CODE" in script, (
+              f"GITLAB_ACTIVATION_CODE not found in db-config script:\n{script}"
+          )
+          assert "/var/keys/activation-code" in script
+
+      with subtest("The activated license is written to the database"):
+          wait_db_config(gitlab)
+          plan = license_plan(gitlab)
+          assert plan == "ultimate", f"expected ultimate license in DB, got {plan!r}"
+
+      with subtest("The activation code was sent to customerPortalUrl"):
+          gitlab.succeed("grep -qF TESTACTIVATIONCODE123456 /tmp/portal-requests.log")
+    '';
+}

--- a/nixos/tests/gitlab/ee-lib.nix
+++ b/nixos/tests/gitlab/ee-lib.nix
@@ -1,0 +1,148 @@
+# Shared fixtures for the GitLab Enterprise Edition license tests
+# (ee.nix and ee-activation.nix).
+#
+# The core trick: GitLab validates a license by RSA-decrypting it with a public
+# key. We generate a throwaway keypair at build time, sign a license blob with
+# gitlab's own gitlab-license gem, and override Gitlab::License.encryption_key with
+# the public half so GitLab accepts the blob exactly as it would a real license.
+# This lets the tests prove a license ends up in the database without any real
+# GitLab-issued credentials.
+
+{ pkgs, lib }:
+
+let
+  licenseGen = pkgs.writeText "gen-license.rb" ''
+    require "gitlab/license"
+    Gitlab::License.encryption_key = OpenSSL::PKey::RSA.new(File.read(ARGV[0]))
+    license = Gitlab::License.new
+    license.licensee = {
+      "Name" => "NixOS Test",
+      "Company" => "NixOS",
+      "Email" => "test@example.com",
+    }
+    license.starts_at = Date.today - 1
+    license.expires_at = Date.today + 365
+    license.cloud_licensing_enabled = true
+    license.restrictions = { plan: "ultimate", active_user_count: 100 }
+    print license.export
+  '';
+
+  # An RSA keypair plus a license blob signed by it. gitlab-license is
+  # edition-independent, so the (free) CE rubyEnv generates the blob, keeping the
+  # fixture out of the unfree gitlab-ee closure.
+  licenseFixture =
+    pkgs.runCommand "gitlab-test-license"
+      {
+        nativeBuildInputs = [
+          pkgs.gitlab.rubyEnv.wrappedRuby
+          pkgs.openssl
+        ];
+      }
+      ''
+        mkdir -p $out
+        openssl genrsa -out key.pem 2048 2>/dev/null
+        openssl rsa -in key.pem -pubout -out $out/key.pub.pem 2>/dev/null
+        ruby ${licenseGen} key.pem > $out/license-blob
+      '';
+in
+{
+  inherit licenseFixture;
+
+  # Initializer that makes GitLab trust our test keypair instead of the
+  # GitLab-issued production key.
+  encryptionKeyOverride = ''
+    Gitlab::License.encryption_key = OpenSSL::PKey::RSA.new(File.read("${licenseFixture}/key.pub.pem"))
+  '';
+
+  # GitLab's HTTP client blocks requests to loopback/private addresses (SSRF
+  # protection), which would stop a cloud-activation request from reaching an
+  # in-VM mock portal. This is the initializer equivalent of the admin setting
+  # "Allow requests to the local network from webhooks and services", applied from
+  # boot so it is in effect when gitlab-db-config runs the activation.
+  allowLocalRequestsOverride = ''
+    module Gitlab
+      module CurrentSettings
+        def self.allow_local_requests_from_web_hooks_and_services?
+          true
+        end
+      end
+    end
+  '';
+
+  # Base gitlab settings shared by both tests. Values are test fixtures only.
+  commonGitlab = {
+    enable = true;
+    databasePasswordFile = pkgs.writeText "dbPassword" "xo0daiF4";
+    initialRootPasswordFile = pkgs.writeText "rootPassword" "notproduction";
+    secrets = {
+      secretFile = pkgs.writeText "secret" "Aig5zaic";
+      otpFile = pkgs.writeText "otpsecret" "Riew9mue";
+      dbFile = pkgs.writeText "dbsecret" "we2quaeZ";
+      jwsFile = pkgs.runCommand "oidcKeyBase" { } "${pkgs.openssl}/bin/openssl genrsa 2048 > $out";
+      activeRecordPrimaryKeyFile = pkgs.writeText "arprimary" "vsaYPZjTRxcbG7W6gNr95AwBmzFUd4Eu";
+      activeRecordDeterministicKeyFile = pkgs.writeText "ardeterministic" "kQarv9wb2JVP7XzLTh5f6DFcMHms4nEC";
+      activeRecordSaltFile = pkgs.writeText "arsalt" "QkgR9CfFU3MXEWGqa7LbP24AntK5ZeYw";
+    };
+    sidekiq.concurrency = 1;
+    puma.workers = 2;
+  };
+
+  # Base node config. Each test runs a single VM, so peak memory stays at one node.
+  commonNode = {
+    nixpkgs.config = lib.mkForce { allowUnfree = true; };
+    virtualisation.memorySize = 6144;
+    virtualisation.cores = 4;
+    virtualisation.useNixStoreImage = true;
+    virtualisation.writableStore = false;
+    # Fail fast on a license-load error instead of retrying forever, so the test
+    # detects it rather than timing out waiting for the unit to go active.
+    systemd.services.gitlab-db-config.serviceConfig.Restart = lib.mkForce "no";
+    services.nginx = {
+      enable = true;
+      recommendedProxySettings = true;
+      virtualHosts.localhost = {
+        locations."/".proxyPass = "http://unix:/run/gitlab/gitlab-workhorse.socket";
+      };
+    };
+  };
+
+  # Shared testScript helpers, prepended to each test's script.
+  helpers = ''
+    import re
+
+    def db_config_script(machine):
+        """Return the content of the gitlab-db-config ExecStart script."""
+        unit = machine.succeed("systemctl cat gitlab-db-config.service")
+        m = re.search(r'ExecStart=(/nix/store/\S+)', unit)
+        assert m, f"Could not find ExecStart path in unit:\n{unit}"
+        return machine.succeed(f"cat {m.group(1)}")
+
+    def wait_db_config(machine, timeout=900):
+        """Wait for gitlab-db-config to reach a terminal state; assert it succeeded.
+
+        With Restart=no the unit ends in active or failed, so we poll for either
+        rather than only 'active' (which would hang on failure). On failure we dump
+        the journal to surface the license-load error.
+        """
+        machine.wait_until_succeeds(
+            "systemctl show -p ActiveState --value gitlab-db-config.service "
+            "| grep -qE '^(active|failed)$'",
+            timeout=timeout,
+        )
+        state = machine.succeed(
+            "systemctl show -p ActiveState --value gitlab-db-config.service"
+        ).strip()
+        if state != "active":
+            machine.execute(
+                "journalctl -u gitlab-db-config.service --no-pager | tail -n 60 >&2"
+            )
+        assert state == "active", f"gitlab-db-config ended in state {state!r}"
+
+    def license_plan(machine):
+        """Return the plan of the currently active license, or 'NONE'."""
+        return machine.succeed(
+            "sudo -u gitlab -H gitlab-rails runner "
+            "'l = License.current; print(l ? l.restrictions[:plan] : %q(NONE))' 2>/dev/null"
+        ).strip()
+  '';
+}

--- a/nixos/tests/gitlab/ee.nix
+++ b/nixos/tests/gitlab/ee.nix
@@ -1,0 +1,103 @@
+# NixOS integration test for GitLab Enterprise Edition (EE) with an offline
+# license file (services.gitlab.enterprise.licenseFile).
+#
+# Proves the full offline path: the module loads the .gitlab-license file during
+# gitlab-db-config, and the license ends up in the database. The license blob is
+# signed by a throwaway keypair that GitLab is made to trust (see ee-lib.nix), so
+# no real GitLab-issued license is needed. Also covers the EE smoke checks:
+# FOSS_ONLY=false, the -ee VERSION suffix, and that the EE-only license rake tasks
+# are present.
+#
+# The EE package is unfree and large, so this test needs NIXPKGS_ALLOW_UNFREE=1 and
+# won't run in Hydra CI unless allowUnfree is set in the evaluation context.
+#
+# Run with:
+#   [nixpkgs]$ NIXPKGS_ALLOW_UNFREE=1 nix-build -A nixosTests.gitlab.gitlab-ee
+
+{ pkgs, lib, ... }:
+
+let
+  eeLib = import ./ee-lib.nix { inherit pkgs lib; };
+in
+{
+  name = "gitlab-ee";
+
+  meta = {
+    maintainers = with lib.maintainers; [ rane ];
+  };
+
+  nodes.gitlab =
+    { ... }:
+    lib.mkMerge [
+      eeLib.commonNode
+      {
+        # The db-config service reads the license file as the gitlab user, so it
+        # must be gitlab-readable (sops-nix/agenix would own it by gitlab in real use).
+        systemd.tmpfiles.rules = [
+          "d /var/keys 0755 root root -"
+          "C+ /var/keys/gitlab-license 0400 gitlab gitlab - ${eeLib.licenseFixture}/license-blob"
+        ];
+
+        services.gitlab = eeLib.commonGitlab // {
+          extraGitlabRb = eeLib.encryptionKeyOverride;
+          enterprise = {
+            enable = true;
+            licenseFile = "/var/keys/gitlab-license";
+            # Set purely to assert env injection; inert for the file path.
+            customerPortalUrl = "https://portal.test.example.com";
+            licenseMode = "test";
+          };
+        };
+      }
+    ];
+
+  testScript =
+    { nodes, ... }:
+    let
+      statePath = nodes.gitlab.services.gitlab.statePath;
+    in
+    eeLib.helpers
+    + ''
+      gitlab.start()
+
+      with subtest("GitLab EE boots and serves the sign-in page"):
+          gitlab.wait_for_unit("gitlab.service")
+          gitlab.wait_for_file("${statePath}/tmp/sockets/gitlab.socket")
+          gitlab.wait_until_succeeds("curl -sSf http://localhost/users/sign_in")
+
+      with subtest("The EE package is installed"):
+          # FOSS_ONLY=false is injected into the service environment by the EE
+          # package passthru; CE sets it to "true". Check via systemctl because the
+          # env is set by the makeWrapper wrappers, not the gitlab user's login env.
+          gitlab.succeed(
+              "systemctl show gitlab.service --property=Environment | grep -q 'FOSS_ONLY=false'"
+          )
+          gitlab.succeed(
+              "GITLAB_PATH=$(systemctl show gitlab.service --property=Environment "
+              + "| grep -oP 'GITLAB_PATH=\\K[^ ]+')"
+              + " && grep -q -- '-ee' \"$GITLAB_PATH/VERSION\""
+          )
+
+      with subtest("Enterprise env vars reach the service environment"):
+          for svc in ["gitlab.service", "gitlab-sidekiq.service"]:
+              gitlab.succeed(
+                  f"systemctl show {svc} --property=Environment "
+                  f"| grep -q 'CUSTOMER_PORTAL_URL=https://portal.test.example.com'"
+              )
+              gitlab.succeed(
+                  f"systemctl show {svc} --property=Environment "
+                  f"| grep -q 'GITLAB_LICENSE_MODE=test'"
+              )
+
+      with subtest("licenseFile is wired into db-config"):
+          script = db_config_script(gitlab)
+          assert "GITLAB_LICENSE_FILE='/var/keys/gitlab-license'" in script, (
+              f"GITLAB_LICENSE_FILE not found in db-config script:\n{script}"
+          )
+
+      with subtest("The license file is loaded into the database"):
+          wait_db_config(gitlab)
+          plan = license_plan(gitlab)
+          assert plan == "ultimate", f"expected ultimate license in DB, got {plan!r}"
+    '';
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds module support for specifying either an offline license file, or an activation code, so that the already packaged `pkgs.gitlab-ee` package can be activated/licensed and the EE features can be used via the module.

Options are also provided to customize the customer portal URL used for online activation, in case staging or a custom portal needs to be used.

Tests are provided to validate the two activation paths - a mocked customer portal API and fake activation key are written to validate that the activation key + license ends up in the DB correctly when configured as a result. Offline license activation carries similar tests.

Full documentation has been added for the `services.gitlab.enterprise` options added to the module, with examples.

I've tested this manually on my local GitLab deployment as well, given I work for GitLab I have access to our staging customer portal server and was able to test a full activation cycle against that customer portal with a valid activation key, and can confirm the instance is now fully licensed and using the enterprise edition as a result, using the module changes in this PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
