### PR TITLE
nixos/regreet: set greeter user home to a writable state dir

### DIFF
--- a/nixos/modules/programs/regreet.nix
+++ b/nixos/modules/programs/regreet.nix
@@ -7,7 +7,13 @@
 let
   cfg = config.programs.regreet;
   settingsFormat = pkgs.formats.toml { };
-  user = config.services.greetd.settings.default_session.user;
+  userName = config.services.greetd.settings.default_session.user;
+  user = config.users.users.${userName} or { };
+  dataDir =
+    if lib.versionAtLeast (cfg.package.version) "0.2.0" then
+      "/var/lib/regreet"
+    else
+      "/var/cache/regreet";
 in
 {
   options.programs.regreet = {
@@ -137,6 +143,25 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = user != { };
+        message = "regreet: user ${userName} does not exist. Please create it before referencing it.";
+      }
+    ];
+
+    warnings = lib.optional ((user ? home) && (user.home == "/var/empty")) ''
+      regreet: the home directory for user ${userName} is set to an immutable path.
+      Consider setting
+      ```
+        users.users.${userName}.home = ${dataDir}; # Directory is created by this module automatically
+      ```
+      or using
+      ```
+        services.greetd.settings.default_session.user = "greeter"; # The default
+      ```
+    '';
+
     environment.systemPackages = [
       cfg.theme.package
       cfg.iconTheme.package
@@ -177,27 +202,20 @@ in
     systemd.tmpfiles.settings."10-regreet" =
       let
         defaultConfig = {
-          inherit user;
-          group =
-            if config.users.users.${user}.group != "" then config.users.users.${user}.group else "greeter";
+          user = userName;
+          group = if ((user.group or "") != "") then user.group else "greeter";
           mode = "0755";
         };
-        dataDir =
-          if lib.versionAtLeast (cfg.package.version) "0.2.0" then
-            { "/var/lib/regreet".d = defaultConfig; }
-          else
-            { "/var/cache/regreet".d = defaultConfig; };
       in
       {
         "/var/log/regreet".d = defaultConfig;
-      }
-      // dataDir;
+        ${dataDir}.d = defaultConfig;
+      };
 
-    assertions = [
-      {
-        assertion = (config.users.users.${user} or { }) != { };
-        message = "regreet: user ${user} does not exist. Please create it before referencing it.";
-      }
-    ];
+    # For GTK pipeline shader cache directory, which is created at `$HOME/.cache`.
+    # By default `$HOME` is `/var/empty` though, owned by root, so GTK is unable
+    # to create it. `/var/empty` is intentionally immutable on NixOS (`chattr +i`),
+    # so `systemd.tmpfiles` cannot create `/var/empty/.cache` either.
+    users.users = lib.mkIf (userName == "greeter") { greeter.home = lib.mkDefault dataDir; };
   };
 }


### PR DESCRIPTION
GTK attempts to create `$HOME/.cache` for its pipeline shader cache when ReGreet starts. The default greeter user home is `/var/empty`, which is immutable on NixOS, so this produces cache-directory creation warnings. Default the built-in greeter user's home to ReGreet's writable state directory while preserving explicit user overrides and only warning for custom users that still use `/var/empty`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
