### PR TITLE
ci: npins → flake

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -8,7 +8,7 @@ inputs:
   target-as-trusted-at:
     description: "Whether and which SHA to checkout for the target commit in the ./nixpkgs/trusted folder."
   untrusted-pin-bump:
-    description: "Commit that bumps ci/pinned.json; when set, ./nixpkgs/untrusted and ./nixpkgs/untrusted-pinned are derived from this commit."
+    description: "Commit that bumps ci lockfile; when set, ./nixpkgs/untrusted and ./nixpkgs/untrusted-pinned are derived from this commit."
 
 runs:
   using: composite
@@ -47,12 +47,28 @@ runs:
           // same time no matter whether its 1, 2 or 3 commits at once.
           async function getPinnedSha(ref) {
             if (!ref) return undefined
-            const { content, encoding } = (await github.rest.repos.getContent({
-              ...context.repo,
-              path: 'ci/pinned.json',
-              ref,
-            })).data
-            const pinned = JSON.parse(Buffer.from(content, encoding).toString())
+
+            async function fetchJson(path) {
+              const { content, encoding } = (await github.rest.repos.getContent({
+                ...context.repo,
+                path,
+                ref,
+              })).data
+
+              return JSON.parse(Buffer.from(content, encoding).toString())
+            }
+
+            try {
+              const lock = await fetchJson('ci/flake.lock')
+              const node = lock.nodes[lock.nodes[lock.root].inputs.nixpkgs]
+              return node.locked.rev
+            } catch (err) {
+              if (err.status !== 404) throw err
+            }
+
+            // ci/flake.lock was added 2026-06-13, we can remove the 404-fallback ~2026-12-25 🎅
+            core.warning(`ci/flake.lock not found at ${ref}; falling back to ci/pinned.json`)
+            const pinned = await fetchJson('ci/pinned.json')
             return pinned.pins.nixpkgs.revision
           }
 
@@ -114,15 +130,15 @@ runs:
 
           // Apply pin bump to untrusted worktree
           if (pin_bump_sha) {
-            console.log('Fetching ci/pinned.json bump commit:', pin_bump_sha)
+            console.log('Fetching ci lockfile bump commit:', pin_bump_sha)
             await writeFile('pin-bump.patch', await getPinBumpDiff(pin_bump_sha))
 
-            console.log('Applying untrusted ci/pinned.json bump to ./nixpkgs/untrusted')
+            console.log('Applying untrusted ci lockfile bump to ./nixpkgs/untrusted')
             try {
               await run('git', '-C', join('nixpkgs', 'untrusted'), 'apply', '--3way', join('..', '..', 'pin-bump.patch'))
             } catch {
               core.setFailed([
-                `Failed to apply ci/pinned.json bump commit ${pin_bump_sha}.`,
+                `Failed to apply ci lockfile bump commit ${pin_bump_sha}.`,
                 `This commit does not apply cleanly onto the untrusted base ${process.env.MERGED_SHA}.`,
                 `Please rebase the PR or ensure the pin bump is standalone.`
               ].join(' '))

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -61,9 +61,9 @@ jobs:
           ref: ${{ inputs.mergedSha }}
           path: untrusted
           sparse-checkout: |
-            ci/pinned.json
+            ci/flake.lock
 
-      - name: Find commit that touched ci/pinned.json
+      - name: Find commit that touched ci lockfile
         id: find-pinned-commit
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
@@ -86,7 +86,7 @@ jobs:
             })
 
             if(comparison.data.commits.length > 50) {
-              core.setFailed('Error: Too many commits in comparison, cannot reliably find pinned.json change.')
+              core.setFailed('Error: Too many commits in comparison, cannot reliably find ci lockfile change.')
               return
             }
 
@@ -98,7 +98,7 @@ jobs:
 
             await logRateLimit('before commit filtering')
 
-            // Filter commits that modified ci/pinned.json
+            // Filter commits that modified ci lockfile
             const commitsModifyingPinned = (
               await Promise.all(
                 comparison.data.commits.map(async (commit) => {
@@ -107,7 +107,7 @@ jobs:
                     ref: commit.sha,
                   })
                   const modifiesPinned = commitDetails.data.files?.some(
-                    (file) => file.filename === "ci/pinned.json"
+                    (file) => file.filename === "ci/flake.lock"
                   )
                   return modifiesPinned ? commit.sha : null
                 })
@@ -118,14 +118,14 @@ jobs:
 
             if (commitsModifyingPinned.length === 0) {
               // This should not happen as testVersions should only be true
-              // when ci/pinned.json was modified in the PR.
-              core.setFailed("Error: ci/pinned.json was not modified in this PR")
+              // when ci lockfile was modified in the PR.
+              core.setFailed("Error: ci lockfile was not modified in this PR")
               return
             } else if (commitsModifyingPinned.length > 1) {
               core.setFailed([
-                "Error: Multiple commits touch ci/pinned.json in this PR:",
+                "Error: Multiple commits touch ci lockfile in this PR:",
                 ...commitsModifyingPinned,
-                "Please ensure only a single commit modifies ci/pinned.json for accurate version matrix evaluation."
+                "Please ensure only a single commit modifies ci/flake.lock for accurate version matrix evaluation."
               ].join("\n"))
               return
             }
@@ -133,7 +133,7 @@ jobs:
             const ciPinBumpCommit = commitsModifyingPinned[0]
             core.setOutput("ciPinBumpCommit", ciPinBumpCommit)
             core.setOutput("ciPinBumpCommitShort", ciPinBumpCommit.substring(0, 7))
-            core.info(`Found pinned.json commit: ${ciPinBumpCommit}`)
+            core.info(`Found ci lockfile commit: ${ciPinBumpCommit}`)
 
       - name: Install Nix
         uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
@@ -141,7 +141,14 @@ jobs:
       - name: Load supported versions
         id: versions
         run: |
-          echo "versions=$(trusted/ci/supportedVersions.nix --arg pinnedJson untrusted/ci/pinned.json)" >> "$GITHUB_OUTPUT"
+          # inputs.nix was added 2026-06-13, so pinned.json support can be removed ~2026-12-25 🎅
+          declare -a args=()
+          if [ -f untrusted/ci/inputs.nix ]; then
+            args+=(--arg inputs 'import ./untrusted/ci/inputs.nix')
+          else
+            args+=(--arg pinnedJson ./untrusted/ci/pinned.json)
+          fi
+          echo "versions=$(trusted/ci/supportedVersions.nix "${args[@]}")" >> "$GITHUB_OUTPUT"
 
   eval:
     runs-on: ubuntu-24.04-arm
@@ -153,7 +160,7 @@ jobs:
         system: ${{ fromJSON(inputs.systems) }}
         version:
           - "" # Default Eval triggering rebuild labels and such.
-          - ${{ fromJSON(needs.versions.outputs.versions || '[]') }} # Only for ci/pinned.json updates.
+          - ${{ fromJSON(needs.versions.outputs.versions || '[]') }} # Only for ci lockfile updates.
     # Failures for versioned Evals will be collected in a separate job below
     # to not interrupt main Eval's compare step.
     continue-on-error: ${{ matrix.version != '' }}
@@ -406,7 +413,7 @@ jobs:
             const ciPinBumpCommit = process.env.CI_PIN_BUMP_COMMIT
 
             core.summary.addHeading('Lix/Nix version comparison')
-            core.summary.addRaw(`\n*Evaluated at commit: \`${ciPinBumpCommit}\` (commit that modified ci/pinned.json)*\n`, true)
+            core.summary.addRaw(`\n*Evaluated at commit: \`${ciPinBumpCommit}\` (commit that modified ci lockfile)*\n`, true)
             core.summary.addTable(
               [].concat(
                 [
@@ -439,9 +446,9 @@ jobs:
                           core.setFailed(
                             `${version} on ${system} has changed outpaths!\n` +
                               `Note: This indicates that commit ${ciPinBumpCommit} ` +
-                              `(which modified ci/pinned.json) also contains other ` +
+                              `(which modified ci lockfile) also contains other ` +
                               `changes affecting package outputs. ` +
-                              `Please ensure ci/pinned.json is updated in a standalone commit.`
+                              `Please ensure ci/flake.lock is updated in a standalone commit.`
                           )
                           return { data: ':x:' }
                         }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
               '.github/workflows/merge-group.yml',
               '.github/workflows/test.yml',
               'ci/github-script/supportedSystems.js',
-              'ci/pinned.json',
+              'ci/flake.lock',
               'ci/supportedBranches.js',
             ].includes(file))) core.setOutput('merge-group', true)
 
@@ -86,7 +86,7 @@ jobs:
               'ci/github-script/reviews.js',
               'ci/github-script/supportedSystems.js',
               'ci/github-script/withRateLimit.js',
-              'ci/pinned.json',
+              'ci/flake.lock',
               'ci/supportedBranches.js',
             ].includes(file))) core.setOutput('pr', true)
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -6,7 +6,7 @@ This is in contrast with [`maintainers/scripts`](../maintainers/scripts) which i
 ## Pinned Nixpkgs
 
 CI may need certain packages from Nixpkgs.
-In order to ensure that the needed packages are generally available without building, [`pinned.json`](./pinned.json) contains a pinned Nixpkgs version tested by Hydra.
+In order to ensure that the needed packages are generally available without building, [`ci`'s flake](./flake.nix) provides a pinned Nixpkgs version tested by Hydra.
 
 Run [`update-pinned.sh`](./update-pinned.sh) to update it.
 

--- a/ci/default.nix
+++ b/ci/default.nix
@@ -1,23 +1,14 @@
 let
-  pinned = (builtins.fromJSON (builtins.readFile ./pinned.json)).pins;
+  inputs = import ./inputs.nix;
 in
 {
   system ? builtins.currentSystem,
 
-  nixpkgs ? null,
+  nixpkgs ? inputs.nixpkgs,
   nixPath ? "nixVersions.latest",
 }:
 let
-  nixpkgs' =
-    if nixpkgs == null then
-      fetchTarball {
-        inherit (pinned.nixpkgs) url;
-        sha256 = pinned.nixpkgs.hash;
-      }
-    else
-      nixpkgs;
-
-  pkgs = import nixpkgs' {
+  pkgs = import nixpkgs {
     inherit system;
     # Nixpkgs generally — and CI specifically — do not use aliases,
     # because we want to ensure they are not load-bearing.
@@ -26,11 +17,7 @@ let
 
   fmt =
     let
-      treefmtNixSrc = fetchTarball {
-        inherit (pinned.treefmt-nix) url;
-        sha256 = pinned.treefmt-nix.hash;
-      };
-      treefmtEval = (import treefmtNixSrc).evalModule pkgs ./treefmt.nix;
+      treefmtEval = (import inputs.treefmt-nix).evalModule pkgs ./treefmt.nix;
       fs = pkgs.lib.fileset;
       nixFilesSrc = fs.toSource {
         root = ../.;

--- a/ci/flake.lock
+++ b/ci/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781173989,
+        "narHash": "sha256-fnzKKPvS+oieI/pTzotA5tkoM47EB1NpaBcgk4R97hE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8c91a71d13451abc40eb9dae8910f972f979852f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/ci/flake.nix
+++ b/ci/flake.nix
@@ -1,0 +1,13 @@
+{
+  description = "Nixpkgs CI locked inputs";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  # This flake is only used for its inputs
+  outputs = inputs: { };
+}

--- a/ci/github-script/prepare.js
+++ b/ci/github-script/prepare.js
@@ -228,7 +228,7 @@ module.exports = async ({ github, context, core, dry }) => {
     ).map((file) => file.filename)
 
     const touched = []
-    if (files.includes('ci/pinned.json')) touched.push('pinned')
+    if (files.includes('ci/flake.lock')) touched.push('pinned')
     core.setOutput('touched', touched)
 
     return

--- a/ci/inputs.nix
+++ b/ci/inputs.nix
@@ -1,0 +1,36 @@
+# This file provides access to the CI-locked flake inputs, without evaluating the flake.
+# Instead, it directly imports the JSON lockfile and returns the root node's inputs.
+let
+  # The `fetchTree` primop is experimental, so provide a compatible fallback
+  fetchNode =
+    builtins.fetchTree or (
+      info:
+      if info.type == "github" then
+        {
+          inherit (info) rev narHash lastModified;
+          outPath = fetchTarball {
+            url = "https://api.${info.host or "github.com"}/repos/${info.owner}/${info.repo}/tarball/${info.rev}";
+            sha256 = info.narHash;
+          };
+        }
+      else if info.type == "tarball" then
+        {
+          outPath = fetchTarball {
+            inherit (info) url;
+            sha256 = info.narHash;
+          };
+        }
+      else if info.type == "path" then
+        {
+          outPath = builtins.path {
+            path = info.path;
+            sha256 = info.narHash;
+          };
+          inherit (info) narHash;
+        }
+      else
+        throw "nixpkgs-ci: unsupported input type '${info.type}'"
+    );
+  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+in
+builtins.mapAttrs (_: node: fetchNode lock.nodes.${node}.locked) lock.nodes.${lock.root}.inputs

--- a/ci/supportedVersions.nix
+++ b/ci/supportedVersions.nix
@@ -1,14 +1,25 @@
 #!/usr/bin/env -S nix-instantiate --eval --strict --json --arg unused true
 # Unused argument to trigger nix-instantiate calling this function with the default arguments.
 {
-  pinnedJson ? ./pinned.json,
+  # ci/inputs.nix was added 2026-06-13, so pinnedJson support can be removed ~2026-12-25 🎅
+  pinnedJson ? null,
+  inputs ? (
+    if pinnedJson == null then
+      import ./inputs.nix
+    else
+      let
+        pinned = builtins.fromJSON (builtins.readFile pinnedJson);
+      in
+      {
+        nixpkgs = fetchTarball {
+          inherit (pinned.pins.nixpkgs) url;
+          sha256 = pinned.pins.nixpkgs.hash;
+        };
+      }
+  ),
+  nixpkgs ? inputs.nixpkgs,
 }:
 let
-  pinned = (builtins.fromJSON (builtins.readFile pinnedJson)).pins;
-  nixpkgs = fetchTarball {
-    inherit (pinned.nixpkgs) url;
-    sha256 = pinned.nixpkgs.hash;
-  };
   pkgs = import nixpkgs {
     config.allowAliases = false;
   };

--- a/ci/update-pinned.sh
+++ b/ci/update-pinned.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p npins -I nixpkgs=../
+#!nix-shell -i bash -I nixpkgs=../
 
 set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-npins --lock-file pinned.json upgrade
-npins --lock-file pinned.json update
+nix --extra-experimental-features 'nix-command flakes' \
+  flake update . --commit-lock-file

--- a/shell.nix
+++ b/shell.nix
@@ -14,9 +14,9 @@
 {
   system ? builtins.currentSystem,
   nixpkgs ? null,
-}:
+}@args:
 let
-  inherit (import ./ci { inherit nixpkgs system; }) pkgs fmt;
+  inherit (import ./ci args) pkgs fmt;
 
   # For `nix-shell -A hello`
   curPkgs = removeAttrs (import ./. { inherit system; }) [


### PR DESCRIPTION
As per my comments in https://github.com/NixOS/nixpkgs/pull/431124#pullrequestreview-3088020976, https://github.com/NixOS/nixpkgs-vet/pull/257, and https://github.com/NixOS/nixfmt/pull/416, this PR ports Nixpkgs' CI lockfile from an npins `pinned.json` to a flake `flake.lock`. This allows using nix's built-in (albeit experimental) tooling to manage locked inputs.

As `ci/` is primarily consumed without using flakes, we only use flake-aware tooling to _manage_ the lockfile, and never actually evaluate the flake itself. Instead, `ci/inputs.nix` is responsible for importing the `ci/flake.lock` as JSON and mapping the root node's inputs to fetchable store objects.

`ci/inputs.nix` can be thought of as a _massively_ stripped down version of [flake-compat], tailored for Nixpkgs CI's needs.

Locked inputs and nar hashes are unchanged.

`ci/pinned.json` will need to be removed in a subsequent PR, as removing it in this PR will lead to many CI failures.

To allow for CI running against PRs with an outdated `base` (i.e. one without `ci/flake.lock`), .github/actions/checkout will fallback to `ci/pinned.json` when `ci/flake.lock` throws 404. We can remove that once base-branches without `ci/flake.lock` are so old that they would effectively require a rebase anyway.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - Ran `nix-shell --run treefmt` from the Nixpkgs root
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
[flake-compat]: https://github.com/NixOS/flake-compat
