### PR TITLE
nvibrant: 1.2.0-unstable-595.58.03 -> 1.2.1-unstable-610.43.02

### DIFF
--- a/pkgs/by-name/nv/nvibrant/hatch_build.patch
+++ b/pkgs/by-name/nv/nvibrant/hatch_build.patch
@@ -1,16 +1,25 @@
 diff --git a/hatch_build.py b/hatch_build.py
-index 036079a..fa2275e 100644
+index da19ad8..f33e582 100644
 --- a/hatch_build.py
 +++ b/hatch_build.py
-@@ -1,6 +1,5 @@
+@@ -1,7 +1,6 @@
+ import hashlib
  import os
  import subprocess
 -import sys
  from pathlib import Path
  from tempfile import TemporaryDirectory
  
-@@ -58,28 +57,27 @@ class BuildHook(BuildHookInterface):
+@@ -57,46 +56,33 @@ class BuildHook(BuildHookInterface):
  
+         build_data["pure_python"] = False
+ 
+-        # Ensure submodule on git main
+-        subprocess.check_call(
+-            ("git", "submodule", "update", "--init", "--remote"),
+-            cwd=Dirs.repository,
+-        )
+-
          # Configure the project
          subprocess.check_call((
 -            sys.executable, "-m", "mesonbuild.mesonmain",
@@ -20,11 +29,23 @@ index 036079a..fa2275e 100644
              "--reconfigure", "--wipe",
          ), cwd=Dirs.repository)
  
+-        # Intended operation
+-        subprocess.check_call(
+-            ("git", "config", "advice.detachedHead", "false"),
+-            cwd=Dirs.opengpu,
+-        )
+-
+         # Keep track of breaking changes
+         hashes: dict[str, str] = dict()
+ 
          # Make binaries for all known driver version
-         for driver in subprocess.check_output(
--            ("git", "tag"), cwd=Dirs.opengpu
-+            ("cat", "./SOURCE_TAGS"), cwd=Dirs.opengpu
-         ).decode().strip().splitlines():
+-        for driver in sorted(subprocess.check_output(
+-            args=("git", "tag"),
++        for driver in subprocess.check_output(
++            args=("cat", "./SOURCE_TAGS"),
+             cwd=Dirs.opengpu
+-        ).decode().strip().splitlines()):
++        ).decode().strip().splitlines():
  
              # Checkout driver version
 -            subprocess.check_call(
@@ -48,29 +69,16 @@ index 036079a..fa2275e 100644
  
              # Find and vendor the binary for this version
              binary = Dirs.build.joinpath("nvibrant")
-@@ -90,25 +88,3 @@ class BuildHook(BuildHookInterface):
+@@ -109,12 +95,6 @@ class BuildHook(BuildHookInterface):
+             build_data["force_include"][str(target)] = f"nvibrant/resources/{target.name}"
+             hashes.setdefault(hashlib.md5(target.read_bytes()).hexdigest(), driver)
  
-             # Include in the wheel
-             build["force_include"][str(target)] = f"nvibrant/resources/{target.name}"
--
 -        # Revert back main branch
 -        subprocess.check_call(
 -            ("git", "checkout", "-f", "main"),
 -            cwd=Dirs.opengpu
 -        )
 -
--# --------------------------------------------------------------------------- #
--
--if __name__ == '__main__':
--
--    # Intended operation
--    subprocess.check_call(
--        ("git", "config", "advice.detachedHead", "false"),
--        cwd=Dirs.opengpu,
--    )
--
--    environ = os.environ.copy()
--    subprocess.check_call(
--        args=("uv", "build", "--wheel", "-o", Dirs.dist),
--        cwd=Dirs.repository,
--    )
+         print("\nBreaking changes across driver versions:")
+ 
+         for hashsum, driver in hashes.items():

--- a/pkgs/by-name/nv/nvibrant/package.nix
+++ b/pkgs/by-name/nv/nvibrant/package.nix
@@ -14,10 +14,10 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   passthru = {
-    nvibrantVersion = "1.2.0";
+    nvibrantVersion = "1.2.1";
 
     oldestDriverVersion = "515.43.04";
-    latestDriverVersion = "595.58.03";
+    latestDriverVersion = "610.43.02";
 
     _version = lib.concatStringsSep "-" [
       finalAttrs.passthru.nvibrantVersion
@@ -31,14 +31,14 @@ python3Packages.buildPythonApplication (finalAttrs: {
         repo = "nvibrant";
         name = "nvibrant";
         tag = "v${finalAttrs.passthru.nvibrantVersion}";
-        hash = "sha256-OQo+VGWz8LNpsCdXbJXWWCrnVE0+t4s220uJ+pTHVKs=";
+        hash = "sha256-M83WSQiJwzFZl8ECkZjKigvLTlMkzRa6o2hqPOt1378=";
       };
       open-gpu = fetchFromGitHub {
         owner = "nvidia";
         repo = "open-gpu-kernel-modules";
         name = "open-gpu";
         tag = finalAttrs.passthru.oldestDriverVersion;
-        hash = "sha256-pSVK5oVob4QBo18ULHnQfO3UrTcC5lDDrTR9ec9pDp8=";
+        hash = "sha256-MfLR5sYSjBrENWkCChcS9rk1zSlRFfTRpof/4lQ3qow=";
 
         # since .git isn't deterministic, we can't use it to checkout tags in
         # the build phase, so instead we generate patches for each version


### PR DESCRIPTION
tl;dr: it now supports v610 drivers.

changelog: https://nvibrant.tremeschin.com/changelog/#v1.2.1
tag diff: https://github.com/Tremeschin/nvibrant/compare/v1.2.0...v1.2.1

there were some light changes to `hatch_build.py` upstream so the patch file has been updated accordingly. auto-updated versions & hashes with [nixpkgs-update](https://github.com/nix-community/nixpkgs-update).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
