### PR TITLE
acme-redirect: init at 0.8.1

### DIFF
--- a/pkgs/by-name/ac/acme-redirect/package.nix
+++ b/pkgs/by-name/ac/acme-redirect/package.nix
@@ -36,15 +36,24 @@ rustPlatform.buildRustPackage (finalAttrs: {
     installManPage acme-redirect.1 acme-redirect.d.5 acme-redirect.conf.5
     popd
 
+    # see nixos option systemd.packages
+    systemdUnitsTarget=$out/lib/systemd/system
+
+    # see nixos option systemd.tmpfiles.packages
+    systemdTmpfilesTarget=$out/lib/tmpfiles.d
+
+    # no nixos option systemd.sysusers.packages exists yet
+    systemdSysusersTarget=$out/lib/sysusers.d
+
     pushd contrib/systemd
-    install -Dm644 -t $out/usr/lib/systemd/system acme-redirect.service acme-redirect-renew.service acme-redirect-renew.timer
-    pushd $out/usr/lib/systemd/system
+    install -Dm644 -t  $systemdUnitsTarget acme-redirect.service acme-redirect-renew.service acme-redirect-renew.timer
+    pushd $systemdUnitsTarget
     substituteInPlace  acme-redirect.service acme-redirect-renew.service \
       --replace-fail '/usr/bin/acme-redirect' $out/bin/acme-redirect
     popd
 
-    install -Dm644 acme-redirect.sysusers $out/usr/lib/sysusers.d/acme-redirect.conf
-    install -Dm644 acme-redirect.tmpfiles $out/usr/lib/tmpfiles.d/acme-redirect.conf
+    install -Dm644 acme-redirect.sysusers $systemdSysusersTarget/acme-redirect.conf
+    install -Dm644 acme-redirect.tmpfiles $systemdTmpfilesTarget/acme-redirect.conf
     popd
   '';
 

--- a/pkgs/by-name/ac/acme-redirect/package.nix
+++ b/pkgs/by-name/ac/acme-redirect/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  scdoc,
+  installShellFiles,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "acme-redirect";
+  version = "0.8.1";
+
+  src = fetchFromGitHub {
+    owner = "kpcyrd";
+    repo = "acme-redirect";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Ksx9uII9xBj6ZhBEXlgf042eyiNhoFm2zhaCl+uJNG4=";
+  };
+
+  cargoHash = "sha256-cdiDQEZkqMRkEmCrZTaaFtcqkLgdPqhdqFUoQcZoGj4=";
+
+  nativeBuildInputs = [
+    pkg-config
+    scdoc
+    installShellFiles
+  ];
+
+  buildInputs = [ openssl ];
+
+  postBuild = "make docs";
+
+  postInstall = ''
+    pushd contrib/docs
+    installManPage acme-redirect.1 acme-redirect.d.5 acme-redirect.conf.5
+    popd
+
+    pushd contrib/systemd
+    install -Dm644 -t $out/usr/lib/systemd/system acme-redirect.service acme-redirect-renew.service acme-redirect-renew.timer
+    pushd $out/usr/lib/systemd/system
+    substituteInPlace  acme-redirect.service acme-redirect-renew.service \
+      --replace-fail '/usr/bin/acme-redirect' $out/bin/acme-redirect
+    popd
+
+    install -Dm644 acme-redirect.sysusers $out/usr/lib/sysusers.d/acme-redirect.conf
+    install -Dm644 acme-redirect.tmpfiles $out/usr/lib/tmpfiles.d/acme-redirect.conf
+    popd
+  '';
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  meta = {
+    description = "Tiny http daemon that answers acme challenges and redirects everything else to https";
+    changelog = "https://github.com/kpcyrd/acme-redirect/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.all;
+    mainProgram = "acme-redirect";
+    maintainers = [ lib.maintainers.haansn08 ];
+  };
+
+})


### PR DESCRIPTION
[acme-redirect](https://github.com/kpcyrd/acme-redirect) is a tiny http daemon that answers acme challenges and redirects everything else to https.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
