### PR TITLE
allmytoes: init at 0.5.1

### DIFF
--- a/pkgs/by-name/al/allmytoes/package.nix
+++ b/pkgs/by-name/al/allmytoes/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  nix-update-script,
+  rustPlatform,
+  fetchFromGitLab,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "allmytoes";
+  version = "0.5.1";
+
+  src = fetchFromGitLab {
+    owner = "allmytoes";
+    repo = "allmytoes";
+    tag = finalAttrs.version;
+    hash = "sha256-BYKcDJN/uKESj0pnb2xvrx1lO6rOGdi+PVT6ywZqjbQ=";
+  };
+
+  cargoHash = "sha256-Pzbruv1E4mMohw//lf1JBoK+4BHDJVr4/9xXE4FrWbA==";
+
+  passthru.updateScript = nix-update-script { };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Provides thumbnails by using the freedesktop-specified thumbnail database (aka XDG standard)";
+    homepage = "https://gitlab.com/allmytoes/allmytoes";
+    mainProgram = "allmytoes";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ luminarleaf ];
+  };
+})


### PR DESCRIPTION
Add [allmytoes](https://gitlab.com/allmytoes/allmytoes) which is a cli tool used to generate and/or provide [XDG Thumbnails](https://specifications.freedesktop.org/thumbnail-spec/thumbnail-spec-latest.html).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
