### PR TITLE
yaziPlugins.allmytoes: init at 0-unstable-2025-11-22

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/allmytoes/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/allmytoes/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkYaziPlugin,
+}:
+mkYaziPlugin {
+  pname = "allmytoes.yazi";
+  version = "0-unstable-2025-11-22";
+
+  src = fetchFromGitHub {
+    owner = "Sonico98";
+    repo = "allmytoes.yazi";
+    rev = "acdc53be76434a82218eed8e1fda5512971bf3cc";
+    hash = "sha256-zZ9L0FrcxFvSuDJwi6VHQXDT7b/sM4DhZ3LPi/i9tig=";
+  };
+
+  meta = {
+    description = "Generate freedesktop-compatible thumbnails while using yazi";
+    homepage = "https://github.com/Sonico98/allmytoes.yazi";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ luminarleaf ];
+  };
+}


### PR DESCRIPTION
Requires #531241

Adds the allmytoes.yazi plugin to use Freedesktop compatible thumbnails in yazi for the image preview.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test