### PR TITLE
maintainers/scripts/update.nix: add team argument

### DIFF
--- a/maintainers/scripts/update.nix
+++ b/maintainers/scripts/update.nix
@@ -8,6 +8,7 @@
 {
   package ? null,
   maintainer ? null,
+  team ? null,
   predicate ? null,
   get-script ? pkg: pkg.updateScript or null,
   path ? null,
@@ -114,6 +115,28 @@ let
   packagesWithUpdateScriptMatchingPredicate =
     cond: packagesWith (path: pkg: (get-script pkg != null) && cond path pkg);
 
+  # Recursively find all packages in `pkgs` with updateScript by given team.
+  packagesWithUpdateScriptAndTeam =
+    team':
+    let
+      team =
+        if !builtins.hasAttr team' lib.teams then
+          throw "Team with name `${team'} does not exist in `maintainers/team-list.nix`."
+        else
+          builtins.getAttr team' lib.teams;
+    in
+    packagesWithUpdateScriptMatchingPredicate (
+      path: pkg:
+      (
+        if builtins.hasAttr "teams" pkg.meta then
+          (
+            if builtins.isList pkg.meta.teams then builtins.elem team pkg.meta.teams else team == pkg.meta.teams
+          )
+        else
+          false
+      )
+    );
+
   # Recursively find all packages in `pkgs` with updateScript by given maintainer.
   packagesWithUpdateScriptAndMaintainer =
     maintainer':
@@ -175,6 +198,8 @@ let
       packagesWithUpdateScriptMatchingPredicate predicate pkgs
     else if maintainer != null then
       packagesWithUpdateScriptAndMaintainer maintainer pkgs
+    else if team != null then
+      packagesWithUpdateScriptAndTeam team pkgs
     else if path != null then
       packagesWithUpdateScript path pkgs
     else
@@ -187,6 +212,10 @@ let
 
     to run all update scripts for all packages that lists \`garbas\` as a maintainer
     and have \`updateScript\` defined, or:
+
+        % nix-shell maintainers/scripts/update.nix --argstr team ngi
+
+    to run update script for a specific team, or
 
         % nix-shell maintainers/scripts/update.nix --argstr package nautilus
 


### PR DESCRIPTION
This would be very helpful for the NGI project!


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
