### PR TITLE
cppcheck: 2.18.3 -> 2.21.0

### DIFF
--- a/pkgs/by-name/cp/cppcheck/package.nix
+++ b/pkgs/by-name/cp/cppcheck/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
 
   # nativeBuildInputs
+  cmake,
   docbook_xml_dtd_45,
   docbook_xsl,
   installShellFiles,
@@ -36,6 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
+    cmake
     docbook_xml_dtd_45
     docbook_xsl
     installShellFiles
@@ -50,11 +52,12 @@ stdenv.mkDerivation (finalAttrs: {
     (python3.withPackages (ps: [ ps.pygments ]))
   ];
 
-  makeFlags = [
-    "PREFIX=$(out)"
-    "MATCHCOMPILER=yes"
-    "FILESDIR=$(out)/share/cppcheck"
-    "HAVE_RULES=yes"
+  cmakeFlags = with lib.strings; [
+    (cmakeBool "BUILD_MANPAGE" true)
+    (cmakeBool "MATCHCOMPILER" true)
+    (cmakeFeature "FILESDIR" "${placeholder "out"}/share/cppcheck")
+    (cmakeBool "HAVE_RULES" true)
+    (cmakeFeature "DB2MAN" "${docbook_xsl}/xml/xsl/docbook/manpages/docbook.xsl")
   ];
 
   enableParallelBuilding = true;
@@ -67,6 +70,9 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     substituteInPlace Makefile \
       --replace-fail 'PCRE_CONFIG = $(shell which pcre-config)' 'PCRE_CONFIG = $(PKG_CONFIG) libpcre'
+    substituteInPlace man/CMakeLists.txt \
+       --replace-fail "/usr/share/sgml/docbook/stylesheet/xsl/nwalsh/manpages/docbook.xsl" \
+                     "${docbook_xsl}/xml/xsl/docbook/manpages/docbook.xsl"
   ''
   # Expected:
   # Internal Error. MathLib::toDoubleNumber: conversion failed: 1invalid
@@ -88,7 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   postInstall = ''
-    installManPage cppcheck.1
+    installManPage man/cppcheck.1
   '';
 
   nativeInstallCheckInputs = [


### PR DESCRIPTION
https://github.com/cppcheck-opensource/cppcheck/releases/tag/2.21.0

Had to add CMake as a dependency to get it to build, otherwise `nix-build` pretends to build and then prints a derivation path without actually having built Cppcheck.

I used Gemini to help with a syntax error that happened when I wrote `$(placeholder "out")` instead of `${placeholder "out"}` and to write the `substituteInPlace` expression.

It seems that `MATCHCOMPILER` is not actually used by Cppcheck's build system, but I am not sure if that matters.

P.S. I started trying to add optional GUI support (default to off) to the package on a different branch, but that can be the subject of another PR.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
