### PR TITLE
build-support/fetchFromRNS: init

### DIFF
--- a/pkgs/build-support/fetchrns/default.nix
+++ b/pkgs/build-support/fetchrns/default.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  fetchgit,
+  python3Packages,
+  formats,
+  writableTmpDirAsHomeHook,
+}:
+lib.makeOverridable (
+  {
+    rnsdConfig ? {
+      reticulum = {
+        enable_transport = true;
+      };
+      interfaces = {
+        "local" = {
+          type = "TCPClientInterface";
+          enabled = true;
+          target_host = "127.0.0.1";
+          target_port = "4242";
+        };
+      };
+    },
+    execRnpath ? false,
+    ...
+  }@args:
+  fetchgit (
+    {
+      preFetch =
+        let
+          settingsFormat = formats.configobj { };
+
+          buildConfig = ''
+            install -D -m 600 ${settingsFormat.generate "rnsd-config" rnsdConfig} $PWD/.config/reticulum/config
+          '';
+
+          exportConfig = ''
+            RNS_CONFIG=$PWD/.config/reticulum
+            export RNS_CONFIG
+          '';
+
+          runRnpath = ''
+            hash="''${url#rns://}"
+            hash="''${hash%%/*}"
+
+            rnpath --config $PWD/.config/reticulum "$hash" --verbose
+          '';
+        in
+        buildConfig + exportConfig + (lib.optionalString execRnpath runRnpath);
+
+      nativeBuildInputs =
+        with python3Packages;
+        [
+          rns
+        ]
+        ++ lib.optionals execRnpath [
+          writableTmpDirAsHomeHook
+        ];
+    }
+    // removeAttrs args [
+      "rnsdConfig"
+      "execRnpath"
+    ]
+  )
+)

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -666,6 +666,8 @@ with pkgs;
   fetchFromRadicle = callPackage ../build-support/fetchradicle { };
   fetchRadiclePatch = callPackage ../build-support/fetchradiclepatch { };
 
+  fetchFromRNS = callPackage ../build-support/fetchrns { };
+
   fetchgx = callPackage ../build-support/fetchgx { };
 
   fetchItchIo = callPackage ../build-support/fetchitchio { };


### PR DESCRIPTION
Initially, this fetcher included a default list of public `rnsd` servers that I had gathered myself.

After giving it some more thought, I removed them. Relying on static addresses is not really aligned with the philosophy of the project, nor with my own view of how Reticulum should be used. I do not think it is a good idea to silently redirect all Reticulum requests to a predefined set of servers.

Instead, I implemented the approach described here: https://reticulum.miraheze.org/wiki/RNS#Security_hardening

The idea is to configure a single local interface that acts as a bridge to the host machine running `fetchFromRNS`.

Here's the configuration being used in the fetcher:

<details>

```ini
[reticulum]
  enable_transport = true
[interfaces]
  [[local]]
    type = TCPClientInterface
    enabled = true
    target_host = 127.0.0.1
    target_port = 4242
```

</details>

This has the advantage of letting the end user run and configure their own `rnsd`, and therefore decide which peers or servers they want to use.

The drawback is that it requires a local `rnsd` instance to be properly configured and running.

An example configuration is shown below:

<details>

```ini
[reticulum]
  enable_transport = true

[interfaces]
  [[bridge]]
    type = TCPServerInterface
    enabled = true
    listen_ip = 0.0.0.0
    listen_port = 4242

  [[<remote>]]
    type = TCPClientInterface
    enabled = true
    target_host = <remote>
    target_port = 4242

  [[<remote>]]
    type = BackboneInterface
    enabled = true
    target_host = <remote>
    target_port = 4242
```

Replace `<remote>` with your preferred online endpoints.

For the `bridge` interface, using `0.0.0.0` is required, as it does not work with `127.0.0.1` in this context.

</details>

I don't know yet if this is the best way to have this in `nixpkgs`, this is the reason why this PR is in `draft`. Feel free to let me know what you think of it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
