### PR TITLE
zen-notes: init at v2.3.0

### DIFF
--- a/pkgs/by-name/ze/zen-notes/package.nix
+++ b/pkgs/by-name/ze/zen-notes/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+}:
+
+let
+  pname = "zennotes";
+  version = "2.3.0";
+
+  src = fetchurl {
+    url = "https://github.com/ZenNotes/zennotes/releases/download/v${version}/ZenNotes-${version}-linux-x86_64.AppImage";
+    hash = "sha256-IvFGK7n3KQVGETmt6hQUy+bZNTOCkfuwH8ifl4KTxxw=";
+  };
+
+  appimage-opts = {
+    inherit pname version src;
+    extraPkgs = pkgs: [
+    ];
+  };
+
+in
+(appimageTools.wrapType2 appimage-opts).overrideAttrs (old: {
+  meta = with lib; {
+    description = "Keyboard-first local Markdown notes with Vim motions, diagrams, and MCP integration";
+    homepage = "https://github.com/ZenNotes/zennotes";
+    license = licenses.mit;
+    maintainers = with maintainers; [ voidwalter ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "zennotes";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
[Zen-notes](https://github.com/ZenNotes/zennotes) is a keyboard-first local Markdown notes with Vim motions, diagrams, and MCP integration. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
