### PR TITLE
mise: 2026.6.0 -> 2026.6.5

### DIFF
--- a/pkgs/by-name/mi/mise/package.nix
+++ b/pkgs/by-name/mi/mise/package.nix
@@ -22,16 +22,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mise";
-  version = "2026.6.0";
+  version = "2026.6.5";
 
   src = fetchFromGitHub {
     owner = "jdx";
     repo = "mise";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-UE+Mo6AtNiVgKOfLS7khAoVNJGyomL5Vb/pfcCke5fI=";
+    hash = "sha256-z3+rGBwqTD0r22cv2Yk9EWyPj+mXJSMV6flrjG2LygA=";
   };
 
-  cargoHash = "sha256-N1/lLQZbkqeQavNGhYBx4PDl0cid+DACzy9gpj5g1rs=";
+  cargoHash = "sha256-Qd57u6dTEUccTic9f5H/Kn5vQT4iZeKKnQtGUzrnP4A=";
 
   nativeBuildInputs = [
     installShellFiles


### PR DESCRIPTION
## Things done

- Built on platform(s):
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - `nix-build -A mise`
  - `nix-build -A mise.tests.version -A mise.tests.usageCompat`
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`
  - Not run; package update only, direct build and passthru tests completed.
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - Covered by `mise.tests.version`.
- [x] Determined the impact on package closure size (by running `nix path-info -S before and after`)
  - Not run.
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).