### PR TITLE
sublime4: drop openssl_1_1

### DIFF
--- a/pkgs/applications/editors/sublime/4/common.nix
+++ b/pkgs/applications/editors/sublime/4/common.nix
@@ -6,6 +6,7 @@
 }:
 
 {
+  config,
   fetchurl,
   stdenv,
   lib,
@@ -22,7 +23,6 @@
   writeShellScript,
   common-updater-scripts,
   curl,
-  openssl_1_1,
   openssl_3_5,
   bzip2,
   sqlite,
@@ -33,7 +33,6 @@ let
   packageAttribute = "sublime4${lib.optionalString dev "-dev"}";
   binaries = [
     "sublime_text"
-    "plugin_host-3.3"
     "plugin_host-3.${if lib.versionAtLeast buildVersion "4205" then "14" else "8"}"
     crashHandlerBinary
   ];
@@ -55,7 +54,6 @@ let
     libxtst
     glib
     libglvnd
-    openssl_1_1
     gtk3
     cairo
     pango
@@ -87,6 +85,10 @@ let
 
     buildPhase = ''
       runHook preBuild
+
+      # Remove old plugin host because it depends on EOL openssl 1.1
+      rm plugin_host-3.3
+      echo '{"disable_plugin_host_3.3": true}' > Packages/Preferences.sublime-settings
 
       for binary in ${builtins.concatStringsSep " " binaries}; do
         patchelf \
@@ -228,5 +230,13 @@ stdenv.mkDerivation (finalAttrs: {
       "aarch64-linux"
       "x86_64-linux"
     ];
+    # FIXME: gated behind allowAliases to workaround https://github.com/NixOS/nixpkgs/issues/523712
+    problems =
+      lib.optionalAttrs config.allowAliases {
+        removal.message = "We have removed Python 3.3 package support ahead of upstream schedule but if you do not use any old packages, this should just work.";
+      }
+      // lib.optionalAttrs (lib.versionOlder buildVersion "4205") {
+        broken.message = "Packages, including core ones, do not run without plug-in host depending on insecure OpenSSL.";
+      };
   };
 })

--- a/pkgs/applications/editors/sublime/4/common.nix
+++ b/pkgs/applications/editors/sublime/4/common.nix
@@ -221,6 +221,7 @@ stdenv.mkDerivation (finalAttrs: {
       demin-dmitriy
       zimbatm
     ];
+    mainProgram = "subl";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
     platforms = [


### PR DESCRIPTION
Tracking: #269713

I didn't mark it broken, because the core functionality seems to work, I can edit and save files. There's an annoying popup however: "plugin_host-3.3 has exited unexpectedly, some plugin functionality won't be available until Sublime Text has restarted" on launch.

Our options are:
- someone fixes this derivation without `openssl_1_1`. According to https://github.com/sublimehq/sublime_text/issues/5984#issuecomment-3172332375, from 4200 (which we have in nixpkgs) we should be able to only depend on `openssl_3`
- mark the whole package as broken
- keep it at this half broken state

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
