### PR TITLE
ninjabrain-bot: init at 1.5.2

### DIFF
--- a/pkgs/by-name/ni/ninjabrain-bot/package.nix
+++ b/pkgs/by-name/ni/ninjabrain-bot/package.nix
@@ -1,0 +1,122 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  maven,
+  makeWrapper,
+  copyDesktopItems,
+  makeDesktopItem,
+  jre,
+  libxkbcommon,
+  libx11,
+  libxcb,
+  libxinerama,
+  libxt,
+  libxtst,
+  nix-update-script,
+}:
+let
+  linuxNativeLibraries = [
+    libxkbcommon
+    libx11
+    libxcb
+    libxinerama
+    libxt
+    libxtst
+  ];
+in
+maven.buildMavenPackage (finalAttrs: {
+  pname = "ninjabrain-bot";
+  version = "1.5.2";
+
+  src = fetchFromGitHub {
+    owner = "Ninjabrain1";
+    repo = "Ninjabrain-Bot";
+    tag = finalAttrs.version;
+    hash = "sha256-uOUPho4UCZxeTtCU4XHJsTR6HuXAnKXd3jk/tSRd4Yc=";
+  };
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  # CI=true skips upstream display-dependent tests; the rest of the suite still runs.
+  env.CI = "true";
+
+  mvnFetchExtraArgs = {
+    env.CI = "true";
+  };
+
+  mvnParameters = "assembly:single";
+  mvnHash = "sha256-EZqijVMLPsZJUZA6pLL1Z5HqSeXSFo82XYRIazVweYw=";
+
+  nativeBuildInputs = [
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 target/ninjabrainbot-${finalAttrs.version}-jar-with-dependencies.jar $out/share/java/ninjabrain-bot.jar
+
+    install -Dm644 src/main/resources/icon.png $out/share/icons/hicolor/640x640/apps/ninjabrain-bot.png
+
+    # Swing text rendering varies outside full desktop environments.
+    makeWrapperArgs=(
+      --add-flags "-Dawt.useSystemAAFontSettings=on"
+      --add-flags "-Dswing.aatext=true"
+      --add-flags "-jar $out/share/java/ninjabrain-bot.jar"
+    )
+
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      makeWrapperArgs+=(
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath linuxNativeLibraries}
+      )
+    ''}
+
+    makeWrapper ${lib.getExe jre} $out/bin/ninjabrain-bot "''${makeWrapperArgs[@]}"
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "ninjabrain-bot";
+      desktopName = "Ninjabrain Bot";
+      comment = "Stronghold calculator for Minecraft speedrunning";
+      type = "Application";
+      exec = "ninjabrain-bot";
+      icon = "ninjabrain-bot";
+      categories = [
+        "Game"
+        "Utility"
+      ];
+      keywords = [
+        "minecraft"
+        "speedrun"
+        "stronghold"
+        "mcsr"
+      ];
+    })
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Stronghold calculator for Minecraft speedrunning";
+    homepage = "https://github.com/Ninjabrain1/Ninjabrain-Bot";
+    changelog = "https://github.com/Ninjabrain1/Ninjabrain-Bot/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      nyxar77
+      Misaka13514
+    ];
+    mainProgram = "ninjabrain-bot";
+    # Match platforms with bundled JNativeHook libraries and JRE support
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+  };
+})


### PR DESCRIPTION

added a package for `Ninjabrain Bot`, a stronghold calculator used in Minecraft speedrunning.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
