### PR TITLE
postgresql_19: init at 19beta1

### DIFF
--- a/pkgs/servers/sql/postgresql/19.nix
+++ b/pkgs/servers/sql/postgresql/19.nix
@@ -1,0 +1,11 @@
+import ./generic.nix {
+  version = "19beta1";
+  rev = "refs/tags/REL_19_BETA1";
+  hash = "sha256-thvbttX8wwGLf5tMJRHl86Xv8OgINzahoqB/AzAdtMI=";
+  muslPatches = {
+    dont-use-locale-a = {
+      url = "https://git.alpinelinux.org/aports/plain/main/postgresql17/dont-use-locale-a-on-musl.patch?id=d69ead2c87230118ae7f72cef7d761e761e1f37e";
+      hash = "sha256-6zjz3OpMx4qTETdezwZxSJPPdOvhCNu9nXvAaU9SwH8=";
+    };
+  };
+}

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -14,6 +14,7 @@ let
     postgresql_16 = ./16.nix;
     postgresql_17 = ./17.nix;
     postgresql_18 = ./18.nix;
+    postgresql_19 = ./19.nix;
   };
 
   mkAttributes =

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -375,7 +375,9 @@ let
         ++ lib.optionals tclSupport [ "--with-tcl" ]
         ++ lib.optionals selinuxSupport [ "--with-selinux" ]
         ++ lib.optionals nlsSupport [ "--enable-nls" ]
-        ++ lib.optionals bonjourSupport [ "--with-bonjour" ];
+        ++ lib.optionals bonjourSupport [ "--with-bonjour" ]
+        # Configure needs a little help to find `nm` when cross-compiling.
+        ++ lib.optionals (atLeast "19") [ "NM=${stdenv'.cc}/bin/${stdenv'.cc.targetPrefix}nm" ];
 
       patches = [
         (

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7870,6 +7870,7 @@ with pkgs;
     postgresql_16
     postgresql_17
     postgresql_18
+    postgresql_19
     ;
 
   inherit (postgresqlJitVersions)
@@ -7878,6 +7879,7 @@ with pkgs;
     postgresql_16_jit
     postgresql_17_jit
     postgresql_18_jit
+    postgresql_19_jit
     ;
   postgresql = postgresql_17;
   postgresql_jit = postgresql_17_jit;
@@ -7887,6 +7889,7 @@ with pkgs;
   postgresql16Packages = recurseIntoAttrs postgresql_16.pkgs;
   postgresql17Packages = recurseIntoAttrs postgresql_17.pkgs;
   postgresql18Packages = recurseIntoAttrs postgresql_18.pkgs;
+  postgresql19Packages = recurseIntoAttrs postgresql_19.pkgs;
 
   postgres-websockets = haskellPackages.postgres-websockets.bin;
   postgrest = haskellPackages.postgrest.bin;


### PR DESCRIPTION
Release Notes:
https://www.postgresql.org/about/news/postgresql-19-beta-1-released-3313/

## Things done

- Built on platform:
  - [x] x86_64-linux
    - [x] pkgsMusl
    - [x] pkgsCross.x86_64-freebsd
  - [x] aarch64-linux
    - [x] pkgsCross.gnu64
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
