### PR TITLE
[backport 26.05] python3Packages.flash-linear-attention: init at 0.5.0; python3Packages.exllamav3: 0.0.38 -> 0.0.42 

### DIFF
--- a/pkgs/development/python-modules/exllamav3/default.nix
+++ b/pkgs/development/python-modules/exllamav3/default.nix
@@ -29,14 +29,14 @@ let
 in
 buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
   pname = "exllamav3";
-  version = "0.0.39";
+  version = "0.0.42";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "turboderp-org";
     repo = "exllamav3";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-auAOnsNOr22TTIBR9L81tp9ZCrSLY4RxXWAJ1E39EwM=";
+    hash = "sha256-kdI2BT7T2+mrdgWE7aXTeqC49WP6qEus+LfQGk0ozhA=";
   };
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/exllamav3/default.nix
+++ b/pkgs/development/python-modules/exllamav3/default.nix
@@ -8,6 +8,7 @@
   setuptools,
 
   flash-attn,
+  flash-linear-attention,
   formatron,
   kbnf,
   marisa-trie,
@@ -28,14 +29,14 @@ let
 in
 buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
   pname = "exllamav3";
-  version = "0.0.38";
+  version = "0.0.39";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "turboderp-org";
     repo = "exllamav3";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-WlHIbnQX1Jd7y5yQzlqXVgBLQ92rnDSWy4z9bEm3WLA=";
+    hash = "sha256-auAOnsNOr22TTIBR9L81tp9ZCrSLY4RxXWAJ1E39EwM=";
   };
 
   pythonRelaxDeps = [
@@ -60,6 +61,7 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
 
   dependencies = [
     flash-attn
+    flash-linear-attention
     formatron
     kbnf
     marisa-trie

--- a/pkgs/development/python-modules/flash-linear-attention/default.nix
+++ b/pkgs/development/python-modules/flash-linear-attention/default.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  einops,
+  torch,
+  transformers,
+
+  # optional-dependencies
+  causal-conv1d,
+  matplotlib,
+  datasets,
+  pytest,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "flash-linear-attention";
+  version = "0.5.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchFromGitHub {
+    owner = "fla-org";
+    repo = "flash-linear-attention";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-g66yGHaBwEyjb+of76tKTtV/7as/2xQuqcjbGs4E3rU=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    einops
+    torch
+    transformers
+  ];
+
+  optional-dependencies = {
+    # tilelang = [ tilelang ];
+    conv1d = [ causal-conv1d ];
+    benchmark = [
+      matplotlib
+      datasets
+    ];
+    test = [ pytest ];
+  };
+
+  # Tests require a GPU
+  doCheck = false;
+
+  pythonImportsCheck = [ "fla" ];
+
+  meta = {
+    description = "Triton-based implementations of causal linear attention";
+    homepage = "https://github.com/fla-org/flash-linear-attention";
+    changelog = "https://github.com/fla-org/flash-linear-attention/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ BatteredBunny ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5695,6 +5695,8 @@ self: super: with self; {
 
   flash-attn = callPackage ../development/python-modules/flash-attn { };
 
+  flash-linear-attention = callPackage ../development/python-modules/flash-linear-attention { };
+
   flash-mla = callPackage ../development/python-modules/flash-mla { };
 
   flashinfer = callPackage ../development/python-modules/flashinfer { };


### PR DESCRIPTION
Backports https://github.com/NixOS/nixpkgs/pull/527194 and https://github.com/NixOS/nixpkgs/pull/528897

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
(cherry picked from commit 5ac3870)