### PR TITLE
[release-26.05] filebrowser: 2.63.3 -> 2.63.14 [CVE]

### DIFF
--- a/pkgs/by-name/fi/filebrowser/package.nix
+++ b/pkgs/by-name/fi/filebrowser/package.nix
@@ -12,13 +12,13 @@
 }:
 
 let
-  version = "2.63.3";
+  version = "2.63.5";
 
   src = fetchFromGitHub {
     owner = "filebrowser";
     repo = "filebrowser";
     rev = "v${version}";
-    hash = "sha256-v3cC8opClvt91MqUIKNZdvCv0hPeCvWPi0IlOMHlWbQ=";
+    hash = "sha256-/X/TztbZDC1hkRL97jkm6Ak8QmKFDMycekLl6NVPS0k=";
   };
 
   frontend = buildNpmPackage rec {
@@ -41,7 +41,7 @@ let
         ;
       fetcherVersion = 3;
       pnpm = pnpm_10;
-      hash = "sha256-g8BWDEymQNOkLYBws0ii4iLnpjB7X4EQl0OzR3GXeq0=";
+      hash = "sha256-UwTA7Eogp2GrvmXDbdfGBTJS3DuOTJ42e6fHlQxSHoA=";
     };
 
     installPhase = ''

--- a/pkgs/by-name/fi/filebrowser/package.nix
+++ b/pkgs/by-name/fi/filebrowser/package.nix
@@ -12,13 +12,13 @@
 }:
 
 let
-  version = "2.63.5";
+  version = "2.63.14";
 
   src = fetchFromGitHub {
     owner = "filebrowser";
     repo = "filebrowser";
     rev = "v${version}";
-    hash = "sha256-/X/TztbZDC1hkRL97jkm6Ak8QmKFDMycekLl6NVPS0k=";
+    hash = "sha256-9CXHoQWr1RpTwFR8JRR72oQZxHrndTrnxYa6/0Z3Mk0=";
   };
 
   frontend = buildNpmPackage rec {


### PR DESCRIPTION
Backport of #530744 to `release-26.05`.

Minimal version + hash bump (2.63.3 -> 2.63.14) that keeps the existing `buildNpmPackage` frontend (source hash and `pnpmDeps` hash updated). The master refactor (#528537) is intentionally **not** backported: it depends on `pnpmBuildHook` (`pkgs/by-name/pn/pnpmBuildHook`, added to master 2026-06-02), which does not exist on this release branch.

### Security fixes
`release-26.05` ships 2.63.3. This bump pulls in the upstream security fixes released between 2.63.3 and 2.63.14:

| Advisory | Severity | Fixed in | Issue |
| --- | --- | --- | --- |
| [GHSA-j9jx-hp4c-ghhh](https://github.com/advisories/GHSA-j9jx-hp4c-ghhh) | High | 2.63.6 | Incorrect access control for public directory shares via rule path rebasing |
| [GHSA-w5fm-68j4-fpc4](https://github.com/advisories/GHSA-w5fm-68j4-fpc4) | High | 2.63.6 | Denial of service via the public login API |
| [GHSA-5ww9-jg6q-38r7](https://github.com/advisories/GHSA-5ww9-jg6q-38r7) | High | 2.63.6 | Cross-user unauthorized share-link deletion (`DeleteWithPathPrefix`) |
| [GHSA-3q2p-72cj-682c](https://github.com/advisories/GHSA-3q2p-72cj-682c) | High | 2.63.7 | Improper access control via pre-created public share for a non-existent path |
| [GHSA-gxjx-7m74-hcq8](https://github.com/advisories/GHSA-gxjx-7m74-hcq8) | Medium | 2.63.6 | Path traversal in download-as-zip/tar via Windows-style backslash separators |
| [GHSA-239w-m3h6-ch8v](https://github.com/advisories/GHSA-239w-m3h6-ch8v) | Medium | 2.63.14 | Symlink following lets scoped users read/overwrite/share files outside their scope |

### Changelog
- Compare: https://github.com/filebrowser/filebrowser/compare/v2.63.3...v2.63.14
- Release notes: https://github.com/filebrowser/filebrowser/releases

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR (via nixpkgs-review-gha; see CI).
- [x] Tested basic functionality (frontend pnpm build + Go build + Go unit tests pass).

(cherry picked from commit bd64720c1771d16e956e859c819f993a5eaa5088)
