### PR TITLE
python3Packages.psycopg: move postgresql tests to passthru

### DIFF
--- a/pkgs/development/python-modules/psycopg/default.nix
+++ b/pkgs/development/python-modules/psycopg/default.nix
@@ -117,7 +117,7 @@ let
   };
 in
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   inherit
     pname
     version
@@ -171,12 +171,12 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     anyio
     pproxy
+    psycopg-c
+    psycopg-pool
     pytestCheckHook
     postgresql
   ]
-  ++ lib.optional stdenv.hostPlatform.isLinux postgresqlTestHook
-  ++ optional-dependencies.c
-  ++ optional-dependencies.pool;
+  ++ lib.optional stdenv.hostPlatform.isLinux postgresqlTestHook;
 
   env = {
     # Introduce this file necessary for the docs build via environment var
@@ -240,4 +240,4 @@ buildPythonPackage rec {
   meta = baseMeta // {
     description = "PostgreSQL database adapter for Python";
   };
-}
+})

--- a/pkgs/development/python-modules/psycopg/default.nix
+++ b/pkgs/development/python-modules/psycopg/default.nix
@@ -174,9 +174,7 @@ buildPythonPackage (finalAttrs: {
     psycopg-c
     psycopg-pool
     pytestCheckHook
-    postgresql
-  ]
-  ++ lib.optional stdenv.hostPlatform.isLinux postgresqlTestHook;
+  ];
 
   env = {
     # Introduce this file necessary for the docs build via environment var
@@ -184,16 +182,10 @@ buildPythonPackage (finalAttrs: {
       url = "https://raw.githubusercontent.com/postgres/postgres/496a1dc44bf1261053da9b3f7e430769754298b4/doc/src/sgml/libpq.sgml";
       hash = "sha256-JwtCngkoi9pb0pqIdNgukY8GbG5pUDZvrGAHZqjFOw4";
     };
-    postgresqlEnableTCP = 1;
-    PGUSER = "psycopg";
-    PGDATABASE = "psycopg";
   };
 
   preCheck = ''
     cd ..
-  ''
-  + lib.optionalString stdenv.hostPlatform.isLinux ''
-    export PSYCOPG_TEST_DSN="host=/build/run/postgresql user=$PGUSER"
   '';
 
   disabledTests = [
@@ -235,6 +227,24 @@ buildPythonPackage (finalAttrs: {
   passthru = {
     c = psycopg-c;
     pool = psycopg-pool;
+    tests = {
+      self = finalAttrs.finalPackage.overrideAttrs (
+        oldAttrs:
+        lib.optionalAttrs stdenv.hostPlatform.isLinux {
+          nativeInstallCheckInputs = oldAttrs.nativeInstallCheckInputs ++ [
+            postgresql
+            postgresqlTestHook
+          ];
+
+          env = oldAttrs.env // {
+            postgresqlEnableTCP = 1;
+            PGUSER = "psycopg";
+            PGDATABASE = "psycopg";
+            PSYCOPG_TEST_DSN = "host=/build/run/postgresql user=psycopg";
+          };
+        }
+      );
+    };
   };
 
   meta = baseMeta // {


### PR DESCRIPTION
This reduces the number of rebuilds for PostgreSQL.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [Package tests] at `passthru.tests`.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
