### PR TITLE
maintainers: remove mboes

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17497,12 +17497,6 @@
     githubId = 9051309;
     name = "Maximilian Bode";
   };
-  mboes = {
-    email = "mboes@tweag.net";
-    github = "mboes";
-    githubId = 51356;
-    name = "Mathieu Boespflug";
-  };
   mBornand = {
     email = "dev.mbornand@systemb.ch";
     github = "mBornand";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -68,7 +68,6 @@ with lib.maintainers;
 
   bazel = {
     members = [
-      mboes
       cbley
       olebedev
       groodt

--- a/pkgs/by-name/ke/keyfuzz/package.nix
+++ b/pkgs/by-name/ke/keyfuzz/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation {
     homepage = "http://0pointer.de/lennart/projects/keyfuzz/";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ mboes ];
+    maintainers = [ ];
   };
 
   src = fetchurl {


### PR DESCRIPTION
## Reasons

- Last commented in [December 2021](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Amboes)
- Hasn't created any PRs / Issues since [May 2019](https://github.com/NixOS/nixpkgs/issues?q=author%3Amboes)
- About 220 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Amboes%20-commenter%3Amboes%20-author%3Amboes%20-reviewed-by%3Amboes) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] keyfuzz