### PR TITLE
maintainers: remove ethercrow

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8409,12 +8409,6 @@
       { fingerprint = "2E51 F618 39D1 FA94 7A73  00C2 34C0 4305 D581 DBFE"; }
     ];
   };
-  ethercrow = {
-    email = "ethercrow@gmail.com";
-    github = "ethercrow";
-    githubId = 222467;
-    name = "Dmitry Ivanov";
-  };
   ethindp = {
     name = "Ethin Probst";
     email = "harlydavidsen@gmail.com";

--- a/pkgs/by-name/tc/tcpkali/package.nix
+++ b/pkgs/by-name/tc/tcpkali/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.bsd2;
     inherit (src.meta) homepage;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ ethercrow ];
+    maintainers = [ ];
     mainProgram = "tcpkali";
   };
 }


### PR DESCRIPTION
## Reasons

- Last commented in [June 2020](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Aethercrow)
- Hasn't created any PRs / Issues since [September 2016](https://github.com/NixOS/nixpkgs/issues?q=author%3Aethercrow)
- About 5 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Aethercrow%20-commenter%3Aethercrow%20-author%3Aethercrow%20-reviewed-by%3Aethercrow) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] tcpkali