### PR TITLE
maintainers: remove aherrmann

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -846,12 +846,6 @@
     githubId = 207841739;
     name = "Savchenko Dmitriy";
   };
-  aherrmann = {
-    email = "andreash87@gmx.ch";
-    github = "aherrmann";
-    githubId = 732652;
-    name = "Andreas Herrmann";
-  };
   ahirner = {
     email = "a.hirner+nixpkgs@gmail.com";
     github = "ahirner";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -70,7 +70,6 @@ with lib.maintainers;
     members = [
       cbley
       groodt
-      aherrmann
       boltzmannrain
     ];
     scope = "Bazel build tool & related tools https://bazel.build/";


### PR DESCRIPTION
## Reasons

- Last commented in [January 2024](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Aaherrmann)
- Hasn't created any PRs / Issues since [October 2023](https://github.com/NixOS/nixpkgs/issues?q=author%3Aaherrmann)
- About 170 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Aaherrmann%20-commenter%3Aaherrmann%20-author%3Aaherrmann%20-reviewed-by%3Aaherrmann) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.