### PR TITLE
maintainers: remove olebedev

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20665,12 +20665,6 @@
     matrix = "@olduser101:matrix.org";
     name = "Nathan Gill";
   };
-  olebedev = {
-    email = "ole6edev@gmail.com";
-    github = "olebedev";
-    githubId = 848535;
-    name = "Oleg Lebedev";
-  };
   oleina = {
     email = "antholeinik@gmail.com";
     github = "antholeole";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -70,7 +70,6 @@ with lib.maintainers;
     members = [
       mboes
       cbley
-      olebedev
       groodt
       aherrmann
       ylecornec

--- a/pkgs/by-name/bk/bkyml/package.nix
+++ b/pkgs/by-name/bk/bkyml/package.nix
@@ -44,6 +44,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     homepage = "https://github.com/joscha/bkyml";
     description = "CLI tool to generate a pipeline.yaml file for Buildkite on the fly";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ olebedev ];
+    maintainers = [ ];
   };
 })


### PR DESCRIPTION
## Reasons

- Last commented in [September 2024](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Aolebedev)
- Hasn't created any PRs / Issues since [July 2023](https://github.com/NixOS/nixpkgs/issues?q=author%3Aolebedev)
- About 130 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Aolebedev%20-commenter%3Aolebedev%20-author%3Aolebedev%20-reviewed-by%3Aolebedev) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] bkyml