### PR TITLE
maintainers: remove ylecornec

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30519,12 +30519,6 @@
     githubId = 1742643;
     name = "Ravi Peters";
   };
-  ylecornec = {
-    email = "yves.stan.lecornec@tweag.io";
-    github = "ylecornec";
-    githubId = 5978566;
-    name = "Yves-Stan Le Cornec";
-  };
   ylh = {
     email = "nixpkgs@ylh.io";
     github = "ylh";

--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -73,7 +73,6 @@ with lib.maintainers;
       olebedev
       groodt
       aherrmann
-      ylecornec
       boltzmannrain
     ];
     scope = "Bazel build tool & related tools https://bazel.build/";


### PR DESCRIPTION
## Reasons

- Last commented in [April 2023](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Aylecornec)
- Hasn't created any PRs / Issues since [October 2022](https://github.com/NixOS/nixpkgs/issues?q=author%3Aylecornec)
- About 130 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Aylecornec%20-commenter%3Aylecornec%20-author%3Aylecornec%20-reviewed-by%3Aylecornec) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.