### PR TITLE
gcan: init at v1.1.1

### DIFF
--- a/pkgs/by-name/gc/gcan/package.nix
+++ b/pkgs/by-name/gc/gcan/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "gcan";
+  version = "1.1.1";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "applicative-systems";
+    repo = "gcan";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BZfdc3ddAa9CPC3GOH9G3QJbECbSRY7ymzIMtYl076M=";
+  };
+
+  cargoHash = "sha256-5oE69FYTAV6JiTAN4A79+ndI0vHrbAi1JeEJcD+eY2c=";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "Analyze, filter, and prune Nix GC roots";
+    homepage = "https://github.com/applicative-systems/gcan";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.tfc ];
+    mainProgram = "gcan";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
`gcan` lists and can filter/sort by minimum size and age all pins that hinder store paths from being deleted by the garbage collector.
It also provides a TUI.

https://github.com/applicative-systems/gcan

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
