### PR TITLE
stalwart-cli: 0.15.5 -> 1.0.8

### DIFF
--- a/pkgs/by-name/st/stalwart-cli/package.nix
+++ b/pkgs/by-name/st/stalwart-cli/package.nix
@@ -1,35 +1,47 @@
 {
   lib,
+  cacert,
+  fetchFromGitHub,
   rustPlatform,
   versionCheckHook,
-  stalwart,
 }:
-
-rustPlatform.buildRustPackage {
-  inherit (stalwart) src version cargoDeps;
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "stalwart-cli";
-
-  cargoBuildFlags = [
-    "--package"
-    "stalwart-cli"
-  ];
-  cargoTestFlags = [
-    "--package"
-    "stalwart-cli"
-  ];
-
+  version = "1.0.8";
+  src = fetchFromGitHub {
+    owner = "stalwartlabs";
+    repo = "cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-teQB+6ZPEH3RXxG8WX4L67ckLCTYfMF4xaiz3S074b0=";
+  };
+  cargoHash = "sha256-yMfWFTXV1gXPqo2OOAN/Fkym9UiHjXDX0tAJOCF2p4U=";
+  __structuredAttrs = true;
+  # `Result::unwrap()` on an `Err` value: Network(reqwest::Error { kind: Builder, source: General("No CA certificates were loaded from the system") })
+  nativeCheckInputs = [ cacert ];
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
-
-  # Prerelease reports incorrect version
-  dontVersionCheck = true;
-
   meta = {
-    inherit (stalwart.meta) license homepage changelog;
-    description = "Stalwart Mail Server CLI";
+    description = "Stalwart Command Line Interface";
+    longDescription = ''
+      A schema-driven command line tool for administering Stalwart Mail and Collaboration Server over its JMAP API.
+
+      The tool fetches the server's schema on first use and derives every command, validation rule, and rendered view from it. The same binary works against any compatible Stalwart deployment without recompilation.
+    '';
+    homepage = "https://github.com/stalwartlabs/cli";
+    changelog = "https://github.com/stalwartlabs/cli/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.OR [
+      lib.licenses.agpl3Only
+      {
+        fullName = "Stalwart Enterprise License 2.0 (SELv2) Agreement";
+        url = "https://github.com/stalwartlabs/cli/blob/main/LICENSES/LicenseRef-SEL.txt";
+        free = false;
+        redistributable = false;
+      }
+    ];
     mainProgram = "stalwart-cli";
     maintainers = with lib.maintainers; [
       giomf
+      debtquity
     ];
   };
-}
+})


### PR DESCRIPTION
To be used during migration process between `0.15.x` to `0.16.x`

* CLI has been separated into it's own repository (stalwartlabs/cli)
  since `0.16.x`
* Add self as maintainer of package

changelog: https://github.com/stalwartlabs/cli/releases/tag/v1.0.8
diff: https://github.com/stalwartlabs/cli/compare/v1.0.0...v1.0.8

Related to: https://github.com/NixOS/nixpkgs/issues/511880


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
