### PR TITLE
maintainers: remove elasticdog

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7859,12 +7859,6 @@
     githubId = 27162016;
     name = "Ramdip Gill";
   };
-  elasticdog = {
-    email = "aaron@elasticdog.com";
-    github = "elasticdog";
-    githubId = 4742;
-    name = "Aaron Bull Schaefer";
-  };
   elatov = {
     email = "elatov@gmail.com";
     github = "elatov";

--- a/pkgs/by-name/ba/bazel-buildtools/package.nix
+++ b/pkgs/by-name/ba/bazel-buildtools/package.nix
@@ -39,9 +39,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/bazelbuild/buildtools";
     changelog = "https://github.com/bazelbuild/buildtools/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [
-      elasticdog
-    ];
     teams = [ lib.teams.bazel ];
   };
 })

--- a/pkgs/by-name/ba/bazelisk/package.nix
+++ b/pkgs/by-name/ba/bazelisk/package.nix
@@ -32,6 +32,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/bazelbuild/bazelisk";
     changelog = "https://github.com/bazelbuild/bazelisk/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ elasticdog ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/tr/transcrypt/package.nix
+++ b/pkgs/by-name/tr/transcrypt/package.nix
@@ -87,7 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://github.com/elasticdog/transcrypt";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.elasticdog ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/development/python-modules/masky/default.nix
+++ b/pkgs/development/python-modules/masky/default.nix
@@ -40,6 +40,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/Z4kSec/Masky";
     changelog = "https://github.com/Z4kSec/Masky/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ elasticdog ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/pywinrm/default.nix
+++ b/pkgs/development/python-modules/pywinrm/default.nix
@@ -51,7 +51,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/diyan/pywinrm/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      elasticdog
       kamadorueda
     ];
   };

--- a/pkgs/development/python-modules/requests-ntlm/default.nix
+++ b/pkgs/development/python-modules/requests-ntlm/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/requests/requests-ntlm";
     changelog = "https://github.com/requests/requests-ntlm/releases/tag/v${version}";
     license = lib.licenses.isc;
-    maintainers = with lib.maintainers; [ elasticdog ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 }


### PR DESCRIPTION
## Reasons

- Last commented in [June 2019](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Aelasticdog)
- Hasn't created any PRs / Issues since [April 2019](https://github.com/NixOS/nixpkgs/issues?q=author%3Aelasticdog)
- About 106 [unanswered](https://github.com/NixOS/nixpkgs/issues?q=involves%3Aelasticdog%20-commenter%3Aelasticdog%20-author%3Aelasticdog%20-reviewed-by%3Aelasticdog) PRs / Issues

See [losing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this if you don't want to be removed from the maintainer list.

## Packages

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] bazelisk
- [ ] transcrypt
- [ ] python3Packages.masky
- [ ] python3Packages.requests-ntlm