### PR TITLE
trivy: 0.71.0 -> 0.71.1

### DIFF
--- a/pkgs/by-name/tr/trivy/package.nix
+++ b/pkgs/by-name/tr/trivy/package.nix
@@ -17,13 +17,13 @@ buildGoModule (finalAttrs: {
   # that the signs present then are not present now.
   # Finally, weigh the risk of a compromised release against the expected
   # benefit of the update, and consider the possibility of not updating.
-  version = "0.71.0"; # Did you read the comment?
+  version = "0.71.1"; # Did you read the comment?
 
   src = fetchFromGitHub {
     owner = "aquasecurity";
     repo = "trivy";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-wlvG8iGPBbHV66SOT0zek2VN1QawksVQwM9LSEItzh4=";
+    hash = "sha256-4/fEc+71i5+biOtywFkwePvKoZkWK1yBWZa/Wg58E5U=";
   };
 
   # Hash mismatch on across Linux and Darwin

--- a/pkgs/by-name/tr/trivy/package.nix
+++ b/pkgs/by-name/tr/trivy/package.nix
@@ -10,14 +10,7 @@
 
 buildGoModule (finalAttrs: {
   pname = "trivy";
-  # As of March 2026, trivy has made compromised releases twice.
-  # At a minimum, before updating, check the diff of this package, and of all
-  # dependencies/GitHub Actions changes, carefully.
-  # Also read about how the previous compromises occurred, and ensure
-  # that the signs present then are not present now.
-  # Finally, weigh the risk of a compromised release against the expected
-  # benefit of the update, and consider the possibility of not updating.
-  version = "0.71.1"; # Did you read the comment?
+  version = "0.71.1";
 
   src = fetchFromGitHub {
     owner = "aquasecurity";
@@ -35,7 +28,6 @@ buildGoModule (finalAttrs: {
 
   ldflags = [
     "-s"
-    "-w"
     "-X=github.com/aquasecurity/trivy/pkg/version/app.ver=${finalAttrs.version}"
   ];
 


### PR DESCRIPTION
Diff: https://github.com/aquasecurity/trivy/compare/v0.71.0...v0.71.1

Changelog: https://github.com/aquasecurity/trivy/releases/tag/v0.71.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
