### PR TITLE
bazel-gazelle: 0.47.0 -> 0.51.3, adopt

### DIFF
--- a/pkgs/by-name/ba/bazel-gazelle/package.nix
+++ b/pkgs/by-name/ba/bazel-gazelle/package.nix
@@ -9,9 +9,9 @@ buildGoModule (finalAttrs: {
   version = "0.51.3";
 
   src = fetchFromGitHub {
-    owner = "bazelbuild";
+    owner = "bazel-contrib";
     repo = "bazel-gazelle";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ooqk4xutkjXoy9Irikos/53+6Mhdh3+WmJF7vo3JVFw=";
   };
 
@@ -22,7 +22,8 @@ buildGoModule (finalAttrs: {
   subPackages = [ "cmd/gazelle" ];
 
   meta = {
-    homepage = "https://github.com/bazelbuild/bazel-gazelle";
+    changelog = "https://github.com/bazel-contrib/bazel-gazelle/releases/tag/${finalAttrs.src.tag}";
+    homepage = "https://github.com/bazel-contrib/bazel-gazelle";
     description = ''
       Gazelle is a Bazel build file generator for Bazel projects. It natively
       supports Go and protobuf, and it may be extended to support new languages

--- a/pkgs/by-name/ba/bazel-gazelle/package.nix
+++ b/pkgs/by-name/ba/bazel-gazelle/package.nix
@@ -30,7 +30,10 @@ buildGoModule (finalAttrs: {
       and custom rule sets.
     '';
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ kalbasit ];
+    maintainers = with lib.maintainers; [
+      kalbasit
+      hythera
+    ];
     mainProgram = "gazelle";
   };
 })

--- a/pkgs/by-name/ba/bazel-gazelle/package.nix
+++ b/pkgs/by-name/ba/bazel-gazelle/package.nix
@@ -6,13 +6,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "bazel-gazelle";
-  version = "0.47.0";
+  version = "0.51.3";
 
   src = fetchFromGitHub {
     owner = "bazelbuild";
     repo = "bazel-gazelle";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-rnJ8rht7ccAI8ceOv3B0mlcY0fQg9Nfy+hu+/pmQQqE=";
+    hash = "sha256-ooqk4xutkjXoy9Irikos/53+6Mhdh3+WmJF7vo3JVFw=";
   };
 
   vendorHash = null;


### PR DESCRIPTION
changelog: https://github.com/bazel-contrib/bazel-gazelle/releases/tag/v0.51.3
diff: https://github.com/bazel-contrib/bazel-gazelle/compare/v0.47.0...v0.51.3

Supersedes #503546

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
