### PR TITLE
python3Packages.low-index: 1.2.1 -> 1.3

### DIFF
--- a/pkgs/development/python-modules/low-index/default.nix
+++ b/pkgs/development/python-modules/low-index/default.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
+  nix-update-script,
 }:
 
 buildPythonPackage rec {
@@ -27,6 +28,13 @@ buildPythonPackage rec {
     ${python.interpreter} -m low_index.test
     runHook postCheck
   '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "v(.*)_as_released"
+    ];
+  };
 
   meta = {
     description = "Enumerates low index subgroups of a finitely presented group";

--- a/pkgs/development/python-modules/low-index/default.nix
+++ b/pkgs/development/python-modules/low-index/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "low-index";
-  version = "1.2.1";
+  version = "1.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "3-manifolds";
     repo = "low_index";
     tag = "v${version}_as_released";
-    hash = "sha256-T8hzC9ulikQ1pUdbXgjuKAX5oMJEycPvXWv74rCkQGY=";
+    hash = "sha256-m3p05bqu70pMOsb9drW1B6+N893eBSZBFTNNS23OY6w=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
https://github.com/3-manifolds/low_index/releases/tag/v1.3_as_released

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
