### PR TITLE
bookorbit: init at 2.8.1, nixos/bookorbit: init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1637,6 +1637,7 @@
   ./services/web-apps/bentopdf.nix
   ./services/web-apps/bluemap.nix
   ./services/web-apps/bluesky-pds.nix
+  ./services/web-apps/bookorbit.nix
   ./services/web-apps/bookstack.nix
   ./services/web-apps/c2fmzq-server.nix
   ./services/web-apps/calibre-web.nix

--- a/nixos/modules/services/web-apps/bookorbit.nix
+++ b/nixos/modules/services/web-apps/bookorbit.nix
@@ -1,0 +1,237 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.bookorbit;
+
+  inherit (lib)
+    getExe
+    getExe'
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    types
+    ;
+
+  postgresqlPackage = config.services.postgresql.package;
+
+  environment = lib.mapAttrsToList (k: v: "${k}=${if builtins.isInt v then toString v else v}") (
+    lib.filterAttrs (_: v: v != null) cfg.environment
+  );
+in
+{
+  options.services.bookorbit = {
+    enable = mkEnableOption "BookOrbit";
+
+    package = mkPackageOption pkgs "bookorbit" { };
+
+    user = mkOption {
+      type = types.str;
+      default = "bookorbit";
+      description = "User account under which BookOrbit runs.";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "bookorbit";
+      description = "Group under which BookOrbit runs.";
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Open the appropriate ports in the firewall for BookOrbit.";
+    };
+
+    createDatabaseLocally = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Create the database locally.";
+    };
+
+    environment = mkOption {
+      type = types.submodule {
+        freeformType = types.attrsOf types.str;
+        options = {
+          APP_DATA_PATH = mkOption {
+            type = types.str;
+            default = "/var/lib/bookorbit";
+            description = "Data storage directory.";
+          };
+          PORT = mkOption {
+            type = types.port;
+            default = 3000;
+            description = "TCP port for the BookOrbit server.";
+          };
+          DATABASE_URL = mkOption {
+            type = types.str;
+            default =
+              if cfg.createDatabaseLocally then
+                "postgresql:///bookorbit?host=/run/postgresql&user=bookorbit"
+              else
+                "";
+            defaultText = lib.literalExpression "if cfg.createDatabaseLocally then \"postgresql:///bookorbit?host=/run/postgresql&user=bookorbit\" else \"\"";
+            description = "The URL of the postgresql database.";
+          };
+        };
+      };
+      default = { };
+      example = {
+        APP_URL = "https://bookorbit.example.com";
+        JWT_SECRET = "change-me";
+        SETUP_BOOTSTRAP_TOKEN = "change-me";
+      };
+      description = ''
+        Environment variables to pass to the BookOrbit service.
+        See <https://bookorbit.app/installation.html#configuration> for available options.
+      '';
+    };
+
+    environmentFile = mkOption {
+      type = types.nullOr types.path;
+      example = "/run/secrets/bookorbit";
+      default = null;
+      description = ''
+        Path of a file with extra environment variables to be loaded from disk.
+        This file is not added to the nix store, so it can be used to pass secrets to BookOrbit.
+        See <https://bookorbit.app/installation.html#configuration> for available options.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.groups = mkIf (cfg.group == "bookorbit") {
+      bookorbit = { };
+    };
+
+    users.users = mkIf (cfg.user == "bookorbit") {
+      bookorbit = {
+        group = cfg.group;
+        description = "bookorbit Daemon user";
+        isSystemUser = true;
+      };
+    };
+
+    systemd.services = {
+      bookorbit = {
+        description = "BookOrbit";
+        after = [
+          "network-online.target"
+          "postgresql.target"
+          "bookorbit-migrate.service"
+        ];
+        requires = [ "bookorbit-migrate.service" ];
+        wants = [
+          "network-online.target"
+          "postgresql.target"
+        ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          User = cfg.user;
+          Group = cfg.group;
+          ExecStart = getExe cfg.package;
+          StateDirectory = "bookorbit";
+          Environment = environment;
+          EnvironmentFile = cfg.environmentFile;
+
+          ProtectSystem = "full";
+          ProtectHome = true;
+          PrivateTmp = true;
+          PrivateDevices = true;
+          PrivateMounts = true;
+          ProtectControlGroups = true;
+          ProtectKernelTunables = true;
+          RestrictSUIDSGID = true;
+          RemoveIPC = true;
+          UMask = "0077";
+
+          CapabilityBoundingSet = [ "" ];
+          NoNewPrivileges = true;
+
+          ProtectKernelModules = true;
+          ProtectKernelLogs = true;
+          ProtectClock = true;
+          SystemCallArchitectures = "native";
+          SystemCallFilter = [
+            "@system-service"
+            "~@privileged"
+            "~@resources"
+            "@chown"
+            "@chmod"
+          ];
+
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+            "AF_UNIX"
+            "AF_NETLINK"
+          ];
+
+          PrivateUsers = true;
+
+          LockPersonality = true;
+          ProtectHostname = true;
+          RestrictRealtime = true;
+          RestrictNamespaces = true;
+          ProtectProc = "invisible";
+          ProcSubset = "pid";
+          DeviceAllow = [ "" ];
+        };
+      };
+
+      postgresql-setup.serviceConfig.ExecStartPost =
+        let
+          extensions = [
+            "uuid-ossp"
+            "pg_trgm"
+            "vector"
+          ];
+          sqlFile = pkgs.writeText "bookorbit-pgext-setup.sql" ''
+            ${lib.concatMapStringsSep "\n" (ext: "CREATE EXTENSION IF NOT EXISTS \"${ext}\";") extensions}
+          '';
+        in
+        mkIf cfg.createDatabaseLocally [
+          ''
+            ${lib.getExe' postgresqlPackage "psql"} -d "bookorbit" -f "${sqlFile}"
+          ''
+        ];
+
+      bookorbit-migrate = {
+        description = "BookOrbit database migration";
+        after = [ "postgresql.target" ];
+        wants = [ "postgresql.target" ];
+
+        serviceConfig = {
+          Type = "oneshot";
+          User = cfg.user;
+          Group = cfg.group;
+          Environment = environment;
+
+          ExecStart = getExe' cfg.package "bookorbit-migrate";
+        };
+      };
+    };
+
+    services.postgresql = mkIf cfg.createDatabaseLocally {
+      enable = true;
+      extensions = ps: with ps; [ pgvector ];
+      ensureDatabases = [ "bookorbit" ];
+      ensureUsers = [
+        {
+          name = "bookorbit";
+          ensureDBOwnership = true;
+        }
+      ];
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.environment.PORT ];
+  };
+
+  meta = {
+    maintainers = with lib.maintainers; [ iv-nn ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -300,6 +300,7 @@ in
   blockbook-frontend = runTest ./blockbook-frontend.nix;
   blocky = runTest ./blocky.nix;
   bluesky-pds = runTest ./bluesky-pds.nix;
+  bookorbit = runTest ./web-apps/bookorbit.nix;
   bookstack = runTest ./bookstack.nix;
   boot = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./boot.nix { };
   boot-stage1 = runTest ./boot-stage1.nix;

--- a/nixos/tests/web-apps/bookorbit.nix
+++ b/nixos/tests/web-apps/bookorbit.nix
@@ -1,0 +1,21 @@
+{ ... }:
+{
+  name = "bookorbit";
+
+  containers.machine = {
+    services.bookorbit = {
+      enable = true;
+      environment = {
+        JWT_SECRET = "abcdefghijklmnop";
+        SETUP_BOOTSTRAP_TOKEN = "abcdefgh";
+      };
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit('bookorbit.service')
+
+    machine.wait_for_open_port(3000)
+    machine.succeed('curl --fail http://localhost:3000 | grep BookOrbit')
+  '';
+}

--- a/pkgs/by-name/bo/bookorbit/package.nix
+++ b/pkgs/by-name/bo/bookorbit/package.nix
@@ -9,6 +9,7 @@
   pnpmConfigHook,
   ffmpeg,
   makeWrapper,
+  nixosTests,
 }:
 let
   pnpm = pnpm_11;
@@ -86,7 +87,13 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    tests = {
+      inherit (nixosTests) bookorbit;
+    };
+
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "BookOrbit, self-hosted library management and reading platform for ebooks, PDFs, audiobooks, and comics.";

--- a/pkgs/by-name/bo/bookorbit/package.nix
+++ b/pkgs/by-name/bo/bookorbit/package.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  nodejs,
+  pnpm_11,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  ffmpeg,
+  makeWrapper,
+}:
+let
+  pnpm = pnpm_11;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bookorbit";
+  version = "2.8.1";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "bookorbit";
+    repo = "bookorbit";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Un30txjsp+sdEPX9DTQ4f0ht7klDhbDptizUzQMP5AA=";
+  };
+
+  pnpmWorkspaces = [
+    "client..."
+    "server..."
+  ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      pnpmWorkspaces
+      ;
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-y/cdgAjv8ZWlF4IikKb0pPqrlakMfTo9nY1Bb9AnxlM=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm
+    pnpmConfigHook
+    ffmpeg
+    makeWrapper
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm --filter client run build-only
+    pnpm --filter server run build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    pnpm --filter server \
+         --config.inject-workspace-packages=true \
+         --prod \
+         deploy $out/lib
+
+    cp -r client/dist $out/lib/public
+    cp -r server/src/db/migrations $out/lib/migrations
+    cp -r koreader-plugin $out/lib/koreader-plugin
+
+    makeWrapper ${nodejs}/bin/node $out/bin/bookorbit \
+      --run "cd $out/lib" \
+      --set NODE_ENV production \
+      --set APP_VERSION ${finalAttrs.version} \
+      --add-flags "$out/lib/dist/main.js"
+
+    makeWrapper ${nodejs}/bin/node $out/bin/bookorbit-migrate \
+      --set NODE_ENV production \
+      --add-flags "$out/lib/dist/scripts/migrate.js"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "BookOrbit, self-hosted library management and reading platform for ebooks, PDFs, audiobooks, and comics.";
+    homepage = "https://github.com/bookorbit/bookorbit";
+    changelog = "https://github.com/bookorbit/bookorbit/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ iv-nn ];
+    mainProgram = "bookorbit";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
BookOrbit - A self-hosted library management and reading platform for ebooks, PDFs, audiobooks, and comics.

https://github.com/bookorbit/bookorbit

I debugged some build issues with opencode and GLM 5.1 ~~and copy/pasted the `preConfigure` and `postPatch` from it~~.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
