### PR TITLE
pipeasio: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -208,6 +208,11 @@
     github = "2hexed";
     githubId = 54501296;
   };
+  _30350n = {
+    name = "Max Schlecht";
+    github = "30350n";
+    githubId = 34186858;
+  };
   _360ied = {
     name = "Brian Zhu";
     email = "therealbarryplayer@gmail.com";

--- a/pkgs/by-name/pi/pipeasio/default.nix
+++ b/pkgs/by-name/pi/pipeasio/default.nix
@@ -1,0 +1,62 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  pipewire,
+  wine64Packages,
+  qt6,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pipeasio";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "30350n";
+    repo = "pipeasio";
+    tag = "support-nixos";
+    hash = "sha256-uGyAGTxRIC0MTlOT9WnJ81mVssEm8T8ETaQsu00Qh7U=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    wine64Packages.stable
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    pipewire
+    qt6.qtbase
+  ];
+
+  cmakeFlags =
+    let
+      WINE_INCLUDE_DIRS = [
+        "${wine64Packages.stable}/include/wine"
+        "${wine64Packages.stable}/include/wine/windows"
+      ];
+    in
+    [ "-DWINE_INCLUDE_DIRS=${builtins.concatStringsSep ";" WINE_INCLUDE_DIRS}" ];
+
+  dontWrapQtApps = true;
+
+  postFixup = ''
+    wrapQtApp $out/bin/pipeasio-settings
+    wrapProgram $out/bin/pipeasio-register \
+        --set PIPEASIO_PREFIX "$out" \
+        --prefix PATH : "${wine64Packages.stable}/bin"
+  '';
+
+  meta = {
+    homepage = "https://m0n7y5.github.io/pipeasio/";
+    changelog = "https://github.com/M0n7y5/pipeasio/releases/tag/${finalAttrs.src.tag}";
+    description = "ASIO to Pipewire driver for WINE";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [
+      _30350n
+    ];
+    platforms = [ "x86_64-linux" ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
[PipeASIO](https://m0n7y5.github.io/pipeasio/) is an alternative/fork of [WineASIO](https://github.com/wineasio/wineasio/) that implements a wine driver that can directly interface with Pipewire.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
