### PR TITLE
github-copilot-cli: 1.0.26 -> 1.0.61

### DIFF
--- a/pkgs/by-name/gi/github-copilot-cli/package.nix
+++ b/pkgs/by-name/gi/github-copilot-cli/package.nix
@@ -15,7 +15,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "github-copilot-cli";
-  version = "1.0.26";
+  version = "1.0.61";
 
   # GitHub provide platform-specific SEA binaries as well as a "universal"
   # package.  Use the universal package as it gives us a bit more flexibility
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   # about how paths should be set up which don't reliably hold when using Nix.
   src = fetchurl {
     url = "https://github.com/github/copilot-cli/releases/download/v${finalAttrs.version}/github-copilot-${finalAttrs.version}.tgz";
-    hash = "sha256-zNO0clQRfgw6CX9K8NaJXsoOhhNjBfK7KAr0AoL7Oqo=";
+    hash = "sha256-8Lks8lHa5XF9ZrC+fU/9VlzD1W32MbRZ7PZtL5YWLTA=";
   };
 
   nativeBuildInputs = [
@@ -58,6 +58,10 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   postInstall = ''
+    # Upstream bundles linuxmusl prebuilds in the universal tarball; they are
+    # not needed on glibc systems and make autoPatchelf fail on musl libc deps.
+    find "$out"/lib/github-copilot-cli -depth -path '*/linuxmusl-*' -exec rm -rf '{}' +
+
     makeWrapper ${nodejs}/bin/node "$out"/bin/copilot \
       --add-flag "$out"/lib/github-copilot-cli/index.js \
       --add-flag --no-auto-update \


### PR DESCRIPTION
This also adjusts the packaging for the current upstream universal tarball: it now contains bundled `linuxmusl-*` native artifacts, and on glibc Linux `autoPatchelf` tries to process them and fails on missing musl libc dependencies. This change removes those musl-only artifacts during install so the package builds successfully while preserving the existing Linux package layout.

This upgrade has been fully automated using GPT-5.4 through GitHub Copilot CLI.

Edit: Added `Assisted-by` in the commit.
~~The git commit doesn't include the required `Assisted-by` as mentionned in the AI Policy since I made the edits directly through GitHub's web interface. I hope this is not a big deal for a simple package version bump.~~
 
 Upstream release notes:
 - https://github.com/github/copilot-cli/releases/tag/v1.0.61
 
pbsds edit: closes https://github.com/NixOS/nixpkgs/pull/522591

 ## Things done
 
 - Built on platform:
   - [x] x86_64-linux
   - [ ] aarch64-linux
   - [ ] x86_64-darwin
   - [ ] aarch64-darwin
 - Tested, as applicable:
   - [ ] [NixOS tests] in [nixos/tests].
   - [ ] [Package tests] at `passthru.tests`.
   - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
 - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
 - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
 - Nixpkgs Release Notes
   - [ ] Package update: when the change is major or breaking.
 - NixOS Release Notes
   - [ ] Module addition: when adding a new NixOS module.
   - [ ] Module update: when the change is significant.
 - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
 - [x] Follows the [automation/AI policy].