### PR TITLE
ergohaven-entropy: init at 1.13.151

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9770,6 +9770,13 @@
     githubId = 34658064;
     name = "Grace Dinh";
   };
+  geekiot-hub = {
+    email = "geekiot@proton.me";
+    github = "geekiot-hub";
+    githubId = 227938479;
+    name = "Kirill Samoylenkov";
+    keys = [ { fingerprint = "955B 97C5 78A3 DF03 D818  25EB 8E40 5DD2 CF84 CCE0"; } ];
+  };
   genga898 = {
     email = "genga898@gmail.com";
     github = "genga898";

--- a/nixos/modules/programs/ergohaven-entropy.nix
+++ b/nixos/modules/programs/ergohaven-entropy.nix
@@ -1,0 +1,33 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.programs.entropy;
+in
+{
+  options.programs.entropy = {
+    enable = mkEnableOption "Entropy keyboard configurator";
+
+    enableVialUdevRules = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Install udev rules for Vial-compatible HID device access.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.groups.plugdev = { };
+
+    environment.systemPackages = [ pkgs.entropy ];
+
+    services.udev.packages = optionals cfg.enableVialUdevRules [ pkgs.entropy ];
+  };
+}

--- a/pkgs/by-name/er/ergohaven-entropy/package.nix
+++ b/pkgs/by-name/er/ergohaven-entropy/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  rustPlatform,
+  pkg-config,
+  makeWrapper,
+  hidapi,
+  systemd,
+  libxcb,
+  libxkbcommon,
+  xkeyboard-config,
+  openssl,
+  gtk3,
+  libglvnd,
+  libx11,
+  libXrandr,
+  wayland,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ergohaven-entropy";
+  version = "1.13.151";
+
+  # TODO: switch back to ergohaven/entropy once upstream provides Cargo.lock and tags
+  src = fetchFromGitHub {
+    owner = "geekiot-hub";
+    repo = "entropy";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-axbMUDdUpUePoYxu3dTZ4lGTF4FAo7UP5/VMOD3+fHM=";
+  };
+
+  cargoHash = "sha256-AmmKAy5xFnShJTYYCMMOaCoT3kgoVaZzcOJrHvk+7NA=";
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    hidapi
+    systemd
+    libxcb
+    libxkbcommon
+    openssl
+    gtk3
+    libglvnd
+    libx11
+    libXrandr
+    wayland
+    xkeyboard-config
+  ];
+
+  env = lib.optionalAttrs stdenv.cc.isGNU {
+    NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
+  };
+
+  postInstall = ''
+        mkdir -p $out/lib/udev/rules.d
+        cat > $out/lib/udev/rules.d/59-vial.rules << RULES
+    KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{serial}=="*vial:f64c2b3c*", MODE="0660", GROUP="plugdev", TAG+="uaccess"
+    RULES
+
+        wrapProgram $out/bin/entropy \
+          --prefix LD_LIBRARY_PATH : ${
+            lib.makeLibraryPath [
+              wayland
+              libglvnd
+              libxkbcommon
+            ]
+          } \
+          --set XKB_CONFIG_ROOT ${xkeyboard-config}/share/X11/xkb
+  '';
+
+  meta = {
+    description = "Modern app for programmable keyboards and input devices";
+    longDescription = ''
+      Entropy is a desktop app with a modern, minimalist, and intuitive
+      interface for configuring programmable input devices running Vial-QMK
+      or Vial-RMK firmware: split keyboards, macropads, trackballs, touchpad
+      modules, and other hardware that exposes keyboard-style firmware
+      features through HID.
+    '';
+    homepage = "https://github.com/ergohaven/entropy";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ geekiot-hub ];
+    mainProgram = "entropy";
+  };
+})


### PR DESCRIPTION
Added [Entropy](https://github.com/ergohaven/entropy) - a desktop application for configuring programmable keyboards and input devices running Vial-QMK/RMK firmware.

Uses a fork from geekiot-hub/entropy because upstream (ergohaven/entropy) does not include a Cargo.lock and does not publish version tags, making it impossible to build the package reproducibly with a pinned dependency set.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
