### PR TITLE
python3Packages.plover: fix plover_build_utils for GUI plugins

### DIFF
--- a/pkgs/development/python-modules/plover-combo/default.nix
+++ b/pkgs/development/python-modules/plover-combo/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  plover,
+  setuptools,
+  wheel,
+  nix-update-script,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "plover-combo";
+  version = "2.0.0-unstable-2025-09-11";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "opensteno";
+    repo = "plover_combo";
+    rev = "82e4b498bd0d7878af4e60fd26453362f41132a8";
+    hash = "sha256-GCRfoYu/LZDIGs/9RXDCcTEke3PHMifBEuDUrGH/Juc=";
+  };
+
+  build-system = [
+    plover
+    setuptools
+    wheel
+  ];
+
+  dependency = [
+    plover
+  ]
+  ++ plover.optional-dependencies.gui-qt;
+
+  pythonImportsCheck = [
+    "plover_combo"
+
+    # Modules providing Plover entry points
+    "plover_combo.combo_ui"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Combo Mode for Plover";
+    homepage = "https://github.com/opensteno/plover_combo";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      ShamrockLee
+    ];
+  };
+})

--- a/pkgs/development/python-modules/plover/4.nix
+++ b/pkgs/development/python-modules/plover/4.nix
@@ -56,6 +56,11 @@ buildPythonPackage (finalAttrs: {
     wcwidth
     xlib
   ];
+  optional-dependencies = {
+    gui-qt = [
+      pyqt5
+    ];
+  };
   nativeBuildInputs = [
     wrapQtAppsHook
   ];

--- a/pkgs/development/python-modules/plover/5.nix
+++ b/pkgs/development/python-modules/plover/5.nix
@@ -36,6 +36,20 @@
   pyobjc-core,
 }:
 
+let
+  # Replacement for missing pyside6-essentials tools,
+  # workaround for https://github.com/NixOS/nixpkgs/issues/277849.
+  # Ideally this would be solved in pyside6 itself but I spent four
+  # hours trying to untangle its build system before giving up. If
+  # anyone wants to spend the time fixing it feel free to request
+  # me (@Pandapip1) as a reviewer.
+  pyside-tools-rcc = buildPackages.writeShellScriptBin "pyside6-rcc" ''
+    exec ${buildPackages.qt6.qtbase}/libexec/rcc -g python "$@"
+  '';
+  pyside-tools-uic = buildPackages.writeShellScriptBin "pyside6-uic" ''
+    exec ${buildPackages.qt6.qtbase}/libexec/uic -g python "$@"
+  '';
+in
 buildPythonPackage (finalAttrs: {
   __structuredAttrs = true;
 
@@ -50,9 +64,13 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-1NpZmUDq806geKANqswPYglHwInxum/c/Hxq7JhTpbc=";
   };
 
-  # pythonRelaxDeps seemingly doesn't work here
   postPatch = ''
+    # pythonRelaxDeps doesn't work for build-system dependencies
     sed -i 's/,<77//g' pyproject.toml
+
+    substituteInPlace plover_build_utils/setup.py \
+      --replace-fail "pyside6-rcc" ${lib.getExe pyside-tools-rcc} \
+      --replace-fail "pyside6-uic" ${lib.getExe pyside-tools-uic}
   '';
 
   pythonRelaxDeps = [
@@ -69,19 +87,6 @@ buildPythonPackage (finalAttrs: {
     setuptools
     pyside6
     wheel
-
-    # Replacement for missing pyside6-essentials tools,
-    # workaround for https://github.com/NixOS/nixpkgs/issues/277849.
-    # Ideally this would be solved in pyside6 itself but I spent four
-    # hours trying to untangle its build system before giving up. If
-    # anyone wants to spend the time fixing it feel free to request
-    # me (@Pandapip1) as a reviewer.
-    (buildPackages.writeShellScriptBin "pyside6-uic" ''
-      exec ${qtbase}/libexec/uic -g python "$@"
-    '')
-    (buildPackages.writeShellScriptBin "pyside6-rcc" ''
-      exec ${qtbase}/libexec/rcc -g python "$@"
-    '')
   ];
   dependencies = [
     appdirs

--- a/pkgs/development/python-modules/plover/5.nix
+++ b/pkgs/development/python-modules/plover/5.nix
@@ -110,6 +110,12 @@ buildPythonPackage (finalAttrs: {
     pyobjc-framework-Cocoa
     pyobjc-framework-Quartz
   ];
+  optional-dependencies = {
+    gui-qt = [
+      # TODO(@ShamrockLee): use PySide6-Essentials once available
+      pyside6
+    ];
+  };
   nativeBuildInputs = [
     wrapQtAppsHook
   ];

--- a/pkgs/development/python-modules/plover/5.nix
+++ b/pkgs/development/python-modules/plover/5.nix
@@ -53,10 +53,16 @@ buildPythonPackage (finalAttrs: {
   # pythonRelaxDeps seemingly doesn't work here
   postPatch = ''
     sed -i 's/,<77//g' pyproject.toml
-    sed -i /PySide6-Essentials/d pyproject.toml
   '';
 
-  pythonRelaxDeps = [ "xkbcommon" ];
+  pythonRelaxDeps = [
+    "xkbcommon"
+  ];
+
+  pythonRemoveDeps = [
+    # We currently don't have it in Nixpkgs.
+    "PySide6-Essentials"
+  ];
 
   build-system = [
     babel

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12823,6 +12823,8 @@ self: super: with self; {
   # https://github.com/opensteno/plover_plugins_registry/blob/master/unsupported.json
   plover = plover_5;
 
+  plover-combo = callPackage ../development/python-modules/plover-combo { };
+
   plover-dict-commands = callPackage ../development/python-modules/plover-dict-commands { };
 
   plover-lapwing-aio = callPackage ../development/python-modules/plover-lapwing-aio { };


### PR DESCRIPTION
- Add `optional-dependencies.gui-qt` for both `python3Packages.plover_4` and `python3Packages.plover_5`.
- Make `python3Packages.plover_5`'s `plover_build_utils` bring `pyside6-rcc` and `pyside6-uic` so that plugins can use it during the build process.
- Add `pythn3Packages.plover-combo` as a simple GUI Plover plugin for testing.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
