### PR TITLE
ergohaven-entropy: init at 0.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9993,6 +9993,13 @@
     githubId = 34658064;
     name = "Grace Dinh";
   };
+  geekiot-hub = {
+    email = "geekiot@proton.me";
+    github = "geekiot-hub";
+    githubId = 227938479;
+    name = "Kirill Samoylenkov";
+    keys = [ { fingerprint = "955B 97C5 78A3 DF03 D818  25EB 8E40 5DD2 CF84 CCE0"; } ];
+  };
   genga898 = {
     email = "genga898@gmail.com";
     github = "genga898";

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -66,6 +66,8 @@
 
 - [LXMD](https://github.com/markqvist/LXMF), a universal, distributed and secure messaging protocol for Reticulum. Available as [services.lxmd](#opt-services.lxmd.enable).
 
+- [Entropy](https://github.com/ergohaven/entropy), a configurator for programmable keyboards and input devices running Vial-QMK/RMK firmware. Available as [programs.entropy](#opt-programs.entropy.enable).
+
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -210,6 +210,7 @@
   ./programs/ente-auth.nix
   ./programs/environment.nix
   ./programs/envision.nix
+  ./programs/ergohaven-entropy.nix
   ./programs/evince.nix
   ./programs/extra-container.nix
   ./programs/fcast-receiver.nix

--- a/nixos/modules/programs/ergohaven-entropy.nix
+++ b/nixos/modules/programs/ergohaven-entropy.nix
@@ -1,0 +1,35 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.entropy;
+  inherit (lib) mkIf;
+in
+{
+  options.programs.entropy = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Enables the Entropy keyboard configurator and sets up necessary
+        udev rules for Vial-QMK/RMK compatible devices.
+        This allows configuring programmable keyboards without root privileges.
+        Ensure your user is a member of the 'plugdev' group after enabling.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users.groups.plugdev = { };
+
+    environment.systemPackages = [ pkgs.ergohaven-entropy ];
+
+    services.udev.packages = [ pkgs.ergohaven-entropy ];
+
+    i18n.inputMethod.ibus.engines = [ pkgs.ergohaven-entropy ];
+  };
+}

--- a/pkgs/by-name/er/ergohaven-entropy/package.nix
+++ b/pkgs/by-name/er/ergohaven-entropy/package.nix
@@ -1,0 +1,140 @@
+{
+  lib,
+  rustPlatform,
+  pkg-config,
+  makeWrapper,
+  makeDesktopItem,
+  copyDesktopItems,
+  iconConvTools,
+  hidapi,
+  systemd,
+  libxcb,
+  libxkbcommon,
+  xkeyboard-config,
+  openssl,
+  gtk3,
+  libglvnd,
+  libx11,
+  libxrandr,
+  wayland,
+  stdenv,
+  fetchFromGitHub,
+  python3,
+  ibus,
+  glib,
+}:
+
+let
+  python = python3.withPackages (
+    ps: with ps; [
+      pygobject3
+      (toPythonModule ibus)
+    ]
+  );
+in
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ergohaven-entropy";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "ergohaven";
+    repo = "entropy";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ibU379pT0/u6xsIOfgK7KjIlmoyoN9+G3J1T2rYwc44=";
+  };
+
+  cargoHash = "sha256-e2bLlqH+2Cv4LBV+JooupcXDUe83NmiFI4zPNMTEW3A=";
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+    copyDesktopItems
+    iconConvTools
+    python
+  ];
+
+  buildInputs = [
+    hidapi
+    systemd
+    libxcb
+    libxkbcommon
+    openssl
+    gtk3
+    libglvnd
+    libx11
+    libxrandr
+    wayland
+    xkeyboard-config
+  ];
+
+  env = lib.optionalAttrs stdenv.cc.isGNU {
+    NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
+  };
+
+  desktopItems = lib.singleton (makeDesktopItem {
+    name = "entropy";
+    exec = "entropy";
+    icon = "entropy";
+    desktopName = "Entropy";
+    comment = "Configure programmable keyboards and input devices";
+    categories = [
+      "Settings"
+      "HardwareSettings"
+    ];
+  });
+
+  postInstall = ''
+    mkdir -p $out/lib/udev/rules.d
+    cat > $out/lib/udev/rules.d/59-vial.rules << RULES
+    KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{serial}=="*vial:f64c2b3c*", MODE="0660", GROUP="plugdev", TAG+="uaccess"
+    RULES
+
+    icoFileToHiColorTheme $src/assets/entropy.ico entropy $out
+
+    install -Dm755 $src/linux/ibus/entropy-ibus-engine $out/share/entropy/ibus/entropy-ibus-engine
+    mkdir -p $out/share/ibus/component
+    substitute $src/linux/ibus/entropy-universal-symbols.xml.in \
+      $out/share/ibus/component/entropy-universal-symbols.xml \
+      --replace-fail "@ENGINE_PATH@" "$out/share/entropy/ibus/entropy-ibus-engine"
+
+    wrapProgram $out/bin/entropy \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          wayland
+          libglvnd
+          libxkbcommon
+        ]
+      } \
+      --set XKB_CONFIG_ROOT ${xkeyboard-config}/share/X11/xkb
+  '';
+
+  postFixup = ''
+    patchShebangs --build $out/share/entropy/ibus/entropy-ibus-engine
+    wrapProgram $out/share/entropy/ibus/entropy-ibus-engine \
+      --prefix GI_TYPELIB_PATH : ${
+        lib.makeSearchPath "lib/girepository-1.0" [
+          glib
+          ibus
+        ]
+      }
+  '';
+
+  meta = {
+    description = "Modern app for programmable keyboards and input devices";
+    longDescription = ''
+      Entropy is a desktop app with a modern, minimalist, and intuitive
+      interface for configuring programmable input devices running Vial-QMK
+      or Vial-RMK firmware: split keyboards, macropads, trackballs, touchpad
+      modules, and other hardware that exposes keyboard-style firmware
+      features through HID.
+    '';
+    homepage = "https://github.com/ergohaven/entropy";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ geekiot-hub ];
+    mainProgram = "entropy";
+  };
+})


### PR DESCRIPTION
Added [Entropy](https://github.com/ergohaven/entropy) - a desktop application for configuring programmable keyboards and input devices running Vial-QMK/RMK firmware.

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/5e93527f-b816-48e4-8720-5ce5771a8699" />

Simple configuration example:
```nix
{
    _class = "nixos";
    programs.entropy.enable = true;
    users.users.<your-user>.extraGroups = [ "plugdev" ];
}
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
