### PR TITLE
cocoa-archive: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14110,6 +14110,11 @@
     githubId = 48174247;
     name = "Aleksandar Nesovic";
   };
+  kayskayskays = {
+    github = "kayskayskays";
+    githubId = 115312476;
+    name = "Kays";
+  };
   kazcw = {
     email = "kaz@lambdaverse.org";
     github = "kazcw";

--- a/pkgs/by-name/co/cocoa-archive/package.nix
+++ b/pkgs/by-name/co/cocoa-archive/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  rustPlatform,
+  fetchCrate,
+  runCommand,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cocoa-archive";
+  version = "0.1.0";
+
+  __structuredAttrs = true;
+
+  src = fetchCrate {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-4QoGeW3Pk1NNZtD1o00xzp2RZBFiaX+iLW2PhPa6SL4=";
+  };
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  doInstallCheck = true;
+
+  cargoHash = "sha256-gDEMQQJn/bgHpviI38BjYqu/r0SRwh9K1m4cC0pQusM=";
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Generate property list archives for supported macOS Cocoa objects";
+    homepage = "https://github.com/kayskayskays/cocoa-archive";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kayskayskays ];
+    mainProgram = "cocoa-archive";
+  };
+})


### PR DESCRIPTION
Adds `cocoa-archive`, a small Rust library and command-line interface for generating `NSKeyedArchiver`-compatible archives for selected macOS Cocoa objects.

I'm the upstream author, and I'd like to maintain the package in nixpkgs as well. It's generally useful for configuring macOS applications that require plist data encoded in this Cocoa-specific format. 

A concrete use case is one that I have familiarity with - this package can be used to enhance Home Manager's `macos-terminal` module, which I also authored. The macOS Terminal.app application stores configuration for terminal profiles in a plist file, and certain parameters such as color and font are encoded as Cocoa archives. This package may come in handy for allowing the configuration of these extra parameters, for this module and for other similar modules.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
