### PR TITLE
nixos/pam: add control and openasroot options to security.pam.oath

### DIFF
--- a/nixos/modules/security/oath.nix
+++ b/nixos/modules/security/oath.nix
@@ -12,6 +12,25 @@
         '';
       };
 
+      control = lib.mkOption {
+        type = lib.types.enum [
+          "required"
+          "requisite"
+          "sufficient"
+          "optional"
+        ];
+        default = "requisite";
+        description = ''
+          This option sets pam "control".
+          If you want to have multi factor authentication, use "required".
+          If you want to use the OATH module instead of a regular password, use "sufficient".
+
+          Read
+          {manpage}`pam.conf(5)`
+          for better understanding of this option.
+        '';
+      };
+
       digits = lib.mkOption {
         type = lib.types.enum [
           6
@@ -22,6 +41,14 @@
         description = ''
           Specify the lib.length of the one-time password in number of
           digits.
+        '';
+      };
+
+      openasroot = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Open the usersfile as root before dropping privileges.
         '';
       };
 

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -1130,10 +1130,10 @@ let
                   {
                     name = "oath";
                     enable = cfg.oathAuth;
-                    control = "requisite";
+                    control = oath.control;
                     modulePath = "${pkgs.oath-toolkit}/lib/security/pam_oath.so";
                     settings = {
-                      inherit (oath) window digits;
+                      inherit (oath) window digits openasroot;
                       usersfile = oath.usersFile;
                     };
                   }


### PR DESCRIPTION
Previously the pam_oath module hardcoded `requisite` as the PAM control flag, making it impossible to use OATH as an alternative to password authentication. This adds a configurable `control` option similar to security.pam.u2f.control.

Also adds `openasroot` to allow reading the usersfile as root before dropping privileges, useful when the file is managed by a secrets manager and only readable by root.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
