### PR TITLE
ib-tws: init at 10.45.1j

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -620,6 +620,12 @@
     githubId = 749381;
     name = "Adam Tulinius";
   };
+  adamyi = {
+    email = "i@adamyi.com";
+    github = "adamyi";
+    githubId = 5311091;
+    name = "Adam Yi";
+  };
   adda = {
     email = "chocholaty.david@protonmail.com";
     matrix = "@adda0:matrix.org";

--- a/pkgs/by-name/ib/ib-tws/package.nix
+++ b/pkgs/by-name/ib/ib-tws/package.nix
@@ -1,0 +1,228 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  copyDesktopItems,
+  makeDesktopItem,
+  makeWrapper,
+
+  alsa-lib,
+  at-spi2-atk,
+  at-spi2-core,
+  atk,
+  cairo,
+  cups,
+  dbus,
+  expat,
+  ffmpeg_7,
+  fontconfig,
+  freetype,
+  gdk-pixbuf,
+  glib,
+  gtk3,
+  libdrm,
+  libgbm,
+  libGL,
+  libx11,
+  libxcb,
+  libxcomposite,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxi,
+  libxkbcommon,
+  libxrandr,
+  libxrender,
+  libxshmfence,
+  libxtst,
+  libxxf86vm,
+  nspr,
+  nss,
+  pango,
+  systemd,
+  zlib,
+}:
+
+let
+  desktopItem = makeDesktopItem {
+    name = "ib-tws";
+    desktopName = "IBKR Trader Workstation";
+    exec = "tws";
+    icon = "tws";
+    categories = [
+      "Office"
+      "Finance"
+    ];
+    startupWMClass = "install4j-jclient-LoginFrame";
+  };
+
+  runtimeLibraries = [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    ffmpeg_7
+    fontconfig
+    freetype
+    gdk-pixbuf
+    glib
+    gtk3
+    libdrm
+    libgbm
+    libGL
+    libx11
+    libxcb
+    libxcomposite
+    libxdamage
+    libxext
+    libxfixes
+    libxi
+    libxkbcommon
+    libxrandr
+    libxrender
+    libxshmfence
+    libxtst
+    libxxf86vm
+    nspr
+    nss
+    pango
+    stdenv.cc.cc.lib
+    systemd
+    zlib
+  ];
+
+  runtimeLibraryPath = lib.makeLibraryPath runtimeLibraries;
+in
+stdenv.mkDerivation {
+  pname = "ib-tws";
+  version = "10.45.1g";
+
+  # IBKR only publishes rolling-channel installer URLs (latest/stable), not
+  # per-version ones, so the URL is constant and the version is just a label.
+  # The pinned hash still makes each eval reproducible and fails closed when
+  # IBKR rotates the bytes; passthru.updateScript re-pins hash + version on bump.
+  # We use stable here so there are fewer version bumps.
+  src = fetchurl {
+    url = "https://download2.interactivebrokers.com/installers/tws/stable-standalone/tws-stable-standalone-linux-x64.sh";
+    hash = "sha256-Il/ULIpQbI9+GEuMNaqBYA0jJfSnDT7ZvyXEjJJn5MY=";
+    executable = true;
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
+
+  desktopItems = [ desktopItem ];
+
+  passthru.updateScript = ./update.sh;
+
+  installPhase = ''
+    runHook preInstall
+
+    install4jRoot="$TMPDIR/install4j"
+    mkdir -p "$install4jRoot" "$out/bin" "$out/jre"
+    export FONTCONFIG_FILE="${fontconfig.out}/etc/fonts/fonts.conf"
+    export XDG_CACHE_HOME="$TMPDIR/xdg-cache"
+    mkdir -p "$XDG_CACHE_HOME"
+
+    payloadSize="$(sed -nE 's/^tail -c ([0-9]+).*/\1/p' "$src")"
+    installerSize="$(stat -c %s "$src")"
+
+    if [ -z "$payloadSize" ]; then
+      echo "could not determine embedded install4j payload size" >&2
+      exit 1
+    fi
+
+    tail -c "$payloadSize" "$src" | tar -xzf - -C "$install4jRoot"
+    tar -xzf "$install4jRoot/jre.tar.gz" -C "$out/jre"
+
+    dataSize="$(sed -nE 's/^file\.size\.0=([0-9]+)/\1/p' "$install4jRoot/stats.properties")"
+    if [ -z "$dataSize" ]; then
+      echo "could not determine install4j data payload size" >&2
+      exit 1
+    fi
+
+    dataOffset=$((installerSize - payloadSize - dataSize))
+    dd \
+      if="$src" \
+      of="$install4jRoot/0.dat" \
+      iflag=skip_bytes,count_bytes \
+      skip="$dataOffset" \
+      count="$dataSize" \
+      status=none
+
+    dynamicLinker="$(cat "$NIX_CC/nix-support/dynamic-linker")"
+    jreLibraryPath="${lib.makeLibraryPath [ zlib ]}:$out/jre/lib:$out/jre/lib/server"
+
+    for file in "$out"/jre/bin/* "$out"/jre/lib/jexec "$out"/jre/lib/jspawnhelper; do
+      if [ -f "$file" ] && [ -x "$file" ]; then
+        patchelf \
+          --set-interpreter "$dynamicLinker" \
+          --set-rpath "$jreLibraryPath" \
+          "$file"
+      fi
+    done
+
+    "$out/jre/bin/java" -version
+
+    # install4j embeds its entry class name as a literal "Installer<N>" string.
+    # We assume the first match is the launcher class; this has held across
+    # releases but is unverified per-version, so revisit if a bump fails here.
+    installerClass="$(grep -aoE 'Installer[0-9]+' "$src" | head -n1)"
+    if [ -z "$installerClass" ]; then
+      echo "could not determine install4j installer class" >&2
+      exit 1
+    fi
+
+    mkdir -p "$TMPDIR/tws-config"
+    (
+      cd "$install4jRoot"
+      export INSTALL4J_JAVA_HOME="$out/jre"
+      export LD_LIBRARY_PATH="${runtimeLibraryPath}:''${LD_LIBRARY_PATH-}"
+
+      "$out/jre/bin/java" \
+        -DjtsConfigDir="$TMPDIR/tws-config" \
+        -classpath "i4jruntime.jar:launcher0.jar" \
+        "install4j.$installerClass" \
+        -q \
+        -dir "$out"
+    )
+
+    makeWrapper "$out/tws" "$out/bin/tws" \
+      --run "mkdir -p \"\$HOME/.tws\"" \
+      --set INSTALL4J_JAVA_HOME "$out/jre" \
+      --prefix LD_LIBRARY_PATH : "${runtimeLibraryPath}" \
+      --add-flags "-J-DjtsConfigDir=\$HOME/.tws" \
+      --add-flags "-J-Dawt.useSystemAAFontSettings=lcd" \
+      --add-flags "-J-Dswing.aatext=true"
+
+    install -Dm644 "$out/.install4j/tws.png" "$out/share/icons/hicolor/128x128/apps/tws.png"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Desktop trading platform for Interactive Brokers";
+    homepage = "https://www.interactivebrokers.com/en/trading/tws.php";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [
+      binaryBytecode
+      binaryNativeCode
+    ];
+    maintainers = with lib.maintainers; [ adamyi ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "tws";
+  };
+}

--- a/pkgs/by-name/ib/ib-tws/package.nix
+++ b/pkgs/by-name/ib/ib-tws/package.nix
@@ -1,0 +1,232 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  copyDesktopItems,
+  makeDesktopItem,
+  makeWrapper,
+
+  alsa-lib,
+  at-spi2-atk,
+  at-spi2-core,
+  atk,
+  cairo,
+  cups,
+  dbus,
+  expat,
+  ffmpeg_7,
+  fontconfig,
+  freetype,
+  gdk-pixbuf,
+  glib,
+  gtk3,
+  libdrm,
+  libgbm,
+  libGL,
+  libx11,
+  libxcb,
+  libxcomposite,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxi,
+  libxkbcommon,
+  libxrandr,
+  libxrender,
+  libxshmfence,
+  libxtst,
+  libxxf86vm,
+  nspr,
+  nss,
+  pango,
+  systemd,
+  zlib,
+}:
+
+let
+  desktopItem = makeDesktopItem {
+    name = "ib-tws";
+    desktopName = "IBKR Trader Workstation";
+    exec = "tws";
+    icon = "tws";
+    categories = [
+      "Office"
+      "Finance"
+    ];
+    startupWMClass = "install4j-jclient-LoginFrame";
+  };
+
+  runtimeLibraries = [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    ffmpeg_7
+    fontconfig
+    freetype
+    gdk-pixbuf
+    glib
+    gtk3
+    libdrm
+    libgbm
+    libGL
+    libx11
+    libxcb
+    libxcomposite
+    libxdamage
+    libxext
+    libxfixes
+    libxi
+    libxkbcommon
+    libxrandr
+    libxrender
+    libxshmfence
+    libxtst
+    libxxf86vm
+    nspr
+    nss
+    pango
+    stdenv.cc.cc.lib
+    systemd
+    zlib
+  ];
+
+  runtimeLibraryPath = lib.makeLibraryPath runtimeLibraries;
+in
+stdenv.mkDerivation {
+  pname = "ib-tws";
+  version = "10.45.1j";
+
+  # IBKR only publishes rolling-channel installer URLs (latest/stable), not
+  # per-version ones, so the URL is constant and the version is just a label.
+  # The pinned hash still makes each eval reproducible and fails closed when
+  # IBKR rotates the bytes; passthru.updateScript re-pins hash + version on bump.
+  # We use stable here so there are fewer version bumps.
+  src = fetchurl {
+    url = "https://download2.interactivebrokers.com/installers/tws/stable-standalone/tws-stable-standalone-linux-x64.sh";
+    hash = "sha256-+hm3dgJ+q23fmddTqsV/4b62sG4xHqpU/6g0M/7p6YY=";
+    executable = true;
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [
+    copyDesktopItems
+    makeWrapper
+  ];
+
+  desktopItems = [ desktopItem ];
+
+  passthru.updateScript = ./update.sh;
+
+  installPhase = ''
+    runHook preInstall
+
+    install4jRoot="$TMPDIR/install4j"
+    mkdir -p "$install4jRoot" "$out/bin" "$out/jre"
+    export FONTCONFIG_FILE="${fontconfig.out}/etc/fonts/fonts.conf"
+    export XDG_CACHE_HOME="$TMPDIR/xdg-cache"
+    mkdir -p "$XDG_CACHE_HOME"
+
+    payloadSize="$(sed -nE 's/^tail -c ([0-9]+).*/\1/p' "$src")"
+    installerSize="$(stat -c %s "$src")"
+
+    if [ -z "$payloadSize" ]; then
+      echo "could not determine embedded install4j payload size" >&2
+      exit 1
+    fi
+
+    tail -c "$payloadSize" "$src" | tar -xzf - -C "$install4jRoot"
+    tar -xzf "$install4jRoot/jre.tar.gz" -C "$out/jre"
+
+    dataSize="$(sed -nE 's/^file\.size\.0=([0-9]+)/\1/p' "$install4jRoot/stats.properties")"
+    if [ -z "$dataSize" ]; then
+      echo "could not determine install4j data payload size" >&2
+      exit 1
+    fi
+
+    dataOffset=$((installerSize - payloadSize - dataSize))
+    dd \
+      if="$src" \
+      of="$install4jRoot/0.dat" \
+      iflag=skip_bytes,count_bytes \
+      skip="$dataOffset" \
+      count="$dataSize" \
+      status=none
+
+    dynamicLinker="$(cat "$NIX_CC/nix-support/dynamic-linker")"
+    jreLibraryPath="${lib.makeLibraryPath [ zlib ]}:$out/jre/lib:$out/jre/lib/server"
+
+    for file in "$out"/jre/bin/* "$out"/jre/lib/jexec "$out"/jre/lib/jspawnhelper; do
+      if [ -f "$file" ] && [ -x "$file" ]; then
+        patchelf \
+          --set-interpreter "$dynamicLinker" \
+          --set-rpath "$jreLibraryPath" \
+          "$file"
+      fi
+    done
+
+    "$out/jre/bin/java" -version
+
+    # install4j embeds its entry class name as a literal "Installer<N>" string.
+    # We assume the first match is the launcher class; this has held across
+    # releases but is unverified per-version, so revisit if a bump fails here.
+    installerClass="$(grep -aoE 'Installer[0-9]+' "$src" | head -n1)"
+    if [ -z "$installerClass" ]; then
+      echo "could not determine install4j installer class" >&2
+      exit 1
+    fi
+
+    mkdir -p "$TMPDIR/tws-config"
+    (
+      cd "$install4jRoot"
+      export INSTALL4J_JAVA_HOME="$out/jre"
+      export LD_LIBRARY_PATH="${runtimeLibraryPath}:''${LD_LIBRARY_PATH-}"
+
+      "$out/jre/bin/java" \
+        -DjtsConfigDir="$TMPDIR/tws-config" \
+        -classpath "i4jruntime.jar:launcher0.jar" \
+        "install4j.$installerClass" \
+        -q \
+        -dir "$out"
+    )
+
+    # The installer drops an uninstaller and its own desktop file (whose Exec
+    # bypasses the wrapper); neither belongs in the store.
+    rm -f "$out"/*.desktop "$out/uninstall"
+
+    makeWrapper "$out/tws" "$out/bin/tws" \
+      --run "mkdir -p \"\$HOME/.tws\"" \
+      --set INSTALL4J_JAVA_HOME "$out/jre" \
+      --prefix LD_LIBRARY_PATH : "${runtimeLibraryPath}" \
+      --add-flags "-J-DjtsConfigDir=\$HOME/.tws" \
+      --add-flags "-J-Dawt.useSystemAAFontSettings=lcd" \
+      --add-flags "-J-Dswing.aatext=true"
+
+    install -Dm644 "$out/.install4j/tws.png" "$out/share/icons/hicolor/128x128/apps/tws.png"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Desktop trading platform for Interactive Brokers";
+    homepage = "https://www.interactivebrokers.com/en/trading/tws.php";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [
+      binaryBytecode
+      binaryNativeCode
+    ];
+    maintainers = with lib.maintainers; [ adamyi ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "tws";
+  };
+}

--- a/pkgs/by-name/ib/ib-tws/update.sh
+++ b/pkgs/by-name/ib/ib-tws/update.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p common-updater-scripts curl gnused nix
+
+set -euo pipefail
+
+base_url="https://download2.interactivebrokers.com/installers/tws/stable-standalone"
+installer_url="$base_url/tws-stable-standalone-linux-x64.sh"
+
+version_json="$(curl -fsSL "$base_url/version.json")"
+version="$(sed -nE 's/^twsstable_callback\(\{"buildVersion":"([^"]+)".*/\1/p' <<< "$version_json")"
+
+if [[ -z "$version" ]]; then
+    echo "Could not parse upstream version from $base_url/version.json" >&2
+    exit 1
+fi
+
+prefetch_hash="$(nix-prefetch-url --executable "$installer_url")"
+hash="$(nix hash convert --hash-algo sha256 --to sri "$prefetch_hash")"
+
+update-source-version ib-tws "$version" "$hash"

--- a/pkgs/by-name/ib/ib-tws/update.sh
+++ b/pkgs/by-name/ib/ib-tws/update.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p common-updater-scripts curl gnused nix
+
+set -euo pipefail
+
+base_url="https://download2.interactivebrokers.com/installers/tws/stable-standalone"
+installer_url="$base_url/tws-stable-standalone-linux-x64.sh"
+
+version_json="$(curl -fsSL "$base_url/version.json")"
+version="$(sed -nE 's/^twsstable_callback\(\{"buildVersion":"([^"]+)".*/\1/p' <<< "$version_json")"
+
+if [[ -z "$version" ]]; then
+    echo "Could not parse upstream version from $base_url/version.json" >&2
+    exit 1
+fi
+
+prefetch_hash="$(nix-prefetch-url --executable "$installer_url")"
+hash="$(nix hash convert --hash-algo sha256 --to sri "$prefetch_hash")"
+
+# --ignore-same-version: IBKR sometimes rotates the installer bytes without
+# bumping buildVersion, which must still be re-pinned.
+update-source-version ib-tws "$version" "$hash" --ignore-same-version


### PR DESCRIPTION
## Description of changes

Re-introduces Interactive Brokers Trader Workstation (TWS) as an unfree package.
The previous `ib-tws` was stuck on the ~2015 952.x build, could no longer connect
to IBKR (#40784), was marked broken in #324591, and removed alongside
`ib-controller` in #327306. There was also a request to bring it back (#397323).

Modern TWS ships as an install4j self-extracting installer bundling its own JRE,
so this carves the install4j payload out of the `.sh`, patchelfs the bundled JRE,
runs the installer headless into `$out`, and redirects runtime config to
`$HOME/.tws`. IBKR publishes no per-version installer URL — only rolling channels
— so `src` tracks the `stable` channel and `passthru.updateScript` re-pins the
hash on bump; an upstream rotation surfaces as a hash mismatch and is resolved by
a version bump.

Only `ib-tws` is re-added (`ib-controller` is out of scope), and no `throw` alias
was left behind after the removal, so the attribute is clean to reuse.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
