### PR TITLE
bintools: create unprefixed symlinks for musl systems using pkgsStatic

### DIFF
--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -271,6 +271,14 @@ stdenvNoCC.mkDerivation {
       basename=$(basename "${if exeSuffix != "" then "\${variant%${exeSuffix}}" else "$variant"}")
       wrap $basename ${./ld-wrapper.sh} $variant
     done
+  ''
+
+  # targetPlatform and hostPlatform have the same config (e.g. differ only in isStatic),
+  # so also create unprefixed symlinks for native toolchain compatibility
+  + optionalString (targetPlatform.config == hostPlatform.config && targetPlatform != hostPlatform) ''
+    for f in $out/bin/${targetPrefix}*; do
+      ln -s "$f" "$out/bin/''${f##*${targetPrefix}}" 2>/dev/null || true
+    done
   '';
 
   strictDeps = true;


### PR DESCRIPTION
## The problem

When using the `pkgsStatic` package set, which creates statically linked binaries using the musl libc, on an *already musl-based* system, any build will fail in the first few seconds as critical `bintools` commands can't found as the binaries are all prefixed. This patch makes it so in the case of something like calling `pkgsStatic` on an already musl-based system, unprefixed binaries are symlinked so they can be found and used.

Anyways I'm aware this solution kinda sucks. But unfortunately I barely stumbled into this one and don't really have the knowledge to go any further. I'm sure I could use an LLM to slop something together but I'd rather not ;) so I'm hoping someone more experienced with the `pkgsStatic` package set and cross compiling infra can take a look. Thanks!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
