### PR TITLE
v2ray-rules-dat: init at 202606122311

### DIFF
--- a/pkgs/by-name/v2/v2ray-rules-dat/package.nix
+++ b/pkgs/by-name/v2/v2ray-rules-dat/package.nix
@@ -1,0 +1,37 @@
+{
+  stdenvNoCC,
+  fetchurl,
+  lib,
+}:
+let
+  version = "202606122311";
+
+  geoipDat = fetchurl {
+    url = "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/${version}/geoip.dat";
+    hash = "sha256-iGGpeUaWtIH7AEPueCssQOgL/Ia7nkLFvWnAj1SDsbU=";
+  };
+
+  geositeDat = fetchurl {
+    url = "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/${version}/geosite.dat";
+    hash = "sha256-/c/3OjfALveNnHS9NxonTeOiZyud6U/X4WHrGZSOs7Q=";
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "v2ray-rules-dat";
+  inherit version;
+  __structuredAttrs = true;
+  strictDeps = true;
+  dontUnpack = true;
+
+  installPhase = ''
+    install -Dm444 ${geoipDat} $out/share/v2ray/geoip.dat
+    install -Dm444 ${geositeDat} $out/share/v2ray/geosite.dat
+  '';
+
+  meta = {
+    description = "Enhanced edition of V2Ray rules dat files";
+    homepage = "https://github.com/Loyalsoldier/v2ray-rules-dat";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ nix-julia ];
+  };
+}


### PR DESCRIPTION
I think i need to first add this package and then edit xray package to use if for geofiles, because xray uses [this geofiles](https://github.com/XTLS/Xray-core/blob/main/.github/workflows/scheduled-assets-update.yml#L43)
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
