### PR TITLE
krunvm: migrate to by-name, switch to finalAttrs, strictDeps, and structuredAttrs

### DIFF
--- a/pkgs/applications/virtualization/krunvm/default.nix
+++ b/pkgs/applications/virtualization/krunvm/default.nix
@@ -14,21 +14,24 @@
   sigtool,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "krunvm";
   version = "0.2.6";
 
   src = fetchFromGitHub {
     owner = "libkrun";
     repo = "krunvm";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-peOaPivQKOwioh5skPNFiA3ptHv9pSsnjpy43cms8O8=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
+    inherit (finalAttrs) src;
     hash = "sha256-MRcQ0Vnd3PJqE2q981JpXPjwMUKT4t+RcOvzWptK7PQ=";
   };
+
+  strictDeps = true;
+  __structuredAttrs = true;
 
   nativeBuildInputs = [
     rustPlatform.cargoSetupHook
@@ -77,4 +80,4 @@ stdenv.mkDerivation rec {
     platforms = libkrun.meta.platforms;
     mainProgram = "krunvm";
   };
-}
+})

--- a/pkgs/by-name/kr/krunvm/package.nix
+++ b/pkgs/by-name/kr/krunvm/package.nix
@@ -7,11 +7,11 @@
   buildah,
   buildah-unwrapped,
   cargo,
+  darwin,
   libiconv,
   libkrun,
   makeWrapper,
   rustc,
-  sigtool,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     asciidoctor
     makeWrapper
   ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [ sigtool ];
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.sigtool ];
 
   buildInputs = [
     libkrun

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2478,10 +2478,6 @@ with pkgs;
 
   keybase-gui = callPackage ../tools/security/keybase/gui.nix { };
 
-  krunvm = callPackage ../applications/virtualization/krunvm {
-    inherit (darwin) sigtool;
-  };
-
   limine-full = limine.override { enableAll = true; };
 
   logstash7 = callPackage ../tools/misc/logstash/7.x.nix {


### PR DESCRIPTION
This pull request refactors the packaging and inclusion of the `krunvm` package in the codebase. The main changes involve moving the package to a new location, updating its build setup for improved maintainability and compatibility, and removing a redundant package reference from the top-level package list.

**Package refactoring and improvements:**

* Moved the `krunvm` package definition from `pkgs/applications/virtualization/krunvm/default.nix` to `pkgs/by-name/kr/krunvm/package.nix`, aligning with the new package organization structure.
* Updated the derivation to use the new `stdenv.mkDerivation (finalAttrs: { ... })` syntax, ensuring more structured and future-proof attribute handling. [[1]](diffhunk://#diff-22d87ff78960053aed6fd00db84bd2cc58ea974ddc0ee01dab00475e766eb099R10-R43) [[2]](diffhunk://#diff-22d87ff78960053aed6fd00db84bd2cc58ea974ddc0ee01dab00475e766eb099L80-R83)
* Changed the way the GitHub source is fetched by using the `tag` attribute instead of `rev`, and updated attribute inheritance for better clarity and correctness.
* Improved Darwin support by referencing `darwin.sigtool` directly in `nativeBuildInputs` and removing the explicit inheritance of `sigtool` in the top-level package list. [[1]](diffhunk://#diff-22d87ff78960053aed6fd00db84bd2cc58ea974ddc0ee01dab00475e766eb099R10-R43) [[2]](diffhunk://#diff-ab5748dc9567516fefba8344056b51ec1866adeace380f46e58a7af3d619ea22L2481-L2484)

**Top-level package list cleanup:**

* Removed the explicit `krunvm` entry from `pkgs/top-level/all-packages.nix`, as the package is now handled through the new structure.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
