### PR TITLE
Gfan: 0.6.2->0.7, license update

### DIFF
--- a/pkgs/by-name/gf/gfan/gfan-0.7-macos.patch
+++ b/pkgs/by-name/gf/gfan/gfan-0.7-macos.patch
@@ -1,0 +1,139 @@
+diff --git a/src/app_components.cpp b/src/app_components.cpp
+index 407c23e..8fc0d86 100644
+--- a/src/app_components.cpp
++++ b/src/app_components.cpp
+@@ -162,7 +162,6 @@ void connectedComponentsOfSlices(PostComplex<mvtyp>& pc, bool saveNoncomets, boo
+   */
+   if (potentialsOutputAndStop) {
+     std::for_each(
+-		  std::execution::seq, 
+ 		  potentials.begin(),
+ 		  potentials.end(),
+ 		  [](Rational p)
+@@ -180,7 +179,6 @@ void connectedComponentsOfSlices(PostComplex<mvtyp>& pc, bool saveNoncomets, boo
+ 		  });
+   } else {
+     std::for_each(
+-		  std::execution::par,//fails to trigger parallelism
+ 		  potentials.begin(),
+ 		  potentials.end(),
+ 		  [pc,minConePotential,maxConePotential,saveNoncomets](Rational p)
+diff --git a/src/gfanlib_circuittableint.h b/src/gfanlib_circuittableint.h
+index 2b5ced4..d53fbec 100644
+--- a/src/gfanlib_circuittableint.h
++++ b/src/gfanlib_circuittableint.h
+@@ -25,6 +25,7 @@ namespace gfan{
+   template<typename> struct MyMakeUnsigned;
+   template <> struct MyMakeUnsigned<int>{typedef unsigned int type;};
+   template <> struct MyMakeUnsigned<long int>{typedef unsigned long int type;};
++  template <> struct MyMakeUnsigned<long long int>{typedef unsigned long long int type;};
+   template <> struct MyMakeUnsigned<__int128>{typedef unsigned __int128 type;};
+
+   class MVMachineIntegerOverflow: public std::exception
+@@ -92,6 +93,15 @@ static std::string toStr(__uint32_t b)
+        return s.str();
+ }
+
++#ifndef _64BITLONGINT
++static std::string toStr(long int b)
++{
++       std::stringstream s;
++       s<<b;
++       return s.str();
++}
++#endif
++
+ class my256s{
+ public:
+        __int128_t lo,hi;
+@@ -213,6 +221,10 @@ static __int128_t extMul(long int a, long int b)
+ {
+        return ((__int128_t)a)*((__int128_t)b);
+ }
++static __int128_t extMul(long long int a, long long int b)
++{
++       return ((__int128_t)a)*((__int128_t)b);
++}
+
+ static __uint128_t unsignedProd64(uint64_t x,uint64_t y)
+ {
+diff --git a/src/gfanlib_memoryresource.cpp b/src/gfanlib_memoryresource.cpp
+index 238a9f8..515f116 100644
+--- a/src/gfanlib_memoryresource.cpp
++++ b/src/gfanlib_memoryresource.cpp
+@@ -10,7 +10,7 @@
+ StackResource stackResource(10160000);
+ StackResource stackResource2(10160000);
+ 
+-std::string memoryResourceToString(const std::experimental::pmr::memory_resource *mr)
++std::string memoryResourceToString(const std::pmr::memory_resource *mr)
+ {
+ 	if(get_default_resource()==mr)
+ 	{
+diff --git a/src/gfanlib_memoryresource.h b/src/gfanlib_memoryresource.h
+index 3eb9e2c..74a5c64 100644
+--- a/src/gfanlib_memoryresource.h
++++ b/src/gfanlib_memoryresource.h
+@@ -6,9 +6,9 @@
+  *      Author: anders
+  */
+ 
+-#include <experimental/memory_resource>
++#include <memory_resource>
+ #include <iostream>
+-#include <experimental/vector>
++#include <vector>
+ #include <assert.h>
+ 
+ 
+@@ -42,9 +42,9 @@ void test() {
+ 
+ template<typename a>
+ //using std::experimental::pmr pmr;
+-using pmrvector=std::experimental::pmr::vector<a>;
+-typedef std::experimental::pmr::memory_resource MR; //Maybe this should be polymorphic_allocator<byte> instead - at least for the constructors using these
+-using std::experimental::pmr::get_default_resource;
++using pmrvector=std::pmr::vector<a>;
++typedef std::pmr::memory_resource MR; //Maybe this should be polymorphic_allocator<byte> instead - at least for the constructors using these
++using std::pmr::get_default_resource;
+ 
+ //DELETE
+ class ResourceWrapper: public MR{
+@@ -76,7 +76,7 @@ public:
+ 	}
+ };
+ 
+-class StackResource: public std::experimental::pmr::memory_resource{
++class StackResource: public std::pmr::memory_resource{
+   /*
+    *
+    * Layout of memory
+@@ -98,7 +98,7 @@ class StackResource: public std::experimental::pmr::memory_resource{
+ 	The header is 4 byte aligned, while the alignment of each block is specified at allocation.
+    */
+ public:
+-  std::experimental::pmr::vector<char> mem;
++  std::pmr::vector<char> mem;
+   int topHeader;
+   int nbytes;
+   memory_resource* parentResource;
+@@ -124,8 +124,8 @@ public:
+ 	  return (firstPossible+((align-1)|(minimumAlignment-1)))& ~((align-1)|(minimumAlignment-1));
+   }
+   StackResource(int nbytes_,
+-		memory_resource* parentResource_=std::experimental::pmr::new_delete_resource(),
+-		memory_resource* fallBackResource_=std::experimental::pmr::null_memory_resource()):
++		memory_resource* parentResource_=std::pmr::new_delete_resource(),
++		memory_resource* fallBackResource_=std::pmr::null_memory_resource()):
+ 	topHeader(0),
+     nbytes(nbytes_),
+     mem(nbytes_,parentResource_),
+@@ -254,7 +254,7 @@ public:
+ };
+ 
+ 
+-std::string memoryResourceToString(const std::experimental::pmr::memory_resource *mr);
++std::string memoryResourceToString(const std::pmr::memory_resource *mr);
+ 
+ // DELETE?
+ class ResourceInvariant

--- a/pkgs/by-name/gf/gfan/package.nix
+++ b/pkgs/by-name/gf/gfan/package.nix
@@ -9,22 +9,19 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "gfan";
-  version = "0.6.2";
+  version = "0.7";
 
   src = fetchurl {
     url = "https://home.math.au.dk/jensen/software/gfan/gfan${finalAttrs.version}.tar.gz";
-    sha256 = "02pihqb1lb76a0xbfwjzs1cd6ay3ldfxsm8dvsbl6qs3vkjxax56";
+    sha256 = "sha256-q4M3V+Hk1KmGYvSqaROUAT6poib2QWuPhWU1bW/MmJ4=";
   };
 
   patches = [
     ./gfan-0.6.2-cddlib-prefix.patch
     (fetchpatch {
-      # removes dead code with invalid member reference in gfanlib
-      name = "clang-19.patch";
-      url = "https://github.com/Singular/Singular/commit/d3f73432d73ac0dd041af83cb35301498e9b57d9.patch";
-      stripLen = 2;
-      extraPrefix = "src/";
-      hash = "sha256-jPGMYx/GOFV7Tk3CqaRWeX/UHkzjeL57eZj4r40s8/g=";
+      name = "cstdint.patch";
+      url = "https://salsa.debian.org/math-team/gfan/-/raw/6bb6bc3dd517b3c26fbcb76bfdc47f04d1978007/debian/patches/cstdint.patch";
+      hash = "sha256-ALD8Exe2SW8TZg0hIfhvUuiEbbT3Sk7v+oLnNsYA8hs=";
     })
   ]
   ++ lib.optionals (stdenv.cc.isClang) [
@@ -33,17 +30,17 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://raw.githubusercontent.com/sagemath/sage/eea1f59394a5066e9acd8ae39a90302820914ee3/build/pkgs/gfan/patches/nodel.patch";
       sha256 = "sha256-RrncSgFyrBIk/Bwe3accxiJ2rpOSJKQ84cV/uBvQsDc=";
     })
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
+    # On MacOS, we need to adress differences in int64_t types and remove the
+    # "experimental/" library and namespace prefixes as well as references to
+    # std::execution.
+    ./gfan-0.7-macos.patch
   ];
 
-  # This test assumes that our implementation of sort behaves identically to the
-  # one used during development, which is not necessarily the case; update the
-  # expected result to be sorted using our copy of sort.
-  postPatch = ''
-    sort testsuite/0008PolynomialSetUnion/output -o testsuite/0008PolynomialSetUnion/output
-    sort testsuite/0008PolynomialSetUnion/outputNew -o testsuite/0008PolynomialSetUnion/outputNew
-  ''
-  + lib.optionalString stdenv.cc.isClang ''
-    substituteInPlace Makefile --replace "-fno-guess-branch-probability" ""
+  postPatch = lib.optionalString stdenv.cc.isClang ''
+    substituteInPlace Makefile --replace-fail "-fno-guess-branch-probability" "" \
+      --replace-fail "-finline-limit=1000" ""
 
     for f in $(find -name "*.h" -or -name "*.cpp"); do
         substituteInPlace "$f" --replace-quiet "log2" "_log2"
@@ -60,6 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     mpir
     cddlib
   ];
+  enableParallelBuilding = true;
   hardeningDisable = [ "libcxxhardeningfast" ];
 
   doCheck = true;

--- a/pkgs/by-name/gf/gfan/package.nix
+++ b/pkgs/by-name/gf/gfan/package.nix
@@ -72,7 +72,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Software package for computing Gröbner fans and tropical varieties";
-    license = lib.licenses.gpl2;
+    license =
+      with lib.licenses;
+      OR [
+        gpl2
+        gpl3
+      ];
     maintainers = [ lib.maintainers.raskin ];
     platforms = lib.platforms.unix;
     homepage = "http://home.math.au.dk/jensen/software/gfan/gfan.html";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
We are still on Gfan v0.6.2 from 2017.  Upgrading to v0.7 requires removing a previous patch (which removed dead code that has now been resurrected) and adding a small patch used by the Debian build, fixing some MacOS stuff*, and removing an old test distinction**.  The [homepage](https://users-math.au.dk/jensen/software/gfan/gfan.html) says
>Gfan is distributed under the terms of the GPL license version 2 or 3 as desired.

This is probably best described as ~~GPL 2+~~ GPL2 or GPL3.  I have this in a separate commit because I think it might be worth backporting.

*Libraries like `experimental/memory_resource` can't be found, which requires a bunch of library and namespace fixes (all in `gfan-0.7-macos.patch` thanks to @wegank).

**The test in question no longer uses `sort`, but a couple of other ones do.  However, I'm not sure that the adjustment is necessary.  We're sorting line-by-line and with basic ASCII characters.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
