### PR TITLE
python3Packages.zstd: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/zstd/default.nix
+++ b/pkgs/development/python-modules/zstd/default.nix
@@ -9,13 +9,15 @@
   pytest,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "zstd";
   version = "1.5.7.3";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-QD5SBfSsBLkuawzaZUvi9R3iaCKKDbAGe8CH+qzy9JU=";
   };
 
@@ -40,7 +42,7 @@ buildPythonPackage rec {
     # Running tests via setup.py triggers an attempt to recompile with the vendored zstd
     ZSTD_EXTERNAL = 1;
     VERSION = zstd.version;
-    PKG_VERSION = version;
+    PKG_VERSION = finalAttrs.version;
   };
 
   nativeCheckInputs = [ pytest ];
@@ -48,10 +50,12 @@ buildPythonPackage rec {
     pytest
   '';
 
+  pythonImportsCheck = [ "zstd" ];
+
   meta = {
     description = "Simple python bindings to Yann Collet ZSTD compression library";
     homepage = "https://github.com/sergey-dryabzhinsky/python-zstd";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ eadwu ];
   };
-}
+})

--- a/pkgs/development/python-modules/zstd/default.nix
+++ b/pkgs/development/python-modules/zstd/default.nix
@@ -3,6 +3,7 @@
   pkg-config,
   fetchPypi,
   buildPythonPackage,
+  setuptools,
   buildPackages,
   zstd,
   pytest,
@@ -11,7 +12,7 @@
 buildPythonPackage rec {
   pname = "zstd";
   version = "1.5.7.3";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
@@ -22,6 +23,8 @@ buildPythonPackage rec {
     substituteInPlace setup.py \
       --replace "/usr/bin/pkg-config" "${buildPackages.pkg-config}/bin/${buildPackages.pkg-config.targetPrefix}pkg-config"
   '';
+
+  build-system = [ setuptools ];
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ zstd ];


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
