### PR TITLE
linux-wallpaperengine: update to rev:b016d7d1fdcf4e5fd2f9c9fa420a8aaa…

### DIFF
--- a/pkgs/by-name/li/linux-wallpaperengine/package.nix
+++ b/pkgs/by-name/li/linux-wallpaperengine/package.nix
@@ -37,11 +37,12 @@
   wayland-scanner,
   zlib,
   nix-update-script,
+  dbus,
 }:
 
 let
   cef = cef-binary.override {
-    version = "135.0.17"; # follow upstream. https://github.com/Almamu/linux-wallpaperengine/blob/a8ce9b6aa14cc10f0396bbb74a16ca12ed3990dc/CMakeLists.txt#L47
+    version = "135.0.17"; # follow upstream. https://github.com/Almamu/linux-wallpaperengine/blob/b39f12757908eda9f4c1039613b914606568bb84/CMakeLists.txt#L47
     gitRevision = "cbc1c5b";
     chromiumVersion = "135.0.7049.52";
 
@@ -53,14 +54,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "linux-wallpaperengine";
-  version = "0-unstable-2026-05-12";
+  version = "0-unstable-2026-06-09";
 
   src = fetchFromGitHub {
     owner = "Almamu";
     repo = "linux-wallpaperengine";
-    rev = "a8ce9b6aa14cc10f0396bbb74a16ca12ed3990dc";
+    rev = "b016d7d1fdcf4e5fd2f9c9fa420a8aaa07fee02d";
     fetchSubmodules = true;
-    hash = "sha256-S9tPlHugYdg5dbOW4OyDPPfVhxBg6purYhc+Bgt3ovM=";
+    hash = "sha256-ExWAYdSFW5plPuS3/jxTPMXIly6zVb5GojE3e37imZM=";
   };
 
   nativeBuildInputs = [
@@ -100,6 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
     wayland-protocols
     wayland-scanner
     zlib
+    dbus
   ];
 
   cmakeFlags = [


### PR DESCRIPTION
Update linux-wallpaper engine to rev b016d7d1fdcf4e5fd2f9c9fa420a8aaa07fee02d

Resolves #531453 

Changelog (commits) of linux-wallpaperengine:

* b016d7d refactor: remove subprocess in favor of dbus and wire up to javascript (#606)
* 44dfa51 refactor: load scene-script builtins from a generated header (#608)
* ce06c02 refactor: read puppet mesh data via BinaryReader/MemoryStream (#604)
* ab76bc0 fix: mute video wallpapers when --silent is used (#605)
* 100b664 chore: cleanup and optimization of scripting engine + anonymous namespace methods (#599)
* f38303d refactor: make CImage::resolveTransform iterative and reuse computed transform (#602)
* 8a00ff7 Improve text rendering compatibility (5/5) (#571)
* a1efb83 Add media thumbnail texture fallback (#570)
* 0ec83fb Remove unused code that breaks clang builds (#558)
* c0f7b83 Tolerate directory properties and bool defaults (#581)
* 8377a55 fix: fall back to active Wayland viewport for mouse input (#576)
* ea1b73d Support point size as a user-configurable property (#572)
* b703b6e fix(cmake): add $ORIGIN/lib64 to INSTALL_RPATH for kissfft on 64-bit Linux (#565)
* c1e37fd fix: GLFWWindowOutput refreshes viewport in all window modes (#563)
* 94eb4c4 Feature/stretching across monitors (#557)
* 21ffa69 fix: --clamp argparse missing .append() blocks multi-screen apply (#577)
* 9e200e4 feat(wayland): add --layer CLI flag to choose wlr-layer-shell layer (#585)
* da4a95b Fix PulseAudio segfault and resource leaks (#566)
* ac84f12 Add scripted scene layer runtime (3/5) (#569)
* 8627c1c Add image puppet and parallax compatibility (#568)
* 095c16c Improve render effect compatibility (#567)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable: (there are not tests for this package)
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
