### PR TITLE
nixos/kubernetes: fix incomplete aggregator configuration

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/apiserver.nix
+++ b/nixos/modules/services/cluster/kubernetes/apiserver.nix
@@ -246,6 +246,37 @@ in
         default = null;
       };
 
+      requestHeaderClientCaFile = lib.mkOption {
+        description = "Kubernetes aggregator CA file.";
+        default = top.caFile;
+        defaultText = lib.literalExpression "config.${otop.caFile}";
+        type = nullOr path;
+      };
+
+      requestHeaderAllowedNames = lib.mkOption {
+        description = "Defines which client cert CNs are trusted to act as proxies.";
+        default = [ "front-proxy-client" ];
+        type = listOf str;
+      };
+
+      requestHeaderExtraHeadersPrefix = lib.mkOption {
+        description = "Kubernetes aggregator extra headers prefix.";
+        default = "X-Remote-Extra-";
+        type = nullOr str;
+      };
+
+      requestHeaderGroupHeaders = lib.mkOption {
+        description = "Kubernetes aggregator group headers.";
+        default = "X-Remote-Group";
+        type = nullOr str;
+      };
+
+      requestHeaderUsernameHeaders = lib.mkOption {
+        description = "Kubernetes aggregator username headers.";
+        default = "X-Remote-User";
+        type = nullOr str;
+      };
+
       proxyClientCertFile = lib.mkOption {
         description = "Client certificate to use for connections to proxy.";
         default = null;
@@ -424,6 +455,31 @@ in
               lib.optionalString (
                 cfg.preferredAddressTypes != null
               ) "--kubelet-preferred-address-types=${cfg.preferredAddressTypes}"
+            } \
+            ${
+              lib.optionalString (
+                cfg.requestHeaderClientCaFile != null
+              ) "--requestheader-client-ca-file=${cfg.requestHeaderClientCaFile}"
+            } \
+            ${
+              lib.optionalString (
+                cfg.requestHeaderAllowedNames != [ ]
+              ) "--requestheader-allowed-names=${lib.concatStringsSep "," cfg.requestHeaderAllowedNames}"
+            } \
+            ${
+              lib.optionalString (
+                cfg.requestHeaderExtraHeadersPrefix != null
+              ) "--requestheader-extra-headers-prefix=${cfg.requestHeaderExtraHeadersPrefix}"
+            } \
+            ${
+              lib.optionalString (
+                cfg.requestHeaderGroupHeaders != null
+              ) "--requestheader-group-headers=${cfg.requestHeaderGroupHeaders}"
+            } \
+            ${
+              lib.optionalString (
+                cfg.requestHeaderUsernameHeaders != null
+              ) "--requestheader-username-headers=${cfg.requestHeaderUsernameHeaders}"
             } \
             ${
               lib.optionalString (


### PR DESCRIPTION
## Things done

Added 5 missing flags in the api-server.
People will have issues trying to setup metrics-server or prometheus-adapter if those are missing.

PS: I noticed that only one CA is being generated and this is not ideal as frontend-proxy cert should have its own separate CA. *Didn't touch anything related to that, but I want to start the conversation on next steps.

- https://kubernetes.io/docs/setup/best-practices/certificates/#configure-certificates-manually
- https://kubernetes.io/docs/tasks/extend-kubernetes/configure-aggregation-layer/#ca-reusage-and-conflicts

```
# source: https://kubernetes.io/docs/tasks/extend-kubernetes/configure-aggregation-layer/#enable-kubernetes-apiserver-flags
# added missing flags
--requestheader-client-ca-file=<path to aggregator CA cert>
--requestheader-allowed-names=front-proxy-client
--requestheader-extra-headers-prefix=X-Remote-Extra-
--requestheader-group-headers=X-Remote-Group
--requestheader-username-headers=X-Remote-User
# *below flags were already present
--proxy-client-cert-file=<path to aggregator proxy cert>
--proxy-client-key-file=<path to aggregator proxy key>
```


- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
