### PR TITLE
protobuf: 35.0 -> 35.1

### DIFF
--- a/pkgs/development/libraries/protobuf/35.nix
+++ b/pkgs/development/libraries/protobuf/35.nix
@@ -2,8 +2,8 @@
 
 callPackage ./generic.nix (
   {
-    version = "35.0";
-    hash = "sha256-J0NA19W44CzgSjKv3A+1An6vDRTDjaWMhDzQGEOtrCk=";
+    version = "35.1";
+    hash = "sha256-nif9xjd+3ASR2pvvSXkzTEWoKi2oKLzV9gMQ3EevBVk=";
   }
   // args
 )

--- a/pkgs/development/python-modules/protobuf/5.nix
+++ b/pkgs/development/python-modules/protobuf/5.nix
@@ -10,6 +10,7 @@ buildPythonPackage rec {
   pname = "protobuf";
   version = "5.29.6";
   pyproject = true;
+  __structuredAttrs = true;
   # nixpkgs-update: no auto update
 
   src = fetchPypi {

--- a/pkgs/development/python-modules/protobuf/6.nix
+++ b/pkgs/development/python-modules/protobuf/6.nix
@@ -11,6 +11,7 @@ buildPythonPackage (finalAttrs: {
   pname = "protobuf";
   version = "6.33.6";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;

--- a/pkgs/development/python-modules/protobuf/7.nix
+++ b/pkgs/development/python-modules/protobuf/7.nix
@@ -11,6 +11,7 @@ buildPythonPackage (finalAttrs: {
   pname = "protobuf";
   version = "7.35.1";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;

--- a/pkgs/development/python-modules/protobuf/7.nix
+++ b/pkgs/development/python-modules/protobuf/7.nix
@@ -9,12 +9,12 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "protobuf";
-  version = "7.35.0";
+  version = "7.35.1";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-ou/YRgX0HlWfGIGwkStECZ0KKsm/RrNHSCPxD7OTsOY=";
+    hash = "sha256-zhFaJv4MOaLCmXPZFNMn5RamRVRkSJ/jzR5RobNU+Bo=";
   };
 
   build-system = [ setuptools ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **protobuf: 35.0 -> 35.1**
  - Diff: https://github.com/protocolbuffers/protobuf/compare/v35.0...v35.1
  - Changelog: https://github.com/protocolbuffers/protobuf/releases/tag/v35.1
- **python3Packages.protobuf5: enable __structuredAttrs**
- **python3Packages.protobuf5: enable __structuredAttrs**

---

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
