### PR TITLE
nixos/gcr-ssh-agent: fix env SSH_AUTH_SOCK

### DIFF
--- a/nixos/modules/services/desktops/gnome/gcr-ssh-agent.nix
+++ b/nixos/modules/services/desktops/gnome/gcr-ssh-agent.nix
@@ -45,5 +45,11 @@ in
       user.services.gcr-ssh-agent.wantedBy = [ "default.target" ];
       user.sockets.gcr-ssh-agent.wantedBy = [ "sockets.target" ];
     };
+
+    environment.extraInit = ''
+      if [ -z "$SSH_AUTH_SOCK" -a -n "$XDG_RUNTIME_DIR" ]; then
+        export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/gcr/ssh"
+      fi
+    '';
   };
 }


### PR DESCRIPTION
The `SSH_AUTH_SOCK` environment variable was not set, and so the ssh agent was not invoked when needed.

This fix is inspired by [nixos/modules/programs/ssh.nix (line 400)](https://github.com/NixOS/nixpkgs/blob/a0374025a863d007d98e3297f6aa46cc3141c2f0/nixos/modules/programs/ssh.nix#L400).

## Things done

Not applicable steps are crossed out.

- [X] changes are backward compatible
- [ ] ~~removed options are declared with `mkRemovedOptionModule`~~
- [ ] ~~changes that are not backward compatible are documented in release notes~~
- [x] module tests succeed on x86_64-linux
- [ ] ~~options types are appropriate~~
- [ ] ~~options description is set~~
- [ ] ~~options example is provided~~
- [ ] ~~documentation affected by the changes is updated~~
