### PR TITLE
jewfetch: init at 0-unstable-2026-06-13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30315,6 +30315,12 @@
     github = "yarektyshchenko";
     githubId = 185304;
   };
+  yarn = {
+    name = "yarncat";
+    github = "yaaaarn";
+    githubId = 30006414;
+    email = "nix@yarncat.moe";
+  };
   yarny = {
     github = "Yarny0";
     githubId = 41838844;

--- a/pkgs/by-name/je/jewfetch/package.nix
+++ b/pkgs/by-name/je/jewfetch/package.nix
@@ -1,0 +1,34 @@
+{
+  rustPlatform,
+  fetchFromGitHub,
+  lib,
+}:
+rustPlatform.buildRustPackage {
+  pname = "jewfetch";
+  version = "0-unstable-2026-06-13";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "salandarman";
+    repo = "jewfetch";
+    rev = "5993815858deeb522171f12f15b9fbd3638c293b";
+    hash = "sha256-bC2hFqbEbv4Eak8vMRkoeQVr5XXvb4f6cPSdMHxK39o=";
+  };
+
+  cargoHash = "sha256-jKGIQ3cBCMHNZ0j9HzwG2t3gQ6grFIhqU1TwUcJSIaQ=";
+
+  postInstall = ''
+    mkdir -p $out/share/jewfetch
+    cp src/config.json $out/share/jewfetch/
+  '';
+
+  meta = {
+    description = "A fetch tool developed for jews";
+    homepage = "https://github.com/salandarman/jewfetch";
+    mainProgram = "jewfetch";
+    license = lib.licenses.unfree;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ yarn ];
+  };
+}


### PR DESCRIPTION
https://github.com/salandarman/jewfetch
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
