### PR TITLE
treewide: fix leftover docbook links

### DIFF
--- a/nixos/doc/manual/development/settings-options.section.md
+++ b/nixos/doc/manual/development/settings-options.section.md
@@ -553,7 +553,7 @@ in
       default = { };
       description = ''
         Configuration for foo, see
-        <link xlink:href="https://example.com/docs/foo"/>
+        <https://example.com/docs/foo/>
         for supported settings.
       '';
     };
@@ -628,7 +628,7 @@ up in the manual.
     default = { };
     description = ''
       Configuration for Foo, see
-      <link xlink:href="https://example.com/docs/foo"/>
+      <https://example.com/docs/foo>
       for supported values.
     '';
   };

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -101,6 +101,9 @@
   "module-services-mautrix-discord-troubleshooting": [
     "index.html#module-services-mautrix-discord-troubleshooting"
   ],
+  "module-services-onedrive": [
+    "index.html#module-services-onedrive"
+  ],
   "module-services-tandoor-recipes-migrating-media-option-move": [
     "index.html#module-services-tandoor-recipes-migrating-media-option-move",
     "index.html#module-services-tandoor-recipes-migrating-media-option-1"

--- a/nixos/modules/services/backup/duplicati.nix
+++ b/nixos/modules/services/backup/duplicati.nix
@@ -72,7 +72,7 @@ in
           Each line in this option should be of the format --option=value.
           The options in this file take precedence over the options provided
           through command line arguments.
-          <link xlink:href="https://duplicati.readthedocs.io/en/latest/06-advanced-options/#parameters-file">Duplicati docs: parameters-file</link>
+          [Duplicati docs: parameters-file](https://duplicati.readthedocs.io/en/latest/06-advanced-options/#parameters-file)
         '';
       };
 
@@ -85,7 +85,7 @@ in
           Each line in the file option should be of the format --option=value.
           The options in this file take precedence over the options provided
           through command line arguments.
-          <link xlink:href="https://duplicati.readthedocs.io/en/latest/06-advanced-options/#parameters-file">Duplicati docs: parameters-file</link>
+          [Duplicati docs: parameters-file](https://duplicati.readthedocs.io/en/latest/06-advanced-options/#parameters-file)
         '';
       };
     };

--- a/nixos/modules/services/networking/onedrive.md
+++ b/nixos/modules/services/networking/onedrive.md
@@ -1,0 +1,39 @@
+# Microsoft OneDrive {#module-services-onedrive}
+
+Microsoft Onedrive is a popular cloud file-hosting service, used by 85%
+of Fortune 500 companies. NixOS uses a popular OneDrive client for Linux
+maintained by github user abraunegg. The Linux client is excellent and
+allows customization of which files or paths to download, not much
+unlike the default Windows OneDrive client by Microsoft itself. The
+client allows syncing with multiple onedrive accounts at the same time,
+of any type- OneDrive personal, OneDrive business, Office365 and
+Sharepoint libraries, without any additional charge.
+
+For more information, guides and documentation, see <https://abraunegg.github.io/>.
+
+To enable OneDrive support, add the following to your
+`configuration.nix`: {option}`services.onedrive.enable` = true;
+
+This installs the `onedrive` package and a service `onedriveLauncher`
+which will instantiate a `onedrive` service for all your OneDrive
+accounts. Follow the steps in documentation of the onedrive client to
+setup your accounts. To use the service with multiple accounts, create a
+file named `onedrive-launcher` in `~/.config` and add the filename of
+the config directory, relative to `~/.config`. For example, if you have
+two OneDrive accounts with configs in `~/.config/onedrive_bob_work` and
+`~/.config/onedrive_bob_personal`, add the following lines:
+
+```
+onedrive_bob_work
+# Not in use:
+# onedrive_bob_office365
+onedrive_bob_personal
+```
+
+No such file needs to be created if you are using only a single OneDrive
+account with config in the default location `~/.config/onedrive`, in the
+absence of `~/.config/onedrive-launcher`, only a single service is
+instantiated, with default config path.
+
+If you wish to use a custom OneDrive package, say from another channel,
+add the following line: {option}`services.onedrive.package` = pkgs.unstable.onedrive;

--- a/nixos/modules/services/networking/onedrive.nix
+++ b/nixos/modules/services/networking/onedrive.nix
@@ -23,17 +23,13 @@ let
 
 in
 {
-  ### Documentation
-  # meta.doc = ./onedrive.xml;
-
-  ### Interface
+  meta.doc = ./onedrive.md;
 
   options.services.onedrive = {
     enable = lib.mkEnableOption "OneDrive service";
 
     package = lib.mkPackageOption pkgs "onedrive" { };
   };
-  ### Implementation
 
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];

--- a/nixos/modules/services/networking/veilid.nix
+++ b/nixos/modules/services/networking/veilid.nix
@@ -92,7 +92,7 @@ in
     settings = mkOption {
       description = ''
         Build veilid-server.conf with nix expression.
-        Check <link xlink:href="https://veilid.gitlab.io/developer-book/admin/config.html#configuration-keys">Configuration Keys</link>.
+        Check [Configuration Keys](https://veilid.gitlab.io/developer-book/admin/config.html#configuration-keys).
       '';
       type = types.submodule {
         freeformType = settingsFormat.type;

--- a/nixos/modules/services/web-apps/agorakit.nix
+++ b/nixos/modules/services/web-apps/agorakit.nix
@@ -272,15 +272,15 @@ in
         Agorakit configuration options to set in the
         <filename>.env</filename> file.
 
-        Refer to <link xlink:href="https://github.com/agorakit/agorakit"/>
+        Refer to <https://github.com/agorakit/agorakit>
         for details on supported values.
 
         Settings containing secret data should be set to an attribute
-        set containing the attribute <literal>_secret</literal> - a
+        set containing the attribute `_secret` - a
         string pointing to a file containing the value the option
         should be set to. See the example to get a better picture of
         this: in the resulting <filename>.env</filename> file, the
-        <literal>OIDC_CLIENT_SECRET</literal> key will be set to the
+        `OIDC_CLIENT_SECRET` key will be set to the
         contents of the <filename>/run/keys/oidc_secret</filename>
         file.
       '';

--- a/nixos/modules/services/web-apps/hatsu.nix
+++ b/nixos/modules/services/web-apps/hatsu.nix
@@ -66,7 +66,7 @@ in
 
       description = ''
         Configuration for Hatsu, see
-        <link xlink:href="https://hatsu.cli.rs/admins/environments.html"/>
+        <https://hatsu.cli.rs/admins/environments.html>
         for supported values.
       '';
     };

--- a/nixos/modules/services/web-apps/monica.nix
+++ b/nixos/modules/services/web-apps/monica.nix
@@ -274,15 +274,15 @@ in
         monica configuration options to set in the
         <filename>.env</filename> file.
 
-        Refer to <link xlink:href="https://github.com/monicahq/monica"/>
+        Refer to <https://github.com/monicahq/monica>
         for details on supported values.
 
         Settings containing secret data should be set to an attribute
-        set containing the attribute <literal>_secret</literal> - a
+        set containing the attribute `_secret` - a
         string pointing to a file containing the value the option
         should be set to. See the example to get a better picture of
         this: in the resulting <filename>.env</filename> file, the
-        <literal>OIDC_CLIENT_SECRET</literal> key will be set to the
+        `OIDC_CLIENT_SECRET` key will be set to the
         contents of the <filename>/run/keys/oidc_secret</filename>
         file.
       '';

--- a/nixos/modules/services/web-apps/rutorrent.nix
+++ b/nixos/modules/services/web-apps/rutorrent.nix
@@ -75,8 +75,8 @@ in
         default = [ "httprpc" ];
         example = literalExpression ''[ "httprpc" "data" "diskspace" "edit" "erasedata" "theme" "trafic" ]'';
         description = ''
-          List of plugins to enable. See the list of <link xlink:href="https://github.com/Novik/ruTorrent/wiki/Plugins#currently-there-are-the-following-plugins">available plugins</link>. Note: the <literal>unpack</literal> plugin needs the nonfree <literal>unrar</literal> package.
-          You need to either enable one of the <literal>rpc</literal> or <literal>httprpc</literal> plugin or enable the <xref linkend="opt-services.rutorrent.nginx.exposeInsecureRPC2mount"/> option.
+          List of plugins to enable. See the list of [available plugins](https://github.com/Novik/ruTorrent/wiki/Plugins#currently-there-are-the-following-plugins). Note: the `unpack` plugin needs the nonfree `unrar` package.
+          You need to either enable one of the `rpc` or `httprpc` plugin or enable the {option}`services.rutorrent.nginx.exposeInsecureRPC2mount` option.
         '';
       };
 
@@ -97,7 +97,7 @@ in
           "pm.max_requests" = 500;
         };
         description = ''
-          Options for ruTorrent's PHP pool. See the documentation on <literal>php-fpm.conf</literal> for details on configuration directives.
+          Options for ruTorrent's PHP pool. See the documentation on `php-fpm.conf` for details on configuration directives.
         '';
       };
 
@@ -107,8 +107,8 @@ in
           default = false;
           description = ''
             Whether to enable nginx virtual host management.
-            Further nginx configuration can be done by adapting <literal>services.nginx.virtualHosts.&lt;name&gt;</literal>.
-            See <xref linkend="opt-services.nginx.virtualHosts"/> for further information.
+            Further nginx configuration can be done by adapting `services.nginx.virtualHosts.<name>`.
+            See {option}`services.nginx.virtualHosts` for further information.
           '';
         };
 
@@ -116,8 +116,8 @@ in
           type = types.bool;
           default = false;
           description = ''
-            If you do not enable one of the <literal>rpc</literal> or <literal>httprpc</literal> plugins you need to expose an RPC mount through scgi using this option.
-            Warning: This allow to run arbitrary commands, as the rtorrent user, so make sure to use authentification. The simplest way would be to use the <literal>services.nginx.virtualHosts.&lt;name&gt;.basicAuth</literal> option.
+            If you do not enable one of the `rpc` or `httprpc` plugins you need to expose an RPC mount through scgi using this option.
+            Warning: This allow to run arbitrary commands, as the rtorrent user, so make sure to use authentication. The simplest way would be to use the {option}`services.nginx.virtualHosts.<name>.basicAuth` option.
           '';
         };
       };

--- a/pkgs/by-name/ma/macfuse-stubs/package.nix
+++ b/pkgs/by-name/ma/macfuse-stubs/package.nix
@@ -58,13 +58,14 @@ stdenv.mkDerivation rec {
     cp -R usr/local/include/fuse{,.h} $out/include
   '';
 
+  passthru.warning = meta.description;
+
   meta = {
     homepage = "https://osxfuse.github.io";
     description = "Build time stubs for FUSE on macOS";
     longDescription = ''
       macFUSE is required for this package to work on macOS. To install macFUSE,
-      use the installer from the <link xlink:href="https://osxfuse.github.io/">
-      project website</link>.
+      use the installer from the [project website](https://osxfuse.github.io/).
     '';
     platforms = lib.platforms.darwin;
     maintainers = with lib.maintainers; [ midchildan ];
@@ -76,10 +77,4 @@ stdenv.mkDerivation rec {
       lgpl2Plus # libfuse
     ];
   };
-
-  passthru.warning = ''
-    macFUSE is required for this package to work on macOS. To install macFUSE,
-    use the installer from the <link xlink:href="https://osxfuse.github.io/">
-    project website</link>.
-  '';
 }

--- a/pkgs/stdenv/generic/problems.nix
+++ b/pkgs/stdenv/generic/problems.nix
@@ -158,7 +158,7 @@ rec {
 
           Package names are taken from `lib.getName`, which looks at the `pname` first and falls back to extracting the "pname" part from the `name` attribute.
 
-          See <link xlink:href="https://nixos.org/manual/nixpkgs/stable/#sec-ignore-problems">Installing packages with problems</link> in the NixOS manual.
+          See [Installing packages with problems](https://nixos.org/manual/nixpkgs/stable/#sec-ignore-problems) in the NixOS manual.
         '';
       };
 


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
