### PR TITLE
scim2-cli: init at 0.2.3

### DIFF
--- a/pkgs/by-name/sc/scim2-cli/package.nix
+++ b/pkgs/by-name/sc/scim2-cli/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+let
+  pp = python3Packages;
+in
+pp.buildPythonApplication (finalAttrs: {
+  pname = "scim2-cli";
+  version = "0.2.3";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "python-scim";
+    repo = "scim2-cli";
+    tag = finalAttrs.version;
+    hash = "sha256-24CqpyEZv5cGG9yp03ATc/m0IVvnIoPlYqODaxXMPRc=";
+  };
+
+  build-system = with pp; [
+    hatchling
+  ];
+
+  nativeCheckInputs = with pp; [
+    pytestCheckHook
+    pytest-httpserver
+  ];
+
+  dependencies =
+    with pp;
+    [
+      click
+      pydanclick
+      scim2-client
+      scim2-tester
+      sphinx-click-rst-to-ansi-formatter
+    ]
+    ++ scim2-tester.optional-dependencies.httpx;
+
+  pythonRemoveDeps = [
+    # docs only deps
+    "pygments"
+  ];
+
+  pythonImportsCheck = [
+    "scim2_cli"
+  ];
+
+  disabledTests = [
+    # click >= 8.2: CliRunner no longer mixes stderr into stdout,
+    # tests assert error messages in result.stdout
+    "test_stdin_bad_json"
+    "test_invalid_command"
+    "test_no_command_scimclient_error"
+    "test_no_command_validation_error"
+    "test_command_validation_error"
+    "test_command_scimclient_error"
+    "test_scimclient_error"
+    "test_bad_resource_type"
+    "test_unknown_resource_type"
+    "test_validation_error"
+    "test_no_command_payload_without_an_id"
+    "test_command_payload_without_an_id"
+  ];
+
+  pytestFlags = [
+    # newer scim2-tester changed the CheckConfig constructor signature
+    "--deselect=tests/test_test.py::test_nominal"
+    "--deselect=tests/test_test.py::test_verbose"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "SCIM application development CLI";
+    homepage = "https://github.com/python-scim/scim2-cli";
+    changelog = "https://github.com/python-scim/scim2-cli/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ marcel ];
+    mainProgram = "scim2-cli";
+  };
+})

--- a/pkgs/development/python-modules/sphinx-click-rst-to-ansi-formatter/default.nix
+++ b/pkgs/development/python-modules/sphinx-click-rst-to-ansi-formatter/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  pytestCheckHook,
+  click,
+  colorama,
+  docutils,
+  nix-update-script,
+}:
+
+buildPythonPackage {
+  pname = "sphinx-click-rst-to-ansi-formatter";
+  version = "0-unstable-2024-09-28";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "hakonhagland";
+    repo = "sphinx-click-rst-to-ansi-formatter";
+    rev = "9297db8e6f1575c64ead1bd2551dad09d79f79b5";
+    hash = "sha256-3B46V0VM5kHNULsIe3aaNP8dbBA48P4ll0BQ/aKZGJM=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  dependencies = [
+    click
+    colorama
+    docutils
+  ];
+
+  pythonRelaxDeps = [
+    "docutils"
+  ];
+
+  pythonImportsCheck = [
+    "sphinx_click.rst_to_ansi_formatter"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "";
+    homepage = "https://github.com/hakonhagland/sphinx-click-rst-to-ansi-formatter";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ marcel ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18553,6 +18553,10 @@ self: super: with self; {
 
   sphinx-click = callPackage ../development/python-modules/sphinx-click { };
 
+  sphinx-click-rst-to-ansi-formatter =
+    callPackage ../development/python-modules/sphinx-click-rst-to-ansi-formatter
+      { };
+
   sphinx-codeautolink = callPackage ../development/python-modules/sphinx-codeautolink { };
 
   sphinx-comments = callPackage ../development/python-modules/sphinx-comments { };


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
