### PR TITLE
nixos/stalwart: Add extraConfig option

### DIFF
--- a/nixos/modules/services/mail/stalwart.nix
+++ b/nixos/modules/services/mail/stalwart.nix
@@ -7,7 +7,9 @@
 let
   cfg = config.services.stalwart;
   configFormat = pkgs.formats.toml { };
-  configFile = configFormat.generate "stalwart.toml" cfg.settings;
+  configFile = pkgs.writers.writeText "stalwart-mail.toml" (
+    (lib.readFile (configFormat.generate "stalwart-mail-generated.toml" cfg.settings)) + cfg.extraConfig
+  );
   useLegacyStorage = lib.versionOlder cfg.stateVersion "24.11";
   pre2605 = lib.versionOlder cfg.stateVersion "26.05";
   stalwartIdentifier = if pre2605 then "stalwart-mail" else "stalwart";
@@ -102,6 +104,20 @@ in
       example = {
         user_admin_password = "/run/keys/stalwart_admin_password";
       };
+    };
+    extraConfig = lib.mkOption {
+      description = ''
+        Settings to append to the end of the configuration file.
+        Especially useful for non-standard TOML patterns such as conditions (see example).
+      '';
+      type = lib.types.lines;
+      default = "";
+      example = ''
+        [auth.dkim]
+        sign = [ { if = "listener != 'smtp'", then = "['rsa', 'ed25519']" },
+                  { "else" = false } ]
+        verify = "relaxed"
+      '';
     };
 
   };

--- a/nixos/tests/stalwart/stalwart-config.nix
+++ b/nixos/tests/stalwart/stalwart-config.nix
@@ -79,6 +79,12 @@ in
         ];
       };
     };
+
+    extraConfig = ''
+      [server.listener.http-extra]
+      bind = ["[::]:8888"]
+      protocol = "http"
+    '';
   };
 
 }

--- a/nixos/tests/stalwart/stalwart.nix
+++ b/nixos/tests/stalwart/stalwart.nix
@@ -74,6 +74,7 @@ in
 
       main.succeed("test -d /var/cache/stalwart-mail/STALWART_WEBADMIN || test -d /var/cache/stalwart/STALWART_WEBADMIN")
       main.succeed("curl --fail http://localhost")
+      main.succeed("curl --fail http://localhost:8888")
     '';
 
   meta = {


### PR DESCRIPTION
This appends the value of the option "extraConfig" to the end of the configuration file to allow the use of non-standard TOML patterns such as conditions.

This PR also adds a test entry for this new option.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
