### PR TITLE
emacs.pkgs.jabber: build with OMEMO support

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
@@ -5097,6 +5097,27 @@
       };
     }
   ) { };
+  keymap-popup = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "keymap-popup";
+      ename = "keymap-popup";
+      version = "0.3.1.0.20260530.4";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/keymap-popup-0.3.1.0.20260530.4.tar";
+        sha256 = "1k6aqp65x3azbipj2pwdg15pip045cawx4im04s84kbk91fx0fxs";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/keymap-popup.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   kind-icon = callPackage (
     {
       elpaBuild,

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -5015,6 +5015,27 @@
       };
     }
   ) { };
+  keymap-popup = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "keymap-popup";
+      ename = "keymap-popup";
+      version = "0.3.1";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/keymap-popup-0.3.1.tar";
+        sha256 = "0m44s8618n7g5pajxiv4k1dfx6l58gr01a3ga26fxc51j1d05q8b";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/keymap-popup.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   kind-icon = callPackage (
     {
       elpaBuild,

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-common-overrides.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-common-overrides.nix
@@ -20,5 +20,22 @@ in
       yasnippet
     ]
   );
+
+  # requires optional dependency for OMEMO support.
+  jabber = super.jabber.overrideAttrs (old: {
+    buildInputs = old.buildInputs ++ [ pkgs.mbedtls ];
+    nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.pkg-config ];
+
+    # We need to run this in postInstall for package directory to become available
+    postInstall =
+      (old.postInstall or "")
+      + "\n"
+      + ''
+        pushd $out/share/emacs/site-lisp/elpa/jabber-*/src
+        make CC=$CC
+        rm -r $out/share/emacs/site-lisp/elpa/jabber-*/src
+        popd
+      '';
+  });
   # keep-sorted end
 }

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
@@ -3225,17 +3225,21 @@
       elpaBuild,
       fetchurl,
       fsm,
+      keymap-popup,
       lib,
     }:
     elpaBuild {
       pname = "jabber";
       ename = "jabber";
-      version = "0.10.5.0.20260423.192938";
+      version = "0.11.0.0.20260614.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/jabber-0.10.5.0.20260423.192938.tar";
-        sha256 = "1q79iv4znishj6rdz1m76r0c8h72i2g47xfh6xfw2gqxbkkyilv3";
+        url = "https://elpa.nongnu.org/nongnu-devel/jabber-0.11.0.0.20260614.0.tar";
+        sha256 = "19h0w85m6vzwwpsgg6ifcyx2j082cgj6dpd7s5yd7pr438jazkn3";
       };
-      packageRequires = [ fsm ];
+      packageRequires = [
+        fsm
+        keymap-popup
+      ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/jabber.html";
         license = lib.licenses.free;

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
@@ -3240,17 +3240,21 @@
       elpaBuild,
       fetchurl,
       fsm,
+      keymap-popup,
       lib,
     }:
     elpaBuild {
       pname = "jabber";
       ename = "jabber";
-      version = "0.10.5";
+      version = "0.11.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/jabber-0.10.5.tar";
-        sha256 = "1vjmajcls0l6mwccqdp7gr4g4r1z6f2qaf2palnimjb7w3gzh4mk";
+        url = "https://elpa.nongnu.org/nongnu/jabber-0.11.0.tar";
+        sha256 = "1wikfd8iqj9r1qrh6cd593vgbkjndfpm9f12ilsdwxwh0nx3cpd7";
       };
-      packageRequires = [ fsm ];
+      packageRequires = [
+        fsm
+        keymap-popup
+      ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/jabber.html";
         license = lib.licenses.free;


### PR DESCRIPTION
Emacs-jabber requires a third-party picomemo library for OMEMO support. It is not strictly required for package to function, but it is needed for E2EE chats. Library is pretty small. so it seems it can be just enabled by default. There are no other clients for picomemo currently, so I do not introduce a new package for it here.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
