### PR TITLE
supercollider: re-enable QtWebEngine and fix -FFTW3F-INCLUDE-DIR build error

### DIFF
--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -16,6 +16,7 @@
   libxt,
   readline,
   useSCEL ? false,
+  useQtWebEngine ? true,
   emacs,
   gitUpdater,
   supercollider-with-plugins,
@@ -65,6 +66,7 @@ stdenv.mkDerivation rec {
     qt6.qtbase
     qt6.qtwebsockets
     qt6.qtwayland
+    qt6.qtwebengine
     readline
   ]
   ++ lib.optional (!stdenv.hostPlatform.isDarwin) alsa-lib;
@@ -74,7 +76,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DSC_WII=OFF"
     "-DSC_EL=${if useSCEL then "ON" else "OFF"}"
-    (lib.cmakeBool "SC_USE_QTWEBENGINE" false)
+    (lib.cmakeBool "SC_USE_QTWEBENGINE" useQtWebEngine)
   ];
 
   passthru = {

--- a/pkgs/development/interpreters/supercollider/plugins/sc3-plugins.nix
+++ b/pkgs/development/interpreters/supercollider/plugins/sc3-plugins.nix
@@ -48,7 +48,9 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Community plugins for SuperCollider";
     homepage = "https://supercollider.github.io/sc3-plugins/";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      pretentiousUsername
+    ];
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
   };

--- a/pkgs/development/interpreters/supercollider/plugins/sc3-plugins.nix
+++ b/pkgs/development/interpreters/supercollider/plugins/sc3-plugins.nix
@@ -6,6 +6,7 @@
   cmake,
   supercollider,
   fftw,
+  fftwFloat,
   gitUpdater,
 }:
 
@@ -25,6 +26,7 @@ stdenv.mkDerivation rec {
   buildInputs = [
     supercollider
     fftw
+    fftwFloat # builds without this will return an error message about no FFTW3F-INCLUDE-DIR
   ];
 
   cmakeFlags = [


### PR DESCRIPTION
## Re-enable QtWebEngine
I've gone ahead and re-enabled QtWebEngine, since it is an important component in SC. Here's the [commit message](https://github.com/pretentiousUsername/nixpkgs/commit/13a75ebbee9ba5fa62d18857d180b2bfb00bca93):
> Qt WebEngine is a major component of the SuperCollider language, especially because it powers the user documentation system, which contains all of the helpfiles for the user's local system that may not be in the online SuperCollider documentation browser (see <https://docs.supercollider.online/Browse.html>). WebEngine has potential security vulnerabilities (see below)---which was why WebEngine was removed in PR https://github.com/NixOS/nixpkgs/pull/480196---however, the documentation browser in SC is not used for anything other than browsing local documentation, which minimizes the potential harms from WebEngine.
>
> Potential security problems with Qt6 WebEngine can be found at the
> following:
> * https://doc.qt.io/qt-6//qtwebengine-security.html
> * (for FreeBSD) https://www.vuxml.org/freebsd/pkg-qt6-webengine.html
>
> Security-conscious users may wish to not use QtWebEngine, and so there
> is an included option to disable it with the `useQtWebEngine` option.

Qt WebEngine has some vulnerabilities, so if anyone would like QtWebEngine to be disabled by default, I can live with that.

## Fix `-FFTW3F-INCLUDE-DIR` build error in sc3-packages
When attempting to build sc3-plugins, there is an issue with the `buildInput`s only including fftw and not fftwFloat, which causes a build error (see the [commit](https://github.com/pretentiousUsername/nixpkgs/commit/24660475aaf0b47c702abf803772b945fbf2af28)). This was fixed by just including fftwFloat.

## Things done
- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
