### PR TITLE
krb5: patch CVE-2026-11850

### DIFF
--- a/pkgs/by-name/kr/krb5/CVE-2026-11850.patch
+++ b/pkgs/by-name/kr/krb5/CVE-2026-11850.patch
@@ -1,0 +1,33 @@
+From 2a5fd83d4436583f2ddc0e193269a4d800ee45c4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Sebasti=C3=A1n=20Alba?= <sebasjosue84@gmail.com>
+Date: Wed, 8 Apr 2026 18:32:25 -0400
+Subject: [PATCH] Prevent read overrun in libkdb_ldap
+
+In berval2tl_data(), reject inputs of length less than 2 to prevent an
+integer underflow and subsequent read overrun.  (The security impact
+is negligible as the attacker would have to control the KDB LDAP
+server.)
+
+[ghudson@mit.edu: wrote commit message]
+
+ticket: 9206 (new)
+tags: pullup
+target_version: 1.22-next
+---
+ plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
+index 418d253d17..9aa68bacd7 100644
+--- a/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
++++ b/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
+@@ -80,6 +80,9 @@ getstringtime(krb5_timestamp);
+ krb5_error_code
+ berval2tl_data(struct berval *in, krb5_tl_data **out)
+ {
++    if (in->bv_len < 2)
++        return EINVAL;
++
+     *out = (krb5_tl_data *) malloc (sizeof (krb5_tl_data));
+     if (*out == NULL)
+         return ENOMEM;

--- a/pkgs/by-name/kr/krb5/package.nix
+++ b/pkgs/by-name/kr/krb5/package.nix
@@ -44,6 +44,8 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
+    # https://github.com/krb5/krb5/pull/1505
+    ./CVE-2026-11850.patch
     # https://github.com/krb5/krb5/pull/1506
     ./CVE-2026-40355-and-CVE-2026-40356.patch
   ]


### PR DESCRIPTION
@samueldr-at-cyberus I guess we overlooked this one in https://github.com/NixOS/nixpkgs/pull/526827.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
