### PR TITLE
zennotes: init at 2.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2,15 +2,15 @@
   List of active NixOS maintainers.
    ```nix
    handle = {
-     # Required
-     name = "Your name";
-     github = "GithubUsername";
-     githubId = your-github-id;
+   # Required
+   name = "Your name";
+   github = "GithubUsername";
+   githubId = your-github-id;
 
-     # Optional
-     email = "address@example.org";
-     matrix = "@user:example.org";
-     keys = [ { fingerprint = "AAAA BBBB CCCC DDDD EEEE  FFFF 0000 1111 2222 3333"; } ];
+   # Optional
+   email = "address@example.org";
+   matrix = "@user:example.org";
+   keys = [ { fingerprint = "AAAA BBBB CCCC DDDD EEEE  FFFF 0000 1111 2222 3333"; } ];
    };
    ```
 
@@ -34,7 +34,7 @@
    If `github` begins with a numeral, `handle` should be prefixed with an underscore.
    ```nix
    _1example = {
-     github = "1example";
+   github = "1example";
    };
    ```
 
@@ -8729,6 +8729,13 @@
     githubId = 201615;
     name = "Fang-Pen Lin";
     keys = [ { fingerprint = "7130 3454 A7CD 0F0A 941A  F9A3 2A26 9964 AD29 2131"; } ];
+  };
+  farahfinn = {
+    email = "frhahmoud@yahoo.co.uk";
+    name = "Farah Finn";
+    github = "farahfinn";
+    githubId = 43724242;
+    keys = [ { fingerprint = "A298 060D 0083 8D70 37D9 811E 6576 D843 0C9D 9EFE"; } ];
   };
   fare = {
     email = "fahree@gmail.com";

--- a/pkgs/by-name/ze/zennotes/package.nix
+++ b/pkgs/by-name/ze/zennotes/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+}:
+let
+  pname = "zennotes";
+  version = "2.3.0";
+
+  src = fetchurl {
+    url = "https://github.com/ZenNotes/zennotes/releases/download/v${version}/ZenNotes-${version}-linux-x86_64.AppImage";
+    hash = "sha256-IvFGK7n3KQVGETmt6hQUy+bZNTOCkfuwH8ifl4KTxxw=";
+  };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  passthru = {
+    strictDeps = true;
+    __structuredAttrs = true;
+  };
+
+  extraInstallCommands = ''
+    install -m 444 -D ${
+      appimageTools.extract { inherit pname version src; }
+    }/ZenNotes.desktop $out/share/applications/zennotes.desktop
+    substituteInPlace $out/share/applications/zennotes.desktop \
+    --replace-fail 'Exec=AppRun' 'Exec=${pname}' \
+    --replace-fail 'Icon=ZenNotes' 'Icon=zennotes'
+    install -m 444 -D ${
+      appimageTools.extract { inherit pname version src; }
+    }/ZenNotes.png $out/share/icons/hicolor/512x512/apps/zennotes.png
+  '';
+  meta = {
+    description = "Keyboard-first, markdow-bsed note-taking app";
+    homepage = "https://github.com/ZenNotes/ZenNotes";
+    license = lib.licenses.mit;
+    mainProgram = "zennotes";
+    maintainers = with lib.maintainers; [ farahfinn ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
### ZenNotes: Keyboard-first Markdown note-taking app

## Things done
  - **Why**: Initial addition to nixpkgs.
  -**Method**: AppImage wrapper using `appimageTools.wrapType2`.
  - **Note**: Packaging the Electron source is complex due to the monorepo structure; the AppImage  provides a stable and tested binary.
  - **First time contributer**: Let me know if I missed anything and please be kind,  I'm still learning 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable
  - [x] x86_64-linux (Niri/Wayland)
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
