### PR TITLE
aws-lc: generate Rust bindings

### DIFF
--- a/pkgs/by-name/aw/aws-lc/package.nix
+++ b/pkgs/by-name/aw/aws-lc/package.nix
@@ -4,10 +4,12 @@
   cmakeMinimal,
   fetchFromGitHub,
   ninja,
+  rust-bindgen,
   testers,
   aws-lc,
   nix-update-script,
   useSharedLibraries ? !stdenv.hostPlatform.isStatic,
+  withRustBindings ? true,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "aws-lc";
@@ -29,10 +31,14 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmakeMinimal
     ninja
+  ]
+  ++ lib.optionals withRustBindings [
+    rust-bindgen
   ];
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" useSharedLibraries)
+    (lib.cmakeBool "GENERATE_RUST_BINDINGS" withRustBindings)
     "-GNinja"
     "-DDISABLE_GO=ON"
     "-DDISABLE_PERL=ON"
@@ -50,6 +56,9 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     moveToOutput lib/crypto/cmake "$dev"
     moveToOutput lib/ssl/cmake "$dev"
+  ''
+  + lib.optionalString withRustBindings ''
+    moveToOutput share/rust "$dev"
   '';
 
   env.NIX_CFLAGS_COMPILE = toString (


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Enables generation of the aws-lc Rust bindings.

This will allow dynamic linking for aws-lc-rs in the future: [aws/aws-lc-rs@main/aws-lc-sys/README.md#using-a-system-installed-aws-lc](https://github.com/aws/aws-lc-rs/blob/main/aws-lc-sys/README.md)

cc @whispersofthedawn @theoparis 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
