### PR TITLE
makeAutostartItem: only use sed on `Exec` key

### DIFF
--- a/pkgs/build-support/make-startupitem/default.nix
+++ b/pkgs/build-support/make-startupitem/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
       target=${name}.desktop
       cp ${package}/share/applications/${srcPrefix}${name}.desktop $target
       ${lib.optionalString (prependExtraArgs != [ ] || appendExtraArgs != [ ]) ''
-        sed -i -r "s/(Exec=)([^ \n]*) *(.*)/\1\2 ${prependArgs}\3${appendArgs}/" $target
+        sed -i -r "s/^(Exec=)([^ \n]*) *(.*)/\1\2 ${prependArgs}\3${appendArgs}/" $target
       ''}
       chmod +rw $target
       echo "X-KDE-autostart-phase=${phase}" >> $target


### PR DESCRIPTION
Fix cases when using `makeStartupItem` and it's `prependExtraArgs` or `appendExtraArgs` option with a desktop file having a `TryExec` key.

The `TryExec` key must either be an absolute path to the binary or the binary name (if present in $PATH). When using either of the two options above, the `TryExec` key will be modified to have the flags as it's content, which is invalid and will break the desktop file.

The change to the sed command makes it so only lines starting with `Exec` are changed, ignoring `TryExec` and preventing the issue from happening.

Link to the FDO specification:
https://specifications.freedesktop.org/desktop-entry/latest/recognized-keys.html


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
