### PR TITLE
flutter: enable strict deps and structured attrs

### DIFF
--- a/pkgs/development/compilers/flutter/engine/default.nix
+++ b/pkgs/development/compilers/flutter/engine/default.nix
@@ -41,6 +41,9 @@ stdenv.mkDerivation (
     inherit url runtimeModes altRuntimeMode;
     inherit (runtimeModesBuilds.${mainRuntimeMode}) version src meta;
 
+    strictDeps = true;
+    __structuredAttrs = true;
+
     dontUnpack = true;
     dontBuild = true;
 

--- a/pkgs/development/compilers/flutter/flutter.nix
+++ b/pkgs/development/compilers/flutter/flutter.nix
@@ -74,6 +74,8 @@ let
       installShellFiles
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.DarwinTools ];
+
+    __structuredAttrs = true;
     strictDeps = true;
 
     preConfigure = ''

--- a/pkgs/development/compilers/flutter/wrapper.nix
+++ b/pkgs/development/compilers/flutter/wrapper.nix
@@ -147,6 +147,9 @@ in
     pname = "flutter-wrapped";
     inherit (flutter) version;
 
+    strictDeps = true;
+    __structuredAttrs = true;
+
     nativeBuildInputs = [
       makeWrapper
     ]


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Enables structured attrs and strict deps in most of Flutter to unblock new Flutter versions from failing nixpkgs-vet.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
