### PR TITLE
python314Packages.aws-sam-translator: 1.106.0 -> 1.110.0; python314Packages.chalice: allow on 3.14

### DIFF
--- a/pkgs/development/python-modules/aws-sam-translator/default.nix
+++ b/pkgs/development/python-modules/aws-sam-translator/default.nix
@@ -10,31 +10,30 @@
   pytest-rerunfailures,
   pytest-xdist,
   pytestCheckHook,
-  pythonAtLeast,
   pyyaml,
+  requests,
   setuptools,
   typing-extensions,
 }:
 
 buildPythonPackage rec {
   pname = "aws-sam-translator";
-  version = "1.106.0";
+  version = "1.110.0";
   pyproject = true;
-
-  # https://github.com/aws/serverless-application-model/issues/3831
-  disabled = pythonAtLeast "3.14";
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = "serverless-application-model";
     tag = "v${version}";
-    hash = "sha256-9KrBoa50lgZcqe/wzt05TsuUYbjRuQXgXTVHjDKBmr4=";
+    hash = "sha256-Zn+6cDyDZSsV9V+zAA8BOPs4aKl0j3dF92/azGYG+OI=";
   };
 
   postPatch = ''
     # don't try to use --cov or fail on new warnings
     rm pytest.ini
   '';
+
+  pythonRelaxDeps = [ "pydantic" ];
 
   build-system = [ setuptools ];
 
@@ -52,6 +51,7 @@ buildPythonPackage rec {
     pytest-xdist
     pytestCheckHook
     pyyaml
+    requests
   ];
 
   preCheck = ''
@@ -64,26 +64,6 @@ buildPythonPackage rec {
 
   disabledTestMarks = [
     "slow"
-  ];
-
-  disabledTests = [
-    # urllib3 2.0 compat
-    "test_plugin_accepts_different_sar_client"
-    "test_plugin_accepts_flags"
-    "test_plugin_accepts_parameters"
-    "test_plugin_default_values"
-    "test_plugin_invalid_configuration_raises_exception"
-    "test_plugin_must_setup_correct_name"
-    "test_must_process_applications"
-    "test_must_process_applications_validate"
-    "test_process_invalid_applications"
-    "test_process_invalid_applications_validate"
-    "test_resolve_intrinsics"
-    "test_sar_service_calls"
-    "test_sar_success_one_app"
-    "test_sar_throttling_doesnt_stop_processing"
-    "test_sleep_between_sar_checks"
-    "test_unexpected_sar_error_stops_processing"
   ];
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/python-modules/chalice/default.nix
+++ b/pkgs/development/python-modules/chalice/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonAtLeast,
 
   # build-system
   setuptools,
@@ -27,8 +26,6 @@ buildPythonPackage (finalAttrs: {
   pname = "chalice";
   version = "1.33.0";
   pyproject = true;
-
-  disabled = pythonAtLeast "3.14";
 
   src = fetchFromGitHub {
     owner = "aws";
@@ -78,7 +75,6 @@ buildPythonPackage (finalAttrs: {
     "test_can_import_env_vars"
     "test_stack_trace_printed_on_error"
     # Don't build
-    "test_can_generate_pipeline_for_all"
     "test_build_wheel"
     # Tests require dist
     "test_setup_tar_gz_hyphens_in_name"


### PR DESCRIPTION
Requires pydantic update from #521373

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
