### PR TITLE
plex-desktop: adding libxcursor

### DIFF
--- a/pkgs/by-name/pl/plex-desktop/package.nix
+++ b/pkgs/by-name/pl/plex-desktop/package.nix
@@ -32,6 +32,7 @@
   libxinerama,
   libxdamage,
   libxcomposite,
+  libxcursor,
   xrandr,
   libxshmfence,
 }:
@@ -151,6 +152,7 @@ buildFHSEnv {
   targetPkgs = pkgs: [
     alsa-lib
     libdrm
+    libxcursor
     xkeyboard_config
   ];
 


### PR DESCRIPTION
Added libxcursor to plex desktop fhs env. This fixes cursor weirdness on my machine.

I can tell plex-desktop needs this package because it tries to open it as evidenced by this strace output:

`407904 openat(AT_FDCWD, "libXcursor.so", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
