### PR TITLE
python3Packages.lark-oapi: init at 1.6.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14591,6 +14591,12 @@
     github = "svelterust";
     githubId = 85593302;
   };
+  knightfemale = {
+    email = "2067834160@qq.com";
+    github = "knightfemale";
+    githubId = 124773040;
+    name = "骑士姬";
+  };
   knightpp = {
     email = "knightpp@proton.me";
     github = "knightpp";

--- a/pkgs/development/python-modules/lark-oapi/default.nix
+++ b/pkgs/development/python-modules/lark-oapi/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  httpx,
+  pycryptodome,
+  pytest-asyncio,
+  pytestCheckHook,
+  requests,
+  requests-toolbelt,
+  websockets,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "lark-oapi";
+  version = "1.6.8";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "larksuite";
+    repo = "oapi-sdk-python";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dFfg24TyCaGX+nu/HuD+UjHibdPMccn/X4V6SVdvO60=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    httpx
+    pycryptodome
+    requests
+    requests-toolbelt
+    websockets
+  ];
+
+  # websockets 16.0 is compatible despite the <16 metadata constraint
+  pythonRelaxDeps = [ "websockets" ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "lark_oapi" ];
+
+  meta = {
+    description = "Larksuite development interface SDK";
+    homepage = "https://github.com/larksuite/oapi-sdk-python";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.knightfemale ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8686,6 +8686,8 @@ self: super: with self; {
 
   lark = callPackage ../development/python-modules/lark { };
 
+  lark-oapi = callPackage ../development/python-modules/lark-oapi { };
+
   laspy = callPackage ../development/python-modules/laspy { };
 
   lastversion = callPackage ../development/python-modules/lastversion { };


### PR DESCRIPTION
## Description of changes

Add `python312Packages.lark-oapi`, the Feishu/Lark OpenAPI SDK for Python. This SDK is required by Hermes Agent's Feishu messaging gateway platform adapter.

- Homepage: https://github.com/larksuite/oapi-sdk-python
- License: MIT
- Wheel-only distribution (no source tarball on PyPI)

`pythonRemoveDeps = [ "websockets" ]` is used because the wheel metadata declares `websockets < 16` but nixpkgs provides websockets 16.0. The dependency is still present in `dependencies` — only the version check is skipped.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
