### PR TITLE
[Backport release-26.05] nvibrant: 1.1.0 -> 1.2.0-unstable-595.58.03, 1.2.0-unstable-595.58.03 -> 1.2.1-unstable-610.43.02

### DIFF
--- a/pkgs/by-name/nv/nvibrant/hatch_build.patch
+++ b/pkgs/by-name/nv/nvibrant/hatch_build.patch
@@ -1,0 +1,76 @@
+diff --git a/hatch_build.py b/hatch_build.py
+index 036079a..fa2275e 100644
+--- a/hatch_build.py
++++ b/hatch_build.py
+@@ -1,6 +1,5 @@
+ import os
+ import subprocess
+-import sys
+ from pathlib import Path
+ from tempfile import TemporaryDirectory
+ 
+@@ -58,28 +57,27 @@ class BuildHook(BuildHookInterface):
+ 
+         # Configure the project
+         subprocess.check_call((
+-            sys.executable, "-m", "mesonbuild.mesonmain",
+-            "setup", Dirs.build,
++            "meson", "setup", Dirs.build,
+             "--buildtype", "release",
+             "--reconfigure", "--wipe",
+         ), cwd=Dirs.repository)
+ 
+         # Make binaries for all known driver version
+         for driver in subprocess.check_output(
+-            ("git", "tag"), cwd=Dirs.opengpu
++            ("cat", "./SOURCE_TAGS"), cwd=Dirs.opengpu
+         ).decode().strip().splitlines():
+ 
+             # Checkout driver version
+-            subprocess.check_call(
+-                ("git", "checkout", "-f", driver),
+-                cwd=Dirs.opengpu,
+-            )
++            if driver != os.environ["OLDEST_DRIVER_VERSION"]:
++                subprocess.check_call(
++                    ("git", "apply", f"./PATCHES/{driver}.patch"),
++                    cwd=Dirs.opengpu,
++                )
+ 
+             # Compile an executable
+-            subprocess.check_call((
+-                sys.executable, "-m", "ninja",
+-                "-C", Dirs.build,
+-            ))
++            subprocess.check_call(
++                ("ninja", "-C", Dirs.build)
++            )
+ 
+             # Find and vendor the binary for this version
+             binary = Dirs.build.joinpath("nvibrant")
+@@ -90,25 +88,3 @@ class BuildHook(BuildHookInterface):
+ 
+             # Include in the wheel
+             build["force_include"][str(target)] = f"nvibrant/resources/{target.name}"
+-
+-        # Revert back main branch
+-        subprocess.check_call(
+-            ("git", "checkout", "-f", "main"),
+-            cwd=Dirs.opengpu
+-        )
+-
+-# --------------------------------------------------------------------------- #
+-
+-if __name__ == '__main__':
+-
+-    # Intended operation
+-    subprocess.check_call(
+-        ("git", "config", "advice.detachedHead", "false"),
+-        cwd=Dirs.opengpu,
+-    )
+-
+-    environ = os.environ.copy()
+-    subprocess.check_call(
+-        args=("uv", "build", "--wheel", "-o", Dirs.dist),
+-        cwd=Dirs.repository,
+-    )

--- a/pkgs/by-name/nv/nvibrant/hatch_build.patch
+++ b/pkgs/by-name/nv/nvibrant/hatch_build.patch
@@ -1,16 +1,25 @@
 diff --git a/hatch_build.py b/hatch_build.py
-index 036079a..fa2275e 100644
+index da19ad8..f33e582 100644
 --- a/hatch_build.py
 +++ b/hatch_build.py
-@@ -1,6 +1,5 @@
+@@ -1,7 +1,6 @@
+ import hashlib
  import os
  import subprocess
 -import sys
  from pathlib import Path
  from tempfile import TemporaryDirectory
  
-@@ -58,28 +57,27 @@ class BuildHook(BuildHookInterface):
+@@ -57,46 +56,33 @@ class BuildHook(BuildHookInterface):
  
+         build_data["pure_python"] = False
+ 
+-        # Ensure submodule on git main
+-        subprocess.check_call(
+-            ("git", "submodule", "update", "--init", "--remote"),
+-            cwd=Dirs.repository,
+-        )
+-
          # Configure the project
          subprocess.check_call((
 -            sys.executable, "-m", "mesonbuild.mesonmain",
@@ -20,11 +29,23 @@ index 036079a..fa2275e 100644
              "--reconfigure", "--wipe",
          ), cwd=Dirs.repository)
  
+-        # Intended operation
+-        subprocess.check_call(
+-            ("git", "config", "advice.detachedHead", "false"),
+-            cwd=Dirs.opengpu,
+-        )
+-
+         # Keep track of breaking changes
+         hashes: dict[str, str] = dict()
+ 
          # Make binaries for all known driver version
-         for driver in subprocess.check_output(
--            ("git", "tag"), cwd=Dirs.opengpu
-+            ("cat", "./SOURCE_TAGS"), cwd=Dirs.opengpu
-         ).decode().strip().splitlines():
+-        for driver in sorted(subprocess.check_output(
+-            args=("git", "tag"),
++        for driver in subprocess.check_output(
++            args=("cat", "./SOURCE_TAGS"),
+             cwd=Dirs.opengpu
+-        ).decode().strip().splitlines()):
++        ).decode().strip().splitlines():
  
              # Checkout driver version
 -            subprocess.check_call(
@@ -48,29 +69,16 @@ index 036079a..fa2275e 100644
  
              # Find and vendor the binary for this version
              binary = Dirs.build.joinpath("nvibrant")
-@@ -90,25 +88,3 @@ class BuildHook(BuildHookInterface):
+@@ -109,12 +95,6 @@ class BuildHook(BuildHookInterface):
+             build_data["force_include"][str(target)] = f"nvibrant/resources/{target.name}"
+             hashes.setdefault(hashlib.md5(target.read_bytes()).hexdigest(), driver)
  
-             # Include in the wheel
-             build["force_include"][str(target)] = f"nvibrant/resources/{target.name}"
--
 -        # Revert back main branch
 -        subprocess.check_call(
 -            ("git", "checkout", "-f", "main"),
 -            cwd=Dirs.opengpu
 -        )
 -
--# --------------------------------------------------------------------------- #
--
--if __name__ == '__main__':
--
--    # Intended operation
--    subprocess.check_call(
--        ("git", "config", "advice.detachedHead", "false"),
--        cwd=Dirs.opengpu,
--    )
--
--    environ = os.environ.copy()
--    subprocess.check_call(
--        args=("uv", "build", "--wheel", "-o", Dirs.dist),
--        cwd=Dirs.repository,
--    )
+         print("\nBreaking changes across driver versions:")
+ 
+         for hashsum, driver in hashes.items():

--- a/pkgs/by-name/nv/nvibrant/package.nix
+++ b/pkgs/by-name/nv/nvibrant/package.nix
@@ -1,38 +1,152 @@
 {
   lib,
-  stdenv,
   fetchFromGitHub,
-  meson,
-  ninja,
-  pkg-config,
+  python3Packages,
+  writeShellScript,
+  common-updater-scripts,
+  coreutils,
+  gitMinimal,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "nvibrant";
-  version = "1.1.0";
+  version = finalAttrs.passthru._version;
+  pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "Tremeschin";
-    repo = "nvibrant";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-RZIi1V3hcwZdaI84Nd0YSQOjDng9/ZDg7aqfTL7GJIU=";
-    fetchSubmodules = true;
+  passthru = {
+    nvibrantVersion = "1.2.0";
+
+    oldestDriverVersion = "515.43.04";
+    latestDriverVersion = "595.58.03";
+
+    _version = lib.concatStringsSep "-" [
+      finalAttrs.passthru.nvibrantVersion
+      "unstable"
+      finalAttrs.passthru.latestDriverVersion
+    ];
+
+    srcAttrs = {
+      nvibrant = fetchFromGitHub {
+        owner = "tremeschin";
+        repo = "nvibrant";
+        name = "nvibrant";
+        tag = "v${finalAttrs.passthru.nvibrantVersion}";
+        hash = "sha256-OQo+VGWz8LNpsCdXbJXWWCrnVE0+t4s220uJ+pTHVKs=";
+      };
+      open-gpu = fetchFromGitHub {
+        owner = "nvidia";
+        repo = "open-gpu-kernel-modules";
+        name = "open-gpu";
+        tag = finalAttrs.passthru.oldestDriverVersion;
+        hash = "sha256-pSVK5oVob4QBo18ULHnQfO3UrTcC5lDDrTR9ec9pDp8=";
+
+        # since .git isn't deterministic, we can't use it to checkout tags in
+        # the build phase, so instead we generate patches for each version
+        # upgrade before .git is removed and apply them incrementally
+        fetchTags = true;
+        postCheckout = ''
+          cd $out
+
+          while IFS= read -r tag; do
+            echo "adding $tag"
+            echo "$tag" >> SOURCE_TAGS
+
+            if [[ "$tag" == ${finalAttrs.passthru.latestDriverVersion} ]]; then
+              echo 'reached end of known tags'
+              break
+            fi
+          done < <(git tag --sort v:refname)
+
+          mkdir PATCHES
+
+          prev_tag=${finalAttrs.passthru.oldestDriverVersion}
+          while IFS= read -r tag; do
+            if [ "$prev_tag" == "$tag" ]; then continue; fi
+
+            echo "generating patch: $prev_tag -> $tag"
+            git diff --minimal --binary "$prev_tag" "$tag" \
+              > "PATCHES/$tag.patch"
+
+            prev_tag=$tag
+          done < SOURCE_TAGS
+          unset prev_tag
+
+          rm -rf .git
+        '';
+      };
+    };
+
+    updateScript = writeShellScript "update-nvibrant" ''
+      set -euo pipefail
+
+      export PATH="${
+        lib.makeBinPath [
+          common-updater-scripts
+          coreutils
+          gitMinimal
+        ]
+      }:$PATH"
+
+      list_tags() {
+        git ls-remote --tags --sort v:refname --refs "$1" |
+          cut --delimiter=/ --field=3-
+      }
+
+      readarray -t nvibrant_tags < <(list_tags \
+        'https://github.com/tremeschin/nvibrant.git')
+
+      readarray -t open_gpu_tags < <(list_tags \
+        'https://github.com/nvidia/open-gpu-kernel-modules.git')
+
+      update-source-version nvibrant "''${nvibrant_tags[-1]:1}" \
+        --version-key=nvibrantVersion --source-key=srcAttrs.nvibrant \
+        --ignore-same-hash --ignore-same-version
+
+      update-source-version nvibrant "''${open_gpu_tags[0]}" \
+        --version-key=oldestDriverVersion --source-key=srcAttrs.open-gpu \
+        --ignore-same-hash --ignore-same-version
+
+      update-source-version nvibrant "''${open_gpu_tags[-1]}" \
+        --version-key=latestDriverVersion --source-key=srcAttrs.open-gpu \
+        --ignore-same-hash --ignore-same-version
+    '';
   };
 
-  nativeBuildInputs = [
+  srcs = lib.attrValues finalAttrs.passthru.srcAttrs;
+  sourceRoot = ".";
+
+  postUnpack = ''
+    mv open-gpu nvibrant/
+    cd nvibrant
+  '';
+
+  # replaces code that depends on .git and uses of python -m {ninja,meson}
+  patches = [ ./hatch_build.patch ];
+
+  configurePhase = ''
+    export OLDEST_DRIVER_VERSION=${finalAttrs.passthru.oldestDriverVersion}
+  '';
+
+  nativeBuildInputs = [ gitMinimal ];
+
+  build-system = with python3Packages; [
+    hatchling
     meson
     ninja
-    pkg-config
   ];
 
-  mesonBuildType = "release";
+  dependencies = with python3Packages; [
+    packaging
+  ];
 
-  meta = with lib; {
+  meta = {
     description = "Configure NVIDIA's Digital Vibrance on Wayland";
     homepage = "https://github.com/Tremeschin/nvibrant";
-    license = licenses.gpl3Only;
-    maintainers = [ maintainers.mikaeladev ];
-    platforms = [ "x86_64-linux" ];
     mainProgram = "nvibrant";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      mikaeladev
+    ];
   };
 })

--- a/pkgs/by-name/nv/nvibrant/package.nix
+++ b/pkgs/by-name/nv/nvibrant/package.nix
@@ -14,10 +14,10 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pyproject = true;
 
   passthru = {
-    nvibrantVersion = "1.2.0";
+    nvibrantVersion = "1.2.1";
 
     oldestDriverVersion = "515.43.04";
-    latestDriverVersion = "595.58.03";
+    latestDriverVersion = "610.43.02";
 
     _version = lib.concatStringsSep "-" [
       finalAttrs.passthru.nvibrantVersion
@@ -31,14 +31,14 @@ python3Packages.buildPythonApplication (finalAttrs: {
         repo = "nvibrant";
         name = "nvibrant";
         tag = "v${finalAttrs.passthru.nvibrantVersion}";
-        hash = "sha256-OQo+VGWz8LNpsCdXbJXWWCrnVE0+t4s220uJ+pTHVKs=";
+        hash = "sha256-M83WSQiJwzFZl8ECkZjKigvLTlMkzRa6o2hqPOt1378=";
       };
       open-gpu = fetchFromGitHub {
         owner = "nvidia";
         repo = "open-gpu-kernel-modules";
         name = "open-gpu";
         tag = finalAttrs.passthru.oldestDriverVersion;
-        hash = "sha256-pSVK5oVob4QBo18ULHnQfO3UrTcC5lDDrTR9ec9pDp8=";
+        hash = "sha256-MfLR5sYSjBrENWkCChcS9rk1zSlRFfTRpof/4lQ3qow=";
 
         # since .git isn't deterministic, we can't use it to checkout tags in
         # the build phase, so instead we generate patches for each version


### PR DESCRIPTION
backports the two most recent PRs to `release-26.05`:
- https://github.com/NixOS/nixpkgs/pull/498407
- https://github.com/NixOS/nixpkgs/pull/531233
