### PR TITLE
lib.findFirst: Reimplement as a recursive function for short-ish inputs

### DIFF
--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -575,33 +575,50 @@ rec {
   findFirstIndex =
     pred: default: list:
     let
-      # A naive recursive implementation would be much simpler, but
-      # would also overflow the evaluator stack. We use `foldl'` as a workaround
-      # because it reuses the same stack space, evaluating the function for one
-      # element after another. We can't return early, so this means that we
-      # sacrifice early cutoff, but that appears to be an acceptable cost. A
-      # clever scheme with "exponential search" is possible, but appears over-
-      # engineered for now. See https://github.com/NixOS/nixpkgs/pull/235267
+      len = length list;
 
-      # Invariant:
-      # - if index < 0 then el == elemAt list (- index - 1) and all elements before el didn't satisfy pred
-      # - if index >= 0 then pred (elemAt list index) and all elements before (elemAt list index) didn't satisfy pred
-      #
-      # We start with index -1 and the 0'th element of the list, which satisfies the invariant
-      resultIndex = foldl' (
-        index: el:
-        if index < 0 then
-          # No match yet before the current index, we need to check the element
-          if pred el then
-            # We have a match! Turn it into the actual index to prevent future iterations from modifying it
-            -index - 1
-          else
-            # Still no match, update the index to the next element (we're counting down, so minus one)
-            index - 1
+      resultIndex =
+        # For short lists use a naive recursive scan.
+        #
+        # It returns as soon as a match is found which the `foldl'` fallback below cannot.
+        #
+        # For the common case where the element exists early cutoff makes it
+        # several times faster than the constant stack fallback.
+        if len < 1024 then
+          let
+            go =
+              i:
+              if i >= len then
+                -1
+              else if pred (elemAt list i) then
+                i
+              else
+                go (i + 1);
+          in
+          go 0
         else
-          # There's already a match, propagate the index without evaluating anything
-          index
-      ) (-1) list;
+          # Constant stack-safe fallback using `foldl'`.
+          # This sacrifices early cutoff, but doesn't blow up for large inputs.
+          #
+          # Invariant:
+          # - if index < 0 then el == elemAt list (- index - 1) and all elements before el didn't satisfy pred
+          # - if index >= 0 then pred (elemAt list index) and all elements before (elemAt list index) didn't satisfy pred
+          #
+          # We start with index -1 and the 0'th element of the list, which satisfies the invariant
+          foldl' (
+            index: el:
+            if index < 0 then
+              # No match yet before the current index, we need to check the element
+              if pred el then
+                # We have a match! Turn it into the actual index to prevent future iterations from modifying it
+                -index - 1
+              else
+                # Still no match, update the index to the next element (we're counting down, so minus one)
+                index - 1
+            else
+              # There's already a match, propagate the index without evaluating anything
+              index
+          ) (-1) list;
     in
     if resultIndex < 0 then default else resultIndex;
 


### PR DESCRIPTION
To achieve early cutoff for the common case where the list element the predicate is looking for exists.

Note: Not sure how impactful this is. Running it through CI for performance testing.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
