### PR TITLE
python3Packages.pynput: unbreak on darwin; add pyobjc-framework-{CoreText,ApplicationServices}

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15120,6 +15120,11 @@
     githubId = 27364685;
     name = "Lorenzo Pasqui";
   };
+  l1n = {
+    github = "l1n";
+    githubId = 1367322;
+    name = "Nova DasSarma";
+  };
   l1npengtul = {
     email = "l1npengtul@l1npengtul.lol";
     github = "l1npengtul";

--- a/pkgs/development/python-modules/pynput/default.nix
+++ b/pkgs/development/python-modules/pynput/default.nix
@@ -14,6 +14,8 @@
   xlib,
   evdev,
   six,
+  pyobjc-framework-ApplicationServices,
+  pyobjc-framework-Quartz,
 
   # tests
   unittestCheckHook,
@@ -52,6 +54,11 @@ buildPythonPackage rec {
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     evdev
     xlib
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # the darwin backend imports HIServices (ApplicationServices) and Quartz
+    pyobjc-framework-ApplicationServices
+    pyobjc-framework-Quartz
   ];
 
   doCheck = false; # requires running X server
@@ -59,7 +66,6 @@ buildPythonPackage rec {
   nativeCheckInputs = [ unittestCheckHook ];
 
   meta = {
-    broken = stdenv.hostPlatform.isDarwin;
     description = "Library to control and monitor input devices";
     homepage = "https://github.com/moses-palmer/pynput";
     license = lib.licenses.lgpl3;

--- a/pkgs/development/python-modules/pyobjc-framework-ApplicationServices/default.nix
+++ b/pkgs/development/python-modules/pyobjc-framework-ApplicationServices/default.nix
@@ -1,0 +1,62 @@
+{
+  buildPythonPackage,
+  setuptools,
+  darwin,
+  pyobjc-core,
+  pyobjc-framework-Cocoa,
+  pyobjc-framework-Quartz,
+  pyobjc-framework-CoreText,
+  lib,
+}:
+
+buildPythonPackage rec {
+  pname = "pyobjc-framework-ApplicationServices";
+  pyproject = true;
+
+  inherit (pyobjc-core) version src;
+
+  sourceRoot = "${src.name}/pyobjc-framework-ApplicationServices";
+
+  build-system = [ setuptools ];
+
+  buildInputs = [ darwin.libffi ];
+
+  nativeBuildInputs = [
+    darwin.DarwinTools # sw_vers
+  ];
+
+  # Same workaround as pyobjc-framework-Quartz; see
+  # https://github.com/ronaldoussoren/pyobjc/pull/641.
+  postPatch = ''
+    substituteInPlace pyobjc_setup.py \
+      --replace-fail "-buildversion" "-buildVersion" \
+      --replace-fail "-productversion" "-productVersion" \
+      --replace-fail "/usr/bin/sw_vers" "sw_vers" \
+      --replace-fail "/usr/bin/xcrun" "xcrun"
+  '';
+
+  dependencies = [
+    pyobjc-core
+    pyobjc-framework-Cocoa
+    pyobjc-framework-Quartz
+    pyobjc-framework-CoreText
+  ];
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-I${darwin.libffi.dev}/include"
+    "-Wno-error=unused-command-line-argument"
+  ];
+
+  pythonImportsCheck = [
+    "ApplicationServices"
+    "HIServices"
+  ];
+
+  meta = {
+    description = "PyObjC wrappers for the ApplicationServices framework on macOS";
+    homepage = "https://github.com/ronaldoussoren/pyobjc";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ l1n ];
+  };
+}

--- a/pkgs/development/python-modules/pyobjc-framework-CoreText/default.nix
+++ b/pkgs/development/python-modules/pyobjc-framework-CoreText/default.nix
@@ -1,0 +1,59 @@
+{
+  buildPythonPackage,
+  setuptools,
+  darwin,
+  pyobjc-core,
+  pyobjc-framework-Cocoa,
+  pyobjc-framework-Quartz,
+  lib,
+}:
+
+buildPythonPackage rec {
+  pname = "pyobjc-framework-CoreText";
+  pyproject = true;
+
+  inherit (pyobjc-core) version src;
+
+  sourceRoot = "${src.name}/pyobjc-framework-CoreText";
+
+  build-system = [ setuptools ];
+
+  buildInputs = [ darwin.libffi ];
+
+  nativeBuildInputs = [
+    darwin.DarwinTools # sw_vers
+  ];
+
+  # Same workaround as pyobjc-framework-Quartz; see
+  # https://github.com/ronaldoussoren/pyobjc/pull/641.
+  postPatch = ''
+    substituteInPlace pyobjc_setup.py \
+      --replace-fail "-buildversion" "-buildVersion" \
+      --replace-fail "-productversion" "-productVersion" \
+      --replace-fail "/usr/bin/sw_vers" "sw_vers" \
+      --replace-fail "/usr/bin/xcrun" "xcrun"
+  '';
+
+  dependencies = [
+    pyobjc-core
+    pyobjc-framework-Cocoa
+    pyobjc-framework-Quartz
+  ];
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-I${darwin.libffi.dev}/include"
+    "-Wno-error=unused-command-line-argument"
+  ];
+
+  pythonImportsCheck = [
+    "CoreText"
+  ];
+
+  meta = {
+    description = "PyObjC wrappers for the CoreText framework on macOS";
+    homepage = "https://github.com/ronaldoussoren/pyobjc";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ l1n ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14754,6 +14754,10 @@ self: super: with self; {
 
   pyobjc-core = callPackage ../development/python-modules/pyobjc-core { };
 
+  pyobjc-framework-ApplicationServices =
+    callPackage ../development/python-modules/pyobjc-framework-ApplicationServices
+      { };
+
   pyobjc-framework-Cocoa = callPackage ../development/python-modules/pyobjc-framework-Cocoa { };
 
   pyobjc-framework-CoreAudio =

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14764,6 +14764,8 @@ self: super: with self; {
     callPackage ../development/python-modules/pyobjc-framework-CoreBluetooth
       { };
 
+  pyobjc-framework-CoreText = callPackage ../development/python-modules/pyobjc-framework-CoreText { };
+
   pyobjc-framework-Quartz = callPackage ../development/python-modules/pyobjc-framework-Quartz { };
 
   pyobjc-framework-Security = callPackage ../development/python-modules/pyobjc-framework-Security { };


### PR DESCRIPTION
## Description of changes

`python3Packages.pynput` is marked `broken = stdenv.hostPlatform.isDarwin`. The root cause is missing dependencies: pynput's macOS backend (`pynput/_util/darwin.py`) does `import HIServices` and uses Quartz/AppKit/CoreFoundation, but the derivation added no pyobjc dependencies on darwin. The two frameworks it needs weren't packaged at all:

- `pyobjc-framework-ApplicationServices` (provides the `HIServices` module) — was missing
- `pyobjc-framework-CoreText` (a dependency of ApplicationServices) — was missing

This PR:

1. packages `pyobjc-framework-CoreText` (modeled on the existing `pyobjc-framework-Quartz`),
2. packages `pyobjc-framework-ApplicationServices`,
3. adds those two frameworks to `pynput`'s darwin `propagatedBuildInputs` and removes the `broken` flag.

### Testing

Built and import-checked on `aarch64-darwin`:

- `python3Packages.pyobjc-framework-CoreText` — builds, `pythonImportsCheck = [ "CoreText" ]` passes
- `python3Packages.pyobjc-framework-ApplicationServices` — builds, `pythonImportsCheck = [ "ApplicationServices" "HIServices" ]` passes
- `python3Packages.pynput` — `from pynput import keyboard, mouse` succeeds and `HIServices.AXIsProcessTrusted()` returns a value

## Things done

- Built on platform(s)
  - [x] aarch64-darwin
  - [ ] x86_64-darwin
  - [ ] x86_64-linux (unaffected — Linux path unchanged)
  - [ ] aarch64-linux
- [x] For non-Linux: Is `sandbox = true` set in `nix.conf`? (N/A — uses system frameworks like the other pyobjc packages)
- [x] Tested compilation of all packages that depend on this change using `nix-build`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

---
**Automation disclosure:** This pull request summary was drafted with Claude Code (model: Claude Opus 4.8) and reviewed by the submitter, who is accountable for it. Per-commit AI assistance is disclosed via `Assisted-by:` trailers.
