### PR TITLE
opendkim: 2.11.0-Beta2 -> 2.11.0-Beta2-unstable-2026-06-06

### DIFF
--- a/pkgs/by-name/op/opendkim/package.nix
+++ b/pkgs/by-name/op/opendkim/package.nix
@@ -16,36 +16,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "opendkim";
-  version = "2.11.0-Beta2";
+  version = "2.11.0-Beta2-unstable-2026-06-06";
 
   src = fetchFromGitHub {
     owner = "trusteddomainproject";
     repo = "OpenDKIM";
-    tag = "rel-opendkim-${lib.replaceString "." "-" finalAttrs.version}";
-    hash = "sha256-/IqWB0s39t8BeqpRIa8MZn4HgXlIMuU2UbYbpZGNo1s=";
+    rev = "db15e09f57cf3e142bbfc1d6e984144077328ab8";
+    hash = "sha256-kfV3Qf/ywIUI5c1zX9DVKqgBnJMtzp9HA+sJG29jLXM=";
   };
-
-  # TODO: remove when is merge
-  patches = [
-    (fetchpatch {
-      # https://github.com/trusteddomainproject/OpenDKIM/pull/288
-      name = "CVE-2020-35766.patch";
-      url = "https://github.com/trusteddomainproject/OpenDKIM/commit/520338d25af68cf263b97ba63037e3f5856a10da.patch";
-      hash = "sha256-O4a4boa67tj0nqxee6V+u7rd3l3RGaiWE+Mu0ib4DWE=";
-    })
-    (fetchpatch {
-      # https://github.com/trusteddomainproject/OpenDKIM/pull/287
-      name = "CVE-2022-48521.patch";
-      url = "https://github.com/trusteddomainproject/OpenDKIM/commit/e67c33e1a08cca793470e6a6ff44082f73f6d222.patch";
-      hash = "sha256-QtxiRM+/NDlQhfGB8XNX1M1PtQyXXarawoF+8pTTMVo=";
-    })
-    (fetchpatch {
-      # https://github.com/trusteddomainproject/OpenDKIM/pull/261
-      name = "fix-old-style-dkimf_base64_encode_file.patch";
-      url = "https://github.com/trusteddomainproject/OpenDKIM/commit/3f0aa0a31c11b9924f826708535071b68c22b731.patch";
-      hash = "sha256-nQCBGef2kjs9ZyHwPreNPQYW6jBOBTDhVq9RyeGSN/Y=";
-    })
-  ];
 
   configureFlags = [
     "--with-milter=${libmilter}"
@@ -75,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = nix-update-script {
     extraArgs = [
-      "--version=unstable"
+      "--version=branch=develop"
       "--version-regex=rel-opendkim-(\\d+)-(\\d+)-(.*)"
     ];
   };


### PR DESCRIPTION
Follow-up on #517633. Opendkim has been merging PRs (incl. the CVE fixes) to the `develop` branch, so I think it makes sense to build our package from that instead of the very outdated `master`.

Not thoroughly tested since I don't run opendkim myself, would appreciate it if someone could make sure this is safe before merging.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
