### PR TITLE
rs-reticulum: 1.0.0 -> 1.0.1

### DIFF
--- a/pkgs/by-name/rs/rs-reticulum/package.nix
+++ b/pkgs/by-name/rs/rs-reticulum/package.nix
@@ -47,6 +47,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/rnid-rs";
 
   passthru.updateScript = nix-update-script { };
 
@@ -56,6 +57,5 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/ratspeak/rsReticulum";
     license = lib.licenses.agpl3Only;
     maintainers = with lib.maintainers; [ drupol ];
-    mainProgram = "rs-reticulum";
   };
 })

--- a/pkgs/by-name/rs/rs-reticulum/package.nix
+++ b/pkgs/by-name/rs/rs-reticulum/package.nix
@@ -1,27 +1,29 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
   pkg-config,
   bzip2,
   dbus,
   python3,
+  versionCheckHook,
   nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rs-reticulum";
-  version = "1.0.0";
+  version = "1.0.1";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "ratspeak";
     repo = "rsReticulum";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-CoA+HOcMkwmo7WUhXCLIwx4hMqLHFQqu6d1NOz1N2PY=";
+    hash = "sha256-MSvIgB/E1Ce8M8vOaXlHQGYnxFf0lT2hg8g0tx6QY/w=";
   };
 
-  cargoHash = "sha256-h8P2PuW3hiyQuvAHhat831dxBGSmV0rxDWB8lffZpac=";
+  cargoHash = "sha256-Kv3aVET69yI28muyaJop4YQEqOxNeyajK7j5J+jDhe0=";
 
   nativeBuildInputs = [
     pkg-config
@@ -37,6 +39,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   __darwinAllowLocalNetworking = true;
+
+  checkFlags = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
+    # Broken since 0.9.4
+    "--skip=actor::tests::test_rate_tracking"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
Diff: https://github.com/ratspeak/rsReticulum/compare/v1.0.0...v1.0.1

Changelog: https://github.com/ratspeak/rsReticulum/releases/tag/v1.0.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
