### PR TITLE
linux/generate-config: disallow conflicting answers to choice questions

### DIFF
--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -1420,13 +1420,10 @@ let
         DRM_AMDGPU_USERPTR = yes;
 
         # We want to prefer PREEMPT_LAZY when available, and fall back on PREEMPT_VOLUNTARY.
-        # It just so happens that kconfig asks for PREEMPT_LAZY first, so doing it like this
-        # does what we want.
-        # FIXME: This is stupid and bad.
-        # See: https://github.com/torvalds/linux/commit/7dadeaa6e851e7d67733f3e24fc53ee107781d0f
+        # The version cutoff is arbitrary, the real cutoff is somewhere around 6.13 depending on target.
         PREEMPT = no;
-        PREEMPT_LAZY = option yes;
-        PREEMPT_VOLUNTARY = option yes;
+        PREEMPT_LAZY = whenAtLeast "6.18" yes;
+        PREEMPT_VOLUNTARY = whenOlder "6.18" yes;
 
         X86_AMD_PLATFORM_DEVICE = lib.mkIf stdenv.hostPlatform.isx86 yes;
         X86_PLATFORM_DRIVERS_DELL = lib.mkIf stdenv.hostPlatform.isx86 (whenAtLeast "5.12" yes);

--- a/pkgs/os-specific/linux/kernel/generate-config.pl
+++ b/pkgs/os-specific/linux/kernel/generate-config.pl
@@ -100,7 +100,13 @@ sub runConfig {
             elsif ($line =~ /choice\[(.*)\]: ###$/) {
                 my $answer = "";
                 foreach my $name (keys %choices) {
-                    $answer = $choices{$name} if ($answers{$name} || "") eq "y";
+                    if (($answers{$name} || "") eq "y") {
+                        if ($answer eq "") {
+                            $answer = $choices{$name};
+                        } else {
+                            die "conflicting answers!"
+                        }
+                    }
                 }
                 print STDERR "CHOICE: $1, ANSWER: $answer\n" if $debug;
                 print OUT "$answer\n" if $1 =~ /-/;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
