### PR TITLE
frzscr: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6645,6 +6645,13 @@
     githubId = 8864716;
     name = "Duarte David";
   };
+  deni111bg = {
+    email = "d1bg@tuta.io";
+    github = "d1bg"
+    githubId = 144280774;
+    name = "Denis Georgiev";
+
+  };
   demin-dmitriy = {
     email = "demindf@gmail.com";
     github = "demin-dmitriy";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6647,7 +6647,7 @@
   };
   deni111bg = {
     email = "d1bg@tuta.io";
-    github = "d1bg"
+    github = "d1bg";
     githubId = 144280774;
     name = "Denis Georgiev";
 

--- a/pkgs/by-name/fr/frzscr/package.nix
+++ b/pkgs/by-name/fr/frzscr/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  scdoc,
+  wayland-scanner,
+  pixman,
+  libpng,
+  libjpeg,
+  wayland,
+  wayland-protocols,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "frzscr";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "heather7283";
+    repo = "frzscr";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-DwgmAdDi5Ez6SLwBeVUIilbgPZGv7LaODERHaFirjFo=";
+  };
+
+  depsBuildBuild = [
+    pkg-config
+  ];
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    scdoc
+    wayland-scanner
+  ];
+
+  buildInputs = [
+    pixman
+    libpng
+    libjpeg
+    wayland
+    wayland-protocols
+  ];
+
+  strictDeps = true;
+
+  meta = {
+    homepage = "https://github.com/heather7283/frzscr";
+    description = "Freeze screen (wayland)";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "frzscr";
+    maintainers = with lib.maintainers; [ deni111bg ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
[frzscr](https://github.com/heather7283/frzscr) is a screen freezing program for wayland, useful for taking screenshots.

## Things done


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
