### PR TITLE
backintime-common: Add dependency on fuse3

### DIFF
--- a/pkgs/by-name/ba/backintime-common/package.nix
+++ b/pkgs/by-name/ba/backintime-common/package.nix
@@ -9,6 +9,7 @@
   cron,
   openssh,
   sshfs-fuse,
+  fuse3,
   gocryptfs,
   which,
   ps,
@@ -73,10 +74,13 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "share" "${python'.sitePackages}"
 
     substituteInPlace "schedule.py" \
-      --replace-fail "'crontab'" "'${cron}/bin/crontab'" \
+      --replace-fail "'crontab'" "'${lib.getExe' cron "crontab"}'" \
       --replace-fail "'which'" "'${lib.getExe which}'" \
       --replace-fail "'ps'" "'${lib.getExe ps}'" \
       --replace-fail "'grep'" "'${lib.getExe gnugrep}'" \
+
+    substituteInPlace mount.py \
+      --replace-fail "'fusermount'" "'${lib.getExe' fuse3 "fusermount3"}'"
 
     substituteInPlace "bitlicense.py" \
       --replace-fail "/usr/share/doc" "$out/share/doc" \


### PR DESCRIPTION
backintime seems to rely on using `fusermount` to unmount fuse backends, which apparently breaks when using `fusermount` instead of `fusermount3` (wtf?), so adding the dependency on fuse3 by including it instead of having it be a run-time dependency, and closing #531574.

Note this will fail to build on the next update after https://github.com/bit-team/backintime/commit/d726625996c33539bbb1c3eaa5d646800b0462c, since we are patching `mount.py`, which seems to have been split into `mountold.py` and a `mount` directory.

Note I haven't tested the bug actually happens on NixOS since I don't use this package, but did grep for `fusermount` to see if there were other uses and there didn't seem to be, on the version we're currently using.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy]. <!-- No AI was used, so it follows it? --!>

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
