### PR TITLE
radar: init at 1.13.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9727,6 +9727,11 @@
     githubId = 4065244;
     name = "Gary Guo";
   };
+  gaupee = {
+    github = "ZeikoFr";
+    githubId = 54892453;
+    name = "Gwendal Aupee";
+  };
   gauravghodinde = {
     email = "gauravghodinde@gmail.com";
     github = "gauravghodinde";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10159,6 +10159,11 @@
     githubId = 4065244;
     name = "Gary Guo";
   };
+  gaupee = {
+    github = "ZeikoFr";
+    githubId = 54892453;
+    name = "Gwendal Aupee";
+  };
   gauravghodinde = {
     email = "gauravghodinde@gmail.com";
     github = "gauravghodinde";

--- a/pkgs/by-name/ra/radar/package.nix
+++ b/pkgs/by-name/ra/radar/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  buildGoModule,
+  buildNpmPackage,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}: let
+  version = "1.7.6";
+
+  src = fetchFromGitHub {
+    owner = "skyhook-io";
+    repo = "radar";
+    tag = "v${version}";
+    hash = "sha256-LT9OThOevyH5mfPI1+/RH2roQfz2jMVBBXVHfhmDxNA=";
+  };
+
+  frontend = buildNpmPackage {
+    pname = "radar-web";
+    inherit version src;
+
+    npmDepsHash = "sha256-HFDTj/9jwYkzdiEZh83UB82ufsJ7BeWVdpuBHfNegLA=";
+    npmDepsFetcherVersion = 2;
+
+    # Upstream's lockfile entry for the deprecated @types/diff stub lacks
+    # `resolved`/`integrity`, so Nix's offline fetcher skips it and the install
+    # fails with ETARGET. Backfill the registry metadata. buildNpmPackage feeds
+    # this same postPatch to fetchNpmDeps, so both stay consistent.
+    postPatch = ''
+      sed -i '/"web\/node_modules\/@types\/diff": {/a\      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-8.0.0.tgz",\n      "integrity": "sha512-o7jqJM04gfaYrdCecCVMbZhNdG6T1MHg/oQoRFdERLV+4d+V7FijhiEAbFu0Usww84Yijk9yH58U4Jk4HbtzZw==",' \
+        package-lock.json
+    '';
+
+    npmWorkspace = "web";
+
+    installPhase = ''
+      runHook preInstall
+      cp -r web/dist "$out"
+      runHook postInstall
+    '';
+  };
+in
+  buildGoModule (finalAttrs: {
+    pname = "radar";
+    inherit version src;
+
+    vendorHash = "sha256-Dg7Dhxt9Yc31RrKNsPRyKZqLXKW++vBjOT8yJT9MhP0=";
+
+    subPackages = ["cmd/explorer"];
+
+    preBuild = ''
+      cp -r ${frontend}/. internal/static/dist/
+    '';
+
+    ldflags = [
+      "-s"
+      "-w"
+      "-X main.version=${finalAttrs.version}"
+    ];
+
+    postInstall = ''
+      mv "$out/bin/explorer" "$out/bin/kubectl-radar"
+    '';
+
+    versionCheckProgramArg = ["version"];
+    nativeInstallCheckInputs = [
+      versionCheckHook
+    ];
+    doInstallCheck = true;
+
+    passthru = {
+      inherit frontend;
+      updateScript = nix-update-script {};
+    };
+
+    meta = {
+      description = "Local-first Kubernetes visibility: topology, event timeline, and service traffic";
+      mainProgram = "kubectl-radar";
+      homepage = "https://github.com/skyhook-io/radar";
+      changelog = "https://github.com/skyhook-io/radar/releases/tag/v${finalAttrs.version}";
+      license = lib.licenses.asl20;
+      maintainers = [lib.maintainers.gaupee];
+      platforms = lib.platforms.unix;
+    };
+  })

--- a/pkgs/by-name/ra/radar/package.nix
+++ b/pkgs/by-name/ra/radar/package.nix
@@ -5,31 +5,23 @@
   fetchFromGitHub,
   versionCheckHook,
   nix-update-script,
-}: let
-  version = "1.7.6";
+}:
+let
+  version = "1.7.8";
 
   src = fetchFromGitHub {
     owner = "skyhook-io";
     repo = "radar";
     tag = "v${version}";
-    hash = "sha256-LT9OThOevyH5mfPI1+/RH2roQfz2jMVBBXVHfhmDxNA=";
+    hash = "sha256-oPWdG1K0cHgFstzKV5XUkhZr9WRGmmgM8bxS4xaXbgE=";
   };
 
   frontend = buildNpmPackage {
     pname = "radar-web";
     inherit version src;
 
-    npmDepsHash = "sha256-HFDTj/9jwYkzdiEZh83UB82ufsJ7BeWVdpuBHfNegLA=";
-    npmDepsFetcherVersion = 2;
-
-    # Upstream's lockfile entry for the deprecated @types/diff stub lacks
-    # `resolved`/`integrity`, so Nix's offline fetcher skips it and the install
-    # fails with ETARGET. Backfill the registry metadata. buildNpmPackage feeds
-    # this same postPatch to fetchNpmDeps, so both stay consistent.
-    postPatch = ''
-      sed -i '/"web\/node_modules\/@types\/diff": {/a\      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-8.0.0.tgz",\n      "integrity": "sha512-o7jqJM04gfaYrdCecCVMbZhNdG6T1MHg/oQoRFdERLV+4d+V7FijhiEAbFu0Usww84Yijk9yH58U4Jk4HbtzZw==",' \
-        package-lock.json
-    '';
+    npmDepsHash = "sha256-2UUS7IAUz4SrZZcu23ERewZIlI3N8yG3Ji5xouQPf5U=";
+    npmDepsFetcherVersion = 3;
 
     npmWorkspace = "web";
 
@@ -40,46 +32,58 @@
     '';
   };
 in
-  buildGoModule (finalAttrs: {
-    pname = "radar";
-    inherit version src;
+buildGoModule (finalAttrs: {
+  pname = "radar";
+  inherit version src;
 
-    vendorHash = "sha256-Dg7Dhxt9Yc31RrKNsPRyKZqLXKW++vBjOT8yJT9MhP0=";
+  __structuredAttrs = true;
 
-    subPackages = ["cmd/explorer"];
+  vendorHash = "sha256-zjTNroU7jwaoZ+UObtEcxYeGk1EHUy6+jRC4OrphOE8=";
 
-    preBuild = ''
-      cp -r ${frontend}/. internal/static/dist/
-    '';
+  subPackages = [ "cmd/explorer" ];
 
-    ldflags = [
-      "-s"
-      "-w"
-      "-X main.version=${finalAttrs.version}"
-    ];
+  preBuild = ''
+    cp -r ${frontend}/. internal/static/dist/
+  '';
 
-    postInstall = ''
-      mv "$out/bin/explorer" "$out/bin/kubectl-radar"
-    '';
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
 
-    versionCheckProgramArg = ["version"];
-    nativeInstallCheckInputs = [
-      versionCheckHook
-    ];
-    doInstallCheck = true;
+  # `subPackages` restricts the default checkPhase to cmd/explorer, so run the
+  # whole test suite explicitly. The e2e tests are gated behind a build tag and
+  # are skipped here.
+  checkPhase = ''
+    runHook preCheck
+    export GOFLAGS=''${GOFLAGS//-trimpath/}
+    go test ./...
+    runHook postCheck
+  '';
 
-    passthru = {
-      inherit frontend;
-      updateScript = nix-update-script {};
-    };
+  postInstall = ''
+    mv "$out/bin/explorer" "$out/bin/kubectl-radar"
+  '';
 
-    meta = {
-      description = "Local-first Kubernetes visibility: topology, event timeline, and service traffic";
-      mainProgram = "kubectl-radar";
-      homepage = "https://github.com/skyhook-io/radar";
-      changelog = "https://github.com/skyhook-io/radar/releases/tag/v${finalAttrs.version}";
-      license = lib.licenses.asl20;
-      maintainers = [lib.maintainers.gaupee];
-      platforms = lib.platforms.unix;
-    };
-  })
+  versionCheckProgramArg = [ "version" ];
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  passthru = {
+    inherit frontend;
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Local-first Kubernetes visibility: topology, event timeline, and service traffic";
+    mainProgram = "kubectl-radar";
+    homepage = "https://github.com/skyhook-io/radar";
+    changelog = "https://github.com/skyhook-io/radar/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.gaupee ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/ra/radar/package.nix
+++ b/pkgs/by-name/ra/radar/package.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  buildGoModule,
+  buildNpmPackage,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+let
+  version = "1.13.0";
+
+  src = fetchFromGitHub {
+    owner = "skyhook-io";
+    repo = "radar";
+    tag = "v${version}";
+    hash = "sha256-/zOSrk9Ez2dCb7AwyUsGbGOUizl1HgrkEFQdpguiEQs=";
+  };
+
+  frontend = buildNpmPackage {
+    pname = "radar-web";
+    inherit version src;
+
+    npmDepsHash = "sha256-Zh+2zV4pmFPAgQPa5/tc3OdC/f2ahzXHNHiOxkKRB/A=";
+    npmDepsFetcherVersion = 2;
+
+    npmWorkspace = "web";
+
+    installPhase = ''
+      runHook preInstall
+      cp -r web/dist "$out"
+      runHook postInstall
+    '';
+  };
+in
+buildGoModule (finalAttrs: {
+  pname = "radar";
+  inherit version src;
+
+  __structuredAttrs = true;
+
+  vendorHash = "sha256-2NfovVO4nKKoSEM8vaekLwPVW90unP5chSNtCXBU80k=";
+
+  subPackages = [ "cmd/explorer" ];
+
+  preBuild = ''
+    cp -r ${frontend}/. internal/static/dist/
+  '';
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  # The httptest-based tests need to bind a loopback listener, which the Darwin
+  # sandbox denies by default ("bind: operation not permitted").
+  __darwinAllowLocalNetworking = true;
+
+  checkFlags = [
+    # Writes a `#!/bin/sh` helper to a temp dir and execs it, but the sandbox
+    # provides no /bin/sh.
+    "-skip=^TestDiagnoseStream_ProcessAndStreamErrors$"
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    export GOFLAGS=''${GOFLAGS//-trimpath/}
+    go test "''${checkFlags[@]}" ./...
+    runHook postCheck
+  '';
+
+  postInstall = ''
+    mv "$out/bin/explorer" "$out/bin/kubectl-radar"
+  '';
+
+  versionCheckProgramArg = [ "-version" ];
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  passthru = {
+    inherit frontend;
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Local-first Kubernetes visibility: topology, event timeline, and service traffic";
+    mainProgram = "kubectl-radar";
+    homepage = "https://github.com/skyhook-io/radar";
+    changelog = "https://github.com/skyhook-io/radar/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.gaupee ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
radar is a local first kubernetes UI 

First time contributer: Let me know if I missed anything.

The app is a bundle of a kubectl plugin and a web-ui.

I've based my work on the makefile of radar https://github.com/skyhook-io/radar/blob/main/Makefile and on how other npm and go packages are builds.

I've used Claude Opus 4.8 to get a better explanation of each part of the file but I did the coding myself, no commit where made by AI.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `9690d87be85b7f1f5e5dbb6d90c17dfb2c9d9e26`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>radar</li>
  </ul>
</details>


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
