### PR TITLE
polymath: init at 1.4.5.8; nixos/flux-keyboard: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18178,6 +18178,14 @@
     github = "michaelvanstraten";
     githubId = 50352631;
   };
+  michailik = {
+    name = "Michail Konstantinidis";
+    github = "MichailiK";
+    githubId = 39029839;
+    email = "git@michaili.dev";
+    matrix = "@michailik:matrix.org";
+    keys = [ { fingerprint = "BF68 0E5D 6D55 01B3 17EF  B7D6 8704 07F9 D274 E6BA"; } ];
+  };
   michalrus = {
     email = "m@michalrus.com";
     github = "michalrus";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6207,6 +6207,12 @@
     githubId = 39523942;
     name = "Alex Clarke";
   };
+  darkjaguar91 = {
+    name = "Brandon Talbot";
+    email = "bjtal91@gmail.com";
+    github = "DarkJaguar91";
+    githubId = 3388903;
+  };
   darkonion0 = {
     name = "Alexandre Peruggia";
     email = "darkgenius1@protonmail.com";

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -34,6 +34,8 @@
 
 - [Matrix Authentication Service](https://github.com/element-hq/matrix-authentication-service) is an OAuth2.0 and OpenID Connect provider for Matrix homeservers (such as Synapse). It replaces standard password authentication with modern OpenID Connect flows, and can delegate authentication to upstream OIDC providers. Available as [services.matrix-authentication-service](#opt-services.matrix-authentication-service.enable).
 
+- [Flux Keyboard](https://fluxkeyboard.com/), support for Flux keyboard. Available as [hardware.flux-keyboard](#opt-hardware.flux-keyboard.enable).
+
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/hardware/flux-keyboard.nix
+++ b/nixos/modules/hardware/flux-keyboard.nix
@@ -1,0 +1,27 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.hardware.flux-keyboard;
+  inherit (lib) mkIf mkEnableOption mkPackageOption;
+in
+{
+  # Mounting during flashing relies on udisks2/udiskie's automounting functionality.
+  options.hardware.flux-keyboard = {
+    enable = mkEnableOption "support for Flux keyboard";
+    package = mkPackageOption pkgs "polymath" { };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    services.udev.packages = [ cfg.package ];
+
+    environment.etc."polkit-1/rules.d/10-rpi-rp2-mount.rules".source =
+      "${cfg.package}/etc/polkit-1/rules.d/10-rpi-rp2-mount.rules";
+  };
+
+  meta.maintainers = with lib.maintainers; [ BatteredBunny ];
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -70,6 +70,7 @@
   ./hardware/facter
   ./hardware/flipperzero.nix
   ./hardware/flirc.nix
+  ./hardware/flux-keyboard.nix
   ./hardware/fw-fanctrl.nix
   ./hardware/glasgow.nix
   ./hardware/gpgsmartcards.nix

--- a/pkgs/by-name/po/polymath/package.nix
+++ b/pkgs/by-name/po/polymath/package.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+
+  dpkg,
+  autoPatchelfHook,
+  makeWrapper,
+
+  atk,
+  coreutils,
+  glib,
+  gnugrep,
+  xprop,
+  libayatana-appindicator,
+  libsecret,
+  libusb1,
+  mpv,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  pname = "polymath";
+  version = "1.4.3.1";
+
+  src = fetchurl {
+    url = "https://fluxkeyboard.com/updates/polymath/linux/deb/polymath_${finalAttrs.version}_amd64.deb";
+    hash = "sha256-cCgG2qwVmkFsIhLdxiMtTCul4Dh2za+zptoKhYKJ3fM=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+    autoPatchelfHook
+  ];
+  buildInputs = [
+    atk
+    glib
+    libayatana-appindicator
+    libsecret
+    libusb1
+    mpv
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    mv usr/* $out/
+    rmdir usr
+    mv ./* $out/
+
+    # Move Pixmaps to icons folder
+    mkdir -p $out/share/icons/hicolor/512x512/apps
+    mv $out/share/pixmaps/polymath.png $out/share/icons/hicolor/512x512/apps/
+    rmdir $out/share/pixmaps
+
+    makeWrapper $out/opt/polymath/polymath $out/bin/polymath \
+        --prefix PATH : ${
+          lib.makeBinPath [
+            coreutils
+            gnugrep
+            xprop
+          ]
+        } \
+        --prefix LD_LIBRARY_PATH : $out/opt/polymath/lib
+
+    # Fix Paths in Desktop file
+    substituteInPlace $out/share/applications/com.fluxkeyboard.polymath.desktop \
+      --replace-fail "Exec=/opt/polymath/polymath" "Exec=polymath" \
+      --replace-fail "Icon=/usr/share/pixmaps/polymath.png" "Icon=polymath"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Flux Keyboard Software";
+    longDescription = "Software to configure and control the Flux Keyboard";
+    homepage = "https://fluxkeyboard.com/";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
+    mainProgram = "polymath";
+    maintainers = with lib.maintainers; [
+      darkjaguar91
+      michailik
+      BatteredBunny
+    ];
+    platforms = [ "x86_64-linux" ];
+  };
+})


### PR DESCRIPTION
Continues on from https://github.com/NixOS/nixpkgs/pull/495100
Got permission from @darkjaguar91 in the flux keyboard discord.

This PR adds `polymath` package which is used for configuring and flashing the keyboard, and `nixos/flux-keyboard` which adds the proper rules needed for connecting and flashing.

Biggest thing im unsure of, is if the `flux-keyboard` module should setup udisks2/udiskie, its required for flashing, but the option is usually setup by a DE, which im personally not on.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
