### PR TITLE
python3Packages.ydiff: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/ydiff/default.nix
+++ b/pkgs/development/python-modules/ydiff/default.nix
@@ -11,15 +11,17 @@
   less,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "ydiff";
   version = "1.5";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "ymattw";
     repo = "ydiff";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-9a7M6+CqGRvO1yainImN2RQVH3XMxE9PTLXJGKekXLg=";
   };
 
@@ -47,6 +49,8 @@ buildPythonPackage rec {
     runHook postCheck
   '';
 
+  pythonImportsCheck = [ "ydiff" ];
+
   meta = {
     description = "View colored, incremental diff in workspace or from stdin with side by side and auto pager support (Was \"cdiff\")";
     mainProgram = "ydiff";
@@ -63,4 +67,4 @@ buildPythonPackage rec {
       despsyched
     ];
   };
-}
+})

--- a/pkgs/development/python-modules/ydiff/default.nix
+++ b/pkgs/development/python-modules/ydiff/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   pygments,
   gitMinimal,
   mercurial,
@@ -13,7 +14,7 @@
 buildPythonPackage rec {
   pname = "ydiff";
   version = "1.5";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ymattw";
@@ -35,6 +36,8 @@ buildPythonPackage rec {
     patchShebangs setup.py
     patchShebangs tests/*.sh
   '';
+
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [ pygments ];
 


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
