### PR TITLE
yafc-ce: add update script passthru attribute

### DIFF
--- a/pkgs/by-name/ya/yafc-ce/package.nix
+++ b/pkgs/by-name/ya/yafc-ce/package.nix
@@ -1,11 +1,18 @@
 {
-  buildDotnetModule,
   lib,
+
+  # Build
+  buildDotnetModule,
   fetchFromGitHub,
   dotnetCorePackages,
+
+  # Runtime
   SDL2,
   SDL2_image,
   SDL2_ttf,
+
+  # Updates
+  nix-update-script,
 }:
 let
   dotnet = dotnetCorePackages.dotnet_8;
@@ -38,6 +45,8 @@ buildDotnetModule (finalAttrs: {
     SDL2_ttf
     SDL2_image
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Powerful Factorio calculator/analyser that works with mods, Community Edition";


### PR DESCRIPTION
The default update script used by r-ryantm does not fetch the updated .NET dependencies, which means most updates won't get an r-ryantm PR. The `nix-update-script` *does* fetch these deps, solving the issue.

This is seen by a [recent log](https://r.ryantm.com/log/yafc-ce/2026-06-01.log) from r-ryantm showing that only the package version and hash were updated, causing a build failure because of NuGet package mismatches.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - Not relevant
- Tested, as applicable:
  - Not relevant
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - Not relevant
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Not relevant
- Nixpkgs Release Notes
  - Not relevant
- NixOS Release Notes
  - Not relevant
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
