### PR TITLE
haskell.packages.ghc912.glib: patch incompatibility with rts

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1547,6 +1547,10 @@ with haskellLib;
     revision = null;
   }) super.svgcairo;
 
+  # Support GHC >= 9.12.3 || >= 9.14.1
+  # Patch from https://github.com/gtk2hs/gtk2hs/pull/349
+  glib = appendPatches [ ./patches/glib-support-rts-at-least-9.12.3-and-9.14.patch ] super.glib;
+
   # Too strict upper bound on tasty-hedgehog (<1.5)
   # https://github.com/typeclasses/ascii-predicates/pull/1
   ascii-predicates = doJailbreak super.ascii-predicates;

--- a/pkgs/development/haskell-modules/patches/glib-support-rts-at-least-9.12.3-and-9.14.patch
+++ b/pkgs/development/haskell-modules/patches/glib-support-rts-at-least-9.12.3-and-9.14.patch
@@ -1,0 +1,24 @@
+From 2e1ddf6f4a28819f42db45859a83f3dd7ed14c0e Mon Sep 17 00:00:00 2001
+From: Tuong Nguyen Manh <tuongnm88@gmail.com>
+Date: Sat, 14 Feb 2026 11:58:29 +0100
+Subject: [PATCH] Fix glib for RTS API change in GHC 9.12.3/9.14.1
+
+---
+ glib/System/Glib/hsgclosure.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/glib/System/Glib/hsgclosure.c b/glib/System/Glib/hsgclosure.c
+index 1610702b..6049827f 100644
+--- a/System/Glib/hsgclosure.c
++++ b/System/Glib/hsgclosure.c
+@@ -107,7 +107,9 @@ gtk2hs_closure_marshal(GClosure *closure,
+     WHEN_DEBUG(g_debug("gtk2hs_closure_marshal(%p): about to rts_evalIO", hc->callback));
+     
+     /* perform the call */
+-    #if __GLASGOW_HASKELL__>=704
++    #if (__GLASGOW_HASKELL__>=912 && __GLASGOW_HASKELL_PATCHLEVEL1__>=3) || __GLASGOW_HASKELL__>=914
++    rts_evalIO(&cap, rts_apply(CAP (HaskellObj)ghc_hs_iface->runIO_closure, call),&ret);
++    #elif __GLASGOW_HASKELL__>=704
+     rts_evalIO(&cap, rts_apply(CAP (HaskellObj)runIO_closure, call),&ret);
+     #else
+     cap=rts_evalIO(CAP rts_apply(CAP (HaskellObj)runIO_closure, call),&ret);


### PR DESCRIPTION
Resolves https://github.com/NixOS/nixpkgs/issues/525467.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
