### PR TITLE
cabal-install: patch for compatibility with semaphore-compat-2.0.0

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -88,11 +88,28 @@ with haskellLib;
   inherit
     (
       let
+        haveSemaphoreCompat200 =
+          # ATTN: we assume that semaphore-compat isn't changed in cabalInstallOverlay!
+          lib.versionAtLeast (self.semaphore-compat.version or "0") "2.0.0"
+          || (
+            lib.versionAtLeast self.ghc.version "9.12.4.20260606" # 9.12.5-rc1
+            && lib.versionOlder self.ghc.version "9.14"
+          );
+
         # !!! Use cself/csuper inside for the actual overrides
         cabalInstallOverlay =
           cself: csuper:
-          lib.optionalAttrs (lib.versionOlder csuper.ghc.version "9.14") {
-            Cabal = cself.Cabal_3_16_1_0;
+          lib.optionalAttrs (haveSemaphoreCompat200 || lib.versionOlder csuper.ghc.version "9.14") {
+            # Waiting on Cabal-3.18 with https://github.com/haskell/cabal/pull/11628
+            Cabal = appendPatches (lib.optionals haveSemaphoreCompat200 [
+              (pkgs.fetchpatch {
+                name = "Cabal-semaphore-compat-2.0.0.patch";
+                url = "https://github.com/haskell/cabal/commit/2cac53be5659a2a74f1748fd6ab1e00183a18765.diff?full_index=1";
+                hash = "sha256-+rcwBQILTc1ezcHb3VDampwMYGEG7S4HF1YKAk7QzUs=";
+                relative = "Cabal";
+              })
+
+            ]) cself.Cabal_3_16_1_0;
             Cabal-syntax = cself.Cabal-syntax_3_16_1_0;
           };
       in
@@ -102,11 +119,23 @@ with haskellLib;
             cabal-install = super.cabal-install.overrideScope cabalInstallOverlay;
             scope = cabal-install.scope;
           in
-          # Some dead code is not properly eliminated on aarch64-darwin, leading
-          # to bogus references to some dependencies.
           overrideCabal (
             old:
-            lib.optionalAttrs (pkgs.stdenv.hostPlatform.isDarwin && pkgs.stdenv.hostPlatform.isAarch64) {
+            {
+              patches = lib.optionals haveSemaphoreCompat200 [
+                # Waiting on cabal-install-3.18 with https://github.com/haskell/cabal/pull/11628
+                (pkgs.fetchpatch {
+                  name = "cabal-install-semaphore-compat-2.0.0.patch";
+                  url = "https://github.com/haskell/cabal/commit/2cac53be5659a2a74f1748fd6ab1e00183a18765.diff?full_index=1";
+                  hash = "sha256-7unna/3+/MPbD/6f5MBgggvy254YRXhHnHIrFzJoboQ=";
+                  relative = "cabal-install";
+                })
+              ];
+
+            }
+            # Some dead code is not properly eliminated on aarch64-darwin, leading
+            # to bogus references to some dependencies.
+            // lib.optionalAttrs (pkgs.stdenv.hostPlatform.isDarwin && pkgs.stdenv.hostPlatform.isAarch64) {
               postInstall = ''
                 ${old.postInstall or ""}
                 remove-references-to -t ${scope.HTTP} "$out/bin/.cabal-wrapped"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- [x] 9.12
- [x] 9.10

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
