### PR TITLE
osmedeus: init at 5.0.3

### DIFF
--- a/pkgs/by-name/os/osmedeus/package.nix
+++ b/pkgs/by-name/os/osmedeus/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "osmedeus";
+  version = "5.0.3";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "j3ssie";
+    repo = "osmedeus";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KsYbPOPP2LCOmZOGZLzuDJtg3UR0Kn9Lkyp1KbsoOjg=";
+  };
+
+  vendorHash = "sha256-sIf54V4jhTOztpTc1y5emMsOB7TNzCvQxByF+iNQF2g=";
+
+  subPackages = [ "cmd/osmedeus" ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=main.CommitHash=${finalAttrs.src.rev}"
+  ];
+
+  # Requires additional setup
+  doCheck = false;
+
+  doInstallCheck = true;
+
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Modern Orchestration Engine for Security";
+    longDescription = ''
+      Osmedeus is a security focused declarative orchestration engine that simplifies complex workflow automation into auditable YAML definitions, complete with encrypted data handling, secure credential management, and sandboxed execution.
+    '';
+    homepage = "https://github.com/j3ssie/osmedeus";
+    changelog = "https://github.com/j3ssie/osmedeus/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ katok ];
+    mainProgram = "osmedeus";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
A utility for orchestration and automation of security workflows. 

https://www.osmedeus.org/

Related to https://github.com/NixOS/nixpkgs/issues/81418

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
