### PR TITLE
openocd-unstable: init at 0.12.0-unstable-2026-06-11

### DIFF
--- a/pkgs/by-name/op/openocd-unstable/package.nix
+++ b/pkgs/by-name/op/openocd-unstable/package.nix
@@ -1,0 +1,30 @@
+{
+  openocd,
+  autoreconfHook,
+  lib,
+  fetchFromGitHub,
+}:
+
+openocd.overrideAttrs (
+  finalAttrs: old: {
+    pname = "openocd-unstable";
+    version = "0.12.0-unstable-2026-06-11";
+    src = fetchFromGitHub {
+      owner = "openocd-org";
+      repo = "openocd";
+      rev = "1bf1ac444a96d9151ae53a1ccf5adf16f8e25e75";
+      hash = "sha256-AuGuy0h8pYVcX8GpW4R/pBHmHsRZEGzqU3KLCmkSAs8=";
+      fetchSubmodules = false;
+    };
+    nativeBuildInputs = old.nativeBuildInputs ++ [
+      autoreconfHook
+    ];
+    meta = openocd.meta // {
+      description = "Free and Open On-Chip Debugging, In-System Programming and Boundary-Scan Testing (git snapshot)";
+      homepage = "https://github.com/openocd-org/openocd";
+      maintainers = with lib.maintainers; [
+        mkannwischer
+      ];
+    };
+  }
+)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
