### PR TITLE
proton-authenticator: fix crash on Wayland

### DIFF
--- a/pkgs/by-name/pr/proton-authenticator/package.nix
+++ b/pkgs/by-name/pr/proton-authenticator/package.nix
@@ -37,10 +37,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     install -Dm755 usr/bin/proton-authenticator $out/bin/${finalAttrs.meta.mainProgram}
     cp -r usr/share $out
 
-    wrapProgram "$out/bin/${finalAttrs.meta.mainProgram}" \
-      --prefix GIO_EXTRA_MODULES : "${glib-networking}/lib/gio/modules"
-
     runHook postInstall
+  '';
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --prefix GIO_EXTRA_MODULES : "${glib-networking}/lib/gio/modules"
+      --set WEBKIT_DISABLE_COMPOSITING_MODE 1
+    )
   '';
 
   meta = {


### PR DESCRIPTION
Set `WEBKIT_DISABLE_COMPOSITING_MODE=1` to prevent WebKitGTK from crashing on Wayland (`Error 71` and `Failed to create GBM buffer`).

Migrate from manual `wrapProgram` to `gappsWrapperArgs` in `preFixup` to avoid double-wrapping, as `wrapGAppsHook4` is already used in `nativeBuildInputs`.

Closes #501569

cc @felschr @pbek

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test