### PR TITLE
lib.systems: compile platform-match patterns once

### DIFF
--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -2,8 +2,7 @@
 let
   inherit (lib) lists;
   inherit (lib.systems) parse;
-  inherit (lib.systems.inspect) predicates;
-  inherit (lib.attrsets) matchAttrs;
+  inherit (lib.systems.inspect) matchAnyAttrs predicates;
 
   all = [
     # Cygwin
@@ -160,31 +159,31 @@ in
   freebsd = filterDoubles predicates.isFreeBSD;
   # Should be better, but MinGW is unclear.
   gnu =
-    filterDoubles (matchAttrs {
+    filterDoubles (matchAnyAttrs {
       kernel = parse.kernels.linux;
       abi = parse.abis.gnu;
     })
-    ++ filterDoubles (matchAttrs {
+    ++ filterDoubles (matchAnyAttrs {
       kernel = parse.kernels.linux;
       abi = parse.abis.gnueabi;
     })
-    ++ filterDoubles (matchAttrs {
+    ++ filterDoubles (matchAnyAttrs {
       kernel = parse.kernels.linux;
       abi = parse.abis.gnueabihf;
     })
-    ++ filterDoubles (matchAttrs {
+    ++ filterDoubles (matchAnyAttrs {
       kernel = parse.kernels.linux;
       abi = parse.abis.gnuabin32;
     })
-    ++ filterDoubles (matchAttrs {
+    ++ filterDoubles (matchAnyAttrs {
       kernel = parse.kernels.linux;
       abi = parse.abis.gnuabi64;
     })
-    ++ filterDoubles (matchAttrs {
+    ++ filterDoubles (matchAnyAttrs {
       kernel = parse.kernels.linux;
       abi = parse.abis.gnuabielfv1;
     })
-    ++ filterDoubles (matchAttrs {
+    ++ filterDoubles (matchAnyAttrs {
       kernel = parse.kernels.linux;
       abi = parse.abis.gnuabielfv2;
     });

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -9,9 +9,11 @@ let
     hasPrefix
     isList
     mapAttrs
-    matchAttrs
     recursiveUpdateUntil
     toList
+    all
+    attrNames
+    isAttrs
     ;
 
   inherit (lib.strings) toJSON;
@@ -490,11 +492,36 @@ rec {
     ) pat1;
 
   matchAnyAttrs =
+    let
+      # Like lib.matchAttrs but with precomputed handlers.
+      # The way matchAnyAttrs is used in lib.systems benefits from partial application.
+      matchAttrs' =
+        pattern:
+        let
+          checks = map (
+            name:
+            let
+              expected = pattern.${name};
+            in
+            if isAttrs expected then
+              let
+                matchSub = matchAttrs' expected;
+              in
+              attrs: attrs ? ${name} && isAttrs attrs.${name} && matchSub attrs.${name}
+            else
+              attrs: attrs ? ${name} && attrs.${name} == expected
+          ) (attrNames pattern);
+        in
+        attrs: all (check: check attrs) checks;
+    in
     patterns:
     if isList patterns then
-      attrs: any (pattern: matchAttrs pattern attrs) patterns
+      let
+        matchers = map matchAttrs' patterns;
+      in
+      attrs: any (matcher: matcher attrs) matchers
     else
-      matchAttrs patterns;
+      matchAttrs' patterns;
 
   predicates = mapAttrs (_: matchAnyAttrs) patterns;
 


### PR DESCRIPTION
The platform predicates & doubles were using `lib.matchAttrs` which runs attrNames & re-inspects patterns on every function call.

This "compiles" the pattern predicate only once.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
