### PR TITLE
deno: de-vendor libffi in rusty-v8

### DIFF
--- a/pkgs/by-name/de/deno/rusty-v8/default.nix
+++ b/pkgs/by-name/de/deno/rusty-v8/default.nix
@@ -16,6 +16,7 @@
   glib,
   glibc,
   icu,
+  libffi,
   python3,
   gn,
   ninja,
@@ -106,6 +107,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   buildInputs = [
     glib
     icu
+    libffi
   ]
   ++ lib.optionals stdenv.targetPlatform.isDarwin [
     apple-sdk_15
@@ -123,6 +125,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     RUSTC_BOOTSTRAP = 1;
     EXTRA_GN_ARGS = lib.concatStringsSep " " (
       [
+        "use_system_libffi=true"
         "use_sysroot=false" # prevent download of debian sysroot
         "clang_version=\"${lib.versions.major llvmPackages.clang.version}\""
         "rustc_version=\"${rustc.version}\""


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I wanted to devendor some of the dependencies in rusty-v8. Doing that with libffi is really easy, with the other dependencies it is not so simple (simdutf, libz, zstd, icu). So we start easy only with libffi.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
