### PR TITLE
canon-capt: update repo with new revision

### DIFF
--- a/pkgs/by-name/ca/canon-capt/package.nix
+++ b/pkgs/by-name/ca/canon-capt/package.nix
@@ -8,17 +8,17 @@
 }:
 
 let
-  version = "0.1.4.2-GxB";
+  version = "2016-06-14";
 in
 stdenv.mkDerivation {
   pname = "canon-capt";
   inherit version;
 
   src = fetchFromGitHub {
-    owner = "mounaiban";
+    owner = "ValdikSS";
     repo = "captdriver";
-    rev = "8ecc3cde1ae9a20dcb015994bb0fea0dbefa2b83";
-    hash = "sha256-FslofWZNmF7G9+lmw1JehRBYZIAXcg6Dmv9xJ/c4Evo=";
+    rev = "892f320c019974a5b737e000fcc2c8582264a131";
+    hash = "sha256-CcLGIhJ8HU0eu2MdA8ssT1EQsNLQicpItmyoClJHW3g=";
   };
 
   nativeBuildInputs = [
@@ -57,6 +57,7 @@ stdenv.mkDerivation {
     mkdir -p $out/share/cups/model/canon
     install -D -m 644 ./ppd/CanonLBP-2900-3000.ppd $out/share/cups/model/canon/CanonLBP-2900-3000.ppd
     install -D -m 644 ./ppd/CanonLBP-3010-3018-3050.ppd $out/share/cups/model/canon/CanonLBP-3010-3018-3050.ppd
+    install -D -m 644 ./ppd/CanonLBP-6000.ppd $out/share/cups/model/canon/CanonLBP-6000.ppd
 
     runHook postInstall
   '';

--- a/pkgs/by-name/ca/canon-capt/package.nix
+++ b/pkgs/by-name/ca/canon-capt/package.nix
@@ -66,7 +66,10 @@ stdenv.mkDerivation {
     description = "Community-driven driver for Canon CAPT-based printers";
     homepage = "https://github.com/mounaiban/captdriver";
     license = lib.licenses.gpl3;
-    maintainers = with lib.maintainers; [ cryptoluks ];
+    maintainers = with lib.maintainers; [
+      cryptoluks
+      theeasternfurry
+    ];
     platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
Currently, the repo at https://github.com/mounaiban/captdriver has been inactive for a long time.

The fork at https://github.com/ValdikSS/captdriver is more actively maintained, with additional bug fixes over the original.

This PR points to the val branch (default branch of the fork), which contains extra patches not present in master.
I only tested on LBP2900 (x86_64-linux) and can confirm it builds and works correctly. Other printer models are untested.

Note: A new [LBP6000 PPD](https://github.com/ValdikSS/captdriver/commit/d05266a3ca62f5ae3dfdeeeb90cb67eff08bf925) has been included from upstream, but is untested as I do not own an LBP6000 printer.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
