### PR TITLE
fluux-messenger: init at 0.16.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10467,6 +10467,11 @@
     githubId = 14929991;
     keys = [ { fingerprint = "F7D3 7890 228A 9074 40E1  FD48 46B9 228E 814A 2AAC"; } ];
   };
+  haansn08 = {
+    name = "Stefan Haan";
+    github = "haansn08";
+    githubId = 6215916;
+  };
   hacker1024 = {
     name = "hacker1024";
     email = "hacker1024@users.sourceforge.net";

--- a/pkgs/by-name/fl/fluux-messenger/package.nix
+++ b/pkgs/by-name/fl/fluux-messenger/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  cargo-tauri,
+  nodejs,
+  npmHooks,
+  fetchNpmDeps,
+  pkg-config,
+  webkitgtk_4_1,
+  libayatana-appindicator,
+  libxscrnsaver,
+  cacert,
+  wrapGAppsHook3,
+  autoPatchelfHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "fluux-messenger";
+  version = "0.16.0";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "processone";
+    repo = "fluux-messenger";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-P4bRyge5EGdlZBdX+gIWh48itkCLQ+EjKLHt4xv6qnY=";
+  };
+
+  cargoRoot = "apps/fluux/src-tauri";
+  cargoHash = "sha256-YIX/F9LMuHFGJ89NIsFLUjjrR7XBoJF78OsyXiSjEqU=";
+
+  npmDeps = fetchNpmDeps {
+    name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
+    inherit (finalAttrs) src;
+    hash = "sha256-rzkFrvLb/0c+pg2SIUnhyTHK2MGL2ugRI9XuHtdm8XE=";
+  };
+
+  nativeBuildInputs = [
+    cargo-tauri.hook
+    nodejs
+    npmHooks.npmConfigHook
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    (wrapGAppsHook3.override { isGraphical = true; })
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    webkitgtk_4_1
+    libayatana-appindicator
+    libxscrnsaver
+    cacert
+  ];
+
+  # libayatana-appindicator is not in the RUNPATH by default
+  runtimeDependencies = [ libayatana-appindicator ];
+
+  tauriBuildFlags = [ "--no-sign" ];
+
+  # setting buildAndTestSubdir from the beginning interferes with buildPhase
+  preCheck = "export buildAndTestSubdir=${finalAttrs.cargoRoot}";
+  # tauriInstallHook only works when we are in cargoRoot
+  preInstall = "pushd $buildAndTestSubdir";
+  postInstall = "popd";
+
+  meta = {
+    description = "XMPP client for communities and organizations";
+    homepage = "https://github.com/processone/fluux-messenger";
+    license = lib.licenses.agpl3Plus;
+    mainProgram = "fluux";
+    maintainers = [ lib.maintainers.haansn08 ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Fluux Messenger is a fast, modern, cross-platform XMPP client for communities and organizations made by ProcessOne, the makes of ejabberd:

https://github.com/processone/fluux-messenger

During writing of this derivation, I also stumbled upon a nullglob in the cargo-tauri hook, which I replaced with "mv -t".

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
