### PR TITLE
itgmaniaPackages.{arrowcloud-theme,zmod-simply-love}: unset nix-update-script extraArgs

### DIFF
--- a/pkgs/by-name/it/itgmania/themes/arrowcloud-theme.nix
+++ b/pkgs/by-name/it/itgmania/themes/arrowcloud-theme.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
     mv * "$out/itgmania/Themes/Arrow Cloud"
   '';
 
-  passthru.updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Arrow Cloud's fork of Zmod";

--- a/pkgs/by-name/it/itgmania/themes/zmod-simply-love.nix
+++ b/pkgs/by-name/it/itgmania/themes/zmod-simply-love.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
     mv * "$out/itgmania/Themes/Zmod Simply Love"
   '';
 
-  passthru.updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Zmod fork of Simply Love";


### PR DESCRIPTION
r-ryantm has been trying to downgrade zmod-simply-love: https://github.com/NixOS/nixpkgs/pull/531617

Removing `--use-github-releases` should fix it.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
