### PR TITLE
lib.extendDerivation: Add fast path for common outputs case

### DIFF
--- a/lib/customisation.nix
+++ b/lib/customisation.nix
@@ -397,19 +397,16 @@ rec {
     ```
   */
   extendDerivation =
+    let
+      singleOutOutput = [ "out" ];
+    in
     condition: passthru: drv:
     let
+      outputs = drv.outputs or singleOutOutput;
+
       commonAttrs =
         drv
-        // listToAttrs (
-          outputsList
-          ++ [
-            {
-              name = "all";
-              value = map (x: x.value) outputsList;
-            }
-          ]
-        )
+        // outputAttrs
         // passthru
         // {
           drvPath =
@@ -420,9 +417,10 @@ rec {
             drv.outPath;
         };
 
-      outputsList = map (outputName: {
-        name = outputName;
-        value = commonAttrs // {
+      mkOutput =
+        outputName:
+        commonAttrs
+        // {
           inherit (drv.${outputName}) type outputName;
           outputSpecified = true;
           drvPath =
@@ -438,7 +436,33 @@ rec {
           ${if passthru ? overrideAttrs then "overrideAttrs" else null} =
             f: (passthru.overrideAttrs f).${outputName};
         };
-      }) (drv.outputs or [ "out" ]);
+
+      outputAttrs =
+        # extendDerivation is a hot path which is called by stdenv.mkDerivation.
+        #
+        # The vast majority of derivations has an outputs outputs list with a single "out" output.
+        # Use this observation to avoid the dynamic listToAttrs & mapping below.
+        if outputs == singleOutOutput then
+          rec {
+            out = mkOutput "out";
+            all = [ out ];
+          }
+        else
+          let
+            outputsList = map (name: {
+              inherit name;
+              value = mkOutput name;
+            }) outputs;
+          in
+          listToAttrs (
+            outputsList
+            ++ [
+              {
+                name = "all";
+                value = map (x: x.value) outputsList;
+              }
+            ]
+          );
     in
     commonAttrs;
 


### PR DESCRIPTION
The vast majority of derivations has an outputs outputs list with a single "out" output. Use this observation to only run listToAttrs/map in the case of different or multiple outputs.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
