### PR TITLE
gram: 2.1.2 -> 2.2.0

### DIFF
--- a/pkgs/by-name/gr/gram/package.nix
+++ b/pkgs/by-name/gr/gram/package.nix
@@ -31,7 +31,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "gram";
-  version = "2.1.2";
+  version = "2.2.0";
 
   outputs = [
     "out"
@@ -44,7 +44,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "GramEditor";
     repo = "gram";
     tag = finalAttrs.version;
-    hash = "sha256-7FzAvC/JMMIFcuTGkL2Ju644UAIsneOMhiDUFnQske4=";
+    hash = "sha256-w0uZ2qAc3Tt6QVRAX97LWW9aOs02fG1SEYCDhpUhinE=";
   };
 
   postPatch = ''
@@ -54,7 +54,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail '$CARGO_ABOUT_VERSION' '${cargo-about.version}'
   '';
 
-  cargoHash = "sha256-feESY8ALSG3xa906HBc4pOKGerQ1jF7VUxzvUcsZbrY=";
+  cargoHash = "sha256-+lmDbawAIRllC7LzGJ9qPMtHXPd5aMoul47YOA7nfXA=";
 
   __structuredAttrs = true;
 
@@ -71,7 +71,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   dontUseCmakeConfigure = true;
 
   buildInputs = [
-    libgit2
+    (libgit2.override { withExperimentalSha256 = true; })
     openssl
     sqlite
     zlib

--- a/pkgs/by-name/li/libgit2/package.nix
+++ b/pkgs/by-name/li/libgit2/package.nix
@@ -17,6 +17,7 @@
   gitstatus,
   llhttp,
   withGssapi ? false,
+  withExperimentalSha256 ? false,
   krb5,
 }:
 
@@ -43,6 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DUSE_HTTP_PARSER=llhttp"
     "-DUSE_SSH=ON"
     (lib.cmakeBool "USE_GSSAPI" withGssapi)
+    (lib.cmakeBool "EXPERIMENTAL_SHA256" withExperimentalSha256)
     "-DBUILD_SHARED_LIBS=${if staticBuild then "OFF" else "ON"}"
   ]
   ++ lib.optionals stdenv.hostPlatform.isWindows [
@@ -87,6 +89,13 @@ stdenv.mkDerivation (finalAttrs: {
       set -x
       ./libgit2_tests ''${testArgs[@]}
     )
+  '';
+
+  postInstall = lib.optionalString withExperimentalSha256 ''
+    # Downstream Rust bindings (git2-rs / git2-sys) expect experimental headers
+    # to be located at 'git2/experimental.h', but upstream libgit2 installs them
+    # into 'git2-experimental/' when EXPERIMENTAL_SHA256 is enabled.
+    ln -s git2-experimental $dev/include/git2
   '';
 
   passthru.tests = lib.mapAttrs (_: v: v.override { libgit2 = finalAttrs.finalPackage; }) {


### PR DESCRIPTION
Changelog: https://codeberg.org/GramEditor/gram/releases/tag/2.2.0

~~I tried to stick with libgit2 and only pass `EXPERIMENTAL_SHA256=ON` as an optional flag via an default false argument but that seemed to be a rabbit hole without much benefit in the end as far as i can tell.~~ The proposed change includes an optional argument for ligbit2 to enable `EXPERIMENTAL_SHA256`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
