### PR TITLE
python3Packages.meshcore: 2.3.0 -> 2.3.7

### DIFF
--- a/pkgs/development/python-modules/meshcore/default.nix
+++ b/pkgs/development/python-modules/meshcore/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  fetchpatch,
   hatchling,
 
   # dependencies
@@ -18,21 +17,13 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "meshcore";
-  version = "2.3.0";
+  version = "2.3.7";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-7Vo1l2qnh04pD8urIZjC5onws1aCULYK7FLmueO9K3s=";
+    hash = "sha256-JnEH4JqW99DWP0vbFALQM6ckuq3Zyb7Pm3GkWBcPYLs=";
   };
-
-  patches = [
-    (fetchpatch {
-      # https://github.com/meshcore-dev/meshcore_py/pull/71
-      url = "https://github.com/meshcore-dev/meshcore_py/commit/9294e574739844e0e291b972b40e1a0a40149e47.patch";
-      hash = "sha256-Ufr+5rDDO32W6dtD7wEU34iLJai3H0dBCEtLS5j4u/0=";
-    })
-  ];
 
   build-system = [ hatchling ];
 

--- a/pkgs/development/python-modules/meshcore/default.nix
+++ b/pkgs/development/python-modules/meshcore/default.nix
@@ -1,10 +1,8 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
+  fetchPypi,
   fetchpatch,
-
-  # build-system
   hatchling,
 
   # dependencies
@@ -23,11 +21,9 @@ buildPythonPackage (finalAttrs: {
   version = "2.3.0";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "meshcore-dev";
-    repo = "meshcore_py";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-Vz2LQaP44Yojf9h2rSBvKRjW99IOj7C5MxqQnIUoIRE=";
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-7Vo1l2qnh04pD8urIZjC5onws1aCULYK7FLmueO9K3s=";
   };
 
   patches = [


### PR DESCRIPTION
Updated `python3Packages.meshcore` from 2.3.0 to 2.3.7 and switched the source to PyPI, since newer upstream releases are published there and not as GitHub tags/releases.

Confirmed test looks good:
```sh
$ nix build .#python3Packages.meshcore
$ nix log "$(nix path-info .#python3Packages.meshcore --derivation)" | rg 'passed|failed|error'
tests/unit/test_error_handling.py ............                           [ 53%]
======================= 141 passed, 8 warnings in 12.02s =======================
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


As an aside, I'm trying to learn more of the nixpkg tooling, `nixpkgs-review rev HEAD` failed on `meshcore-cli`:
```
--------- Report for 'x86_64-linux' ---------
1 package failed to build:
python314Packages.meshcore-cli

4 packages built:
home-assistant-custom-components.meshcore meshcore-cli python313Packages.meshcore python314Packages.meshcore
```


<details>
<summary>Logs showing maybe the python 3.14 vs 3.13 path is messed up in the review env as python3.14 is using path for python3.13?

Please point me in the right direction if this is something I should fix for meshcore
</summary>

```
[nix-shell:~/.cache/nixpkgs-review/rev-6bb6fca4bb08449b5724a69c76586b8a49af416d/logs]$ cat python314Packages.meshcore-cli-x86_64-linux.log
structuredAttrs is enabled
Sourcing python-remove-tests-dir-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing pypa-build-hook
Using pypaBuildPhase
Sourcing python-runtime-deps-check-hook
Using pythonRuntimeDepsCheckHook
Sourcing pypa-install-hook
Using pypaInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
Sourcing python-catch-conflicts-hook.sh
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/824jqzvvrcp1kdvlz7n7nfp5z0rzm6xb-source
source root is source
setting SOURCE_DATE_EPOCH to timestamp 315619200 of file "source/src/meshcore_cli/meshcore_cli.py"
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
no configure script, doing nothing
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
Executing pypaBuildPhase
Creating a wheel...
pypa build flags: --no-isolation --outdir dist/ --wheel
* Getting build dependencies for wheel...
* Building wheel...
Successfully built meshcore_cli-1.5.0-py3-none-any.whl
Finished creating a wheel...
Finished executing pypaBuildPhase
Running phase: pythonRuntimeDepsCheckHook
@nix { "action": "setPhase", "phase": "pythonRuntimeDepsCheckHook" }
Executing pythonRuntimeDepsCheck
Checking runtime dependencies for meshcore_cli-1.5.0-py3-none-any.whl
Finished executing pythonRuntimeDepsCheck
Running phase: installPhase
@nix { "action": "setPhase", "phase": "installPhase" }
Executing pypaInstallPhase
Successfully installed meshcore_cli-1.5.0-py3-none-any.whl
Finished executing pypaInstallPhase
Running phase: pythonOutputDistPhase
@nix { "action": "setPhase", "phase": "pythonOutputDistPhase" }
Executing pythonOutputDistPhase
Finished executing pythonOutputDistPhase
Running phase: fixupPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
shrinking RPATHs of ELF executables and libraries in /nix/store/zgbgxzlyzk6h8d7ij724szngznnmb6k7-python3.14-meshcore-cli-1.5.0-dist
checking for references to /build/ in /nix/store/zgbgxzlyzk6h8d7ij724szngznnmb6k7-python3.14-meshcore-cli-1.5.0-dist...
patching script interpreter paths in /nix/store/zgbgxzlyzk6h8d7ij724szngznnmb6k7-python3.14-meshcore-cli-1.5.0-dist
shrinking RPATHs of ELF executables and libraries in /nix/store/fsl1qwanc6zmn3dlsjh4ym4027wma1vi-python3.14-meshcore-cli-1.5.0
checking for references to /build/ in /nix/store/fsl1qwanc6zmn3dlsjh4ym4027wma1vi-python3.14-meshcore-cli-1.5.0...
patching script interpreter paths in /nix/store/fsl1qwanc6zmn3dlsjh4ym4027wma1vi-python3.14-meshcore-cli-1.5.0
stripping (with command strip and flags -S -p) in  /nix/store/fsl1qwanc6zmn3dlsjh4ym4027wma1vi-python3.14-meshcore-cli-1.5.0/lib /nix/store/fsl1qwanc6zmn3dlsjh4ym4027wma1vi-python3.14-meshcore-cli-1.5.0/bin
Rewriting #!/nix/store/zrx2128nk8aadnvhjc3n8za9hw08hqx9-python3-3.14.4/bin/python3.14 to #!/nix/store/zrx2128nk8aadnvhjc3n8za9hw08hqx9-python3-3.14.4
wrapping `/nix/store/fsl1qwanc6zmn3dlsjh4ym4027wma1vi-python3.14-meshcore-cli-1.5.0/bin/meshcli'...
Rewriting #!/nix/store/zrx2128nk8aadnvhjc3n8za9hw08hqx9-python3-3.14.4/bin/python3.14 to #!/nix/store/zrx2128nk8aadnvhjc3n8za9hw08hqx9-python3-3.14.4
wrapping `/nix/store/fsl1qwanc6zmn3dlsjh4ym4027wma1vi-python3.14-meshcore-cli-1.5.0/bin/meshcore-cli'...
Executing pythonRemoveTestsDir
Finished executing pythonRemoveTestsDir
Running phase: pythonCatchConflictsPhase
@nix { "action": "setPhase", "phase": "pythonCatchConflictsPhase" }
Running phase: pythonRemoveBinBytecodePhase
@nix { "action": "setPhase", "phase": "pythonRemoveBinBytecodePhase" }
Running phase: pythonImportsCheckPhase
@nix { "action": "setPhase", "phase": "pythonImportsCheckPhase" }
Executing pythonImportsCheckPhase
Check whether the following modules can be imported: meshcore_cli
```

```
[nix-shell:~/.cache/nixpkgs-review/rev-6bb6fca4bb08449b5724a69c76586b8a49af416d/logs]$ python3
Python 3.14.4 (main, Apr  7 2026, 13:13:20) [GCC 15.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import meshcore_cli
>>> meshcore_cli.__file__
'/nix/store/gddx8diwyxj6pfw62sx2p5449cw5qy4w-python3.13-meshcore-cli-1.5.0/lib/python3.13/site-packages/meshcore_cli/__init__.py'
>>>
```
</details>