### PR TITLE
librepcb: 2.0.0 -> 2.1.1

### DIFF
--- a/pkgs/by-name/li/librepcb/package.nix
+++ b/pkgs/by-name/li/librepcb/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "librepcb";
-  version = "2.0.0";
+  version = "2.1.1";
 
   src = fetchFromGitHub {
     owner = "librepcb";
     repo = "librepcb";
     rev = version;
-    hash = "sha256-8hMPrpqwGNYXUTJGL/CMSP+Sjv5F6ZTkJHqauuOxwTw=";
+    hash = "sha256-UcX4r2TxinL2S3tPIiYRsPpYmKzdAx3Al0irkbXf5/g=";
     fetchSubmodules = true;
   };
 
@@ -38,13 +38,13 @@ stdenv.mkDerivation rec {
   cargoDeps1 = rustPlatform.fetchCargoVendor {
     inherit src;
     cargoRoot = "libs/librepcb/rust-core";
-    hash = "sha256-1td3WjxbDq2lX7c0trpYRhO82ChNAG/ZABBRsekYtq4=";
+    hash = "sha256-1wHk8ynP3VnkypwY/C7nikfMSF0qU0L+CbBKoVxjlEc=";
   };
 
   cargoDeps2 = rustPlatform.fetchCargoVendor {
     inherit src;
     cargoRoot = "libs/slint";
-    hash = "sha256-DYcKoaOXYFvAi5VyWdhli73s7qrypeXmzGJNhVzcWtY=";
+    hash = "sha256-UX/7a0hzFBmPZKufcDKcICrXEM+rKcvqEq2pg1riBxo=";
   };
 
   postPatch = ''
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
     [source.crates-io]
     replace-with = "vendored-sources"
     [source.vendored-sources]
-    directory = "${cargoDeps1}"
+    directory = "${cargoDeps1}/source-registry-0"
     EOF
 
     # Set up cargo config for the second Rust library
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
     [source.crates-io]
     replace-with = "vendored-sources"
     [source.vendored-sources]
-    directory = "${cargoDeps2}"
+    directory = "${cargoDeps2}/source-registry-0"
     EOF
   '';
 


### PR DESCRIPTION
Update package and fix compilation problems.

Ref: #519922

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
