### PR TITLE
nixos/run0: switch to run0-sudo-shim

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -46,6 +46,8 @@
 
 - `komodo` has been updated to the v2 release line (2.x). See the [upstream v1 → v2 upgrade guide](https://github.com/moghtech/komodo/releases/tag/v2.0.0).
 
+- `security.run0.enableSudoAlias` now uses the `run0-sudo-shim` instead of a shell-script to improve compatibility.
+
 - `boot.loader.systemd-boot` gained support for [Automatic Boot Assessment](https://systemd.io/AUTOMATIC_BOOT_ASSESSMENT/) via the new [`boot.loader.systemd-boot.bootCounting`](#opt-boot.loader.systemd-boot.bootCounting.enable) options, allowing automatic detection of and recovery from bad NixOS generations. As part of this change, boot loader entries on the ESP/XBOOTLDR partition are now named `nixos-<content-hash>.conf` instead of `nixos-generation-<n>.conf`; existing entries are migrated automatically on the next `nixos-rebuild boot`/`switch`.
 
 - The `newuidmap` and `newgidmap` security wrappers are now installed with `cap_setuid`/`cap_setgid` file capabilities instead of the setuid-root bit, matching shadow's `--with-fcaps` install mode and other major distributions. Rootless containers (podman, docker-rootless, unprivileged user namespaces) are unaffected. The only behavioural change is that mapping host uid 0 via `/etc/subuid` (which NixOS never configures by default) additionally requires `cap_setfcap`; users who explicitly grant uid 0 in a subuid range can restore the previous behaviour with `security.wrappers.newuidmap.capabilities = lib.mkForce "cap_setuid,cap_setfcap+ep";`.

--- a/nixos/modules/security/run0.nix
+++ b/nixos/modules/security/run0.nix
@@ -11,17 +11,11 @@ let
     mkIf
     mkMerge
     mkOption
+    mkPackageOption
+    mkAliasOptionModule
     ;
 
   cfg = config.security.run0;
-
-  sudoAlias = pkgs.writeShellScriptBin "sudo" ''
-    if [[ "$1" == -* ]]; then
-      echo "This script is a sudo-alias to systemd's run0 and does not support any sudo parameters."
-      exit 1
-    fi
-    exec run0 "$@"
-  '';
 in
 {
   options.security.run0 = {
@@ -36,8 +30,16 @@ in
       '';
     };
 
-    enableSudoAlias = mkEnableOption "make {command}`sudo` an alias to {command}`run0`.";
+    sudo-shim.enable = mkEnableOption "make {command}`sudo` an alias to {command}`run0`.";
+    sudo-shim.package = mkPackageOption pkgs "run0-sudo-shim" { };
   };
+
+  imports = [
+    (mkAliasOptionModule
+      [ "security" "run0" "enableSudoAlias" ]
+      [ "security" "run0" "sudo-shim" "enable" ]
+    )
+  ];
 
   config = mkMerge [
     {
@@ -58,8 +60,8 @@ in
       assertions = [
         {
           assertion =
-            cfg.enableSudoAlias -> (!config.security.sudo.enable && !config.security.sudo-rs.enable);
-          message = "`security.run0.enableSudoAlias` cannot be enabled if `security.sudo` or `security.sudo-rs` are enabled.";
+            cfg.sudo-shim.enable -> (!config.security.sudo.enable && !config.security.sudo-rs.enable);
+          message = "`security.run0.sudo-shim.enable` cannot be enabled if `security.sudo` or `security.sudo-rs` are enabled.";
         }
       ];
 
@@ -74,7 +76,7 @@ in
         '';
       };
 
-      environment.systemPackages = lib.optional cfg.enableSudoAlias sudoAlias;
+      environment.systemPackages = lib.optional cfg.sudo-shim.enable cfg.sudo-shim.package;
     })
   ];
 

--- a/nixos/modules/security/run0.nix
+++ b/nixos/modules/security/run0.nix
@@ -77,4 +77,12 @@ in
       environment.systemPackages = lib.optional cfg.enableSudoAlias sudoAlias;
     })
   ];
+
+  meta = {
+    maintainers = with lib.maintainers; [
+      zimward
+      grimmauld
+      kuflierl
+    ];
+  };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Now with release note entry!

CC: @LordGrimmauld @kuflierl @arcayr if you want to maintain the nixos module too

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
