### PR TITLE
wewa: init at 0.3.5

### DIFF
--- a/pkgs/by-name/we/wewa/package.nix
+++ b/pkgs/by-name/we/wewa/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  rustPlatform,
+  atk,
+  gtk-layer-shell,
+  gtk3,
+  glib,
+  glib-networking,
+  nix-update-script,
+  webkitgtk_4_1,
+  wrapGAppsHook3,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "wewa";
+  version = "0.3.5";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "ownself";
+    repo = "wewa";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-cVd3v02sT/RnpM2u5thS2esb/GLJ2++07tTK7UjPXnU=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    atk
+    gtk3
+    glib
+    glib-networking
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    gtk-layer-shell
+    webkitgtk_4_1
+  ];
+
+  cargoHash = "sha256-Jvl9+LiFvMI1k7jCJh2WPz7FaPo0KSxSVLaCXbFAXKs=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Cross-platform cli dynamic wallpaper tool to make website or shader as your wallpaper";
+    homepage = "https://github.com/ownself/wewa";
+    changelog = "https://github.com/ownself/wewa/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ choco98 ];
+    mainProgram = "wewa";
+  };
+})


### PR DESCRIPTION
Adds wewa, a cross-platform cli dynamic wallpaper tool to make website or shader as your wallpaper at v0.3.5. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
