### PR TITLE
trivalent: init at 149.0.7827.114-445306

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -229,6 +229,7 @@ let
   };
 
   isElectron = packageName == "electron";
+  widevineSupport = extraAttrs.widevineSupport or (packageName == "chromium");
   rustcVersion = buildPackages.rustc.version;
   llvmVersion = buildPackages.rustc.llvmPackages.llvm.version;
   # libpng has been replaced by the png rust crate
@@ -462,9 +463,8 @@ let
       # Optional patch to use SOURCE_DATE_EPOCH in compute_build_timestamp.py (should be upstreamed):
       ./patches/no-build-timestamps.patch
     ]
-    ++ lib.optionals (packageName == "chromium") [
-      # This patch is limited to chromium and ungoogled-chromium because electron-source sets
-      # enable_widevine to false.
+    ++ lib.optionals widevineSupport [
+      # Not applied to electron-source, which sets enable_widevine to false.
       #
       # The patch disables the automatic Widevine download (component) that happens at runtime
       # completely (~/.config/chromium/WidevineCdm/). This would happen if chromium encounters DRM
@@ -894,7 +894,7 @@ let
         use_gio = true;
         use_cups = cupsSupport;
       }
-      // lib.optionalAttrs (packageName == "chromium") {
+      // lib.optionalAttrs widevineSupport {
         # Enabling the Widevine here doesn't affect whether we can redistribute the chromium package.
         # Widevine in this drv is a bit more complex than just that. See Widevine patch somewhere above.
         enable_widevine = true;
@@ -1066,6 +1066,7 @@ stdenv.mkDerivation (
     "name"
     "gnFlags"
     "buildTargets"
+    "widevineSupport"
   ]
   // {
     passthru = base.passthru // (extraAttrs.passthru or { });

--- a/pkgs/by-name/tr/trivalent/browser.nix
+++ b/pkgs/by-name/tr/trivalent/browser.nix
@@ -1,0 +1,185 @@
+{
+  lib,
+  fetchFromGitHub,
+  chromium,
+  libGL,
+  vulkan-loader,
+  pciutils,
+}:
+
+let
+  chromiumVersion = "149.0.7827.114";
+  trivalentBuild = "445306";
+  version = "${chromiumVersion}-${trivalentBuild}";
+
+  src = fetchFromGitHub {
+    owner = "secureblue";
+    repo = "Trivalent";
+    tag = version;
+    hash = "sha256-pWCSBb+OGk+xB9Z5VEkhmY4v1HrXU3js/40vbFp+hac=";
+  };
+in
+
+chromium.mkDerivation (base: {
+  packageName = "trivalent";
+  inherit version;
+
+  buildTargets = [ "chrome" ];
+
+  widevineSupport = true;
+
+  patches =
+    # trivalent-etc-dir.patch already sets InitialPrefsPath, drop the conflicting one
+    lib.filter (patch: baseNameOf (toString patch) != "chromium-initial-prefs.patch") base.patches;
+  # trivalent.spec
+  postPatch = ''
+    # Upstream flattens each series into rpm's SOURCES/, so patches apply in basename order
+    applyPatchDir() {
+      find "$1" -name '*.patch' -printf '%f\t%p\n' | sort | cut -f2- |
+        while IFS= read -r patchFile; do
+          echo "applying patch $patchFile"
+          patch -p1 --fuzz=2 --no-backup-if-mismatch -i "$patchFile"
+        done
+    }
+    applyPatchDir ${src}/patches/third_party/vanadium
+    applyPatchDir ${src}/patches/trivalent
+
+    # Chrome/Chromium -> Trivalent string branding
+    find . -type f \( -iname "*.grd" -o -iname "*.grdp" -o -iname "*.xtb" \) \
+        ! -path "*ash_strings*" \
+        ! -path "*android*" \
+        ! -path "*chromeos_strings*" \
+        ! -path "*ios/chrome*" \
+        ! -path "*tools/grit/*" \
+        ! -path "*device/fido/*" \
+        ! -path "*chromeos/*" \
+        ! -path "*remoting_strings*" \
+        -exec sed -i \
+            -e 's/\bph>Chromium<ph\b/REMOVE_PLACEHOLDER_CHROMIUM_PROJECT_TAG/g' \
+            -e 's/\bGoogle Chrome\b/REMOVE_PLACEHOLDER_GOOGLE_CHROME/g' \
+            -e 's/\Chrome Web Store\b/REMOVE_PLACEHOLDER_CHROME_WEB_STORE/g' \
+            -e 's/\bThe Chromium Authors\b/REMOVE_PLACEHOLDER_THE_CHROMIUM_AUTHORS/g' \
+            -e 's/\bChrom\(e\|ium\)\b/Trivalent/g' \
+            -e 's/REMOVE_PLACEHOLDER_GOOGLE_CHROME/Google Chrome/g' \
+            -e 's/REMOVE_PLACEHOLDER_CHROME_WEB_STORE/Chrome Web Store/g' \
+            -e 's/REMOVE_PLACEHOLDER_THE_CHROMIUM_AUTHORS/The Chromium Authors/g' \
+            -e 's/REMOVE_PLACEHOLDER_CHROMIUM_PROJECT_TAG/ph>Chromium<ph/g' {} +
+
+    for themeDir in \
+      "chrome/app/theme/chromium:16 24 32 48 64 128 256" \
+      "chrome/app/theme/chromium/linux:24 48 64 128 256" \
+      "chrome/app/theme/default_100_percent/chromium:16 32" \
+      "chrome/app/theme/default_100_percent/chromium/linux:16 32" \
+      "chrome/app/theme/default_200_percent/chromium:16 32"
+    do
+      for size in ''${themeDir#*:}; do
+        cp ${src}/build/resources/trivalent$size.png \
+          "''${themeDir%%:*}/product_logo_$size.png"
+      done
+    done
+  ''
+  + base.postPatch;
+
+  # trivalent.spec
+  gnFlags = {
+    is_cfi = true;
+    use_cfi_cast = true;
+
+    enable_reporting = false;
+    enable_remoting = false;
+    enable_vr = false;
+
+    use_webgpu_on_vulkan_via_gl_interop = false;
+
+    use_static_angle = true;
+    angle_shared_libvulkan = false;
+
+    enable_swiftshader = false;
+    enable_swiftshader_vulkan = false;
+    dawn_use_swiftshader = false;
+    angle_enable_swiftshader = false;
+
+    build_dawn_tests = false;
+    enable_perfetto_unittests = false;
+    angle_has_histograms = false;
+    safe_browsing_use_unrar = false;
+    use_kerberos = true;
+    rtc_link_pipewire = true;
+    v8_enable_drumbrake = true;
+
+    google_api_key = "";
+    enable_hangout_services_extension = false;
+  };
+
+  preBuild = (base.preBuild or "") + ''
+    # CFI/ThinLTO link line is huge, raise the stack limit so ARG_MAX fits it
+    ulimit -s 1048576
+  '';
+
+  installPhase = ''
+    mkdir -p "$libExecPath"
+
+    find "$buildPath" -maxdepth 1 -name '*.so' -exec cp -v -t "$libExecPath/" {} +
+
+    cp -v "$buildPath/"*.pak "$buildPath/"*.bin "$libExecPath/"
+    cp -v "$buildPath/icudtl.dat" "$libExecPath/"
+    cp -vLR "$buildPath/locales" "$buildPath/resources" "$libExecPath/"
+    cp -v "$buildPath/chrome_crashpad_handler" "$libExecPath/"
+    cp -v "$buildPath/chrome" "$libExecPath/$packageName"
+
+    mkdir -vp "$out/share/man/man1"
+    cp -v "$buildPath/chrome.1" "$out/share/man/man1/$packageName.1"
+
+    for icon_file in chrome/app/theme/chromium/product_logo_*[0-9].png; do
+      num_and_suffix="''${icon_file##*logo_}"
+      icon_size="''${num_and_suffix%.*}"
+      expr "$icon_size" : "^[0-9][0-9]*$" || continue
+      logo_output_path="$out/share/icons/hicolor/''${icon_size}x''${icon_size}/apps"
+      mkdir -vp "$logo_output_path"
+      cp -v "$icon_file" "$logo_output_path/$packageName.png"
+    done
+
+    install -Dm644 ${src}/build/install/trivalent.desktop \
+      "$out/share/applications/trivalent.desktop"
+    substituteInPlace "$out/share/applications/trivalent.desktop" \
+      --replace-fail "Exec=/usr/bin/trivalent" "Exec=trivalent"
+
+    # Strip the license comment before <?xml> that makes it invalid XML
+    mkdir -p "$out/share/metainfo"
+    sed -n '/<?xml/,$p' ${src}/build/install/trivalent.appdata.xml \
+      > "$out/share/metainfo/trivalent.appdata.xml"
+  '';
+
+  # Base postFixup patches libGLESv2.so and bundled libvulkan, neither exists here
+  postFixup = ''
+    patchelf --set-rpath "${
+      lib.makeLibraryPath [
+        libGL
+        vulkan-loader
+        pciutils
+      ]
+    }:$(patchelf --print-rpath "$libExecPath/$packageName")" "$libExecPath/$packageName"
+  '';
+
+  requiredSystemFeatures = [ "big-parallel" ];
+
+  meta = {
+    description = "Security hardened Chromium for desktop Linux";
+    homepage = "https://github.com/secureblue/Trivalent";
+    changelog = "https://github.com/secureblue/Trivalent/releases/tag/${version}";
+    license = with lib.licenses; [
+      bsd3
+      gpl2Only
+      asl20
+    ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    mainProgram = "trivalent";
+    maintainers = with lib.maintainers; [ aaravrav ];
+    # Patch set is version-locked to Chromium
+    broken = chromium.upstream-info.version != chromiumVersion;
+    timeout = 172800; # 48h
+  };
+})

--- a/pkgs/by-name/tr/trivalent/package.nix
+++ b/pkgs/by-name/tr/trivalent/package.nix
@@ -1,0 +1,126 @@
+{
+  lib,
+  stdenv,
+  callPackage,
+  chromium,
+  coreutils,
+  makeWrapper,
+  xdg-utils,
+  glib,
+  gtk3,
+  gtk4,
+  adwaita-icon-theme,
+  gsettings-desktop-schemas,
+  libva,
+  pipewire,
+  wayland,
+  libkrb5,
+  runCommand,
+  widevine-cdm,
+
+  proprietaryCodecs ? true,
+  enableWideVine ? false,
+  commandLineArgs ? "",
+}:
+
+let
+  browser = callPackage ./browser.nix {
+    chromium = chromium.override { inherit proprietaryCodecs; };
+  };
+
+  browserWV =
+    if enableWideVine then
+      runCommand (browser.name + "-wv") { } ''
+        mkdir -p $out
+        cp -a ${browser}/* $out/
+        chmod u+w $out/libexec/trivalent
+        cp -a ${widevine-cdm}/share/google/chrome/WidevineCdm $out/libexec/trivalent/
+      ''
+    else
+      browser;
+in
+stdenv.mkDerivation {
+  pname = "trivalent";
+  inherit (browser) version;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [
+    # needed for GSETTINGS_SCHEMAS_PATH
+    gsettings-desktop-schemas
+    glib
+    gtk3
+    gtk4
+
+    # needed for XDG_ICON_DIRS
+    adwaita-icon-theme
+
+    # needed for kerberos at runtime
+    libkrb5
+  ];
+
+  buildCommand =
+    let
+      browserBinary = "${browserWV}/libexec/trivalent/trivalent";
+      libPath = lib.makeLibraryPath [
+        libva
+        pipewire
+        wayland
+        gtk3
+        gtk4
+        libkrb5
+      ];
+
+      wrapperArgs = [
+        # Refuse to run as root (upstream launcher behavior)
+        "--run 'if [ \"$EUID\" -eq 0 ]; then echo \"Trivalent must not be run as root.\" >&2; exit 1; fi'"
+
+        # Make generated desktop shortcuts have a valid executable name.
+        "--set CHROME_WRAPPER trivalent"
+        "--suffix LD_LIBRARY_PATH : ${libPath}"
+
+        # https://github.com/NixOS/nixpkgs/issues/352131
+        "--unset LD_PRELOAD"
+        "--unset LD_AUDIT"
+        "--unset LD_PROFILE"
+
+        # Avoid glycin issues (upstream launcher behavior)
+        "--set GDK_DISABLE icon-nodes"
+
+        "--prefix XDG_DATA_DIRS : \"$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH\""
+      ]
+      # Hardware CFI (IBT + shadow stack), as the upstream launcher sets
+      ++ lib.optional stdenv.hostPlatform.isx86_64 "--set GLIBC_TUNABLES glibc.cpu.x86_ibt=on:glibc.cpu.x86_shstk=permissive"
+      # Fallback for xdg-open and friends
+      ++ lib.optional (!xdg-utils.meta.broken) "--suffix PATH : ${xdg-utils}/bin"
+      ++ [
+        # std{in,out,err} are shared with untrusted child processes (http://crbug.com/376567)
+        "--run 'exec < /dev/null'"
+        "--run 'exec > >(exec ${coreutils}/bin/cat)'"
+        "--run 'exec 2> >(exec ${coreutils}/bin/cat >&2)'"
+
+        ''--add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"''
+        "--add-flags ${lib.escapeShellArg commandLineArgs}"
+      ];
+    in
+    ''
+      mkdir -p "$out/bin"
+
+      makeWrapper "${browserBinary}" "$out/bin/trivalent" \
+        ${lib.concatStringsSep " \\\n  " wrapperArgs}
+
+      mkdir -p "$out/share"
+      ln -s -t "$out/share/" '${browserWV}'/share/*
+    '';
+
+  passthru = {
+    inherit browser;
+  };
+
+  meta = browser.meta // {
+    license = browser.meta.license ++ lib.optional enableWideVine lib.licenses.unfree;
+  };
+}


### PR DESCRIPTION
Adds the [Trivalent](https://github.com/secureblue/Trivalent) browser. Closes #352131

However some issues need to be sorted out before the PR is mergeable:
- [ ] A volunteer maintainer with commit rights needed as per the nixpkgs browser policy.
- [x] ~Whether to port the `bwrap` hardening layer: Trivalent's Fedora launcher uses `brwap`. Im not aware of any other browser doing this in nixpkgs.~ As discussed in #trivalent-dev in secureblue's Discord, "the bwrap layer isnt needed, really. Its mostly to remove hardened_malloc, not for significant security". The included wrapper already clears `LD_PRELOAD`, `LD_AUDIT`, and `LD_PROFILE`, which covers the hardened_malloc issue. 
- [ ] How to adapt Trivalent's GPU sandbox allowlists to NixOS:  Some of Trivalent's GPU sandbox hardening is incompatible with NixOS because it references paths like `/usr/lib64/...`. This is done via the `--libgallium-version` flag which is passed by default upstream but is disabled in this PR for now. I am not sure what these paths should be changed to for NixOS.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
