### PR TITLE
tests.{trivial-builders.symlinkJoin,replaceVars}: fix group mismatches 

### DIFF
--- a/pkgs/build-support/trivial-builders/test/symlink-join.nix
+++ b/pkgs/build-support/trivial-builders/test/symlink-join.nix
@@ -1,7 +1,7 @@
 {
   symlinkJoin,
   writeTextFile,
-  runCommand,
+  runCommandLocal,
   testers,
 }:
 
@@ -31,7 +31,7 @@ let
     text = "qux";
   };
 
-  emulatedSymlinkJoinFooBarStrip = runCommand "symlinkJoin-strip-foo-bar" { } ''
+  emulatedSymlinkJoinFooBarStrip = runCommandLocal "symlinkJoin-strip-foo-bar" { } ''
     mkdir $out
     ln -s ${foo}/etc/test.d/foo $out/
     ln -s ${bar}/etc/test.d/bar $out/
@@ -48,7 +48,7 @@ in
         baz
       ];
     };
-    expected = runCommand "symlinkJoin-foo-bar-baz" { } ''
+    expected = runCommandLocal "symlinkJoin-foo-bar-baz" { } ''
       mkdir -p $out/{var/lib/arbitrary,etc/test.d}
       ln -s {${foo},${bar}}/etc/test.d/* $out/etc/test.d
       ln -s ${baz}/var/lib/arbitrary/baz $out/var/lib/arbitrary/
@@ -66,7 +66,7 @@ in
         baz
       ];
     };
-    expected = runCommand "symlinkJoin-foo-bar-baz" { } ''
+    expected = runCommandLocal "symlinkJoin-foo-bar-baz" { } ''
       mkdir -p $out/{var/lib/arbitrary,etc/test.d}
       ln -s {${foo},${bar}}/etc/test.d/* $out/etc/test.d
       ln -s ${baz}/var/lib/arbitrary/baz $out/var/lib/arbitrary/
@@ -115,7 +115,7 @@ in
   };
 
   symlinkJoin-fails-on-missing =
-    runCommand "symlinkJoin-fails-on-missing"
+    runCommandLocal "symlinkJoin-fails-on-missing"
       {
         failed = testBuildFailure (symlinkJoin {
           name = "symlinkJoin-fail";
@@ -134,7 +134,7 @@ in
       '';
 
   symlinkJoin-fails-on-file =
-    runCommand "symlinkJoin-fails-on-file"
+    runCommandLocal "symlinkJoin-fails-on-file"
       {
         failed = testBuildFailure (symlinkJoin {
           name = "symlinkJoin-fail";

--- a/pkgs/test/replace-vars/default.nix
+++ b/pkgs/test/replace-vars/default.nix
@@ -6,6 +6,7 @@
   lib,
   runCommand,
   testers,
+  writeText,
 }:
 let
   inherit (testers) testEqualContents testBuildFailure;
@@ -22,7 +23,7 @@ let
         };
 
         expected = mkExpectation (
-          builtins.toFile "source.txt" ''
+          writeText "source.txt" ''
             All human beings are born free and are the same in dignity and rights.
             They are endowed with reason and conscience and should act towards
             one another in a spirit of shared humanity.
@@ -53,7 +54,7 @@ let
           {
             failed =
               let
-                src = builtins.toFile "source.txt" ''
+                src = writeText "source.txt" ''
                   Header.
                   before @whatIsThis@ middle @It'sOdd2Me@ after.
                   @cannot detect due to space@
@@ -86,7 +87,7 @@ let
         };
 
         expected = mkExpectation (
-          builtins.toFile "source.txt" ''
+          writeText "source.txt" ''
             All human beings are born free and are the same in dignity and rights.
             They are endowed with reason and conscience and should act towards
             one another in a spirit of @brotherhood@.
@@ -101,7 +102,7 @@ let
           {
             failed =
               let
-                src = builtins.toFile "source.txt" ''
+                src = writeText "source.txt" ''
                   @a@
                   @b@
                   @c@
@@ -127,7 +128,7 @@ let
           {
             failed =
               let
-                src = builtins.toFile "source.txt" ''
+                src = writeText "source.txt" ''
                   @a@
                   @b@
                 '';


### PR DESCRIPTION
I observed some failing tests due to group mismatches on Darwin, e.g.

```
--- /nix/store/w7fr9zs91z02c1bbd54lxkvipwn7xfhd-symlinkJoin
+++ /nix/store/7r2jq748ikrryqzm55cwbxqpng276wpd-symlinkJoin-foo-bar-baz
├── stat {}
│ @@ -1,7 +1,7 @@
│
│    Size: 128          Blocks: 0          IO Block: 4096   directory
│ -Device: 1,15 Access: (0555/dr-xr-xr-x)  Uid: (    0/    root)   Gid: (    0/   wheel)
│ +Device: 1,15 Access: (0555/dr-xr-xr-x)  Uid: (    0/    root)   Gid: (  350/  nixbld)
```

and

```
replaceVars-succeeds
--- /nix/store/wahj58fiii5j1jy6s9mpbdyxzhq3plnb-source.txt
+++ /nix/store/bfmykrc9r5ycy0dj8l1z2p9c5116dny8-expected
├── stat {}
│ @@ -1,7 +1,7 @@
│
│    Size: 96           Blocks: 0          IO Block: 4096   directory
│ -Device: 1,15 Access: (0555/dr-xr-xr-x)  Uid: (    0/    root)   Gid: (    0/   wheel)
│ +Device: 1,15 Access: (0555/dr-xr-xr-x)  Uid: (    0/    root)   Gid: (  350/  nixbld)
│
│  Modify: 1970-01-01 00:00:01.000000000 +0000
```

Not sure if there's a better way to do this...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
