### PR TITLE
nixos/scx-loader: fix failure to run when `/etc` is immutable

### DIFF
--- a/nixos/modules/services/scheduling/scx-loader.nix
+++ b/nixos/modules/services/scheduling/scx-loader.nix
@@ -75,7 +75,11 @@ in
       }
     ];
 
-    environment.systemPackages = [ cfg.package ] ++ cfg.schedsPackages;
+    environment = {
+      systemPackages = [ cfg.package ] ++ cfg.schedsPackages;
+      etc."scx_loader.toml".source = configFile;
+    };
+
     systemd.packages = [ cfg.package ];
     services.dbus.packages = [ cfg.package ];
 
@@ -84,10 +88,6 @@ in
     systemd.services.scx_loader = {
       path = cfg.schedsPackages;
       wantedBy = [ "multi-user.target" ];
-      serviceConfig = {
-        TemporaryFileSystem = [ "/etc" ];
-        BindReadOnlyPaths = [ "${configFile.outPath}:/etc/scx_loader.toml" ];
-      };
     };
   };
 


### PR DESCRIPTION
When `system.etc.overlay.mutable = false;`, the scx-loader fails to run unless the file `/etc/scx_loader.toml` exists or is created by scx-loader at runtime.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
