### PR TITLE
backintime-common: modernize

### DIFF
--- a/pkgs/by-name/ba/backintime-common/package.nix
+++ b/pkgs/by-name/ba/backintime-common/package.nix
@@ -15,6 +15,7 @@
   gnugrep,
   man,
   asciidoctor,
+  bashNonInteractive,
 }:
 
 let
@@ -46,6 +47,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-/33Lx62S/9RcqrfJumE6/o3KnAObBa3DcmuGkcOXIQE=";
   };
 
+  __structuredAttrs = true;
+  strictDeps = true;
+  enableParallelBuilding = true;
   outputs = [
     "out"
     "man"
@@ -55,12 +59,13 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     makeWrapper
     gettext
+    asciidoctor
+    man
   ];
 
   buildInputs = [
     python'
-    man
-    asciidoctor
+    bashNonInteractive
   ];
 
   installFlags = [ "DEST=$(out)" ];

--- a/pkgs/by-name/ba/backintime-common/package.nix
+++ b/pkgs/by-name/ba/backintime-common/package.nix
@@ -46,6 +46,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-/33Lx62S/9RcqrfJumE6/o3KnAObBa3DcmuGkcOXIQE=";
   };
 
+  outputs = [
+    "out"
+    "man"
+    "doc"
+  ];
+
   nativeBuildInputs = [
     makeWrapper
     gettext
@@ -79,7 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "'grep'" "'${lib.getExe gnugrep}'" \
 
     substituteInPlace "bitlicense.py" \
-      --replace-fail "/usr/share/doc" "$out/share/doc" \
+      --replace-fail "/usr/share/doc" "$doc/share/doc" \
   '';
 
   dontAddPrefix = true;

--- a/pkgs/by-name/ba/backintime-qt/package.nix
+++ b/pkgs/by-name/ba/backintime-qt/package.nix
@@ -49,7 +49,6 @@ stdenv.mkDerivation {
     version
     src
     installFlags
-    meta
     dontAddPrefix
     ;
 
@@ -105,4 +104,15 @@ stdenv.mkDerivation {
     wrapProgram "$out/bin/backintime-qt_polkit" \
       --prefix PATH : "${lib.getBin polkit}/bin:$PATH"
   '';
+
+  meta = {
+    inherit (backintime-common.meta)
+      homepage
+      description
+      license
+      maintainers
+      platforms
+      longDescription
+      ;
+  };
 }


### PR DESCRIPTION
Set `__structuredAttrs`, `strictDeps`, `enableParallelBuilding`. These changes did not affect the output (i.e. `nix store make-content-addressed` still gives the same output).

Also split out `man` & `doc` outputs.
This resulted in the following output size changes:
- `out`: `3152K` -> `2864K`
- `doc`: `0` -> `272K`
- `man`: `0` -> `16K`


cc:
- https://github.com/NixOS/nixpkgs/issues/178468
- https://github.com/NixOS/nixpkgs/issues/205690
- https://github.com/NixOS/nixpkgs/issues/515268

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
