### PR TITLE
python3Packages.vsts: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/vsts/default.nix
+++ b/pkgs/development/python-modules/vsts/default.nix
@@ -7,14 +7,16 @@
   msrest,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
+  pname = "vsts";
   version = "0.1.25";
   pyproject = true;
-  pname = "vsts";
+
+  __structuredAttrs = true;
 
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "15sgwqa72ynpahj101r2kc15s3dnsafg5gqx0sz3hnqz29h925ys";
+    inherit (finalAttrs) pname version;
+    hash = "sha256-2heRYBIfWzi+Bh2/8pzStg1dApsiBxAkVNd6cRTmT5c=";
   };
 
   build-system = [ setuptools ];
@@ -22,7 +24,7 @@ buildPythonPackage rec {
   dependencies = [ msrest ];
 
   postPatch = ''
-    substituteInPlace setup.py --replace "msrest>=0.6.0,<0.7.0" "msrest"
+    substituteInPlace setup.py --replace-fail "msrest>=0.6.0,<0.7.0" "msrest"
   '';
 
   # Tests are highly impure
@@ -30,10 +32,12 @@ buildPythonPackage rec {
     ${python.interpreter} -c 'import vsts.version; print(vsts.version.VERSION)'
   '';
 
+  pythonImportsCheck = [ "vsts" ];
+
   meta = {
     description = "Python APIs for interacting with and managing Azure DevOps";
     homepage = "https://github.com/microsoft/azure-devops-python-api";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/vsts/default.nix
+++ b/pkgs/development/python-modules/vsts/default.nix
@@ -3,12 +3,13 @@
   lib,
   python,
   fetchPypi,
+  setuptools,
   msrest,
 }:
 
 buildPythonPackage rec {
   version = "0.1.25";
-  format = "setuptools";
+  pyproject = true;
   pname = "vsts";
 
   src = fetchPypi {
@@ -16,7 +17,9 @@ buildPythonPackage rec {
     sha256 = "15sgwqa72ynpahj101r2kc15s3dnsafg5gqx0sz3hnqz29h925ys";
   };
 
-  propagatedBuildInputs = [ msrest ];
+  build-system = [ setuptools ];
+
+  dependencies = [ msrest ];
 
   postPatch = ''
     substituteInPlace setup.py --replace "msrest>=0.6.0,<0.7.0" "msrest"


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
