### PR TITLE
nixos/anki-sync-server: add support for hashed passwords

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -28,6 +28,8 @@
 
 - `services.llama-cpp` is now configured using structured `services.llama-cpp.settings` attribute.
 
+- `services.anki-sync-server.hashedPasswords` has had an option `services.anki-sync-server.hashedPasswords` added, which is enabled by default on `stateVersion` `26.11` and higher. Consider enabling it if you want to use hashed passwords instead of plaintext passwords for `anki-sync-server`.
+
 - Python 2 has been removed from the top-level package set, as it is long past end-of-life. The `python2`, `python27`, `python2Full`, `python27Full`, `python2Packages`, and `python27Packages` attributes, along with the legacy `python`, `pythonFull`, and `pythonPackages` aliases, now throw an error directing you to `python3`. The `isPy2` and `isPy27` package flags have been removed accordingly. The only remaining Python 2 interpreter is vendored inside the `resholve` package for its `oil` dependency and is not exposed for general use.
 
 - `systemd.user.extraConfig` has been removed in favor of the structured [](#opt-systemd.user.settings.Manager) option. Use `systemd.user.settings.Manager` to set any `systemd-user.conf(5)` option directly. For example, replace `systemd.user.extraConfig = "DefaultTimeoutStartSec=60";` with `systemd.user.settings.Manager.DefaultTimeoutStartSec = 60;`.

--- a/nixos/modules/services/misc/anki-sync-server.md
+++ b/nixos/modules/services/misc/anki-sync-server.md
@@ -42,6 +42,31 @@ Here, `passwordFile` is the path to a file containing just the password in
 plaintext. Make sure to set permissions to make this file unreadable to any
 user besides root.
 
+To avoid using plaintext passwords you can enable hashed passwords:
+(If your `stateVersion ≥ 26.11` this is enabled by default)
+```nix
+{
+  services.anki-sync-server = {
+    hashedPasswords = true;
+    users = [
+      {
+        username = "user";
+        password = "$pbkdf2-sha256$i=600000,l=32$9anYFhbNoLGCS6wz8yiNHg$4GS6mcHmjWq1cNRah7zl1EgT8TS7fk9vutL5cr9WHZc";
+      }
+    ];
+  };
+}
+```
+
+::: {.note}
+This will interpret all password options for this module as hashed passwords.
+As of writing only pbkdf2-sha256 is supported in anki for hashed passwords.
+:::
+
+::: {.tip}
+A valid pbkdf2-sha256 hash can be generated using the `pbkdf2-password-hash` package.
+:::
+
 By default, synced data are stored in */var/lib/anki-sync-server/*ankiuser**.
 You can change the directory by using `services.anki-sync-server.baseDirectory`
 

--- a/nixos/modules/services/misc/anki-sync-server.nix
+++ b/nixos/modules/services/misc/anki-sync-server.nix
@@ -69,6 +69,18 @@ in
       description = "Whether to open the firewall for the specified port.";
     };
 
+    hashedPasswords = mkOption {
+      default = if (lib.versionAtLeast config.system.stateVersion "26.11") then true else false;
+      type = types.bool;
+      example = true;
+      description = ''
+        If this option is set, all passwords specified in {option}`services.anki-sync-server.users.*.password` and {option}`services.anki-sync-server.users.*.passwordFile` need to be specified as pbkdf2-sha256 hashes instead.
+        Mixing hashed and plaintext passwords is not supported by anki.
+
+        The pbkdf2-sha256 hashes need to specified like this: `$pbkdf2-sha256$i=600000,l=32$g6qx1Io6LBOBCPaddQZGrw$nTbHvImoONfL+Ju4n2IIg0Lw+pWQvrmiGTMyE/XNejk` and can be generated using the `pbkdf2-password-hash` package.
+      '';
+    };
+
     users = mkOption {
       type =
         with types;
@@ -83,10 +95,11 @@ in
               default = null;
               description = ''
                 Password accepted by anki-sync-server for the associated username.
-                **WARNING**: This option is **not secure**. This password will
+                **WARNING**: **If** {option}`services.anki-sync-server.hashedPasswords` is disabled (this is the case for `stateVersion < 26.11`), this option is **not secure**. This password will
                 be stored in *plaintext* and will be visible to *all users*.
-                See {option}`services.anki-sync-server.users.passwordFile` for
-                a more secure option.
+
+                **NOTE**: `stateVersion ≥ 26.11` sets hashedPasswords by default.
+                See the description of {option}`services.anki-sync-server.hashedPasswords` for details on how to specify the required hash format.
               '';
             };
             passwordFile = mkOption {
@@ -96,6 +109,9 @@ in
                 File containing the password accepted by anki-sync-server for
                 the associated username.  Make sure to make readable only by
                 root.
+
+                **NOTE**: `stateVersion ≥ 26.11` requires hashedPasswords by default.
+                See the description of {option}`services.anki-sync-server.hashedPasswords` for details on how to specify the required hash format.
               '';
             };
           };
@@ -130,6 +146,7 @@ in
         StateDirectory = name;
         ExecStart = anki-sync-server-run;
         Restart = "always";
+        Environment = lib.optional cfg.hashedPasswords "PASSWORDS_HASHED=1";
         LoadCredential = map (
           x: "${specEscape x.user.username}:${specEscape (toString x.user.passwordFile)}"
         ) usersWithIndexesFile;

--- a/nixos/tests/anki-sync-server.nix
+++ b/nixos/tests/anki-sync-server.nix
@@ -44,6 +44,7 @@ let
     # and check we got it?
   '';
   testPasswordFile = pkgs.writeText "anki-password" "passfilepassword";
+  testHashedPasswordFile = pkgs.writeText "anki-password" "$pbkdf2-sha256$i=600000,l=32$RagpwNMr9yv709bN/HyvKA$UC73Ef1IBePbkpl96YKDrgj0zsWAN054cLAzm0/bpJo";
 in
 {
   name = "anki-sync-server";
@@ -54,6 +55,7 @@ in
   nodes.machine = {
     services.anki-sync-server = {
       enable = true;
+      hashedPasswords = false;
       users = [
         {
           username = "user";
@@ -67,6 +69,22 @@ in
     };
   };
 
+  nodes.machineHashedPasswords = {
+    services.anki-sync-server = {
+      enable = true;
+      hashedPasswords = true;
+      users = [
+        {
+          username = "user";
+          password = "$pbkdf2-sha256$i=600000,l=32$g6qx1Io6LBOBCPaddQZGrw$nTbHvImoONfL+Ju4n2IIg0Lw+pWQvrmiGTMyE/XNejk";
+        }
+        {
+          username = "passfileuser";
+          passwordFile = testHashedPasswordFile;
+        }
+      ];
+    };
+  };
   testScript = ''
     start_all()
 
@@ -77,5 +95,13 @@ in
 
     with subtest("Can sync"):
         machine.succeed("${ankiSyncTest}")
+
+    with subtest("hashed passwords: Server starts successfully"):
+        # service won't start without users
+        machineHashedPasswords.wait_for_unit("anki-sync-server.service")
+        machineHashedPasswords.wait_for_open_port(27701)
+
+    with subtest("hashed passwords: Can sync"):
+        machineHashedPasswords.succeed("${ankiSyncTest}")
   '';
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Anki Sync Server currently only allows specifying passwords in plain text. (see pr #519214 for details)

## Things done
In #519214 there was some discussion on the documentation of this change.
I added that and the ability to activate the feature without having to increase the stateVersion.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
