### PR TITLE
services/parsec-host: add remote control compatibility via Sunshine backend

### DIFF
--- a/nixos/modules/services/parsec-host.nix
+++ b/nixos/modules/services/parsec-host.nix
@@ -1,0 +1,45 @@
+{ config, pkgs, lib, ... }:
+
+{
+  options.services.parsec-host = {
+    enable = lib.mkEnableOption "Parsec Host compatibility layer (via Sunshine)";
+
+    backend = lib.mkOption {
+      type = lib.types.enum [ "sunshine" "none" ];
+      default = "sunshine";
+      description = "Backend used to provide hosting capabilities for Parsec on Linux.";
+    };
+  };
+
+  config = lib.mkIf config.services.parsec-host.enable {
+    environment.systemPackages = with pkgs; [
+      parsec
+      (if config.services.parsec-host.backend == "sunshine" then sunshine else null)
+    ];
+
+    services.udev.extraRules = [
+      "KERNEL==\"uinput\", MODE=\"0660\", GROUP=\"input\""
+    ];
+
+    users.users.parsec-host = {
+      isNormalUser = true;
+      extraGroups = [ "input" "video" "audio" ];
+    };
+
+    networking.firewall.allowedTCPPorts = [ 47984 47989 ];
+    networking.firewall.allowedUDPPorts = [ 47998 47999 48000 ];
+
+    systemd.services.parsec-host-sunshine = lib.mkIf (config.services.parsec-host.backend == "sunshine") {
+      description = "Parsec Host Compatibility Service (Sunshine)";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = "${pkgs.sunshine}/bin/sunshine";
+        Restart = "on-failure";
+        User = "parsec-host";
+        Group = "parsec-host";
+        Environment = "DISPLAY=:0";
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Description

Add `services.parsec-host` module to enable Parsec-like remote control functionality on NixOS.

Since Parsec does not officially support hosting on Linux, this module integrates **Sunshine** as the hosting backend, providing:

- High-performance remote desktop streaming (low latency)
- Input injection (keyboard/mouse control) via `uinput`
- Firewall configuration for required ports
- Dedicated service user for isolation

## Motivation

Users running NixOS who want to control their machine remotely (as a host) cannot do so with the official Parsec client, as hosting is Windows/macOS only.

## Changes

- Added `nixos/modules/services/parsec-host.nix`
- Module provides `services.parsec-host` option with `enable` and `backend` settings
- Installs `parsec` (client) and `sunshine` (hosting backend)
- Configures `uinput` udev rules for input control
- Opens firewall ports (TCP 47984, 47989; UDP 47998-48000)
- Sets up systemd service for Sunshine

## Testing

Users can enable with:

```nix
services.parsec-host = {
  enable = true;
  backend = "sunshine";
};
```

Then connect from any Parsec/Moonlight client.

## Checklist

- [ ] Tests added/updated
- [ ] Module follows NixOS conventions
- [ ] Documentation updated (if applicable)