### PR TITLE
python3Packages.curl-cffi: add missing `rich` dependency

### DIFF
--- a/pkgs/development/python-modules/curl-cffi/default.nix
+++ b/pkgs/development/python-modules/curl-cffi/default.nix
@@ -17,6 +17,7 @@
   pytest-trio,
   pytestCheckHook,
   python-multipart,
+  rich,
   trustme,
   uvicorn,
   websockets,
@@ -46,6 +47,7 @@ buildPythonPackage rec {
   dependencies = [
     cffi
     certifi
+    rich
   ];
 
   pythonImportsCheck = [ "curl_cffi" ];


### PR DESCRIPTION
otherwise `$out/bin/curl-cffi` fails:
> Traceback (most recent call last):
>   File "/nix/store/jdi22r7swyiml492lms3ril9b45phmf9-python3.13-curl-cffi-0.15.0/bin/.curl-cffi-wrapped", line 6, in <module>
>     from curl_cffi.cli import main
>   File "/nix/store/jdi22r7swyiml492lms3ril9b45phmf9-python3.13-curl-cffi-0.15.0/lib/python3.13/site-packages/curl_cffi/cli/__init__.py", line 6, in <module>
>     from .run import handle_run, parse_http_file  # noqa: F401
>     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/nix/store/jdi22r7swyiml492lms3ril9b45phmf9-python3.13-curl-cffi-0.15.0/lib/python3.13/site-packages/curl_cffi/cli/run.py", line 11, in <module>
>     from .request import _execute_request
>   File "/nix/store/jdi22r7swyiml492lms3ril9b45phmf9-python3.13-curl-cffi-0.15.0/lib/python3.13/site-packages/curl_cffi/cli/request.py", line 12, in <module>
>     from .output import determine_print_spec, handle_download, print_output
>   File "/nix/store/jdi22r7swyiml492lms3ril9b45phmf9-python3.13-curl-cffi-0.15.0/lib/python3.13/site-packages/curl_cffi/cli/output.py", line 12, in <module>
>     from rich.console import Console
> ModuleNotFoundError: No module named 'rich'

`rich` was being propagated by `litestar` -- added to `nativeCheckInputs` in 4985af20df0a. build with `doCheck = false` and it's clear that upstream wants `rich` at runtime:

> Running phase: pythonRuntimeDepsCheckHook
> Executing pythonRuntimeDepsCheck
> Checking runtime dependencies for curl_cffi-0.15.0-cp310-abi3-linux_aarch64.whl
>   - rich not installed


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
