### PR TITLE
mirth: init at 0-unstable-2026-05-28

### DIFF
--- a/pkgs/applications/editors/vim/plugins/non-generated/mirth/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/mirth/default.nix
@@ -1,0 +1,15 @@
+{ vimUtils, mirth }:
+
+vimUtils.buildVimPlugin {
+  pname = "mirth";
+  inherit (mirth) version;
+  src = mirth.vim;
+  meta = {
+    inherit (mirth.meta)
+      homepage
+      license
+      platforms
+      ;
+    description = "Syntax highlighting & filetype detection for the Mirth programming language";
+  };
+}

--- a/pkgs/by-name/mi/mirth/package.nix
+++ b/pkgs/by-name/mi/mirth/package.nix
@@ -1,0 +1,106 @@
+{
+  lib,
+  fetchFromSourcehut,
+  buildPackages,
+  stdenv,
+  makeBinaryWrapper,
+}:
+
+stdenv.mkDerivation {
+  name = "mirth";
+  version = "0-unstable-2026-05-28";
+
+  src = fetchFromSourcehut {
+    owner = "~typeswitch";
+    repo = "mirth";
+    rev = "b180112a547cb803e3bf5720a0bb08f8bffa9742";
+    hash = "sha256-6nd1DrN3sGobmOh+E/8hYUFW2tBSFLdaEPXrViKDVSc=";
+  };
+
+  outputs = [
+    "out"
+    "lib"
+    "bin"
+    "doc"
+    "examples"
+    "vim"
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  postPatch = ''
+    # Replace hard-coded GCC with stdenv’s C compiler.
+    # NOTE: newer GCC requires optimization level ≥1 to use fortity. -O1 is
+    # fast enough as a default for the compiler stages.
+    substituteInPlace Makefile \
+      --replace-fail "-O0" "-O1" \
+      --replace-fail "CC=gcc \$(C99FLAGS)" "CC=${buildPackages.stdenv.cc.targetPrefix}cc \$(C99FLAGS)"
+
+    # Override the final binary, mirth3, with the target’s C compiler & -O2
+    # optimization for distribution.
+    echo "bin/mirth3: CC := ${stdenv.cc.targetPrefix}cc \$(C99FLAGS) -O2" >>Makefile
+  '';
+
+  buildFlags = [
+    "bin/mirth2"
+    "bin/mirth3"
+  ];
+
+  doCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -d "$lib/lib/mirth" "$doc/share/doc/mirth/tutorial" \
+      "$examples/share/mirth/examples" "$vim/share/vim-plugins/mirth"
+
+    cp -Tr lib "$lib/lib/mirth"
+    cp -Tr examples "$examples/share/mirth/examples"
+    cp -Tr tutorial "$doc/share/doc/mirth/tutorial"
+    cp -Tr tools/mirth-vim  "$vim/share/vim-plugins/mirth"
+
+    bin/mirth2 src/main.mth --docs "$doc/share/doc/mirth" -c
+    install -Dm644 LICENSE README.md -t "$doc/share/doc/mirth"
+
+    # stages 0–2 aren’t needed anymore
+    install -Dm755 bin/mirth3 "$bin/bin/mirth"
+
+    runHook postInstall
+  '';
+
+  # The raw binary @ $bin needs wrapping to get the stdlib @ $lib. By wrapping
+  # it here, it will be more flexible towards allowing users to wrap the Mirth
+  # binary with their own stdlib & other packages.
+  postFixup = ''
+    makeBinaryWrapper "$bin/bin/mirth" "$out/bin/mirth" \
+      --add-flags "-P $lib/lib/mirth"
+  '';
+
+  meta = {
+    description = "Concatenative functional programming language with strong static linear types";
+    longDescription = ''
+      Mirth is inspired by Forth, Joy, Haskell, Lisp, and monoidal category theory.
+      Mirth compiles to C99.
+    '';
+    homepage = "https://git.sr.ht/~typeswitch/mirth";
+    license = lib.licenses.bsd0;
+    mainProgram = "mirth";
+    # https://git.sr.ht/~typeswitch/mirth/tree/main/item/src/mirth.h#L4-22
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "aarch64-windows"
+      "i686-linux"
+      "i686-windows"
+      "x86_64-darwin"
+      "x86_64-linux"
+      "x86_64-windows"
+    ];
+    maintainers = with lib.maintainers; [ toastal ];
+  };
+}

--- a/pkgs/by-name/mi/mirth/package.nix
+++ b/pkgs/by-name/mi/mirth/package.nix
@@ -34,6 +34,14 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ makeBinaryWrapper ];
 
   postPatch = ''
+    ${lib.optionalString (with stdenv.buildPlatform; isAarch64 && isLinux) /* sh */ ''
+      # Bug report: https://todo.sr.ht/~typeswitch/mirth/16
+      substituteInPlace bin/mirth0.c \
+        --replace-fail "WRAP_I63(24LL);" "WRAP_I63(16LL);"
+      substituteInPlace lib/std/world.mth \
+        --replace-fail "Linux -> 24u," "Linux -> running-arch Arch.ARM64 = if(16u, 24u),"
+    ''}
+
     # Replace hard-coded GCC with stdenv’s C compiler.
     # NOTE: newer GCC requires optimization level ≥1 to use fortity. -O1 is
     # fast enough as a default for the compiler stages.
@@ -51,7 +59,8 @@ stdenv.mkDerivation {
     "bin/mirth3"
   ];
 
-  doCheck = true;
+  # st_mode substitution intentionally diverges from the pre-generated mirth0.c
+  doCheck = with stdenv.buildPlatform; !(isAarch64 && isLinux);
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/mi/mirth/package.nix
+++ b/pkgs/by-name/mi/mirth/package.nix
@@ -66,12 +66,12 @@ stdenv.mkDerivation {
     runHook preInstall
 
     install -d "$lib/lib/mirth" "$doc/share/doc/mirth/tutorial" \
-      "$examples/share/mirth/examples" "$vim/share/vim-plugins/mirth"
+      "$examples/share/mirth/examples" "$vim"
 
     cp -Tr lib "$lib/lib/mirth"
     cp -Tr examples "$examples/share/mirth/examples"
     cp -Tr tutorial "$doc/share/doc/mirth/tutorial"
-    cp -Tr tools/mirth-vim  "$vim/share/vim-plugins/mirth"
+    cp -Tr tools/mirth-vim  "$vim"
 
     bin/mirth2 src/main.mth --docs "$doc/share/doc/mirth" -c
     install -Dm644 LICENSE README.md -t "$doc/share/doc/mirth"

--- a/pkgs/by-name/mi/mirth/package.nix
+++ b/pkgs/by-name/mi/mirth/package.nix
@@ -17,6 +17,28 @@ stdenv.mkDerivation {
     hash = "sha256-6nd1DrN3sGobmOh+E/8hYUFW2tBSFLdaEPXrViKDVSc=";
   };
 
+  postPatch =
+    # Bug report: https://todo.sr.ht/~typeswitch/mirth/16
+    lib.optionalString (with stdenv.buildPlatform; isAarch64 && isLinux) ''
+      substituteInPlace bin/mirth0.c \
+        --replace-fail "WRAP_I63(24LL);" "WRAP_I63(16LL);"
+      substituteInPlace lib/std/world.mth \
+        --replace-fail "Linux -> 24u," "Linux -> running-arch Arch.ARM64 = if(16u, 24u),"
+    ''
+    # Replace hard-coded GCC with stdenv’s C compiler.
+    # NOTE: newer GCC requires optimization level ≥1 to use fortity. -O1 is
+    # fast enough as a default for the compiler stages.
+    + ''
+      substituteInPlace Makefile \
+        --replace-fail "-O0" "-O1" \
+        --replace-fail "CC=gcc \$(C99FLAGS)" "CC=${buildPackages.stdenv.cc.targetPrefix}cc \$(C99FLAGS)"
+    ''
+    # Override the final binary, mirth3, with the target’s C compiler & -O2
+    # optimization for distribution.
+    + ''
+      echo "bin/mirth3: CC := ${stdenv.cc.targetPrefix}cc \$(C99FLAGS) -O2" >>Makefile
+    '';
+
   outputs = [
     "out"
     "lib"
@@ -32,27 +54,6 @@ stdenv.mkDerivation {
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   nativeBuildInputs = [ makeBinaryWrapper ];
-
-  postPatch = ''
-    ${lib.optionalString (with stdenv.buildPlatform; isAarch64 && isLinux) /* sh */ ''
-      # Bug report: https://todo.sr.ht/~typeswitch/mirth/16
-      substituteInPlace bin/mirth0.c \
-        --replace-fail "WRAP_I63(24LL);" "WRAP_I63(16LL);"
-      substituteInPlace lib/std/world.mth \
-        --replace-fail "Linux -> 24u," "Linux -> running-arch Arch.ARM64 = if(16u, 24u),"
-    ''}
-
-    # Replace hard-coded GCC with stdenv’s C compiler.
-    # NOTE: newer GCC requires optimization level ≥1 to use fortity. -O1 is
-    # fast enough as a default for the compiler stages.
-    substituteInPlace Makefile \
-      --replace-fail "-O0" "-O1" \
-      --replace-fail "CC=gcc \$(C99FLAGS)" "CC=${buildPackages.stdenv.cc.targetPrefix}cc \$(C99FLAGS)"
-
-    # Override the final binary, mirth3, with the target’s C compiler & -O2
-    # optimization for distribution.
-    echo "bin/mirth3: CC := ${stdenv.cc.targetPrefix}cc \$(C99FLAGS) -O2" >>Makefile
-  '';
 
   buildFlags = [
     "bin/mirth2"


### PR DESCRIPTION
Mirth is a concatenative functional programming language with strong static linear types.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.