### PR TITLE
memento: 1.7.0 -> 2.0.0

### DIFF
--- a/pkgs/by-name/me/memento/package.nix
+++ b/pkgs/by-name/me/memento/package.nix
@@ -42,31 +42,38 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "memento";
-  version = "1.7.0";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
     owner = "ripose-jp";
     repo = "Memento";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-6ipzorykt9GoGTHTTLCyDf7vXx9mT5AITKA9pyQ3GwI=";
+    hash = "sha256-Mg6Gxy8FwqNjE9m4uOQnEY95PZJSQllDBU2KnS8UOHE=";
   };
 
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail $'\tQml\n' $'\tQml\n\tQmlPrivate\n'
+  '';
+
   cmakeFlags = [
-    (lib.cmakeBool "SYSTEM_QCORO" true)
-    (lib.cmakeBool "SYSTEM_MOCR" true)
+    (lib.cmakeBool "MEMENTO_SYSTEM_QCORO" true)
+    (lib.cmakeBool "MEMENTO_SYSTEM_MOCR" true)
   ]
   ++ lib.optionals withOcr [
-    (lib.cmakeBool "OCR_SUPPORT" true)
+    (lib.cmakeBool "MEMENTO_OCR_SUPPORT" true)
   ];
 
   nativeBuildInputs = [
     cmake
     makeWrapper
+    qt6Packages.qttools
     qt6Packages.wrapQtAppsHook
   ];
 
   buildInputs = [
     qt6Packages.qtbase
+    qt6Packages.qtdeclarative
     qt6Packages.qtsvg
     qt6Packages.qtwayland
     sqlite


### PR DESCRIPTION
       > -- Could NOT find Qt6LinguistTools (missing: Qt6LinguistTools_DIR)
       > CMake Error at CMakeLists.txt:169 (find_package):
       >   Found package configuration file:

TODO: squash to change commit message

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
