### PR TITLE
python3Packages.unearth: fix tests with new pacakging 26.0

### DIFF
--- a/pkgs/development/python-modules/unearth/0001-fix-support-packaging-26.0-changes.patch
+++ b/pkgs/development/python-modules/unearth/0001-fix-support-packaging-26.0-changes.patch
@@ -1,0 +1,16 @@
+# From https://github.com/frostming/unearth/commit/69ece0800edeefb1daf035bb0ee348e17a4393fd
+
+--- a/tests/test_evaluator.py
++++ b/tests/test_evaluator.py
+@@ -251,9 +251,9 @@
+         ("8.1.3", ">=8.0", None, True),
+         ("7.1", ">=8.0", None, False),
+         ("8.0.0a0", ">=8.0.0dev0", None, True),
+-        ("8.0.0dev0", ">=7", None, False),
++        ("8.0.0dev0", ">=7", False, False),
+         ("8.0.0dev0", ">=7", True, True),
+-        ("8.0.0a0", "", None, False),
++        ("8.0.0a0", "", False, False),
+         ("8.0.0a0", ">=8.0.0dev0", False, False),
+     ],
+ )

--- a/pkgs/development/python-modules/unearth/default.nix
+++ b/pkgs/development/python-modules/unearth/default.nix
@@ -23,6 +23,10 @@ buildPythonPackage rec {
     hash = "sha256-HlPX9S9G3V+HXnf/HFWxJHfiFaCS5LZsl2SnffSptSA=";
   };
 
+  patches = [
+    ./0001-fix-support-packaging-26.0-changes.patch
+  ];
+
   build-system = [ pdm-backend ];
 
   dependencies = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* Resolves #529384 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
