### PR TITLE
p2pool: 4.14 -> 4.16

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12197,6 +12197,11 @@
     github = "james-atkins";
     githubId = 9221409;
   };
+  jamesgallicchio = {
+    name = "James Gallicchio";
+    github = "JamesGallicchio";
+    githubId = 13753903;
+  };
   jamespeapen = {
     name = "James Eapen";
     email = "james.eapen@vai.org";

--- a/pkgs/by-name/p2/p2pool/package.nix
+++ b/pkgs/by-name/p2/p2pool/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "p2pool";
-  version = "4.14";
+  version = "4.16";
 
   src = fetchFromGitHub {
     owner = "SChernykh";
     repo = "p2pool";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-osVzCx5h52qbSG4iwd3r7lsxtkqakGDJp6W3Xfs0t4E=";
+    hash = "sha256-PXJT+hFLD4LSy11/FvzDhi3RdsDYuzcxqr3nYn5XzDk=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/p2/p2pool/package.nix
+++ b/pkgs/by-name/p2/p2pool/package.nix
@@ -62,6 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
       ratsclub
       JacoMalan1
       jk
+      jamesgallicchio
     ];
     mainProgram = "p2pool";
     platforms = lib.platforms.all;


### PR DESCRIPTION
Supercedes #518294

Changelogs:
- v4.15 https://github.com/SChernykh/p2pool/releases/tag/v4.15
- v4.15.1 https://github.com/SChernykh/p2pool/releases/tag/v4.15.1
- v4.16 https://github.com/SChernykh/p2pool/releases/tag/v4.16

4.16 apparently fixes a vulnerability in the p2pool consensus algorithm, so it is a somewhat urgent update for miners.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
