### PR TITLE
python3Packages.crytic-compile: 0.3.11 -> 0.4.1, migrate to pyproject, enable __structuredAttrs, use finalAttrs

### DIFF
--- a/pkgs/development/python-modules/crytic-compile/default.nix
+++ b/pkgs/development/python-modules/crytic-compile/default.nix
@@ -9,7 +9,7 @@
   toml,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "crytic-compile";
   version = "0.3.11";
   format = "setuptools";
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "crytic";
     repo = "crytic-compile";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-NVAIVUfh1bizg/HG1z7Ze6o5w6wto744Ogq0LPg0gXg=";
   };
 
@@ -41,11 +41,11 @@ buildPythonPackage rec {
     description = "Abstraction layer for smart contract build systems";
     mainProgram = "crytic-compile";
     homepage = "https://github.com/crytic/crytic-compile";
-    changelog = "https://github.com/crytic/crytic-compile/releases/tag/${src.tag}";
+    changelog = "https://github.com/crytic/crytic-compile/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.agpl3Plus;
     maintainers = with lib.maintainers; [
       arturcygan
       hellwolf
     ];
   };
-}
+})

--- a/pkgs/development/python-modules/crytic-compile/default.nix
+++ b/pkgs/development/python-modules/crytic-compile/default.nix
@@ -1,18 +1,19 @@
 {
   lib,
   buildPythonPackage,
-  cbor2,
   fetchFromGitHub,
+  pytestCheckHook,
+  uv-build,
+  cbor2,
   pycryptodome,
-  setuptools,
   solc-select,
-  toml,
+  solc,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "crytic-compile";
-  version = "0.3.11";
-  format = "setuptools";
+  version = "0.4.1";
+  pyproject = true;
 
   __structuredAttrs = true;
 
@@ -20,19 +21,33 @@ buildPythonPackage (finalAttrs: {
     owner = "crytic";
     repo = "crytic-compile";
     tag = finalAttrs.version;
-    hash = "sha256-NVAIVUfh1bizg/HG1z7Ze6o5w6wto744Ogq0LPg0gXg=";
+    hash = "sha256-7FEjye7ukvNeF2LKUo4X/lAprXR87rc6WWtjBJnVL+0=";
   };
 
-  propagatedBuildInputs = [
+  dependencies = [
     cbor2
     pycryptodome
-    setuptools
     solc-select
-    toml
   ];
 
-  # Test require network access
-  doCheck = false;
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.6,<0.10" "uv_build"
+  '';
+
+  build-system = [
+    uv-build
+  ];
+
+  nativeBuildInputs = [
+    pytestCheckHook
+    solc
+  ];
+
+  # Tests require network access
+  disabledTestPaths = [
+    "tests/test_sourcify_proxy.py"
+  ];
 
   # required for import check to work
   # PermissionError: [Errno 13] Permission denied: '/homeless-shelter'

--- a/pkgs/development/python-modules/crytic-compile/default.nix
+++ b/pkgs/development/python-modules/crytic-compile/default.nix
@@ -14,6 +14,8 @@ buildPythonPackage (finalAttrs: {
   version = "0.3.11";
   format = "setuptools";
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "crytic";
     repo = "crytic-compile";

--- a/pkgs/development/python-modules/slither-analyzer/default.nix
+++ b/pkgs/development/python-modules/slither-analyzer/default.nix
@@ -39,6 +39,8 @@ buildPythonPackage (finalAttrs: {
   version = "0.11.5";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "crytic";
     repo = "slither";

--- a/pkgs/development/python-modules/slither-analyzer/default.nix
+++ b/pkgs/development/python-modules/slither-analyzer/default.nix
@@ -16,8 +16,17 @@
   web3,
 
   # tests
+  pytestCheckHook,
   versionCheckHook,
   writableTmpDirAsHomeHook,
+
+  # test dependencies
+  deepdiff,
+  filelock,
+  numpy,
+  pytest-insta,
+  pytest-xdist,
+  vyper,
 
   # postFixup
   solc,
@@ -53,15 +62,129 @@ buildPythonPackage (finalAttrs: {
   ];
 
   nativeCheckInputs = [
+    pytestCheckHook
     versionCheckHook
     writableTmpDirAsHomeHook
+
+    deepdiff
+    filelock
+    numpy
+    pytest-insta
+    pytest-xdist
+    vyper
   ];
+
   versionCheckKeepEnvironment = [ "HOME" ];
 
   postFixup = lib.optionalString withSolc ''
     wrapProgram $out/bin/slither \
       --prefix PATH : "${lib.makeBinPath [ solc ]}"
   '';
+
+  disabledTests = [
+    # Require network
+    "test_abstract_contract"
+    "test_arithmetic_usage"
+    "test_backup_source_file"
+    "test_concrete_contract"
+    "test_constant_folding_binary_expressions"
+    "test_constant_folding_rational"
+    "test_constant_folding_unary"
+    "test_contract_comments"
+    "test_contract_function_parameter"
+    "test_contract_name_collision"
+    "test_custom_storage_layout"
+    "test_cycle"
+    "test_enum_max_min"
+    "test_fallback_receive"
+    "test_find_variable_scope_with_renaming"
+    "test_function_can_send_eth"
+    "test_function_id_rec_structure"
+    "test_functions"
+    "test_functions_ids"
+    "test_inheritance_printer"
+    "test_inheritance_with_duplicate_names"
+    "test_inheritance_with_renaming"
+    "test_interface_generation"
+    "test_internal_call_reorder"
+    "test_issue_1846_ternary_in_ternary[False]"
+    "test_issue_1846_ternary_in_ternary[True]"
+    "test_local_alias"
+    "test_name_resolution_compact"
+    "test_name_resolution_legacy_post_0_5_0"
+    "test_name_resolution_legacy_pre_0_5_0"
+    "test_nested_ifs_with_loop_compact"
+    "test_nested_ifs_with_loop_legacy"
+    "test_operation_reads"
+    "test_overridden_function_reorder"
+    "test_overrides"
+    "test_parameter_no_library"
+    "test_private_variable"
+    "test_public_variable"
+    "test_reentrant"
+    "test_references_user_defined_aliases"
+    "test_references_user_defined_types_when_casting"
+    "test_return_multiple_with_struct[False]"
+    "test_return_multiple_with_struct[True]"
+    "test_scope_is_checked"
+    "test_should_mutate_function_includes_modifier"
+    "test_should_mutate_function_matching_selector"
+    "test_should_mutate_function_no_filter"
+    "test_should_mutate_function_no_match"
+    "test_slithir_printer"
+    "test_source_mapping_inheritance[0.6.12]"
+    "test_source_mapping_inheritance[0.8.7]"
+    "test_source_mapping_inheritance[0.8.8]"
+    "test_source_mapping_top_level_defs"
+    "test_storage_layout"
+    "test_struct_constructor_reorder"
+    "test_ternary_conversions"
+    "test_ternary_tuple"
+    "test_top_level_using_for"
+    "test_tuple_order"
+    "test_tuple_reassign"
+    "test_upgradeable_comments"
+    "test_upgrades_compare"
+    "test_upgrades_implementation_var"
+    "test_using_for_alias_contract"
+    "test_using_for_alias_top_level"
+    "test_using_for_constant_folding"
+    "test_using_for_global_collision"
+    "test_using_for_in_library"
+    "test_using_for_top_level_implicit_conversion"
+    "test_using_for_top_level_same_name"
+    "test_virtual_is_implemented"
+    "test_virtual_override_references_and_implementations"
+    "test_with_explicit_return[False]"
+    "test_with_explicit_return[True]"
+    "test_yul_parser_assembly_slot"
+    "test_yul_parser_sstore_sload"
+
+    # Require ganache which isn't in nixpkgs
+    "test_read_storage[StorageLayout-storage_layout]"
+    "test_read_storage[UnstructuredStorageLayout-unstructured_storage]"
+
+    # Triggers https://github.com/crytic/slither/issues/2796
+    "test_phi_entry_point_internal_call"
+    "test_call_with_default_args"
+
+    # Doesn't work with vyper >= 0.4.0
+    "test_vyper_functions"
+
+    # ERROR:CryticCompile:Constructor must be marked as `@deploy`
+    "test_references_self_identifier"
+
+    #ERROR:CryticCompile:Calls to external nonpayable functions must use the `extcall` keyword.
+    "test_interface_conversion_and_call_resolution"
+  ];
+
+  disabledTestPaths = [
+    # Errors with ConnectionError
+    "tests/unit/slithir/test_ssa_generation.py"
+
+    # Triggers https://github.com/crytic/slither/issues/2796
+    "tests/e2e/vyper_parsing/test_ast_parsing.py"
+  ];
 
   pythonImportsCheck = [
     "slither"

--- a/pkgs/development/python-modules/slither-analyzer/default.nix
+++ b/pkgs/development/python-modules/slither-analyzer/default.nix
@@ -48,6 +48,10 @@ buildPythonPackage (finalAttrs: {
     web3
   ];
 
+  pythonRelaxDeps = [
+    "crytic-compile"
+  ];
+
   nativeCheckInputs = [
     versionCheckHook
     writableTmpDirAsHomeHook


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974
- use `finalAttrs`
- enable `__structuredAttrs`
- 0.3.11 -> 0.4.1, [changelog 0.4.0](https://github.com/crytic/crytic-compile/releases/tag/0.4.0), [changelog 0.4.1](https://github.com/crytic/crytic-compile/releases/tag/0.4.1), 0.4.0 also changed the build system to use `uv_build` `pyproject.toml` with `pyproject.toml` `uv_build` instead of `setuptools` with `setup.py`
- enable most tests

Also for `python3Packages.slither-analyzer`:
- relax `crytic-compile` dependency
- enable most tests, the ones that are broken already are on master
- enable `__structuredAttrs`
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
