### PR TITLE
python3Packages.a2a-sdk: disable tests that fail on Darwin

### DIFF
--- a/pkgs/development/python-modules/a2a-sdk/default.nix
+++ b/pkgs/development/python-modules/a2a-sdk/default.nix
@@ -27,6 +27,7 @@
   sqlalchemy,
   sse-starlette,
   starlette,
+  stdenv,
   uv-dynamic-versioning,
   uvicorn,
 }:
@@ -104,10 +105,18 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "a2a" ];
 
-  disabledTests = lib.optionals (pythonAtLeast "3.14") [
-    # _pickle.PicklingError: Can't pickle local object <function...
-    "test_notification_triggering"
-  ];
+  disabledTests =
+    [ ]
+    ++ lib.optionals (pythonAtLeast "3.14") [
+      # _pickle.PicklingError: Can't pickle local object <function...
+      "test_notification_triggering"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # AttributeError: Can't get local object 'FastAPI.setup.<locals>.openap…
+      "test_notification_triggering_with_in_message_config_e2e"
+      "test_notification_triggering_after_config_change_e2e"
+      "test_trace_function_sync_attribute_extractor_error_logged"
+    ];
 
   meta = {
     description = "Python SDK for the Agent2Agent (A2A) Protocol";


### PR DESCRIPTION
Disabled three broken tests.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
