### PR TITLE
python3Packages.langsmith: 0.7.37 -> 0.8.15

### DIFF
--- a/pkgs/development/python-modules/langsmith/default.nix
+++ b/pkgs/development/python-modules/langsmith/default.nix
@@ -14,6 +14,7 @@
   requests,
   requests-toolbelt,
   uuid-utils,
+  websockets,
   xxhash,
   zstandard,
 
@@ -32,14 +33,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "langsmith";
-  version = "0.7.37";
+  version = "0.8.15";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langsmith-sdk";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-E3bszn3w7MaNLVjpgSfEQEyzzqWQp056BjXIcY9YJCM=";
+    hash = "sha256-T/ts7YRD2kUulzcRVBSgH6XXwEpDRwbZUfxx4ELv7nA=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/python";
@@ -55,6 +56,7 @@ buildPythonPackage (finalAttrs: {
     requests
     requests-toolbelt
     uuid-utils
+    websockets
     xxhash
     zstandard
   ];
@@ -101,6 +103,9 @@ buildPythonPackage (finalAttrs: {
 
     # google-adk isn't packaged (and has an enormous number of dependencies)
     "tests/unit_tests/wrappers/test_google_adk.py"
+
+    # strands-agents isn't packaged
+    "tests/unit_tests/wrappers/test_strands_agents.py"
   ];
 
   pythonImportsCheck = [ "langsmith" ];


### PR DESCRIPTION
1. Version bump
2. Disabled test that uses an unsupported package in nixpkgs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
