### PR TITLE
vscode-langservers-extracted: extract directly from vscodium 

### DIFF
--- a/pkgs/by-name/vs/vscode-langservers-extracted/package.nix
+++ b/pkgs/by-name/vs/vscode-langservers-extracted/package.nix
@@ -1,56 +1,88 @@
 {
   lib,
-  stdenv,
-  buildNpmPackage,
-  fetchFromGitHub,
-  unzip,
+  stdenvNoCC,
   vscodium,
   vscode-extensions,
+  nodejs-slim,
+  makeBinaryWrapper,
+  unzip,
+  runCommandLocal,
 }:
 
-buildNpmPackage rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
+  inherit (vscodium) version src;
   pname = "vscode-langservers-extracted";
-  version = "4.10.0";
 
-  srcs = [
-    (fetchFromGitHub {
-      owner = "hrsh7th";
-      repo = "vscode-langservers-extracted";
-      rev = "v${version}";
-      hash = "sha256-3m9+HZY24xdlLcFKY/5DfvftqprwLJk0vve2ZO1aEWk=";
-    })
-    vscodium.src
+  sourceRoot =
+    if stdenvNoCC.hostPlatform.isDarwin then
+      "VSCodium.app/Contents/Resources/app/extensions"
+    else
+      "resources/app/extensions";
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+  ]
+  # The Darwin release is a zip.
+  # stdenv unpacks the Linux tarball (tar.gz) natively.
+  # FIXME: update vscodium.src to use fetchTarball & fetchZip
+  ++ lib.optionals stdenvNoCC.hostPlatform.isDarwin [
+    unzip
   ];
 
-  sourceRoot = "source";
+  __structuredAttrs = true;
+  strictDeps = true;
+  dontConfigure = true;
+  dontBuild = true;
 
-  npmDepsHash = "sha256-XGlFtmikUrnnWXsAYzTqw2K7Y2O0bUtYug0xXFIASBQ=";
+  installPhase = ''
+    runHook preInstall
 
-  nativeBuildInputs = [ unzip ];
+    for language in css html json; do
+      server="$language-language-features/server/dist/node/''${language}ServerMain.js"
+      install -Dm644 "$server" \
+        "$out/lib/extensions/$server"
+      makeBinaryWrapper ${lib.getExe nodejs-slim} "$out/bin/vscode-$language-language-server" \
+        --add-flag "$out/lib/extensions/$server"
+    done
 
-  buildPhase =
-    let
-      extensions =
-        if stdenv.hostPlatform.isDarwin then
-          "../VSCodium.app/Contents/Resources/app/extensions"
-        else
-          "../resources/app/extensions";
-    in
-    ''
-      npx babel ${extensions}/css-language-features/server/dist/node \
-        --out-dir lib/css-language-server/node/
-      npx babel ${extensions}/html-language-features/server/dist/node \
-        --out-dir lib/html-language-server/node/
-      npx babel ${extensions}/json-language-features/server/dist/node \
-        --out-dir lib/json-language-server/node/
-      cp -r ${vscode-extensions.dbaeumer.vscode-eslint}/share/vscode/extensions/dbaeumer.vscode-eslint/server/out \
-        lib/eslint-language-server
-    '';
+    server="eslint-language-features/server/out/eslintServer.js"
+    install -Dm644 "${vscode-extensions.dbaeumer.vscode-eslint}/share/vscode/extensions/dbaeumer.vscode-eslint/server/out/eslintServer.js" \
+      "$out/lib/extensions/$server"
+    makeBinaryWrapper ${lib.getExe nodejs-slim} "$out/bin/vscode-eslint-language-server" \
+      --add-flag "$out/lib/extensions/$server"
+
+    # Use VSCodium bundled TypeScript
+    mkdir -p "$out/lib/extensions/node_modules"
+    cp -a node_modules/typescript "$out/lib/extensions/node_modules/typescript"
+
+    runHook postInstall
+  '';
+
+  passthru.tests.initialization =
+    runCommandLocal "vscode-langservers-extracted-initialization"
+      {
+        nativeBuildInputs = [ finalAttrs.finalPackage ];
+      }
+      ''
+        request() {
+          init_request='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":null,"rootUri":null,"capabilities":{}}}'
+          content_length=''${#init_request}
+          printf "Content-Length: %d\r\n\r\n%s" "$content_length" "$init_request"
+          sleep 1
+        }
+
+        for language in css html json eslint; do
+          echo "Checking $language language server"
+          response=$(request | timeout 3 "vscode-$language-language-server" --stdio) || true
+          grep -q '"capabilities"' <<< "$response"
+        done
+
+        touch $out
+      '';
 
   meta = {
+    inherit (vscodium.meta) license platforms;
     description = "HTML/CSS/JSON/ESLint language servers extracted from vscode";
-    homepage = "https://github.com/hrsh7th/vscode-langservers-extracted";
-    license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ lord-valen ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Resolves #531366

Replaces the use of `hrsh7th/vscode-langservers-extracted` with direct  wrappers instead.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
