### PR TITLE
pdm: 2.26.6 -> 2.27.0, unbreak

### DIFF
--- a/pkgs/by-name/pd/pdm/package.nix
+++ b/pkgs/by-name/pd/pdm/package.nix
@@ -12,13 +12,6 @@ let
   python = python3.override {
     self = python;
     packageOverrides = _: super: {
-      resolvelib = super.resolvelib.overridePythonAttrs (old: rec {
-        version = "1.1.0";
-        src = old.src.override {
-          tag = version;
-          hash = "sha256-UBdgFN+fvbjz+rp8+rog8FW2jwO/jCfUPV7UehJKiV8=";
-        };
-      });
       # pdm requires ...... -> ghostscript-with-X which is AGPL only
       matplotlib = super.matplotlib.override { enableTk = false; };
       # pdm requires ...... -> jbig2dec which is AGPL only
@@ -30,14 +23,14 @@ let
 in
 python.pkgs.buildPythonApplication rec {
   pname = "pdm";
-  version = "2.26.6";
+  version = "2.27.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pdm-project";
     repo = "pdm";
     tag = version;
-    hash = "sha256-khgaI9ivwF6i2zlW57vQtBwQpk5mzYVCV4lMOio7ibw=";
+    hash = "sha256-Ju1UoyThWoPnU9HJzdgA9ry+G1pXOhXmPIoydTg7VXo=";
   };
 
   pythonRelaxDeps = [ "hishel" ];

--- a/pkgs/development/python-modules/unearth/default.nix
+++ b/pkgs/development/python-modules/unearth/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  fetchpatch,
   packaging,
   pdm-backend,
   httpx,
@@ -22,6 +23,16 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-HlPX9S9G3V+HXnf/HFWxJHfiFaCS5LZsl2SnffSptSA=";
   };
+
+  patches = [
+    # https://github.com/frostming/unearth/pull/176
+    (fetchpatch {
+      name = "fix-packaging-26.0-changes.patch";
+      url = "https://github.com/frostming/unearth/commit/69ece0800edeefb1daf035bb0ee348e17a4393fd.patch";
+      hash = "sha256-t/Ubv9qC1Fvh4JsnfVgOZO/O7ZpCGHugBUt9qAjnH8c=";
+      excludes = [ "pdm.lock" ];
+    })
+  ];
 
   build-system = [ pdm-backend ];
 


### PR DESCRIPTION
- **python3Packages.unearth: unbreak with patch from upstream**
- **pdm: 2.26.6 -> 2.27.0**

The downgraded resolvelib is not compatible with the newest `packaging`, I checked upstream and they have explicitly enabled a newer version of resolvelib.

* fixes https://hydra.nixos.org/build/329669767
* fixes https://hydra.nixos.org/build/330615863
* fixes https://github.com/NixOS/nixpkgs/issues/512985
* fixes https://github.com/NixOS/nixpkgs/issues/529384
* closes https://github.com/NixOS/nixpkgs/pull/513116
* closes https://github.com/NixOS/nixpkgs/pull/505960
* closes https://github.com/NixOS/nixpkgs/pull/531757

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
