### PR TITLE
python3Packages.githubkit: 0.14.4 -> 0.16.0, unbreak

### DIFF
--- a/pkgs/development/python-modules/githubkit/default.nix
+++ b/pkgs/development/python-modules/githubkit/default.nix
@@ -8,55 +8,105 @@
   pydantic,
   pyjwt,
   pytest-cov-stub,
-  pytest-xdist,
   pytestCheckHook,
   typing-extensions,
   uv-build,
 }:
 
-buildPythonPackage rec {
+let
+
+  mkGithubkitSchema =
+    {
+      pname,
+      version,
+      src,
+    }:
+    buildPythonPackage {
+      inherit pname version src;
+      sourceRoot = "${src.name}/packages/${pname}";
+      pyproject = true;
+
+      # circular dependencies
+      pythonRemoveDeps = [
+        "githubkit"
+        "githubkit-schemas"
+      ];
+
+      build-system = [ uv-build ];
+    };
+
+in
+
+buildPythonPackage (finalAttrs: {
   pname = "githubkit";
-  version = "0.14.4";
+  version = "0.16.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "yanyongyu";
     repo = "githubkit";
-    tag = "v${version}";
-    hash = "sha256-ia4ixtui7F8NauytXYi2aaiKXejIOHNijQrSm2RtzdU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-zVUJWwmRx/2phkDWwWyazhPdwthsMMcE0S7E4R1TebQ=";
   };
 
-  pythonRelaxDeps = [ "hishel" ];
+  passthru.schemas = {
+    githubkit-schemas = mkGithubkitSchema {
+      pname = "githubkit-schemas";
+      version = "26.6.14";
+      inherit (finalAttrs) src;
+    };
+
+    githubkit-schemas-2022-11-28 = mkGithubkitSchema {
+      pname = "githubkit-schemas-2022-11-28";
+      version = "26.6.14";
+      inherit (finalAttrs) src;
+    };
+
+    githubkit-schemas-2026-03-10 = mkGithubkitSchema {
+      pname = "githubkit-schemas-2026-03-10";
+      version = "26.6.14";
+      inherit (finalAttrs) src;
+    };
+
+    githubkit-schemas-ghec-2022-11-28 = mkGithubkitSchema {
+      pname = "githubkit-schemas-ghec-2022-11-28";
+      version = "26.6.14";
+      inherit (finalAttrs) src;
+    };
+
+    githubkit-schemas-ghec-2026-03-10 = mkGithubkitSchema {
+      pname = "githubkit-schemas-ghec-2026-03-10";
+      version = "26.6.14";
+      inherit (finalAttrs) src;
+    };
+  };
 
   build-system = [ uv-build ];
 
   dependencies = [
-    hishel
+    anyio
     httpx
-    pydantic
+    hishel
     typing-extensions
-  ];
+    pydantic
+  ]
+  ++ hishel.optional-dependencies.async
+  ++ hishel.optional-dependencies.httpx
+  # for simplicity we just propagate all schemas, rather than litter pkgs/development/python-modules
+  ++ lib.attrValues finalAttrs.passthru.schemas;
 
   optional-dependencies = {
-    all = [
-      anyio
-      pyjwt
-    ];
+    all = [ pyjwt ];
     jwt = [ pyjwt ];
     auth-app = [ pyjwt ];
-    auth-oauth-device = [ anyio ];
-    auth = [
-      anyio
-      pyjwt
-    ];
+    auth-oauth-device = [ ];
+    auth = [ pyjwt ];
   };
 
   nativeCheckInputs = [
     pytestCheckHook
     pytest-cov-stub
-    pytest-xdist
-  ]
-  ++ lib.concatAttrValues optional-dependencies;
+  ];
 
   pythonImportsCheck = [ "githubkit" ];
 
@@ -71,11 +121,10 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    broken = true;
     description = "GitHub SDK for Python";
     homepage = "https://github.com/yanyongyu/githubkit";
-    changelog = "https://github.com/yanyongyu/githubkit/releases/tag/${src.tag}";
+    changelog = "https://github.com/yanyongyu/githubkit/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/hishel/default.nix
+++ b/pkgs/development/python-modules/hishel/default.nix
@@ -1,35 +1,35 @@
 {
   lib,
+  anyio,
   anysqlite,
-  boto3,
   buildPythonPackage,
   fetchFromGitHub,
+  fastapi,
   hatch-fancy-pypi-readme,
   hatchling,
   httpx,
   inline-snapshot,
-  moto,
   msgpack,
   pytest-asyncio,
   pytestCheckHook,
-  pyyaml,
   redis,
   redisTestHook,
+  requests,
+  fakeredis,
   time-machine,
-  trio,
   typing-extensions,
 }:
 
 buildPythonPackage rec {
   pname = "hishel";
-  version = "1.1.10";
+  version = "1.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "karpetrosyan";
     repo = "hishel";
     tag = version;
-    hash = "sha256-+DAB1zVolAyzKXnOjxrvhqGLMBECY7Hmwt7IWLoOV/g=";
+    hash = "sha256-aD6sHMM7dzy6n1EJN/+K+7H5nu5ohGfru224pSAf1Nc=";
   };
 
   postPatch = ''
@@ -42,26 +42,28 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
-    httpx
     msgpack
     typing-extensions
   ];
 
   optional-dependencies = {
+    async = [
+      anyio
+      anysqlite
+    ];
+    requests = [ requests ];
+    httpx = [ httpx ];
+    fastapi = [ fastapi ];
     redis = [ redis ];
-    s3 = [ boto3 ];
-    sqlite = [ anysqlite ];
-    yaml = [ pyyaml ];
   };
 
   nativeCheckInputs = [
     inline-snapshot
-    moto
     pytest-asyncio
     pytestCheckHook
     redisTestHook
+    fakeredis
     time-machine
-    trio
   ]
   ++ lib.concatAttrValues optional-dependencies;
 


### PR DESCRIPTION
- **python3Packages.hishel: 1.1.10 -> 1.3.0**
- **python3Packages.githubkit: 0.14.4 -> 0.16.0**

---

* githubkit got marked broken during zhf, now https://github.com/yanyongyu/githubkit/issues/263 closed
* closes https://github.com/NixOS/nixpkgs/pull/470393
* fixes https://hydra.nixos.org/build/329656717

packaging the subpackages was a bit annoying, i opted not to add them to the `python3Packages` scope for simplicity.

i tested building pdm with https://github.com/NixOS/nixpkgs/pull/531813 cherrypicked into this branch, it builds :+1:


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
