### PR TITLE
lib.systems.architectures: Add PowerPC / Power ISA information

### DIFF
--- a/lib/systems/architectures.nix
+++ b/lib/systems/architectures.nix
@@ -399,6 +399,13 @@ rec {
       "altivec"
       "vsx"
     ];
+    e5500 = [
+      # v2.06, but does not implement AltiVec or VSX
+    ];
+    e6500 = [
+      "altivec"
+      # v2.06, but does not implement VSX
+    ];
     # Power ISA v2.07
     power8 = [
       "altivec"
@@ -599,6 +606,8 @@ rec {
       "power5+" = withInferiors [ "power5" ];
       power6 = withInferiors [ "power5+" ];
       power7 = withInferiors [ "power6" ];
+      e5500 = withInferiors [ "power4" ]; # does not have POWER7's usual extensions
+      e6500 = withInferiors [ "power5+" ]; # does not have POWER7's usual extensions
       power8 = withInferiors [ "power7" ];
       power9 = withInferiors [ "power8" ];
       power10 = withInferiors [ "power9" ];

--- a/lib/systems/architectures.nix
+++ b/lib/systems/architectures.nix
@@ -373,6 +373,53 @@ rec {
       "lamcas"
       "ld-seq-sa"
     ];
+
+    # Power ISA
+    # ~ PowerPC v2.01?
+    power4 = [ ];
+    G5 = [
+      "altivec"
+    ];
+    # PowerPC v2.02
+    power5 = [ ];
+    cell = [
+      "altivec"
+    ];
+    # Power ISA v2.03
+    "power5+" = [
+      "altivec"
+    ];
+    # Power ISA v2.04: no suitable -mcpu value for POWER5++ or PA6T
+    # Power ISA v2.05
+    power6 = [
+      "altivec"
+    ];
+    # Power ISA v2.06
+    power7 = [
+      "altivec"
+      "vsx"
+    ];
+    # Power ISA v2.07
+    power8 = [
+      "altivec"
+      "vsx"
+      "vsx-2"
+    ];
+    # Power ISA v3.0
+    power9 = [
+      "altivec"
+      "vsx"
+      "vsx-2"
+      "vsx-3"
+    ];
+    # Power ISA v3.1
+    power10 = [
+      "altivec"
+      "vsx"
+      "vsx-2"
+      "vsx-3"
+    ];
+
     # other
     armv5te = [ ];
     armv6 = [ ];
@@ -544,6 +591,18 @@ rec {
         "la64v1.1"
       ];
 
+      # Power ISA
+      power4 = [ ];
+      G5 = withInferiors [ "power4" ];
+      power5 = withInferiors [ "power4" ];
+      cell = withInferiors [ "power5" ];
+      "power5+" = withInferiors [ "power5" ];
+      power6 = withInferiors [ "power5+" ];
+      power7 = withInferiors [ "power6" ];
+      power8 = withInferiors [ "power7" ];
+      power9 = withInferiors [ "power8" ];
+      power10 = withInferiors [ "power9" ];
+
       # other
       armv5te = [ ];
       armv6 = [ ];
@@ -634,5 +693,9 @@ rec {
       fma4Support = featureSupport "fma4";
       lsxSupport = featureSupport "lsx";
       lasxSupport = featureSupport "lasx";
+      altivecSupport = featureSupport "altivec";
+      vsxSupport = featureSupport "vsx";
+      vsx-2Support = featureSupport "vsx-2";
+      vsx-3Support = featureSupport "vsx-3";
     };
 }

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -139,9 +139,14 @@ let
             # assume compatible cpu have all the instructions included
             final.parsed.cpu == platform.parsed.cpu
             ->
-              # if platform has gcc.arch, final must also have and can execute the gcc.arch of platform
+              # if platform has gcc.arch / gcc.cpu, final must also have and can execute the gcc.arch / gcc.cpu of platform
               (
-                platform ? gcc.arch -> final ? gcc.arch && architectures.canExecute final.gcc.arch platform.gcc.arch
+                (
+                  platform ? gcc.arch -> final ? gcc.arch && architectures.canExecute final.gcc.arch platform.gcc.arch
+                )
+                && (
+                  platform ? gcc.cpu -> final ? gcc.cpu && architectures.canExecute final.gcc.cpu platform.gcc.cpu
+                )
               )
           );
 
@@ -418,7 +423,7 @@ let
 
       }
       // mapAttrs (n: v: v final.parsed) inspect.predicates
-      // mapAttrs (n: v: v final.gcc.arch or "default") architectures.predicates
+      // mapAttrs (n: v: v final.gcc.arch or final.gcc.cpu or "default") architectures.predicates
       // args
       // {
         rust = rust // {

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -423,7 +423,14 @@ let
 
       }
       // mapAttrs (n: v: v final.parsed) inspect.predicates
-      // mapAttrs (n: v: v final.gcc.arch or final.gcc.cpu or "default") architectures.predicates
+      // (
+        let
+          defaultArchitectureTarget = if final.isPower64 && final.isLittleEndian then "power8" else "default";
+        in
+        mapAttrs (
+          n: v: v final.gcc.arch or final.gcc.cpu or defaultArchitectureTarget
+        ) architectures.predicates
+      )
       // args
       // {
         rust = rust // {

--- a/pkgs/development/libraries/nss/generic.nix
+++ b/pkgs/development/libraries/nss/generic.nix
@@ -108,7 +108,6 @@ stdenv.mkDerivation rec {
       target = getArch stdenv.hostPlatform;
       target_system = stdenv.hostPlatform.uname.system;
       host = getArch stdenv.buildPlatform;
-      targetIsPpc64le = stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isLittleEndian;
 
       buildFlags = [
         "-v"
@@ -129,8 +128,8 @@ stdenv.mkDerivation rec {
         "-DOS=${target_system}"
       ]
       ++ lib.optionals stdenv.hostPlatform.isPower [
-        "-Ddisable_altivec=${if targetIsPpc64le then "0" else "1"}"
-        "-Ddisable_crypto_vsx=${if targetIsPpc64le then "0" else "1"}"
+        "-Ddisable_altivec=${if stdenv.hostPlatform.altivecSupport then "0" else "1"}"
+        "-Ddisable_crypto_vsx=${if stdenv.hostPlatform.vsx-2Support then "0" else "1"}"
       ]
       ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
         "--disable-tests"


### PR DESCRIPTION
An idea for how to re-allow AltiVec & VSX on big-endian POWER, as long as the user makes sure that their `gcc.cpu` matches their target system's capabilities. Chose `nss` as a test for the new `altivecSupport` and `vsx-2Support` checks.

So far, only "tested" by importing Nixpkgs with `crossSystem` set to these values, and checking the values of `stdenv.hostPlatform.{altivec,vsx-2}Support`:

- `"powerpc64-linux"` -> no AltiVec, no VSX
- `{ system = "powerpc64-linux"; gcc.arch = "G5"; }` -> AltiVec, no VSX
- `"powerpc64le-linux"` -> AltiVec, VSX

This would possibly also allow users to opt into hardware-implemented IEEE quad-precision floats in glibc, but this is *wayyyyyyy* past what my hardware supports, so I likely won't be handling that :).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
