### PR TITLE
vramfs: init at unstable-2025-11-02

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21206,6 +21206,11 @@
     githubId = 20658472;
     name = "Parthiv Krishna";
   };
+  pascal = {
+    github = "Pascal0577";
+    githubId = 181921662;
+    name = "pascal";
+  };
   pascalj = {
     email = "nix@pascalj.de";
     github = "pascalj";

--- a/pkgs/by-name/vr/vramfs/package.nix
+++ b/pkgs/by-name/vr/vramfs/package.nix
@@ -1,0 +1,48 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  pkg-config,
+  fuse3,
+  opencl-clhpp,
+  ocl-icd,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vramfs";
+  version = "unstable-2025-11-02";
+
+  src = fetchFromGitHub {
+    owner = "Overv";
+    repo = "vramfs";
+    rev = "cc2605e11a08ccd5651a816d28ec4d11f18836c9";
+    hash = "sha256-BllW4kP4hYtqhhcdjz/WzunyvmaLuSFl1ia2Zad4NUM=";
+  };
+
+  strictDeps = true;
+
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    fuse3
+    opencl-clhpp
+    ocl-icd
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 bin/vramfs $out/bin/vramfs
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "VRAM based file system for Linux";
+    homepage = "https://github.com/Overv/vramfs";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "vramfs";
+    maintainers = with lib.maintainers; [ pascal ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds [vramfs](https://github.com/Overv/vramfs) to nixpkgs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
