### PR TITLE
plasma-panel-colorizer: fix presets not being listed, take 2

### DIFF
--- a/pkgs/by-name/pl/plasma-panel-colorizer/package.nix
+++ b/pkgs/by-name/pl/plasma-panel-colorizer/package.nix
@@ -37,6 +37,8 @@ stdenv.mkDerivation (finalAttrs: {
     kdePackages.plasma-desktop
   ];
 
+  propagatedUserEnvPkgs = [ glib ];
+
   strictDeps = true;
 
   cmakeFlags = [

--- a/pkgs/by-name/pl/plasma-panel-colorizer/package.nix
+++ b/pkgs/by-name/pl/plasma-panel-colorizer/package.nix
@@ -5,7 +5,16 @@
   cmake,
   kdePackages,
   nix-update-script,
+  makeWrapper,
+  python3,
+  glib,
 }:
+let
+  pythonEnv = python3.withPackages (p: [
+    p.dbus-python
+    p.pygobject3
+  ]);
+in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "plasma-panel-colorizer";
@@ -21,6 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     kdePackages.extra-cmake-modules
+    makeWrapper
   ];
 
   buildInputs = [
@@ -39,12 +49,27 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = nix-update-script { };
 
+  patches = [ ./use-dbus-service-directly.patch ];
+
+  postPatch = ''
+    substituteInPlace package/contents/ui/tools/service.py \
+      --replace-fail '#!/usr/bin/env python' '#!${lib.getExe pythonEnv}'
+  '';
+
+  postInstall = ''
+    chmod 755 $out/share/plasma/plasmoids/luisbocanegra.panel.colorizer/contents/ui/tools/{list_presets.sh,service.py}
+
+    wrapProgram $out/share/plasma/plasmoids/luisbocanegra.panel.colorizer/contents/ui/tools/service.py \
+      --prefix GI_TYPELIB_PATH : "${glib.out}/lib/girepository-1.0"
+  '';
+
   meta = {
     description = "Fully-featured widget to bring Latte-Dock and WM status bar customization features to the default KDE Plasma panel";
     homepage = "https://github.com/luisbocanegra/plasma-panel-colorizer";
     changelog = "https://github.com/luisbocanegra/plasma-panel-colorizer/blob/main/CHANGELOG.md";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ HeitorAugustoLN ];
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
     inherit (kdePackages.kwindowsystem.meta) platforms;
   };
 })

--- a/pkgs/by-name/pl/plasma-panel-colorizer/use-dbus-service-directly.patch
+++ b/pkgs/by-name/pl/plasma-panel-colorizer/use-dbus-service-directly.patch
@@ -1,0 +1,11 @@
+--- a/package/contents/ui/DBusServiceModel.qml
++++ b/package/contents/ui/DBusServiceModel.qml
+@@ -8,7 +8,7 @@ Item {
+     property string toolsDir: Qt.resolvedUrl("./tools").toString().substring(7) + "/"
+     property string serviceUtil: toolsDir + "service.py"
+     property string pythonExecutable: plasmoid.configuration.pythonExecutable
+-    property string serviceCmd: pythonExecutable + " '" + serviceUtil + "' " + Plasmoid.containment.id + " " + Plasmoid.id
++    property string serviceCmd: serviceUtil + " " + Plasmoid.containment.id + " " + Plasmoid.id
+     readonly property string service: Plasmoid.metaData.pluginId + ".c" + Plasmoid.containment.id + ".w" + Plasmoid.id
+     readonly property string path: "/preset"
+ 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Supersedes #383192. Kept the changes from what @HeitorAugustoLN (thanks for the initial work!) started except I updated the patches to make to work with plasma-panel-colorizer v7.2.0.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

