### PR TITLE
zennotes-desktop: init at 2.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13861,6 +13861,13 @@
     githubId = 2396926;
     name = "Justin Woo";
   };
+  justkrysteq = {
+    email = "justkrysteq@proton.me";
+    github = "justkrysteq";
+    githubId = 43525126;
+    name = "Krysteq";
+    matrix = "@krysteq:matrix.org";
+  };
   jvanbruegge = {
     email = "supermanitu@gmail.com";
     github = "jvanbruegge";

--- a/pkgs/by-name/ze/zennotes-desktop/package.nix
+++ b/pkgs/by-name/ze/zennotes-desktop/package.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  makeDesktopItem,
+  copyDesktopItems,
+  electron_41,
+  makeBinaryWrapper,
+  nix-update-script,
+
+  installCli ? false,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "zennotes-desktop";
+  version = "2.3.0";
+  npmDepsHash = "sha256-7IpGnxVjaJvfSZyKjOylGMhFqa1bx8Ry5O1yqYfNnCE=";
+
+  src = fetchFromGitHub {
+    owner = "ZenNotes";
+    repo = "zennotes";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+tLPVnnMbtMa5blSwHav9ZMlnkUsrdG62mMGxhbmy6g=";
+  };
+
+  npmWorkspace = "apps/desktop";
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    copyDesktopItems
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/node_modules/zennotes-monorepo
+    cp -r . $out/lib/node_modules/zennotes-monorepo/
+
+    for icon in apps/desktop/build/icons/*.png; do
+      size="$(basename "$icon" .png)"
+      install -Dm644 $icon $out/share/icons/hicolor/$size/apps/zennotes-desktop.png
+    done
+
+    mkdir -p $out/bin
+    makeWrapper ${electron_41}/bin/electron $out/bin/zennotes-desktop \
+      --add-flags "$out/lib/node_modules/zennotes-monorepo/apps/desktop"
+
+    ${lib.optionalString installCli ''
+      makeWrapper ${electron_41}/libexec/electron/electron $out/bin/zen \
+        --set ELECTRON_RUN_AS_NODE 1 \
+        --add-flags "$out/lib/node_modules/zennotes-monorepo/apps/desktop/out/main/cli.js"
+    ''}
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "zennotes-desktop";
+      desktopName = "ZenNotes";
+      exec = "zennotes-desktop %U";
+      icon = "zennotes-desktop";
+      comment = "Keyboard-first local Markdown notes";
+      categories = [
+        "Office"
+        "Utility"
+        "TextEditor"
+      ];
+      startupWMClass = "ZenNotes";
+      mimeTypes = [
+        "text/markdown"
+        "x-scheme-handler/zennotes"
+      ];
+    })
+  ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };
+
+  meta = {
+    description = "Keyboard-first local Markdown notes with Vim motions, diagrams, and MCP integration";
+    homepage = "https://zennotes.org/";
+    changelog = "https://github.com/ZenNotes/zennotes/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ justkrysteq ];
+    mainProgram = "zennotes-desktop";
+    platforms = lib.platforms.darwin ++ lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
This PR adds [ZenNotes](https://zennotes.org/) desktop client. ZenNotes is a keyboard-first local Markdown note-taking app with Vim motions, pretty similar to [Obsidian](https://obsidian.md/).

I am aware that [this PR](https://github.com/NixOS/nixpkgs/pull/530901) and [this PR](https://github.com/NixOS/nixpkgs/pull/531516) exist, yet they don't share the behavior I included for the [CLI](https://zennotes.org/#cli) and they don't take into account that the server version exists (for which I have another package already). 

I originally planned to get it upstreamed here after [this PR](https://github.com/ZenNotes/zennotes/pull/149) got merged, but it looks like the interest is higher than expected as proven by [this repo](https://github.com/ptdewey/zennotes-flake) and [this repo](https://github.com/Nuhddy/zennotes-flake), so to prevent more implementations of the same package from being created like [here](https://github.com/ZenNotes/zennotes/pull/176) I'm doing it now. I'll make a PR for the server package later because there's a smaller interest in it.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
