### PR TITLE
yanone-kaffeesatz: build from source, use installFonts

### DIFF
--- a/pkgs/by-name/ya/yanone-kaffeesatz/package.nix
+++ b/pkgs/by-name/ya/yanone-kaffeesatz/package.nix
@@ -1,32 +1,73 @@
 {
   lib,
   stdenvNoCC,
-  fetchzip,
+  fetchFromGitHub,
+  yq-go,
+  python3Packages,
+  installFonts,
 }:
 
 stdenvNoCC.mkDerivation {
   pname = "yanone-kaffeesatz";
-  version = "2004";
+  version = "2.003-unstable-2023-12-13";
 
-  src = fetchzip {
-    url = "https://yanone.de/2015/data/UIdownloads/Yanone%20Kaffeesatz.zip";
-    stripRoot = false;
-    hash = "sha256-8yAB73UJ77/c8/VLqiFeT1KtoBQzOh+vWrI+JA2dCoY=";
+  outputs = [
+    "out"
+    "webfont"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "yanone";
+    repo = "kaffeesatz";
+    rev = "104c0ced99e8390bf5b138c5ca6065c0f5fcc333";
+    hash = "sha256-iOTehvcM4RdDz0HF4AW6mOjOGfAa40HeuwUo847Ph1M=";
   };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    yq-go
+    installFonts
+    python3Packages.fontmake
+    python3Packages.fontbakery
+    python3Packages.gftools
+  ];
+
+  dontUseNinjaBuild = true;
+  dontUseNinjaInstall = true;
+
+  env.PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION = "python";
+
+  # Patch out references to venv and 'venv' make target to avoid a bunch of warnings
+  # So the underlying 'venv/touchfile' is never run
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail "venv: venv/touchfile" "" \
+      --replace-fail "build.stamp: venv" "build.stamp:" \
+      --replace-fail "test: venv build.stamp" "test: build.stamp" \
+      --replace-fail "proof: venv build.stamp" "proof: build.stamp" \
+      --replace-fail ". venv/bin/activate; " ""
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    make build
+    runHook postBuild
+  '';
 
   installPhase = ''
     runHook preInstall
-
-    install -Dm644 *.otf -t $out/share/fonts/opentype
-
     runHook postInstall
   '';
 
   meta = {
     description = "Free font classic";
-    maintainers = with lib.maintainers; [ mt-caret ];
+    maintainers = with lib.maintainers; [
+      mt-caret
+      pancaek
+    ];
     platforms = with lib.platforms; all;
-    homepage = "https://yanone.de/fonts/kaffeesatz/";
+    homepage = "https://yanone.de";
     license = lib.licenses.ofl;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Sorry about the ugly diff/large commit, wasn't sure of a way to split this up that was actually helpful.
Part of #495640
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
