### PR TITLE
pkgsChecked, pkgsParallel, pkgsStrict, pkgsStructured: init

### DIFF
--- a/pkgs/test/top-level/default.nix
+++ b/pkgs/test/top-level/default.nix
@@ -82,4 +82,18 @@ lib.recurseIntoAttrs {
     assert cross.makeWrapper ? __spliced;
     assert appended.makeWrapper ? __spliced;
     pkgs.emptyFile;
+
+  massRebuildVariantComposition =
+    let
+      variants = [
+        "pkgsChecked"
+        "pkgsParallel"
+        "pkgsStrict"
+        "pkgsStructured"
+      ];
+      all = lib.getAttrFromPath variants pkgs;
+      all-reversed = lib.getAttrFromPath (lib.reverseList variants) pkgs;
+    in
+    assert pkgs.config.allowVariants -> (all.hello == all-reversed.hello);
+    pkgs.emptyFile;
 }

--- a/pkgs/top-level/variants.nix
+++ b/pkgs/top-level/variants.nix
@@ -173,4 +173,10 @@ self: super: {
     ]
     ++ overlays;
   };
+
+  pkgsStrict = nixpkgsFun {
+    config = super.config // {
+      strictDepsByDefault = true;
+    };
+  };
 }

--- a/pkgs/top-level/variants.nix
+++ b/pkgs/top-level/variants.nix
@@ -174,9 +174,24 @@ self: super: {
     ++ overlays;
   };
 
+  pkgsChecked = nixpkgsFun {
+    config = super.config // {
+      doCheckByDefault = true;
+    };
+  };
+  pkgsParallel = nixpkgsFun {
+    config = super.config // {
+      enableParallelBuildingByDefault = true;
+    };
+  };
   pkgsStrict = nixpkgsFun {
     config = super.config // {
       strictDepsByDefault = true;
+    };
+  };
+  pkgsStructured = nixpkgsFun {
+    config = super.config // {
+      structuredAttrsByDefault = true;
     };
   };
 }


### PR DESCRIPTION
- Based on top of #481485
- cc https://github.com/NixOS/nixpkgs/issues/178468
- cc https://github.com/NixOS/nixpkgs/issues/205690

Closes #481485

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
