### PR TITLE
lib.lists: remove fold

### DIFF
--- a/doc/doc-support/lib-function-locations.nix
+++ b/doc/doc-support/lib-function-locations.nix
@@ -17,9 +17,9 @@ let
           location = builtins.unsafeGetAttrPos name set;
         }
       ]
-      ++ lib.optionals (builtins.length prefix == 0 && builtins.isAttrs set.${name}) (
-        libDefPos (prefix ++ [ name ]) set.${name}
-      )
+      ++ lib.optionals (
+        builtins.length prefix == 0 && (lib.tryEval (builtins.isAttrs set.${name})).value
+      ) (libDefPos (prefix ++ [ name ]) set.${name})
     ) (builtins.attrNames set);
 
   libset =

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -143,13 +143,9 @@ rec {
     fold' 0;
 
   /**
-    `fold` is an alias of `foldr` for historic reasons.
-
-    ::: {.warning}
-    This function will be removed in 26.05.
-    :::
+    `fold` was an alias of `foldr` for historic reasons.
   */
-  fold = warn "fold has been deprecated, use foldr instead" foldr;
+  fold = throw "fold is a removed alias of foldr, use it instead"; # TODO: Remove in 26.11
 
   /**
     “left fold”, like `foldr`, but from the left:


### PR DESCRIPTION
Deprecated in #456532 for removal in 26.05, so it's time to drop this. A quick grep didn't turn up any in-tree usages.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
