### PR TITLE
chhoto-url: Enable git LFS for pulling the images

### DIFF
--- a/pkgs/by-name/ch/chhoto-url/package.nix
+++ b/pkgs/by-name/ch/chhoto-url/package.nix
@@ -14,7 +14,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "SinTan1729";
     repo = "chhoto-url";
     tag = finalAttrs.version;
-    hash = "sha256-B6bMuy/EEveYtQtGBO5CNeEUlPK8eQ412k+SwlRPm2M=";
+    hash = "sha256-n8fCQeY0gIyZuACKWa8Fk9TQ680PpVS2MHMFy7UgDwk=";
+    fetchLFS = true;
   };
 
   sourceRoot = "${finalAttrs.src.name}/actix";


### PR DESCRIPTION
Upstream switched to using LFS for storing the images (favicon, etc): https://github.com/SinTan1729/chhoto-url/commit/fcbb3e13e503163075061553430453d5e16e758a

Without this fix none of the images in the interface work.

## Things done

Yeah, I haven't done anything more than see LFS headers in the files being served, checked that the source repo has added LFS recently and found the flag that should enable pulling FLS inputs.

But hey, I'm a human at least :)

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
