### PR TITLE
fastfetch-unwrapped: migrate from fastfetch.minimal

### DIFF
--- a/pkgs/by-name/fa/fastfetch-unwrapped/package.nix
+++ b/pkgs/by-name/fa/fastfetch-unwrapped/package.nix
@@ -1,0 +1,169 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  apple-sdk_15,
+  chafa,
+  cmake,
+  dbus,
+  dconf,
+  ddcutil,
+  enlightenment,
+  glib,
+  hwdata,
+  imagemagick,
+  libdrm,
+  libelf,
+  libglvnd,
+  libpulseaudio,
+  libselinux,
+  libsepol,
+  libsysprof-capture,
+  libva,
+  libvdpau,
+  libxau,
+  libxcb,
+  libxdmcp,
+  libxext,
+  libxrandr,
+  moltenvk,
+  nix-update-script,
+  ocl-icd,
+  opencl-headers,
+  pcre2,
+  pkg-config,
+  python3,
+  rpm,
+  sqlite,
+  util-linux,
+  versionCheckHook,
+  vulkan-loader,
+  wayland,
+  xfconf,
+  yyjson,
+  zfs,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fastfetch-unwrapped";
+  version = "2.64.2";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "fastfetch-cli";
+    repo = "fastfetch";
+    tag = finalAttrs.version;
+    hash = "sha256-isSVcmtNglHy7+F3yemGyY8Jnsy3h5mjOnl159CyJ2Q=";
+  };
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    python3
+  ];
+
+  buildInputs = [
+    chafa
+    imagemagick
+    sqlite
+    yyjson
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    dbus
+    dconf
+    ddcutil
+    enlightenment.efl
+    glib
+    libdrm
+    libelf
+    libglvnd
+    libpulseaudio
+    libselinux
+    libsepol
+    libsysprof-capture
+    libva
+    libvdpau
+    libxau
+    libxcb
+    libxdmcp
+    libxext
+    libxrandr
+    ocl-icd
+    opencl-headers
+    pcre2
+    rpm
+    util-linux
+    vulkan-loader
+    wayland
+    xfconf
+    zfs
+    zlib
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    apple-sdk_15
+    moltenvk
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeOptionType "filepath" "CMAKE_INSTALL_SYSCONFDIR" "${placeholder "out"}/etc")
+    (lib.cmakeBool "ENABLE_DIRECTX_HEADERS" false)
+    (lib.cmakeBool "ENABLE_SYSTEM_YYJSON" true)
+
+    # Upstream defaults optional feature support to on when the platform allows it.
+    (lib.cmakeBool "ENABLE_IMAGEMAGICK6" false)
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    # Embed these databases instead of referring to hwdata and libdrm at runtime.
+    (lib.cmakeBool "ENABLE_EMBEDDED_PCIIDS" true)
+    (lib.cmakeBool "ENABLE_EMBEDDED_AMDGPUIDS" true)
+  ];
+
+  # Upstream completions run Python when shells expand options from
+  # `fastfetch --help-raw`. Keep this runtime dependency explicit until
+  # upstream generates static completions at build time.
+  postPatch = ''
+    substituteInPlace completions/fastfetch.{bash,fish,zsh} --replace-fail python3 '${python3.interpreter}'
+  '';
+
+  preConfigure = lib.optionalString stdenv.hostPlatform.isLinux ''
+    buildDir="''${cmakeBuildDir:-build}"
+    mkdir -p "$buildDir"
+    cp ${hwdata}/share/hwdata/pci.ids "$buildDir/pci.ids"
+    cp ${libdrm}/share/libdrm/amdgpu.ids "$buildDir/amdgpu.ids"
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Actively maintained, feature-rich and performance oriented, neofetch like system information tool";
+    homepage = "https://github.com/fastfetch-cli/fastfetch";
+    changelog = "https://github.com/fastfetch-cli/fastfetch/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      defelo
+      khaneliman
+      luftmensch-luftmensch
+    ];
+    platforms = lib.platforms.all;
+    mainProgram = "fastfetch";
+    longDescription = ''
+      Fast and highly customizable system info script.
+
+      This unwrapped build compiles optional feature support but does not wrap
+      runtime libraries into its closure.
+    '';
+  };
+})

--- a/pkgs/by-name/fa/fastfetch/package.nix
+++ b/pkgs/by-name/fa/fastfetch/package.nix
@@ -1,53 +1,36 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
+  runCommand,
   apple-sdk_15,
   chafa,
-  cmake,
   dbus,
   dconf,
   ddcutil,
   enlightenment,
   glib,
-  hwdata,
   imagemagick,
-  libxrandr,
   libdrm,
   libelf,
   libglvnd,
   libpulseaudio,
-  libselinux,
-  libsepol,
-  libsysprof-capture,
-  libxcb,
   libva,
   libvdpau,
+  libxcb,
+  libxrandr,
   makeBinaryWrapper,
   moltenvk,
-  nix-update-script,
   ocl-icd,
-  opencl-headers,
-  pcre2,
-  pkg-config,
-  python3,
   rpm,
   sqlite,
-  util-linux,
-  versionCheckHook,
   vulkan-loader,
   wayland,
   xfconf,
-  libxext,
-  libxdmcp,
-  libxau,
-  yyjson,
-  zlib,
   zfs,
+  zlib,
+  fastfetch-unwrapped,
 
-  fastfetch,
-
-  # Feature flags
+  # Runtime dependency selectors. fastfetch-unwrapped is always built with support enabled.
   audioSupport ? true,
   brightnessSupport ? true,
   codecSupport ? true,
@@ -67,280 +50,168 @@
   x11Support ? true,
   xfceSupport ? true,
   zfsSupport ? false,
+
+  runtimeDependencies ? null,
+  extraRuntimeDependencies ? [ ],
+  runtimePrograms ? [ ],
+  extraRuntimePrograms ? [ ],
 }:
-stdenv.mkDerivation (finalAttrs: {
-  pname = "fastfetch";
-  version = "2.64.2";
 
-  strictDeps = true;
-  __structuredAttrs = true;
+let
+  unwrapped = fastfetch-unwrapped;
 
-  src = fetchFromGitHub {
-    owner = "fastfetch-cli";
-    repo = "fastfetch";
-    tag = finalAttrs.version;
-    hash = "sha256-isSVcmtNglHy7+F3yemGyY8Jnsy3h5mjOnl159CyJ2Q=";
-  };
-
-  outputs = [
-    "out"
-    "man"
-  ];
-
-  nativeBuildInputs = [
-    cmake
-    makeBinaryWrapper
-    pkg-config
-    python3
-  ];
-
-  buildInputs =
-    let
-      commonDeps = [ yyjson ];
-
-      # Cross-platform optional dependencies
-      imageDeps = lib.optionals imageSupport [
-        # Image output as ascii art.
-        chafa
-        # Images in terminal using sixel or kitty graphics protocol
-        imagemagick
-      ];
-
-      sqliteDeps = lib.optionals sqliteSupport [
-        # linux - Needed for pkg & rpm package count.
-        # darwin - Used for fast wallpaper detection before macOS Sonoma
-        sqlite
-      ];
-
-      linuxCoreDeps = lib.optionals stdenv.hostPlatform.isLinux (
-        [ hwdata ]
-        # Fallback if both `wayland` and `x11` are not available. AMD GPU properties detection
-        ++ lib.optional (!x11Support && !waylandSupport) libdrm
-      );
-
-      linuxFeatureDeps = lib.optionals stdenv.hostPlatform.isLinux (
-        lib.optionals audioSupport [
-          # Sound device detection
-          libpulseaudio
-        ]
-        ++ lib.optionals brightnessSupport [
-          # Brightness detection of external displays
-          ddcutil
-        ]
-        ++ lib.optionals codecSupport [
-          # Hardware-accelerated video codec detection
-          libva
-          libvdpau
-        ]
-        ++ lib.optionals dbusSupport [
-          # Bluetooth, wifi, player & media detection
-          dbus
-        ]
-        ++ lib.optionals enlightenmentSupport [
-          # Eet support for reading Enlightenment window manager configuration.
-          enlightenment.efl
-        ]
-        ++ lib.optionals gnomeSupport [
-          # Needed for values that are only stored in DConf + Fallback for GSettings.
-          dconf
-          glib
-          # Required by glib messages
-          libsysprof-capture
-          pcre2
-          # Required by gio messages
-          libselinux
-          util-linux
-          # Required by selinux
-          libsepol
-        ]
-        ++ lib.optionals imageSupport [
-          # Faster image output when using kitty graphics protocol.
-          zlib
-        ]
-        ++ lib.optionals openclSupport [
-          # OpenCL module
-          ocl-icd
-          opencl-headers
-        ]
-        ++ lib.optionals openglSupport [
-          # OpenGL module
-          libglvnd
-        ]
-        ++ lib.optionals rpmSupport [
-          # Slower fallback for rpm package count. Needed on openSUSE.
-          rpm
-        ]
-        ++ lib.optionals terminalSupport [
-          # Needed for st terminal font detection.
-          libelf
-        ]
-        ++ lib.optionals vulkanSupport [
-          # Vulkan module & fallback for GPU output
-          vulkan-loader
-        ]
-        ++ lib.optionals waylandSupport [
-          # Better display performance and output in wayland sessions. Supports different refresh rates per monitor.
-          wayland
-        ]
-        ++ lib.optionals x11Support [
-          # At least one of them sould be present in X11 sessions for better display detection and faster WM detection.
-          # The *randr ones provide multi monitor support The libxcb* ones usually have better performance.
-          libxrandr
-          libxcb
-          # Required by libxcb messages
-          libxau
-          libxdmcp
-          libxext
-        ]
-        ++ lib.optionals xfceSupport [
-          #  Needed for XFWM theme and XFCE Terminal font.
-          xfconf
-        ]
-        ++ lib.optionals zfsSupport [
-          # Needed for zpool module
-          zfs
-        ]
-      );
-
-      macosDeps = lib.optionals stdenv.hostPlatform.isDarwin [
-        apple-sdk_15
-        moltenvk
-      ];
-    in
-    commonDeps ++ imageDeps ++ sqliteDeps ++ linuxCoreDeps ++ linuxFeatureDeps ++ macosDeps;
-
-  cmakeFlags = [
-    (lib.cmakeOptionType "filepath" "CMAKE_INSTALL_SYSCONFDIR" "${placeholder "out"}/etc")
-    (lib.cmakeBool "ENABLE_DIRECTX_HEADERS" false)
-    (lib.cmakeBool "ENABLE_SYSTEM_YYJSON" true)
-
-    # Feature flags
-    (lib.cmakeBool "BUILD_FLASHFETCH" flashfetchSupport)
-
-    (lib.cmakeBool "ENABLE_IMAGEMAGICK6" false)
-    (lib.cmakeBool "ENABLE_IMAGEMAGICK7" imageSupport)
-    (lib.cmakeBool "ENABLE_CHAFA" imageSupport)
-
-    (lib.cmakeBool "ENABLE_SQLITE3" sqliteSupport)
-
-    (lib.cmakeBool "ENABLE_LIBZFS" zfsSupport)
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    (lib.cmakeBool "ENABLE_PULSE" audioSupport)
-
-    (lib.cmakeBool "ENABLE_VA" codecSupport)
-    (lib.cmakeBool "ENABLE_VDPAU" codecSupport)
-
-    (lib.cmakeBool "ENABLE_DDCUTIL" brightnessSupport)
-
-    (lib.cmakeBool "ENABLE_DBUS" dbusSupport)
-
-    (lib.cmakeBool "ENABLE_EET" enlightenmentSupport)
-
-    (lib.cmakeBool "ENABLE_ELF" terminalSupport)
-
-    (lib.cmakeBool "ENABLE_GIO" gnomeSupport)
-    (lib.cmakeBool "ENABLE_DCONF" gnomeSupport)
-
-    (lib.cmakeBool "ENABLE_ZLIB" imageSupport)
-
-    (lib.cmakeBool "ENABLE_OPENCL" openclSupport)
-
-    (lib.cmakeBool "ENABLE_EGL" openglSupport)
-    (lib.cmakeBool "ENABLE_GLX" openglSupport)
-
-    (lib.cmakeBool "ENABLE_RPM" rpmSupport)
-
-    (lib.cmakeBool "ENABLE_DRM" (!x11Support && !waylandSupport))
-    (lib.cmakeBool "ENABLE_DRM_AMDGPU" (!x11Support && !waylandSupport))
-
-    (lib.cmakeBool "ENABLE_VULKAN" vulkanSupport)
-
-    (lib.cmakeBool "ENABLE_WAYLAND" waylandSupport)
-
-    (lib.cmakeBool "ENABLE_XCB_RANDR" x11Support)
-    (lib.cmakeBool "ENABLE_XRANDR" x11Support)
-
-    (lib.cmakeBool "ENABLE_XFCONF" xfceSupport)
-
-    (lib.cmakeOptionType "filepath" "CUSTOM_PCI_IDS_PATH" "${hwdata}/share/hwdata/pci.ids")
-    (lib.cmakeOptionType "filepath" "CUSTOM_AMDGPU_IDS_PATH" "${libdrm}/share/libdrm/amdgpu.ids")
-  ];
-
-  postPatch = ''
-    substituteInPlace completions/fastfetch.{bash,fish,zsh} --replace-fail python3 '${python3.interpreter}'
-  '';
-
-  postInstall = ''
-    wrapProgram $out/bin/fastfetch \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath finalAttrs.buildInputs}"
-  ''
-  + lib.optionalString flashfetchSupport ''
-    wrapProgram $out/bin/flashfetch \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath finalAttrs.buildInputs}"
-  '';
-
-  nativeInstallCheckInputs = [ versionCheckHook ];
-  doInstallCheck = true;
-
-  passthru = {
-    updateScript = nix-update-script { };
-    # finalAttrs.finalPackage.override doesn’t exist
-    minimal = fastfetch.override {
-      audioSupport = false;
-      brightnessSupport = false;
-      codecSupport = false;
-      dbusSupport = false;
-      enlightenmentSupport = false;
-      flashfetchSupport = false;
-      gnomeSupport = false;
-      imageSupport = false;
-      openclSupport = false;
-      openglSupport = false;
-      rpmSupport = false;
-      sqliteSupport = false;
-      terminalSupport = false;
-      vulkanSupport = false;
-      waylandSupport = false;
-      x11Support = false;
-      xfceSupport = false;
-    };
-  };
-
-  meta = {
-    description = "Actively maintained, feature-rich and performance oriented, neofetch like system information tool";
-    homepage = "https://github.com/fastfetch-cli/fastfetch";
-    changelog = "https://github.com/fastfetch-cli/fastfetch/releases/tag/${finalAttrs.version}";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [
-      luftmensch-luftmensch
-      khaneliman
-      defelo
+  defaultRuntimeDependencies =
+    lib.optionals imageSupport [
+      # Image output as ascii art.
+      chafa
+      # Images in terminal using sixel or kitty graphics protocol
+      imagemagick
+    ]
+    ++ lib.optionals sqliteSupport [
+      # linux - Needed for pkg & rpm package count.
+      # darwin - Used for fast wallpaper detection before macOS Sonoma
+      sqlite
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux (
+      [
+        # DRM display and AMD GPU detection.
+        libdrm
+      ]
+      ++ lib.optionals audioSupport [
+        # Sound device detection
+        libpulseaudio
+      ]
+      ++ lib.optionals brightnessSupport [
+        # Brightness detection of external displays
+        ddcutil
+      ]
+      ++ lib.optionals codecSupport [
+        # Hardware-accelerated video codec detection
+        libva
+        libvdpau
+      ]
+      ++ lib.optionals dbusSupport [
+        # Bluetooth, wifi, player & media detection
+        dbus
+      ]
+      ++ lib.optionals enlightenmentSupport [
+        # Eet support for reading Enlightenment window manager configuration.
+        enlightenment.efl
+      ]
+      ++ lib.optionals gnomeSupport [
+        # Needed for values that are only stored in DConf + Fallback for GSettings.
+        dconf
+        glib
+      ]
+      ++ lib.optionals imageSupport [
+        # Faster image output when using kitty graphics protocol.
+        zlib
+      ]
+      ++ lib.optionals openclSupport [
+        # OpenCL module
+        ocl-icd
+      ]
+      ++ lib.optionals openglSupport [
+        # OpenGL module
+        libglvnd
+      ]
+      ++ lib.optionals rpmSupport [
+        # Slower fallback for rpm package count. Needed on openSUSE.
+        rpm
+      ]
+      ++ lib.optionals terminalSupport [
+        # Needed for st terminal font detection.
+        libelf
+      ]
+      ++ lib.optionals vulkanSupport [
+        # Vulkan module & fallback for GPU output
+        vulkan-loader
+      ]
+      ++ lib.optionals waylandSupport [
+        # Better display performance and output in wayland sessions.
+        wayland
+      ]
+      ++ lib.optionals x11Support [
+        # Better display detection and faster WM detection in X11 sessions.
+        libxrandr
+        libxcb
+      ]
+      ++ lib.optionals xfceSupport [
+        # Needed for XFWM theme and XFCE Terminal font.
+        xfconf
+      ]
+      ++ lib.optionals zfsSupport [
+        # Needed for zpool module
+        zfs
+      ]
+    )
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      apple-sdk_15
+      moltenvk
     ];
-    platforms = lib.platforms.all;
-    mainProgram = "fastfetch";
-    longDescription = ''
-      Fast and highly customizable system info script.
 
-      Feature flags (all default to 'true' except rpmSupport, flashfetchSupport and zfsSupport):
-      * audioSupport: PulseAudio functionality
-      * brightnessSupport: External display brightness detection via DDCUtil
-      * codecSupport: Hardware-accelerated video codec detection
-      * dbusSupport: DBus functionality for Bluetooth, WiFi, player & media detection
-      * enlightenmentSupport: Enlightenment configuration detection via EFL's Eet
-      * flashfetchSupport: Build the flashfetch utility (default: false)
-      * gnomeSupport: GNOME integration (dconf, dbus, gio)
-      * imageSupport: Image rendering (chafa and imagemagick)
-      * openclSupport: OpenCL features
-      * openglSupport: OpenGL features
-      * rpmSupport: RPM package detection (default: false)
-      * sqliteSupport: Package counting via SQLite
-      * terminalSupport: Terminal font detection
-      * vulkanSupport: Vulkan GPU information and DRM features
-      * waylandSupport: Wayland display detection
-      * x11Support: X11 display information
-      * xfceSupport: XFCE integration for theme and terminal font detection
-      * zfsSupport: zpool information
-    '';
-  };
-})
+  resolvedRuntimeDependencies =
+    (if runtimeDependencies == null then defaultRuntimeDependencies else runtimeDependencies)
+    ++ extraRuntimeDependencies;
+
+  resolvedRuntimePrograms = runtimePrograms ++ extraRuntimePrograms;
+
+  runtimeLibraryPath = lib.makeLibraryPath resolvedRuntimeDependencies;
+  runtimeProgramPath = lib.makeBinPath resolvedRuntimePrograms;
+in
+runCommand "fastfetch-${unwrapped.version}"
+  {
+    pname = "fastfetch";
+    inherit (unwrapped) version;
+
+    strictDeps = true;
+    __structuredAttrs = true;
+
+    outputs = [
+      "out"
+      "man"
+    ];
+
+    nativeBuildInputs = [ makeBinaryWrapper ];
+
+    passthru = (removeAttrs unwrapped.passthru [ "updateScript" ]) // {
+      inherit unwrapped;
+      runtimeDependencies = resolvedRuntimeDependencies;
+      runtimePrograms = resolvedRuntimePrograms;
+      minimal = lib.warnOnInstantiate "`fastfetch.minimal` has been renamed to `fastfetch-unwrapped`" unwrapped;
+    };
+
+    meta = unwrapped.meta // {
+      priority = (unwrapped.meta.priority or lib.meta.defaultPriority) - 1;
+      longDescription = ''
+        Fast and highly customizable system info script.
+
+        This wrapped package makes optional runtime libraries available to the
+        full-featured fastfetch-unwrapped binary.
+      '';
+    };
+
+    preferLocalBuild = true;
+  }
+  ''
+    makeWrapperArgs=(--inherit-argv0)
+
+    if [ -n "${runtimeLibraryPath}" ]; then
+      makeWrapperArgs+=(--prefix LD_LIBRARY_PATH : "${runtimeLibraryPath}")
+    fi
+
+    if [ -n "${runtimeProgramPath}" ]; then
+      makeWrapperArgs+=(--prefix PATH : "${runtimeProgramPath}")
+    fi
+
+    mkdir -p "$out/bin"
+    makeWrapper ${unwrapped}/bin/fastfetch "$out/bin/fastfetch" "''${makeWrapperArgs[@]}"
+
+    ${lib.optionalString flashfetchSupport ''
+      makeWrapper ${unwrapped}/bin/flashfetch "$out/bin/flashfetch" "''${makeWrapperArgs[@]}"
+    ''}
+
+    ln -s ${unwrapped}/share "$out/share"
+
+    ln -s ${unwrapped.man} "$man"
+  ''

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -721,7 +721,7 @@ mapAliases {
   fabs = throw "'fabs' has been removed due to being broken for more than a year; see RFC 180"; # Added 2026-02-05
   fancontrol-gui = throw "'fancontrol-gui' has been removed due to outdated KF5 dependencies"; # Added 2026-05-01
   fast-cli = throw "'fast-cli' has been removed because it was unmaintainable in nixpkgs"; # Added 2025-11-17
-  fastfetchMinimal = warnAlias "'fastfetchMinimal' has been renamed to 'fastfetch.minimal'" fastfetch.minimal; # Added 2026-05-18
+  fastfetchMinimal = warnAlias "'fastfetchMinimal' has been renamed to 'fastfetch-unwrapped'" fastfetch-unwrapped; # Added 2026-05-18
   fastJson = warnAlias "'fastJson' has been renamed to 'libfastjson'" libfastjson; # Added 2026-02-08
   fastnlo_toolkit = throw "'fastnlo_toolkit' has been renamed to/replaced by 'fastnlo-toolkit'"; # Converted to throw 2025-10-27
   faustPhysicalModeling = warnAlias "'faustPhysicalModeling' has been renamed to 'faust-physicalmodeling'" faust-physicalmodeling; # Added 2026-02-08


### PR DESCRIPTION
Convert the passthru override approach to a simple unwrapped/wrapped variant approach to make the split more obvious what is being done. Also makes the `minimal` version of fastfetch still build with support for runtime discovery of optional dependencies.

Was one of the first derivations I ever wrote for nixpkgs and am basically just rewriting it with how I would do things nowadays to keep this a clean separation of userbase of the package. Simplified the `minimal` to an unwrapped variant to support runtime linking of features by building with all enabled and just not wrapping them. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
