### PR TITLE
lincity-ng: 2.14.2 -> 2.15.0

### DIFF
--- a/pkgs/by-name/li/lincity-ng/package.nix
+++ b/pkgs/by-name/li/lincity-ng/package.nix
@@ -1,9 +1,9 @@
 {
   stdenv,
-  SDL2,
-  SDL2_image,
-  SDL2_mixer,
-  SDL2_ttf,
+  sdl3,
+  sdl3-image,
+  sdl3-mixer,
+  sdl3-ttf,
   cmake,
   fetchFromGitHub,
   fmt,
@@ -23,13 +23,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lincity-ng";
-  version = "2.14.2";
+  version = "2.15.0";
 
   src = fetchFromGitHub {
     owner = "lincity-ng";
     repo = "lincity-ng";
     tag = "lincity-ng-${finalAttrs.version}";
-    hash = "sha256-HW+bB9xnrok8tWKIJJUt3Qgo5e9HmI6NZORG4PazmEM=";
+    hash = "sha256-NgOMbFsK/8njP3hOT9N9E9TRipSW+7CAw1oVDW1F5QU=";
   };
 
   hardeningDisable = [ "format" ];
@@ -47,10 +47,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     fmt
-    SDL2
-    SDL2_image
-    SDL2_mixer
-    SDL2_ttf
+    sdl3
+    sdl3-image
+    sdl3-mixer
+    sdl3-ttf
     libx11
     libwebp
     libtiff
@@ -68,8 +68,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   env.NIX_CFLAGS_COMPILE = "
-    -I${lib.getDev SDL2_image}/include/SDL2
-    -I${lib.getDev SDL2_mixer}/include/SDL2
+    -I${lib.getDev sdl3-image}/include/SDL3
+    -I${lib.getDev sdl3-mixer}/include/SDL3
   ";
 
   meta = {


### PR DESCRIPTION
https://github.com/lincity-ng/lincity-ng/releases/tag/lincity-ng-2.15.0

I tested the game by running it. Tried to place a coal power plant but couldn't because my tech level was too low or something.

Question: Is `hardeningDisable = [ "format" ]` necessary? The game seems to compile just fine without that line (v2.14.2 compiles just fine without it as well). That line was added in aff1f4ab948b9 in PR #18083 back in 2016.

The game upgraded from SDL2 to SDL3 between v2.14.2 and v2.15.

Didn't use AI to assist with making the PR this time as it was pretty simple.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
