### PR TITLE
kakounePlugins.kak-ansi: 0.2.4 -> 0.3.0

### DIFF
--- a/pkgs/applications/editors/kakoune/plugins/overrides.nix
+++ b/pkgs/applications/editors/kakoune/plugins/overrides.nix
@@ -47,13 +47,13 @@ self: super: {
 
   kak-ansi = stdenv.mkDerivation (finalAttrs: {
     pname = "kak-ansi";
-    version = "0.2.4";
+    version = "0.3.0";
 
     src = fetchFromGitHub {
       owner = "eraserhd";
       repo = "kak-ansi";
       rev = "v${finalAttrs.version}";
-      sha256 = "kFjTYFy0KF5WWEHU4hHFAnD/03/d3ptjqMMbTSaGImE=";
+      sha256 = "sha256-Tp+cKZxDESlpks6l+6J0H/1BvHyfQSqCxeutUcsZrEc=";
     };
 
     installPhase = ''


### PR DESCRIPTION
updates `kakounePlugins.kak-ansi` to the latest git revision manually

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].