### PR TITLE
stalwart: 0.15.5 -> 0.16.10

### DIFF
--- a/pkgs/by-name/st/stalwart_0_15/package.nix
+++ b/pkgs/by-name/st/stalwart_0_15/package.nix
@@ -30,6 +30,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-T7ft+GQLLPWgVFoo3m3pLDwgXRwa5idRFlhKjDLkQaw=";
   };
 
+  __structuredAttrs = true;
   cargoHash = "sha256-WneUROKV+uLX1d5TIOanO0jhHLsHHpFcXKUB6zdbSzA=";
 
   depsBuildBuild = [

--- a/pkgs/by-name/st/stalwart_0_15/spam-filter.nix
+++ b/pkgs/by-name/st/stalwart_0_15/spam-filter.nix
@@ -2,7 +2,7 @@
   lib,
   fetchFromGitHub,
   stdenv,
-  stalwart,
+  stalwart_0_15,
   nix-update-script,
 }:
 
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-2D/0mnkV4G/Gyr48rbMGTo6uTL7pe+AT+DNKqkBTIbA=";
   };
-
+  __structuredAttrs = true;
   buildPhase = ''
     bash ./build.sh
   '';
@@ -38,6 +38,6 @@ stdenv.mkDerivation (finalAttrs: {
       mit
       asl20
     ];
-    inherit (stalwart.meta) maintainers;
+    inherit (stalwart_0_15.meta) maintainers;
   };
 })

--- a/pkgs/by-name/st/stalwart_0_15/webadmin.nix
+++ b/pkgs/by-name/st/stalwart_0_15/webadmin.nix
@@ -1,7 +1,7 @@
 {
   lib,
   rustPlatform,
-  stalwart,
+  stalwart_0_15,
   fetchFromGitHub,
   trunk,
   tailwindcss_3,
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     name = "${finalAttrs.pname}-npm-deps";
     hash = "sha256-na1HEueX8w7kuDp8LEtJ0nD1Yv39cyk6sEMpS1zix2s=";
   };
-
+  __structuredAttrs = true;
   cargoHash = "sha256-qYIg1BthkpS77I6duYGGX168Y/IO8Mx4SWMQbE0BwDA=";
 
   postPatch = ''
@@ -72,6 +72,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/stalwartlabs/webadmin";
     changelog = "https://github.com/stalwartlabs/webadmin/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.agpl3Only;
-    inherit (stalwart.meta) maintainers;
+    inherit (stalwart_0_15.meta) maintainers;
   };
 })

--- a/pkgs/by-name/st/stalwart_0_16/package.nix
+++ b/pkgs/by-name/st/stalwart_0_16/package.nix
@@ -1,0 +1,300 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  protobuf,
+  bzip2,
+  openssl,
+  sqlite,
+  foundationdb,
+  zstd,
+  stdenv,
+  nix-update-script,
+  rocksdb,
+  callPackage,
+  python3Packages,
+  cacert,
+  libredirect,
+  writeTextFile,
+  withFoundationdb ? false,
+  stalwartEnterprise ? false,
+}:
+let
+  migrate_v016 =
+    {
+      src,
+      version,
+    }:
+    python3Packages.buildPythonApplication {
+      pname = "migrate_v016";
+      inherit src version;
+      __structuredAttrs = true;
+      format = "other";
+      dontBuild = true;
+      dependencies = [
+        python3Packages.urllib3
+        python3Packages.requests
+      ];
+      installPhase = ''
+        runHook preInstall
+        mkdir -p $out/bin
+        cp $src/resources/scripts/migrate_v016.py $out/bin/migrate_v016
+        chmod +x $out/bin/migrate_v016
+        runHook postInstall
+      '';
+      postFixUp = ''
+        wrapPythonPrograms
+      '';
+    };
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "stalwart" + (lib.optionalString stalwartEnterprise "-enterprise");
+  version = "0.16.10";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "stalwartlabs";
+    repo = "stalwart";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-zP2FwRX9eaP8xn8WElf/1N4doHnvZ4rKQLYrUDoYwkQ=";
+  };
+
+  cargoHash = "sha256-HVS89Wtjb2nIdyygP8bPRbVhyMRnJlZDfoCQqiMdVe0=";
+
+  env = {
+    OPENSSL_NO_VENDOR = true;
+    ZSTD_SYS_USE_PKG_CONFIG = true;
+    ROCKSDB_INCLUDE_DIR = "${rocksdb}/include";
+    ROCKSDB_LIB_DIR = "${rocksdb}/lib";
+  }
+  //
+    lib.optionalAttrs
+      (stdenv.hostPlatform.isLinux && (stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isArmv7))
+      {
+        JEMALLOC_SYS_WITH_LG_PAGE = 16;
+      };
+
+  depsBuildBuild = [
+    pkg-config
+    zstd
+  ];
+
+  nativeBuildInputs = [
+    protobuf
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    bzip2
+    openssl
+    sqlite
+    zstd
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && withFoundationdb) [ foundationdb ];
+
+  # Issue: https://github.com/stalwartlabs/stalwart/issues/1104
+  buildNoDefaultFeatures = true;
+  buildFeatures = [
+    "sqlite"
+    "postgres"
+    "mysql"
+    "rocks"
+    "s3"
+    "redis"
+    "azure"
+    "nats"
+  ]
+  ++ lib.optionals withFoundationdb [ "foundationdb" ]
+  ++ lib.optionals stalwartEnterprise [ "enterprise" ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    openssl
+    # ... panicked at crates/utils/src/lib.rs:94:17: Failed to build TLS connectors: Failed to build platform verifier: unexpected error: No CA certificates were loaded from the system
+    cacert
+  ];
+
+  # Allow network access during tests on Darwin/macOS
+  __darwinAllowLocalNetworking = true;
+  # Allow access to DNS settings exposed via config daemon
+  # thread ... panicked at tests/src/lib.rs:49:13: Errors: [ Build { ... , message: "Failed to read system DNS config: failed to access System Configuration dynamic store", }, ]
+  #  -> https://github.com/hickory-dns/hickory-dns/blob/f09321075b1f97902b7bc4ca4ffda7816fcf2971/crates/resolver/src/system_conf/apple.rs#L21
+  #    ->  https://crates.io/crates/system-configuration
+  #      -> https://developer.apple.com/documentation/systemconfiguration/scdynamicstore?language=objc
+  #        -> "The handle to an open dynamic store session with the system configuration daemon." (configd)
+  sandboxProfile = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    (allow mach-lookup (global-name "com.apple.SystemConfiguration.configd"))
+  '';
+
+  preCheck =
+    let
+      nsswitch = writeTextFile {
+        name = "nsswitch.conf";
+        text = ''
+          hosts: files dns
+        '';
+      };
+      hosts = writeTextFile {
+        name = "hosts";
+        text = ''
+          127.0.0.1 localhost
+        '';
+      };
+      # ... panicked at tests/src/lib.rs:49:13: Errors: [ Build { ... , message: "Failed to read system DNS config: io error: No such file or directory (os error 2)" }, ... ]
+      #   -> https://github.com/hickory-dns/hickory-dns/blob/v0.26.1/crates/resolver/src/system_conf/unix.rs#L25
+      #   -> known issue: https://github.com/hickory-dns/hickory-dns/issues/2959
+      resolvConf = writeTextFile {
+        name = "resolv.conf";
+        text = ''
+          nameserver 127.0.0.1
+        '';
+      };
+    in
+    (lib.optionalString stdenv.hostPlatform.isLinux ''
+      export NIX_REDIRECTS="/etc/nsswitch.conf=${nsswitch}:/etc/hosts=${hosts}:/etc/resolv.conf=${resolvConf}"
+      export LD_PRELOAD="${libredirect}/lib/libredirect.so"
+    '')
+    + ''
+      export STORE=RocksDb
+    '';
+
+  checkFlags = lib.forEach (
+    [
+      # Require running mysql, postgresql daemon
+      "directory::imap::imap_directory"
+      "directory::internal::internal_directory"
+      "directory::ldap::ldap_directory"
+      "directory::sql::sql_directory"
+      "directory::oidc::oidc_directory"
+      "store::blob::blob_tests"
+      "store::lookup::lookup_tests"
+      "smtp::lookup::sql::lookup_sql"
+      # Require running ldap directory
+      "directory::directory_tests"
+      # Require running nats or redis instance
+      "cluster::broadcast::cluster_tests"
+      # flaky tests: ... panicked at tests/src/utils/jmap.rs:434:32: Missing created item 0: { "methodResponses": [ [ "x:Domain/set", { "accountId": "d333333", "notCreated": { "i0": { "type": "primaryKeyViolation", "properties": [ "name" ], "objectId": { "object": "Domain", "id": "c" } } } }, "0" ] ], "sessionState": "a22d1fca" }
+      "cluster::stress::stress_tests"
+      "imap::imap_tests"
+      "system::system_tests"
+      "telemetry::telemetry_tests"
+      # flaky test: ... panicked at tests/src/utils/jmap.rs:434:32: Missing created item 0: { "methodResponses": [ [ "error", { "type": "serverUnavailable", description": "This server is temporarily unavailable. Attempting this same operation later may succeed." }, "0" ] ], "sessionState": "a22d1fca" }
+      "jmap::jmap_tests"
+      "automation::automation_tests"
+      # thread 'webdav::webdav_tests' (4676902) panicked at tests/src/utils/webdav.rs:591:13: Expected 201 Created but got 409 Conflict
+      "webdav::webdav_tests"
+      # panicked at tests/src/smtp/inbound/mod.rs:270:18: Unexpected event: WorkerDone { queue_id: 312710620013133824, queue_name: QueueName([100, 101, 102, 97, 117, 108, 116, 0]), status: Completed }
+      "smtp::outbound::smtp::smtp_delivery"
+      # flaky test: ... panicked at tests/src/smtp/outbound/lmtp.rs:245:5: assertion `left == right` failed
+      #   left: 3
+      #   right: 4
+      "smtp::outbound::lmtp::lmtp_delivery"
+      # flaky test: ... panicked at tests/src/smtp/reporting/analyze.rs:110:5: assertion `left == right` failed
+      #   left: 0
+      #   right: 5
+      "smtp::reporting::analyze::report_analyze"
+      # flaky test: ... panicked at tests/src/smtp/queue/manager.rs:200:32: Expected rcpt b not found in [Recipient { address: "c", retry: Schedule { due: 1781399468, inner: 0 }, notify: Schedule { due: 1781399473, inner: 0 }, expires: Ttl(9), queue: QueueName([100, 101, 102, 97, 117, 108, 116, 0]), status: Scheduled, flags: 0, orcpt: None }]
+      "smtp::queue::manager::queue_due"
+      # flaky test: ... panicked at tests/src/smtp/queue/retry.rs:237:5: assertion `left == right` failed
+      #   left: [1, 2, 2]
+      #  right: [1, 2, 3]
+      "smtp::queue::retry::queue_retry"
+      # error[E0432]: unresolved import `r2d2_sqlite`
+      "backend::sqlite::pool::SqliteConnectionManager::with_init"
+      # thread 'smtp::management::queue::manage_queue' panicked at tests/src/smtp/inbound/mod.rs:45:23: No queue event received.
+      # NOTE: Test unreliable on high load systems
+      "smtp::management::queue::manage_queue"
+      # NOTE: long running test(s), needs live dependencies, likely to fail on systems under high load
+      "smtp::inbound::antispam::antispam"
+    ]
+    # ... panicked at tests/src/lib.rs:49:13: Errors: [ Build { ... , message: "Invalid address: failed to lookup address information: Temporary failure in name resolution", }, ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      "smtp::inbound::auth::auth"
+      "smtp::inbound::basic::basic_commands"
+      "smtp::inbound::data::data"
+      "smtp::inbound::dmarc::dmarc"
+      "smtp::inbound::ehlo::ehlo"
+      "smtp::inbound::limits::limits"
+      "smtp::inbound::mail::mail"
+      "smtp::inbound::milter::milter_session"
+      "smtp::inbound::milter::mta_hook_session"
+      "smtp::inbound::rcpt::rcpt"
+      "smtp::inbound::rewrite::address_rewrite"
+      "smtp::inbound::scripts::sieve_scripts"
+      "smtp::inbound::sign::sign_and_seal"
+      "smtp::inbound::throttle::throttle_inbound"
+      "smtp::inbound::vrfy::vrfy_expn"
+      "smtp::lookup::expressions::expressions"
+      "smtp::lookup::utils::strategies"
+      "smtp::management::report::manage_reports"
+      "smtp::outbound::dane::dane_test"
+      # since 0.16.10
+      "smtp::outbound::dane::dane_downgrade_on_tlsa_servfail"
+      "smtp::outbound::dane::dane_verify"
+      "smtp::outbound::extensions::extensions"
+      "smtp::outbound::fallback_relay::fallback_relay"
+      "smtp::outbound::ip_lookup::ip_lookup_strategy"
+      "smtp::outbound::mta_sts::mta_sts_verify"
+      "smtp::outbound::throttle::throttle_outbound"
+      "smtp::outbound::tls::starttls_optional"
+      "smtp::queue::concurrent::concurrent_queue"
+      "smtp::queue::dsn::generate_dsn"
+      "smtp::queue::virtualq::virtual_queue"
+      "smtp::reporting::dmarc::report_dmarc"
+      "smtp::reporting::scheduler::report_scheduler"
+      "smtp::reporting::tls::report_tls"
+      "store::search_tests"
+      "store::store_tests"
+    ]
+  ) (test: "--skip=${test}");
+
+  postInstall = ''
+    mkdir -p $out/etc/stalwart
+
+    mkdir -p $out/lib/systemd/system
+
+    substitute resources/systemd/stalwart-mail.service $out/lib/systemd/system/stalwart.service \
+      --replace-fail "__PATH__" "$out"
+
+    ln -s ${migrate_v016 { inherit (finalAttrs) src version; }}/bin/migrate_v016 $out/bin/migrate_v016
+  '';
+
+  passthru = {
+    inherit rocksdb; # make used rocksdb version available (e.g., for backup scripts)
+    webui = callPackage ./webui.nix { };
+    spam-filter = callPackage ./spam-filter.nix { };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Secure, modern, all-in-one mail and collaboration server";
+    longDescription = ''
+      Secure, scalable and fluent in every protocol (IMAP, JMAP, SMTP, CalDAV, CardDAV, WebDAV).
+    '';
+    homepage = "https://github.com/stalwartlabs/stalwart";
+    changelog = "https://github.com/stalwartlabs/stalwart/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = [
+      lib.licenses.agpl3Only
+    ]
+    ++ lib.optionals stalwartEnterprise [
+      {
+        fullName = "Stalwart Enterprise License 2.0 (SELv2) Agreement";
+        url = "https://github.com/stalwartlabs/stalwart/blob/${finalAttrs.src.tag}/LICENSES/LicenseRef-SEL.txt";
+        free = false;
+        redistributable = false;
+      }
+    ];
+
+    mainProgram = "stalwart";
+    maintainers = with lib.maintainers; [
+      happysalada
+      onny
+      oddlama
+      pandapip1
+      norpol
+      debtquity
+    ];
+  };
+})

--- a/pkgs/by-name/st/stalwart_0_16/spam-filter-generate-rules-json-use-current-working-dir.patch
+++ b/pkgs/by-name/st/stalwart_0_16/spam-filter-generate-rules-json-use-current-working-dir.patch
@@ -1,0 +1,21 @@
+diff --git a/generate_rules_json.py b/generate_rules_json.py
+index d0977d3..c54e976 100644
+--- a/generate_rules_json.py
++++ b/generate_rules_json.py
+@@ -1,6 +1,7 @@
+ #!/usr/bin/env python3
+ import json
+ import gzip
++import os
+ from pathlib import Path
+ 
+ try:
+@@ -11,7 +12,7 @@ except ImportError:
+     except ImportError:
+         raise ImportError("Install tomli: pip install tomli")
+ 
+-BASE_DIR = Path(__file__).parent
++BASE_DIR = Path(os.getcwd())
+ 
+ def load_toml(path: Path) -> dict:
+     raw = path.read_text(encoding="utf-8")

--- a/pkgs/by-name/st/stalwart_0_16/spam-filter.nix
+++ b/pkgs/by-name/st/stalwart_0_16/spam-filter.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  stalwart_0_16,
+  nix-update-script,
+  python3Packages,
+}:
+let
+  generate_rules_json =
+    {
+      src,
+      version,
+    }:
+    python3Packages.buildPythonApplication {
+      pname = "generate_rules_json";
+      inherit src version;
+      __structuredAttrs = true;
+      format = "other";
+      dontBuild = true;
+      dependencies = [ python3Packages.tomli ];
+      installPhase = ''
+        runHook preInstall
+        mkdir -p $out/bin
+        cp generate_rules_json.py $out/bin/generate_rules_json
+        chmod +x $out/bin/generate_rules_json
+        runHook postInstall
+      '';
+      postFixup = ''
+        wrapPythonPrograms
+      '';
+      patches = [ ./spam-filter-generate-rules-json-use-current-working-dir.patch ];
+    };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "spam-filter";
+  version = "3.0.0";
+
+  src = fetchFromGitHub {
+    owner = "stalwartlabs";
+    repo = "spam-filter";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-mADA62eOHV7cJf4khkLh/OX0eQHRUus6nlGkieGFsKA=";
+  };
+
+  __structuredAttrs = true;
+
+  buildPhase = ''
+    runHook preBuild
+    ${generate_rules_json { inherit (finalAttrs) src version; }}/bin/generate_rules_json
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp spam-filter.toml $out/
+    cp spam-filter-rules.json.gz $out/
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Spam filter module for the Stalwart server";
+    homepage = "https://github.com/stalwartlabs/spam-filter";
+    changelog = "https://github.com/stalwartlabs/spam-filter/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license =
+      with lib.licenses;
+      OR [
+        mit
+        asl20
+      ];
+    inherit (stalwart_0_16.meta) maintainers;
+  };
+})

--- a/pkgs/by-name/st/stalwart_0_16/webui.nix
+++ b/pkgs/by-name/st/stalwart_0_16/webui.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  buildNpmPackage,
+  gnutar,
+  stalwart_0_16,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+buildNpmPackage (finalAttrs: {
+  pname = "webui";
+  version = "1.0.4";
+
+  src = fetchFromGitHub {
+    owner = "stalwartlabs";
+    repo = "webui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-V1g5lzkmO2NadRETwmp7ijEuzG3n83uO+6O1wdlF8G8=";
+  };
+
+  npmDepsHash = "sha256-XusIkv2lSwO/FXy+QsLAtcrSwN28SUa07/kj39Mr+u0=";
+  __structuredAttrs = true;
+
+  env = {
+    # https://github.com/stalwartlabs/webui/tree/main#environment-variables
+    # https://github.com/stalwartlabs/webui/blob/main/.env.development
+    VITE_API_BASE_URL = "";
+    VITE_OAUTH_CLIENT_ID = "stalwart-webui";
+  };
+
+  nativeBuildInputs = [ gnutar ];
+  preBuild = ''
+    rm .env.development
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    npm run test
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    tar -czvf $out/webui.tar.gz dist
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Stalwart WebUI";
+    longDescription = ''
+      Stalwart WebUI is schema-driven single-page application for administering Stalwart.
+
+      After authentication the panel fetches a JSON schema from the server and dynamically
+      generates all forms, lists, navigation, and layouts from that schema. Nothing is hardcoded.
+    '';
+    homepage = "https://github.com/stalwartlabs/webui";
+    changelog = "https://github.com/stalwartlabs/webui/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.OR [
+      lib.licenses.agpl3Only
+      {
+        fullName = "Stalwart Enterprise License 2.0 (SELv2) Agreement";
+        url = "https://github.com/stalwartlabs/webui/blob/main/LICENSES/LicenseRef-SEL.txt";
+        free = false;
+        redistributable = false;
+      }
+    ];
+    inherit (stalwart_0_16.meta) maintainers;
+  };
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -2096,6 +2096,7 @@ mapAliases {
   src = throw "The \"src\" package has been renamed to \"simple-revision-control\". If you encounter this error and did not intend to use that package you may have a falsely constructed overlay."; # Added 2025-11-19
   ssm-agent = throw "'ssm-agent' has been renamed to/replaced by 'amazon-ssm-agent'"; # Converted to throw 2025-10-27
   stacer = throw "'stacer' has been removed because it was abandoned upstream and relied upon vulnerable software"; # Added 2025-11-08
+  stalwart = warnAlias "`stalwart` is currently pinned to `0.15.5`. If `0.16.x` is needed, it is available as `stalwart_0_16`. Note: `stalwart_0_16` is not compatible with `services.stalwart` at this time." stalwart_0_15;
   stalwart-mail = warnAlias "'stalwart-mail' has been renamed to/replaced by 'stalwart'" stalwart; # Added 2026-01-19
   starpls-bin = throw "'starpls-bin' has been renamed to/replaced by 'starpls'"; # Converted to throw 2025-10-27
   station = throw "station has been removed from nixpkgs, as there were no committers among its maintainers to unblock security issues"; # Added 2025-06-16

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7730,10 +7730,10 @@ with pkgs;
     enableAirplay2 = true;
   };
 
-  stalwart-webadmin = stalwart.webadmin;
-  stalwart-spam-filter = stalwart.spam-filter;
+  stalwart-webadmin = stalwart_0_15.webadmin;
+  stalwart-spam-filter = stalwart_0_15.spam-filter;
 
-  stalwart-enterprise = stalwart.override {
+  stalwart-enterprise = stalwart_0_15.override {
     stalwartEnterprise = true;
   };
 


### PR DESCRIPTION
* diff: https://github.com/stalwartlabs/stalwart/compare/v0.15.5...v0.16.10
* changelog: https://github.com/stalwartlabs/stalwart/releases/tag/v0.16.10
* update module to run more upstream unit/integration tests
* clean up module to increase readability and group phase attributes
  logically
* update doCheck to run on all linux and darwin platforms

---

stalwart_0_16.spam-filter: init at 3.0.0

* 3.x.x introduces non-backwards compatible changes thus only compatible
  with stalwart versions 0.16.x or greater
* diff: https://github.com/stalwartlabs/spam-filter/compare/v2.0.5...v3.0.0
* changelog: https://github.com/stalwartlabs/spam-filter/releases/tag/v3.0.0

---

stalwart_0_16.webui: init at 1.0.4

* upstream switched to Vite as frontend framework
* repo: https://github.com/stalwartlabs/webui
* diff: https://github.com/stalwartlabs/webui/compare/v1.0.0...v1.0.4
* changelog: https://github.com/stalwartlabs/webui/releases/tag/v1.0.4

Resolves: https://github.com/NixOS/nixpkgs/issues/511880

---

stalwart: rename to stalwart_0_15

* pin existing package defined at `stalwart` to `0.15.5`
* add `stalwart` alias with warning to `stalwart_0_15`
* update `stalwart-webadmin`, `stalwart-spam-filter`,
  `stalwart-enterprise` references
* add __structuredAttrs attr

---

stalwart.spam-filter: rename to stalwart_0_15.spam-filter

* move sub-package to `stalwart_0_15`
* add __structuredAttrs attr

---

stalwart.webadmin: rename to stalwart_0_15.webadmin

* move sub-package to `stalwart_0_15`
* add __structuredAttrs attr

Related: https://github.com/NixOS/nixpkgs/issues/511880
Related to: #511880 #512341

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
