### PR TITLE
[Backport release-25.11] openssl_4_0: 4.0.0 -> 4.0.1; openssl_3: 3.0.20 -> 3.0.21

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -484,8 +484,8 @@ in
   };
 
   openssl_4_0 = common {
-    version = "4.0.0";
-    hash = "sha256-wyz0mpWcTzRflgaYLdNufSj3xYsZwuJddWJNKz0veaw=";
+    version = "4.0.1";
+    hash = "sha256-LbPzoNbqS1nh8JSs4sjNU23/uHzcOQhMWvoeb3833Qk=";
 
     patches = [
       # Support for NIX_SSL_CERT_FILE, motivation:

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -429,8 +429,8 @@ in
   };
 
   openssl_3 = common {
-    version = "3.0.20";
-    hash = "sha256-yAoB38cOzk3CEWiTLDdzkELUBNRszIGlmG3XUxTs2m8=";
+    version = "3.0.21";
+    hash = "sha256-YX4pr45CH0ZklISkk35IxoXkf0ZIgWfJgviLxOwdUi8=";
 
     patches = [
       # Support for NIX_SSL_CERT_FILE, motivation:


### PR DESCRIPTION
Manual backport of PR https://github.com/NixOS/nixpkgs/pull/530955

We have no openssl 3.5.x on NixOS 25.11, so that commit is skipped, which is why the auto-backport failed.