### PR TITLE
gzrt: 0.8 -> 0.9.1

### DIFF
--- a/pkgs/by-name/gz/gzrt/package.nix
+++ b/pkgs/by-name/gz/gzrt/package.nix
@@ -1,17 +1,19 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   zlib,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gzrt";
-  version = "0.8";
+  version = "0.9.1";
 
-  src = fetchurl {
-    url = "https://www.urbanophile.com/arenn/coding/gzrt/gzrt-${finalAttrs.version}.tar.gz";
-    sha256 = "1vhzazj47xfpbfhzkwalz27cc0n5gazddmj3kynhk0yxv99xrdxh";
+  src = fetchFromGitHub {
+    owner = "arenn";
+    repo = "gzrt";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2RzQ/xrtADplVqUeB6suU3fKhJePYM7EkuIV59JSR3Q=";
   };
 
   buildInputs = [ zlib ];
@@ -22,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    homepage = "https://www.urbanophile.com/arenn/hacking/gzrt/";
+    homepage = "https://github.com/arenn/gzrt";
     description = "Gzip Recovery Toolkit";
     maintainers = [ ];
     mainProgram = "gzrecover";


### PR DESCRIPTION
Update to 0.9.1

Change homepage and source repo to github which contains a newer version.
Same repo is used in Debian: https://salsa.debian.org/salvage-team/gzrt/-/commit/20a5d8fea5ba1af2f501e77f577483db22e7deb8

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
