### PR TITLE
[Backport release-25.11] knot-dns: 3.5.4 -> 3.5.5

### DIFF
--- a/pkgs/by-name/kn/knot-dns/package.nix
+++ b/pkgs/by-name/kn/knot-dns/package.nix
@@ -34,11 +34,11 @@
 
 stdenv.mkDerivation rec {
   pname = "knot-dns";
-  version = "3.5.4";
+  version = "3.5.5";
 
   src = fetchurl {
     url = "https://secure.nic.cz/files/knot-dns/knot-${version}.tar.xz";
-    sha256 = "sha256-SgvIkt+qWhUP8oVfCojyJnEkvCcYGOrporH22kh8NOQ=";
+    sha256 = "38502c1472247c955aa3329bb5722e61ca765b833e3497d71f891ebf8e77fa04";
   };
 
   outputs = [


### PR DESCRIPTION
This is a manual backport of PR https://github.com/NixOS/nixpkgs/pull/531010
(failing surely because of the finalAttrs change which's happened in the meantime)
- - -
https://gitlab.nic.cz/knot/knot-dns/-/releases/v3.5.5
(cherry picked from commit 7cc6af93c1dc2b1295a6e015539b8e470b66af50)
