### PR TITLE
home-assistant-custom-components.mypyllant: 0.9.13 -> 0.9.16

### DIFF
--- a/pkgs/development/python-modules/mypyllant/default.nix
+++ b/pkgs/development/python-modules/mypyllant/default.nix
@@ -26,14 +26,14 @@
 
 buildPythonPackage rec {
   pname = "mypyllant";
-  version = "0.9.12";
+  version = "0.9.15";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "signalkraft";
     repo = "myPyllant";
     tag = "v${version}";
-    hash = "sha256-ZVk9QV5Q5bEeS3dsyFkhdPOJDqwf76o6XW5VSBuutMw=";
+    hash = "sha256-MaEk1IU0wCuR/rE3PYhSAjG925K/9N+1i6hVdgDg7YQ=";
   };
 
   build-system = [

--- a/pkgs/servers/home-assistant/custom-components/mypyllant/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/mypyllant/package.nix
@@ -19,13 +19,13 @@
 buildHomeAssistantComponent rec {
   owner = "signalkraft";
   domain = "mypyllant";
-  version = "0.9.13";
+  version = "0.9.16";
 
   src = fetchFromGitHub {
     owner = "signalkraft";
     repo = "mypyllant-component";
     tag = "v${version}";
-    hash = "sha256-ydayYZjebVQULYyF3KWJHuSg89dY+bGYe+5zHGxfnEw=";
+    hash = "sha256-+v8FqmP92FkfywJRH9JPvpTRyOAuTKAjNnnLXy6sLV8=";
   };
 
   dependencies = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The mypyllant Home Assistant custom component has been broken since #522938, due to a version bump in `python3.pkgs.mypyllant` that wasn't compatible with `home-assistant-custom-components.mypyllant`.

Now upstream has updated both packages, which build normally again.

So, this PR bumps both packages and fixes the build.

Here's a summary of changes:

- `python3.pkgs.mypyllant`: 0.9.12 -> 0.9.15
- `home-assistant-custom-components.mypyllant`: 0.9.13 -> 0.9.16

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
