### PR TITLE
gitlab-runner: add outputLimit option

### DIFF
--- a/nixos/modules/services/continuous-integration/gitlab-runner/runner.nix
+++ b/nixos/modules/services/continuous-integration/gitlab-runner/runner.nix
@@ -161,6 +161,7 @@ let
                       ++ service.registrationFlags
                       ++ optional (service.buildsDir != null) "--builds-dir ${service.buildsDir}"
                       ++ optional (service.cloneUrl != null) "--clone-url ${service.cloneUrl}"
+                      ++ optional (service.outputLimit != null) "--output-limit ${toString service.outputLimit}"
                       ++ optional (
                         service.preGetSourcesScript != null
                       ) "--pre-get-sources-script ${service.preGetSourcesScript}"
@@ -576,6 +577,13 @@ in
               ];
               description = ''
                 Whitelist allowed privileged services.
+              '';
+            };
+            outputLimit = mkOption {
+              type = types.nullOr types.int;
+              default = null;
+              description = ''
+                Maximum build log size in kilobytes. Default is 4096 (4 MB).
               '';
             };
             preGetSourcesScript = mkOption {


### PR DESCRIPTION

This makes controlable in nix-pkgs of how much of the buildlog is captured before it gets truncated, default is 4MB which may not be enough for large builds.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
