### PR TITLE
libwebsockets: Fix darwin dylib install names

### DIFF
--- a/pkgs/by-name/li/libwebsockets/package.nix
+++ b/pkgs/by-name/li/libwebsockets/package.nix
@@ -65,7 +65,15 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace "cmake/libwebsockets-config.cmake.in" --replace-fail \
       "set(LIBWEBSOCKETS_LIBRARIES websockets websockets_shared)" \
       "set(LIBWEBSOCKETS_LIBRARIES websockets)"
-  '';
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # Fix doubled store path in macOS install_name
+    substituteInPlace CMakeLists.txt \
+      --replace-fail \
+        'SET(CMAKE_INSTALL_NAME_DIR "''${CMAKE_INSTALL_PREFIX}/''${LWS_INSTALL_LIB_DIR}")' \
+        'SET(CMAKE_INSTALL_NAME_DIR "''${LWS_INSTALL_LIB_DIR}")'
+  ''
+  + lib.optionalString stdenv.hostPlatform.isStatic "";
 
   postInstall = ''
     # Fix path that will be incorrect on move to "dev" output.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

On darwin the dylib install names are duplicated, e.g.
`/nix/store/zdi6lgpkn5ci6gmzd0ikcdk7x64z9jf2-libwebsockets-4.4.5//nix/store/zdi6lgpkn5ci6gmzd0ikcdk7x64z9jf2-libwebsockets-4.4.5/lib/libwebsockets-evlib_uv.dylib` instead of
`/nix/store/yav1p3b3q5wfz4a34qlgv191z7i1kjq6-libwebsockets-4.4.5/lib/libwebsockets-evlib_uv.dylib`.
This leads to runtime issues in packages linking libwebsockets.

<details><summary>otool output <b>before</b> the changes in this PR</summary>

```
% otool -L result/lib/libwebsockets*
result/lib/libwebsockets-evlib_uv.dylib:
        /nix/store/zdi6lgpkn5ci6gmzd0ikcdk7x64z9jf2-libwebsockets-4.4.5//nix/store/zdi6lgpkn5ci6gmzd0ikcdk7x64z9jf2-libwebsockets-4.4.5/lib/libwebsockets-evlib_uv.dylib (compatibility version 0.0.0, current version 0.0.0)
        /nix/store/zdi6lgpkn5ci6gmzd0ikcdk7x64z9jf2-libwebsockets-4.4.5//nix/store/zdi6lgpkn5ci6gmzd0ikcdk7x64z9jf2-libwebsockets-4.4.5/lib/libwebsockets.20.dylib (compatibility version 20.0.0, current version 0.0.0)
        /nix/store/69kvh89l278cw3dxxv9c6yhik3ws5d72-libuv-1.52.1/lib/libuv.1.dylib (compatibility version 2.0.0, current version 2.0.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1345.100.2)
        /nix/store/a3hhkd5vzw97issax60xx47qfnkl6ddf-openssl-3.6.2/lib/libssl.3.dylib (compatibility version 3.0.0, current version 3.0.0)
        /nix/store/a3hhkd5vzw97issax60xx47qfnkl6ddf-openssl-3.6.2/lib/libcrypto.3.dylib (compatibility version 3.0.0, current version 3.0.0)
result/lib/libwebsockets.20.dylib:
        /nix/store/zdi6lgpkn5ci6gmzd0ikcdk7x64z9jf2-libwebsockets-4.4.5//nix/store/zdi6lgpkn5ci6gmzd0ikcdk7x64z9jf2-libwebsockets-4.4.5/lib/libwebsockets.20.dylib (compatibility version 20.0.0, current version 0.0.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1345.100.2)
        /nix/store/a3hhkd5vzw97issax60xx47qfnkl6ddf-openssl-3.6.2/lib/libssl.3.dylib (compatibility version 3.0.0, current version 3.0.0)
        /nix/store/a3hhkd5vzw97issax60xx47qfnkl6ddf-openssl-3.6.2/lib/libcrypto.3.dylib (compatibility version 3.0.0, current version 3.0.0)
result/lib/libwebsockets.dylib:
        /nix/store/zdi6lgpkn5ci6gmzd0ikcdk7x64z9jf2-libwebsockets-4.4.5//nix/store/zdi6lgpkn5ci6gmzd0ikcdk7x64z9jf2-libwebsockets-4.4.5/lib/libwebsockets.20.dylib (compatibility version 20.0.0, current version 0.0.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1345.100.2)
        /nix/store/a3hhkd5vzw97issax60xx47qfnkl6ddf-openssl-3.6.2/lib/libssl.3.dylib (compatibility version 3.0.0, current version 3.0.0)
        /nix/store/a3hhkd5vzw97issax60xx47qfnkl6ddf-openssl-3.6.2/lib/libcrypto.3.dylib (compatibility version 3.0.0, current version 3.0.0)
```

</details> 

<details><summary>otool output <b>after</b> the changes in this PR</summary>

```
otool -L result/lib/libwebsockets*
result/lib/libwebsockets-evlib_uv.dylib:
        /nix/store/yav1p3b3q5wfz4a34qlgv191z7i1kjq6-libwebsockets-4.4.5/lib/libwebsockets-evlib_uv.dylib (compatibility version 0.0.0, current version 0.0.0)
        /nix/store/yav1p3b3q5wfz4a34qlgv191z7i1kjq6-libwebsockets-4.4.5/lib/libwebsockets.20.dylib (compatibility version 20.0.0, current version 0.0.0)
        /nix/store/69kvh89l278cw3dxxv9c6yhik3ws5d72-libuv-1.52.1/lib/libuv.1.dylib (compatibility version 2.0.0, current version 2.0.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1345.100.2)
        /nix/store/a3hhkd5vzw97issax60xx47qfnkl6ddf-openssl-3.6.2/lib/libssl.3.dylib (compatibility version 3.0.0, current version 3.0.0)
        /nix/store/a3hhkd5vzw97issax60xx47qfnkl6ddf-openssl-3.6.2/lib/libcrypto.3.dylib (compatibility version 3.0.0, current version 3.0.0)
result/lib/libwebsockets.20.dylib:
        /nix/store/yav1p3b3q5wfz4a34qlgv191z7i1kjq6-libwebsockets-4.4.5/lib/libwebsockets.20.dylib (compatibility version 20.0.0, current version 0.0.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1345.100.2)
        /nix/store/a3hhkd5vzw97issax60xx47qfnkl6ddf-openssl-3.6.2/lib/libssl.3.dylib (compatibility version 3.0.0, current version 3.0.0)
        /nix/store/a3hhkd5vzw97issax60xx47qfnkl6ddf-openssl-3.6.2/lib/libcrypto.3.dylib (compatibility version 3.0.0, current version 3.0.0)
result/lib/libwebsockets.dylib:
        /nix/store/yav1p3b3q5wfz4a34qlgv191z7i1kjq6-libwebsockets-4.4.5/lib/libwebsockets.20.dylib (compatibility version 20.0.0, current version 0.0.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1345.100.2)
        /nix/store/a3hhkd5vzw97issax60xx47qfnkl6ddf-openssl-3.6.2/lib/libssl.3.dylib (compatibility version 3.0.0, current version 3.0.0)
        /nix/store/a3hhkd5vzw97issax60xx47qfnkl6ddf-openssl-3.6.2/lib/libcrypto.3.dylib (compatibility version 3.0.0, current version 3.0.0)
```

</details> 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
