### PR TITLE
createrepo-rs: init at 0.1.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12144,6 +12144,12 @@
     github = "james-atkins";
     githubId = 9221409;
   };
+  jamesarch = {
+    email = "han.shan@live.cn";
+    github = "jamesarch";
+    githubId = 2214753;
+    name = "jamesarch";
+  };
   jamespeapen = {
     name = "James Eapen";
     email = "james.eapen@vai.org";

--- a/pkgs/by-name/cr/createrepo-rs/package.nix
+++ b/pkgs/by-name/cr/createrepo-rs/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "createrepo-rs";
+  version = "0.1.9";
+
+  src = fetchFromGitHub {
+    owner = "jamesarch";
+    repo = "createrepo_rs";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-4y29y0xvmOngkTt2P6+UZxxH1SQ2taAT4TSbuALkj34=";
+  };
+
+  cargoHash = "sha256-70KuriwRVWSRKpGMYF5kY0e1PA4lL7YSU5j8p7ojdgA=";
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Pure Rust RPM repository metadata generator — dnf/yum-compatible, zero FFI";
+    homepage = "https://github.com/jamesarch/createrepo_rs";
+    changelog = "https://github.com/jamesarch/createrepo_rs/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "createrepo_rs";
+    maintainers = with lib.maintainers; [ jamesarch ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
## Description

Add `createrepo-rs`, a pure Rust implementation of `createrepo_c` for generating RPM repository metadata. Compatible with `dnf`/`yum`.

- Zero FFI, no C library dependencies
- Parallel metadata generation
- Supports gzip, zstd, bzip2, xz compression

## Checklist

- [x] package builds: `nix build .#createrepo-rs` (tested in Docker container, aarch64-linux)
- [x] `meta.description` does not start with article
- [x] `meta.license` accurately matches source
- [x] `meta.mainProgram` set
- [x] added myself to `maintainers/maintainer-list.nix`
- [ ] NixOS module (not applicable — CLI tool)