### PR TITLE
pkgs.formats.configobj: init

### DIFF
--- a/nixos/doc/manual/development/settings-options.section.md
+++ b/nixos/doc/manual/development/settings-options.section.md
@@ -322,6 +322,14 @@ have a predefined type and string generator already declared under
 
     The attribute `lib.type.atom` contains the used INI atom.
 
+`pkgs.formats.configobj` { }
+
+:   A function taking an attribute set with values
+
+    It returns a set with [ConfigObj](https://pypi.org/project/configobj/)-specific attributes `type` and `generate` as specified [below](#pkgs-formats-result).
+    The type of the input is an attribute mapping supporting both atoms and nested attribute sets (sections/subsections), as supported by ConfigObj.
+    The renderer is based on Python's `configobj` module.
+
 `pkgs.formats.iniWithGlobalSection` { *`listsAsDuplicateKeys`* ? false, *`listToValue`* ? null, \.\.\. }
 
 :   A function taking an attribute set with values

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -131,6 +131,8 @@ optionalAttrs allowAliases aliases
 
   php = (import ./formats/php/default.nix { inherit lib pkgs; }).format;
 
+  configobj = (import ./formats/configobj/default.nix { inherit lib pkgs; }).format;
+
   json =
     { }:
     {

--- a/pkgs/pkgs-lib/formats/configobj/default.nix
+++ b/pkgs/pkgs-lib/formats/configobj/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  pkgs,
+}:
+let
+  inherit (lib)
+    toJSON
+    ;
+
+  inherit (lib.types)
+    serializableValueWith
+    ;
+in
+{
+  format =
+    { }:
+    {
+      type = serializableValueWith { typeName = "ConfigObj mapping"; };
+
+      generate =
+        name: value:
+        pkgs.runCommandLocal name
+          {
+            nativeBuildInputs = [
+              (pkgs.python3.withPackages (ps: [ ps.configobj ]))
+            ];
+
+            valuesJSON = toJSON value;
+            __structuredAttrs = true;
+            strictDeps = true;
+          }
+          ''
+            printf "%s" "$valuesJSON" | python3 ${./generate.py} > "$out"
+          '';
+    };
+}

--- a/pkgs/pkgs-lib/formats/configobj/generate.py
+++ b/pkgs/pkgs-lib/formats/configobj/generate.py
@@ -1,0 +1,7 @@
+import json
+import sys
+from configobj import ConfigObj
+
+config = ConfigObj(interpolation=False, encoding="UTF8")
+config.update(json.load(sys.stdin))
+config.write(sys.stdout.buffer)

--- a/pkgs/pkgs-lib/tests/formats.nix
+++ b/pkgs/pkgs-lib/tests/formats.nix
@@ -229,6 +229,110 @@ runBuildTests {
     '';
   };
 
+  configobjAtoms = shouldPass {
+    format = formats.configobj { };
+    input = {
+      bool = true;
+      int = 10;
+      float = 3.141;
+      str = "string";
+    };
+    expected = ''
+      bool = True
+      float = 3.141
+      int = 10
+      str = string
+    '';
+  };
+
+  configobjListWithoutListToValue = shouldPass {
+    format = formats.configobj { };
+    input = {
+      items = [
+        1
+        true
+        "x"
+      ];
+    };
+    expected = ''
+      items = 1, True, x
+    '';
+  };
+
+  configobjNestedAttrsets = shouldPass {
+    format = formats.configobj { };
+    input = {
+      server = {
+        host = "127.0.0.1";
+        port = 8080;
+        enabled = true;
+        tags = [
+          "web"
+          "nix"
+          42
+        ];
+      };
+
+      logging = {
+        level = "info";
+        rotate = true;
+      };
+
+      interfaces = {
+        local = {
+          address = "123";
+          coin = {
+            foo = "bar";
+          };
+        };
+        remote = {
+          address = "456";
+        };
+      };
+    };
+    expected = ''
+      [interfaces]
+      [[local]]
+      address = 123
+      [[[coin]]]
+      foo = bar
+      [[remote]]
+      address = 456
+      [logging]
+      level = info
+      rotate = True
+      [server]
+      enabled = True
+      host = 127.0.0.1
+      port = 8080
+      tags = web, nix, 42
+    '';
+  };
+
+  configobjNullableValues = shouldPass {
+    format = formats.configobj { };
+    input = {
+      nullable = null;
+      nested = {
+        keep = "ok";
+        missing = null;
+      };
+    };
+    expected = ''
+      nullable = None
+      [nested]
+      keep = ok
+      missing = None
+    '';
+  };
+
+  configobjInvalidAtom = shouldFail {
+    format = formats.configobj { };
+    input = {
+      function = _: 1;
+    };
+  };
+
   iniInvalidAtom = shouldFail {
     format = formats.ini { };
     input = {


### PR DESCRIPTION
This PR:

- Introduce a new format `configobj`, using https://pypi.org/project/configobj/. It is similar to a regular INI file, but it can contain nested sections. Some projects uses this very particular format.
- Will be useful in https://github.com/NixOS/nixpkgs/pull/530406 to build Reticulum configuration
- Some other modules might benefit from this (`sabnzbd` CC @strangeglyph)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
