### PR TITLE
dae: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/by-name/da/dae/package.nix
+++ b/pkgs/by-name/da/dae/package.nix
@@ -10,17 +10,17 @@
 
 buildGoModule (finalAttrs: {
   pname = "dae";
-  version = "1.0.0";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "daeuniverse";
     repo = "dae";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-RpbWZEoGrCq3Py0hu6YDie6ErDTLS3oabqScPzhCtm0=";
+    hash = "sha256-Kc51VQuqObxKXVXGv5CnDm4/3XYqjPvrpAQSVb2vxSM=";
     fetchSubmodules = true;
   };
 
-  vendorHash = "sha256-u2DCHmX7vRNWIQ2Ir3UrxPGduggEqoUr1rnkDfwsT0I=";
+  vendorHash = "sha256-juxIsZt1T33epN8CbzDc02MmlW5PtYa4pcGxuX9OpH4=";
 
   proxyVendor = true;
 


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
- For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = true`
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = false`
- Tested, as applicable:
  - [x] `nix build .#dae`
  - [x] `./result/bin/dae --version`
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Not run; single package version bump.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`
- [x] Determined the impact on package closure size. Not checked; source/vendor update only.
- [x] Ensured that relevant documentation is up to date.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
- [x] Fits [Automation/AI Policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).

## Notes

Updates dae to the upstream `v1.1.0` release.