### PR TITLE
giflib: suppress missing symbol error on Darwin

### DIFF
--- a/pkgs/by-name/gi/giflib/0001-Suppress-undefined-symbol-error-on-Darwin.patch
+++ b/pkgs/by-name/gi/giflib/0001-Suppress-undefined-symbol-error-on-Darwin.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Randy Eckenrode <randy@largeandhighquality.com>
+Date: Sun, 14 Jun 2026 10:49:22 -0400
+Subject: [PATCH] Suppress undefined symbol error on Darwin
+
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index f347162..720bffa 100644
+--- a/Makefile
++++ b/Makefile
+@@ -133,7 +133,7 @@ libgif.a: $(OBJECTS) $(HEADERS)
+ 
+ $(LIBUTILSO): $(UOBJECTS) $(UHEADERS)
+ ifeq ($(UNAME), Darwin)
+-	$(CC) $(CFLAGS) -dynamiclib -current_version $(LIBVER) $(UOBJECTS) -o $(LIBUTILSO)
++	$(CC) $(CFLAGS) -dynamiclib -current_version $(LIBVER) $(UOBJECTS) -Wl,-U,_GifErrorString -o $(LIBUTILSO)
+ else
+ 	$(CC) $(CFLAGS) $(CPPLAGS) -shared $(LDFLAGS) -Wl,-soname -Wl,$(LIBUTILSOMAJOR) -o $(LIBUTILSO) $(UOBJECTS)
+ endif
+-- 
+2.54.0
+

--- a/pkgs/by-name/gi/giflib/package.nix
+++ b/pkgs/by-name/gi/giflib/package.nix
@@ -27,6 +27,9 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
+    # Fix missing symbol error on Darwin when linking libutil.dylib.
+    # Based on discussion in https://sourceforge.net/p/giflib/bugs/189/.
+    ./0001-Suppress-undefined-symbol-error-on-Darwin.patch
   ]
   ++ lib.optionals stdenv.hostPlatform.isMinGW [
     # Build dll libraries.


### PR DESCRIPTION
giflib fails to build due to a missing symbol in libutil.dylib. The included patch is based on the discussion in the upstream bug. Unfortunately, the problem is being blamed on the toolchain, so I don’t know whether or when this will be fixed upstream. In the meantime, I’m vendoring a patch to fix the build in Nixpkgs.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
