### PR TITLE
nixtamal: 1.6.0 → 1.7.0

### DIFF
--- a/pkgs/by-name/ni/nixtamal/package.nix
+++ b/pkgs/by-name/ni/nixtamal/package.nix
@@ -6,6 +6,8 @@
   ocamlPackages,
   darwin,
   makeBinaryWrapper,
+  removeReferencesTo,
+  installShellFiles,
   coreutils,
   curl,
   gawk,
@@ -13,14 +15,13 @@
   nix-prefetch-fossil,
   nix-prefetch-git,
   nix-prefetch-pijul,
-  removeReferencesTo,
   testers,
   nixtamal,
 }:
 
 ocamlPackages.buildDunePackage (finalAttrs: {
   pname = "nixtamal";
-  version = "1.6.0";
+  version = "1.7.0";
   release_year = 2026;
 
   minimalOCamlVersion = "5.3";
@@ -29,19 +30,20 @@ ocamlPackages.buildDunePackage (finalAttrs: {
     url = "https://darcs.toastal.in.th/nixtamal/stable/";
     mirrors = [ "https://smeder.ee/~toastal/nixtamal.darcs" ];
     rev = finalAttrs.version;
-    hash = "sha256-OOAulI6ZJGbbUMi68jnJQ+cJpZVQYL5F5HUfdOZ3wEs=";
+    hash = "sha256-EMm/hAmOZw5Zcmr3XUTz9M2LigqTnZpDElGMxWML6ug=";
   };
 
   nativeBuildInputs = [
     makeBinaryWrapper
     removeReferencesTo
+    installShellFiles
+    # Completions
+    ocamlPackages.cmdliner
     # For manpages
     python3Packages.docutils
     python3Packages.pygments
   ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    darwin.sigtool
-  ];
+  ++ lib.optional stdenv.hostPlatform.isDarwin darwin.sigtool;
 
   buildInputs = with ocamlPackages; [
     cmdliner
@@ -104,9 +106,8 @@ ocamlPackages.buildDunePackage (finalAttrs: {
        --libdir="$lib/lib/ocaml/${ocamlPackages.ocaml.version}/site-lib" \
        nixtamal
 
-    for dep in "${ocamlPackages.ocaml}" "${ocamlPackages.camomile}"
-    do
-        remove-references-to -t "$dep" "$bin/bin/nixtamal"
+    for dep in "${ocamlPackages.ocaml}" "${ocamlPackages.camomile}"; do
+       remove-references-to -t "$dep" "$bin/bin/nixtamal"
     done
 
     wrapProgram "$bin/bin/nixtamal" --prefix PATH : ${
@@ -120,6 +121,17 @@ ocamlPackages.buildDunePackage (finalAttrs: {
         nix-prefetch-pijul
       ]
     }
+
+    ${lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) /* sh */ ''
+      mkdir -p "$TMPDIR"
+      cmdliner tool-completion --standalone-completion bash nixtamal >"$TMPDIR/completion.bash"
+      cmdliner tool-completion --standalone-completion zsh nixtamal >"$TMPDIR/completion.zsh"
+      substituteInPlace "$TMPDIR/completion.zsh" --replace-fail "_nixtamal_cmdliner" "_nixtamal"
+
+      installShellCompletion --bash --cmd nixtamal "$TMPDIR/completion.bash"
+      installShellCompletion --fish --cmd nixtamal "script/completion.fish"
+      installShellCompletion --zsh --cmd nixtamal "$TMPDIR/completion.zsh"
+    ''}
 
     runHook postInstall
   '';
@@ -143,14 +155,14 @@ ocamlPackages.buildDunePackage (finalAttrs: {
     changelog = "https://nixtamal.toast.al/changelog/";
     description = "Fulfilling input pinning for Nix";
     longDescription = ''
-      Nixtamal’s keys features
-
-      • Automate the manual work of input pinning, allowing to lock & refresh inputs
-      • Declarative KDL manifest file over imperative CLI flags
+      • Automate the manual work of input pinning for dependency management
+      • Allow easy ways to lock & refresh those inputs
+      • Declarative manifest file over imperative CLI flags
       • diff/grep-friendly lockfile
-      • Host, forge, VCS-agnostic
-      • Choose eval time fetchers (builtins) or build time fetchers (Nixpkgs, default) — which opens up fetching Darcs, Pijul, & Fossil
-      • Supports mirrors
+      • Declarative patch/diff management for inputs
+      • Host-, forge-, VCS-agnostic
+      • Choose eval time fetchers (builtins) or build time fetchers (Nixpkgs, default) — which opens up fetching now-supported Darcs, Pijul, & Fossil
+      • Supports mirrors, failing over when a server is down
       • Override hash algorithm on a per-project & per-input basis — including BLAKE3 support
       • Custom freshness commands
       • No experimental Nix features required

--- a/pkgs/by-name/ni/nixtamal/package.nix
+++ b/pkgs/by-name/ni/nixtamal/package.nix
@@ -21,7 +21,7 @@
 
 ocamlPackages.buildDunePackage (finalAttrs: {
   pname = "nixtamal";
-  version = "1.7.0";
+  version = "1.7.1";
   release_year = 2026;
 
   minimalOCamlVersion = "5.3";
@@ -30,7 +30,7 @@ ocamlPackages.buildDunePackage (finalAttrs: {
     url = "https://darcs.toastal.in.th/nixtamal/stable/";
     mirrors = [ "https://smeder.ee/~toastal/nixtamal.darcs" ];
     rev = finalAttrs.version;
-    hash = "sha256-EMm/hAmOZw5Zcmr3XUTz9M2LigqTnZpDElGMxWML6ug=";
+    hash = "sha256-C6d6Ra9w0NG78QSVFS4Glj3HoNRugXjowjFOoJbzHT0=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Adds shell completions & syncs synopsis


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.