### PR TITLE
deterministic-uname: add setup hook

### DIFF
--- a/pkgs/by-name/de/deterministic-uname/package.nix
+++ b/pkgs/by-name/de/deterministic-uname/package.nix
@@ -46,6 +46,9 @@ replaceVarsWith {
     modDirVersion = if modDirVersion != "" then modDirVersion else "unknown";
   };
 
+  # coreutils uname is in initialPath, so ordinarily appears in PATH before packages in nativeBuildInputs.
+  setupHook = ./setup-hook.sh;
+
   meta = {
     description = "Print certain system information (hardcoded with lib/system values)";
     mainProgram = "uname";

--- a/pkgs/by-name/de/deterministic-uname/setup-hook.sh
+++ b/pkgs/by-name/de/deterministic-uname/setup-hook.sh
@@ -1,0 +1,8 @@
+# PATH is overwritten after package setup hooks are run,
+# so the variable change needs to be delayed until a phase.
+# An entry in prePhases is the earliest possible, useful
+# in case an unpack or patch hook attempts to run uname.
+unamePreHook() {
+  export PATH="@out@/bin:$PATH"
+}
+appendToVar prePhases unamePreHook


### PR DESCRIPTION

Several packages were adding deterministic-uname to `nativeBuildInputs`, but that is insufficient for its use. Add a setup hook to make its use more obvious

Done to fix an issue when building gitMinimal cross from linux to freebsd


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Add a new hook to the default deterministic-uname package. This will change stdenv, as it modifies the git derivation, though it should not cause binary changes.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
