### PR TITLE
notepad-next: 0.12 -> 0.14, adopt package 

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11025,6 +11025,12 @@
     github = "HolgerPeters";
     githubId = 4097049;
   };
+  Holiu0618 = {
+    email = "zvttt9db@anonaddy.me";
+    github = "Holiu0618";
+    githubId = 165534185;
+    name = "Holiu";
+  };
   hollowman6 = {
     email = "hollowman@hollowman.ml";
     github = "HollowMan6";

--- a/pkgs/by-name/no/notepad-next/package.nix
+++ b/pkgs/by-name/no/notepad-next/package.nix
@@ -1,40 +1,106 @@
 {
   lib,
   fetchFromGitHub,
-  qt5,
+  qt6,
   stdenv,
+  cmake,
 }:
 
+let
+  ads-src = fetchFromGitHub {
+    owner = "githubuser0xFFFF";
+    repo = "Qt-Advanced-Docking-System";
+    rev = "34b68d6eab1556cf851d24e033909332771f3dfe";
+    hash = "sha256-ojXH9lXs4lzhgclA8BFmyOuWy4DQE0SGK3OzuhHp000=";
+  };
+
+  qsimpleupdater-src = fetchFromGitHub {
+    owner = "alex-spataru";
+    repo = "QSimpleUpdater";
+    rev = "8e7017f7fbdc2b4b1a26ed1eef9ebcba6a50639c";
+    hash = "sha256-YU7z0U8W3s9RE41FPrWObpUOzTpqOQl4nDgyTqvnofc=";
+  };
+
+  singleapplication-src = fetchFromGitHub {
+    owner = "itay-grudev";
+    repo = "SingleApplication";
+    rev = "494772e98cef0aa88124f154feb575cc60b08b38";
+    hash = "sha256-OwfAikUJ+rC0BSLXILs0fBd1ilzu31ghMslwrgbnKhk=";
+  };
+
+  editorconfig-core-qt-src = fetchFromGitHub {
+    owner = "editorconfig";
+    repo = "editorconfig-core-qt";
+    rev = "ab62f0554abf2bbe4d45427b36a8b2f81ca7b4ab";
+    hash = "sha256-EMvkww+SWsLnjCB3gYykz0miLiSFpreoRHJpzgysX/0=";
+  };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "notepad-next";
-  version = "0.12";
+  version = "0.14";
 
   src = fetchFromGitHub {
     owner = "dail8859";
     repo = "NotepadNext";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-YD4tIPh5iJpbcDMZk334k2AV9jTVWCSGP34Mj2x0cJ0=";
+    hash = "sha256-XVwB8y3SrVmw0/PhvkpUDirm4QZ4ltKjDcyJOdS+1CU=";
     # External dependencies - https://github.com/dail8859/NotepadNext/issues/135
     fetchSubmodules = true;
   };
 
   nativeBuildInputs = [
-    qt5.qmake
-    qt5.qttools
-    qt5.wrapQtAppsHook
+    cmake
+    qt6.qttools
+    qt6.wrapQtAppsHook
   ];
-  buildInputs = [ qt5.qtx11extras ];
 
-  # Fix build with GCC 14+: Scintilla needs cstdint for intptr_t/uintptr_t types
-  # https://github.com/dail8859/NotepadNext/issues/752
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtsvg
+    qt6.qt5compat
+  ];
+
+  cmakeFlags = [
+    "-DCPM_USE_LOCAL_PACKAGES=ON"
+  ];
+
   postPatch = ''
-    sed -i '1i #include <cstdint>' src/scintilla/include/ScintillaTypes.h
-  '';
+    mkdir -p thirdparty/{ads,QSimpleUpdater,SingleApplication,editorconfig_core_qt}
+    cp -r --no-preserve=mode ${ads-src}/* thirdparty/ads/
+    cp -r --no-preserve=mode ${qsimpleupdater-src}/* thirdparty/QSimpleUpdater/
+    cp -r --no-preserve=mode ${singleapplication-src}/* thirdparty/SingleApplication/
+    cp -r --no-preserve=mode ${editorconfig-core-qt-src}/* thirdparty/editorconfig_core_qt/
 
-  qmakeFlags = [
-    "PREFIX=${placeholder "out"}"
-    "src/NotepadNext.pro"
-  ];
+    # Fix build with GCC 14+: Scintilla needs cstdint for intptr_t/uintptr_t types
+    # https://github.com/dail8859/NotepadNext/issues/752
+    substituteInPlace thirdparty/scintilla/include/ScintillaTypes.h \
+      --replace-fail '#ifndef SCINTILLATYPES_H' '#ifndef SCINTILLATYPES_H
+    #include <cstdint>'
+
+    find thirdparty/ads -name "CMakeLists.txt" -exec sed -i 's/VERSION ''${VERSION_SHORT}/VERSION "4.3.1"/g' {} +
+
+    substituteInPlace thirdparty/SingleApplication/singleapplication.cpp \
+      --replace-fail '#include "singleapplication.h"' '#include <QDebug>
+    #include <QMap>
+    #include <QLocalSocket>
+    #include "singleapplication.h"'
+
+    substituteInPlace thirdparty/SingleApplication/singleapplication_p.h \
+      --replace-fail '#ifndef SINGLEAPPLICATION_P_H' '#ifndef SINGLEAPPLICATION_P_H
+    #include <QMap>
+    #include <QLocalSocket>'
+
+    echo "set(QAPPLICATION_CLASS QApplication)" > thirdparty/CMakeLists.txt
+    echo "add_subdirectory(ads)" >> thirdparty/CMakeLists.txt
+    echo "add_subdirectory(QSimpleUpdater)" >> thirdparty/CMakeLists.txt
+    echo "add_subdirectory(SingleApplication)" >> thirdparty/CMakeLists.txt
+    echo "add_subdirectory(editorconfig_core_qt)" >> thirdparty/CMakeLists.txt
+    echo "add_subdirectory(lua)" >> thirdparty/CMakeLists.txt
+    echo "add_subdirectory(scintilla)" >> thirdparty/CMakeLists.txt
+    echo "add_subdirectory(lexilla)" >> thirdparty/CMakeLists.txt
+    echo "add_subdirectory(uchardet)" >> thirdparty/CMakeLists.txt
+    echo "target_link_libraries(lexilla PRIVATE scintilla)" >> thirdparty/CMakeLists.txt
+  '';
 
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     mv $out/bin $out/Applications
@@ -43,12 +109,12 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s $out/Applications/NotepadNext.app/Contents/MacOS/NotepadNext $out/bin/NotepadNext
   '';
 
-  meta = {
+  meta = with lib; {
     homepage = "https://github.com/dail8859/NotepadNext";
     description = "Cross-platform, reimplementation of Notepad++";
-    license = lib.licenses.gpl3Plus;
-    platforms = lib.platforms.unix;
-    maintainers = [ ];
+    license = licenses.gpl3Plus;
+    platforms = platforms.unix;
+    maintainers = with lib.maintainers; [ Holiu0618 ];
     broken = stdenv.hostPlatform.isAarch64;
     mainProgram = "NotepadNext";
   };


### PR DESCRIPTION
notepad-next: 0.12 -> 0.14
Changelog: https://github.com/dail8859/NotepadNext/releases/tag/v0.14

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
