### PR TITLE
elixir/erlang: deprecated top-level attributes

### DIFF
--- a/pkgs/by-name/cl/cl/package.nix
+++ b/pkgs/by-name/cl/cl/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   rebar3,
-  erlang,
+  beamPackages,
   opencl-headers,
   ocl-icd,
 }:
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   '';
 
   buildInputs = [
-    erlang
+    beamPackages.erlang
     rebar3
     opencl-headers
     ocl-icd

--- a/pkgs/by-name/er/erlang-language-platform/package.nix
+++ b/pkgs/by-name/er/erlang-language-platform/package.nix
@@ -3,7 +3,7 @@
   lib,
   fetchurl,
   autoPatchelfHook,
-  erlang,
+  beamPackages,
 }:
 let
   # erlang-language-platform supports multiple OTP versions.
@@ -15,7 +15,7 @@ let
       "elp-macos-${arch}-apple-darwin"
     else
       "elp-linux-${arch}-unknown-linux-gnu";
-  otp_version = "otp-${lib.versions.major erlang.version}";
+  otp_version = "otp-${lib.versions.major beamPackages.erlang.version}";
   release_major = "${platform}-${otp_version}";
 
   hashes = builtins.fromJSON (builtins.readFile ./hashes.json);

--- a/pkgs/by-name/gl/gleam/package.nix
+++ b/pkgs/by-name/gl/gleam/package.nix
@@ -6,7 +6,7 @@
   fetchFromGitHub,
   git,
   pkg-config,
-  erlang,
+  beamPackages,
   nodejs,
   bun,
   deno,
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [
     pkg-config
-    erlang
+    beamPackages.erlang
   ];
 
   nativeCheckInputs = [

--- a/pkgs/by-name/me/mercury/package.nix
+++ b/pkgs/by-name/me/mercury/package.nix
@@ -7,7 +7,7 @@
   bison,
   texinfo,
   openjdk8_headless,
-  erlang,
+  beamPackages,
   makeWrapper,
   readline,
 }:
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     bison
     texinfo
     openjdk8_headless
-    erlang
+    beamPackages.erlang
     readline
   ];
 
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
       wrapProgram $out/bin/$e \
         --prefix PATH ":" "${gcc}/bin" \
         --prefix PATH ":" "${openjdk8_headless}/bin" \
-        --prefix PATH ":" "${erlang}/bin"
+        --prefix PATH ":" "${beamPackages.erlang}/bin"
     done
   '';
 

--- a/pkgs/by-name/pl/plausible/package.nix
+++ b/pkgs/by-name/pl/plausible/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   beam27Packages,
-  elixir_1_18,
   buildNpmPackage,
   rustPlatform,
   fetchFromGitHub,
@@ -130,7 +129,7 @@ let
           $out/lazy_html/_build/c/third_party/lexbor/${lexborCommit}
       '';
 
-  beamPackages = beam27Packages.extend (self: super: { elixir = elixir_1_18; });
+  beamPackages = beam27Packages.extend (self: super: { elixir = self.elixir_1_18; });
 
 in
 beamPackages.mixRelease rec {

--- a/pkgs/by-name/ra/rabbitmq-server/package.nix
+++ b/pkgs/by-name/ra/rabbitmq-server/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   beam27Packages,
-  elixir_1_18,
   stdenv,
   fetchurl,
   python3,
@@ -41,7 +40,7 @@ let
     ]
   );
 
-  beamPackages = beam27Packages.extend (self: super: { elixir = elixir_1_18; });
+  beamPackages = beam27Packages.extend (self: super: { elixir = self.elixir_1_18; });
 in
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/by-name/ts/tsung/package.nix
+++ b/pkgs/by-name/ts/tsung/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   makeWrapper,
-  erlang,
+  beamPackages,
   python3,
   python3Packages,
   perlPackages,
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   propagatedBuildInputs = [
-    erlang
+    beamPackages.erlang
     gnuplot
     perlPackages.perl
     perlPackages.TemplateToolkit

--- a/pkgs/by-name/wi/wings/package.nix
+++ b/pkgs/by-name/wi/wings/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  erlang,
+  beamPackages,
   cl,
   libGL,
   libGLU,
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ git ];
   buildInputs = [
-    erlang
+    beamPackages.erlang
     cl
     libGL
     libGLU
@@ -93,7 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
     fi
     cat << EOF > $out/bin/wings
     #!${runtimeShell}
-    ${erlang}/bin/erl \
+    ${beamPackages.erlang}/bin/erl \
       -pa $out/lib/wings-${finalAttrs.version}/ebin -run wings_start start_halt "$@"
     EOF
     chmod +x $out/bin/wings

--- a/pkgs/by-name/ya/yaws/package.nix
+++ b/pkgs/by-name/ya/yaws/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  erlang,
+  beamPackages,
   pam,
   perl,
   autoreconfHook,
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [
-    erlang
+    beamPackages.erlang
     pam
     perl
   ];

--- a/pkgs/servers/http/couchdb/3.nix
+++ b/pkgs/servers/http/couchdb/3.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchurl,
-  erlang,
+  beamMinimalPackages,
   icu,
   openssl,
   python3,
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   '';
 
   nativeBuildInputs = [
-    erlang
+    beamMinimalPackages.erlang
   ];
 
   buildInputs = [

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -687,8 +687,12 @@ mapAliases {
   electron_37 = throw "electron_37 has been removed in favor of newer versions"; # Added 2026-03-20
   electron_37-bin = throw "electron_37-bin has been removed in favor of newer versions"; # Added 2026-03-20
   elementsd-simplicity = throw "'elementsd-simplicity' has been removed due to lack of maintenance, consider using 'elementsd' instead"; # Added 2025-06-04
+  elixir = warnAlias "'elixir' is deprecated in favor of using the beamPackages sets. Use 'beamPackages.elixir' instead." beamPackages.elixir; # added 2026-06-15
   elixir_1_15 = throw "'elixir_1_15' has been removed, due to the removal of erlang_26 as EOL"; # added 2026-04-01
   elixir_1_16 = throw "'elixir_1_16' has been removed, due to the removal of erlang_26 as EOL"; # added 2026-04-01
+  elixir_1_17 = warnAlias "'elixir_1_17' is deprecated in favor of using the beamPackages sets. Use 'beamPackages.elixir_1_17' instead." beamPackages.elixir_1_17; # added 2026-06-15
+  elixir_1_18 = warnAlias "'elixir_1_18' is deprecated in favor of using the beamPackages sets. Use 'beamPackages.elixir_1_18' instead." beamPackages.elixir_1_18; # added 2026-06-15
+  elixir_1_19 = warnAlias "'elixir_1_19' is deprecated in favor of using the beamPackages sets. Use 'beamPackages.elixir_1_19' instead." beamPackages.elixir_1_19; # added 2026-06-15
   elixir_ls = throw "'elixir_ls' has been renamed to/replaced by 'elixir-ls'"; # Converted to throw 2025-10-27
   elm-github-install = throw "'elm-github-install' has been removed as it is abandoned upstream and only supports Elm 0.18.0"; # Added 2025-08-25
   emacsMacport = throw "'emacsMacport' has been renamed to/replaced by 'emacs-macport'"; # Converted to throw 2025-10-27
@@ -708,8 +712,11 @@ mapAliases {
   epick = throw "'epick' has been removed as it has been unmaintained upstream since November 2022"; # Added 2026-02-07
   eris-go = throw "'eris-go' has been removed due to a hostile upstream moving tags and breaking src FODs"; # Added 2025-09-01
   eriscmd = throw "'eriscmd' has been removed due to a hostile upstream moving tags and breaking src FODs"; # Added 2025-09-01
+  erlang = warnAlias "'erlang' is deprecated in favor of using the beamPackages sets. Use 'beamPackages.erlang' instead." beamPackages.erlang; # added 2026-06-15
   erlang-ls = throw "'erlang-ls' has been removed as it has been archived upstream. Consider using 'erlang-language-platform' instead"; # Added 2025-10-02
   erlang_26 = throw "'erlang_26' has been removed, as it is EOL"; # added 2026-04-01
+  erlang_27 = warnAlias "'erlang_27' is deprecated in favor of using the beamPackages sets. Use 'beam27Packages.erlang' instead." beam27Packages.erlang; # added 2026-06-15
+  erlang_28 = warnAlias "'erlang_28' is deprecated in favor of using the beamPackages sets. Use 'beam28Packages.erlang' instead." beam28Packages.erlang; # added 2026-06-15
   esbuild-config = throw "'esbuild-config' has been removed as it has been unmaintained upstream since September 2022"; # Added 2026-02-07
   etBook = warnAlias "'etBook' has been renamed to 'et-book'" et-book; # Added 2026-02-08
   ethercalc = throw "'ethercalc' has been removed from nixpkgs as the project was old, unmaintained, and could not be packaged well in nixpkgs"; # Added 2025-11-28
@@ -717,6 +724,7 @@ mapAliases {
   eureka-ideas = throw "'eureka-ideas' has been removed as it has been unmaintained upstream since April 2023"; # Added 2026-02-07
   evolve-core = throw "'evolve-core' has been removed, as it hindered the removal of flutter329"; # Added 2026-01-25
   eww-wayland = throw "'eww-wayland' has been renamed to/replaced by 'eww'"; # Converted to throw 2025-10-27
+  ex_doc = warnAlias "'ex_doc' is deprecated in favor of using the beamPackages sets. Use 'beamPackages.ex_doc' instead." beamPackages.ex_doc; # added 2026-06-15
   f3d_egl = warnAlias "'f3d' now build with egl support by default, so `f3d_egl` is deprecated, consider using 'f3d' instead." f3d; # Added 2025-07-18
   fabs = throw "'fabs' has been removed due to being broken for more than a year; see RFC 180"; # Added 2026-02-05
   fancontrol-gui = throw "'fancontrol-gui' has been removed due to outdated KF5 dependencies"; # Added 2026-05-01
@@ -1126,6 +1134,7 @@ mapAliases {
   ledger_agent = throw "ledger-agent has been removed because upstream dropped Ledger support"; # Added 2026-03-11
   lesstif = throw "'lesstif' has been removed due to its being broken and unmaintained upstream. Consider using 'motif' instead."; # Added 2025-06-09
   lexical = throw "'lexical' has been removed because it was deprecated and archived upstream. Consider using 'beamPackages.expert' instead"; # Added 2026-02-24
+  lfe = warnAlias "'lfe' is deprecated in favor of using the beamPackages sets. Use 'beam27Packages.lfe' instead." beam27Packages.lfe; # added 2026-06-15
   lfs = throw "'lfs' has been renamed to/replaced by 'dysk'"; # Converted to throw 2025-10-27
   libAppleWM = libapplewm; # Added 2026-02-04
   libast = throw "'libast' has been removed due to lack of maintenance upstream."; # Added 2025-06-09

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4617,26 +4617,8 @@ with pkgs;
     wxSupport = false;
   };
 
-  inherit (beam.interpreters)
-    erlang
-    erlang_28
-    erlang_27
-    ;
-
-  inherit (beam.packages.erlang_28.beamPackages)
-    elixir_1_19
-    ;
-
-  inherit (beam.packages.erlang_27.beamPackages)
-    elixir
-    elixir_1_18
-    elixir_1_17
+  inherit (beamPackages)
     elixir-ls
-    ex_doc
-    lfe
-    ;
-
-  inherit (beam.packages.erlang)
     erlfmt
     elvis-erlang
     rebar
@@ -7554,9 +7536,7 @@ with pkgs;
 
   clickhouse-cli = with python3Packages; toPythonApplication clickhouse-cli;
 
-  couchdb3 = callPackage ../servers/http/couchdb/3.nix {
-    erlang = beamMinimalPackages.erlang;
-  };
+  couchdb3 = callPackage ../servers/http/couchdb/3.nix { };
 
   dict = callPackage ../servers/dict {
     flex = flex_2_5_35;


### PR DESCRIPTION
These top-level attributes are duplicative, and more likely to cause footguns for users. Let's deprecate them and direct people to use the package sets.

Closes: #526423

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
