### PR TITLE
upower: fix missing expectBatteryRecalibration

### DIFF
--- a/nixos/modules/services/hardware/upower.nix
+++ b/nixos/modules/services/hardware/upower.nix
@@ -211,6 +211,14 @@ in
           to `true`.
         '';
       };
+      expectBatteryRecalibration = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Lets you override the logic which would have shut down your laptop while
+          performing a battery recalibration.
+        '';
+      };
 
     };
 
@@ -261,6 +269,7 @@ in
         TimeAction = cfg.timeAction;
         AllowRiskyCriticalPowerAction = cfg.allowRiskyCriticalPowerAction;
         CriticalPowerAction = cfg.criticalPowerAction;
+        ExpectBatteryRecalibration = cfg.expectBatteryRecalibration;
       };
     };
   };


### PR DESCRIPTION

UPower 1.19.1 introduced the `ExpectBatteryRecalibration` option in its configuration file. This option allows overriding the logic that would otherwise shut down a laptop prematurely while performing a battery recalibration (for example, when using TLP).

Currently, the UPower NixOS module does not expose this option, and since it doesn't provide an `extraConfig` field, users are forced to overwrite the entire `/etc/UPower/UPower.conf` file via `environment.etc` with `lib.mkForce`.

Relevant TLP documentation: https://linrunner.de/tlp/faq/battery.html#thinkpad-shuts-down-before-tlp-recalibrate-discharge-is-complete

## Things done
nixos/upower: add expectBatteryRecalibration option

- Added the `services.upower.expectBatteryRecalibration` boolean option to the module.
- Updated the configuration generator (`lib.generators.toINI`) to include `ExpectBatteryRecalibration` in the output configuration.

 fix  #531958

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
