### PR TITLE
rustPlatform: Improve Cargo.lock mismatch error message

### DIFF
--- a/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-setup-hook.sh
@@ -67,15 +67,16 @@ cargoSetupPostPatchHook() {
       fi
 
       echo
-      echo "ERROR: cargoHash or cargoSha256 is out of date"
+      echo "ERROR: Cargo.lock is not the same as in $cargoDepsCopy"
       echo
-      echo "Cargo.lock is not the same in $cargoDepsCopy"
-      echo
-      echo "To fix the issue:"
-      echo '1. Set cargoHash/cargoSha256 to an empty string: `cargoHash = "";`'
+      echo "Did you update src attribute but forgot to update cargoHash? To fix the issue:"
+      echo '1. Set cargoHash to an empty string: `cargoHash = "";`'
       echo '2. Build the derivation and wait for it to fail with a hash mismatch'
       echo '3. Copy the "got: sha256-..." value back into the cargoHash field'
       echo '   You should have: cargoHash = "sha256-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX=";'
+      echo
+      echo "Did you use patches attribute when you should have used cargoPatches? To fix the issue:"
+      echo "   Move patches affecting Cargo.lock to cargoPatches"
       echo
 
       exit 1


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The wording of the message suggests that "cargoHash or cargoSha256 is out of date" is the error. But that's an assumption that can be wrong. The error is a mismatch between Cargo.lock in cargoDeps vs in the package. For me the problem was not caused by cargoHash (which, in fact, I did generate exactly as this error message suggests), but because I was trying to apply not-yet-merged patch.

Also removed mention of cargoSha256, as that's outdated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

### Notify maintainers
@Mic92 @winterqt