### PR TITLE
onnx: 1.21.0 -> 1.22.0

### DIFF
--- a/pkgs/by-name/on/onnx/package.nix
+++ b/pkgs/by-name/on/onnx/package.nix
@@ -23,9 +23,8 @@ let
     ;
   inherit (python3Packages)
     build
-    pybind11
     python
-    setuptools
+    scikit-build-core
     ;
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -33,13 +32,13 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   pname = "onnx";
-  version = "1.21.0";
+  version = "1.22.0";
 
   src = fetchFromGitHub {
     owner = "onnx";
     repo = "onnx";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-eF6BdTwTuHh6ckuLGN1d6z2GLU47lPqtzu4zIv8+cTs=";
+    hash = "sha256-gc65t/VN3kdvV9tiFoOk6Sw+OZe4Udgm3VcZPP9gzpE=";
   };
 
   outputs = [
@@ -51,9 +50,8 @@ stdenv.mkDerivation (finalAttrs: {
     build
     cmake
     ninja
-    pybind11
     python
-    setuptools
+    scikit-build-core
   ];
 
   # NOTE: python3Packages.protobuf does not propagate a dependency on protobuf's dev output, so we must bring it in
@@ -63,14 +61,23 @@ stdenv.mkDerivation (finalAttrs: {
     python3Packages.protobuf
   ];
 
-  # Declared in setup.py
-  cmakeBuildDir = ".setuptools-cmake-build";
+  # Standalone C++ build directory for the libonnx C++ library (`out`).
+  # Kept separate from the Python wheel's build directory (scikit-build-core hardcodes
+  # `.setuptools-cmake-build` in pyproject.toml, where it builds onnx with ONNX_INSTALL=OFF):
+  # sharing the directory would clobber this build's install prefix and leave `out` empty.
+  cmakeBuildDir = "build-cpp";
 
-  # Python setup.py just takes stuff from the environment.
+  # scikit-build-core's cmake.define reads several of these from the environment (see pyproject.toml).
   env = {
-    # NOTE: Darwin requires a static build; otherwise, tests fail in the Python package.
-    BUILD_SHARED_LIBS = if stdenv.hostPlatform.isDarwin then "0" else "1";
-    ONNX_BUILD_PYTHON = "1";
+    # NOTE: onnx is built statically on all platforms.
+    # Since 1.22.0, libonnx is built with hidden symbol visibility, and ONNX refuses to combine
+    # ONNX_BUILD_PYTHON=ON with BUILD_SHARED_LIBS=ON: both the Python extension and the C++ gtests
+    # link ONNX internals not on the public API surface, which a hidden-visibility shared libonnx
+    # does not export. Building statically (as Darwin already required) keeps the wheel and the C++
+    # tests linkable.
+    # No consumer links the C++ libonnx as a shared library (onnxruntime builds onnx from its own source).
+    BUILD_SHARED_LIBS = "0";
+
     ONNX_BUILD_TESTS = if finalAttrs.finalPackage.doCheck then "1" else "0";
     # ONNX_ML is enabled by default.
     # See: https://github.com/onnx/onnx/blob/b751946c3d59a3c8358abcc0569b59e6ddb08cdd/CMakeLists.txt#L66-L73
@@ -87,15 +94,19 @@ stdenv.mkDerivation (finalAttrs: {
     export MAX_JOBS=$NIX_BUILD_CORES
   '';
 
-  # Leave the CMake bulid directory, export the `cmakeFlags` environment variable as CMAKE_ARGS so setup.py will pick
-  # them up, do the python build from the top-level, then resume the C++ build.
+  # Leave the CMake build directory, export the `cmakeFlags` as CMAKE_ARGS so scikit-build-core will
+  # pick them up, build the Python wheel from the top-level, then resume the C++ build.
   preBuild = ''
     pushd ..
     nixLog "exporting cmakeFlags as CMAKE_ARGS for Python build"
-    export CMAKE_ARGS="''${cmakeFlags[*]}"
+    # Reuse the C++ build flags, additionally enabling the Python extension for the wheel.
+    export CMAKE_ARGS="''${cmakeFlags[*]} -DONNX_BUILD_PYTHON=ON"
     nixLog "building Python wheel"
+    # --skip-dependency-check: upstream pins protobuf==4.25.1 as a build dep, but we build against
+    # nixpkgs' protobuf. --no-isolation: use the build tools from nativeBuildInputs.
     pyproject-build \
       --no-isolation \
+      --skip-dependency-check \
       --outdir "$dist/" \
       --wheel
     popd >/dev/null

--- a/pkgs/by-name/on/onnx/package.nix
+++ b/pkgs/by-name/on/onnx/package.nix
@@ -23,9 +23,8 @@ let
     ;
   inherit (python3Packages)
     build
-    pybind11
     python
-    setuptools
+    scikit-build-core
     ;
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -33,14 +32,20 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   pname = "onnx";
-  version = "1.21.0";
+  version = "1.22.0";
 
   src = fetchFromGitHub {
     owner = "onnx";
     repo = "onnx";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-eF6BdTwTuHh6ckuLGN1d6z2GLU47lPqtzu4zIv8+cTs=";
+    hash = "sha256-gc65t/VN3kdvV9tiFoOk6Sw+OZe4Udgm3VcZPP9gzpE=";
   };
+
+  # We can't use pythonRelaxDeps as we're not using buildPythonPackage
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "protobuf==4.25.1" "protobuf"
+  '';
 
   outputs = [
     "out"
@@ -51,9 +56,8 @@ stdenv.mkDerivation (finalAttrs: {
     build
     cmake
     ninja
-    pybind11
     python
-    setuptools
+    scikit-build-core
   ];
 
   # NOTE: python3Packages.protobuf does not propagate a dependency on protobuf's dev output, so we must bring it in
@@ -63,14 +67,23 @@ stdenv.mkDerivation (finalAttrs: {
     python3Packages.protobuf
   ];
 
-  # Declared in setup.py
-  cmakeBuildDir = ".setuptools-cmake-build";
+  # Standalone C++ build directory for the libonnx C++ library (`out`).
+  # Kept separate from the Python wheel's build directory (scikit-build-core hardcodes
+  # `.setuptools-cmake-build` in pyproject.toml, where it builds onnx with ONNX_INSTALL=OFF):
+  # sharing the directory would clobber this build's install prefix and leave `out` empty.
+  cmakeBuildDir = "build-cpp";
 
-  # Python setup.py just takes stuff from the environment.
+  # scikit-build-core's cmake.define reads several of these from the environment (see pyproject.toml).
   env = {
-    # NOTE: Darwin requires a static build; otherwise, tests fail in the Python package.
-    BUILD_SHARED_LIBS = if stdenv.hostPlatform.isDarwin then "0" else "1";
-    ONNX_BUILD_PYTHON = "1";
+    # NOTE: onnx is built statically on all platforms.
+    # Since 1.22.0, libonnx is built with hidden symbol visibility, and ONNX refuses to combine
+    # ONNX_BUILD_PYTHON=ON with BUILD_SHARED_LIBS=ON: both the Python extension and the C++ gtests
+    # link ONNX internals not on the public API surface, which a hidden-visibility shared libonnx
+    # does not export. Building statically (as Darwin already required) keeps the wheel and the C++
+    # tests linkable.
+    # No consumer links the C++ libonnx as a shared library (onnxruntime builds onnx from its own source).
+    BUILD_SHARED_LIBS = "0";
+
     ONNX_BUILD_TESTS = if finalAttrs.finalPackage.doCheck then "1" else "0";
     # ONNX_ML is enabled by default.
     # See: https://github.com/onnx/onnx/blob/b751946c3d59a3c8358abcc0569b59e6ddb08cdd/CMakeLists.txt#L66-L73
@@ -92,8 +105,10 @@ stdenv.mkDerivation (finalAttrs: {
   preBuild = ''
     pushd ..
     nixLog "exporting cmakeFlags as CMAKE_ARGS for Python build"
-    export CMAKE_ARGS="''${cmakeFlags[*]}"
+    # Reuse the C++ build flags, additionally enabling the Python extension for the wheel.
+    export CMAKE_ARGS="''${cmakeFlags[*]} -DONNX_BUILD_PYTHON=ON"
     nixLog "building Python wheel"
+    # --no-isolation: use the build tools from nativeBuildInputs.
     pyproject-build \
       --no-isolation \
       --outdir "$dist/" \

--- a/pkgs/development/python-modules/onnx/default.nix
+++ b/pkgs/development/python-modules/onnx/default.nix
@@ -62,7 +62,6 @@ buildPythonPackage {
 
   enabledTestPaths = [
     "onnx/test"
-    "examples"
   ];
 
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/onnx/onnx/compare/v1.21.0...v1.22.0
Changelog: https://github.com/onnx/onnx/releases/tag/v1.22.0

fixes https://github.com/NixOS/nixpkgs/issues/539898

cc @acairncross @ConnorBaker

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test