### PR TITLE
kubebuilder: 4.13.1 -> 4.15.0, adopt

### DIFF
--- a/pkgs/by-name/ku/kubebuilder/package.nix
+++ b/pkgs/by-name/ku/kubebuilder/package.nix
@@ -69,6 +69,8 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/kubernetes-sigs/kubebuilder";
     changelog = "https://github.com/kubernetes-sigs/kubebuilder/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      hythera
+    ];
   };
 })

--- a/pkgs/by-name/ku/kubebuilder/package.nix
+++ b/pkgs/by-name/ku/kubebuilder/package.nix
@@ -12,16 +12,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "kubebuilder";
-  version = "4.13.1";
+  version = "4.15.0";
 
   src = fetchFromGitHub {
     owner = "kubernetes-sigs";
     repo = "kubebuilder";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-WOqrQb2haoEp57OHFo1Y1fon0lJedI/hEYKE4xrIbpM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-iTC5HY4E54YG+isSgW2515Kz83+khzANAml78z8EG88=";
   };
 
-  vendorHash = "sha256-1lbf1hXJfhdTu6Gm7dcbJlB3beITxBD83gMltZgg7Pg=";
+  vendorHash = "sha256-7rXunagWkUWGL5v+xkmyLELwrIEuRVGPk4SK8/lotio=";
 
   subPackages = [
     "internal/cli/cmd"


### PR DESCRIPTION
changelog: https://github.com/kubernetes-sigs/kubebuilder/releases/tag/v4.15.0
diff: https://github.com/kubernetes-sigs/kubebuilder/compare/v4.14.0...v4.15.0

Closes #515055

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
