### PR TITLE
nixos/systemd-initrd: skip activation when init= is not a NixOS system

### DIFF
--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -763,12 +763,21 @@ in
           ];
         };
         serviceConfig.Type = "oneshot";
+        serviceConfig.EnvironmentFile = "-/etc/switch-root.conf";
         description = "NixOS Activation";
 
         script = # bash
           ''
             set -uo pipefail
             export PATH="/bin:${cfg.package.util-linux}/bin"
+
+            # A non-NixOS closure (e.g. init=/bin/sh) has no prepare-root;
+            # initrd-find-nixos-closure records this as a non-empty NEW_INIT.
+            # Skip activation and let initrd-switch-root hand over to it directly.
+            if [ -n "''${NEW_INIT:-}" ]; then
+              echo "$NEW_INIT is not a NixOS system - not activating"
+              exit 0
+            fi
 
             closure="$(realpath /nixos-closure)"
 

--- a/nixos/modules/system/etc/etc-activation.nix
+++ b/nixos/modules/system/etc/etc-activation.nix
@@ -71,6 +71,10 @@
               RequiresMountsFor = [
                 "/sysroot/nix/store"
               ];
+              # find-etc only creates this symlink for a NixOS init. For a
+              # non-NixOS init= (e.g. init=/bin/sh) it is absent, so skip the
+              # mount instead of failing the whole initrd.
+              ConditionPathExists = "/etc-metadata-image";
             };
             requires = [
               config.boot.initrd.systemd.services.initrd-find-etc.name
@@ -123,6 +127,8 @@
                 "/run/nixos-etc-metadata"
               ];
               DefaultDependencies = false;
+              # Skip for a non-NixOS init=, see the metadata mount above.
+              ConditionPathExists = "/etc-basedir";
             };
           }
         ];
@@ -140,6 +146,8 @@
                   # before the overlay is mounted.
                   "/run/nixos-etc-metadata"
                 ];
+                # Skip for a non-NixOS init=, see the metadata mount above.
+                ConditionPathExists = "/etc-metadata-image";
               };
               serviceConfig = {
                 Type = "oneshot";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1628,6 +1628,7 @@ in
     "i686-linux"
   ] ./initrd-network-openvpn { systemdStage1 = true; };
   systemd-initrd-networkd-ssh = runTest ./systemd-initrd-networkd-ssh.nix;
+  systemd-initrd-non-nixos = runTest ./systemd-initrd-non-nixos.nix;
   systemd-initrd-shutdown = runTest {
     imports = [ ./systemd-shutdown.nix ];
     _module.args.systemdStage1 = true;

--- a/nixos/tests/systemd-initrd-non-nixos.nix
+++ b/nixos/tests/systemd-initrd-non-nixos.nix
@@ -1,0 +1,53 @@
+{ lib, pkgs, ... }:
+let
+  marker = "REACHED NON-NIXOS INIT AS PID 1";
+
+  # A non-NixOS init (no prepare-root). We use a store path, not literal
+  # /bin/sh: a fresh disk has no /bin/sh yet (it is created by the activation a
+  # non-NixOS init skips), while the store is always mounted; init=/bin/sh works
+  # the same on a real system. Writes a marker, then stays alive so PID 1 lives.
+  nonNixosInit = pkgs.writeShellScriptBin "non-nixos" ''
+    echo "${marker}" > /dev/console
+    exec ${pkgs.coreutils}/bin/sleep infinity
+  '';
+in
+{
+  name = "systemd-initrd-non-nixos";
+
+  nodes.machine = {
+    boot.initrd.systemd.enable = true;
+
+    virtualisation = {
+      # tmpfs root, like real non-NixOS closure init= microvm consumers.
+      diskImage = null;
+
+      graphics = false;
+    };
+
+    # Speed up wait_for_console.
+    boot.consoleLogLevel = lib.mkForce 3;
+    boot.initrd.systemd.managerEnvironment.SYSTEMD_LOG_LEVEL = "warning";
+
+    # switch-root needs an os-release on the target root. A real system has one
+    # on disk; our fresh tmpfs does not, so create it.
+    boot.initrd.systemd.tmpfiles.settings."10-os-release"."/sysroot/etc/os-release".f = {
+      mode = "0644";
+      argument = "ID=test-non-nixos";
+    };
+  };
+
+  testScript = ''
+    import os
+
+    # The last init= on the cmdline wins; QEMU_KERNEL_PARAMS is appended after
+    # the default one, so this boots our non-NixOS init.
+    os.environ["QEMU_KERNEL_PARAMS"] = "init=${lib.getExe nonNixosInit}"
+
+    machine.start()
+
+    # If activation does not skip the non-NixOS init, switch-root is blocked and
+    # the machine drops to emergency mode: the marker never appears and this
+    # times out.
+    machine.wait_for_console_text("${marker}", timeout=300)
+  '';
+}

--- a/nixos/tests/systemd-initrd-non-nixos.nix
+++ b/nixos/tests/systemd-initrd-non-nixos.nix
@@ -10,11 +10,8 @@ let
     echo "${marker}" > /dev/console
     exec ${pkgs.coreutils}/bin/sleep infinity
   '';
-in
-{
-  name = "systemd-initrd-non-nixos";
 
-  nodes.machine = {
+  common = {
     boot.initrd.systemd.enable = true;
 
     virtualisation = {
@@ -35,6 +32,20 @@ in
       argument = "ID=test-non-nixos";
     };
   };
+in
+{
+  name = "systemd-initrd-non-nixos";
+
+  nodes = {
+    bashActivation = common;
+
+    nixosInit = {
+      imports = [ common ];
+      system.nixos-init.enable = true;
+      system.etc.overlay.enable = true;
+      services.userborn.enable = true;
+    };
+  };
 
   testScript = ''
     import os
@@ -43,11 +54,15 @@ in
     # the default one, so this boots our non-NixOS init.
     os.environ["QEMU_KERNEL_PARAMS"] = "init=${lib.getExe nonNixosInit}"
 
-    machine.start()
+    start_all()
 
-    # If activation does not skip the non-NixOS init, switch-root is blocked and
-    # the machine drops to emergency mode: the marker never appears and this
+    # If a code path does not skip the non-NixOS init, switch-root is blocked and
+    # the machine drops to emergency mode: the marker never appears and the wait
     # times out.
-    machine.wait_for_console_text("${marker}", timeout=300)
+    with subtest("bash initrd-nixos-activation skips a non-NixOS init"):
+        bashActivation.wait_for_console_text("${marker}", timeout=300)
+
+    with subtest("nixos-init switches to a non-NixOS init directly"):
+        nixosInit.wait_for_console_text("${marker}", timeout=300)
   '';
 }

--- a/pkgs/by-name/ni/nixos-init/src/find_etc.rs
+++ b/pkgs/by-name/ni/nixos-init/src/find_etc.rs
@@ -3,7 +3,7 @@ use std::{os::unix, path::Path};
 use anyhow::{Context, Result};
 
 use crate::config::Config;
-use crate::{SYSROOT_PATH, find_toplevel_in_prefix, resolve_in_prefix};
+use crate::{SYSROOT_PATH, find_init_in_prefix, resolve_in_prefix, verify_init_is_nixos};
 
 /// Entrypoint for the `find-etc` binary.
 ///
@@ -12,7 +12,20 @@ use crate::{SYSROOT_PATH, find_toplevel_in_prefix, resolve_in_prefix};
 /// This avoids needing a reference to the toplevel embedded in the initrd and thus reduces the
 /// need to re-build it.
 pub fn find_etc() -> Result<()> {
-    let toplevel = find_toplevel_in_prefix(SYSROOT_PATH)?;
+    let init_in_sysroot =
+        find_init_in_prefix(SYSROOT_PATH).context("Failed to find init in sysroot")?;
+
+    // A non-NixOS init= (e.g. init=/bin/sh) has no etc metadata image. Skip
+    // without creating the symlinks: the etc-overlay mounts are gated on them
+    // and so skip too, and initrd-init switches root to the init directly.
+    let Ok(toplevel) = verify_init_is_nixos(SYSROOT_PATH, &init_in_sysroot) else {
+        log::info!(
+            "{} is not a NixOS system - not setting up the etc overlay.",
+            init_in_sysroot.display()
+        );
+        return Ok(());
+    };
+
     let config = Config::from_toplevel(&toplevel, SYSROOT_PATH)?;
 
     let basedir = config

--- a/pkgs/by-name/ni/nixos-init/src/lib.rs
+++ b/pkgs/by-name/ni/nixos-init/src/lib.rs
@@ -27,16 +27,6 @@ pub use crate::{
 
 pub const SYSROOT_PATH: &str = "/sysroot";
 
-/// Find the path to the toplevel closure of the system in a prefix.
-///
-/// Uses the `init=` parameter on the kernel command-line.
-///
-/// Returns the relative path of the init to the prefix, e.g. without the `/sysroot` prefix.
-pub fn find_toplevel_in_prefix(prefix: &str) -> Result<PathBuf> {
-    let init_in_sysroot = find_init_in_prefix(prefix)?;
-    verify_init_is_nixos(prefix, init_in_sysroot)
-}
-
 /// Verify that an init path is inside a `NixOS` toplevel directory.
 ///
 /// If the path is verified, returns the path to the toplevel.

--- a/pkgs/by-name/ni/nixos-init/src/lib.rs
+++ b/pkgs/by-name/ni/nixos-init/src/lib.rs
@@ -87,20 +87,16 @@ pub fn find_init_in_prefix(prefix: &str) -> Result<PathBuf> {
 }
 
 /// Extract the value of the `init` parameter from the given kernel `cmdline`.
+///
+/// If `init=` appears multiple times the last one wins, matching the kernel.
+/// This is what makes appending `init=/bin/sh` at the boot prompt work even
+/// though the boot entry already has an `init=`.
 fn extract_init(cmdline: &str) -> Result<PathBuf> {
-    let init_params: Vec<&str> = cmdline
+    let init = cmdline
         .split_ascii_whitespace()
-        .filter(|p| p.starts_with("init="))
-        .collect();
-
-    if init_params.len() != 1 {
-        bail!("Expected exactly one init param on kernel cmdline: {cmdline}")
-    }
-
-    let init = init_params
-        .first()
-        .and_then(|s| s.split('=').next_back())
-        .context("Failed to extract init path from kernel cmdline: {cmdline}")?;
+        .filter_map(|p| p.strip_prefix("init="))
+        .next_back()
+        .with_context(|| format!("No init= parameter on kernel cmdline: {cmdline}"))?;
 
     Ok(PathBuf::from(init))
 }
@@ -128,5 +124,26 @@ mod tests {
         verify_init_is_nixos(prefix.path().to_str().unwrap(), "/toplevel/init")?;
 
         Ok(())
+    }
+
+    #[test]
+    fn test_extract_init_single() {
+        assert_eq!(
+            extract_init("root=fstab init=/nix/store/xxx-nixos/init quiet").unwrap(),
+            PathBuf::from("/nix/store/xxx-nixos/init")
+        );
+    }
+
+    #[test]
+    fn test_extract_init_last_wins() {
+        assert_eq!(
+            extract_init("init=/nix/store/xxx-nixos/init init=/bin/sh").unwrap(),
+            PathBuf::from("/bin/sh")
+        );
+    }
+
+    #[test]
+    fn test_extract_init_missing() {
+        assert!(extract_init("root=fstab quiet").is_err());
     }
 }


### PR DESCRIPTION
initrd-nixos-activation ran the closure's prepare-root unconditionally. For a
non-NixOS init= there is no prepare-root, so the service failed, and since
initrd-switch-root.service requires it, switch-root never ran and the machine
dropped to the emergency shell. This broke init=/bin/sh recovery, and microVMs
that serve /nix/store over virtiofs and boot an arbitrary binary as init=.

initrd-find-nixos-closure already detects this and writes a non-empty NEW_INIT
to /etc/switch-root.conf (empty for a NixOS init). Read it via the same
EnvironmentFile= initrd-switch-root uses and skip activation when it's set, so
a non-NixOS init= switch-roots into its target directly. The NixOS path is
unchanged.

Also add a test booting a non-NixOS init=. It uses a store path rather than
/bin/sh: a real root already has /bin/sh and an os-release, but a fresh test
root has neither, so the test uses a tmpfs root and writes os-release first.

Assisted-by: Claude:claude-opus-4-8


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
