### PR TITLE
koreader: 2025.10 -> 2026.03

### DIFF
--- a/pkgs/by-name/ko/koreader/package.nix
+++ b/pkgs/by-name/ko/koreader/package.nix
@@ -11,13 +11,13 @@
   gtk3-x11,
   luajit,
   sdcv,
-  SDL2,
+  sdl3,
   openssl,
   writeScript,
 }:
 
 let
-  version = "2025.10";
+  version = "2026.03";
 
   # LuaJIT with table.pack/unpack support for KOReader
   # https://github.com/koreader/koreader-base/tree/master/thirdparty/luajit
@@ -35,12 +35,15 @@ let
     owner = "koreader";
     tag = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-uYKN5fgIdCVH+pXU2lmsGu7HxZbDld5EJVO9o7Tk8BA=";
+    hash = "sha256-KWpWlFoBEAhVDuRTiF7yj1wlKLzYmvcngI9iWqsDuQY=";
   };
 in
 stdenv.mkDerivation {
   pname = "koreader";
   inherit version;
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src =
     let
@@ -54,11 +57,11 @@ stdenv.mkDerivation {
       };
     in
     fetchurl {
-      url = "https://github.com/koreader/koreader/releases/download/v${version}/koreader-${version}-${arch}.deb";
+      url = "https://github.com/koreader/koreader/releases/download/v${version}/koreader_${version}-1_${arch}.deb";
       hash = selectSystem {
-        aarch64-linux = "sha256-z92sguFe5qcPmHk+Orm8vHJycVeZY3cYGByU6xIcrkA=";
-        armv7l-linux = "sha256-kVO+eUwGMULJZwbxZwbeooqRDF8oZPiuo47a7lNsl3I=";
-        x86_64-linux = "sha256-OYzMOUFzUzkYvcjjMX0FZBkZs//9ie3025lhhFOrt9M=";
+        aarch64-linux = "sha256-4ulpMXYcICQ5/9Q0GGn9lkbW0ntzIfUHQ5woTAhyXLU=";
+        armv7l-linux = "sha256-diMWFhL0D5bWPQFc9vvZZRPMfNxlxchGyT8Lz/TLHPs=";
+        x86_64-linux = "sha256-OhBu3oj9IqNmK5ngCkXvucVQq5aJohObgENtjdDcQcE=";
       };
     };
 
@@ -73,7 +76,7 @@ stdenv.mkDerivation {
     gtk3-x11
     luajit_koreader
     sdcv
-    SDL2
+    sdl3
     openssl
   ];
 
@@ -90,8 +93,9 @@ stdenv.mkDerivation {
   ''
   # Link SSL/network libraries
   + ''
-    ln -sf ${openssl.out}/lib/libcrypto.so.3 $out/lib/koreader/libs/libcrypto.so.1.1
-    ln -sf ${openssl.out}/lib/libssl.so.3 $out/lib/koreader/libs/libssl.so.1.1
+    ln -sf ${lib.getLib openssl}/lib/libcrypto.so.3 $out/lib/koreader/libs/libcrypto.so.1.1
+    ln -sf ${lib.getLib openssl}/lib/libssl.so.3 $out/lib/koreader/libs/libssl.so.1.1
+    ln -sf ${lib.getLib sdl3}/lib/libSDL3.so.0 $out/lib/koreader/libs/libSDL3.so.0
   ''
   # Copy fonts
   + ''
@@ -105,7 +109,7 @@ stdenv.mkDerivation {
     wrapProgram $out/bin/koreader --prefix LD_LIBRARY_PATH : $out/lib/koreader/libs:${
       lib.makeLibraryPath [
         gtk3-x11
-        SDL2
+        sdl3
         glib
         stdenv.cc.cc
         openssl.out


### PR DESCRIPTION
Diff : https://github.com/koreader/koreader/compare/v2025.10...v2026.03
Changelog : https://github.com/koreader/koreader/releases/tag/v2026.03

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
