### PR TITLE
cdparanoia: fix build for FreeBSD

### DIFF
--- a/pkgs/by-name/cd/cdparanoia-iii/freebsd.patch
+++ b/pkgs/by-name/cd/cdparanoia-iii/freebsd.patch
@@ -1,0 +1,45 @@
+From 368ea1fcdf4e8f9a5de4e7ade590242292ccb8fa Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Mon, 15 Jun 2026 18:40:07 +0200
+Subject: [PATCH] Fix designated initializers in memcpy arguments
+
+On FreeBSD, memcpy is a macro, and the lack of parentheses causes a
+compilation failure.
+---
+ interface/scsi_interface.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/interface/scsi_interface.c b/interface/scsi_interface.c
+index adbb9bf..7805559 100644
+--- a/interface/scsi_interface.c
++++ b/interface/scsi_interface.c
+@@ -674,7 +674,7 @@ static int scsi_read_toc (cdrom_drive *d){
+   }
+ 
+   for (i = first; i <= last; i++){
+-    memcpy(cmd, (char []){ 0x43, 0, 0, 0, 0, 0, 0, 0, 12, 0}, 10);
++    memcpy(cmd, ((char []){ 0x43, 0, 0, 0, 0, 0, 0, 0, 12, 0}), 10);
+     cmd[1]=d->lun<<5;
+     cmd[6]=i;
+     
+@@ -695,7 +695,7 @@ static int scsi_read_toc (cdrom_drive *d){
+     }
+   }
+ 
+-  memcpy(cmd, (char []){ 0x43, 0, 0, 0, 0, 0, 0, 0, 12, 0}, 10);
++  memcpy(cmd, ((char []){ 0x43, 0, 0, 0, 0, 0, 0, 0, 12, 0}), 10);
+   cmd[1]=d->lun<<5;
+   cmd[6]=0xAA;
+     
+@@ -745,7 +745,7 @@ static int scsi_read_toc2 (cdrom_drive *d){
+   }
+ 
+   for (i = 0; i < tracks; i++){
+-    memcpy(cmd, (char[]){ 0xe5, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 10);
++    memcpy(cmd, ((char[]){ 0xe5, 0, 0, 0, 0, 0, 0, 0, 0, 0}), 10);
+     cmd[5]=i+1;
+     cmd[8]=255;
+     
+-- 
+2.54.0
+

--- a/pkgs/by-name/cd/cdparanoia-iii/package.nix
+++ b/pkgs/by-name/cd/cdparanoia-iii/package.nix
@@ -62,6 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
         url = "https://salsa.debian.org/optical-media-team/cdparanoia/-/raw/f7bab3024c5576da1fdb7497abbd6abc8959a98c/debian/patches/04-endian.patch";
         hash = "sha256-krfprwls0L3hsNfoj2j69J5k1RTKEQtzE0fLYG9EJKo=";
       })
+      ./freebsd.patch
     ]
     ++ lib.optional stdenv.hostPlatform.isMusl ./utils.patch
     ++ lib.optional (!stdenv.hostPlatform.isDarwin) [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
