### PR TITLE
python3Packages.volvooncall: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/volvooncall/default.nix
+++ b/pkgs/development/python-modules/volvooncall/default.nix
@@ -7,6 +7,7 @@
   docopt,
   fetchFromGitHub,
   fetchpatch,
+  setuptools,
   geopy,
   mock,
   pytest-asyncio_0,
@@ -16,7 +17,7 @@
 buildPythonPackage rec {
   pname = "volvooncall";
   version = "0.10.4";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "molobrakos";
@@ -34,7 +35,9 @@ buildPythonPackage rec {
     })
   ];
 
-  propagatedBuildInputs = [ aiohttp ];
+  build-system = [ setuptools ];
+
+  dependencies = [ aiohttp ];
 
   optional-dependencies = {
     console = [

--- a/pkgs/development/python-modules/volvooncall/default.nix
+++ b/pkgs/development/python-modules/volvooncall/default.nix
@@ -14,15 +14,17 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "volvooncall";
   version = "0.10.4";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "molobrakos";
     repo = "volvooncall";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-xr3g93rt3jvxVZrZY7cFh5eBP3k0arsejsgvx8p5EV4=";
   };
 
@@ -56,16 +58,16 @@ buildPythonPackage rec {
     pytest-asyncio_0
     pytestCheckHook
   ]
-  ++ optional-dependencies.mqtt;
+  ++ finalAttrs.passthru.optional-dependencies.mqtt;
 
   pythonImportsCheck = [ "volvooncall" ];
 
   meta = {
     description = "Retrieve information from the Volvo On Call web service";
     homepage = "https://github.com/molobrakos/volvooncall";
-    changelog = "https://github.com/molobrakos/volvooncall/releases/tag/v${version}";
+    changelog = "https://github.com/molobrakos/volvooncall/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.unlicense;
     mainProgram = "voc";
     maintainers = with lib.maintainers; [ dotlambda ];
   };
-}
+})


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
