### PR TITLE
gcc/ng: reference landed `find_a_program` commits instead of mailing list

### DIFF
--- a/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/ng/common/gcc/default.nix
@@ -57,23 +57,28 @@ stdenv.mkDerivation (finalAttrs: {
     })
     (fetchpatch {
       name = "find_a_program-separate-from-find_a_file.patch";
-      url = "https://inbox.sourceware.org/gcc-patches/20250822234120.1988059-1-git@JohnEricson.me/raw";
-      hash = "sha256-0gaWaeFZq+a8q7Bcr3eILNjHh1LfzL/Lz4F+W+H6XIU=";
+      url = "https://github.com/gcc-mirror/gcc/commit/948eb02800777d0318ee2a38bf32076afee739f2.diff";
+      hash = "sha256-doXak3VfdWR/BP9XiJaU7uJz7rex78N1oaW6CqYwKaQ=";
     })
     (fetchpatch {
       name = "simplify-find_a_program-and-find_a_file.patch";
-      url = "https://inbox.sourceware.org/gcc-patches/20250822234120.1988059-2-git@JohnEricson.me/raw";
-      hash = "sha256-ojdyszxLGL+njHK4eAaeBkxAhFTDI57j6lGuAf0A+N0=";
+      url = "https://github.com/gcc-mirror/gcc/commit/073b4656d07e40f83a1db7f4462ab2d68b1875a2.diff";
+      hash = "sha256-kW6ZHyMzsn7snUBuDx4XLriaFGWZ1fixNc9UH8O5els=";
+    })
+    (fetchpatch {
+      name = "for_each_path-fix-uninitialized-ret-PR121806.patch";
+      url = "https://github.com/gcc-mirror/gcc/commit/6b008944e7bc3a342a734c4fcf1001d63fd0a6f8.diff";
+      hash = "sha256-preG5DdRX+a0NIebsapAVnqiLYtPjsR4H5BkAXL/65g=";
     })
     (fetchpatch {
       name = "for_each_path-pass-machine-specific.patch";
-      url = "https://inbox.sourceware.org/gcc-patches/20250822234120.1988059-3-git@JohnEricson.me/raw";
-      hash = "sha256-C5jUSyNchmZcE8RTXc2dHfCqNKuBHeiouLruK9UooSM=";
+      url = "https://github.com/gcc-mirror/gcc/commit/f62f68e7c4bde0385fbd2dba3e926586dd2f1281.diff";
+      hash = "sha256-NsgGnTMQTnz1c4urr6jeoGOzQ4xeJ/p+F53osNDYDCA=";
     })
     (fetchpatch {
       name = "find_a_program-search-with-machine-prefix.patch";
-      url = "https://inbox.sourceware.org/gcc-patches/20250822234120.1988059-4-git@JohnEricson.me/raw";
-      hash = "sha256-MwcO4OXPlcdaSYivsh5ru+Cfq6qybeAtgCgTEPGYg40=";
+      url = "https://github.com/gcc-mirror/gcc/commit/a514707ffd7d58b140686036c2dece43ecb7d33c.diff";
+      hash = "sha256-54/HzM+aeWq8CTkQu8Pualqc/LgRLS0+8EY8uPUsD+s=";
     })
 
     (getVersionFile "gcc/fix-collect2-paths.diff")


### PR DESCRIPTION
The `find_a_program`/`for_each_path` machine-prefix patch series has now landed on gcc `master`, so point the `fetchpatch` entries at the `gcc-mirror/gcc` commit `.diff`s rather than the v5 mailing-list `raw` URLs (matching the existing `for_each_path` rework patch).

Linking the approving mailing list posts, along with the commit hash each of the 4 commits (by title) landed as.

- <https://inbox.sourceware.org/gcc-patches/6c3a085d-fa62-4b24-b4ca-ee5c6ac11be0@oss.qualcomm.com/>

  Approved the first two patches together.

  1. `find_a_program: Separate from find_a_file` → 948eb02800777d0318ee2a38bf32076afee739f2
  2. `driver: Simplify find_a_program and find_a_file` → 073b4656d07e40f83a1db7f4462ab2d68b1875a2

- <https://inbox.sourceware.org/gcc-patches/324798d3-effb-4dc5-86ab-a1c461390d64@oss.qualcomm.com/>

  3. `for_each_path: Pass to callback whether dir is machine-disambiguated` → f62f68e7c4bde0385fbd2dba3e926586dd2f1281

- <https://inbox.sourceware.org/gcc-patches/ae270a41-fae9-4442-a276-0433ea752f2e@oss.qualcomm.com/>

  4. `find_a_program: Search with machine prefix in some cases` → a514707ffd7d58b140686036c2dece43ecb7d33c

We also include an additional commit,
6b008944e7bc3a342a734c4fcf1001d63fd0a6f8, a one-line `for_each_path` fix against a mistake that I made in the previous commit. It is applied as a prerequisite both so we also have the fix, and because without the latter patches would have conflicts.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
