### PR TITLE
cudaPackages.libnvshmem: default withNccl to nccl.meta.available

### DIFF
--- a/pkgs/development/cuda-modules/packages/libnvshmem.nix
+++ b/pkgs/development/cuda-modules/packages/libnvshmem.nix
@@ -32,7 +32,7 @@
   withIbgda ? true,
   withLibfabric ? true,
   withMpi ? true,
-  withNccl ? true,
+  withNccl ? nccl.meta.available,
   withPmix ? true,
   withUcx ? true,
 }:


### PR DESCRIPTION
`withNccl` currently defaults to `true`, unconditionally adding `nccl` to `buildInputs`. 

This is problematic on platforms where NCCL is unavailable, such as pre-Thor Jetson (Orin), where `nccl.meta.available` is `false` due to its `badPlatforms` assertion. In such cases, libnvshmem would still pull the unavailable `nccl` into its closure, leading to an eval-time error.

We are changing the default to `nccl.meta.available` to make libnvshmem skip NCCL automatically on platforms where NCCL is unsupported. We preserving the existing behaviour everywhere else (x86_64-linux, Thor Jetson) where `nccl.meta.available` is `true`.

Note that this guard has already been added to other CUDA modules such as `cudaPackages.cudss` in #437723.

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux (`cudaCapabilities = [ "8.7" ];`)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].