### PR TITLE
qdl: 2.6 -> 2.7

### DIFF
--- a/pkgs/by-name/qd/qdl/package.nix
+++ b/pkgs/by-name/qd/qdl/package.nix
@@ -2,32 +2,56 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch2,
+  meson,
   pkg-config,
   libxml2,
   libusb1,
+  libzip,
+  cmocka,
+  ninja,
   nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "qdl";
-  version = "2.6";
+  version = "2.7";
 
   src = fetchFromGitHub {
     owner = "linux-msm";
     repo = "qdl";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/lvKMC0bJdfqhPCuBYChX/6Aybpu+cPg0Vjl2HDbOeE=";
+    hash = "sha256-oZ/1Pe81VOAmZiywSC2jC1OcDtaH84GAuo8AqiE77d4=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  patches = [
+    # allow VERSION to be overridden, will land in 2.8
+    (fetchpatch2 {
+      url = "https://github.com/linux-msm/qdl/commit/6f8700ed81b3614baa12786a9845c9abeab1e178.patch";
+      hash = "sha256-fDC34Wq4MadDDLHVQ5zuRKE2zD2dOMTU8EGINcJTYuI=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    meson
+    pkg-config
+    cmocka
+    ninja
+  ];
   buildInputs = [
     libxml2
     libusb1
+    libzip
   ];
 
-  makeFlags = [
-    "VERSION=${finalAttrs.src.rev}"
-    "prefix=${placeholder "out"}"
+  mesonFlags = [
+    "--prefix=${placeholder "out"}"
+    "-DVERSION=${finalAttrs.src.rev}"
+
+    # Tests currently fail to link but seem rather new
+    # https://github.com/linux-msm/qdl/issues/260
+    # test_contents_selectors.c:(.text+0x234e): undefined reference to `firehose_alloc_op'
+    "-Dtests=disabled"
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Switch to the new Meson build system.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
