### PR TITLE
wasmer: add shell completions

### DIFF
--- a/pkgs/by-name/wa/wasmer/package.nix
+++ b/pkgs/by-name/wa/wasmer/package.nix
@@ -9,6 +9,7 @@
   nix-update,
   curl,
   writeShellApplication,
+  installShellFiles,
   llvmPackages_21,
   libffi,
   libxml2,
@@ -83,6 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
     rustc
     rustPlatform.cargoSetupHook
     rustPlatform.bindgenHook
+    installShellFiles
   ]
   ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
 
@@ -142,9 +144,19 @@ stdenv.mkDerivation (finalAttrs: {
       V8_LIB_DIR = "${v8Prebuilt}/lib";
     };
 
-  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    install -Dm755 target/release/libwasmer.dylib $out/lib/libwasmer.dylib
-  '';
+  postInstall =
+    lib.optionalString stdenv.hostPlatform.isDarwin ''
+      install -Dm755 target/release/libwasmer.dylib $out/lib/libwasmer.dylib
+    ''
+    + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      # gen-completions uses argv[0] as the command name, so invoke wasmer with
+      # `exec -a wasmer` to avoid baking the absolute store path into the output
+      # (which produces invalid fish function names that fail to load).
+      installShellCompletion --cmd wasmer \
+        --bash <(exec -a wasmer $out/bin/wasmer gen-completions bash) \
+        --fish <(exec -a wasmer $out/bin/wasmer gen-completions fish) \
+        --zsh <(exec -a wasmer $out/bin/wasmer gen-completions zsh)
+    '';
 
   passthru.updateScript = lib.getExe (writeShellApplication {
     name = "update-wasmer";


### PR DESCRIPTION
Adds shell completions to `wasmer`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
