### PR TITLE
craftos-pc,craftos-pc-accelerated: add accelerated variant

### DIFF
--- a/pkgs/by-name/cr/craftos-pc/package.nix
+++ b/pkgs/by-name/cr/craftos-pc/package.nix
@@ -14,34 +14,64 @@
   pngpp,
   libwebp,
   libx11,
+  enableLuaJIT ? false,
 }:
 
 let
   version = "2.8.3";
-  craftos2-lua = fetchFromGitHub {
-    owner = "MCJack123";
-    repo = "craftos2-lua";
-    rev = "v${version}";
-    hash = "sha256-OCHN/ef83X4r5hZcPfFFvNJHjINCTiK+COf369/WPsA=";
-  };
   craftos2-rom = fetchFromGitHub {
     owner = "McJack123";
     repo = "craftos2-rom";
     rev = "v${version}";
     hash = "sha256-YidLt/JLwBMW0LMo5Q5PV6wGhF0J72FGX+iWYn6v0Z4=";
   };
+
+  luaCtx =
+    if enableLuaJIT then
+      {
+        pname = "craftos-pc-accelerated";
+        binName = "craftos-luajit";
+        luaDir = "craftos2-luajit";
+        luaLib = "libluajit-craftos.so";
+        luaSrc = fetchFromGitHub {
+          owner = "MCJack123";
+          repo = "craftos2-luajit";
+          rev = "4f4466fd3fafd3523e2c07e91c478b73b6748f0c";
+          hash = "sha256-YmecY6R2AHmk5S+RdfFtaXzLV9GksLdjTIGlrr+FpPo=";
+        };
+        craftosSrc = fetchFromGitHub {
+          owner = "MCJack123";
+          repo = "craftos2";
+          rev = "v${version}-luajit";
+          hash = "sha256-F7Y/9hlLL/r5R+oJtbIiQm8aZbKJqjl7AYrUum/+Aes=";
+        };
+      }
+    else
+      {
+        pname = "craftos-pc";
+        binName = "craftos";
+        luaDir = "craftos2-lua";
+        luaLib = "liblua${stdenv.hostPlatform.extensions.sharedLibrary}";
+        luaSrc = fetchFromGitHub {
+          owner = "MCJack123";
+          repo = "craftos2-lua";
+          rev = "v${version}";
+          hash = "sha256-OCHN/ef83X4r5hZcPfFFvNJHjINCTiK+COf369/WPsA=";
+        };
+        craftosSrc = fetchFromGitHub {
+          owner = "MCJack123";
+          repo = "craftos2";
+          rev = "v${version}";
+          hash = "sha256-DbxAsXxpsa42dF6DaLmgIa+Hs/PPqJ4dE97PoKxG2Ig=";
+        };
+      };
 in
 
-stdenv.mkDerivation rec {
-  pname = "craftos-pc";
+stdenv.mkDerivation (finalAttrs: {
+  pname = luaCtx.pname;
   inherit version;
 
-  src = fetchFromGitHub {
-    owner = "MCJack123";
-    repo = "craftos2";
-    rev = "v${version}";
-    hash = "sha256-DbxAsXxpsa42dF6DaLmgIa+Hs/PPqJ4dE97PoKxG2Ig=";
-  };
+  src = luaCtx.craftosSrc;
 
   nativeBuildInputs = [
     unzip
@@ -63,11 +93,14 @@ stdenv.mkDerivation rec {
     libx11
   ];
   strictDeps = true;
+  __structuredAttrs = true;
 
   preBuild = ''
-    cp -R ${craftos2-lua}/* ./craftos2-lua/
-    chmod -R u+w ./craftos2-lua
-    make -C craftos2-lua ${if stdenv.hostPlatform.isDarwin then "macosx" else "linux"}
+    cp -R ${luaCtx.luaSrc}/* ./${luaCtx.luaDir}/
+    chmod -R u+w ./${luaCtx.luaDir}
+    make -C ${luaCtx.luaDir} ${
+      lib.optionalString (!enableLuaJIT) (if stdenv.hostPlatform.isDarwin then "macosx" else "linux")
+    }
   '';
 
   buildPhase = ''
@@ -87,13 +120,13 @@ stdenv.mkDerivation rec {
   installPhase = ''
     mkdir -p $out/bin $out/lib $out/share/craftos $out/include
     DESTDIR=$out/bin make install
-    cp ./craftos2-lua/src/liblua${stdenv.hostPlatform.extensions.sharedLibrary} $out/lib
+    cp ./${luaCtx.luaDir}/src/${luaCtx.luaLib} $out/lib
     ${lib.optionalString stdenv.hostPlatform.isDarwin ''
-      chmod +w $out/bin/craftos
-      install_name_tool -change liblua${stdenv.hostPlatform.extensions.sharedLibrary} $out/lib/liblua${stdenv.hostPlatform.extensions.sharedLibrary} $out/bin/craftos
+      chmod +w $out/bin/${luaCtx.binName}
+      install_name_tool -change ${luaCtx.luaLib} $out/lib/${luaCtx.luaLib} $out/bin/${luaCtx.binName}
     ''}
     ${lib.optionalString stdenv.hostPlatform.isLinux ''
-      patchelf --replace-needed craftos2-lua/src/liblua${stdenv.hostPlatform.extensions.sharedLibrary} liblua${stdenv.hostPlatform.extensions.sharedLibrary} $out/bin/craftos
+      patchelf --replace-needed ${luaCtx.luaDir}/src/${luaCtx.luaLib} ${luaCtx.luaLib} $out/bin/${luaCtx.binName}
     ''}
     cp -R api $out/include/CraftOS-PC
     cp -R ${craftos2-rom}/* $out/share/craftos
@@ -113,12 +146,18 @@ stdenv.mkDerivation rec {
   '';
 
   passthru.tests = {
-    eval-hello-world = callPackage ./test-eval-hello-world { };
-    eval-periphemu = callPackage ./test-eval-periphemu { };
+    eval-hello-world = callPackage ./test-eval-hello-world {
+      craftos-pc = finalAttrs.finalPackage;
+    };
+    eval-periphemu = callPackage ./test-eval-periphemu {
+      craftos-pc = finalAttrs.finalPackage;
+    };
   };
 
   meta = {
-    description = "Implementation of the CraftOS-PC API written in C++ using SDL";
+    description =
+      "Implementation of the CraftOS-PC API written in C++ using SDL"
+      + lib.optionalString enableLuaJIT " (LuaJIT-accelerated variant)";
     homepage = "https://www.craftos-pc.cc";
     license = with lib.licenses; [
       mit
@@ -130,6 +169,6 @@ stdenv.mkDerivation rec {
       tomodachi94
       viluon
     ];
-    mainProgram = "craftos";
+    mainProgram = luaCtx.binName;
   };
-}
+})

--- a/pkgs/by-name/cr/craftos-pc/test-eval-hello-world/default.nix
+++ b/pkgs/by-name/cr/craftos-pc/test-eval-hello-world/default.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   stdenv,
   craftos-pc,
   gnugrep,
@@ -16,7 +17,7 @@ stdenv.mkDerivation {
     mkdir $HOME/.local $HOME/.config
     export XDG_CONFIG_DIR=$HOME/.config
     export XDG_DATA_DIR=$HOME/.local
-    craftos --headless --script ${./init.lua} | grep "Hello Nixpkgs!" > /dev/null
+    ${lib.getExe craftos-pc} --headless --script ${./init.lua} | grep "Hello Nixpkgs!" > /dev/null
     touch $out
   '';
 }

--- a/pkgs/by-name/cr/craftos-pc/test-eval-periphemu/default.nix
+++ b/pkgs/by-name/cr/craftos-pc/test-eval-periphemu/default.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   stdenv,
   craftos-pc,
   gnugrep,
@@ -15,7 +16,7 @@ stdenv.mkDerivation {
     mkdir $HOME/.local $HOME/.config
     export XDG_CONFIG_DIR=$HOME/.config
     export XDG_DATA_DIR=$HOME/.local
-    if craftos --headless --script ${./init.lua} | grep -q "FAIL"; then
+    if ${lib.getExe craftos-pc} --headless --script ${./init.lua} | grep -q "FAIL"; then
         exit 1
     fi
     touch $out

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1410,6 +1410,8 @@ with pkgs;
     else
       throw "freshBootstrapTools: unknown hostPlatform ${stdenv.hostPlatform.config}";
 
+  craftos-pc-accelerated = craftos-pc.override { enableLuaJIT = true; };
+
   crystfel-headless = crystfel.override { withGui = false; };
 
   inherit (callPackages ../tools/security/bitwarden-directory-connector { })


### PR DESCRIPTION
Add the LuaJIT-based accelerated variant of `craftos`. The package is released in two flavours, e.g. `2.8.3` and `2.8.3-luajit`. We select with the new `enableLuaJIT` flag, defaulting to `false` (old behaviour). The packages are similar enough that I opted for this approach instead of adding a new top-level entry.

This was done first by Copilot, then stripped of comments and code duplication. Tests pass for both packages and I also tested them manually.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
