### PR TITLE
cuda-modules: surface capability-category helpers into _cuda.db and _cuda.lib

### DIFF
--- a/pkgs/development/cuda-modules/_cuda/db/default.nix
+++ b/pkgs/development/cuda-modules/_cuda/db/default.nix
@@ -62,4 +62,61 @@ bootstrapData
   cudaArchNameToCapabilities = lib.groupBy (
     cudaCapability: db.cudaCapabilityToInfo.${cudaCapability}.archName
   ) db.allSortedCudaCapabilities;
+
+  /**
+    All architecture-specific CUDA capabilities, sorted by version.
+
+    # Type
+
+    ```
+    architectureSpecificCudaCapabilities :: [CudaCapability]
+    ```
+  */
+  architectureSpecificCudaCapabilities = lib.filter (
+    cudaCapability: db.cudaCapabilityToInfo.${cudaCapability}.isArchitectureSpecific
+  ) db.allSortedCudaCapabilities;
+
+  /**
+    All family-specific CUDA capabilities, sorted by version.
+
+    # Type
+
+    ```
+    familySpecificCudaCapabilities :: [CudaCapability]
+    ```
+  */
+  familySpecificCudaCapabilities = lib.filter (
+    cudaCapability: db.cudaCapabilityToInfo.${cudaCapability}.isFamilySpecific
+  ) db.allSortedCudaCapabilities;
+
+  /**
+    All Jetson CUDA capabilities, sorted by version.
+
+    # Type
+
+    ```
+    jetsonCudaCapabilities :: [CudaCapability]
+    ```
+  */
+  jetsonCudaCapabilities = lib.filter (
+    cudaCapability: db.cudaCapabilityToInfo.${cudaCapability}.isJetson
+  ) db.allSortedCudaCapabilities;
+
+  /**
+    Mapping of CUDA micro-architecture name to Jetson capabilities belonging to that
+    micro-architecture.
+
+    This is a Jetson-only subset of `cudaArchNameToCapabilities`: only architectures that have at
+    least one Jetson capability appear as keys, and their values contain only the Jetson
+    capabilities for that architecture.
+
+    # Type
+
+    ```
+    cudaArchNameToJetsonCapabilities :: AttrSet NonEmptyStr (NonEmptyListOf CudaCapability)
+    ```
+  */
+  cudaArchNameToJetsonCapabilities = lib.groupBy (
+    cudaCapability: db.cudaCapabilityToInfo.${cudaCapability}.archName
+  ) db.jetsonCudaCapabilities;
 }

--- a/pkgs/development/cuda-modules/_cuda/db/default.nix
+++ b/pkgs/development/cuda-modules/_cuda/db/default.nix
@@ -119,4 +119,17 @@ bootstrapData
   cudaArchNameToJetsonCapabilities = lib.groupBy (
     cudaCapability: db.cudaCapabilityToInfo.${cudaCapability}.archName
   ) db.jetsonCudaCapabilities;
+
+  /**
+    The micro-architecture names that have at least one Jetson capability.
+
+    This is the set of valid `archName` values for `_cuda.lib.cudaCapabilitiesAreJetsonArch`.
+
+    # Type
+
+    ```
+    jetsonArchNames :: [String]
+    ```
+  */
+  jetsonArchNames = lib.attrNames db.cudaArchNameToJetsonCapabilities;
 }

--- a/pkgs/development/cuda-modules/_cuda/db/default.nix
+++ b/pkgs/development/cuda-modules/_cuda/db/default.nix
@@ -119,17 +119,4 @@ bootstrapData
   cudaArchNameToJetsonCapabilities = lib.groupBy (
     cudaCapability: db.cudaCapabilityToInfo.${cudaCapability}.archName
   ) db.jetsonCudaCapabilities;
-
-  /**
-    The micro-architecture names that have at least one Jetson capability.
-
-    This is the set of valid `archName` values for `_cuda.lib.cudaCapabilitiesIncludeJetsonArch`.
-
-    # Type
-
-    ```
-    jetsonArchNames :: [String]
-    ```
-  */
-  jetsonArchNames = lib.attrNames db.cudaArchNameToJetsonCapabilities;
 }

--- a/pkgs/development/cuda-modules/_cuda/db/default.nix
+++ b/pkgs/development/cuda-modules/_cuda/db/default.nix
@@ -123,7 +123,7 @@ bootstrapData
   /**
     The micro-architecture names that have at least one Jetson capability.
 
-    This is the set of valid `archName` values for `_cuda.lib.cudaCapabilitiesAreJetsonArch`.
+    This is the set of valid `archName` values for `_cuda.lib.cudaCapabilitiesIncludeJetsonArch`.
 
     # Type
 

--- a/pkgs/development/cuda-modules/_cuda/lib/cuda.nix
+++ b/pkgs/development/cuda-modules/_cuda/lib/cuda.nix
@@ -1,4 +1,11 @@
 { _cuda, lib }:
+let
+  jetsonSubset =
+    cudaCapabilities: lib.intersectLists _cuda.db.jetsonCudaCapabilities cudaCapabilities;
+  jetsonArchSubset =
+    archName: cudaCapabilities:
+    lib.intersectLists (_cuda.db.cudaArchNameToJetsonCapabilities.${archName} or [ ]) cudaCapabilities;
+in
 {
   /**
     Returns whether a capability should be built by default for a particular CUDA version.
@@ -161,8 +168,7 @@
 
     : The list of CUDA capabilities to check
   */
-  _cudaCapabilitiesAreJetson =
-    cudaCapabilities: lib.intersectLists _cuda.db.jetsonCudaCapabilities cudaCapabilities != [ ];
+  _cudaCapabilitiesAreJetson = cudaCapabilities: jetsonSubset cudaCapabilities != [ ];
 
   /**
     Returns whether a list of CUDA capabilities includes any Jetson capability belonging to the
@@ -190,9 +196,71 @@
     : The list of CUDA capabilities to check
   */
   _cudaCapabilitiesAreJetsonArch =
-    archName: cudaCapabilities:
-    lib.intersectLists (_cuda.db.cudaArchNameToJetsonCapabilities.${archName} or [ ]) cudaCapabilities
-    != [ ];
+    archName: cudaCapabilities: jetsonArchSubset archName cudaCapabilities != [ ];
+
+  /**
+    Returns the Jetson capabilities within a list of CUDA capabilities.
+
+    # Type
+
+    ```
+    cudaCapabilitiesJetsonSubset :: (cudaCapabilities :: [CudaCapability]) -> [CudaCapability]
+    ```
+
+    # Inputs
+
+    `cudaCapabilities`
+
+    : The list of CUDA capabilities to filter
+  */
+  cudaCapabilitiesJetsonSubset = jetsonSubset;
+
+  /**
+    Returns whether a list of CUDA capabilities includes any Jetson capability.
+
+    This is the stable public API for `_cudaCapabilitiesAreJetson`.
+
+    # Type
+
+    ```
+    cudaCapabilitiesAreJetson :: (cudaCapabilities :: [CudaCapability]) -> Bool
+    ```
+
+    # Inputs
+
+    `cudaCapabilities`
+
+    : The list of CUDA capabilities to check
+  */
+  cudaCapabilitiesAreJetson = cudaCapabilities: jetsonSubset cudaCapabilities != [ ];
+
+  /**
+    Returns whether a list of CUDA capabilities includes any Jetson capability belonging to the
+    given micro-architecture.
+
+    This is the stable public API for `_cudaCapabilitiesAreJetsonArch`.
+
+    # Type
+
+    ```
+    cudaCapabilitiesAreJetsonArch
+      :: (archName :: String)
+      -> (cudaCapabilities :: [CudaCapability])
+      -> Bool
+    ```
+
+    # Inputs
+
+    `archName`
+
+    : The micro-architecture name (e.g. `"Ampere"`, `"Blackwell"`)
+
+    `cudaCapabilities`
+
+    : The list of CUDA capabilities to check
+  */
+  cudaCapabilitiesAreJetsonArch =
+    archName: cudaCapabilities: jetsonArchSubset archName cudaCapabilities != [ ];
 
   /**
     A predicate which, given a package, returns true if the package has a free license or one of NVIDIA's licenses.

--- a/pkgs/development/cuda-modules/_cuda/lib/cuda.nix
+++ b/pkgs/development/cuda-modules/_cuda/lib/cuda.nix
@@ -103,6 +103,98 @@
   _mkCudaVariant = version: "cuda${lib.versions.major version}";
 
   /**
+    Returns whether a list of CUDA capabilities includes any architecture-specific capability.
+
+    NOTE: No guarantees are made about this function's stability. You may use it at your own risk.
+
+    # Type
+
+    ```
+    _cudaCapabilitiesAreArchitectureSpecific :: (cudaCapabilities :: [CudaCapability]) -> Bool
+    ```
+
+    # Inputs
+
+    `cudaCapabilities`
+
+    : The list of CUDA capabilities to check
+  */
+  _cudaCapabilitiesAreArchitectureSpecific =
+    cudaCapabilities:
+    lib.intersectLists _cuda.db.architectureSpecificCudaCapabilities cudaCapabilities != [ ];
+
+  /**
+    Returns whether a list of CUDA capabilities includes any family-specific capability.
+
+    NOTE: No guarantees are made about this function's stability. You may use it at your own risk.
+
+    # Type
+
+    ```
+    _cudaCapabilitiesAreFamilySpecific :: (cudaCapabilities :: [CudaCapability]) -> Bool
+    ```
+
+    # Inputs
+
+    `cudaCapabilities`
+
+    : The list of CUDA capabilities to check
+  */
+  _cudaCapabilitiesAreFamilySpecific =
+    cudaCapabilities:
+    lib.intersectLists _cuda.db.familySpecificCudaCapabilities cudaCapabilities != [ ];
+
+  /**
+    Returns whether a list of CUDA capabilities includes any Jetson capability.
+
+    NOTE: No guarantees are made about this function's stability. You may use it at your own risk.
+
+    # Type
+
+    ```
+    _cudaCapabilitiesAreJetson :: (cudaCapabilities :: [CudaCapability]) -> Bool
+    ```
+
+    # Inputs
+
+    `cudaCapabilities`
+
+    : The list of CUDA capabilities to check
+  */
+  _cudaCapabilitiesAreJetson =
+    cudaCapabilities: lib.intersectLists _cuda.db.jetsonCudaCapabilities cudaCapabilities != [ ];
+
+  /**
+    Returns whether a list of CUDA capabilities includes any Jetson capability belonging to the
+    given micro-architecture.
+
+    NOTE: No guarantees are made about this function's stability. You may use it at your own risk.
+
+    # Type
+
+    ```
+    _cudaCapabilitiesAreJetsonArch
+      :: (archName :: String)
+      -> (cudaCapabilities :: [CudaCapability])
+      -> Bool
+    ```
+
+    # Inputs
+
+    `archName`
+
+    : The micro-architecture name (e.g. `"Ampere"`, `"Blackwell"`)
+
+    `cudaCapabilities`
+
+    : The list of CUDA capabilities to check
+  */
+  _cudaCapabilitiesAreJetsonArch =
+    archName: cudaCapabilities:
+    lib.intersectLists (_cuda.db.cudaArchNameToJetsonCapabilities.${archName} or [ ]) cudaCapabilities
+    != [ ];
+
+  /**
     A predicate which, given a package, returns true if the package has a free license or one of NVIDIA's licenses.
 
     This function is intended to be provided as `config.allowUnfreePredicate` when `import`-ing Nixpkgs.

--- a/pkgs/development/cuda-modules/_cuda/lib/cuda.nix
+++ b/pkgs/development/cuda-modules/_cuda/lib/cuda.nix
@@ -239,55 +239,6 @@
     lib.intersectLists (_cuda.db.cudaArchNameToJetsonCapabilities.${archName} or [ ]) cudaCapabilities;
 
   /**
-    Returns whether a list of CUDA capabilities includes any Jetson capability.
-
-    This is the stable public API for `_cudaCapabilitiesIncludeJetson`.
-
-    # Type
-
-    ```
-    cudaCapabilitiesIncludeJetson :: (cudaCapabilities :: [CudaCapability]) -> Bool
-    ```
-
-    # Inputs
-
-    `cudaCapabilities`
-
-    : The list of CUDA capabilities to check
-  */
-  cudaCapabilitiesIncludeJetson =
-    cudaCapabilities: _cuda.lib.getJetsonCudaCapabilities cudaCapabilities != [ ];
-
-  /**
-    Returns whether a list of CUDA capabilities includes any Jetson capability belonging to the
-    given micro-architecture.
-
-    This is the stable public API for `_cudaCapabilitiesIncludeJetsonArch`.
-
-    # Type
-
-    ```
-    cudaCapabilitiesIncludeJetsonArch
-      :: (archName :: String)
-      -> (cudaCapabilities :: [CudaCapability])
-      -> Bool
-    ```
-
-    # Inputs
-
-    `archName`
-
-    : The micro-architecture name (e.g. `"Ampere"`, `"Blackwell"`)
-
-    `cudaCapabilities`
-
-    : The list of CUDA capabilities to check
-  */
-  cudaCapabilitiesIncludeJetsonArch =
-    archName: cudaCapabilities:
-    _cuda.lib.getJetsonCudaCapabilitiesForArch archName cudaCapabilities != [ ];
-
-  /**
     A predicate which, given a package, returns true if the package has a free license or one of NVIDIA's licenses.
 
     This function is intended to be provided as `config.allowUnfreePredicate` when `import`-ing Nixpkgs.

--- a/pkgs/development/cuda-modules/_cuda/lib/cuda.nix
+++ b/pkgs/development/cuda-modules/_cuda/lib/cuda.nix
@@ -1,11 +1,4 @@
 { _cuda, lib }:
-let
-  jetsonSubset =
-    cudaCapabilities: lib.intersectLists _cuda.db.jetsonCudaCapabilities cudaCapabilities;
-  jetsonArchSubset =
-    archName: cudaCapabilities:
-    lib.intersectLists (_cuda.db.cudaArchNameToJetsonCapabilities.${archName} or [ ]) cudaCapabilities;
-in
 {
   /**
     Returns whether a capability should be built by default for a particular CUDA version.
@@ -117,7 +110,7 @@ in
     # Type
 
     ```
-    _cudaCapabilitiesAreArchitectureSpecific :: (cudaCapabilities :: [CudaCapability]) -> Bool
+    _cudaCapabilitiesIncludeArchitectureSpecific :: (cudaCapabilities :: [CudaCapability]) -> Bool
     ```
 
     # Inputs
@@ -126,7 +119,7 @@ in
 
     : The list of CUDA capabilities to check
   */
-  _cudaCapabilitiesAreArchitectureSpecific =
+  _cudaCapabilitiesIncludeArchitectureSpecific =
     cudaCapabilities:
     lib.intersectLists _cuda.db.architectureSpecificCudaCapabilities cudaCapabilities != [ ];
 
@@ -138,7 +131,7 @@ in
     # Type
 
     ```
-    _cudaCapabilitiesAreFamilySpecific :: (cudaCapabilities :: [CudaCapability]) -> Bool
+    _cudaCapabilitiesIncludeFamilySpecific :: (cudaCapabilities :: [CudaCapability]) -> Bool
     ```
 
     # Inputs
@@ -147,7 +140,7 @@ in
 
     : The list of CUDA capabilities to check
   */
-  _cudaCapabilitiesAreFamilySpecific =
+  _cudaCapabilitiesIncludeFamilySpecific =
     cudaCapabilities:
     lib.intersectLists _cuda.db.familySpecificCudaCapabilities cudaCapabilities != [ ];
 
@@ -159,7 +152,7 @@ in
     # Type
 
     ```
-    _cudaCapabilitiesAreJetson :: (cudaCapabilities :: [CudaCapability]) -> Bool
+    _cudaCapabilitiesIncludeJetson :: (cudaCapabilities :: [CudaCapability]) -> Bool
     ```
 
     # Inputs
@@ -168,7 +161,8 @@ in
 
     : The list of CUDA capabilities to check
   */
-  _cudaCapabilitiesAreJetson = cudaCapabilities: jetsonSubset cudaCapabilities != [ ];
+  _cudaCapabilitiesIncludeJetson =
+    cudaCapabilities: _cuda.lib.getJetsonCudaCapabilities cudaCapabilities != [ ];
 
   /**
     Returns whether a list of CUDA capabilities includes any Jetson capability belonging to the
@@ -179,7 +173,7 @@ in
     # Type
 
     ```
-    _cudaCapabilitiesAreJetsonArch
+    _cudaCapabilitiesIncludeJetsonArch
       :: (archName :: String)
       -> (cudaCapabilities :: [CudaCapability])
       -> Bool
@@ -195,8 +189,9 @@ in
 
     : The list of CUDA capabilities to check
   */
-  _cudaCapabilitiesAreJetsonArch =
-    archName: cudaCapabilities: jetsonArchSubset archName cudaCapabilities != [ ];
+  _cudaCapabilitiesIncludeJetsonArch =
+    archName: cudaCapabilities:
+    _cuda.lib.getJetsonCudaCapabilitiesForArch archName cudaCapabilities != [ ];
 
   /**
     Returns the Jetson capabilities within a list of CUDA capabilities.
@@ -204,7 +199,7 @@ in
     # Type
 
     ```
-    cudaCapabilitiesJetsonSubset :: (cudaCapabilities :: [CudaCapability]) -> [CudaCapability]
+    getJetsonCudaCapabilities :: (cudaCapabilities :: [CudaCapability]) -> [CudaCapability]
     ```
 
     # Inputs
@@ -213,17 +208,45 @@ in
 
     : The list of CUDA capabilities to filter
   */
-  cudaCapabilitiesJetsonSubset = jetsonSubset;
+  getJetsonCudaCapabilities =
+    cudaCapabilities: lib.intersectLists _cuda.db.jetsonCudaCapabilities cudaCapabilities;
 
   /**
-    Returns whether a list of CUDA capabilities includes any Jetson capability.
-
-    This is the stable public API for `_cudaCapabilitiesAreJetson`.
+    Returns the Jetson capabilities within a list of CUDA capabilities that belong to the given
+    micro-architecture.
 
     # Type
 
     ```
-    cudaCapabilitiesAreJetson :: (cudaCapabilities :: [CudaCapability]) -> Bool
+    getJetsonCudaCapabilitiesForArch
+      :: (archName :: String)
+      -> (cudaCapabilities :: [CudaCapability])
+      -> [CudaCapability]
+    ```
+
+    # Inputs
+
+    `archName`
+
+    : The micro-architecture name (e.g. `"Ampere"`, `"Blackwell"`)
+
+    `cudaCapabilities`
+
+    : The list of CUDA capabilities to filter
+  */
+  getJetsonCudaCapabilitiesForArch =
+    archName: cudaCapabilities:
+    lib.intersectLists (_cuda.db.cudaArchNameToJetsonCapabilities.${archName} or [ ]) cudaCapabilities;
+
+  /**
+    Returns whether a list of CUDA capabilities includes any Jetson capability.
+
+    This is the stable public API for `_cudaCapabilitiesIncludeJetson`.
+
+    # Type
+
+    ```
+    cudaCapabilitiesIncludeJetson :: (cudaCapabilities :: [CudaCapability]) -> Bool
     ```
 
     # Inputs
@@ -232,18 +255,19 @@ in
 
     : The list of CUDA capabilities to check
   */
-  cudaCapabilitiesAreJetson = cudaCapabilities: jetsonSubset cudaCapabilities != [ ];
+  cudaCapabilitiesIncludeJetson =
+    cudaCapabilities: _cuda.lib.getJetsonCudaCapabilities cudaCapabilities != [ ];
 
   /**
     Returns whether a list of CUDA capabilities includes any Jetson capability belonging to the
     given micro-architecture.
 
-    This is the stable public API for `_cudaCapabilitiesAreJetsonArch`.
+    This is the stable public API for `_cudaCapabilitiesIncludeJetsonArch`.
 
     # Type
 
     ```
-    cudaCapabilitiesAreJetsonArch
+    cudaCapabilitiesIncludeJetsonArch
       :: (archName :: String)
       -> (cudaCapabilities :: [CudaCapability])
       -> Bool
@@ -259,8 +283,9 @@ in
 
     : The list of CUDA capabilities to check
   */
-  cudaCapabilitiesAreJetsonArch =
-    archName: cudaCapabilities: jetsonArchSubset archName cudaCapabilities != [ ];
+  cudaCapabilitiesIncludeJetsonArch =
+    archName: cudaCapabilities:
+    _cuda.lib.getJetsonCudaCapabilitiesForArch archName cudaCapabilities != [ ];
 
   /**
     A predicate which, given a package, returns true if the package has a free license or one of NVIDIA's licenses.

--- a/pkgs/development/cuda-modules/_cuda/lib/default.nix
+++ b/pkgs/development/cuda-modules/_cuda/lib/default.nix
@@ -20,6 +20,9 @@
     _cudaCapabilityIsSupported
     _mkCudaVariant
     allowUnfreeCudaPredicate
+    cudaCapabilitiesAreJetson
+    cudaCapabilitiesAreJetsonArch
+    cudaCapabilitiesJetsonSubset
     ;
 
   # See ./licenses.nix for documentation.

--- a/pkgs/development/cuda-modules/_cuda/lib/default.nix
+++ b/pkgs/development/cuda-modules/_cuda/lib/default.nix
@@ -12,6 +12,10 @@
 
   # See ./cuda.nix for documentation.
   inherit (import ./cuda.nix { inherit _cuda lib; })
+    _cudaCapabilitiesAreArchitectureSpecific
+    _cudaCapabilitiesAreFamilySpecific
+    _cudaCapabilitiesAreJetson
+    _cudaCapabilitiesAreJetsonArch
     _cudaCapabilityIsDefault
     _cudaCapabilityIsSupported
     _mkCudaVariant

--- a/pkgs/development/cuda-modules/_cuda/lib/default.nix
+++ b/pkgs/development/cuda-modules/_cuda/lib/default.nix
@@ -20,8 +20,6 @@
     _cudaCapabilityIsSupported
     _mkCudaVariant
     allowUnfreeCudaPredicate
-    cudaCapabilitiesIncludeJetson
-    cudaCapabilitiesIncludeJetsonArch
     getJetsonCudaCapabilities
     getJetsonCudaCapabilitiesForArch
     ;

--- a/pkgs/development/cuda-modules/_cuda/lib/default.nix
+++ b/pkgs/development/cuda-modules/_cuda/lib/default.nix
@@ -12,17 +12,18 @@
 
   # See ./cuda.nix for documentation.
   inherit (import ./cuda.nix { inherit _cuda lib; })
-    _cudaCapabilitiesAreArchitectureSpecific
-    _cudaCapabilitiesAreFamilySpecific
-    _cudaCapabilitiesAreJetson
-    _cudaCapabilitiesAreJetsonArch
+    _cudaCapabilitiesIncludeArchitectureSpecific
+    _cudaCapabilitiesIncludeFamilySpecific
+    _cudaCapabilitiesIncludeJetson
+    _cudaCapabilitiesIncludeJetsonArch
     _cudaCapabilityIsDefault
     _cudaCapabilityIsSupported
     _mkCudaVariant
     allowUnfreeCudaPredicate
-    cudaCapabilitiesAreJetson
-    cudaCapabilitiesAreJetsonArch
-    cudaCapabilitiesJetsonSubset
+    cudaCapabilitiesIncludeJetson
+    cudaCapabilitiesIncludeJetsonArch
+    getJetsonCudaCapabilities
+    getJetsonCudaCapabilitiesForArch
     ;
 
   # See ./licenses.nix for documentation.

--- a/pkgs/development/cuda-modules/backendStdenv/default.nix
+++ b/pkgs/development/cuda-modules/backendStdenv/default.nix
@@ -20,7 +20,14 @@ let
     toJSON
     toString
     ;
-  inherit (_cuda.db) allSortedCudaCapabilities cudaCapabilityToInfo nvccCompatibilities;
+  inherit (_cuda.db)
+    allSortedCudaCapabilities
+    architectureSpecificCudaCapabilities
+    cudaCapabilityToInfo
+    familySpecificCudaCapabilities
+    jetsonCudaCapabilities
+    nvccCompatibilities
+    ;
   inherit (_cuda.lib)
     _cudaCapabilityIsDefault
     _cudaCapabilityIsSupported
@@ -43,20 +50,6 @@ let
     versionOlder
     ;
   inherit (lib.versions) major;
-
-  # NOTE: By virtue of processing a sorted list (allSortedCudaCapabilities), our groups will be sorted.
-
-  architectureSpecificCudaCapabilities = filter (
-    cudaCapability: cudaCapabilityToInfo.${cudaCapability}.isArchitectureSpecific
-  ) allSortedCudaCapabilities;
-
-  familySpecificCudaCapabilities = filter (
-    cudaCapability: cudaCapabilityToInfo.${cudaCapability}.isFamilySpecific
-  ) allSortedCudaCapabilities;
-
-  jetsonCudaCapabilities = filter (
-    cudaCapability: cudaCapabilityToInfo.${cudaCapability}.isJetson
-  ) allSortedCudaCapabilities;
 
   passthruExtra = {
     nvccHostCCMatchesStdenvCC = backendStdenv.cc == stdenv.cc;


### PR DESCRIPTION
Three capability-category filters (`architectureSpecificCudaCapabilities`, `familySpecificCudaCapabilities`, `jetsonCudaCapabilities`) were computed as inline let-bindings in `backendStdenv/default.nix`. 

The logic was not reusable outside `backendStdenv`: downstream consumers that need "is this a Jetson build?" cannot read `cudaPackages.backendStdenv.hasJetsonCudaCapability` from the lib fixpoint without infinite recursion — it pulls the whole cudaPackages scope. They were forced to re-derive the logic from `_cuda.db` themselves.

Moves the three category lists into `_cuda.db` alongside `allSortedCudaCapabilities` and `cudaArchNameToCapabilities`, adds _-prefixed predicates to _cuda.lib, and updates backendStdenv to inherit from `_cuda.db`.