### PR TITLE
homebox: 0.25.0 -> 0.26.2

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -123,6 +123,8 @@
 
 - `keycloak` was updated to >= 26.7.0 and includes some breaking internal (API) changes. See the [upstream migration guide](https://www.keycloak.org/docs/latest/upgrading/#migrating-to-26-7-0) for more information.
 
+- `homebox` v0.26.0 introduced a new, required value to be set, `HBOX_AUTH_API_KEY_PEPPER`. It cannot be started without this.
+
 - `librest` providing 0.7 ABI was removed. `librest_1_0` providing 1.0 ABI was renamed to `librest` and `librest_1_0` was kept as an alias.
 
 - `luaPackages.lrexlib-pcre` has been removed as part of the process to fully migrate from the end-of-life PRCE library to PCRE2. `luaPackages.lrexlib-pcre2` and multiple other versions of lrexlib can be used instead.

--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -123,8 +123,6 @@
 
 - `keycloak` was updated to >= 26.7.0 and includes some breaking internal (API) changes. See the [upstream migration guide](https://www.keycloak.org/docs/latest/upgrading/#migrating-to-26-7-0) for more information.
 
-- `homebox` v0.26.0 introduced a new, required value to be set, `HBOX_AUTH_API_KEY_PEPPER`. It cannot be started without this.
-
 - `librest` providing 0.7 ABI was removed. `librest_1_0` providing 1.0 ABI was renamed to `librest` and `librest_1_0` was kept as an alias.
 
 - `luaPackages.lrexlib-pcre` has been removed as part of the process to fully migrate from the end-of-life PRCE library to PCRE2. `luaPackages.lrexlib-pcre2` and multiple other versions of lrexlib can be used instead.
@@ -164,6 +162,8 @@
   Maintainers using `fetchurl` for `drv.src` are urged to adapt their `drv.meta.identifiers.purlParts` for proper identification.
 
 - The fwts efi-runtime kernel module was removed.
+
+- `homebox` v0.26.0 introduced a new, required value to be set, `HBOX_AUTH_API_KEY_PEPPER`. If one is not provided the module will create one, it is recommended that you back this up as it is part of API Key generation and validation.
 
 - Emacs loads the `early-default` library after `early-init.el`.
   Users can add `early-init.el` via `emacs.pkgs.withPackages`

--- a/nixos/modules/services/web-apps/homebox.nix
+++ b/nixos/modules/services/web-apps/homebox.nix
@@ -1,12 +1,14 @@
 {
   lib,
   config,
+  options,
   pkgs,
   ...
 }:
 let
   cfg = config.services.homebox;
   inherit (lib)
+    literalExpression
     mkEnableOption
     mkPackageOption
     mkDefault
@@ -17,6 +19,11 @@ let
 
   defaultUser = "homebox";
   defaultGroup = "homebox";
+
+  pepperDefault =
+    (cfg.secrets ? HBOX_AUTH_API_KEY_PEPPER)
+    && (cfg.secrets.HBOX_AUTH_API_KEY_PEPPER == "/var/lib/homebox/api-pepper-secret");
+  opts = options.services.homebox;
 in
 {
   options.services.homebox = {
@@ -61,6 +68,37 @@ in
         '';
       };
     };
+    secrets = mkOption {
+      type = types.submodule {
+        options = {
+          HBOX_AUTH_API_KEY_PEPPER = mkOption {
+            type = types.externalPath;
+            default = "/var/lib/homebox/api-pepper-secret";
+            description = ''
+              Path to the API key pepper secret file (required for homebox to start).
+            '';
+            example = "/run/secrets/homebox-api-pepper";
+          };
+        };
+        freeformType = types.attrsOf types.externalPath;
+      };
+
+      default = { };
+      description = ''
+        This follows the same structure as {option}`${opts.settings}`
+        but the value of each key is a path.
+
+        The specified secret path is then read by systemd via [`LoadCredential=`]
+        and templated into {option}`${opts.settings}` for you.
+
+        [`LoadCredential=`]: https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#Credentials
+      '';
+      example = literalExpression ''
+        {
+          HBOX_AUTH_API_KEY_PEPPER = "/run/secrets/homebox-api-pepper";
+        }
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -92,7 +130,7 @@ in
         HBOX_DATABASE_DRIVER = "sqlite3";
         HBOX_DATABASE_SQLITE_PATH = "/var/lib/homebox/data/homebox.db?_pragma=busy_timeout=999&_pragma=journal_mode=WAL&_fk=1";
         HBOX_OPTIONS_ALLOW_REGISTRATION = "false";
-        HBOX_OPTIONS_CHECK_GITHUB_RELEASE = "false";
+        HBOX_OPTIONS_GITHUB_RELEASE_CHECK = "false";
         HBOX_MODE = "production";
         # Fix this startup issue:
         #   failed to create modcache index dir: mkdir /var/empty/.cache: read-only file system
@@ -121,58 +159,92 @@ in
         }
       ];
     };
-    systemd.services.homebox = {
-      requires = lib.optional cfg.database.createLocally "postgresql.target";
-      after = lib.optional cfg.database.createLocally "postgresql.target";
-      environment = lib.filterAttrs (_: v: v != null) cfg.settings;
-      preStart = ''
-        "${pkgs.coreutils}/bin/rm" -rf /var/lib/homebox/tmp
-        "${pkgs.coreutils}/bin/mkdir" -p /var/lib/homebox/tmp
+    systemd.services.homebox-setup = mkIf pepperDefault {
+      script = ''
+        if [ ! -r "$STATE_DIRECTORY"/api-pepper-secret ]; then
+          umask 0277
+          openssl rand -base64 48 > "$STATE_DIRECTORY"/api-pepper-secret
+        fi
       '';
+      path = [
+        pkgs.openssl
+      ];
       serviceConfig = {
+        Type = "oneshot";
         User = cfg.user;
         Group = cfg.group;
-        ExecStart = lib.getExe cfg.package;
-        LimitNOFILE = "1048576";
-        PrivateTmp = true;
-        PrivateDevices = true;
-        Restart = "always";
         StateDirectory = "homebox";
-
-        # Hardening
-        CapabilityBoundingSet = "";
-        LockPersonality = true;
-        MemoryDenyWriteExecute = true;
-        PrivateUsers = true;
-        ProtectClock = true;
-        ProtectControlGroups = true;
-        ProtectHome = true;
-        ProtectHostname = true;
-        ProtectKernelLogs = true;
-        ProtectKernelModules = true;
-        ProtectKernelTunables = true;
-        ProtectProc = "invisible";
-        ProcSubset = "pid";
-        ProtectSystem = "strict";
-        RestrictAddressFamilies = [
-          "AF_UNIX"
-          "AF_INET"
-          "AF_INET6"
-          "AF_NETLINK"
-        ];
-        RestrictNamespaces = true;
-        RestrictRealtime = true;
-        SystemCallArchitectures = "native";
-        SystemCallFilter = [
-          "@system-service"
-          "@pkey"
-        ];
-        RestrictSUIDSGID = true;
-        PrivateMounts = true;
-        UMask = "0077";
       };
-      wantedBy = [ "multi-user.target" ];
     };
+    systemd.services.homebox =
+      let
+        deps =
+          lib.optionals pepperDefault [
+            "homebox-setup.service"
+          ]
+          ++ lib.optionals cfg.database.createLocally [
+            "postgresql.target"
+          ];
+      in
+      {
+        requires = deps;
+        after = deps;
+        environment = lib.filterAttrs (_: v: v != null) cfg.settings;
+        preStart = ''
+          "${pkgs.coreutils}/bin/rm" -rf /var/lib/homebox/tmp
+          "${pkgs.coreutils}/bin/mkdir" -p /var/lib/homebox/tmp
+        '';
+        script = ''
+          ${lib.strings.concatLines (
+            lib.mapAttrsToList (name: _: "export ${name}=$(<\"$CREDENTIALS_DIRECTORY\"/${name})") cfg.secrets
+          )}
+
+          exec ${lib.getExe cfg.package}
+        '';
+        serviceConfig = {
+          User = cfg.user;
+          Group = cfg.group;
+          LoadCredential = (lib.mapAttrsToList (name: path: "${name}:${path}") cfg.secrets);
+          LimitNOFILE = "1048576";
+          PrivateTmp = true;
+          PrivateDevices = true;
+          Restart = "always";
+          StateDirectory = "homebox";
+
+          # Hardening
+          CapabilityBoundingSet = "";
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          PrivateUsers = true;
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHome = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectProc = "invisible";
+          ProcSubset = "pid";
+          ProtectSystem = "strict";
+          RestrictAddressFamilies = [
+            "AF_UNIX"
+            "AF_INET"
+            "AF_INET6"
+            "AF_NETLINK"
+          ];
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          SystemCallArchitectures = "native";
+          SystemCallFilter = [
+            "@system-service"
+            "@pkey"
+          ];
+          RestrictSUIDSGID = true;
+          PrivateMounts = true;
+          UMask = "0077";
+        };
+        wantedBy = [ "multi-user.target" ];
+      };
   };
   meta.maintainers = with lib.maintainers; [
     patrickdag

--- a/nixos/tests/homebox.nix
+++ b/nixos/tests/homebox.nix
@@ -4,8 +4,8 @@ let
 in
 {
   name = "homebox";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ patrickdag ];
+  meta = {
+    inherit (pkgs.homebox.meta) maintainers;
   };
   nodes =
     let
@@ -21,6 +21,31 @@ in
           imports = [ self.simple ];
           services.homebox.database.createLocally = true;
         };
+
+        explicitPepper =
+          {
+            config,
+            lib,
+            ...
+          }:
+          let
+            inherit (config.services.homebox)
+              user
+              group
+              ;
+          in
+          {
+            systemd.tmpfiles.rules = [
+              "d /run/homebox 0700 ${user} ${group}"
+              "f /run/homebox/pepper 0400 ${user} ${group} - 0a7524fa7b4555ab793c177557b7b8db6619b47cc0574fb99716315e03b6ddf1d67961ee9bf36b19bef448ed3e530957"
+            ];
+            imports = [ self.simple ];
+            services.homebox = {
+              secrets = {
+                HBOX_AUTH_API_KEY_PEPPER = "/run/homebox/pepper";
+              };
+            };
+          };
       };
     in
     self;
@@ -37,5 +62,6 @@ in
     simple.send_monitor_command("quit")
     simple.wait_for_shutdown()
     test_homebox(postgres)
+    test_homebox(explicitPepper)
   '';
 }

--- a/pkgs/by-name/ho/homebox/package.nix
+++ b/pkgs/by-name/ho/homebox/package.nix
@@ -13,18 +13,18 @@
 }:
 let
   pname = "homebox";
-  version = "0.25.0";
+  version = "0.26.2";
   src = fetchFromGitHub {
     owner = "sysadminsmedia";
     repo = "homebox";
     tag = "v${version}";
-    hash = "sha256-mAC7n8AjsSHzO+l0ILJhf4LPAuVZ5KIYO6mXftZpVbE=";
+    hash = "sha256-JUhRpUWbydy28Xw7j6oCKJLBmaOxcruWAdkqm+hvouY=";
   };
 in
 buildGoModule {
   inherit pname version src;
 
-  vendorHash = "sha256-FuZEGUduKZyTuW63z3rk8g1KE8wyx55xoNSvqbvF0PA=";
+  vendorHash = "sha256-peQaPSbxGn8MnbZPqCi5ptW+dMh9l4W1hB6HqBLTqh4=";
   modRoot = "backend";
   # the goModules derivation inherits our buildInputs and buildPhases
   # Since we do pnpm thing in those it fails if we don't explicitly remove them
@@ -42,7 +42,7 @@ buildGoModule {
     src = "${src}/frontend";
     pnpm = pnpm_10;
     fetcherVersion = 3;
-    hash = "sha256-LrK0ijH8ahmDU4t9ckmIf1TJmybLLDRRHA67djUwRBk=";
+    hash = "sha256-oHS2uMWyuqpiK7yWznmZ2mgxPJpWsyOZL2wz6zBu0cc=";
   };
   pnpmRoot = "../frontend";
 


### PR DESCRIPTION
- homebox: 0.25.0 -> 0.26.2
- nixos.homebox: handle new AUTH_API_KEY_PEPPER configuration

If a pepper file is not defined and present, we will create one for the user.

Used Copilot:GPT-5.4 to search nixpkgs to come up with the `systemd.tmpfiles.rules` block to set the secret in the test (assisted-by declared in commit).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
