### PR TITLE
legitify: unbreak build

### DIFF
--- a/pkgs/by-name/le/legitify/package.nix
+++ b/pkgs/by-name/le/legitify/package.nix
@@ -4,23 +4,42 @@
   fetchFromGitHub,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "legitify";
   version = "1.0.11";
 
   src = fetchFromGitHub {
     owner = "Legit-Labs";
     repo = "legitify";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ijW0vvamuqcN6coV5pAtmjAUjzNXxiqr2S9EwrNlrJc=";
   };
 
-  vendorHash = "sha256-QwSh7+LuwdbBtrIGk3ZK6cMW9h7wzNArPT/lVZgUGBU=";
+  vendorHash = "sha256-XPfqQFGJ5yZJVFzHq4zzTXzwuxsAPJvTrZBK+gZWRKE=";
+
+  overrideModAttrs = oldAttrs: {
+    postPatch = (oldAttrs.postPatch or "") + ''
+      export GOCACHE=$TMPDIR/go-cache
+      export GOPATH=$TMPDIR/go
+      go mod edit -replace golang.org/x/tools=golang.org/x/tools@v0.30.0
+      go mod tidy
+    '';
+    postBuild = (oldAttrs.postBuild or "") + ''
+      cp go.mod go.sum vendor/
+    '';
+  };
+
+  preBuild = ''
+    if [ -d vendor ]; then
+      chmod -R u+w vendor
+      cp vendor/go.mod vendor/go.sum .
+    fi
+  '';
 
   ldflags = [
     "-w"
     "-s"
-    "-X=github.com/Legit-Labs/legitify/internal/version.Version=${version}"
+    "-X=github.com/Legit-Labs/legitify/internal/version.Version=${finalAttrs.version}"
   ];
 
   preCheck = ''
@@ -30,10 +49,9 @@ buildGoModule rec {
   meta = {
     description = "Tool to detect and remediate misconfigurations and security risks of GitHub assets";
     homepage = "https://github.com/Legit-Labs/legitify";
-    changelog = "https://github.com/Legit-Labs/legitify/releases/tag/${src.tag}";
+    changelog = "https://github.com/Legit-Labs/legitify/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "legitify";
-    broken = true;
   };
-}
+})


### PR DESCRIPTION
Fix build for legitify

Only works with go1.24 - fix by replacing golang.org/x/tools dependency version.


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
