### PR TITLE
dumbpipe: 0.33.0 -> 0.39.0

### DIFF
--- a/pkgs/by-name/du/dumbpipe/package.nix
+++ b/pkgs/by-name/du/dumbpipe/package.nix
@@ -7,16 +7,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "dumbpipe";
-  version = "0.33.0";
+  version = "0.39.0";
 
   src = fetchFromGitHub {
     owner = "n0-computer";
     repo = "dumbpipe";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-8iubiYZTOCGD7BjqMDnOi3Or1b7cYffL2HBEikUCXF8=";
+    hash = "sha256-AoWWFlMjo1bZUq5RY4gjpEMydULHaCKSSxBh45a7pdI=";
   };
 
-  cargoHash = "sha256-nc/xGi+9kX9OAGLs2uTHMp8Z9+6DLKTvVki2RgNAUV0=";
+  cargoHash = "sha256-je2/GjCCDymYGhho6yf7SNQ3YkLCLQ5nEqHPNdDXjbQ=";
 
   __darwinAllowLocalNetworking = true;
 


### PR DESCRIPTION
Changelogs...don't exist? Best I could do is the differences between releases:

- 0.39.0: https://github.com/n0-computer/dumbpipe/compare/v0.38.0...v0.39.0
- 0.38.0: https://github.com/n0-computer/dumbpipe/compare/v0.37.0...v0.38.0
- 0.37.0: https://github.com/n0-computer/dumbpipe/compare/v0.36.0...v0.37.0
- 0.36.0: https://github.com/n0-computer/dumbpipe/compare/v0.35.0...v0.36.0
- 0.35.0: https://github.com/n0-computer/dumbpipe/compare/v0.34.0...v0.35.0
- 0.34.0: https://github.com/n0-computer/dumbpipe/compare/v0.33.0...v0.34.0

Just discovered the tool because of git-annex' iroh integration, so would welcome reviews by people actually familiar with the tool.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
