### PR TITLE
discord: fix Darwin wrapper bypass

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/darwin.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/darwin.nix
@@ -113,6 +113,9 @@ stdenv.mkDerivation (finalAttrs: {
       --run '[ -t 1 ] || exec > /dev/null 2>&1' \
       --add-flags ${lib.escapeShellArg commandLineArgs}
 
+    mkdir -p $out/bin
+    ln -s "$out/Applications/${desktopName}.app/Contents/MacOS/${binaryName}" "$out/bin/${binaryName}"
+
     runHook postInstall
   '';
 

--- a/pkgs/applications/networking/instant-messengers/discord/darwin.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/darwin.nix
@@ -107,11 +107,10 @@ stdenv.mkDerivation (finalAttrs: {
       '') moduleSrcs
     )}
 
-    # wrap executable to $out/bin
-    mkdir -p $out/bin
-    makeWrapper "$out/Applications/${desktopName}.app/Contents/MacOS/${binaryName}" "$out/bin/${binaryName}" \
+    wrapProgram "$out/Applications/${desktopName}.app/Contents/MacOS/${binaryName}" \
       ${lib.strings.optionalString disableUpdates "--run ${lib.getExe finalAttrs.disableBreakingUpdates}"} \
       --run "${finalAttrs.stageModules} \"$out/Applications/${desktopName}.app/Contents/Resources/modules\"" \
+      --run '[ -t 1 ] || exec > /dev/null 2>&1' \
       --add-flags ${lib.escapeShellArg commandLineArgs}
 
     runHook postInstall

--- a/pkgs/applications/networking/instant-messengers/discord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/default.nix
@@ -72,6 +72,7 @@ let
     license = lib.licenses.unfree;
     mainProgram = "discord";
     maintainers = with lib.maintainers; [
+      anish
       artturin
       _4evy
       infinidoge

--- a/pkgs/applications/networking/instant-messengers/discord/disable-breaking-updates.py
+++ b/pkgs/applications/networking/instant-messengers/discord/disable-breaking-updates.py
@@ -45,6 +45,8 @@ else:
     settings = {}
 
 required_settings = {"SKIP_HOST_UPDATE": True}
+if sys.platform == "darwin":
+    required_settings["USE_NEW_UPDATER"] = False
 if "@skipModuleUpdate@" == "true":
     required_settings["SKIP_MODULE_UPDATE"] = True
 

--- a/pkgs/applications/networking/instant-messengers/discord/wrapper.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/wrapper.nix
@@ -98,7 +98,7 @@ let
       {
         pythonInterpreter = python3.interpreter;
         configDirName = lib.toLower binaryName;
-        skipModuleUpdate = lib.boolToString withOpenASAR;
+        skipModuleUpdate = "true";
         meta.mainProgram = "disable-breaking-updates.py";
       }
       ''


### PR DESCRIPTION
Update all Discord variant sources using `update.py`. Additionally, three Darwin-specific fixes:

* Mirror the module symlink fix from #530640 for `darwin.nix`. The staging script now removes and recreates the modules directory on every launch so stale symlinks pointing at GC'd store paths are not reused.

* Wrap the binary in-place inside the `.app` bundle. The existing wrapper at `$out/bin` isn't invoked when launching via Spotlight/Dock/Finder (macOS runs `Contents/MacOS/<binary>` directly), so `disable-breaking-updates` and `stageModules` never ran. Moving the wrapper to the `CFBundleExecutable` path ensures they run regardless of how Discord is launched. stdout/stderr are redirected to `/dev/null` when no tty is attached to avoid `EIO`/`EPIPE` from `console.log` in the main process.

* Force the legacy updater and skip module updates on Darwin. The Rust updater (active since #515876) ignores `SKIP_HOST_UPDATE`, instead downloading the newer host and force-relaunching via ShipIt. This can't replace the immutable store bundle and causes an auth-prompt loop. Setting `USE_NEW_UPDATER=false` falls back to the legacy updater, which honors `SKIP_HOST_UPDATE` (matching Linux, where the Rust updater never initializes). Module updates are also skipped, since modules are read-only store symlinks the updater can't write to (EACCES).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
