### PR TITLE
osmium: 0.0.26-alpha -> 0.0.29-alpha

### DIFF
--- a/pkgs/by-name/os/osmium/package.nix
+++ b/pkgs/by-name/os/osmium/package.nix
@@ -29,11 +29,11 @@
 
 stdenv.mkDerivation rec {
   pname = "osmium";
-  version = "0.0.26-alpha";
+  version = "0.0.29-alpha";
 
   src = fetchurl {
     url = "https://updater.osmium.chat/Osmium-${version}-x64.tar.gz";
-    hash = "sha256-6hsXZ9ykM7x4RNqixolK3/C9K0OBjMuUNIWYjjj8uCs=";
+    hash = "sha256-UbYnT/9bkMCii4rkAlkUBQcHc6DyAkOa8rQl+9e3NZU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/os/osmium/package.nix
+++ b/pkgs/by-name/os/osmium/package.nix
@@ -25,9 +25,6 @@
   libnotify,
   libpulseaudio,
   writeShellApplication,
-  curl,
-  yq,
-  common-updater-scripts,
 }:
 
 stdenv.mkDerivation rec {
@@ -108,18 +105,7 @@ stdenv.mkDerivation rec {
   };
 
   passthru = {
-    updateScript = lib.getExe (writeShellApplication {
-      name = "update-osmium";
-      runtimeInputs = [
-        curl
-        yq
-        common-updater-scripts
-      ];
-      text = ''
-        version="$(curl -s https://updater.osmium.chat/alpha-linux.yml | yq .version)"
-        update-source-version osmium "$version"
-      '';
-    });
+    updateScript = ./update.sh;
   };
 
   meta = {

--- a/pkgs/by-name/os/osmium/update.sh
+++ b/pkgs/by-name/os/osmium/update.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl yq common-updater-scripts
+
+version="$(curl -s https://updater.osmium.chat/alpha-linux.yml | yq -r .version)"
+update-source-version osmium "$version"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Update script previously had an error where the version string was updated without the quotes around the new version removed leading to errors in the resulting output. Because it has been broken for some time I also used it to update to the most recent version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
