### PR TITLE
openclaw: 2026.6.5 -> 2026.6.6

### DIFF
--- a/pkgs/by-name/op/openclaw/package.nix
+++ b/pkgs/by-name/op/openclaw/package.nix
@@ -11,7 +11,7 @@
   versionCheckHook,
   rolldown,
   installShellFiles,
-  version ? "2026.6.5",
+  version ? "2026.6.6",
 }:
 let
   pnpm = pnpm_11.override { nodejs-slim = nodejs-slim_22; };
@@ -24,10 +24,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     owner = "openclaw";
     repo = "openclaw";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-hiYbIhE13XMFIeB0zmb6AHlfw8le6vpJgCqN81YWGsE=";
+    hash = "sha256-sgLyNHQNnuEWZBaIxqJUz9o0x+P1EgNuLlUfy1iRunk=";
   };
 
-  pnpmDepsHash = "sha256-7RQJAVWqhauG8JrF8AD1VU1IJRM+SH05aHAfmFaXraU=";
+  pnpmDepsHash = "sha256-D8ujY5Y7ix3/j6Z8ZMAIXnemQ0hDNkheBLsNMMCxBHQ=";
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;

--- a/pkgs/by-name/op/openclaw/package.nix
+++ b/pkgs/by-name/op/openclaw/package.nix
@@ -5,7 +5,7 @@
   fetchFromGitHub,
   fetchPnpmDeps,
   pnpmConfigHook,
-  pnpm_10,
+  pnpm_11,
   nodejs-slim_22,
   makeWrapper,
   versionCheckHook,
@@ -14,7 +14,7 @@
   version ? "2026.6.6",
 }:
 let
-  pnpm = pnpm_10.override { nodejs-slim = nodejs-slim_22; };
+  pnpm = pnpm_11.override { nodejs-slim = nodejs-slim_22; };
   # Keep fetchPnpmDeps and frozen offline install aligned on patchedDependencies.
   stripPatchedDeps = ''
     sed -i '/^patchedDependencies:/,/^[^ ]/{/^patchedDependencies:/d;/^  /d;}' pnpm-lock.yaml pnpm-workspace.yaml
@@ -31,12 +31,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-sgLyNHQNnuEWZBaIxqJUz9o0x+P1EgNuLlUfy1iRunk=";
   };
 
-  pnpmDepsHash = "sha256-VrDxGDh/AHqVzQBfUAZP1KaC1M5YBYKI+wPSyPOf65M=";
+  pnpmDepsHash = "sha256-eADEHT4CW8ffCKwEfQjjrQ63oZQUYmRYymYQpMT8/gY=";
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     inherit pnpm;
-    fetcherVersion = 3;
+    fetcherVersion = 4;
     hash = finalAttrs.pnpmDepsHash;
     prePnpmInstall = stripPatchedDeps;
   };

--- a/pkgs/by-name/op/openclaw/package.nix
+++ b/pkgs/by-name/op/openclaw/package.nix
@@ -27,7 +27,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-sgLyNHQNnuEWZBaIxqJUz9o0x+P1EgNuLlUfy1iRunk=";
   };
 
-  pnpmDepsHash = "sha256-D8ujY5Y7ix3/j6Z8ZMAIXnemQ0hDNkheBLsNMMCxBHQ=";
+  pnpmDepsHash = "sha256-eADEHT4CW8ffCKwEfQjjrQ63oZQUYmRYymYQpMT8/gY=";
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;

--- a/pkgs/by-name/op/openclaw/package.nix
+++ b/pkgs/by-name/op/openclaw/package.nix
@@ -15,8 +15,7 @@
 }:
 let
   pnpm = pnpm_10.override { nodejs-slim = nodejs-slim_22; };
-  # Lockfile predates pnpm 11's stricter overrides/patchedDependencies
-  # validation; strip patchedDependencies from both files for frozen install.
+  # Keep fetchPnpmDeps and frozen offline install aligned on patchedDependencies.
   stripPatchedDeps = ''
     sed -i '/^patchedDependencies:/,/^[^ ]/{/^patchedDependencies:/d;/^  /d;}' pnpm-lock.yaml pnpm-workspace.yaml
   '';

--- a/pkgs/by-name/op/openclaw/package.nix
+++ b/pkgs/by-name/op/openclaw/package.nix
@@ -5,7 +5,7 @@
   fetchFromGitHub,
   fetchPnpmDeps,
   pnpmConfigHook,
-  pnpm_11,
+  pnpm_10,
   nodejs-slim_22,
   makeWrapper,
   versionCheckHook,
@@ -14,7 +14,12 @@
   version ? "2026.6.6",
 }:
 let
-  pnpm = pnpm_11.override { nodejs-slim = nodejs-slim_22; };
+  pnpm = pnpm_10.override { nodejs-slim = nodejs-slim_22; };
+  # Lockfile predates pnpm 11's stricter overrides/patchedDependencies
+  # validation; strip patchedDependencies from both files for frozen install.
+  stripPatchedDeps = ''
+    sed -i '/^patchedDependencies:/,/^[^ ]/{/^patchedDependencies:/d;/^  /d;}' pnpm-lock.yaml pnpm-workspace.yaml
+  '';
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "openclaw";
@@ -27,13 +32,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-sgLyNHQNnuEWZBaIxqJUz9o0x+P1EgNuLlUfy1iRunk=";
   };
 
-  pnpmDepsHash = "sha256-eADEHT4CW8ffCKwEfQjjrQ63oZQUYmRYymYQpMT8/gY=";
+  pnpmDepsHash = "sha256-VrDxGDh/AHqVzQBfUAZP1KaC1M5YBYKI+wPSyPOf65M=";
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     inherit pnpm;
-    fetcherVersion = 4;
+    fetcherVersion = 3;
     hash = finalAttrs.pnpmDepsHash;
+    prePnpmInstall = stripPatchedDeps;
   };
 
   buildInputs = [ rolldown ];
@@ -45,6 +51,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     makeWrapper
     installShellFiles
   ];
+
+  postPatch = stripPatchedDeps;
 
   buildPhase = ''
     runHook preBuild


### PR DESCRIPTION
Update OpenClaw from 2026.6.5 to 2026.6.6.

Changelog: https://github.com/openclaw/openclaw/releases/tag/v2026.6.6

This also adjusts the pnpm dependency-fetch path for this release. OpenClaw's lockfile and workspace metadata currently disagree around `patchedDependencies`, which breaks reproducible frozen/offline installation. The package now normalizes those files before both `fetchPnpmDeps` and the build-time pnpm install, so both phases see the same input.

Changes:
- Update OpenClaw to 2026.6.6
- Update source and pnpm dependency hashes
- Keep `pnpm_11` for this package
- Use `fetcherVersion = 4` for `fetchPnpmDeps`
- Strip mismatched `patchedDependencies` metadata before dependency fetch and build

Assisted-by: Codex (GPT-5.5)

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests).
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`.
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage).
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs.
- [x] Follows the [automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy).