### PR TITLE
kr106: init to 2.5.13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5723,6 +5723,12 @@
     githubId = 4162215;
     keys = [ { fingerprint = "CE97 9DEE 904C 26AA 3716  78C2 96A4 38F9 EE72 572F"; } ];
   };
+  crop = {
+    email = "crop_tech@proton.me";
+    name = "crop";
+    github = "crop2000";
+    githubId = 176233921;
+  };
   crschnick = {
     email = "crschnick@xpipe.io";
     name = "Christopher Schnick";

--- a/pkgs/by-name/kr/kr106/package.nix
+++ b/pkgs/by-name/kr/kr106/package.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  alsa-lib,
+  freetype,
+  fontconfig,
+  libGL,
+  libx11,
+  libxcursor,
+  libxext,
+  libxinerama,
+  libxrandr,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "kr106";
+  version = "2.5.13";
+
+  src = fetchFromGitHub {
+    owner = "kayrockscreenprinting";
+    repo = "ultramaster_kr106";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-R0nvtdhhrT+ucpBSsWjJEUCInd4/0jDammlUsaCgL6M=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    alsa-lib
+    freetype
+    fontconfig
+    libGL
+    libx11
+    libxcursor
+    libxext
+    libxinerama
+    libxrandr
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "KR106_COPY_AFTER_BUILD" false)
+  ];
+
+  # JUCE dlopen's these at runtime, crashes without them
+  env.NIX_LDFLAGS = toString [
+    "-lX11"
+    "-lXext"
+    "-lXcursor"
+    "-lXinerama"
+    "-lXrandr"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    cp -r KR106_artefacts/Release/LV2  $out/lib/lv2
+    cp -r KR106_artefacts/Release/VST3 $out/lib/vst3
+    cp -r KR106_artefacts/Release/CLAP $out/lib/clap
+    install -Dm755 "KR106_artefacts/Release/Standalone/Ultramaster KR-106" $out/bin/kr106
+
+    runHook postInstall
+  '';
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Synthesizer plugin emulating the Roland Juno-6, Juno-60 and Juno-106";
+    homepage = "https://kayrock.org/kr106";
+    downloadPage = "https://github.com/kayrockscreenprinting/ultramaster_kr106";
+    changelog = "https://kayrock.org/kr106/changelog.html";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ crop ];
+    platforms = lib.platforms.linux;
+    mainProgram = "kr106";
+  };
+})


### PR DESCRIPTION
add kr106 

which is a lv2/vst/clap plugin, a software synthesizer, 

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
