### PR TITLE
libu2f-emu: install headers back in original location

### DIFF
--- a/pkgs/by-name/li/libu2f-emu/package.nix
+++ b/pkgs/by-name/li/libu2f-emu/package.nix
@@ -39,12 +39,6 @@ stdenv.mkDerivation {
     # Fix header guard typo: TRANSaCTION_H -> TRANSACTION_H
     substituteInPlace src/usb/transaction.h \
       --replace-fail "define TRANSaCTION_H" "define TRANSACTION_H"
-
-    # Install headers into a u2f-emu/ subdirectory so consumers can
-    # use #include <u2f-emu/u2f-emu.h> (expected by QEMU).
-    substituteInPlace src/meson.build \
-      --replace-fail "install_headers(u2f_emu_headers)" \
-                     "install_headers(u2f_emu_headers, subdir: 'u2f-emu')"
   '';
 
   # Disable -Werror: upstream uses OpenSSL EC_KEY APIs deprecated since 3.0.


### PR DESCRIPTION
Since QEMU v11, this can be reverted.
Reference: https://github.com/qemu/qemu/commit/4ef8aca3d186126153d2f90cc007b656063060ab

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
