### PR TITLE
polonium: reinit at 1.1

### DIFF
--- a/pkgs/by-name/po/polonium/package.nix
+++ b/pkgs/by-name/po/polonium/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildNpmPackage,
+  kdePackages,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "polonium";
+  version = "1.1";
+
+  src = fetchFromGitHub {
+    owner = "zeroxoneafour";
+    repo = "polonium";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Rn6mfn1R7K36fcLfIlt89SSfDQ8r6Ck0lHcI0H/yGWI=";
+    fetchSubmodules = true;
+  };
+
+  npmDepsHash = "sha256-9j5UxPRfFnaqDAW877TDNHH4rmN5QvzsUSeRVCjIz3g=";
+
+  __structuredAttrs = true;
+
+  dontConfigure = true;
+
+  # the installer does a bunch of stuff that fails in our sandbox, so just build here and then we
+  # manually do the install
+  buildFlags = [
+    "res"
+    "src"
+  ];
+
+  dontNpmBuild = true;
+
+  dontWrapQtApps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/kwin/scripts/polonium
+    cp -a pkg/. $out/share/kwin/scripts/polonium
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Auto-tiler that uses KWin 6.0+ tiling functionality";
+    homepage = "https://polonium.vaughanm.xyz/";
+    downloadPage = "https://github.com/zeroxoneafour/polonium/releases";
+    changelog = "https://github.com/zeroxoneafour/polonium/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      nelind
+      HeitorAugustoLN
+    ];
+    inherit (kdePackages.kwin.meta) platforms;
+  };
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1777,7 +1777,6 @@ mapAliases {
   podofo_0_10 = warnAlias "'podofo_0_10' has been renamed to 'podofo0'" podofo0; # Added 2026-05-08
   podofo_1_0 = throw "'podofo_1_0' has been deprecated in favour of 'podofo'"; # Added 2026-05-08
   polipo = throw "'polipo' has been removed as it is unmaintained upstream"; # Added 2025-05-18
-  polonium = throw "'polonium' has been removed, as Plasma 5 has reached end of life."; # Added 2026-05-01
   polyml56 = throw "'polyml56' has been deprecated in favor of polyml"; # Added 2026-06-01
   polyml57 = throw "'polyml57' has been deprecated in favor of polyml"; # Added 2026-06-01
   polypane = throw "'polypane' has been removed due to lack of maintenance in nixpkgs"; # Added 2025-06-25


### PR DESCRIPTION
polonium was dropped because upstream development had stopped. now upstream development has started back up and a new stable release was tagged a few days ago. this reinits polonium at that new stable 1.1 release. the derivation is largely based on the old one but updated to use kdePackages and follow upstreams tooling changes.

@peterhoeg @kotatsuyaki and @HeitorAugustoLN were maintainers on the original package. i dont know if any of you want to pick it up again, if not id by happy to take it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
