### PR TITLE
python3Packages.parsedmarc: 9.6.0 -> 10.1.1

### DIFF
--- a/pkgs/by-name/pa/parsedmarc/package.nix
+++ b/pkgs/by-name/pa/parsedmarc/package.nix
@@ -1,44 +1,7 @@
 {
-  python3,
+  python3Packages,
   fetchFromGitHub,
 }:
 
-let
-  python = python3.override {
-    self = python;
-    packageOverrides = self: super: {
-      # https://github.com/domainaware/parsedmarc/issues/464
-      msgraph-core = super.msgraph-core.overridePythonAttrs (old: rec {
-        version = "0.2.2";
-
-        src = fetchFromGitHub {
-          owner = "microsoftgraph";
-          repo = "msgraph-sdk-python-core";
-          rev = "v${version}";
-          hash = "sha256-eRRlG3GJX3WeKTNJVWgNTTHY56qiUGOlxtvEZ2xObLA=";
-        };
-
-        nativeBuildInputs = with self; [
-          flit-core
-        ];
-
-        propagatedBuildInputs = with self; [
-          requests
-        ];
-
-        nativeCheckInputs = with self; [
-          pytestCheckHook
-          responses
-        ];
-
-        disabledTestPaths = [
-          "tests/integration"
-        ];
-
-        pythonImportsCheck = [ "msgraph.core" ];
-      });
-    };
-  };
-in
-with python.pkgs;
+with python3Packages;
 toPythonApplication parsedmarc

--- a/pkgs/development/python-modules/kafka-python/default.nix
+++ b/pkgs/development/python-modules/kafka-python/default.nix
@@ -1,0 +1,84 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  pythonAtLeast,
+
+  # build system
+  setuptools,
+
+  # optional dependencies
+  crc32c,
+  lz4,
+  pyperf,
+  python-snappy,
+  zstandard,
+
+  # test dependencies
+  pytestCheckHook,
+  pytest-mock,
+  pytest-timeout,
+  xxhash,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "kafka-python";
+  version = "2.3.2";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  disabled = pythonAtLeast "3.14";
+
+  src = fetchFromGitHub {
+    owner = "dpkp";
+    repo = "kafka-python";
+    tag = finalAttrs.version;
+    hash = "sha256-FC5ntcRy2iF2sqYVxWg11EcGA5ncpuUuQHOkBG0paog=";
+  };
+
+  build-system = [ setuptools ];
+
+  optional-dependencies = {
+    benchmarks = [ pyperf ];
+    crc32c = [ crc32c ];
+    lz4 = [ lz4 ];
+    snappy = [ python-snappy ];
+    zstd = [ zstandard ];
+  };
+
+  pythonImportsCheck = [
+    "kafka"
+    "kafka.admin"
+    "kafka.benchmarks"
+    "kafka.cli"
+    "kafka.consumer"
+    "kafka.coordinator"
+    "kafka.metrics"
+    "kafka.partitioner"
+    "kafka.producer"
+    "kafka.protocol"
+    "kafka.record"
+    "kafka.sasl"
+    "kafka.serializer"
+    "kafka.vendor"
+  ];
+
+  nativeCheckInputs = [
+    pytest-mock
+    pytest-timeout
+    pytestCheckHook
+    xxhash
+  ]
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
+
+  meta = {
+    changelog = "https://github.com/dpkp/kafka-python/blob/${finalAttrs.src.tag}/CHANGES.md";
+    description = "Pure Python client for Apache Kafka";
+    homepage = "https://github.com/dpkp/kafka-python";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      de11n
+      despsyched
+    ];
+  };
+})

--- a/pkgs/development/python-modules/mail-parser/default.nix
+++ b/pkgs/development/python-modules/mail-parser/default.nix
@@ -2,58 +2,56 @@
   lib,
   buildPythonPackage,
   python,
-  glibcLocales,
+  extract-msg,
   fetchFromGitHub,
+  hatchling,
   pytest-cov-stub,
+  pytest-mock,
   pytestCheckHook,
-  setuptools,
-  six,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "mail-parser";
-  version = "4.1.4";
+  version = "4.4.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "SpamScope";
     repo = "mail-parser";
-    tag = version;
-    hash = "sha256-wwLUD/k26utugK/Yx9eXYEdSOvrk0Cy6RkXGDnzZ+fE=";
+    tag = finalAttrs.version;
+    hash = "sha256-fuL2cWQSkYQKhG/UVNOp4ch4MrZINizvsPCQUzb3Z9c=";
   };
 
-  env.LC_ALL = "en_US.utf-8";
+  build-system = [ hatchling ];
 
-  nativeBuildInputs = [ glibcLocales ];
-
-  build-system = [ setuptools ];
-
-  pythonRemoveDeps = [ "ipaddress" ];
-
-  dependencies = [
-    six
-  ];
+  optional-dependencies = {
+    outlook = [ extract-msg ];
+  };
 
   pythonImportsCheck = [ "mailparser" ];
 
   nativeCheckInputs = [
     pytest-cov-stub
+    pytest-mock
     pytestCheckHook
-  ];
+  ]
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 
-  # Taken from .travis.yml
+  # Taken from .github/workflows/main.yml
   postCheck = ''
     ${python.interpreter} -m mailparser -v
     ${python.interpreter} -m mailparser -h
     ${python.interpreter} -m mailparser -f tests/mails/mail_malformed_3 -j
+    ${python.interpreter} -m mailparser -f tests/mails/mail_outlook_1 -j
     cat tests/mails/mail_malformed_3 | ${python.interpreter} -m mailparser -k -j
   '';
 
   meta = {
+    changelog = "https://github.com/SpamScope/mail-parser/releases/tag/${finalAttrs.src.tag}";
     description = "Mail parser for python 2 and 3";
-    mainProgram = "mailparser";
+    mainProgram = "mail-parser";
     homepage = "https://github.com/SpamScope/mail-parser";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ psyanticy ];
   };
-}
+})

--- a/pkgs/development/python-modules/mailsuite/default.nix
+++ b/pkgs/development/python-modules/mailsuite/default.nix
@@ -1,24 +1,35 @@
 {
   lib,
+  azure-identity,
+  authres,
   buildPythonPackage,
+  cryptography,
+  dkimpy,
   dnspython,
   expiringdict,
-  fetchPypi,
+  fetchFromGitHub,
+  google-api-python-client,
+  google-auth,
+  google-auth-oauthlib,
   hatchling,
   html2text,
   imapclient,
   mail-parser,
+  msgraph-sdk,
   publicsuffix2,
+  pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "mailsuite";
-  version = "1.11.2";
+  version = "2.2.2";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-ilcOH27lVKhh/xFO/dkWZkwtx6wPYrKTWR3n1xqoUdk=";
+  src = fetchFromGitHub {
+    owner = "seanthegeek";
+    repo = "mailsuite";
+    tag = finalAttrs.version;
+    hash = "sha256-qQ+AaelLQED0mWCAItx/3d7o9QVUnhUVxvdCfnNRqzQ=";
   };
 
   pythonRelaxDeps = [ "mail-parser" ];
@@ -26,6 +37,9 @@ buildPythonPackage rec {
   build-system = [ hatchling ];
 
   dependencies = [
+    authres
+    cryptography
+    dkimpy
     dnspython
     expiringdict
     html2text
@@ -34,16 +48,30 @@ buildPythonPackage rec {
     publicsuffix2
   ];
 
+  optional-dependencies = {
+    all = lib.concatAttrValues (lib.removeAttrs finalAttrs.passthru.optional-dependencies [ "all" ]);
+    gmail = [
+      google-api-python-client
+      google-auth
+      google-auth-oauthlib
+    ];
+    msgraph = [
+      azure-identity
+      msgraph-sdk
+    ];
+  };
+
   pythonImportsCheck = [ "mailsuite" ];
 
-  # Module has no tests
-  doCheck = false;
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
 
   meta = {
     description = "Python package to simplify receiving, parsing, and sending email";
     homepage = "https://seanthegeek.github.io/mailsuite/";
-    changelog = "https://github.com/seanthegeek/mailsuite/blob/master/CHANGELOG.md";
+    changelog = "https://github.com/seanthegeek/mailsuite/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ talyz ];
   };
-}
+})

--- a/pkgs/development/python-modules/parsedmarc/default.nix
+++ b/pkgs/development/python-modules/parsedmarc/default.nix
@@ -16,17 +16,10 @@
   elasticsearch-dsl,
   elasticsearch,
   expiringdict,
-  geoip2,
-  google-api-core,
-  google-api-python-client,
-  google-auth-httplib2,
-  google-auth-oauthlib,
-  google-auth,
-  imapclient,
-  kafka-python-ng,
+  kafka-python,
   lxml,
   mailsuite,
-  msgraph-core,
+  maxminddb,
   nixosTests,
   opensearch-py,
   publicsuffixlist,
@@ -38,7 +31,7 @@
   xmltodict,
 
   # test
-  unittestCheckHook,
+  pytestCheckHook,
 }:
 
 let
@@ -49,14 +42,14 @@ let
 in
 buildPythonPackage rec {
   pname = "parsedmarc";
-  version = "9.6.0";
+  version = "10.1.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "domainaware";
     repo = "parsedmarc";
     tag = version;
-    hash = "sha256-ez7QMFsSvJzxhfCPA4G6oGQhqAzcgKBTJMiMogIJvNg=";
+    hash = "sha256-dFwlcbR8NNKrDBoKPDX9M82tTK5aCbeP3KMF/BctgMc=";
   };
 
   postPatch = ''
@@ -82,17 +75,10 @@ buildPythonPackage rec {
     elasticsearch
     elasticsearch-dsl
     expiringdict
-    geoip2
-    google-api-core
-    google-api-python-client
-    google-auth
-    google-auth-httplib2
-    google-auth-oauthlib
-    imapclient
-    kafka-python-ng
+    kafka-python
     lxml
     mailsuite
-    msgraph-core
+    maxminddb
     opensearch-py
     publicsuffixlist
     pygelf
@@ -101,10 +87,17 @@ buildPythonPackage rec {
     tqdm
     urllib3
     xmltodict
-  ];
+  ]
+  ++ mailsuite.optional-dependencies.gmail
+  ++ mailsuite.optional-dependencies.msgraph;
 
   nativeCheckInputs = [
-    unittestCheckHook
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # contacts DNS servers at 1.1.1.1 and 8.8.8.8
+    "test_general_dns_settings_with_defaults"
   ];
 
   pythonImportsCheck = [ "parsedmarc" ];
@@ -121,7 +114,5 @@ buildPythonPackage rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ talyz ];
     mainProgram = "parsedmarc";
-    # https://github.com/domainaware/parsedmarc/issues/464
-    broken = lib.versionAtLeast msgraph-core.version "1.0.0";
   };
 }

--- a/pkgs/development/python-modules/pytest-kafka/default.nix
+++ b/pkgs/development/python-modules/pytest-kafka/default.nix
@@ -1,9 +1,13 @@
 {
-  lib,
   buildPythonPackage,
   fetchFromGitLab,
+  lib,
+
+  # build system
   setuptools,
-  kafka-python-ng,
+
+  # dependencies
+  kafka-python,
   port-for,
   pytest,
 }:
@@ -23,7 +27,7 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   dependencies = [
-    kafka-python-ng
+    kafka-python
     port-for
     pytest
   ];

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -298,7 +298,6 @@ mapAliases {
   jupyter_core = throw "'jupyter_core' has been renamed to/replaced by 'jupyter-core'"; # Converted to throw 2025-10-29
   jupyter_server = throw "'jupyter_server' has been renamed to/replaced by 'jupyter-server'"; # Converted to throw 2025-10-29
   jupyterlab_server = throw "'jupyterlab_server' has been renamed to/replaced by 'jupyterlab-server'"; # Converted to throw 2025-10-29
-  kafka-python = throw "'kafka-python' has been renamed to/replaced by 'kafka-python-ng'"; # Converted to throw 2025-10-29
   Kajiki = throw "'Kajiki' has been renamed to/replaced by 'kajiki'"; # Converted to throw 2025-10-29
   keepkey-agent = throw "keepkey-agent has been removed because upstream dropped KeepKey support"; # Added 2026-03-11
   keepkey_agent = throw "keepkey-agent has been removed because upstream dropped KeepKey support"; # Added 2026-03-11

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8342,6 +8342,8 @@ self: super: with self; {
 
   kaa-metadata = callPackage ../development/python-modules/kaa-metadata { };
 
+  kafka-python = callPackage ../development/python-modules/kafka-python { };
+
   kafka-python-ng = callPackage ../development/python-modules/kafka-python-ng { };
 
   kaggle = callPackage ../development/python-modules/kaggle { };


### PR DESCRIPTION
Diff: https://github.com/domainaware/parsedmarc/compare/9.6.0...10.1.1

Changelog: https://github.com/domainaware/parsedmarc/blob/10.1.1/CHANGELOG.md

depends on https://github.com/NixOS/nixpkgs/pull/441688

closes https://github.com/NixOS/nixpkgs/pull/513949

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
