### PR TITLE
pod2mdoc: modernize

### DIFF
--- a/pkgs/by-name/po/pod2mdoc/package.nix
+++ b/pkgs/by-name/po/pod2mdoc/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  installShellFiles,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -18,18 +19,25 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace Makefile --replace-fail "-DHAVE_OHASH=1" "-DHAVE_OHASH=0"
   '';
 
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
   installPhase = ''
-    mkdir -p $out/bin
-    mkdir -p $out/share/man/man1
-    install -m 0755 pod2mdoc $out/bin
-    install -m 0444 pod2mdoc.1 $out/share/man/man1
+    runHook preInstall
+    installBin pod2mdoc
+    installManPage pod2mdoc.1
+    runHook postInstall
   '';
 
-  enableParallelBuild = true;
+  enableParallelBuilding = true;
+  strictDeps = true;
+  __structuredAttrs = true;
 
   meta = {
     homepage = "https://mandoc.bsd.lv/pod2mdoc/";
     description = "Converter from POD into mdoc";
+    changelog = "https://mandoc.bsd.lv/pod2mdoc/ChangeLog";
     license = lib.licenses.isc;
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ ramkromberg ];


### PR DESCRIPTION
Noticed `enableParallelBuild` in the package recipe, which should actually be `enableParallelBuilding`.

With just 3 or 4 small files to compile, this does not really do much, but while we're at it, let's touch up the package a bit.

- cc https://github.com/NixOS/nixpkgs/issues/178468
- cc https://github.com/NixOS/nixpkgs/issues/205690

The output stays the same (modulo path).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
