### PR TITLE
wyoming-faster-whisper: 3.1.0 -> 3.2.0

### DIFF
--- a/nixos/modules/services/home-automation/wyoming/faster-whisper.nix
+++ b/nixos/modules/services/home-automation/wyoming/faster-whisper.nix
@@ -39,6 +39,17 @@ in
             options = {
               enable = mkEnableOption "Wyoming faster-whisper server";
 
+              task = mkOption {
+                type = enum [
+                  "transcribe"
+                  "translate"
+                ];
+                default = "transcribe";
+                description = ''
+                  Whisper task to perform.
+                '';
+              };
+
               zeroconf = {
                 enable = mkEnableOption "zeroconf discovery" // {
                   default = true;
@@ -349,6 +360,8 @@ in
                 options.uri
                 "--device"
                 options.device
+                "--whisper-task"
+                options.task
                 "--stt-library"
                 options.sttLibrary
                 "--model"

--- a/pkgs/by-name/wy/wyoming-faster-whisper/package.nix
+++ b/pkgs/by-name/wy/wyoming-faster-whisper/package.nix
@@ -6,14 +6,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "wyoming-faster-whisper";
-  version = "3.1.0";
+  version = "3.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "rhasspy";
     repo = "wyoming-faster-whisper";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-p1FCyj/D7ndKJD1/V5YzhT0xlkg61DSx2m3DCELmPO8=";
+    hash = "sha256-4tgBsraFd7IUHw6p/59FHzuUISOaALxBU7H8V0yQl0E=";
   };
 
   build-system = with python3Packages; [
@@ -23,11 +23,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
   pythonRelaxDeps = [
     "faster-whisper"
     "wyoming"
-  ];
-
-  pythonRemoveDeps = [
-    # https://github.com/rhasspy/wyoming-faster-whisper/pull/81
-    "requests"
   ];
 
   dependencies = with python3Packages; [
@@ -58,7 +53,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "wyoming_faster_whisper"
   ];
 
-  # no tests
+  # tests require models from huggingface
   doCheck = false;
 
   meta = {


### PR DESCRIPTION
https://github.com/rhasspy/wyoming-faster-whisper/releases/tag/v3.2.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
