### PR TITLE
ieda: `enableParallelBuilding` & `__structuredAttrs`

### DIFF
--- a/pkgs/by-name/ie/ieda/package.nix
+++ b/pkgs/by-name/ie/ieda/package.nix
@@ -81,11 +81,9 @@ stdenv.mkDerivation {
     (lib.cmakeBool "CMD_BUILD" true)
     (lib.cmakeBool "SANITIZER" false)
     (lib.cmakeBool "BUILD_STATIC_LIB" false)
+    (lib.cmakeOptionType "filepath" "CMAKE_RUNTIME_OUTPUT_DIRECTORY" "${placeholder "out"}/bin")
+    (lib.cmakeOptionType "filepath" "CMAKE_LIBRARY_OUTPUT_DIRECTORY" "${placeholder "out"}/lib")
   ];
-
-  preConfigure = ''
-    cmakeFlags+=" -DCMAKE_RUNTIME_OUTPUT_DIRECTORY:FILEPATH=$out/bin -DCMAKE_LIBRARY_OUTPUT_DIRECTORY:FILEPATH=$out/lib"
-  '';
 
   buildInputs = [
     rustpkgs.iir-rust
@@ -130,7 +128,8 @@ stdenv.mkDerivation {
 
   doInstallCheck = !stdenv.hostPlatform.isAarch64; # Tests will fail on aarch64-linux, wait for upstream fix: https://github.com/microsoft/onnxruntime/issues/10038
 
-  enableParallelBuild = true;
+  enableParallelBuilding = true;
+  __structuredAttrs = true;
 
   passthru.updateScript = ./update.sh;
 


### PR DESCRIPTION
Noticed that this package had `enableParallelBuild` instead of `enableParallelBuilding`, decided to fix that, and, while we're here, also set `__structuredAttrs`, which required using `placeholder` for some `cmakeFlags` instead of patching them in `preConfigure`.

Output remained the same, modulo path.

- cc https://github.com/NixOS/nixpkgs/issues/205690

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
