### PR TITLE
mir: 2.26.0 -> 2.28.0

### DIFF
--- a/pkgs/by-name/mi/miracle-wm/package.nix
+++ b/pkgs/by-name/mi/miracle-wm/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  fetchpatch,
   gitUpdater,
   nixosTests,
   boost,
@@ -41,6 +42,17 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-7JtdSopKBHfFK0KsV0+9OxrOx3vrSydmZSmAiBvKQiI=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "0001-miracle-wm-mir2.28.patch";
+      url = "https://github.com/miracle-wm-org/miracle-wm/commit/0fcfb54c59327d0776f6e8074e885080731a95c4.patch";
+      excludes = [
+        ".github/workflows/test-deb-install.yml"
+      ];
+      hash = "sha256-HuXwPkM0whLFIy8HM6n9bG9I/DZOuzAajmDpJMZt9BQ=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \

--- a/pkgs/servers/mir/default.nix
+++ b/pkgs/servers/mir/default.nix
@@ -5,9 +5,9 @@ let
 in
 {
   mir = common {
-    version = "2.26.0";
-    hash = "sha256-gADqNNkaYj8KQ67wWzUWT4LuTQh1S+w/qLhVDKdBH4Q=";
-    cargoHash = "sha256-bG2p5Gz34yQJLI1Wuejq6o+jXLn6O2eZE1XGddvxkV4=";
+    version = "2.28.0";
+    hash = "sha256-sSxV20loRXQfGWMI1zAzrAwww00bc/BQqJaFB8whH5E=";
+    cargoHash = "sha256-AHB4OYP2kU47EsutOxYa693pMLgyXuF1p+mLXg2cIGs=";
   };
 
   mir_2_15 = common {


### PR DESCRIPTION
https://github.com/canonical/mir/releases/tag/v2.28.0

~~`miracle-wm` FTBFS with this, still need to check their commit log for a fix…~~ Resolved.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
