### PR TITLE
nixos/adguardhome: allow AF_UNIX when log.file=="syslog"

### DIFF
--- a/nixos/modules/services/networking/adguardhome.nix
+++ b/nixos/modules/services/networking/adguardhome.nix
@@ -228,6 +228,8 @@ in
           "AF_INET"
           "AF_INET6"
         ]
+        # AF_UNIX to be able to connect to e.g. /dev/log
+        ++ lib.optionals (cfg.settings.log.file or "" == "syslog") [ "AF_UNIX" ]
         ++ lib.optionals cfg.allowDHCP [ "AF_PACKET" ];
         RestrictNamespaces = true;
         RestrictRealtime = true;

--- a/nixos/tests/adguardhome.nix
+++ b/nixos/tests/adguardhome.nix
@@ -22,6 +22,14 @@
       };
     };
 
+    syslogConf = {
+      services.adguardhome = {
+        enable = true;
+
+        settings.log.file = "syslog";
+      };
+    };
+
     declarativeConf = {
       services.adguardhome = {
         enable = true;
@@ -121,6 +129,12 @@
     with subtest("Default schema_version 23 config test"):
       schemaVersionBefore23.wait_for_unit("adguardhome.service")
       schemaVersionBefore23.wait_for_open_port(3000)
+
+    with subtest("Logging to syslog test"):
+      # AdGuard is expected to fail when it cannot connect to syslog
+      # hence its sufficient to look whether the service starts at all
+      syslogConf.wait_for_unit("adguardhome.service")
+      syslogConf.wait_for_open_port(3000)
 
     with subtest("Declarative config test, DNS will be reachable"):
       declarativeConf.wait_for_unit("adguardhome.service")


### PR DESCRIPTION
This PR adds a conditional setting, allowing adguardhome.service to use AF_UNIX when log.file is set to "syslog", as otherwise the service fails to start because it cannot initialize its logging to syslog/journal.

Also added a test ensuring that logging to syslog keeps working in the future with naive setting.

This feature was broken by PR #487773 which was introduced into stable with 26.05. Hence I would prefer if this PR could be considered for backporting to 26.05 to fix this regression. But I would leave the final decision to a maintainer of AdGuardHome. I have added the backport tag for now. Thanks for considering.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
