### PR TITLE
Revert "lib/systems: move kernel configuration out of the platform structure"

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -19,13 +19,6 @@
 
 - `uhttpmock` providing 0.0 ABI was removed. `uhttpmock_1_0` providing 1.0 ABI was renamed to `uhttpmock` and `uhttpmock_1_0` was kept as an alias.
 
-- Linux kernel configuration has been moved out of the `linux-kernel` field of the platform structure into the kernel builders:
-  - `linux-kernel.name` has been removed.
-  - `linux-kernel.target` is available as the `target` parameter and passthru attribute on the kernel builders.
-  - `linux-kernel.installTarget` has been removed, as it should not be necessary to customize.
-  - `linux-kernel.DTB` is available as the `buildDTBs` parameter and passthru attribute on the kernel builders.
-  - `linux-kernel.{autoModules,preferBuiltin,extraConfig}` were already available as kernel builder parameters.
-
 - The `img` argument of `vmTools` has been renamed to `kernelImage`, as it collided with the top-level `img` package.
   Additionally, the kernel module tree used inside the VM has been split out of the `kernel` argument into a new `kernelModules` argument (defaulting to `kernel`).
   Callers that overrode `kernel` with a module tree (e.g. from `pkgs.aggregateModules`) to make extra modules available must now pass it via `kernelModules` instead, keeping `kernel` pointing at a bootable kernel derivation.

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -299,10 +299,12 @@ let
         inherit
           (
             {
+              linux-kernel = args.linux-kernel or { };
               gcc = args.gcc or { };
             }
             // platforms.select final
           )
+          linux-kernel
           gcc
           ;
 
@@ -690,11 +692,6 @@ let
         };
       };
     in
-    # TODO: Remove in 27.05.
-    assert
-      args ? linux-kernel
-      -> throw "lib.systems.elaborate: linux-kernel has been removed; see the 26.11 release notes";
-
     assert final.useAndroidPrebuilt -> final.isAndroid;
     assert foldl' (pass: { assertion, message }: if assertion final then pass else throw message) true (
       final.parsed.abi.assertions or [ ]

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -3,21 +3,74 @@
 # targetPlatform, etc) containing at least the minimal set of attrs
 # required (see types.parsedPlatform in lib/systems/parse.nix).  This
 # file takes an already-valid platform and further elaborates it with
-# optional fields; currently these are: gcc, and rustc.
+# optional fields; currently these are: linux-kernel, gcc, and rustc.
 
 { lib }:
 rec {
+  pc = {
+    linux-kernel = {
+      name = "pc";
+
+      baseConfig = "defconfig";
+      # Build whatever possible as a module, if not stated in the extra config.
+      autoModules = true;
+      target = "bzImage";
+    };
+  };
+
+  ##
+  ## POWER
+  ##
+
+  powernv = {
+    linux-kernel = {
+      name = "PowerNV";
+
+      baseConfig = "powernv_defconfig";
+      target = "vmlinux";
+      autoModules = true;
+    };
+  };
+
+  ppc64 = {
+    linux-kernel = {
+      name = "powerpc64";
+
+      baseConfig = "ppc64_defconfig";
+      target = "vmlinux";
+      autoModules = true;
+    };
+  };
+
   ##
   ## ARM
   ##
 
   armv5tel-multiplatform = {
+    linux-kernel = {
+      name = "armv5tel-multiplatform";
+
+      baseConfig = "multi_v5_defconfig";
+      DTB = true;
+      autoModules = true;
+      preferBuiltin = true;
+      target = "zImage";
+    };
     gcc = {
       arch = "armv5te";
     };
   };
 
   raspberrypi = {
+    linux-kernel = {
+      name = "raspberrypi";
+
+      baseConfig = "bcm2835_defconfig";
+      DTB = true;
+      autoModules = true;
+      preferBuiltin = true;
+      target = "zImage";
+    };
     gcc = {
       # https://en.wikipedia.org/wiki/Raspberry_Pi#Specifications
       arch = "armv6kz";
@@ -52,6 +105,7 @@ rec {
 
   # https://developer.android.com/ndk/guides/abis#v7a
   armv7a-android = {
+    linux-kernel.name = "armeabi-v7a";
     gcc = {
       arch = "armv7-a";
       float-abi = "softfp";
@@ -60,6 +114,14 @@ rec {
   };
 
   armv7l-hf-multiplatform = {
+    linux-kernel = {
+      name = "armv7l-hf-multiplatform";
+      baseConfig = "defconfig";
+      DTB = true;
+      autoModules = true;
+      preferBuiltin = true;
+      target = "zImage";
+    };
     gcc = {
       # Some table about fpu flags:
       # http://community.arm.com/servlet/JiveServlet/showImage/38-1981-3827/blogentry-103749-004812900+1365712953_thumb.png
@@ -84,6 +146,14 @@ rec {
   };
 
   aarch64-multiplatform = {
+    linux-kernel = {
+      name = "aarch64-multiplatform";
+      baseConfig = "defconfig";
+      DTB = true;
+      autoModules = true;
+      preferBuiltin = true;
+      target = "Image";
+    };
     gcc = {
       arch = "armv8-a";
     };
@@ -101,6 +171,9 @@ rec {
   ##
 
   ben_nanonote = {
+    linux-kernel = {
+      name = "ben_nanonote";
+    };
     gcc = {
       arch = "mips32";
       float = "soft";
@@ -157,6 +230,17 @@ rec {
   ## Other
   ##
 
+  riscv-multiplatform = {
+    linux-kernel = {
+      name = "riscv-multiplatform";
+      target = "Image";
+      autoModules = true;
+      preferBuiltin = true;
+      baseConfig = "defconfig";
+      DTB = true;
+    };
+  };
+
   loongarch64-multiplatform = {
     gcc = {
       # https://github.com/loongson/la-softdev-convention/blob/master/la-softdev-convention.adoc#10-operating-system-package-build-requirements
@@ -168,6 +252,14 @@ rec {
       # https://github.com/llvm/llvm-project/pull/132173
       cmodel = "medium";
     };
+    linux-kernel = {
+      name = "loongarch-multiplatform";
+      target = "vmlinuz.efi";
+      autoModules = true;
+      preferBuiltin = true;
+      baseConfig = "defconfig";
+      DTB = true;
+    };
   };
 
   # This function takes a minimally-valid "platform" and returns an
@@ -175,13 +267,17 @@ rec {
   # included in the platform in order to further elaborate it.
   select =
     platform:
+    # x86
+    if platform.isx86 then
+      pc
+
     # ARM
-    if platform.isAarch32 then
+    else if platform.isAarch32 then
       let
         version = platform.parsed.cpu.version or null;
       in
       if version == null then
-        { }
+        pc
       else if lib.versionOlder version "6" then
         armv5tel-multiplatform
       else if lib.versionOlder version "7" then
@@ -195,8 +291,23 @@ rec {
     else if platform.isLoongArch64 then
       loongarch64-multiplatform
 
+    else if platform.isRiscV then
+      riscv-multiplatform
+
     else if platform.parsed.cpu == lib.systems.parse.cpuTypes.mipsel then
       (import ./examples.nix { inherit lib; }).mipsel-linux-gnu
+
+    else if platform.isPower64 then
+      if platform.isLittleEndian then powernv else ppc64
+
+    else if platform.isSh4 then
+      {
+        linux-kernel = {
+          target = "vmlinux";
+          # SH arch doesn't have a 'make install' target.
+          installTarget = "vmlinux";
+        };
+      }
 
     else
       { };

--- a/nixos/modules/hardware/device-tree.nix
+++ b/nixos/modules/hardware/device-tree.nix
@@ -123,8 +123,7 @@ in
   options = {
     hardware.deviceTree = {
       enable = lib.mkOption {
-        default = config.boot.kernelPackages.kernel.buildDTBs;
-        defaultText = lib.literalExpression "config.boot.kernelPackages.kernel.buildDTBs";
+        default = pkgs.stdenv.hostPlatform.linux-kernel.DTB or false;
         type = lib.types.bool;
         description = ''
           Build device tree files. These are used to describe the

--- a/nixos/modules/installer/netboot/netboot.nix
+++ b/nixos/modules/installer/netboot/netboot.nix
@@ -111,7 +111,7 @@ with lib;
       #!ipxe
       # Use the cmdline variable to allow the user to specify custom kernel params
       # when chainloading this script from other iPXE scripts like netboot.xyz
-      kernel ${config.boot.kernelPackages.kernel.target} init=${config.system.build.toplevel}/init initrd=initrd ${toString config.boot.kernelParams} ''${cmdline}
+      kernel ${pkgs.stdenv.hostPlatform.linux-kernel.target} init=${config.system.build.toplevel}/init initrd=initrd ${toString config.boot.kernelParams} ''${cmdline}
       initrd initrd
       boot
     '';

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -139,8 +139,8 @@ in
 
     system.boot.loader.kernelFile = mkOption {
       internal = true;
-      default = config.boot.kernelPackages.kernel.target;
-      defaultText = literalExpression "config.boot.kernelPackages.kernel.target";
+      default = pkgs.stdenv.hostPlatform.linux-kernel.target;
+      defaultText = literalExpression "pkgs.stdenv.hostPlatform.linux-kernel.target";
       type = types.str;
       description = ''
         Name of the kernel file to be passed to the bootloader.

--- a/nixos/modules/system/boot/loader/generations-dir/generations-dir.nix
+++ b/nixos/modules/system/boot/loader/generations-dir/generations-dir.nix
@@ -66,6 +66,7 @@ in
 
     system.build.installBootLoader = generationsDirBuilder;
     system.boot.loader.id = "generationsDir";
+    system.boot.loader.kernelFile = pkgs.stdenv.hostPlatform.linux-kernel.target;
 
   };
 }

--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -152,7 +152,7 @@ let
     tarball
     // {
       meta = {
-        description = "NixOS system tarball for ${system}";
+        description = "NixOS system tarball for ${system} - ${stdenv.hostPlatform.linux-kernel.name}";
         maintainers = map (x: lib.maintainers.${x}) maintainers;
       };
       inherit config;
@@ -188,7 +188,7 @@ let
         modules = makeModules module { };
       };
       build = configEvaled.config.system.build;
-      kernelTarget = build.kernel.target;
+      kernelTarget = configEvaled.pkgs.stdenv.hostPlatform.linux-kernel.target;
     in
     configEvaled.pkgs.symlinkJoin {
       name = "netboot";

--- a/pkgs/build-support/vm/default.nix
+++ b/pkgs/build-support/vm/default.nix
@@ -32,7 +32,7 @@
   kernel ? linux,
   # Name of the kernel image file inside the `kernel` output.
   kernelImage ?
-    kernel.target or (throw ''
+    stdenv.hostPlatform.linux-kernel.target or kernel.target or (throw ''
       vmTools: the `kernel` argument (${kernel.name or "<unknown>"}) has no
       `target` attribute, so the kernel image filename cannot be determined.
 

--- a/pkgs/os-specific/linux/kernel/build.nix
+++ b/pkgs/os-specific/linux/kernel/build.nix
@@ -63,19 +63,6 @@ lib.makeOverridable (
     kernelPatches ? [ ],
     # The kernel .config file
     configfile,
-    target ?
-      if stdenv.hostPlatform.isx86 then
-        "bzImage"
-      else if stdenv.hostPlatform.isAarch32 then
-        "zImage"
-      else if stdenv.hostPlatform.isAarch64 || stdenv.hostPlatform.isRiscV then
-        "Image"
-      else if stdenv.hostPlatform.isLoongArch64 then
-        "vmlinuz.efi"
-      else
-        "vmlinux",
-    buildDTBs ?
-      stdenv.hostPlatform.isAarch || stdenv.hostPlatform.isRiscV || stdenv.hostPlatform.isLoongArch64,
     # Manually specified nixexpr representing the config
     # If unspecified, this will be autodetected from the .config
     config ? lib.optionalAttrs (builtins.isPath configfile || allowImportFromDerivation) (
@@ -152,7 +139,9 @@ lib.makeOverridable (
     isModular = config.isYes "MODULES";
     withRust = config.isYes "RUST";
 
-    inherit buildDTBs target;
+    target = stdenv.hostPlatform.linux-kernel.target or "vmlinux";
+
+    buildDTBs = stdenv.hostPlatform.linux-kernel.DTB or false;
 
     # Dependencies that are required to build kernel modules
     moduleBuildDependencies = [
@@ -215,7 +204,7 @@ lib.makeOverridable (
 
     buildFlags = [
       "KBUILD_BUILD_VERSION=1-NixOS"
-      target
+      stdenv.hostPlatform.linux-kernel.target
       "vmlinux" # for "perf" and things like that
       "scripts_gdb"
     ]
@@ -507,8 +496,6 @@ lib.makeOverridable (
         config
         kernelPatches
         configfile
-        target
-        buildDTBs
         moduleBuildDependencies
         stdenv
         commonMakeFlags
@@ -524,7 +511,7 @@ lib.makeOverridable (
 
     # Some image types need special install targets
     installTargets = [
-      (
+      (stdenv.hostPlatform.linux-kernel.installTarget or (
         if
           (target == "zImage" || target == "Image.gz" || target == "vmlinuz.efi")
           && builtins.elem stdenv.hostPlatform.linuxArch [
@@ -537,6 +524,7 @@ lib.makeOverridable (
           "zinstall"
         else
           "install"
+      )
       )
     ];
 

--- a/pkgs/os-specific/linux/kernel/common-config.nix
+++ b/pkgs/os-specific/linux/kernel/common-config.nix
@@ -1134,7 +1134,7 @@ let
         useZstd = stdenv.buildPlatform.is64bit;
       in
       {
-        # The default target assumes uncompressed on RISC-V.
+        # stdenv.hostPlatform.linux-kernel.target assumes uncompressed on RISC-V.
         KERNEL_UNCOMPRESSED = lib.mkIf stdenv.hostPlatform.isRiscV yes;
 
         KERNEL_XZ = lib.mkIf (

--- a/pkgs/os-specific/linux/kernel/common-flags.nix
+++ b/pkgs/os-specific/linux/kernel/common-flags.nix
@@ -36,4 +36,5 @@
     "CFLAGS_KERNEL=-I${clangLib}/lib/clang/${majorVer}/include"
   ]
 )
+++ (stdenv.hostPlatform.linux-kernel.makeFlags or [ ])
 ++ extraMakeFlags

--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -32,16 +32,7 @@ lib.makeOverridable (
     version,
 
     # Allows overriding the default defconfig
-    # TODO: Reconsider some of these defaults?
-    defconfig ?
-      if stdenv.hostPlatform.isAarch32 && stdenv.hostPlatform.parsed.cpu.version or null == "5" then
-        "multi_v5_defconfig"
-      else if stdenv.hostPlatform.isAarch32 && stdenv.hostPlatform.parsed.cpu.version or null == "6" then
-        "bcm2835_defconfig"
-      else if stdenv.hostPlatform.isPower64 then
-        if stdenv.hostPlatform.isLittleEndian then "powernv_defconfig" else "ppc64_defconfig"
-      else
-        "defconfig",
+    defconfig ? null,
 
     # Legacy overrides to the intermediate kernel config, as string
     extraConfig ? "",
@@ -75,17 +66,20 @@ lib.makeOverridable (
     # symbolic name and `patch' is the actual patch.  The patch may
     # optionally be compressed with gzip or bzip2.
     kernelPatches ? [ ],
-    ignoreConfigErrors ? !(stdenv.hostPlatform.isx86 || stdenv.hostPlatform.isAarch64),
+    ignoreConfigErrors ?
+      !lib.elem stdenv.hostPlatform.linux-kernel.name or "" [
+        "aarch64-multiplatform"
+        "pc"
+      ],
     extraMeta ? { },
     extraPassthru ? { },
 
     isLTS ? false,
     isZen ? false,
 
-    autoModules ? true,
-    # TODO: Remove this default?
-    preferBuiltin ?
-      stdenv.hostPlatform.isAarch || stdenv.hostPlatform.isRiscV || stdenv.hostPlatform.isLoongArch64,
+    # easy overrides to stdenv.hostPlatform.linux-kernel members
+    autoModules ? stdenv.hostPlatform.linux-kernel.autoModules or true,
+    preferBuiltin ? stdenv.hostPlatform.linux-kernel.preferBuiltin or false,
     kernelArch ? stdenv.hostPlatform.linuxArch,
     kernelTests ? { },
 
@@ -122,7 +116,9 @@ lib.makeOverridable (
     intermediateNixConfig =
       configfile.moduleStructuredConfig.intermediateNixConfig
       # extra config in legacy string format
-      + extraConfig;
+      + extraConfig
+      # need the 'or ""' at the end in case enableCommonConfig = true and extraConfig is not present
+      + lib.optionalString enableCommonConfig stdenv.hostPlatform.linux-kernel.extraConfig or "";
 
     structuredConfigFromPatches = map (
       {
@@ -209,7 +205,8 @@ lib.makeOverridable (
       buildPhase =
         let
           # e.g. "defconfig"
-          kernelBaseConfig = defconfig;
+          kernelBaseConfig =
+            if defconfig != null then defconfig else stdenv.hostPlatform.linux-kernel.baseConfig or "defconfig";
           kernelIntermediateConfig = writeText "kernel-intermediate-config" (
             kernelConfigFun intermediateNixConfig
           );


### PR DESCRIPTION
This reverts commit 31d1d80b3fb5ca92da5836376cae81fa523da428 from #530133

As per https://github.com/NixOS/nixpkgs/pull/530133#discussion_r3417428329 I think we should revert this for now, then consider how to re-apply with `lib.trivial.oldestSupportedRelease` in mind.

TL;DR it should be possible for `lib.systems.elaborate` to re-elaborate a platform elaborated by another (older) instance of `lib`.


> [!NOTE]
> I'd prefer to merge #532194 instead of this one
