### PR TITLE
ayatana-indicator-bluetooth: 24.5.0 -> 26.6.1

### DIFF
--- a/pkgs/by-name/ay/ayatana-indicator-bluetooth/package.nix
+++ b/pkgs/by-name/ay/ayatana-indicator-bluetooth/package.nix
@@ -10,6 +10,7 @@
   gobject-introspection,
   intltool,
   libayatana-common,
+  libnotify,
   lomiri,
   pkg-config,
   systemd,
@@ -19,13 +20,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ayatana-indicator-bluetooth";
-  version = "24.5.0";
+  version = "26.6.1";
 
   src = fetchFromGitHub {
     owner = "AyatanaIndicators";
     repo = "ayatana-indicator-bluetooth";
     tag = finalAttrs.version;
-    hash = "sha256-EreOhrlWbSZtwazsvwWsPji2iLfQxr2LbjCI13Hrb28=";
+    hash = "sha256-qaVn8rOfL59F8LKqi6InlpXNwohoETB3feExNyBvByM=";
   };
 
   postPatch = ''
@@ -50,6 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     lomiri.cmake-extras
     glib
     libayatana-common
+    libnotify
     systemd
   ];
 


### PR DESCRIPTION
https://github.com/AyatanaIndicators/ayatana-indicator-bluetooth/blob/26.6.1/ChangeLog

26.6.0 apparently added a new pairing agent, for handling pairing with a new device from the indicator. Haven't checked that yet, and I'm not sure if it's possible to set up an environment with a fake bluetooth interface and a fake devices in our VM tests, so I'll have to check if i have some hardware-capable hardware for testing that manually…

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
