### PR TITLE
nmstate: clean up vendor tarball usage, add updateScript

### DIFF
--- a/pkgs/by-name/nm/nmstate/package.nix
+++ b/pkgs/by-name/nm/nmstate/package.nix
@@ -10,31 +10,28 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nmstate";
   version = "2.2.57";
 
-  srcs = [
-    (fetchFromGitHub {
-      owner = "nmstate";
-      repo = "nmstate";
-      tag = "v${finalAttrs.version}";
-      hash = "sha256-7X51XmoSwlIrbsdJFfTQ23bhO3bitkHXOObL6JaGpvI=";
-    })
-    (fetchurl {
-      url = "https://github.com/nmstate/nmstate/releases/download/v${finalAttrs.version}/nmstate-vendor-${finalAttrs.version}.tar.xz";
-      hash = "sha256-stOHNezPLPjSrt/f3HmhqWMxSaSfOh/hYVGB2+l8Pb4=";
-    })
-  ];
-  sourceRoot = ".";
-  postUnpack = ''
-    mv vendor source/rust/
-    cd source
-  '';
+  src = fetchFromGitHub {
+    owner = "nmstate";
+    repo = "nmstate";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7X51XmoSwlIrbsdJFfTQ23bhO3bitkHXOObL6JaGpvI=";
+  };
 
-  postPatch = ''
-    substituteInPlace packaging/nmstate.service --replace-fail /usr/bin $out/bin
-  '';
+  vendorTarball = fetchurl {
+    url = "https://github.com/nmstate/nmstate/releases/download/v${finalAttrs.version}/nmstate-vendor-${finalAttrs.version}.tar.xz";
+    hash = "sha256-stOHNezPLPjSrt/f3HmhqWMxSaSfOh/hYVGB2+l8Pb4=";
+  };
 
   cargoRoot = "rust";
   buildAndTestSubdir = finalAttrs.cargoRoot;
   cargoVendorDir = "vendor";
+
+  postPatch = ''
+    # the tarball has a directory called "vendor" in it
+    tar xf "$vendorTarball" -C "$cargoRoot"
+
+    substituteInPlace packaging/nmstate.service --replace-fail /usr/bin $out/bin
+  '';
 
   nativeBuildInputs = [
     libfaketime

--- a/pkgs/by-name/nm/nmstate/package.nix
+++ b/pkgs/by-name/nm/nmstate/package.nix
@@ -4,6 +4,7 @@
   fetchurl,
   rustPlatform,
   libfaketime,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -42,6 +43,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
     source_date=$(date --utc --date=@$SOURCE_DATE_EPOCH "+%F %T")
     PREFIX=$out LIBDIR=$out/lib RELEASE=1 SKIP_PYTHON_INSTALL=1 faketime -f "$source_date" make install
   '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      # also update the hash for vendorTarball
+      "--custom-dep=vendorTarball"
+    ];
+  };
 
   meta = {
     description = "Nmstate: A Declarative Network API";


### PR DESCRIPTION
I was looking at this package and couldn't not try to simplify it.

For context:
I'm in the process of rethinking how using upstream-provided vendor directories are handled.
This package is an outlier in both the fact that it does some weird magic in the unpack phase and that upstream itself doesn't supply a `.cargo/config.toml` file to use for the source replacements. This PR only removes the weird magic.

The PR also adds a proper way to automatically update both the src and the vendorTarball FODs

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
