### PR TITLE
nmstate: fix install logic to not do a rebuild

### DIFF
--- a/pkgs/by-name/nm/nmstate/package.nix
+++ b/pkgs/by-name/nm/nmstate/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   fetchurl,
   rustPlatform,
@@ -40,10 +41,18 @@ rustPlatform.buildRustPackage (finalAttrs: {
     libfaketime
   ];
 
-  postInstall = ''
-    ln -s ../target rust/target
+  # don't use cargoInstallHook's installPhase because the Makefile handles installing both the binaries and the extra files
+  installPhase = ''
+    runHook preInstall
+
+    # the target location and layout created by cargoBuildHook is different than what the Makefile expects
+    substituteInPlace Makefile \
+      --replace-fail 'rust/target/release' 'target/${stdenv.hostPlatform.rust.cargoShortTarget}/release'
+
     source_date=$(date --utc --date=@$SOURCE_DATE_EPOCH "+%F %T")
     PREFIX=$out LIBDIR=$out/lib RELEASE=1 SKIP_PYTHON_INSTALL=1 faketime -f "$source_date" make install
+
+    runHook postInstall
   '';
 
   meta = {


### PR DESCRIPTION
Discovered some issues while working on https://github.com/NixOS/nixpkgs/pull/532152

Firstly, I moved the install logic into `installPhase`, because previously `cargoInstallHook` still ran even though the `Makefile` would handle installing the main binary and the `.so` and `.a` files.

Secondly, I edited the `Makefile` so that it actually detects the binaries built by `cargoBuildHook`, so that it doesn't try to rebuild the app in the expected location.

The other solution would have been to get rid of `cargoBuildHook` entirely and *just* run `make install`. This would've meant that everything would be done in the `installPhase`, even the building. I'd rather avoid that so I did what I did. It would be cleaner, though.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
