### PR TITLE
plugdata: use upstream desktop item

### DIFF
--- a/pkgs/by-name/pl/plugdata/package.nix
+++ b/pkgs/by-name/pl/plugdata/package.nix
@@ -4,8 +4,6 @@
   fetchFromGitHub,
   fetchpatch2,
   ensureNewerSourcesForZipFilesHook,
-  makeDesktopItem,
-  copyDesktopItems,
   cmake,
   pkg-config,
   alsa-lib,
@@ -49,7 +47,6 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     pkg-config
     ensureNewerSourcesForZipFilesHook
-    copyDesktopItems
     python3
     makeWrapper
     writableTmpDirAsHomeHook
@@ -75,21 +72,6 @@ stdenv.mkDerivation (finalAttrs: {
     libjack2
     expat
     webkitgtk_4_1
-  ];
-
-  desktopItems = [
-    (makeDesktopItem {
-      name = "PlugData";
-      desktopName = "PlugData";
-      exec = "plugdata";
-      icon = "plugdata_logo";
-      comment = "Pure Data as a plugin, with a new GUI";
-      type = "Application";
-      categories = [
-        "AudioVideo"
-        "Music"
-      ];
-    })
   ];
 
   env.NIX_LDFLAGS = toString [
@@ -131,7 +113,8 @@ stdenv.mkDerivation (finalAttrs: {
     cp -r Plugins/VST3/plugdata{,-fx}.vst3 $out/lib/vst3
     cp -r Plugins/LV2/plugdata{,-fx}.lv2   $out/lib/lv2
 
-    install -Dm444 $src/Resources/Icons/plugdata_logo_linux.png $out/share/icons/hicolor/512x512/apps/plugdata_logo.png
+    install -Dm444 Resources/Icons/plugdata_logo_linux.png $out/share/icons/hicolor/512x512/apps/plugdata.png
+    install -Dm444 Resources/Installer/plugdata.desktop -t $out/share/applications
 
     runHook postInstall
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
this fixes the icon in the gnome overview due to startupwmclass, and also means it's one less thing to manually keep in sync with upstream.

apologies for not catching it sooner, gnome makes this hard to catch by eye without fully installing on your system, which i didn't do during the pixmaps migration, (i only looked at `result/`, so I didn't catch that the naming was inconsistent).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
