### PR TITLE
lemmy: update documentation

### DIFF
--- a/nixos/modules/services/web-apps/lemmy.md
+++ b/nixos/modules/services/web-apps/lemmy.md
@@ -1,26 +1,24 @@
 # Lemmy {#module-services-lemmy}
 
-Lemmy is a federated alternative to reddit in rust.
+Lemmy is a federated alternative to Reddit in Rust.
 
 ## Quickstart {#module-services-lemmy-quickstart}
 
-The minimum to start lemmy is
+The minimum to start Lemmy is
 
 ```nix
 {
   services.lemmy = {
     enable = true;
-    settings = {
-      hostname = "lemmy.union.rocks";
-      database.createLocally = true;
-    };
+    settings.hostname = "lemmy.union.rocks";
+    database.createLocally = true;
     caddy.enable = true;
   };
 }
 ```
 
 This will start the backend on port 8536 and the frontend on port 1234.
-It will expose your instance with a caddy reverse proxy to the hostname you've provided.
+It will expose your instance with a Caddy reverse proxy to the hostname you've provided.
 Postgres will be initialized on that same instance automatically.
 
 ## Usage {#module-services-lemmy-usage}
@@ -29,5 +27,4 @@ On first connection you will be asked to define an admin user.
 
 ## Missing {#module-services-lemmy-missing}
 
-- Exposing with nginx is not implemented yet.
-- This has been tested using a local database with a unix socket connection. Using different database settings will likely require modifications
+- This has been tested using a local database with a Unix socket connection. Using different database settings will likely require modifications.


### PR DESCRIPTION
settings.database.createLocally was changed to just database.createLocally and there's now an option to enable nginx for Lemmy


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
