### PR TITLE
Revert "nixos/xdg/autostart: actually disable generation of autostart units"

### DIFF
--- a/nixos/modules/config/xdg/autostart.nix
+++ b/nixos/modules/config/xdg/autostart.nix
@@ -4,33 +4,21 @@
     teams = [ lib.teams.freedesktop ];
   };
 
-  options.xdg.autostart = {
-    enable =
-      lib.mkEnableOption "auto-starting of desktop applications according to the [XDG Autostart specification](https://specifications.freedesktop.org/autostart-spec/latest)."
-      // lib.mkOption {
-        default = true;
-      };
-    install =
-      lib.mkEnableOption ''
-        install desktop files following the [XDG Autostart specification](https://specifications.freedesktop.org/autostart-spec/latest) into `/etc/xdg/autostart/`.
-
-        These are handled by your desktop environment or [`systemd-xdg-autostart-generator`](https://www.freedesktop.org/software/systemd/man/latest/systemd-xdg-autostart-generator.html).
-      ''
-      // lib.mkOption {
-        default = true;
-      };
+  options = {
+    xdg.autostart.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Whether to install files to support the
+        [XDG Autostart specification](https://specifications.freedesktop.org/autostart-spec/latest).
+      '';
+    };
   };
 
-  config = {
-    # FIXME this does not actually work because "/etc/xdg" is linked
-    # unconditionally in `nixos/modules/config/system-path.nix`
-    environment.pathsToLink = lib.mkIf config.xdg.autostart.install [
+  config = lib.mkIf config.xdg.autostart.enable {
+    environment.pathsToLink = [
       "/etc/xdg/autostart"
     ];
-
-    # On by default
-    systemd.user.generators.systemd-xdg-autostart-generator = lib.mkIf (!config.xdg.autostart.enable) (
-      lib.mkDefault "/dev/null"
-    );
   };
+
 }


### PR DESCRIPTION
Reverts NixOS/nixpkgs#530372

There's no reason to add a new option. If `enable = false` isn't functioning, just fix that. I think removing the line at https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/config/system-path.nix#L190 will resolve the issue.

cc @Atemu 