### PR TITLE
netlist2svg: init at 1.1.5

### DIFF
--- a/pkgs/by-name/ne/netlist2svg/package.nix
+++ b/pkgs/by-name/ne/netlist2svg/package.nix
@@ -20,6 +20,8 @@ buildNpmPackage rec {
 
   npmDepsHash = "sha256-dmK6SeiG+QgpA8IVZ6xiRoIRF1Zair3XeBOQCvjhwAE=";
 
+  __structuredAttrs = true;
+
   dontNpmBuild = true;
 
   doCheck = true;
@@ -52,6 +54,6 @@ buildNpmPackage rec {
     description = "Draw SVG digital circuits schematics from yosys JSON netlists";
     homepage = "https://github.com/ajsb85/netlist2svg";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/ne/netlist2svg/package.nix
+++ b/pkgs/by-name/ne/netlist2svg/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  runCommandLocal,
+  netlist2svg,
+  yosys,
+}:
+
+buildNpmPackage rec {
+  pname = "netlist2svg";
+  version = "1.1.5";
+
+  src = fetchFromGitHub {
+    owner = "ajsb85";
+    repo = "netlist2svg";
+    tag = "v${version}";
+    hash = "sha256-/BH4XRDHf2k12LNBZci1yLDJ3ZFukIRZvLT1CrhLUc0=";
+  };
+
+  npmDepsHash = "sha256-dmK6SeiG+QgpA8IVZ6xiRoIRF1Zair3XeBOQCvjhwAE=";
+
+  dontNpmBuild = true;
+
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+
+    node --trace-warnings test/test-all.js
+
+    runHook postCheck
+  '';
+
+  # An integration test: Synthesize a circuit from hdl and generate a diagram
+  passthru.tests.netlist2svg-yosys-integration-test =
+    runCommandLocal "netlist2svg-yosys-integration-test"
+      {
+        nativeBuildInputs = [
+          netlist2svg
+          yosys
+        ];
+      }
+      ''
+        yosys -p "prep -top helloworld -flatten; aigmap; write_json circuit.json" ${./test.v}
+        netlist2svg circuit.json -o circuit.svg
+        test -s circuit.svg
+        touch $out
+      '';
+
+  meta = {
+    description = "Draw SVG digital circuits schematics from yosys JSON netlists";
+    homepage = "https://github.com/ajsb85/netlist2svg";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+  };
+}

--- a/pkgs/by-name/ne/netlist2svg/test.v
+++ b/pkgs/by-name/ne/netlist2svg/test.v
@@ -1,0 +1,4 @@
+module helloworld(input clk, input d, output reg q);
+    always @(posedge clk)
+        q <= d;
+endmodule


### PR DESCRIPTION
This PR adds the **Netlist2SVG** package, a modernized fork of the original `netlistsvg` project. 

Netlist2SVG draws SVG digital circuit schematics from Yosys JSON netlists. This fork introduces several key improvements:
- **Project Renaming:** Consistent naming as Netlist2SVG across all components.
- **Theme Support:** Native support for both light and dark modes within a single SVG file using CSS media queries.
- **Deterministic Builds:** Includes a `package-lock.json` to ensure reproducible builds and simplify maintenance for downstream distributors like Nixpkgs.
- **Automated CI/CD:** Modernized build pipeline with NPM Trusted Publishing and supply chain security audits.

## Things done

- Built on platform:
  - [x] x86_64-linux (Verified during SRI hash calculation)
- Tested, as applicable:
  - [x] [Package tests] at `passthru.tests` (Includes a Yosys-based integration test synthesizing and rendering `test.v`).
- [x] Tested basic functionality of all binary files.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md