### PR TITLE
lib/systems: gate linux-kernel assertion behind oldestSupportedRelease

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -17,6 +17,10 @@ let
 
   inherit (lib.strings) toJSON;
 
+  inherit (lib.trivial)
+    oldestSupportedReleaseIsAtLeast
+    ;
+
   doubles = import ./doubles.nix { inherit lib; };
   parse = import ./parse.nix { inherit lib; };
   inspect = import ./inspect.nix { inherit lib; };
@@ -690,9 +694,12 @@ let
         };
       };
     in
-    # TODO: Remove in 27.05.
+    # Platforms elaborated by pre-26.11 Nixpkgs will include the `linux-kernel` attr,
+    # so we can't assert its absence until 26.11 is the oldest supported release.
+    # Assertion will activate during the 27.05 cycle, when 26.05 support ends.
+    # TODO: Remove assertion in the 27.11 cycle.
     assert
-      args ? linux-kernel
+      oldestSupportedReleaseIsAtLeast 2611 && args ? linux-kernel
       -> throw "lib.systems.elaborate: linux-kernel has been removed; see the 26.11 release notes";
 
     assert final.useAndroidPrebuilt -> final.isAndroid;


### PR DESCRIPTION
A platform elaborated by an older supported revision of Nixpkgs would trip the assertion if it is re-elaborated by this Nixpkgs revision.

Avoid this by checking `oldestSupportedReleaseIsAtLeast 2511`, as 25.11 (current unstable) is the version that stopped adding `linux-kernel` to elaborated systems.

Closes #532148 - this is an alternative to reverting the change as a whole.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
