### PR TITLE
reticulated: init at 1.0.2

### DIFF
--- a/pkgs/by-name/re/reticulated/package.nix
+++ b/pkgs/by-name/re/reticulated/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "reticulated";
+  version = "1.0.2";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "RFnexus";
+    repo = "reticulated";
+    tag = finalAttrs.version;
+    hash = "sha256-55eK9AObUw8JLn4sNC5O8dNrfscwTwQpkVQAR+O9Lcw=";
+  };
+
+  postPatch = ''
+    substituteInPlace sim/config.py \
+      --replace-fail 'os.path.join(BASE_DIR, "web")' '"${placeholder "out"}/share/web"'
+  '';
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    fastapi
+    lxmf
+    rns
+    uvicorn
+    websockets
+  ];
+
+  postInstall = ''
+    mkdir -p "$out/share"
+    cp -r web "$out/share/"
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/reticulated \
+      --set PYTHONPATH $PYTHONPATH \
+      --set SIM_DATA_DIR "/tmp"
+  '';
+
+  pythonImportsCheck = [ "sim" ];
+
+  # No --version flag and no Python tests
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/RFnexus/reticulated/releases/tag/${finalAttrs.src.tag}";
+    description = "Reticulum Network Stack Simulator";
+    homepage = "https://github.com/RFnexus/reticulated";
+    license = lib.licenses.unlicense;
+    maintainers = with lib.maintainers; [ drupol ];
+    mainProgram = "reticulated";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
