### PR TITLE
treewide: migrate trivial overrides to by-name

### DIFF
--- a/pkgs/by-name/_7/_7zz-rar/package.nix
+++ b/pkgs/by-name/_7/_7zz-rar/package.nix
@@ -1,0 +1,5 @@
+{
+  _7zz,
+}:
+
+_7zz.override { enableUnfree = true; }

--- a/pkgs/by-name/ac/acl2-minimal/package.nix
+++ b/pkgs/by-name/ac/acl2-minimal/package.nix
@@ -1,0 +1,5 @@
+{
+  acl2,
+}:
+
+acl2.override { certifyBooks = false; }

--- a/pkgs/by-name/ad/adaptivecppWithCuda/package.nix
+++ b/pkgs/by-name/ad/adaptivecppWithCuda/package.nix
@@ -1,0 +1,5 @@
+{
+  adaptivecpp,
+}:
+
+adaptivecpp.override { cudaSupport = true; }

--- a/pkgs/by-name/ad/adaptivecppWithRocm/package.nix
+++ b/pkgs/by-name/ad/adaptivecppWithRocm/package.nix
@@ -1,0 +1,5 @@
+{
+  adaptivecpp,
+}:
+
+adaptivecpp.override { rocmSupport = true; }

--- a/pkgs/by-name/ad/adwaita-qt6/package.nix
+++ b/pkgs/by-name/ad/adwaita-qt6/package.nix
@@ -1,0 +1,5 @@
+{
+  adwaita-qt,
+}:
+
+adwaita-qt.override { useQt6 = true; }

--- a/pkgs/by-name/al/alice-tools-qt5/package.nix
+++ b/pkgs/by-name/al/alice-tools-qt5/package.nix
@@ -1,0 +1,5 @@
+{
+  alice-tools,
+}:
+
+alice-tools.override { withQt5 = true; }

--- a/pkgs/by-name/al/alice-tools-qt6/package.nix
+++ b/pkgs/by-name/al/alice-tools-qt6/package.nix
@@ -1,0 +1,5 @@
+{
+  alice-tools,
+}:
+
+alice-tools.override { withQt6 = true; }

--- a/pkgs/by-name/ap/appimageupdate-qt/package.nix
+++ b/pkgs/by-name/ap/appimageupdate-qt/package.nix
@@ -1,0 +1,5 @@
+{
+  appimageupdate,
+}:
+
+appimageupdate.override { withQtUI = true; }

--- a/pkgs/by-name/ar/arcan-wrapped/package.nix
+++ b/pkgs/by-name/ar/arcan-wrapped/package.nix
@@ -1,0 +1,5 @@
+{
+  arcan,
+}:
+
+arcan.wrapper.override { }

--- a/pkgs/by-name/ar/arduino/package.nix
+++ b/pkgs/by-name/ar/arduino/package.nix
@@ -1,0 +1,5 @@
+{
+  arduino-core,
+}:
+
+arduino-core.override { withGui = true; }

--- a/pkgs/by-name/ar/arpack-mpi/package.nix
+++ b/pkgs/by-name/ar/arpack-mpi/package.nix
@@ -1,0 +1,5 @@
+{
+  arpack,
+}:
+
+arpack.override { useMpi = true; }

--- a/pkgs/by-name/au/audacious/package.nix
+++ b/pkgs/by-name/au/audacious/package.nix
@@ -1,0 +1,5 @@
+{
+  audacious-bare,
+}:
+
+audacious-bare.override { withPlugins = true; }

--- a/pkgs/by-name/ba/bambootracker-qt6/package.nix
+++ b/pkgs/by-name/ba/bambootracker-qt6/package.nix
@@ -1,0 +1,5 @@
+{
+  bambootracker,
+}:
+
+bambootracker.override { withQt6 = true; }

--- a/pkgs/by-name/bl/blas-ilp64/package.nix
+++ b/pkgs/by-name/bl/blas-ilp64/package.nix
@@ -1,0 +1,5 @@
+{
+  blas,
+}:
+
+blas.override { isILP64 = true; }

--- a/pkgs/by-name/bo/bogofilter-db/package.nix
+++ b/pkgs/by-name/bo/bogofilter-db/package.nix
@@ -1,0 +1,6 @@
+{
+  bogofilter,
+  db,
+}:
+
+bogofilter.override { database = db; }

--- a/pkgs/by-name/bo/bogofilter-sqlite/package.nix
+++ b/pkgs/by-name/bo/bogofilter-sqlite/package.nix
@@ -1,0 +1,6 @@
+{
+  bogofilter,
+  sqlite,
+}:
+
+bogofilter.override { database = sqlite; }

--- a/pkgs/by-name/bo/boinc-headless/package.nix
+++ b/pkgs/by-name/bo/boinc-headless/package.nix
@@ -1,0 +1,5 @@
+{
+  boinc,
+}:
+
+boinc.override { headless = true; }

--- a/pkgs/by-name/bo/botanEsdm/package.nix
+++ b/pkgs/by-name/bo/botanEsdm/package.nix
@@ -1,0 +1,5 @@
+{
+  botan3,
+}:
+
+botan3.override { withEsdm = true; }

--- a/pkgs/by-name/bo/bozohttpd-minimal/package.nix
+++ b/pkgs/by-name/bo/bozohttpd-minimal/package.nix
@@ -1,0 +1,5 @@
+{
+  bozohttpd,
+}:
+
+bozohttpd.override { minimal = true; }

--- a/pkgs/by-name/bt/btop-cuda/package.nix
+++ b/pkgs/by-name/bt/btop-cuda/package.nix
@@ -1,0 +1,5 @@
+{
+  btop,
+}:
+
+btop.override { cudaSupport = true; }

--- a/pkgs/by-name/bt/btop-rocm/package.nix
+++ b/pkgs/by-name/bt/btop-rocm/package.nix
@@ -1,0 +1,5 @@
+{
+  btop,
+}:
+
+btop.override { rocmSupport = true; }

--- a/pkgs/by-name/ca/cameractrls-gtk3/package.nix
+++ b/pkgs/by-name/ca/cameractrls-gtk3/package.nix
@@ -1,0 +1,5 @@
+{
+  cameractrls,
+}:
+
+cameractrls.override { withGtk = 3; }

--- a/pkgs/by-name/ca/cameractrls-gtk4/package.nix
+++ b/pkgs/by-name/ca/cameractrls-gtk4/package.nix
@@ -1,0 +1,5 @@
+{
+  cameractrls,
+}:
+
+cameractrls.override { withGtk = 4; }

--- a/pkgs/by-name/co/codeblocksFull/package.nix
+++ b/pkgs/by-name/co/codeblocksFull/package.nix
@@ -1,0 +1,5 @@
+{
+  codeblocks,
+}:
+
+codeblocks.override { contribPlugins = true; }

--- a/pkgs/by-name/co/colmapWithCuda/package.nix
+++ b/pkgs/by-name/co/colmapWithCuda/package.nix
@@ -1,0 +1,5 @@
+{
+  colmap,
+}:
+
+colmap.override { cudaSupport = true; }

--- a/pkgs/by-name/co/colord-gtk4/package.nix
+++ b/pkgs/by-name/co/colord-gtk4/package.nix
@@ -1,0 +1,5 @@
+{
+  colord-gtk,
+}:
+
+colord-gtk.override { withGtk4 = true; }

--- a/pkgs/by-name/cr/crystfel-headless/package.nix
+++ b/pkgs/by-name/cr/crystfel-headless/package.nix
@@ -1,0 +1,5 @@
+{
+  crystfel,
+}:
+
+crystfel.override { withGui = false; }

--- a/pkgs/by-name/da/davix-copy/package.nix
+++ b/pkgs/by-name/da/davix-copy/package.nix
@@ -1,0 +1,5 @@
+{
+  davix,
+}:
+
+davix.override { enableThirdPartyCopy = true; }

--- a/pkgs/by-name/db/dblatexFull/package.nix
+++ b/pkgs/by-name/db/dblatexFull/package.nix
@@ -1,0 +1,5 @@
+{
+  dblatex,
+}:
+
+dblatex.override { enableAllFeatures = true; }

--- a/pkgs/by-name/dd/ddnet-server/package.nix
+++ b/pkgs/by-name/dd/ddnet-server/package.nix
@@ -1,0 +1,5 @@
+{
+  ddnet,
+}:
+
+ddnet.override { buildClient = false; }

--- a/pkgs/by-name/dm/dmenu-rs-enable-plugins/package.nix
+++ b/pkgs/by-name/dm/dmenu-rs-enable-plugins/package.nix
@@ -1,0 +1,5 @@
+{
+  dmenu-rs,
+}:
+
+dmenu-rs.override { enablePlugins = true; }

--- a/pkgs/by-name/do/docker-client/package.nix
+++ b/pkgs/by-name/do/docker-client/package.nix
@@ -1,0 +1,5 @@
+{
+  docker,
+}:
+
+docker.override { clientOnly = true; }

--- a/pkgs/by-name/ep/eprover-ho/package.nix
+++ b/pkgs/by-name/ep/eprover-ho/package.nix
@@ -1,0 +1,5 @@
+{
+  eprover,
+}:
+
+eprover.override { enableHO = true; }

--- a/pkgs/by-name/fa/factorio-demo/package.nix
+++ b/pkgs/by-name/fa/factorio-demo/package.nix
@@ -1,0 +1,5 @@
+{
+  factorio,
+}:
+
+factorio.override { releaseType = "demo"; }

--- a/pkgs/by-name/fa/factorio-headless/package.nix
+++ b/pkgs/by-name/fa/factorio-headless/package.nix
@@ -1,0 +1,5 @@
+{
+  factorio,
+}:
+
+factorio.override { releaseType = "headless"; }

--- a/pkgs/by-name/fa/factorio-space-age/package.nix
+++ b/pkgs/by-name/fa/factorio-space-age/package.nix
@@ -1,0 +1,5 @@
+{
+  factorio,
+}:
+
+factorio.override { releaseType = "expansion"; }

--- a/pkgs/by-name/fc/fceux-qt5/package.nix
+++ b/pkgs/by-name/fc/fceux-qt5/package.nix
@@ -1,0 +1,5 @@
+{
+  fceux,
+}:
+
+fceux.override { ___qtVersion = "5"; }

--- a/pkgs/by-name/fc/fceux-qt6/package.nix
+++ b/pkgs/by-name/fc/fceux-qt6/package.nix
@@ -1,0 +1,5 @@
+{
+  fceux,
+}:
+
+fceux.override { ___qtVersion = "6"; }

--- a/pkgs/by-name/ff/fftwLongDouble/package.nix
+++ b/pkgs/by-name/ff/fftwLongDouble/package.nix
@@ -1,0 +1,5 @@
+{
+  fftw,
+}:
+
+fftw.override { precision = "long-double"; }

--- a/pkgs/by-name/ff/fftwMpi/package.nix
+++ b/pkgs/by-name/ff/fftwMpi/package.nix
@@ -1,0 +1,5 @@
+{
+  fftw,
+}:
+
+fftw.override { enableMpi = true; }

--- a/pkgs/by-name/ff/fftwSinglePrec/package.nix
+++ b/pkgs/by-name/ff/fftwSinglePrec/package.nix
@@ -1,0 +1,5 @@
+{
+  fftw,
+}:
+
+fftw.override { precision = "single"; }

--- a/pkgs/by-name/fi/firewalld-gui/package.nix
+++ b/pkgs/by-name/fi/firewalld-gui/package.nix
@@ -1,0 +1,5 @@
+{
+  firewalld,
+}:
+
+firewalld.override { withGui = true; }

--- a/pkgs/by-name/fl/fluffychat-web/package.nix
+++ b/pkgs/by-name/fl/fluffychat-web/package.nix
@@ -1,0 +1,5 @@
+{
+  fluffychat,
+}:
+
+fluffychat.override { targetFlutterPlatform = "web"; }

--- a/pkgs/by-name/ga/gawkInteractive/package.nix
+++ b/pkgs/by-name/ga/gawkInteractive/package.nix
@@ -1,0 +1,5 @@
+{
+  gawk,
+}:
+
+gawk.override { interactive = true; }

--- a/pkgs/by-name/gd/gdbHostCpuOnly/package.nix
+++ b/pkgs/by-name/gd/gdbHostCpuOnly/package.nix
@@ -1,0 +1,5 @@
+{
+  gdb,
+}:
+
+gdb.override { hostCpuOnly = true; }

--- a/pkgs/by-name/ge/geoclue2-with-demo-agent/package.nix
+++ b/pkgs/by-name/ge/geoclue2-with-demo-agent/package.nix
@@ -1,0 +1,5 @@
+{
+  geoclue2,
+}:
+
+geoclue2.override { withDemoAgent = true; }

--- a/pkgs/by-name/gh/ghdl-gcc/package.nix
+++ b/pkgs/by-name/gh/ghdl-gcc/package.nix
@@ -1,0 +1,5 @@
+{
+  ghdl,
+}:
+
+ghdl.override { backend = "gcc"; }

--- a/pkgs/by-name/gh/ghdl-llvm/package.nix
+++ b/pkgs/by-name/gh/ghdl-llvm/package.nix
@@ -1,0 +1,5 @@
+{
+  ghdl,
+}:
+
+ghdl.override { backend = "llvm"; }

--- a/pkgs/by-name/gh/ghdl-mcode/package.nix
+++ b/pkgs/by-name/gh/ghdl-mcode/package.nix
@@ -1,0 +1,5 @@
+{
+  ghdl,
+}:
+
+ghdl.override { backend = "mcode"; }

--- a/pkgs/by-name/gi/giac-with-xcas/package.nix
+++ b/pkgs/by-name/gi/giac-with-xcas/package.nix
@@ -1,0 +1,5 @@
+{
+  giac,
+}:
+
+giac.override { enableGUI = true; }

--- a/pkgs/by-name/gm/gmpxx/package.nix
+++ b/pkgs/by-name/gm/gmpxx/package.nix
@@ -1,0 +1,5 @@
+{
+  gmp,
+}:
+
+gmp.override { cxx = true; }

--- a/pkgs/by-name/go/go2tv-lite/package.nix
+++ b/pkgs/by-name/go/go2tv-lite/package.nix
@@ -1,0 +1,5 @@
+{
+  go2tv,
+}:
+
+go2tv.override { withGui = false; }

--- a/pkgs/by-name/gp/gparted-full/package.nix
+++ b/pkgs/by-name/gp/gparted-full/package.nix
@@ -1,0 +1,5 @@
+{
+  gparted,
+}:
+
+gparted.override { withAllTools = true; }

--- a/pkgs/by-name/gp/gpm-ncurses/package.nix
+++ b/pkgs/by-name/gp/gpm-ncurses/package.nix
@@ -1,0 +1,5 @@
+{
+  gpm,
+}:
+
+gpm.override { withNcurses = true; }

--- a/pkgs/by-name/gr/graphicsmagick_q16/package.nix
+++ b/pkgs/by-name/gr/graphicsmagick_q16/package.nix
@@ -1,0 +1,5 @@
+{
+  graphicsmagick,
+}:
+
+graphicsmagick.override { quantumdepth = 16; }

--- a/pkgs/by-name/gr/gridcoin-researchd/package.nix
+++ b/pkgs/by-name/gr/gridcoin-researchd/package.nix
@@ -1,0 +1,5 @@
+{
+  gridcoin-research,
+}:
+
+gridcoin-research.override { withGui = false; }

--- a/pkgs/by-name/gr/gruppled-white-cursors/package.nix
+++ b/pkgs/by-name/gr/gruppled-white-cursors/package.nix
@@ -1,0 +1,5 @@
+{
+  gruppled-black-cursors,
+}:
+
+gruppled-black-cursors.override { theme = "white"; }

--- a/pkgs/by-name/gr/gruppled-white-lite-cursors/package.nix
+++ b/pkgs/by-name/gr/gruppled-white-lite-cursors/package.nix
@@ -1,0 +1,5 @@
+{
+  gruppled-black-lite-cursors,
+}:
+
+gruppled-black-lite-cursors.override { theme = "white"; }

--- a/pkgs/by-name/hd/hdf5-cpp/package.nix
+++ b/pkgs/by-name/hd/hdf5-cpp/package.nix
@@ -1,0 +1,5 @@
+{
+  hdf5,
+}:
+
+hdf5.override { cppSupport = true; }

--- a/pkgs/by-name/hd/hdf5-fortran/package.nix
+++ b/pkgs/by-name/hd/hdf5-fortran/package.nix
@@ -1,0 +1,5 @@
+{
+  hdf5,
+}:
+
+hdf5.override { fortranSupport = true; }

--- a/pkgs/by-name/hi/highfive-mpi/package.nix
+++ b/pkgs/by-name/hi/highfive-mpi/package.nix
@@ -1,0 +1,6 @@
+{
+  highfive,
+  hdf5-mpi,
+}:
+
+highfive.override { hdf5 = hdf5-mpi; }

--- a/pkgs/by-name/hp/hplipWithPlugin/package.nix
+++ b/pkgs/by-name/hp/hplipWithPlugin/package.nix
@@ -1,0 +1,5 @@
+{
+  hplip,
+}:
+
+hplip.override { withPlugin = true; }

--- a/pkgs/by-name/ht/htop-vim/package.nix
+++ b/pkgs/by-name/ht/htop-vim/package.nix
@@ -1,0 +1,5 @@
+{
+  htop,
+}:
+
+htop.override { withVimKeys = true; }

--- a/pkgs/by-name/in/inspircdMinimal/package.nix
+++ b/pkgs/by-name/in/inspircdMinimal/package.nix
@@ -1,0 +1,5 @@
+{
+  inspircd,
+}:
+
+inspircd.override { extraModules = [ ]; }

--- a/pkgs/by-name/ja/jackmix_jack1/package.nix
+++ b/pkgs/by-name/ja/jackmix_jack1/package.nix
@@ -1,0 +1,6 @@
+{
+  jackmix,
+  jack1,
+}:
+
+jackmix.override { jack = jack1; }

--- a/pkgs/by-name/js/jsoncppSecureMemory/package.nix
+++ b/pkgs/by-name/js/jsoncppSecureMemory/package.nix
@@ -1,0 +1,5 @@
+{
+  jsoncpp,
+}:
+
+jsoncpp.override { secureMemory = true; }

--- a/pkgs/by-name/ka/kanata-with-cmd/package.nix
+++ b/pkgs/by-name/ka/kanata-with-cmd/package.nix
@@ -1,0 +1,5 @@
+{
+  kanata,
+}:
+
+kanata.override { withCmd = true; }

--- a/pkgs/by-name/la/lagrange-tui/package.nix
+++ b/pkgs/by-name/la/lagrange-tui/package.nix
@@ -1,0 +1,5 @@
+{
+  lagrange,
+}:
+
+lagrange.override { enableTUI = true; }

--- a/pkgs/by-name/la/lapack-ilp64/package.nix
+++ b/pkgs/by-name/la/lapack-ilp64/package.nix
@@ -1,0 +1,5 @@
+{
+  lapack,
+}:
+
+lapack.override { isILP64 = true; }

--- a/pkgs/by-name/li/libappindicator-gtk2/package.nix
+++ b/pkgs/by-name/li/libappindicator-gtk2/package.nix
@@ -1,0 +1,5 @@
+{
+  libappindicator,
+}:
+
+libappindicator.override { gtkVersion = "2"; }

--- a/pkgs/by-name/li/libappindicator-gtk3/package.nix
+++ b/pkgs/by-name/li/libappindicator-gtk3/package.nix
@@ -1,0 +1,5 @@
+{
+  libappindicator,
+}:
+
+libappindicator.override { gtkVersion = "3"; }

--- a/pkgs/by-name/li/libastyle/package.nix
+++ b/pkgs/by-name/li/libastyle/package.nix
@@ -1,0 +1,5 @@
+{
+  astyle,
+}:
+
+astyle.override { asLibrary = true; }

--- a/pkgs/by-name/li/libdbusmenu-gtk2/package.nix
+++ b/pkgs/by-name/li/libdbusmenu-gtk2/package.nix
@@ -1,0 +1,5 @@
+{
+  libdbusmenu,
+}:
+
+libdbusmenu.override { gtkVersion = "2"; }

--- a/pkgs/by-name/li/libdbusmenu-gtk3/package.nix
+++ b/pkgs/by-name/li/libdbusmenu-gtk3/package.nix
@@ -1,0 +1,5 @@
+{
+  libdbusmenu,
+}:
+
+libdbusmenu.override { gtkVersion = "3"; }

--- a/pkgs/by-name/li/libindicator-gtk2/package.nix
+++ b/pkgs/by-name/li/libindicator-gtk2/package.nix
@@ -1,0 +1,5 @@
+{
+  libindicator,
+}:
+
+libindicator.override { gtkVersion = "2"; }

--- a/pkgs/by-name/li/libindicator-gtk3/package.nix
+++ b/pkgs/by-name/li/libindicator-gtk3/package.nix
@@ -1,0 +1,5 @@
+{
+  libindicator,
+}:
+
+libindicator.override { gtkVersion = "3"; }

--- a/pkgs/by-name/li/libjack2/package.nix
+++ b/pkgs/by-name/li/libjack2/package.nix
@@ -1,0 +1,5 @@
+{
+  jack2,
+}:
+
+jack2.override { prefix = "lib"; }

--- a/pkgs/by-name/li/libjpeg8/package.nix
+++ b/pkgs/by-name/li/libjpeg8/package.nix
@@ -1,0 +1,5 @@
+{
+  libjpeg_turbo,
+}:
+
+libjpeg_turbo.override { enableJpeg8 = true; }

--- a/pkgs/by-name/li/libkrun-sev/package.nix
+++ b/pkgs/by-name/li/libkrun-sev/package.nix
@@ -1,0 +1,5 @@
+{
+  libkrun,
+}:
+
+libkrun.override { variant = "sev"; }

--- a/pkgs/by-name/li/libkrun-tdx/package.nix
+++ b/pkgs/by-name/li/libkrun-tdx/package.nix
@@ -1,0 +1,5 @@
+{
+  libkrun,
+}:
+
+libkrun.override { variant = "tdx"; }

--- a/pkgs/by-name/li/libnma-gtk4/package.nix
+++ b/pkgs/by-name/li/libnma-gtk4/package.nix
@@ -1,0 +1,5 @@
+{
+  libnma,
+}:
+
+libnma.override { withGtk4 = true; }

--- a/pkgs/by-name/li/libportal-gtk3/package.nix
+++ b/pkgs/by-name/li/libportal-gtk3/package.nix
@@ -1,0 +1,5 @@
+{
+  libportal,
+}:
+
+libportal.override { variant = "gtk3"; }

--- a/pkgs/by-name/li/libportal-gtk4/package.nix
+++ b/pkgs/by-name/li/libportal-gtk4/package.nix
@@ -1,0 +1,5 @@
+{
+  libportal,
+}:
+
+libportal.override { variant = "gtk4"; }

--- a/pkgs/by-name/li/libportal-qt5/package.nix
+++ b/pkgs/by-name/li/libportal-qt5/package.nix
@@ -1,0 +1,5 @@
+{
+  libportal,
+}:
+
+libportal.override { variant = "qt5"; }

--- a/pkgs/by-name/li/libportal-qt6/package.nix
+++ b/pkgs/by-name/li/libportal-qt6/package.nix
@@ -1,0 +1,5 @@
+{
+  libportal,
+}:
+
+libportal.override { variant = "qt6"; }

--- a/pkgs/by-name/li/libubox-nossl/package.nix
+++ b/pkgs/by-name/li/libubox-nossl/package.nix
@@ -1,0 +1,5 @@
+{
+  libubox,
+}:
+
+libubox.override { with_ustream_ssl = false; }

--- a/pkgs/by-name/li/libva/package.nix
+++ b/pkgs/by-name/li/libva/package.nix
@@ -1,0 +1,5 @@
+{
+  libva-minimal,
+}:
+
+libva-minimal.override { minimal = false; }

--- a/pkgs/by-name/li/libxc_7/package.nix
+++ b/pkgs/by-name/li/libxc_7/package.nix
@@ -1,0 +1,5 @@
+{
+  libxc,
+}:
+
+libxc.override { version = "7.0.0"; }

--- a/pkgs/by-name/li/libxcrypt-legacy/package.nix
+++ b/pkgs/by-name/li/libxcrypt-legacy/package.nix
@@ -1,0 +1,5 @@
+{
+  libxcrypt,
+}:
+
+libxcrypt.override { enableHashes = "all"; }

--- a/pkgs/by-name/li/libzint/package.nix
+++ b/pkgs/by-name/li/libzint/package.nix
@@ -1,0 +1,5 @@
+{
+  zint-qt,
+}:
+
+zint-qt.override { withGUI = false; }

--- a/pkgs/by-name/li/lightdm_qt/package.nix
+++ b/pkgs/by-name/li/lightdm_qt/package.nix
@@ -1,0 +1,5 @@
+{
+  lightdm,
+}:
+
+lightdm.override { withQt5 = true; }

--- a/pkgs/by-name/li/limine-full/package.nix
+++ b/pkgs/by-name/li/limine-full/package.nix
@@ -1,0 +1,5 @@
+{
+  limine,
+}:
+
+limine.override { enableAll = true; }

--- a/pkgs/by-name/li/linux-router-without-wifi/package.nix
+++ b/pkgs/by-name/li/linux-router-without-wifi/package.nix
@@ -1,0 +1,5 @@
+{
+  linux-router,
+}:
+
+linux-router.override { useWifiDependencies = false; }

--- a/pkgs/by-name/lk/lklWithFirewall/package.nix
+++ b/pkgs/by-name/lk/lklWithFirewall/package.nix
@@ -1,0 +1,5 @@
+{
+  lkl,
+}:
+
+lkl.override { firewallSupport = true; }

--- a/pkgs/by-name/ls/lshw-gui/package.nix
+++ b/pkgs/by-name/ls/lshw-gui/package.nix
@@ -1,0 +1,5 @@
+{
+  lshw,
+}:
+
+lshw.override { withGUI = true; }

--- a/pkgs/by-name/lu/luabind_luajit/package.nix
+++ b/pkgs/by-name/lu/luabind_luajit/package.nix
@@ -1,0 +1,6 @@
+{
+  luabind,
+  luajit,
+}:
+
+luabind.override { lua = luajit; }

--- a/pkgs/by-name/lu/luanti-client/package.nix
+++ b/pkgs/by-name/lu/luanti-client/package.nix
@@ -1,0 +1,5 @@
+{
+  luanti,
+}:
+
+luanti.override { buildServer = false; }

--- a/pkgs/by-name/lu/luanti-server/package.nix
+++ b/pkgs/by-name/lu/luanti-server/package.nix
@@ -1,0 +1,5 @@
+{
+  luanti,
+}:
+
+luanti.override { buildClient = false; }

--- a/pkgs/by-name/ma/mariadb-embedded/package.nix
+++ b/pkgs/by-name/ma/mariadb-embedded/package.nix
@@ -1,0 +1,5 @@
+{
+  mariadb,
+}:
+
+mariadb.override { withEmbedded = true; }

--- a/pkgs/by-name/me/mercurialFull/package.nix
+++ b/pkgs/by-name/me/mercurialFull/package.nix
@@ -1,0 +1,5 @@
+{
+  mercurial,
+}:
+
+mercurial.override { fullBuild = true; }

--- a/pkgs/by-name/mi/miniupnpd-nftables/package.nix
+++ b/pkgs/by-name/mi/miniupnpd-nftables/package.nix
@@ -1,0 +1,5 @@
+{
+  miniupnpd,
+}:
+
+miniupnpd.override { firewall = "nftables"; }

--- a/pkgs/by-name/mk/mkShellNoCC/package.nix
+++ b/pkgs/by-name/mk/mkShellNoCC/package.nix
@@ -1,0 +1,6 @@
+{
+  mkShell,
+  stdenvNoCC,
+}:
+
+mkShell.override { stdenv = stdenvNoCC; }

--- a/pkgs/by-name/mk/mkosi-full/package.nix
+++ b/pkgs/by-name/mk/mkosi-full/package.nix
@@ -1,0 +1,5 @@
+{
+  mkosi,
+}:
+
+mkosi.override { withQemu = true; }

--- a/pkgs/by-name/mt/mtr-gui/package.nix
+++ b/pkgs/by-name/mt/mtr-gui/package.nix
@@ -1,0 +1,5 @@
+{
+  mtr,
+}:
+
+mtr.override { withGtk = true; }

--- a/pkgs/by-name/ne/nest-mpi/package.nix
+++ b/pkgs/by-name/ne/nest-mpi/package.nix
@@ -1,0 +1,5 @@
+{
+  nest,
+}:
+
+nest.override { withMpi = true; }

--- a/pkgs/by-name/ne/neuron-mpi/package.nix
+++ b/pkgs/by-name/ne/neuron-mpi/package.nix
@@ -1,0 +1,5 @@
+{
+  neuron,
+}:
+
+neuron.override { useMpi = true; }

--- a/pkgs/by-name/ni/nix-info-tested/package.nix
+++ b/pkgs/by-name/ni/nix-info-tested/package.nix
@@ -1,0 +1,5 @@
+{
+  nix-info,
+}:
+
+nix-info.override { doCheck = true; }

--- a/pkgs/by-name/nv/nv-codec-headers-10/package.nix
+++ b/pkgs/by-name/nv/nv-codec-headers-10/package.nix
@@ -1,0 +1,5 @@
+{
+  nv-codec-headers,
+}:
+
+nv-codec-headers.override { majorVersion = "10"; }

--- a/pkgs/by-name/nv/nv-codec-headers-11/package.nix
+++ b/pkgs/by-name/nv/nv-codec-headers-11/package.nix
@@ -1,0 +1,5 @@
+{
+  nv-codec-headers,
+}:
+
+nv-codec-headers.override { majorVersion = "11"; }

--- a/pkgs/by-name/nv/nv-codec-headers-12/package.nix
+++ b/pkgs/by-name/nv/nv-codec-headers-12/package.nix
@@ -1,0 +1,5 @@
+{
+  nv-codec-headers,
+}:
+
+nv-codec-headers.override { majorVersion = "12"; }

--- a/pkgs/by-name/nv/nv-codec-headers-9/package.nix
+++ b/pkgs/by-name/nv/nv-codec-headers-9/package.nix
@@ -1,0 +1,5 @@
+{
+  nv-codec-headers,
+}:
+
+nv-codec-headers.override { majorVersion = "9"; }

--- a/pkgs/by-name/op/open-vm-tools-headless/package.nix
+++ b/pkgs/by-name/op/open-vm-tools-headless/package.nix
@@ -1,0 +1,5 @@
+{
+  open-vm-tools,
+}:
+
+open-vm-tools.override { withX = false; }

--- a/pkgs/by-name/op/openblasCompat/package.nix
+++ b/pkgs/by-name/op/openblasCompat/package.nix
@@ -1,0 +1,5 @@
+{
+  openblas,
+}:
+
+openblas.override { blas64 = false; }

--- a/pkgs/by-name/op/opensplatWithCuda/package.nix
+++ b/pkgs/by-name/op/opensplatWithCuda/package.nix
@@ -1,0 +1,5 @@
+{
+  opensplat,
+}:
+
+opensplat.override { cudaSupport = true; }

--- a/pkgs/by-name/op/opensplatWithRocm/package.nix
+++ b/pkgs/by-name/op/opensplatWithRocm/package.nix
@@ -1,0 +1,5 @@
+{
+  opensplat,
+}:
+
+opensplat.override { rocmSupport = true; }

--- a/pkgs/by-name/op/ophcrack-cli/package.nix
+++ b/pkgs/by-name/op/ophcrack-cli/package.nix
@@ -1,0 +1,5 @@
+{
+  ophcrack,
+}:
+
+ophcrack.override { enableGui = false; }

--- a/pkgs/by-name/op/opnplug/package.nix
+++ b/pkgs/by-name/op/opnplug/package.nix
@@ -1,0 +1,5 @@
+{
+  adlplug,
+}:
+
+adlplug.override { type = "OPN"; }

--- a/pkgs/by-name/p4/p4est-dbg/package.nix
+++ b/pkgs/by-name/p4/p4est-dbg/package.nix
@@ -1,0 +1,5 @@
+{
+  p4est,
+}:
+
+p4est.override { debug = true; }

--- a/pkgs/by-name/p4/p4est-sc-dbg/package.nix
+++ b/pkgs/by-name/p4/p4est-sc-dbg/package.nix
@@ -1,0 +1,5 @@
+{
+  p4est-sc,
+}:
+
+p4est-sc.override { debug = true; }

--- a/pkgs/by-name/pc/pcre-cpp/package.nix
+++ b/pkgs/by-name/pc/pcre-cpp/package.nix
@@ -1,0 +1,5 @@
+{
+  pcre,
+}:
+
+pcre.override { variant = "cpp"; }

--- a/pkgs/by-name/pd/pdfium-binaries-v8/package.nix
+++ b/pkgs/by-name/pd/pdfium-binaries-v8/package.nix
@@ -1,0 +1,5 @@
+{
+  pdfium-binaries,
+}:
+
+pdfium-binaries.override { withV8 = true; }

--- a/pkgs/by-name/pg/pgadmin4-desktopmode/package.nix
+++ b/pkgs/by-name/pg/pgadmin4-desktopmode/package.nix
@@ -1,0 +1,5 @@
+{
+  pgadmin4,
+}:
+
+pgadmin4.override { server-mode = false; }

--- a/pkgs/by-name/pi/pinegrow6/package.nix
+++ b/pkgs/by-name/pi/pinegrow6/package.nix
@@ -1,0 +1,5 @@
+{
+  pinegrow,
+}:
+
+pinegrow.override { pinegrowVersion = "6"; }

--- a/pkgs/by-name/pm/pmars-x11/package.nix
+++ b/pkgs/by-name/pm/pmars-x11/package.nix
@@ -1,0 +1,5 @@
+{
+  pmars,
+}:
+
+pmars.override { enableXwinGraphics = true; }

--- a/pkgs/by-name/po/pokerth-server/package.nix
+++ b/pkgs/by-name/po/pokerth-server/package.nix
@@ -1,0 +1,5 @@
+{
+  pokerth,
+}:
+
+pokerth.override { target = "server"; }

--- a/pkgs/by-name/qb/qbittorrent-enhanced-nox/package.nix
+++ b/pkgs/by-name/qb/qbittorrent-enhanced-nox/package.nix
@@ -1,0 +1,5 @@
+{
+  qbittorrent-enhanced,
+}:
+
+qbittorrent-enhanced.override { guiSupport = false; }

--- a/pkgs/by-name/qb/qbittorrent-nox/package.nix
+++ b/pkgs/by-name/qb/qbittorrent-nox/package.nix
@@ -1,0 +1,5 @@
+{
+  qbittorrent,
+}:
+
+qbittorrent.override { guiSupport = false; }

--- a/pkgs/by-name/qm/qmplay2-qt5/package.nix
+++ b/pkgs/by-name/qm/qmplay2-qt5/package.nix
@@ -1,0 +1,5 @@
+{
+  qmplay2,
+}:
+
+qmplay2.override { qtVersion = "5"; }

--- a/pkgs/by-name/qm/qmplay2-qt6/package.nix
+++ b/pkgs/by-name/qm/qmplay2-qt6/package.nix
@@ -1,0 +1,5 @@
+{
+  qmplay2,
+}:
+
+qmplay2.override { qtVersion = "6"; }

--- a/pkgs/by-name/ra/raxml-mpi/package.nix
+++ b/pkgs/by-name/ra/raxml-mpi/package.nix
@@ -1,0 +1,5 @@
+{
+  raxml,
+}:
+
+raxml.override { useMpi = true; }

--- a/pkgs/by-name/re/recoll-nox/package.nix
+++ b/pkgs/by-name/re/recoll-nox/package.nix
@@ -1,0 +1,5 @@
+{
+  recoll,
+}:
+
+recoll.override { withGui = false; }

--- a/pkgs/by-name/rs/rstudio-server/package.nix
+++ b/pkgs/by-name/rs/rstudio-server/package.nix
@@ -1,0 +1,5 @@
+{
+  rstudio,
+}:
+
+rstudio.override { server = true; }

--- a/pkgs/by-name/rs/rstudioServerWrapper/package.nix
+++ b/pkgs/by-name/rs/rstudioServerWrapper/package.nix
@@ -1,0 +1,6 @@
+{
+  rstudioWrapper,
+  rstudio-server,
+}:
+
+rstudioWrapper.override { rstudio = rstudio-server; }

--- a/pkgs/by-name/ru/rust-jemalloc-sys-unprefixed/package.nix
+++ b/pkgs/by-name/ru/rust-jemalloc-sys-unprefixed/package.nix
@@ -1,0 +1,5 @@
+{
+  rust-jemalloc-sys,
+}:
+
+rust-jemalloc-sys.override { unprefixed = true; }

--- a/pkgs/by-name/ru/rusty-psn-gui/package.nix
+++ b/pkgs/by-name/ru/rusty-psn-gui/package.nix
@@ -1,0 +1,5 @@
+{
+  rusty-psn,
+}:
+
+rusty-psn.override { withGui = true; }

--- a/pkgs/by-name/se/seabios-coreboot/package.nix
+++ b/pkgs/by-name/se/seabios-coreboot/package.nix
@@ -1,0 +1,5 @@
+{
+  seabios,
+}:
+
+seabios.override { ___build-type = "coreboot"; }

--- a/pkgs/by-name/se/seabios-csm/package.nix
+++ b/pkgs/by-name/se/seabios-csm/package.nix
@@ -1,0 +1,5 @@
+{
+  seabios,
+}:
+
+seabios.override { ___build-type = "csm"; }

--- a/pkgs/by-name/se/seabios-qemu/package.nix
+++ b/pkgs/by-name/se/seabios-qemu/package.nix
@@ -1,0 +1,5 @@
+{
+  seabios,
+}:
+
+seabios.override { ___build-type = "qemu"; }

--- a/pkgs/by-name/st/strongswanNM/package.nix
+++ b/pkgs/by-name/st/strongswanNM/package.nix
@@ -1,0 +1,5 @@
+{
+  strongswan,
+}:
+
+strongswan.override { enableNetworkManager = true; }

--- a/pkgs/by-name/st/strongswanTNC/package.nix
+++ b/pkgs/by-name/st/strongswanTNC/package.nix
@@ -1,0 +1,5 @@
+{
+  strongswan,
+}:
+
+strongswan.override { enableTNC = true; }

--- a/pkgs/by-name/st/strongswanTPM/package.nix
+++ b/pkgs/by-name/st/strongswanTPM/package.nix
@@ -1,0 +1,5 @@
+{
+  strongswan,
+}:
+
+strongswan.override { enableTPM2 = true; }

--- a/pkgs/by-name/su/supercollider_scel/package.nix
+++ b/pkgs/by-name/su/supercollider_scel/package.nix
@@ -1,0 +1,5 @@
+{
+  supercollider,
+}:
+
+supercollider.override { useSCEL = true; }

--- a/pkgs/by-name/sw/swi-prolog-gui/package.nix
+++ b/pkgs/by-name/sw/swi-prolog-gui/package.nix
@@ -1,0 +1,5 @@
+{
+  swi-prolog,
+}:
+
+swi-prolog.override { withGui = true; }

--- a/pkgs/by-name/sy/synergyWithoutGUI/package.nix
+++ b/pkgs/by-name/sy/synergyWithoutGUI/package.nix
@@ -1,0 +1,5 @@
+{
+  synergy,
+}:
+
+synergy.override { withGUI = false; }

--- a/pkgs/by-name/te/teeworlds-server/package.nix
+++ b/pkgs/by-name/te/teeworlds-server/package.nix
@@ -1,0 +1,5 @@
+{
+  teeworlds,
+}:
+
+teeworlds.override { buildClient = false; }

--- a/pkgs/by-name/te/testdisk-qt/package.nix
+++ b/pkgs/by-name/te/testdisk-qt/package.nix
@@ -1,0 +1,5 @@
+{
+  testdisk,
+}:
+
+testdisk.override { enableQt = true; }

--- a/pkgs/by-name/te/texinfoInteractive/package.nix
+++ b/pkgs/by-name/te/texinfoInteractive/package.nix
@@ -1,0 +1,5 @@
+{
+  texinfo,
+}:
+
+texinfo.override { interactive = true; }

--- a/pkgs/by-name/tr/trackma-curses/package.nix
+++ b/pkgs/by-name/tr/trackma-curses/package.nix
@@ -1,0 +1,5 @@
+{
+  trackma,
+}:
+
+trackma.override { withCurses = true; }

--- a/pkgs/by-name/tr/trackma-gtk/package.nix
+++ b/pkgs/by-name/tr/trackma-gtk/package.nix
@@ -1,0 +1,5 @@
+{
+  trackma,
+}:
+
+trackma.override { withGTK = true; }

--- a/pkgs/by-name/tr/trackma-qt/package.nix
+++ b/pkgs/by-name/tr/trackma-qt/package.nix
@@ -1,0 +1,5 @@
+{
+  trackma,
+}:
+
+trackma.override { withQT = true; }

--- a/pkgs/by-name/tr/trilinos-mpi/package.nix
+++ b/pkgs/by-name/tr/trilinos-mpi/package.nix
@@ -1,0 +1,5 @@
+{
+  trilinos,
+}:
+
+trilinos.override { withMPI = true; }

--- a/pkgs/by-name/tr/truecrack-cuda/package.nix
+++ b/pkgs/by-name/tr/truecrack-cuda/package.nix
@@ -1,0 +1,5 @@
+{
+  truecrack,
+}:
+
+truecrack.override { cudaSupport = true; }

--- a/pkgs/by-name/tt/ttfautohint-nox/package.nix
+++ b/pkgs/by-name/tt/ttfautohint-nox/package.nix
@@ -1,0 +1,5 @@
+{
+  ttfautohint,
+}:
+
+ttfautohint.override { enableGUI = false; }

--- a/pkgs/by-name/uu/uutils-coreutils-noprefix/package.nix
+++ b/pkgs/by-name/uu/uutils-coreutils-noprefix/package.nix
@@ -1,0 +1,5 @@
+{
+  uutils-coreutils,
+}:
+
+uutils-coreutils.override { prefix = null; }

--- a/pkgs/by-name/va/vanillara/package.nix
+++ b/pkgs/by-name/va/vanillara/package.nix
@@ -1,0 +1,5 @@
+{
+  vanillatd,
+}:
+
+vanillatd.override { appName = "vanillara"; }

--- a/pkgs/by-name/va/vaultwarden-mysql/package.nix
+++ b/pkgs/by-name/va/vaultwarden-mysql/package.nix
@@ -1,0 +1,5 @@
+{
+  vaultwarden,
+}:
+
+vaultwarden.override { dbBackend = "mysql"; }

--- a/pkgs/by-name/va/vaultwarden-postgresql/package.nix
+++ b/pkgs/by-name/va/vaultwarden-postgresql/package.nix
@@ -1,0 +1,5 @@
+{
+  vaultwarden,
+}:
+
+vaultwarden.override { dbBackend = "postgresql"; }

--- a/pkgs/by-name/vc/vcpkg-tool-unwrapped/package.nix
+++ b/pkgs/by-name/vc/vcpkg-tool-unwrapped/package.nix
@@ -1,0 +1,5 @@
+{
+  vcpkg-tool,
+}:
+
+vcpkg-tool.override { doWrap = false; }

--- a/pkgs/by-name/vl/vlc-bin-universal/package.nix
+++ b/pkgs/by-name/vl/vlc-bin-universal/package.nix
@@ -1,0 +1,5 @@
+{
+  vlc-bin,
+}:
+
+vlc-bin.override { variant = "universal"; }

--- a/pkgs/by-name/vt/vtkWithQt6/package.nix
+++ b/pkgs/by-name/vt/vtkWithQt6/package.nix
@@ -1,0 +1,5 @@
+{
+  vtk,
+}:
+
+vtk.override { withQt6 = true; }

--- a/pkgs/by-name/wa/waydroid-nftables/package.nix
+++ b/pkgs/by-name/wa/waydroid-nftables/package.nix
@@ -1,0 +1,5 @@
+{
+  waydroid,
+}:
+
+waydroid.override { withNftables = true; }

--- a/pkgs/by-name/wi/wireshark-cli/package.nix
+++ b/pkgs/by-name/wi/wireshark-cli/package.nix
@@ -1,0 +1,5 @@
+{
+  wireshark,
+}:
+
+wireshark.override { withQt = false; }

--- a/pkgs/by-name/xg/xgboostWithCuda/package.nix
+++ b/pkgs/by-name/xg/xgboostWithCuda/package.nix
@@ -1,0 +1,5 @@
+{
+  xgboost,
+}:
+
+xgboost.override { cudaSupport = true; }

--- a/pkgs/by-name/ya/yarn-berry_3/package.nix
+++ b/pkgs/by-name/ya/yarn-berry_3/package.nix
@@ -1,0 +1,5 @@
+{
+  yarn-berry,
+}:
+
+yarn-berry.override { berryVersion = 3; }

--- a/pkgs/by-name/ya/yarn-berry_4/package.nix
+++ b/pkgs/by-name/ya/yarn-berry_4/package.nix
@@ -1,0 +1,5 @@
+{
+  yarn-berry,
+}:
+
+yarn-berry.override { berryVersion = 4; }

--- a/pkgs/by-name/za/zap-chip-gui/package.nix
+++ b/pkgs/by-name/za/zap-chip-gui/package.nix
@@ -1,0 +1,5 @@
+{
+  zap-chip,
+}:
+
+zap-chip.override { withGui = true; }

--- a/pkgs/by-name/ze/zeroc-ice-cpp11/package.nix
+++ b/pkgs/by-name/ze/zeroc-ice-cpp11/package.nix
@@ -1,0 +1,5 @@
+{
+  zeroc-ice,
+}:
+
+zeroc-ice.override { cpp11 = true; }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -298,8 +298,6 @@ with pkgs;
 
   appimageTools = callPackage ../build-support/appimage { };
 
-  appimageupdate-qt = appimageupdate.override { withQtUI = true; };
-
   stripJavaArchivesHook = makeSetupHook {
     name = "strip-java-archives-hook";
     propagatedBuildInputs = [ strip-nondeterminism ];
@@ -369,10 +367,6 @@ with pkgs;
 
   buildLakePackage = callPackage ../build-support/lake { };
 
-  cameractrls-gtk4 = cameractrls.override { withGtk = 4; };
-
-  cameractrls-gtk3 = cameractrls.override { withGtk = 3; };
-
   cgal_5 = callPackage ../by-name/cg/cgal/5.nix { };
 
   checkpointBuildTools = callPackage ../build-support/checkpoint-build.nix { };
@@ -408,8 +402,6 @@ with pkgs;
   dnf4 = python3Packages.callPackage ../development/python-modules/dnf4/wrapper.nix { };
 
   inherit (gridlock) nyarr;
-
-  lshw-gui = lshw.override { withGUI = true; };
 
   kdePackages = callPackage ../kde { };
 
@@ -815,7 +807,6 @@ with pkgs;
   mkBinaryCache = callPackage ../build-support/binary-cache { };
 
   mkShell = callPackage ../build-support/mkshell { };
-  mkShellNoCC = mkShell.override { stdenv = stdenvNoCC; };
 
   nixBufferBuilders = import ../applications/editors/emacs/build-support/buffer.nix {
     inherit lib writeText;
@@ -1031,13 +1022,9 @@ with pkgs;
 
   ### TOOLS
 
-  _7zz-rar = _7zz.override { enableUnfree = true; };
-
   acquire = with python3Packages; toPythonApplication acquire;
 
   actdiag = with python3.pkgs; toPythonApplication actdiag;
-
-  opnplug = adlplug.override { type = "OPN"; };
 
   aflplusplus = callPackage ../tools/security/aflplusplus { wine = null; };
 
@@ -1049,9 +1036,6 @@ with pkgs;
     akku
     akkuPackages
     ;
-
-  alice-tools-qt5 = alice-tools.override { withQt5 = true; };
-  alice-tools-qt6 = alice-tools.override { withQt6 = true; };
 
   auditwheel = with python3Packages; toPythonApplication auditwheel;
 
@@ -1076,18 +1060,10 @@ with pkgs;
     crate = "api";
   };
 
-  htop-vim = htop.override { withVimKeys = true; };
-
   inherit (callPackages ../tools/networking/iroh/default.nix { })
     iroh-relay
     iroh-dns-server
     ;
-
-  kanata-with-cmd = kanata.override { withCmd = true; };
-
-  linux-router-without-wifi = linux-router.override { useWifiDependencies = false; };
-
-  mkosi-full = mkosi.override { withQemu = true; };
 
   openbugs = pkgsi686Linux.callPackage ../applications/science/machine-learning/openbugs { };
 
@@ -1122,8 +1098,6 @@ with pkgs;
   };
 
   vprof = with python3Packages; toPythonApplication vprof;
-
-  waydroid-nftables = waydroid.override { withNftables = true; };
 
   winbox = winbox4;
 
@@ -1231,9 +1205,6 @@ with pkgs;
       pkgsCross.riscv32.callPackage ../applications/emulators/box86 args
     else
       throw "Don't know 32-bit platform for cross from: ${stdenv.hostPlatform.stdenv}";
-
-  fceux-qt5 = fceux.override { ___qtVersion = "5"; };
-  fceux-qt6 = fceux.override { ___qtVersion = "6"; };
 
   kega-fusion = pkgsi686Linux.callPackage ../applications/emulators/kega-fusion { };
 
@@ -1367,10 +1338,6 @@ with pkgs;
     };
   };
 
-  arduino = arduino-core.override { withGui = true; };
-
-  arpack-mpi = arpack.override { useMpi = true; };
-
   authentik-outposts = recurseIntoAttrs (callPackages ../by-name/au/authentik/outposts.nix { });
 
   autoflake = with python3.pkgs; toPythonApplication autoflake;
@@ -1394,8 +1361,6 @@ with pkgs;
       callPackage ../stdenv/freebsd/make-bootstrap-tools.nix { }
     else
       throw "freshBootstrapTools: unknown hostPlatform ${stdenv.hostPlatform.config}";
-
-  crystfel-headless = crystfel.override { withGui = false; };
 
   inherit (callPackages ../tools/security/bitwarden-directory-connector { })
     bitwarden-directory-connector-cli
@@ -1440,8 +1405,6 @@ with pkgs;
 
   foxdot = with python3Packages; toPythonApplication foxdot;
 
-  fluffychat-web = fluffychat.override { targetFlutterPlatform = "web"; };
-
   gams = callPackage ../tools/misc/gams (config.gams or { });
 
   gancioPlugins = recurseIntoAttrs (callPackage ../by-name/ga/gancio/plugins.nix { });
@@ -1451,8 +1414,6 @@ with pkgs;
   gistyc = with python3Packages; toPythonApplication gistyc;
 
   glm_1_0_1 = callPackage ../by-name/gl/glm/1_0_1.nix { };
-
-  go2tv-lite = go2tv.override { withGui = false; };
 
   hinit = haskell.lib.compose.justStaticExecutables haskellPackages.hinit;
 
@@ -1533,11 +1494,6 @@ with pkgs;
   behave = with python3Packages; toPythonApplication behave;
 
   blockdiag = with python3Packages; toPythonApplication blockdiag;
-
-  bogofilter-sqlite = bogofilter.override { database = sqlite; };
-  bogofilter-db = bogofilter.override { database = db; };
-
-  bozohttpd-minimal = bozohttpd.override { minimal = true; };
 
   cabal2nix-unwrapped = haskell.lib.compose.justStaticExecutables (
     haskellPackages.generateOptparseApplicativeCompletions [ "cabal2nix" ] haskellPackages.cabal2nix
@@ -1659,8 +1615,6 @@ with pkgs;
     ocamlPackages = ocaml-ng.ocamlPackages_4_14;
   };
 
-  dblatexFull = dblatex.override { enableAllFeatures = true; };
-
   latex2mathml = with python3Packages; toPythonApplication latex2mathml;
 
   pgf = pgf2;
@@ -1767,10 +1721,6 @@ with pkgs;
 
   nltk-data = recurseIntoAttrs (callPackage ../tools/text/nltk-data { });
 
-  seabios-coreboot = seabios.override { ___build-type = "coreboot"; };
-  seabios-csm = seabios.override { ___build-type = "csm"; };
-  seabios-qemu = seabios.override { ___build-type = "qemu"; };
-
   seaborn-data = callPackage ../tools/misc/seaborn-data { };
 
   nodepy-runtime = with python3.pkgs; toPythonApplication nodepy-runtime;
@@ -1837,8 +1787,6 @@ with pkgs;
 
   bzip2 = callPackage ../tools/compression/bzip2 { };
 
-  davix-copy = davix.override { enableThirdPartyCopy = true; };
-
   libceph = ceph.lib;
   ceph-client = ceph.client;
   ceph-dev = ceph;
@@ -1848,8 +1796,6 @@ with pkgs;
     citrix_workspace_25_08_10
     ;
   citrix_workspace = citrix_workspace_26_01_0;
-
-  colord-gtk4 = colord-gtk.override { withGtk4 = true; };
 
   connmanFull = connman.override {
     # TODO: Why is this in `connmanFull` and not the default build? See TODO in
@@ -2065,8 +2011,6 @@ with pkgs;
 
   uusi = haskell.lib.compose.justStaticExecutables haskellPackages.uusi;
 
-  uutils-coreutils-noprefix = uutils-coreutils.override { prefix = null; };
-
   xkcdpass = with python3Packages; toPythonApplication xkcdpass;
 
   zonemaster-cli = perlPackages.ZonemasterCLI;
@@ -2155,8 +2099,6 @@ with pkgs;
     extensions = gawkextlib.full;
   };
   gawkextlib = callPackage ../tools/text/gawk/gawkextlib.nix { };
-
-  gawkInteractive = gawk.override { interactive = true; };
 
   gibberish-detector = with python3Packages; toPythonApplication gibberish-detector;
 
@@ -2256,8 +2198,6 @@ with pkgs;
 
   google-compute-engine = with python3.pkgs; toPythonApplication google-compute-engine;
 
-  gparted-full = gparted.override { withAllTools = true; };
-
   gdown = with python3Packages; toPythonApplication gdown;
 
   gpt4all-cuda = gpt4all.override {
@@ -2314,10 +2254,6 @@ with pkgs;
     mpiSupport = true;
     cppSupport = false;
   };
-
-  hdf5-cpp = hdf5.override { cppSupport = true; };
-
-  hdf5-fortran = hdf5.override { fortranSupport = true; };
 
   hdf5-fortran-mpi = hdf5.override {
     fortranSupport = true;
@@ -2451,8 +2387,6 @@ with pkgs;
     inherit (darwin) sigtool;
   };
 
-  limine-full = limine.override { enableAll = true; };
-
   logstash7 = callPackage ../tools/misc/logstash/7.x.nix {
     # https://www.elastic.co/support/matrix#logstash-and-jvm
     jre = jdk11_headless;
@@ -2465,8 +2399,6 @@ with pkgs;
   logstash = logstash7;
 
   logstash-contrib = callPackage ../tools/misc/logstash/contrib.nix { };
-
-  lagrange-tui = lagrange.override { enableTUI = true; };
 
   kzipmix = pkgsi686Linux.callPackage ../tools/compression/kzipmix { };
 
@@ -2606,11 +2538,6 @@ with pkgs;
     eri3PureSh = false;
   };
 
-  libportal-gtk3 = libportal.override { variant = "gtk3"; };
-  libportal-gtk4 = libportal.override { variant = "gtk4"; };
-  libportal-qt5 = libportal.override { variant = "qt5"; };
-  libportal-qt6 = libportal.override { variant = "qt6"; };
-
   licensee = callPackage ../tools/package-management/licensee { };
 
   linux-gpib = callPackage ../applications/science/electronics/linux-gpib/user.nix { };
@@ -2626,8 +2553,6 @@ with pkgs;
   marimo = with python3Packages; toPythonApplication marimo;
 
   mcstatus = with python3Packages; toPythonApplication mcstatus;
-
-  miniupnpd-nftables = miniupnpd.override { firewall = "nftables"; };
 
   mir-qualia = callPackage ../tools/text/mir-qualia {
     pythonPackages = python3Packages;
@@ -2648,8 +2573,6 @@ with pkgs;
   };
 
   metasploit = callPackage ../tools/security/metasploit { };
-
-  mtr-gui = mtr.override { withGtk = true; };
 
   multitran = recurseIntoAttrs (
     let
@@ -2696,8 +2619,6 @@ with pkgs;
     };
   });
 
-  libnma-gtk4 = libnma.override { withGtk4 = true; };
-
   inherit (callPackages ../servers/nextcloud { })
     nextcloud32
     nextcloud33
@@ -2740,8 +2661,6 @@ with pkgs;
   nwdiag = with python3Packages; toPythonApplication nwdiag;
 
   ome_zarr = with python3Packages; toPythonApplication ome-zarr;
-
-  ophcrack-cli = ophcrack.override { enableGui = false; };
 
   open-interpreter = with python3Packages; toPythonApplication open-interpreter;
 
@@ -2855,8 +2774,6 @@ with pkgs;
 
   pdfminer = with python3Packages; toPythonApplication pdfminer-six;
 
-  pdfium-binaries-v8 = pdfium-binaries.override { withV8 = true; };
-
   pdsh = callPackage ../tools/networking/pdsh {
     rsh = true; # enable internal rsh implementation
     ssh = openssh;
@@ -2957,8 +2874,6 @@ with pkgs;
     opensslSupport = false;
   };
 
-  recoll-nox = recoll.override { withGui = false; };
-
   reptor = with python3.pkgs; toPythonApplication reptor;
 
   inherit (callPackage ../development/misc/resholve { })
@@ -3041,10 +2956,6 @@ with pkgs;
 
   stutter = haskell.lib.compose.justStaticExecutables haskellPackages.stutter;
 
-  strongswanTNC = strongswan.override { enableTNC = true; };
-  strongswanTPM = strongswan.override { enableTPM2 = true; };
-  strongswanNM = strongswan.override { enableNetworkManager = true; };
-
   stylish-haskell = haskell.lib.compose.justStaticExecutables haskellPackages.stylish-haskell;
 
   su = shadow.su;
@@ -3081,12 +2992,6 @@ with pkgs;
     withPlymouth = true;
   };
 
-  trackma-curses = trackma.override { withCurses = true; };
-
-  trackma-gtk = trackma.override { withGTK = true; };
-
-  trackma-qt = trackma.override { withQT = true; };
-
   trezorctl =
     with python3Packages;
     toPythonApplication (
@@ -3104,8 +3009,6 @@ with pkgs;
   translatepy = with python3.pkgs; toPythonApplication translatepy;
 
   trytond = with python3Packages; toPythonApplication trytond;
-
-  ttfautohint-nox = ttfautohint.override { enableGUI = false; };
 
   uftraceFull = uftrace.override {
     withLuaJIT = true;
@@ -3138,11 +3041,7 @@ with pkgs;
 
   testdisk = libsForQt5.callPackage ../tools/system/testdisk { };
 
-  testdisk-qt = testdisk.override { enableQt = true; };
-
   tweet-hs = haskell.lib.compose.justStaticExecutables haskellPackages.tweet-hs;
-
-  truecrack-cuda = truecrack.override { cudaSupport = true; };
 
   unbound-with-systemd = unbound.override {
     withSystemd = true;
@@ -3207,11 +3106,9 @@ with pkgs;
 
   yapf = with python3Packages; toPythonApplication yapf;
 
-  yarn-berry_4 = yarn-berry.override { berryVersion = 4; };
   yarn-berry_4-fetcher = callPackage ../by-name/ya/yarn-berry/fetcher {
     yarn-berry = yarn-berry_4;
   };
-  yarn-berry_3 = yarn-berry.override { berryVersion = 3; };
   yarn-berry_3-fetcher = callPackage ../by-name/ya/yarn-berry/fetcher {
     yarn-berry = yarn-berry_3;
   };
@@ -3291,9 +3188,6 @@ with pkgs;
   semeru-bin = semeru-bin-21;
   semeru-jre-bin = semeru-jre-bin-21;
 
-  adaptivecppWithCuda = adaptivecpp.override { cudaSupport = true; };
-  adaptivecppWithRocm = adaptivecpp.override { rocmSupport = true; };
-
   binaryen = callPackage ../development/compilers/binaryen {
     nodejs = nodejs-slim;
     inherit (python3Packages) filecheck;
@@ -3302,11 +3196,6 @@ with pkgs;
   codon = callPackage ../development/compilers/codon {
     inherit (llvmPackages) lld stdenv;
   };
-
-  colmapWithCuda = colmap.override { cudaSupport = true; };
-
-  opensplatWithRocm = opensplat.override { rocmSupport = true; };
-  opensplatWithCuda = opensplat.override { cudaSupport = true; };
 
   chickenPackages_4 = recurseIntoAttrs (callPackage ../development/compilers/chicken/4 { });
   chickenPackages_5 = recurseIntoAttrs (callPackage ../development/compilers/chicken/5 { });
@@ -3788,12 +3677,6 @@ with pkgs;
       meta.broken = stdenv.hostPlatform.isDarwin;
     }
   );
-
-  ghdl-mcode = ghdl.override { backend = "mcode"; };
-
-  ghdl-gcc = ghdl.override { backend = "gcc"; };
-
-  ghdl-llvm = ghdl.override { backend = "llvm"; };
 
   gcc-arm-embedded = gcc-arm-embedded-15;
 
@@ -4335,8 +4218,6 @@ with pkgs;
     swiftpm2nix
     ;
 
-  swi-prolog-gui = swi-prolog.override { withGui = true; };
-
   teyjus = callPackage ../development/compilers/teyjus {
     inherit (ocaml-ng.ocamlPackages_4_14) buildDunePackage;
     stdenv = gcc14Stdenv;
@@ -4451,8 +4332,6 @@ with pkgs;
   zulu = zulu21;
 
   ### DEVELOPMENT / INTERPRETERS
-
-  acl2-minimal = acl2.override { certifyBooks = false; };
 
   uiua-unstable = callPackage ../by-name/ui/uiua/package.nix { uiua_versionType = "unstable"; };
 
@@ -4857,8 +4736,6 @@ with pkgs;
     fftw = fftwSinglePrec;
   };
 
-  supercollider_scel = supercollider.override { useSCEL = true; };
-
   supercolliderPlugins = recurseIntoAttrs {
     sc3-plugins = callPackage ../development/interpreters/supercollider/plugins/sc3-plugins.nix {
       fftw = fftwSinglePrec;
@@ -4979,8 +4856,6 @@ with pkgs;
     ;
 
   apacheKafka = apacheKafka_4_2;
-
-  libastyle = astyle.override { asLibrary = true; };
 
   aws-adfs = with python3Packages; toPythonApplication aws-adfs;
 
@@ -5566,7 +5441,6 @@ with pkgs;
     texinfo7
     ;
   texinfo = texinfo7;
-  texinfoInteractive = texinfo.override { interactive = true; };
 
   tflint-plugins = recurseIntoAttrs (callPackage ../development/tools/analysis/tflint-plugins { });
 
@@ -5577,15 +5451,11 @@ with pkgs;
     enablePythonApi = false;
   };
 
-  gdbHostCpuOnly = gdb.override { hostCpuOnly = true; };
-
   valgrind-light = (valgrind.override { gdb = null; }).overrideAttrs (oldAttrs: {
     meta = oldAttrs.meta // {
       description = "${oldAttrs.meta.description} (without GDB)";
     };
   });
-
-  vcpkg-tool-unwrapped = vcpkg-tool.override { doWrap = false; };
 
   wild =
     let
@@ -5688,8 +5558,6 @@ with pkgs;
 
   boost = boost189;
 
-  botanEsdm = botan3.override { withEsdm = true; };
-
   c-aresMinimal = callPackage ../by-name/c-/c-ares/package.nix { withCMake = false; };
 
   niv = lib.getBin (haskell.lib.compose.justStaticExecutables haskellPackages.niv);
@@ -5791,15 +5659,12 @@ with pkgs;
     ffmpeg-full
     ;
 
-  fftwSinglePrec = fftw.override { precision = "single"; };
   fftwFloat = fftwSinglePrec; # the configure option is just an alias
-  fftwLongDouble = fftw.override { precision = "long-double"; };
   # Need gcc >= 4.6.0 to build with FFTW with quad precision, but Darwin defaults to Clang
   fftwQuad = fftw.override {
     precision = "quad-precision";
     stdenv = gccStdenv;
   };
-  fftwMpi = fftw.override { enableMpi = true; };
 
   fltk_1_3-minimal = fltk_1_3.override {
     withGL = false;
@@ -5833,8 +5698,6 @@ with pkgs;
   makeFontsCache = callPackage ../development/libraries/fontconfig/make-fonts-cache.nix { };
 
   gamt = callPackage ../by-name/am/amtterm/package.nix { withGamt = true; };
-
-  geoclue2-with-demo-agent = geoclue2.override { withDemoAgent = true; };
 
   geoipWithDatabase = makeOverridable (callPackage ../by-name/ge/geoip/package.nix) {
     drvName = "geoip-tools";
@@ -5871,8 +5734,6 @@ with pkgs;
         stdenv = gccStdenv; # doesn't compile without gcc
       }
   );
-
-  jsoncppSecureMemory = jsoncpp.override { secureMemory = true; };
 
   mtrace = callPackage ../development/libraries/glibc/mtrace.nix { };
 
@@ -5997,7 +5858,6 @@ with pkgs;
 
   gmp6 = callPackage ../development/libraries/gmp/6.x.nix { };
   gmp = gmp6;
-  gmpxx = gmp.override { cxx = true; };
 
   #GMP ex-satellite, so better keep it near gmp
   # A GMP fork
@@ -6062,8 +5922,6 @@ with pkgs;
     withGraphite2 = true;
     withIcu = true;
   };
-
-  highfive-mpi = highfive.override { hdf5 = hdf5-mpi; };
 
   hunspellDicts = recurseIntoAttrs (callPackages ../by-name/hu/hunspell/dictionaries.nix { });
 
@@ -6145,8 +6003,6 @@ with pkgs;
 
   itk = itk_5;
 
-  rust-jemalloc-sys-unprefixed = rust-jemalloc-sys.override { unprefixed = true; };
-
   json2yaml = haskell.lib.compose.justStaticExecutables haskellPackages.json2yaml;
 
   libkrb5 = krb5; # TODO(de11n) Try to make krb5 reuse libkrb5 as a dependency
@@ -6156,9 +6012,6 @@ with pkgs;
   };
 
   lcms = lcms2;
-
-  libappindicator-gtk2 = libappindicator.override { gtkVersion = "2"; };
-  libappindicator-gtk3 = libappindicator.override { gtkVersion = "3"; };
 
   libbass = (callPackage ../development/libraries/audio/libbass { }).bass;
   libbass_fx = (callPackage ../development/libraries/audio/libbass { }).bass_fx;
@@ -6187,9 +6040,6 @@ with pkgs;
     withSqlite = false;
   };
 
-  libdbusmenu-gtk2 = libdbusmenu.override { gtkVersion = "2"; };
-  libdbusmenu-gtk3 = libdbusmenu.override { gtkVersion = "3"; };
-
   dwarfdump = libdwarf.bin;
 
   libfm-extra = libfm.override {
@@ -6207,8 +6057,6 @@ with pkgs;
     genPosixLockObjOnly = true;
   };
 
-  libindicator-gtk2 = libindicator.override { gtkVersion = "2"; };
-  libindicator-gtk3 = libindicator.override { gtkVersion = "3"; };
   inherit (callPackage ../development/libraries/libliftoff { }) libliftoff_0_4 libliftoff_0_5;
   libliftoff = libliftoff_0_5;
 
@@ -6281,7 +6129,6 @@ with pkgs;
 
   # also known as libturbojpeg
   libjpeg = libjpeg_turbo;
-  libjpeg8 = libjpeg_turbo.override { enableJpeg8 = true; };
 
   malcontent = callPackage ../development/libraries/malcontent { };
 
@@ -6316,8 +6163,6 @@ with pkgs;
 
   libtorrent-rasterbar = libtorrent-rasterbar-2_0_x;
 
-  libubox-nossl = libubox.override { with_ustream_ssl = false; };
-
   libubox = callPackage ../development/libraries/libubox { with_ustream_ssl = true; };
 
   libubox-mbedtls = libubox.override {
@@ -6350,7 +6195,6 @@ with pkgs;
   );
 
   libva-minimal = callPackage ../development/libraries/libva { minimal = true; };
-  libva = libva-minimal.override { minimal = false; };
   libva-utils = callPackage ../development/libraries/libva/utils.nix { };
 
   libwnck = callPackage ../development/libraries/libwnck { };
@@ -6367,7 +6211,6 @@ with pkgs;
       fetchurl = stdenv.fetchurlBoot;
     };
   };
-  libxcrypt-legacy = libxcrypt.override { enableHashes = "all"; };
 
   libxkbcommon = libxkbcommon_8;
 
@@ -6412,8 +6255,6 @@ with pkgs;
   };
 
   luabind = callPackage ../development/libraries/luabind { lua = lua5_1; };
-
-  luabind_luajit = luabind.override { lua = luajit; };
 
   luksmeta = callPackage ../development/libraries/luksmeta {
     asciidoc = asciidoc-full;
@@ -6551,11 +6392,6 @@ with pkgs;
       _: dicts
     );
 
-  nv-codec-headers-9 = nv-codec-headers.override { majorVersion = "9"; };
-  nv-codec-headers-10 = nv-codec-headers.override { majorVersion = "10"; };
-  nv-codec-headers-11 = nv-codec-headers.override { majorVersion = "11"; };
-  nv-codec-headers-12 = nv-codec-headers.override { majorVersion = "12"; };
-
   nvidiaCtkPackages = recurseIntoAttrs (
     callPackage ../by-name/nv/nvidia-container-toolkit/packages.nix { }
   );
@@ -6667,7 +6503,6 @@ with pkgs;
     ;
 
   # pcre32 seems unused
-  pcre-cpp = pcre.override { variant = "cpp"; };
 
   pcre2 = callPackage ../development/libraries/pcre2 { };
 
@@ -7022,8 +6857,6 @@ with pkgs;
     pythonSupport = true;
   };
 
-  vtkWithQt6 = vtk.override { withQt6 = true; };
-
   wayland = callPackage ../development/libraries/wayland { };
   wayland-scanner = callPackage ../development/libraries/wayland/scanner.nix { };
 
@@ -7057,8 +6890,6 @@ with pkgs;
   xapian-omega = callPackage ../development/libraries/xapian/tools/omega {
     libmagic = file;
   };
-
-  xgboostWithCuda = xgboost.override { cudaSupport = true; };
 
   zlib = callPackage ../development/libraries/zlib {
     stdenv =
@@ -7096,8 +6927,6 @@ with pkgs;
 
   # This should be kept updated to ensure the default zls version matches the default zig version.
   zls = zls_0_16;
-
-  libzint = zint-qt.override { withGUI = false; };
 
   aroccPackages = recurseIntoAttrs (callPackage ../development/compilers/arocc { });
   arocc = aroccPackages.latest;
@@ -7398,8 +7227,6 @@ with pkgs;
     packages = [ ];
   };
 
-  rstudioServerWrapper = rstudioWrapper.override { rstudio = rstudio-server; };
-
   rPackages =
     recurseIntoAttrsWith
       {
@@ -7576,8 +7403,6 @@ with pkgs;
     theme-spring = callPackage ../servers/icingaweb2/theme-spring { };
   };
 
-  inspircdMinimal = inspircd.override { extraModules = [ ]; };
-
   inherit (callPackages ../servers/http/jetty { })
     jetty_11
     jetty_12
@@ -7738,7 +7563,6 @@ with pkgs;
     mariadb_118
     ;
   mariadb = mariadb_114;
-  mariadb-embedded = mariadb.override { withEmbedded = true; };
 
   mongodb = hiPrio mongodb-7_0;
 
@@ -7985,11 +7809,6 @@ with pkgs;
       fusePackages.fuse_3
   );
 
-  gpm-ncurses = gpm.override { withNcurses = true; };
-
-  btop-cuda = btop.override { cudaSupport = true; };
-  btop-rocm = btop.override { rocmSupport = true; };
-
   ipu6ep-camera-hal = ipu6-camera-hal.override {
     ipuVersion = "ipu6ep";
   };
@@ -8004,11 +7823,6 @@ with pkgs;
   iptables-nftables-compat = iptables;
 
   jool-cli = callPackage ../os-specific/linux/jool/cli.nix { };
-
-  libkrun-sev = libkrun.override { variant = "sev"; };
-  libkrun-tdx = libkrun.override { variant = "tdx"; };
-
-  lklWithFirewall = lkl.override { firewallSupport = true; };
 
   inherit (callPackages ../os-specific/linux/kernel-headers { inherit (pkgsBuildBuild) elf-header; })
     linuxHeaders
@@ -8166,8 +7980,6 @@ with pkgs;
       unixtools.net-tools;
 
   nftables = callPackage ../os-specific/linux/nftables { };
-
-  open-vm-tools-headless = open-vm-tools.override { withX = false; };
 
   pam =
     if stdenv.hostPlatform.isLinux then
@@ -8405,8 +8217,6 @@ with pkgs;
 
   ### DATA
 
-  adwaita-qt6 = adwaita-qt.override { useQt6 = true; };
-
   dejavu_fonts = lowPrio (callPackage ../data/fonts/dejavu-fonts { });
 
   docbook_sgml_dtd_41 = callPackage ../data/sgml+xml/schemas/sgml-dtd/docbook/4.1.nix { };
@@ -8454,9 +8264,6 @@ with pkgs;
   oceanic-theme = callPackage ../data/themes/gtk-theme-framework { theme = "oceanic"; };
 
   spacx-gtk-theme = callPackage ../data/themes/gtk-theme-framework { theme = "spacx"; };
-
-  gruppled-white-cursors = gruppled-black-cursors.override { theme = "white"; };
-  gruppled-white-lite-cursors = gruppled-black-lite-cursors.override { theme = "white"; };
 
   iosevka-comfy = recurseIntoAttrs (callPackages ../data/fonts/iosevka/comfy.nix { });
 
@@ -8616,10 +8423,6 @@ with pkgs;
     protobuf = protobuf_21;
   };
 
-  audacious = audacious-bare.override { withPlugins = true; };
-
-  bambootracker-qt6 = bambootracker.override { withQt6 = true; };
-
   awesome = callPackage ../applications/window-managers/awesome {
     cairo = cairo.override { xcbSupport = true; };
     inherit (texFunctions) fontsConf;
@@ -8676,8 +8479,6 @@ with pkgs;
   cni = callPackage ../applications/networking/cluster/cni { };
   cni-plugins = callPackage ../applications/networking/cluster/cni/plugins.nix { };
 
-  codeblocksFull = codeblocks.override { contribPlugins = true; };
-
   cudatext-qt = callPackage ../applications/editors/cudatext { widgetset = "qt5"; };
   cudatext-gtk = callPackage ../applications/editors/cudatext { widgetset = "gtk2"; };
   cudatext = cudatext-qt;
@@ -8715,15 +8516,12 @@ with pkgs;
 
   djview4 = djview;
 
-  dmenu-rs-enable-plugins = dmenu-rs.override { enablePlugins = true; };
-
   inherit (callPackage ../applications/virtualization/docker { })
     docker_25
     docker_29
     ;
 
   docker = docker_29;
-  docker-client = docker.override { clientOnly = true; };
 
   docker-gc = callPackage ../applications/virtualization/docker/gc.nix { };
   docker-machine-hyperkit =
@@ -8806,8 +8604,6 @@ with pkgs;
         ];
       };
 
-  firewalld-gui = firewalld.override { withGui = true; };
-
   fossil = callPackage ../applications/version-management/fossil {
     sqlite = sqlite.override { enableDeserialize = true; };
   };
@@ -8841,7 +8637,6 @@ with pkgs;
   };
 
   tshark = wireshark-cli;
-  wireshark-cli = wireshark.override { withQt = false; };
 
   buildMozillaMach =
     opts: callPackage (import ../build-support/build-mozilla-mach/default.nix opts) { };
@@ -9014,7 +8809,6 @@ with pkgs;
 
   minari = python3Packages.toPythonApplication python3Packages.minari;
 
-  graphicsmagick_q16 = graphicsmagick.override { quantumdepth = 16; };
   graphicsmagick-imagemagick-compat = graphicsmagick.imagemagick-compat;
 
   gpsbabel-gui = gpsbabel.override {
@@ -9141,8 +8935,6 @@ with pkgs;
     callPackages ../applications/graphics/inkscape/extensions.nix { }
   );
 
-  jackmix_jack1 = jackmix.override { jack = jack1; };
-
   inherit (callPackage ../applications/networking/cluster/k3s { })
     k3s_1_33
     k3s_1_34
@@ -9248,8 +9040,6 @@ with pkgs;
 
   mendeley = callPackage ../applications/office/mendeley { };
 
-  mercurialFull = mercurial.override { fullBuild = true; };
-
   monotone = callPackage ../applications/version-management/monotone {
     lua = lua5;
   };
@@ -9332,8 +9122,6 @@ with pkgs;
   pcmanfm-qt = lxqt.pcmanfm-qt;
 
   pijuice = with python3Packages; toPythonApplication pijuice;
-
-  pinegrow6 = pinegrow.override { pinegrowVersion = "6"; };
 
   pipe-viewer = perlPackages.callPackage ../applications/video/pipe-viewer { };
 
@@ -9447,10 +9235,6 @@ with pkgs;
   puredata-with-plugins =
     plugins: callPackage ../by-name/pu/puredata/wrapper.nix { inherit plugins; };
 
-  qbittorrent-nox = qbittorrent.override { guiSupport = false; };
-
-  qbittorrent-enhanced-nox = qbittorrent-enhanced.override { guiSupport = false; };
-
   qemu-python-utils = python3Packages.toPythonApplication (
     python3Packages.qemu.override {
       fuseSupport = true;
@@ -9468,9 +9252,6 @@ with pkgs;
   };
 
   wrapQemuBinfmtP = callPackage ../by-name/qe/qemu/binfmt-p-wrapper.nix { };
-
-  qmplay2-qt5 = qmplay2.override { qtVersion = "5"; };
-  qmplay2-qt6 = qmplay2.override { qtVersion = "6"; };
 
   quasselClient = quassel.override {
     monolithic = false;
@@ -9544,8 +9325,6 @@ with pkgs;
     backend = "wayland";
   };
 
-  rstudio-server = rstudio.override { server = true; };
-
   foks-server = foks.server;
 
   inherit (callPackages ../applications/radio/rtl-sdr { })
@@ -9555,8 +9334,6 @@ with pkgs;
     ;
 
   rtl-sdr = rtl-sdr-blog;
-
-  rusty-psn-gui = rusty-psn.override { withGui = true; };
 
   scantailor-advanced = callPackage ../applications/graphics/scantailor/advanced.nix { };
 
@@ -9572,8 +9349,6 @@ with pkgs;
   maestral = with python3Packages; toPythonApplication maestral;
 
   myfitnesspal = with python3Packages; toPythonApplication myfitnesspal;
-
-  lightdm_qt = lightdm.override { withQt5 = true; };
 
   curaengine_stable = callPackage ../applications/misc/curaengine/stable.nix { };
 
@@ -9637,8 +9412,6 @@ with pkgs;
   supersonic-wayland = supersonic.override {
     waylandSupport = true;
   };
-
-  synergyWithoutGUI = synergy.override { withGUI = false; };
 
   tabbed = callPackage ../applications/window-managers/tabbed {
     # if you prefer a custom config, write the config.h in tabbed.config.h
@@ -9865,8 +9638,6 @@ with pkgs;
     }
   );
 
-  vlc-bin-universal = vlc-bin.override { variant = "universal"; };
-
   libvlc = vlc.override {
     withQt5 = false;
     onlyLibVLC = true;
@@ -10056,8 +9827,6 @@ with pkgs;
   zathuraPkgs = recurseIntoAttrs (callPackage ../applications/misc/zathura { });
   zathura = zathuraPkgs.zathuraWrapper;
 
-  zeroc-ice-cpp11 = zeroc-ice.override { cpp11 = true; };
-
   zed-editor-fhs = zed-editor.fhs;
 
   zynaddsubfx-fltk = zynaddsubfx.override {
@@ -10085,8 +9854,6 @@ with pkgs;
   elementsd = elements.override {
     withGui = false;
   };
-
-  gridcoin-researchd = gridcoin-research.override { withGui = false; };
 
   groestlcoind = groestlcoin.override {
     withGui = false;
@@ -10130,10 +9897,6 @@ with pkgs;
     fteqcc
     ;
 
-  pmars-x11 = pmars.override { enableXwinGraphics = true; };
-
-  vanillara = vanillatd.override { appName = "vanillara"; };
-
   anki-utils = callPackage ../by-name/an/anki/addons/anki-utils.nix { };
   ankiAddons = recurseIntoAttrs (callPackage ../by-name/an/anki/addons { });
 
@@ -10166,8 +9929,6 @@ with pkgs;
     ncurses = null;
   };
 
-  ddnet-server = ddnet.override { buildClient = false; };
-
   dwarf-fortress-packages = recurseIntoAttrs (callPackage ../games/dwarf-fortress { });
 
   inherit (dwarf-fortress-packages) dwarf-fortress dwarf-fortress-full dwarf-therapist;
@@ -10189,21 +9950,15 @@ with pkgs;
     experimental = true;
   };
 
-  factorio-headless = factorio.override { releaseType = "headless"; };
-
   factorio-headless-experimental = factorio.override {
     releaseType = "headless";
     experimental = true;
   };
 
-  factorio-demo = factorio.override { releaseType = "demo"; };
-
   factorio-demo-experimental = factorio.override {
     releaseType = "demo";
     experimental = true;
   };
-
-  factorio-space-age = factorio.override { releaseType = "expansion"; };
 
   factorio-space-age-experimental = factorio.override {
     releaseType = "expansion";
@@ -10266,9 +10021,6 @@ with pkgs;
 
   minecraftServers = callPackage ../by-name/mi/minecraft-server/versions.nix { };
 
-  luanti-client = luanti.override { buildServer = false; };
-  luanti-server = luanti.override { buildClient = false; };
-
   blightmud-tts = callPackage ../by-name/bl/blightmud/package.nix { withTTS = true; };
 
   run-npush = callPackage ../by-name/np/npush/run.nix { };
@@ -10287,8 +10039,6 @@ with pkgs;
   papermcServers = callPackages ../games/papermc { };
 
   papermc = papermcServers.papermc;
-
-  pokerth-server = pokerth.override { target = "server"; };
 
   inherit (import ../games/quake3 pkgs.callPackage)
     quake3wrapper
@@ -10333,8 +10083,6 @@ with pkgs;
   steam-run-free = steam.run-free;
 
   protonup-ng = with python3Packages; toPythonApplication protonup-ng;
-
-  teeworlds-server = teeworlds.override { buildClient = false; };
 
   tengine = callPackage ../servers/http/tengine {
     modules = with nginxModules; [
@@ -10392,7 +10140,6 @@ with pkgs;
 
   ### DESKTOP ENVIRONMENTS
 
-  arcan-wrapped = arcan.wrapper.override { };
   arcan-all-wrapped = arcan.wrapper.override {
     name = "arcan-all-wrapped";
     appls = [
@@ -10494,8 +10241,6 @@ with pkgs;
 
   ### SCIENCE/CHEMISTY
 
-  libxc_7 = pkgs.libxc.override { version = "7.0.0"; };
-
   molbar = with python3Packages; toPythonApplication molbar;
 
   nwchem = callPackage ../applications/science/chemistry/nwchem {
@@ -10522,10 +10267,6 @@ with pkgs;
     inherit (llvmPackages) openmp;
   };
 
-  nest-mpi = nest.override { withMpi = true; };
-
-  neuron-mpi = neuron.override { useMpi = true; };
-
   neuron-full = neuron-mpi.override {
     useCore = true;
     useRx3d = true;
@@ -10535,17 +10276,11 @@ with pkgs;
     inherit (perlPackages) perl TextFormat;
   };
 
-  raxml-mpi = raxml.override { useMpi = true; };
-
   ### SCIENCE/MACHINE LEARNING
 
   streamlit = with python3Packages; toPythonApplication streamlit;
 
   ### SCIENCE/MATH
-
-  blas-ilp64 = blas.override { isILP64 = true; };
-
-  lapack-ilp64 = lapack.override { isILP64 = true; };
 
   liblapack = lapack-reference;
 
@@ -10557,7 +10292,6 @@ with pkgs;
 
   # A version of OpenBLAS using 32-bit integers on all platforms for compatibility with
   # standard BLAS and LAPACK.
-  openblasCompat = openblas.override { blas64 = false; };
 
   magma-cuda = magma.override {
     cudaSupport = true;
@@ -10586,16 +10320,10 @@ with pkgs;
     cudaSupport = true;
   };
 
-  p4est-sc-dbg = p4est-sc.override { debug = true; };
-
-  p4est-dbg = p4est.override { debug = true; };
-
   scalapack-ilp64 = scalapack.override {
     blas = blas-ilp64;
     lapack = lapack-ilp64;
   };
-
-  trilinos-mpi = trilinos.override { withMPI = true; };
 
   wolfram-for-jupyter-kernel = callPackage ../applications/editors/jupyter-kernels/wolfram { };
 
@@ -10737,10 +10465,6 @@ with pkgs;
     ocaml = ocaml-ng.ocamlPackages_4_14_unsafe_string.ocaml;
   };
 
-  eprover-ho = eprover.override { enableHO = true; };
-
-  giac-with-xcas = giac.override { enableGUI = true; };
-
   glucose-syrup = glucose.override {
     enableUnfree = true;
   };
@@ -10837,8 +10561,6 @@ with pkgs;
 
   ### SCIENCE / MISC
 
-  boinc-headless = boinc.override { headless = true; };
-
   celestia = callPackage ../applications/science/astronomy/celestia {
     inherit (gnome2) gtkglext;
   };
@@ -10915,11 +10637,7 @@ with pkgs;
     inherit (kubernetes-helm-wrapped.passthru) pluginsDir;
   };
 
-  hplipWithPlugin = hplip.override { withPlugin = true; };
-
   hjson = with python3Packages; toPythonApplication hjson;
-
-  libjack2 = jack2.override { prefix = "lib"; };
 
   jack_autoconnect = jack-autoconnect;
 
@@ -11096,7 +10814,6 @@ with pkgs;
   nix-diff = haskell.lib.compose.justStaticExecutables haskellPackages.nix-diff;
 
   nix-info = callPackage ../tools/nix/info { };
-  nix-info-tested = nix-info.override { doCheck = true; };
 
   nix-prefetch-github = with python3Packages; toPythonApplication nix-prefetch-github;
 
@@ -11133,8 +10850,6 @@ with pkgs;
       inherit (python3Packages) supervisor;
     }
   );
-
-  pgadmin4-desktopmode = pgadmin4.override { server-mode = false; };
 
   philipstv = with python3Packages; toPythonApplication philipstv;
 
@@ -11196,8 +10911,6 @@ with pkgs;
   vaultenv = haskell.lib.justStaticExecutables haskellPackages.vaultenv;
 
   vaultwarden-sqlite = vaultwarden;
-  vaultwarden-mysql = vaultwarden.override { dbBackend = "mysql"; };
-  vaultwarden-postgresql = vaultwarden.override { dbBackend = "postgresql"; };
   vaultwarden-webvault = vaultwarden.webvault;
 
   vimUtils = callPackage ../applications/editors/vim/plugins/utils/vim-utils.nix { };
@@ -11249,8 +10962,6 @@ with pkgs;
   );
 
   yamale = with python3Packages; toPythonApplication yamale;
-
-  zap-chip-gui = zap-chip.override { withGui = true; };
 
   myEnvFun = callPackage ../misc/my-env {
     inherit (stdenv) mkDerivation;


### PR DESCRIPTION
Migrate all trivial overrides defined in `all-packages.nix` to by-name. Initially migrated via AI-generated script, which is included below, and then manually looked over for any issues.

<details>
<summary>Migration script</summary>

```
#!/usr/bin/env bash
set -euo pipefail

INPUT="pkgs/top-level/all-packages.nix"
TMPFILE=$(mktemp)

while IFS= read -r line; do
    if [[ "$line" =~ ^[[:space:]]{2}([a-zA-Z0-9_-]+)[[:space:]]*=[[:space:]]*(.+\.override[[:space:]]*\{[^}]+\})[[:space:]]*\;[[:space:]]*$ ]]; then
        pkg_name="${BASH_REMATCH[1]}"
        override_expr="${BASH_REMATCH[2]}"
        base_pkg="${override_expr%%.override*}"

        prefix="${pkg_name:0:2}"
        dir="pkgs/by-name/${prefix}/${pkg_name}"
        outfile="${dir}/package.nix"

        if [[ -e "$outfile" ]]; then
            echo "Skipping (exists): $outfile"
            printf '%s\n' "$line" >> "$TMPFILE"
            continue
        fi

        mkdir -p "$dir"
        cat > "$outfile" <<NIXEOF
{
  ${base_pkg},
}:

${override_expr}
NIXEOF
        echo "Created: $outfile"
        # Line is dropped by not writing it to TMPFILE
    else
        printf '%s\n' "$line" >> "$TMPFILE"
    fi
done < "$INPUT"

mv "$TMPFILE" "$INPUT"
```

</details>

TLDR: Migrates every line in all-packages.nix that appears to override a package and be top-level. The script had issues with these packages, which I have manually fixed up: `enableDebugging`, `arcan-wrapped`, `bogofilter-db`, `bogofilter-sqlite`, `highfive-mpi`, `jackmix_jack1`, `luabind_luajit`, `mkShellNoCC`, `rstudioServerWrapper`, `libxc`. By far the most common issue was just that the script assumed no other packages were being imported, but there was one case where a function got improperly migrated.

I believe this PR should be ready to merge, provided that evaluation succeeds and no rebuilds/additions/deletions are reported. I don't think there can be any breakage if that's the case (famous last words?). For extra assurance, a quick skim of the diff is pretty easy.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
