### PR TITLE
python3Packages.crypto{datahub,parser,lyzer}: 1.1.0 -> 1.2.1

### DIFF
--- a/pkgs/development/python-modules/cryptodatahub/default.nix
+++ b/pkgs/development/python-modules/cryptodatahub/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "cryptodatahub";
-  version = "1.1.0";
+  version = "1.2.1";
   pyproject = true;
 
   src = fetchFromGitLab {
     owner = "coroner";
     repo = "cryptodatahub";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Tz2VbWS5/sGjRsOKR7eWpWAJVNv1QMSjkepI7fVZq6w=";
+    hash = "sha256-Zu8E3k6jHFK+IIHWOalmdv/mPGhT7JjgjFkGiLxA4iI=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/cryptolyzer/default.nix
+++ b/pkgs/development/python-modules/cryptolyzer/default.nix
@@ -19,14 +19,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "cryptolyzer";
-  version = "1.1.0";
+  version = "1.2.1";
   pyproject = true;
 
   src = fetchFromGitLab {
     owner = "coroner";
     repo = "cryptolyzer";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-z9RuboCWHEqw4aFfQTjWly/UP9Yed0R+VdMLVXxdBmc=";
+    hash = "sha256-v+himg/DOBlIRiWBIGkxiahT3JGp384Ed4cUCIq6TOw=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/cryptoparser/default.nix
+++ b/pkgs/development/python-modules/cryptoparser/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "cryptoparser";
-  version = "1.1.0";
+  version = "1.2.1";
   pyproject = true;
 
   src = fetchFromGitLab {
     owner = "coroner";
     repo = "cryptoparser";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Zd305BFM3G8LMQqDwtbwRPy6ooNXJ61UzWBwVewh0F4=";
+    hash = "sha256-thhpXfLH5yB3pMUKFrMUJ8+8IGchF813ApKUrN+UuZA=";
   };
 
   patches = [


### PR DESCRIPTION
Supersedes and closes https://github.com/NixOS/nixpkgs/pull/515646

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
