### PR TITLE
gomacro: unbreak build

### DIFF
--- a/pkgs/by-name/go/gomacro/package.nix
+++ b/pkgs/by-name/go/gomacro/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 }:
 
-buildGoModule {
+buildGoModule (finalAttrs: {
   pname = "gomacro";
   version = "2.7-unstable-2024-01-07";
 
@@ -15,7 +15,26 @@ buildGoModule {
     hash = "sha256-16u3eByFmnY12M2CEhSJKLIT0KP9nbvTv+BnqWwNTcg=";
   };
 
-  vendorHash = "sha256-ok71QlBHGasGVt+CGwGqhgmx5JLkQcdlU/KX+W1A5Ws=";
+  vendorHash = "sha256-/2wnzc56knUH/GE5h7oMLhnM+8vPCFICu1wfgUcJJEE=";
+
+  overrideModAttrs = oldAttrs: {
+    postPatch = (oldAttrs.postPatch or "") + ''
+      export GOCACHE=$TMPDIR/go-cache
+      export GOPATH=$TMPDIR/go
+      go mod edit -replace golang.org/x/tools=golang.org/x/tools@v0.30.0
+      go mod tidy
+    '';
+    postBuild = (oldAttrs.postBuild or "") + ''
+      cp go.mod go.sum vendor/
+    '';
+  };
+
+  preBuild = ''
+    if [ -d vendor ]; then
+      chmod -R u+w vendor
+      cp vendor/go.mod vendor/go.sum .
+    fi
+  '';
 
   subPackages = [ "." ];
 
@@ -25,6 +44,5 @@ buildGoModule {
     homepage = "https://github.com/cosmos72/gomacro";
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [ shofius ];
-    broken = true;
   };
-}
+})


### PR DESCRIPTION
Fix build of gomacro with new go version by updating golang.org/x/tools dependency.

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
