### PR TITLE
bouncarr: init at 1.0.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -36,6 +36,8 @@
 
 - [Matrix Authentication Service](https://github.com/element-hq/matrix-authentication-service) is an OAuth2.0 and OpenID Connect provider for Matrix homeservers (such as Synapse). It replaces standard password authentication with modern OpenID Connect flows, and can delegate authentication to upstream OIDC providers. Available as [services.matrix-authentication-service](#opt-services.matrix-authentication-service.enable).
 
+- [Bouncarr](https://github.com/teknostom/bouncarr), an authentication proxy that puts the *arr stack (Sonarr, Radarr, Lidarr, ...) behind Jellyfin's single sign-on. Available as [services.bouncarr](#opt-services.bouncarr.enable).
+
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -839,6 +839,7 @@
   ./services/misc/bees.nix
   ./services/misc/bepasty.nix
   ./services/misc/blenderfarm.nix
+  ./services/misc/bouncarr.nix
   ./services/misc/calibre-server.nix
   ./services/misc/canto-daemon.nix
   ./services/misc/castsponsorskip.nix

--- a/nixos/modules/services/misc/bouncarr.nix
+++ b/nixos/modules/services/misc/bouncarr.nix
@@ -1,0 +1,159 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+let
+  cfg = config.services.bouncarr;
+  format = pkgs.formats.yaml { };
+  stateDir = "/var/lib/bouncarr";
+  # Bouncarr only reads config.yaml from its working directory
+  configPath = "${stateDir}/config.yaml";
+  secretsReplacement = utils.genJqSecretsReplacement {
+    loadCredential = true;
+  } cfg.settings configPath;
+  port = lib.attrByPath [ "server" "port" ] 3000 cfg.settings;
+in
+{
+  options.services.bouncarr = {
+    enable = lib.mkEnableOption "bouncarr";
+
+    package = lib.mkPackageOption pkgs "bouncarr" { };
+
+    settings = lib.mkOption {
+      type = format.type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          jellyfin = {
+            url = "http://localhost:8096";
+            api_key._secret = "/run/secrets/bouncarr-jellyfin-api-key";
+          };
+          arr_apps = [
+            {
+              name = "sonarr";
+              url = "http://localhost:8989";
+            }
+            {
+              name = "radarr";
+              url = "http://localhost:7878";
+            }
+          ];
+          server.port = 3000;
+          security.secure_cookies = true;
+        }
+      '';
+      description = ''
+        Configuration for bouncarr. See the
+        [example configuration](https://github.com/teknostom/bouncarr/blob/master/config.example.yaml)
+        for available options. Secret values can be loaded from files using
+        `._secret = "/path/to/secret";`.
+      '';
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/run/secrets/bouncarr.env";
+      description = "Environment file as defined in {manpage}`systemd.exec(5)`.";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether to open the firewall for the specified port.";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "bouncarr";
+      description = "User account under which Bouncarr runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "bouncarr";
+      description = "Group under which Bouncarr runs.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.users = lib.mkIf (cfg.user == "bouncarr") {
+      bouncarr = {
+        isSystemUser = true;
+        group = cfg.group;
+        home = stateDir;
+        description = "Bouncarr service user";
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == "bouncarr") {
+      bouncarr = { };
+    };
+
+    systemd.services.bouncarr = {
+      description = "Authentication proxy for the *arr stack using Jellyfin SSO";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      preStart = secretsReplacement.script;
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        StateDirectory = "bouncarr";
+        StateDirectoryMode = "0700";
+        WorkingDirectory = stateDir;
+        ExecStart = lib.getExe cfg.package;
+        Restart = "on-failure";
+        RestartSec = 5;
+        LoadCredential = secretsReplacement.credentials;
+        EnvironmentFile = lib.mkIf (cfg.environmentFile != null) [ cfg.environmentFile ];
+
+        # Hardening
+        CapabilityBoundingSet = "";
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        PrivateUsers = true;
+        ProtectHostname = true;
+        ProtectClock = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        ProtectProc = "invisible";
+        ProcSubset = "pid";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        RestrictSUIDSGID = true;
+        RestrictRealtime = true;
+        RemoveIPC = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@resources"
+        ];
+        UMask = "0077";
+      };
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [ port ];
+    };
+  };
+
+  meta.maintainers = [ lib.maintainers.anish ];
+}

--- a/nixos/modules/services/misc/servarr/radarr.nix
+++ b/nixos/modules/services/misc/servarr/radarr.nix
@@ -11,7 +11,7 @@ in
 {
   options = {
     services.radarr = {
-      enable = lib.mkEnableOption "Radarr, a UsetNet/BitTorrent movie downloader";
+      enable = lib.mkEnableOption "Radarr, a Usenet/BitTorrent movie downloader";
 
       package = lib.mkPackageOption pkgs "radarr" { };
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -305,6 +305,7 @@ in
   bootspec = handleTestOn [ "x86_64-linux" ] ./bootspec.nix { };
   borgbackup = runTest ./borgbackup.nix;
   borgmatic = runTest ./borgmatic.nix;
+  bouncarr = runTest ./bouncarr.nix;
   bpf = runTestOn [ "x86_64-linux" "aarch64-linux" ] ./bpf.nix;
   bpftune = runTest ./bpftune.nix;
   breitbandmessung = runTest ./breitbandmessung.nix;

--- a/nixos/tests/bouncarr.nix
+++ b/nixos/tests/bouncarr.nix
@@ -1,0 +1,56 @@
+{ lib, ... }:
+{
+  name = "bouncarr";
+
+  meta.maintainers = [ lib.maintainers.anish ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.bouncarr = {
+        enable = true;
+        settings = {
+          jellyfin = {
+            url = "http://127.0.0.1:8096";
+            api_key._secret = "/etc/bouncarr-jellyfin-api-key";
+          };
+          arr_apps = [
+            {
+              name = "sonarr";
+              url = "http://127.0.0.1:8989";
+            }
+          ];
+          server = {
+            host = "127.0.0.1";
+            port = 3000;
+          };
+        };
+        # Exercise the environmentFile code path.
+        environmentFile = "/etc/bouncarr.env";
+      };
+
+      environment.etc."bouncarr-jellyfin-api-key".text = "test-api-key";
+      environment.etc."bouncarr.env".text = "JWT_SECRET=test-jwt-secret";
+
+      environment.systemPackages = [ pkgs.curl ];
+    };
+
+  testScript = ''
+    machine.wait_for_unit("bouncarr.service")
+    machine.wait_for_open_port(3000)
+
+    # Health endpoint confirms config.yaml loaded and the service is serving.
+    machine.succeed(
+        "curl -sf http://127.0.0.1:3000/health | grep -q '\"status\":\"ok\"'"
+    )
+
+    # Protected *arr routes reject requests without a valid token.
+    status = machine.succeed(
+        "curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:3000/sonarr"
+    ).strip()
+    assert status == "401", f"expected 401 for unauthenticated /sonarr, got {status}"
+
+    # The Jellyfin API key secret must be substituted into config.yaml.
+    machine.succeed("grep -q test-api-key /var/lib/bouncarr/config.yaml")
+  '';
+}

--- a/pkgs/by-name/bo/bouncarr/package.nix
+++ b/pkgs/by-name/bo/bouncarr/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   pkg-config,
   openssl,
+  nixosTests,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -24,6 +25,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ openssl ];
+
+  passthru.tests = {
+    inherit (nixosTests) bouncarr;
+  };
 
   meta = {
     description = "Authentication proxy for the *arr stack using Jellyfin SSO";

--- a/pkgs/by-name/bo/bouncarr/package.nix
+++ b/pkgs/by-name/bo/bouncarr/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "bouncarr";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "teknostom";
+    repo = "bouncarr";
+    tag = finalAttrs.version;
+    hash = "sha256-+LwI6gPdoIKp8Nwhjg7Tlo5ckT2UGRizj/XIC0LBCZ8=";
+  };
+
+  cargoHash = "sha256-rWkjLV8H8ryrUd+3VOVq90XIyNsRnavCAmw0NYKWpgQ=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ];
+
+  meta = {
+    description = "Authentication proxy for the *arr stack using Jellyfin SSO";
+    homepage = "https://github.com/teknostom/bouncarr";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ anish ];
+    mainProgram = "bouncarr";
+  };
+})


### PR DESCRIPTION
Bouncarr (https://github.com/teknostom/bouncarr) is an authentication proxy for the *arr stack (Sonarr, Radarr, Lidarr, etc.) that uses Jellyfin's single sign-on. It sits in front of the *arr services and gates access through Jellyfin credentials.

This PR includes a package for the upstream Rust binary, `services.bouncarr`, and a VM test for startup / auth.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
