### PR TITLE
git-today: init at 0.1.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3614,6 +3614,12 @@
     github = "bitbloxhub";
     githubId = 45184892;
   };
+  bitSheriff = {
+    email = "root@bitsheriff.dev";
+    github = "bitSheriff";
+    githubId = 44727821;
+    name = "bitSheriff";
+  };
   bizmyth = {
     email = "andrew.p.council@gmail.com";
     github = "bizmythy";

--- a/pkgs/by-name/gi/git-today/package.nix
+++ b/pkgs/by-name/gi/git-today/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  zlib,
+  libgit2,
+  apple-sdk,
+  stdenv,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "git-today";
+  version = "0.1.7";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "bitSheriff";
+    repo = "git-today";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jvXhIGyqlQjgZN/Gx/2vsvk1U3SDpypn0mBYumNCOow=";
+  };
+
+  cargoHash = "sha256-cnGyig8X9OgWFHR9pCIl4NdfjmGTQLWsXoNxEa92H50=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    openssl
+    zlib
+    libgit2
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    apple-sdk
+  ];
+
+  env.LIBGIT2_SYS_USE_PKG_CONFIG = 1;
+
+  meta = {
+    description = "A tool to recap your daily git work";
+    homepage = "https://github.com/bitSheriff/git-today";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bitSheriff ];
+    mainProgram = "git-today";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

This PR initializes `git-today` at version 0.1.7. `git-today` is a command-line tool to recap your daily git work by analyzing local repositories and displaying neat, customizable tables of commit statistics, author workloads, and changed files.
  
Homepage: https://github.com/bitSheriff/git-today
  
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
