### PR TITLE
tau-{radio,tower}: init at 0.2.3

### DIFF
--- a/pkgs/by-name/ta/tau-radio/package.nix
+++ b/pkgs/by-name/ta/tau-radio/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+
+  pkg-config,
+
+  alsa-lib,
+  jack2,
+  libogg,
+  libopus,
+  libopusenc,
+  libshout,
+
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tau-radio";
+  version = "0.2.3";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "tau-org";
+    repo = "tau-radio";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1SKlZ+htlCsO7ClZDbFbKyw8v9zgV5pKDEtL57D49f8=";
+  };
+
+  cargoHash = "sha256-X1uHKYgt9ddvr/cBDW9HaHawG5uv2sU416jyL/XTPF4=";
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    libogg
+    libopus
+    libopusenc
+    libshout
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    alsa-lib
+    jack2
+  ];
+
+  # fatal error: 'opus.h' file not found
+  env.NIX_CFLAGS_COMPILE = "-I${libopus.dev}/include/opus";
+
+  postPatch = ''
+    # The opusenc crate hardcodes `*const i8`, but bindgen generates `*const c_char`,
+    # which is `u8` on `aarch64-linux`, causing a type mismatch on that platform
+    substituteInPlace $cargoDepsCopy/*/opusenc-*/src/comments.rs \
+      --replace-fail \
+        "picture.as_ptr() as *const i8," \
+        "picture.as_ptr() as *const std::ffi::c_char,"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Web radio - Hijacks audio device using CLAP and Ogg/Opus";
+    homepage = "https://github.com/tau-org/tau-radio";
+    mainProgram = "tau-radio";
+    license = lib.licenses.eupl12;
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/by-name/ta/tau-tower/package.nix
+++ b/pkgs/by-name/ta/tau-tower/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+
+  perl,
+  pkg-config,
+
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tau-tower";
+  version = "0.2.3";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "tau-org";
+    repo = "tau-tower";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-vbUR2ZfnomUkWdz2xdFReR6B0lzz4dKM88RonAWu994=";
+  };
+
+  cargoHash = "sha256-Qv97FTiccfQSBI2OBfl31p3oF/JCL/+UXkK+owuByDY=";
+
+  nativeBuildInputs = [
+    perl
+    pkg-config
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Webradio server - broadcasts audio source to clients";
+    homepage = "https://github.com/tau-org/tau-tower";
+    mainProgram = "tau-tower";
+    license = lib.licenses.eupl12;
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})


### PR DESCRIPTION
[Tau-radio](https://github.com/tau-org/tau-radio) is a tool built for livestreaming audio to a server running an instance of the [Tau-tower](https://github.com/tau-org/tau-tower) web-radio server.

Tracking: https://github.com/ngi-nix/projects/issues/130

> [!NOTE]
> - Work done as part of the [Nix@NGI](https://nixos.org/community/teams/ngi) packaging effort 
> - Derivations migrated from NGIpkgs [^1] [^2].

[^1]: https://github.com/ngi-nix/ngipkgs/blob/d7c35a71abc13d983aaf6f2713e970cff0e5223b/pkgs/by-name/tau-radio/package.nix
[^2]: https://github.com/ngi-nix/ngipkgs/blob/d7c35a71abc13d983aaf6f2713e970cff0e5223b/pkgs/by-name/tau-tower/package.nix

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
