### PR TITLE
python3Packages.comet-ml: 3.55.0 -> 3.58.1

### DIFF
--- a/pkgs/development/python-modules/comet-ml/default.nix
+++ b/pkgs/development/python-modules/comet-ml/default.nix
@@ -17,21 +17,24 @@
   setuptools,
   simplejson,
   urllib3,
+  versionCheckHook,
   wrapt,
   wurlitzer,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "comet-ml";
-  version = "3.55.0";
+  version = "3.58.1";
+  pyproject = true;
+  __structuredAttrs = true;
 
+  # No GitHub repository
   src = fetchPypi {
     pname = "comet_ml";
-    inherit version;
-    hash = "sha256-bNfh6tVpsU2LrSLcAKy5lXLgd4lbo3/6dzzMB4+Eh08=";
+    inherit (finalAttrs) version;
+    hash = "sha256-6DHmsd7CcFd1QU06G09CVMeVuHGAtn8Rxsr1++epdeU=";
   };
 
-  pyproject = true;
   build-system = [
     setuptools
   ];
@@ -62,6 +65,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "comet_ml" ];
 
+  nativeCheckInputs = [
+    versionCheckHook
+    # Skip pytestCheckHook, as Python tests require a lot of additional dependencies to run.
+  ];
+
   meta = {
     description = "Platform designed to help machine learning teams track, compare, explain, and optimize their models";
     homepage = "https://www.comet.com/site/";
@@ -70,4 +78,4 @@ buildPythonPackage rec {
     maintainers = with lib.maintainers; [ jherland ];
     mainProgram = "comet";
   };
-}
+})

--- a/pkgs/development/python-modules/executorch/default.nix
+++ b/pkgs/development/python-modules/executorch/default.nix
@@ -54,7 +54,7 @@
 }:
 buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
   pname = "executorch";
-  version = "1.2.0";
+  version = "1.3.1";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -68,7 +68,7 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
     name = "executorch";
 
     fetchSubmodules = true;
-    hash = "sha256-Rkw6+keOygQaf6iOCpGoW9JgXiCimgx8gsxLEH3bxME=";
+    hash = "sha256-UyMPY+qYTHYZDeftj4YVqzO2ibTswzd+HWW5JeXHW0Q=";
   };
 
   postPatch =
@@ -76,8 +76,8 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
     ''
       substituteInPlace exir/_serialize/_flatbuffer.py \
         --replace-fail \
-          'flatc_path = "flatc"' \
-          'flatc_path = "${lib.getExe pkgs.flatbuffers}"'
+          '_flatc_cached_path = os.getenv("FLATC_EXECUTABLE", "flatc")' \
+          '_flatc_cached_path = os.getenv("FLATC_EXECUTABLE", "${lib.getExe pkgs.flatbuffers}")'
     ''
     # Relax build-system dependencies
     + ''
@@ -102,13 +102,6 @@ buildPythonPackage.override { inherit (torch) stdenv; } (finalAttrs: {
 
       sed -i "1i #include <cstdint>" backends/apple/coreml/runtime/inmemoryfs/memory_buffer.hpp
       sed -i "1i #include <cstdint>" extension/llm/tokenizers/third-party/sentencepiece/src/sentencepiece_processor.h
-    ''
-    # AssertionError: '1.3.0' != '0.1.0'
-    + ''
-      substituteInPlace extension/llm/tokenizers/test/test_python_bindings.py \
-        --replace-fail \
-          'self.assertEqual(pytorch_tokenizers.__version__, "0.1.0")' \
-          'self.assertEqual(pytorch_tokenizers.__version__, "${pytorch-tokenizers.version}")'
     '';
 
   env = {


### PR DESCRIPTION
Commits:

- **python3Packages.comet-ml: 3.55.0 -> 3.58.1**
- **python3Packages.executorch: 1.2.0 -> 1.3.1 (#490038)**


It seems upgrading comet-ml by itself causes executorch to break (see #490038). Upgrading both appears to work.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
