### PR TITLE
fluux-messenger: 0.16.0 -> 0.16.1

### DIFF
--- a/pkgs/by-name/fl/fluux-messenger/package.nix
+++ b/pkgs/by-name/fl/fluux-messenger/package.nix
@@ -18,7 +18,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "fluux-messenger";
-  version = "0.16.0";
+  version = "0.16.1";
   __structuredAttrs = true;
   strictDeps = true;
 
@@ -26,16 +26,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "processone";
     repo = "fluux-messenger";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-P4bRyge5EGdlZBdX+gIWh48itkCLQ+EjKLHt4xv6qnY=";
+    hash = "sha256-os6zEB1E3D4WSRfru/UCDY0mgZxy0Zu/YcjhMbXt47g=";
   };
 
   cargoRoot = "apps/fluux/src-tauri";
-  cargoHash = "sha256-YIX/F9LMuHFGJ89NIsFLUjjrR7XBoJF78OsyXiSjEqU=";
+  cargoHash = "sha256-V6iDPPBpdJQV5PA/isRy+Gz6NdwUUEj3mf9PM/nX10s=";
 
   npmDeps = fetchNpmDeps {
     name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
     inherit (finalAttrs) src;
-    hash = "sha256-rzkFrvLb/0c+pg2SIUnhyTHK2MGL2ugRI9XuHtdm8XE=";
+    hash = "sha256-iMkb7QZZrKjzmTzvWGbw8reF1nX4Avd1XKzyybz3q00=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Upstream release and changelog: https://github.com/processone/fluux-messenger/releases/tag/v0.16.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
