### PR TITLE
[26.05] pizauth: fix systemd units substitutions

### DIFF
--- a/pkgs/by-name/pi/pizauth/package.nix
+++ b/pkgs/by-name/pi/pizauth/package.nix
@@ -19,6 +19,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-9cDVbDCb8vY6KxreyiMX3gp13bXZpxTQOwYbk6TEVpc=";
 
+  preConfigure = ''
+    substituteInPlace lib/systemd/user/pizauth.service \
+      --replace-fail /usr/bin/ ''${!outputBin}/bin/
+  '';
+
   postInstall = ''
     make PREFIX=$out install ${lib.optionalString stdenv.hostPlatform.isLinux "install-systemd"}
   '';

--- a/pkgs/by-name/pi/pizauth/package.nix
+++ b/pkgs/by-name/pi/pizauth/package.nix
@@ -22,6 +22,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
   preConfigure = ''
     substituteInPlace lib/systemd/user/pizauth.service \
       --replace-fail /usr/bin/ ''${!outputBin}/bin/
+    # Upstream's Makefile uses target/release/pizauth as a Makefile target that
+    # the `install` target depends upon. Nixpkgs' cargoBuildHook defaults to
+    # using the explicit `--target @rustcTargetSpec@` flag, so that the
+    # executable always ends up in
+    # `target/${stdenv.hostPlatform.rust.rustcTargetSpec}/release`. To make the
+    # Makefile not run cargo build again, we use this substitution.
+    substituteInPlace Makefile \
+      --replace-fail target/release target/${stdenv.hostPlatform.rust.rustcTargetSpec}/release
   '';
 
   postInstall = ''


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test