### PR TITLE
h2o: 2.3.0-rolling-2026-06-10 → 2.3.0-rolling-2026-06-17

### DIFF
--- a/pkgs/by-name/h2/h2o/package.nix
+++ b/pkgs/by-name/h2/h2o/package.nix
@@ -24,13 +24,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "h2o";
-  version = "2.3.0-rolling-2026-06-16";
+  version = "2.3.0-rolling-2026-06-17";
 
   src = fetchFromGitHub {
     owner = "h2o";
     repo = "h2o";
-    rev = "293a78a96ad566b9a091177fb4279584239dc281";
-    hash = "sha256-rEpLW7mnPCuX4AUqhgmdSaiZoRtRx6pMwNompN4xLZU=";
+    rev = "e42097ed965e2e7d59dcca61e881a80c159e66f2";
+    hash = "sha256-C5NdwFDOk6AZiMWpwBKdEdUmLJAOBzZ4pM5XuVCaiWk=";
   };
 
   outputs = [

--- a/pkgs/by-name/h2/h2o/package.nix
+++ b/pkgs/by-name/h2/h2o/package.nix
@@ -24,13 +24,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "h2o";
-  version = "2.3.0-rolling-2026-06-17";
+  version = "2.3.0-rolling-2026-06-22";
 
   src = fetchFromGitHub {
     owner = "h2o";
     repo = "h2o";
-    rev = "e42097ed965e2e7d59dcca61e881a80c159e66f2";
-    hash = "sha256-C5NdwFDOk6AZiMWpwBKdEdUmLJAOBzZ4pM5XuVCaiWk=";
+    rev = "f12fb3cca02ba31e89c87bc90041fe800dbed3f2";
+    hash = "sha256-OJ/MF6A6lcxWKgcOntCVc0fkcnQ9FJx8Wn2Pewz0h84=";
   };
 
   outputs = [

--- a/pkgs/by-name/h2/h2o/package.nix
+++ b/pkgs/by-name/h2/h2o/package.nix
@@ -24,13 +24,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "h2o";
-  version = "2.3.0-rolling-2026-06-10";
+  version = "2.3.0-rolling-2026-06-16";
 
   src = fetchFromGitHub {
     owner = "h2o";
     repo = "h2o";
-    rev = "ed7899d1c234fd15d272a0ac6404ffbd89a3c772";
-    hash = "sha256-oT31ZuB0e8wkxovP/sbs52m396IG4mdh0tf8WBs8egA=";
+    rev = "293a78a96ad566b9a091177fb4279584239dc281";
+    hash = "sha256-rEpLW7mnPCuX4AUqhgmdSaiZoRtRx6pMwNompN4xLZU=";
   };
 
   outputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
