### PR TITLE
nixos/uwsm: set restartIfChanged = false on session units

### DIFF
--- a/nixos/modules/programs/wayland/uwsm.nix
+++ b/nixos/modules/programs/wayland/uwsm.nix
@@ -37,6 +37,11 @@ let
         ;
     }
   ) cfg.waylandCompositors;
+
+  sessionServices = [
+    "wayland-wm@"
+    "wayland-session-bindpid@"
+  ];
 in
 {
   options.programs.uwsm = {
@@ -136,6 +141,17 @@ in
 
         # UWSM recommends dbus broker for better compatibility
         services.dbus.implementation = "broker";
+
+        # Restarting these kills the graphical session, same treatment as the
+        # display-manager modules.
+        systemd.user.services = lib.genAttrs sessionServices (_: {
+          restartIfChanged = false;
+          # Defining the units here generates drop-ins; without this they
+          # would carry the NixOS default Environment="PATH=coreutils:…",
+          # clobbering the PATH that uwsm imported into the user manager
+          # and breaking spawn actions that rely on it.
+          enableDefaultPath = false;
+        });
       }
 
       (lib.mkIf (cfg.waylandCompositors != { }) {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix the desktop session being killed when uwsm is updated. The approach here was copied from the niri module.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
