### PR TITLE
mkslides: init at 2.0.18

### DIFF
--- a/pkgs/by-name/mk/mkslides/package.nix
+++ b/pkgs/by-name/mk/mkslides/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  python3Packages,
+  fetchPypi,
+  fetchpatch2,
+}:
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "mkslides";
+  version = "2.0.18";
+
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-pxCnoU03xuOZoLctSX4HbxprTGvBLCtawojnqgdVT6M=";
+  };
+
+  patches = [
+    (fetchpatch2 {
+      url = "https://github.com/MartenBE/mkslides/commit/2ffc01714ef55c979afe2528acdcedb49e773f2f.patch?full_index=1";
+      hash = "sha256-a4SsOF9oevcoUhajC//hieAh7JkhW2rfwHjoCuRwBho=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.8.23,<0.9.0" "uv_build"
+  '';
+
+  build-system = with python3Packages; [ uv-build ];
+
+  dependencies = with python3Packages; [
+    beautifulsoup4
+    click
+    emoji
+    jinja2
+    jsonschema
+    livereload
+    markdown
+    natsort
+    omegaconf
+    python-frontmatter
+    pyyaml
+    rich
+    treelib
+    types-beautifulsoup4
+    types-markdown
+  ];
+
+  meta = {
+    description = "Build static HTML slideshow files from Markdown files.";
+    homepage = "https://github.com/MartenBE/mkslides";
+    changelog = "https://github.com/MartenBE/mkslides/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ungeskriptet ];
+    mainProgram = "mkslides";
+  };
+
+  __structuredAttrs = true;
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
