### PR TITLE
nixos/zfs: add option exportAllByShutdown

### DIFF
--- a/nixos/modules/tasks/filesystems/zfs.nix
+++ b/nixos/modules/tasks/filesystems/zfs.nix
@@ -382,6 +382,18 @@ in
         '';
       };
 
+      exportAllByShutdown = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Export all ZFS pool(s) before shutting down.
+
+          This allows other systems OS to import the ZFS pools
+          after NixOS's clean shutdown.
+          It requires all datasets to be unmounted before shutdown.
+        '';
+      };
+
       requestEncryptionCredentials = lib.mkOption {
         type = lib.types.either lib.types.bool (lib.types.listOf lib.types.str);
         default = true;
@@ -917,7 +929,10 @@ in
             lib.nameValuePair "zfs-sync-${pool}" {
               description = "Sync ZFS pool \"${pool}\"";
               wantedBy = [ "shutdown.target" ];
-              before = [ "final.target" ];
+              before = [
+                "zfs-export-${pool}.service"
+                "final.target"
+              ];
               unitConfig = {
                 DefaultDependencies = false;
               };
@@ -927,6 +942,35 @@ in
               };
               script = ''
                 ${cfgZfs.package}/sbin/zfs set nixos:shutdown-time="$(date)" "${pool}"
+              '';
+            };
+
+          # Export ZFS pools prior to poweroff
+          createExportService =
+            pool:
+            lib.nameValuePair "zfs-export-${pool}" {
+              description = "Export ZFS pool \"${pool}\"";
+              wantedBy = [ "shutdown.target" ];
+              before = [
+                "final.target"
+              ];
+              after = [
+                "zfs-sync-${pool}.service"
+              ];
+              unitConfig = {
+                DefaultDependencies = false;
+              };
+              serviceConfig = {
+                Type = "oneshot";
+                RemainAfterExit = true;
+                StandardOutput = "journal";
+                StandardError = "journal";
+              };
+              script = ''
+                ${cfgZfs.package}/sbin/zfs export "${pool}" || {
+                  # Tolerate and inform failed `zfs export`
+                  echo "Warning: Failed to export pool ${pool}. Some datasets may still be mounted." >&2
+                }
               '';
             };
 
@@ -941,6 +985,7 @@ in
         lib.listToAttrs (
           map createImportService' dataPools
           ++ map createSyncService allPools
+          ++ lib.optionals cfgZfs.exportAllByShutdown (map createExportService allPools)
           ++ map createZfsService [
             "zfs-mount"
             "zfs-share"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR introduces a NixOS configuration option `boot.zfs.exportAllByShutdown`, which optionally exports all ZFS pools before shutdown to allow other OSes to cleanly import the ZFS pools after NixOS's clean shutdown.

Fixes #24556
- #24556

> [!NOTE]
> I'm new to writing systemd units and would need someone familiar with systemd configuration to help catch potential rough edges.
>
> I asked GitHub Copilot (with Claude Haiku 4.5) for ~NixOS test generation and~ review suggestions about my initial implementation.

Update:

Could anyone help me write a NixOS test for this change?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
