### PR TITLE
python3Packages.warrant: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/warrant/default.nix
+++ b/pkgs/development/python-modules/warrant/default.nix
@@ -16,19 +16,21 @@ buildPythonPackage {
   version = "0.6.1";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   # move to fetchPyPi when https://github.com/capless/warrant/issues/97 is fixed
   src = fetchFromGitHub {
     owner = "capless";
     repo = "warrant";
     rev = "ff2e4793d8479e770f2461ef7cbc0c15ee784395";
-    sha256 = "0gw3crg64p1zx3k5js0wh0x5bldgs7viy4g8hld9xbka8q0374hi";
+    hash = "sha256-EZIzAEZqrp4ahegRH/fRr9FVOoAcaFnm6D9cYl5mgz8=";
   };
 
   patches = [
     (fetchpatch {
       name = "fix-pip10-compat.patch";
       url = "https://github.com/capless/warrant/commit/ae17d17d9888b9218a8facf6f6ad0bf4adae9a12.patch";
-      sha256 = "1lvqi2qfa3kxdz05ab2lc7xnd3piyvvnz9kla2jl4pchi876z17c";
+      hash = "sha256-7IRvDoqQXUKlUHSmb/f28Y5m+2FULFXAb30O5bCIeNM=";
     })
   ];
 
@@ -37,7 +39,7 @@ buildPythonPackage {
   # this needs to go when 0.6.2 or later is released
   postPatch = ''
     substituteInPlace requirements.txt \
-      --replace "python-jose-cryptodome>=1.3.2" "python-jose>=2.0.0"
+      --replace-fail "python-jose-cryptodome>=1.3.2" "python-jose>=2.0.0"
   '';
 
   nativeCheckInputs = [ mock ];
@@ -51,6 +53,8 @@ buildPythonPackage {
 
   # all the checks are failing
   doCheck = false;
+
+  pythonImportsCheck = [ "warrant" ];
 
   meta = {
     description = "Python library for using AWS Cognito with support for SRP";

--- a/pkgs/development/python-modules/warrant/default.nix
+++ b/pkgs/development/python-modules/warrant/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   fetchpatch,
+  setuptools,
   mock,
   boto3,
   envs,
@@ -13,7 +14,7 @@
 buildPythonPackage {
   pname = "warrant";
   version = "0.6.1";
-  format = "setuptools";
+  pyproject = true;
 
   # move to fetchPyPi when https://github.com/capless/warrant/issues/97 is fixed
   src = fetchFromGitHub {
@@ -31,6 +32,8 @@ buildPythonPackage {
     })
   ];
 
+  build-system = [ setuptools ];
+
   # this needs to go when 0.6.2 or later is released
   postPatch = ''
     substituteInPlace requirements.txt \
@@ -39,7 +42,7 @@ buildPythonPackage {
 
   nativeCheckInputs = [ mock ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     boto3
     envs
     python-jose


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
