### PR TITLE
python3Packages.websockify: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/websockify/default.nix
+++ b/pkgs/development/python-modules/websockify/default.nix
@@ -12,15 +12,17 @@
   simplejson,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "websockify";
   version = "0.13.0";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchFromGitHub {
     owner = "novnc";
     repo = "websockify";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-b57L4o071zEt/gX9ZVzEpcnp0RCeo3peZrby2mccJgQ=";
   };
 
@@ -48,8 +50,8 @@ buildPythonPackage rec {
     description = "WebSockets support for any application/server";
     mainProgram = "websockify";
     homepage = "https://github.com/kanaka/websockify";
-    changelog = "https://github.com/novnc/websockify/releases/tag/${src.tag}";
+    changelog = "https://github.com/novnc/websockify/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.lgpl3Only;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/websockify/default.nix
+++ b/pkgs/development/python-modules/websockify/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
   jwcrypto,
   numpy,
   pytestCheckHook,
@@ -14,7 +15,7 @@
 buildPythonPackage rec {
   pname = "websockify";
   version = "0.13.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "novnc";
@@ -23,7 +24,9 @@ buildPythonPackage rec {
     hash = "sha256-b57L4o071zEt/gX9ZVzEpcnp0RCeo3peZrby2mccJgQ=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     jwcrypto
     numpy
     redis

--- a/pkgs/development/python-modules/websockify/default.nix
+++ b/pkgs/development/python-modules/websockify/default.nix
@@ -38,6 +38,8 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  __darwinAllowLocalNetworking = true;
+
   disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
     # this test failed on macos
     # https://github.com/novnc/websockify/issues/552

--- a/pkgs/development/python-modules/websockify/default.nix
+++ b/pkgs/development/python-modules/websockify/default.nix
@@ -49,7 +49,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "WebSockets support for any application/server";
     mainProgram = "websockify";
-    homepage = "https://github.com/kanaka/websockify";
+    homepage = "https://github.com/novnc/websockify";
     changelog = "https://github.com/novnc/websockify/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.lgpl3Only;
     maintainers = [ ];


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
