### PR TITLE
fetch: init at 2.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9876,6 +9876,12 @@
     githubId = 3217744;
     name = "Peter Ferenczy";
   };
+  ghastrum = {
+    name = "Dennis Malmin";
+    email = "dennis.malmin@tuta.com";
+    github = "Ghastrum";
+    githubId = 276720856;
+  };
   ghostbuster91 = {
     name = "Kasper Kondzielski";
     email = "kghost0@gmail.com";

--- a/pkgs/by-name/fe/fetch/package.nix
+++ b/pkgs/by-name/fe/fetch/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  # linux dependencies
+  makeWrapper,
+  fastfetch,
+  pciutils,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fetch";
+  version = "2.1.0";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "areofyl";
+    repo = "fetch";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9ixx7XJcY4ktcN/lUfjvFljvHIEO2ktOebeGgL0ulHg=";
+  };
+
+  makeFlags = [ "PREFIX=${placeholder "out"}" ];
+  nativeBuildInputs = [ makeWrapper ];
+  postInstall = ''
+    wrapProgram $out/bin/fetch \
+    --prefix PATH : ${
+      lib.makeBinPath [
+        fastfetch
+        pciutils
+      ]
+    }
+  '';
+
+  meta = {
+    description = "Animated 3D fetch tool that renders your distro logo as a spinning bas-relief";
+    homepage = "https://github.com/areofyl/fetch";
+    changelog = "https://github.com/areofyl/fetch/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ ghastrum ];
+    mainProgram = "fetch";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## [Areofyl fetch](https://github.com/areofyl/fetch)
Takes any ASCII/Unicode distro logo, turns each character into a point cloud based on its visual density, and renders it as a rotating 3D relief with Blinn-Phong shading. System info is gathered natively from /proc, /sys, and GTK config no external dependencies required.


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
