### PR TITLE
python3Packages.pygitguardian: 1.30.0 -> 1.31.0-unstable-2026-06-16; ggshield: 1.50.4 -> 1.52.0

### DIFF
--- a/pkgs/by-name/gg/ggshield/package.nix
+++ b/pkgs/by-name/gg/ggshield/package.nix
@@ -5,49 +5,34 @@
   python3,
 }:
 
-let
-  py = python3.override {
-    packageOverrides = self: super: {
-
-      # Doesn't support latest marshmallow
-      marshmallow = super.marshmallow.overridePythonAttrs (oldAttrs: rec {
-        version = "3.26.2";
-        src = fetchFromGitHub {
-          owner = "marshmallow-code";
-          repo = "marshmallow";
-          tag = version;
-          hash = "sha256-ioe+aZHOW8r3wF3UknbTjAP0dEggd/NL9PTkPVQ46zM=";
-        };
-      });
-    };
-  };
-in
-
-py.pkgs.buildPythonApplication (finalAttrs: {
+python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "ggshield";
-  version = "1.50.4";
+  version = "1.52.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "GitGuardian";
     repo = "ggshield";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-wwGj7i1GoxNzdfUhcL7mulgQAPtz5WhbT67hgbcMxpo=";
+    hash = "sha256-bz3R1ylmkaYF3Wt/ylzeE2IsWKvZ8bmoF39Xu4tVzFU=";
   };
 
   pythonRelaxDeps = true;
 
-  build-system = with py.pkgs; [ hatchling ];
+  build-system = with python3.pkgs; [ hatchling ];
 
-  dependencies = with py.pkgs; [
+  dependencies = with python3.pkgs; [
     charset-normalizer
     click
+    configupdater
     cryptography
+    filelock
     keyring
     marshmallow
     marshmallow-dataclass
     notify-py
     oauthlib
+    packaging
     platformdirs
     pygitguardian
     pyjwt
@@ -56,6 +41,7 @@ py.pkgs.buildPythonApplication (finalAttrs: {
     requests
     rich
     sigstore
+    tomli
     truststore
     typing-extensions
     urllib3
@@ -64,7 +50,7 @@ py.pkgs.buildPythonApplication (finalAttrs: {
   nativeCheckInputs = [
     git
   ]
-  ++ (with py.pkgs; [
+  ++ (with python3.pkgs; [
     jsonschema
     pyfakefs
     pytest-factoryboy
@@ -100,6 +86,8 @@ py.pkgs.buildPythonApplication (finalAttrs: {
     "test_generate_files_from_paths"
     # Nixpkgs issue
     "test_get_file_sha_in_ref"
+    # Generated hooks config references pytest binary, instead of ggshield CLI. Odd!
+    "test_install_cursor_local_fresh"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/pygitguardian/default.nix
+++ b/pkgs/development/python-modules/pygitguardian/default.nix
@@ -15,20 +15,15 @@
 
 buildPythonPackage rec {
   pname = "pygitguardian";
-  version = "1.30.0";
+  version = "1.32.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "GitGuardian";
     repo = "py-gitguardian";
     tag = "v${version}";
-    hash = "sha256-8kKTqthpkH3A5secb8TqbM+/twA77R81y80MOPNQZPA=";
+    hash = "sha256-f8DkRwgtwaB5R78zklAI0ZvA2gfSwsHFOS3IgDgcEEo=";
   };
-
-  pythonRelaxDeps = [
-    "marshmallow-dataclass"
-    "setuptools"
-  ];
 
   build-system = [ pdm-backend ];
 
@@ -53,10 +48,8 @@ buildPythonPackage rec {
   meta = {
     description = "Library to access the GitGuardian API";
     homepage = "https://github.com/GitGuardian/py-gitguardian";
-    changelog = "https://github.com/GitGuardian/py-gitguardian/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/GitGuardian/py-gitguardian/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
-    # https://github.com/GitGuardian/py-gitguardian/issues/167
-    broken = lib.versionAtLeast marshmallow.version "4";
   };
 }


### PR DESCRIPTION
We can now update this to use Marshmallow 4!


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
