### PR TITLE
iroh-relay: Add module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1282,6 +1282,7 @@
   ./services/networking/iodine.nix
   ./services/networking/iperf3.nix
   ./services/networking/ircd-hybrid/default.nix
+  ./services/networking/iroh-relay.nix
   ./services/networking/iscsi/initiator.nix
   ./services/networking/iscsi/root-initiator.nix
   ./services/networking/iscsi/target.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1262,6 +1262,7 @@
   ./services/networking/iodine.nix
   ./services/networking/iperf3.nix
   ./services/networking/ircd-hybrid/default.nix
+  ./services/networking/iroh-relay.nix
   ./services/networking/iscsi/initiator.nix
   ./services/networking/iscsi/root-initiator.nix
   ./services/networking/iscsi/target.nix

--- a/nixos/modules/services/networking/iroh-relay.nix
+++ b/nixos/modules/services/networking/iroh-relay.nix
@@ -1,0 +1,119 @@
+{
+  pkgs,
+  lib,
+  ...
+}:
+
+{ config, ... }:
+
+let
+  format = pkgs.formats.toml { };
+
+  cfg = config.services.iroh-relay;
+in
+{
+  options.services.iroh-relay = {
+    enable = lib.mkEnableOption "iroh-relay";
+
+    package = lib.mkPackageOption pkgs "iroh-relay" { };
+
+    settings = {
+      dev_mode = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+      };
+
+      ssl = {
+        certificate_path = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+        };
+
+        private_key_path = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+        };
+      };
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "iroh-relay";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "iroh-relay";
+    };
+
+    logLevel = lib.mkOption {
+      type = lib.types.str;
+      default = "info";
+      description = ''
+        The log level for the firezone application. See
+        [RUST_LOG](https://docs.rs/env_logger/latest/env_logger/#enabling-logging)
+        for the format.
+      '';
+    };
+
+    openHttpPort = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+    };
+
+    openQuicPort = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      group = "${cfg.group}";
+    };
+
+    users.groups."${cfg.group}" = { };
+
+    networking.firewall.allowedTCPPorts =
+      (lib.optionals cfg.openHttpPort [ 3340 ]) ++ (lib.optionals cfg.openQuicPort [ 7824 ]);
+
+    systemd.services.iroh-relay = {
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+
+      serviceConfig =
+        let
+          devFlag = lib.optionalString cfg.settings.dev_mode "--dev";
+
+          configFile = format.generate "config.toml" (
+            lib.filterAttrsRecursive (_: v: v != null) cfg.settings
+          );
+        in
+        {
+          Type = "simple";
+          Environment = [
+            "RUST_LOG=${cfg.logLevel}"
+          ];
+          ExecStart = "${pkgs.lib.getExe cfg.package} --config-path=${configFile} ${devFlag}";
+
+          User = "${cfg.user}";
+          Group = "${cfg.group}";
+
+          RuntimeDirectory = "iroh-relay";
+          StateDirectory = "iroh-relay";
+          ConfigurationDirectory = "iroh-relay";
+
+          PrivateTmp = true;
+          PrivateDevices = true;
+          PrivateIPC = true;
+          ProtectControlGroups = true;
+          RemoveIPC = true;
+
+          SystemCallFilter = "@system-service";
+          SystemCallErrorNumber = "EPERM";
+        };
+    };
+  };
+}

--- a/nixos/modules/services/networking/iroh-relay.nix
+++ b/nixos/modules/services/networking/iroh-relay.nix
@@ -1,0 +1,139 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+
+let
+  format = pkgs.formats.toml { };
+
+  cfg = config.services.iroh-relay;
+
+  tomlFormat = pkgs.formats.toml { };
+in
+{
+  options.services.iroh-relay = {
+    enable = lib.mkEnableOption "iroh-relay";
+
+    package = lib.mkPackageOption pkgs "iroh-relay" { };
+
+    dev_mode = lib.mkOption {
+      description = "Pass the --dev argument to the iroh-relay binary";
+      type = lib.types.bool;
+      default = false;
+    };
+
+    settings = lib.mkOption {
+      type = tomlFormat.type;
+      description = "See [iroh-relay configuration](https://github.com/n0-computer/iroh/tree/main/iroh-relay)";
+      example = {
+        enable_relay = true;
+        http_bind_addr = "[::]:3340";
+        limits = {
+          access_conn_limit = 1000;
+          accept_conn_burst = 1200;
+          client.rx = {
+            bytes_per_second = 1024;
+            max_burst_bytes = 2048;
+          };
+        };
+      };
+    };
+
+    user = lib.mkOption {
+      description = "The user under which the relay should run";
+      type = lib.types.str;
+      default = "iroh-relay";
+    };
+
+    group = lib.mkOption {
+      description = "The group under which the relay should run";
+      type = lib.types.str;
+      default = "iroh-relay";
+    };
+
+    logLevel = lib.mkOption {
+      type = lib.types.str;
+      default = "info";
+      description = ''
+        The log level for the firezone application. See
+        [RUST_LOG](https://docs.rs/env_logger/latest/env_logger/#enabling-logging)
+        for the format.
+      '';
+    };
+
+    openHttpPort = lib.mkOption {
+      description = "Whether to open the HTTP port for the iroh-relay";
+      type = lib.types.bool;
+      default = false;
+    };
+
+    openQuicPort = lib.mkOption {
+      description = "Whether to open the QUIC port for the iroh-relay";
+      type = lib.types.bool;
+      default = false;
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      group = "${cfg.group}";
+    };
+
+    users.groups."${cfg.group}" = { };
+
+    networking.firewall.allowedTCPPorts =
+      let
+        httpPort =
+          if !isNull cfg.settings.http_bind_addr then
+            pkgs.lib.pipe cfg.settings.http_bind_addr [
+              (pkgs.lib.strings.splitString ":")
+              pkgs.lib.lists.reverseList
+              builtins.head
+              pkgs.lib.toInt
+            ]
+          else if cfg.dev_mode then
+            3340
+          else
+            80;
+      in
+      (lib.optionals cfg.openHttpPort [ httpPort ]) ++ (lib.optionals cfg.openQuicPort [ 7824 ]);
+
+    systemd.services.iroh-relay = {
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+
+      serviceConfig =
+        let
+          devFlag = lib.optionalString cfg.dev_mode "--dev";
+          configFile = format.generate "config.toml" cfg.settings;
+        in
+        {
+          Type = "simple";
+          Environment = [
+            "RUST_LOG=${cfg.logLevel}"
+          ];
+          ExecStart = "${pkgs.lib.getExe cfg.package} --config-path=${configFile} ${devFlag}";
+
+          User = "${cfg.user}";
+          Group = "${cfg.group}";
+
+          RuntimeDirectory = "iroh-relay";
+          StateDirectory = "iroh-relay";
+          ConfigurationDirectory = "iroh-relay";
+
+          PrivateTmp = true;
+          PrivateDevices = true;
+          PrivateIPC = true;
+          ProtectControlGroups = true;
+          RemoveIPC = true;
+
+          SystemCallFilter = "@system-service";
+          SystemCallErrorNumber = "EPERM";
+        };
+    };
+  };
+}


### PR DESCRIPTION
As per [#Infrastructure > Move iroh relay + DNS infrastructure to radicle.dev/network @ 💬](https://radicle.zulipchat.com/#narrow/channel/610570-Infrastructure/topic/Move.20iroh.20relay.20.2B.20DNS.20infrastructure.20to.20radicle.2Edev.2Fnetwork/near/603665618), the @NixOS/radicle people are interested in this.

This is extracted from a private project of mine, and may not have everything that needs to be added for a fully functional and usable nixos module. I hope the radicle people can help with getting this up to the quality we (and they) want :laughing: 

@NixOS/radicle feel free to send me patches ([git-send-email](https://git-send-email.io) is as fine as is CCing me in commits or any other way that notifies me and I can fetch patches to apply to this PR!)

---


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
