### PR TITLE
python3Packages.deap: migrate to pyproject, enable __structuredAttrs, use finalAttrs, 1.4.3 -> 1.4.4

### DIFF
--- a/pkgs/development/python-modules/deap/default.nix
+++ b/pkgs/development/python-modules/deap/default.nix
@@ -12,6 +12,8 @@ buildPythonPackage (finalAttrs: {
   version = "1.4.3";
   format = "setuptools";
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
     inherit (finalAttrs) version;
     pname = "deap";

--- a/pkgs/development/python-modules/deap/default.nix
+++ b/pkgs/development/python-modules/deap/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  setuptools,
   matplotlib,
   numpy,
   pytestCheckHook,
@@ -10,7 +11,7 @@
 buildPythonPackage (finalAttrs: {
   pname = "deap";
   version = "1.4.3";
-  format = "setuptools";
+  pyproject = true;
 
   __structuredAttrs = true;
 
@@ -20,10 +21,15 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-fJcIj7BYNb3CVb7EdcsOd43itD5Ey++/K81lWu7IZf0=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
     matplotlib
     numpy
   ];
+
   nativeCheckInputs = [ pytestCheckHook ];
 
   meta = {

--- a/pkgs/development/python-modules/deap/default.nix
+++ b/pkgs/development/python-modules/deap/default.nix
@@ -7,13 +7,14 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "deap";
   version = "1.4.3";
   format = "setuptools";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) version;
+    pname = "deap";
     hash = "sha256-fJcIj7BYNb3CVb7EdcsOd43itD5Ey++/K81lWu7IZf0=";
   };
 
@@ -32,4 +33,4 @@ buildPythonPackage rec {
       psyanticy
     ];
   };
-}
+})

--- a/pkgs/development/python-modules/deap/default.nix
+++ b/pkgs/development/python-modules/deap/default.nix
@@ -3,14 +3,14 @@
   buildPythonPackage,
   fetchPypi,
   setuptools,
-  matplotlib,
+  moocore,
   numpy,
   pytestCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "deap";
-  version = "1.4.3";
+  version = "1.4.4";
   pyproject = true;
 
   __structuredAttrs = true;
@@ -18,7 +18,7 @@ buildPythonPackage (finalAttrs: {
   src = fetchPypi {
     inherit (finalAttrs) version;
     pname = "deap";
-    hash = "sha256-fJcIj7BYNb3CVb7EdcsOd43itD5Ey++/K81lWu7IZf0=";
+    hash = "sha256-UNS9kk/KWhaj26i/2xFApV6cJM5QgWq09Wg9LzHC1zQ=";
   };
 
   build-system = [
@@ -26,7 +26,7 @@ buildPythonPackage (finalAttrs: {
   ];
 
   dependencies = [
-    matplotlib
+    moocore
     numpy
   ];
 


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974
- use `finalAttrs`
- enable `__structuredAttrs`
- 1.4.3 -> 1.4.4: changes: https://github.com/DEAP/deap/compare/332a64de8ccacc7f4310b2caf800999cb6307cf6...8a96fd3a75026f7b30e835f595a5199c75634ddf
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
