### PR TITLE
pkgs.formats.elixirConf: Allow for Elixir charlists

### DIFF
--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -607,6 +607,8 @@ optionalAttrs allowAliases aliases
           elixirMap value
         else if _elixirType == "tuple" then
           tuple value
+        else if _elixirType == "charlist" then
+          charlist value
         else
           abort "formats.elixirConf: should never happen (_elixirType = ${_elixirType})";
 
@@ -619,6 +621,8 @@ optionalAttrs allowAliases aliases
         "%{${entries}}";
 
       tuple = values: "{${listContent values}}";
+
+      charlist = value: "~c\"${value}\"";
 
       toConf =
         let
@@ -687,6 +691,12 @@ optionalAttrs allowAliases aliases
             _elixirType = "atom";
           };
 
+          # Make an Elixir charlist out of a string.
+          mkCharlist = value: {
+            inherit value;
+            _elixirType = "charlist";
+          };
+
           # Make an Elixir tuple out of a list.
           mkTuple = value: {
             inherit value;
@@ -725,6 +735,12 @@ optionalAttrs allowAliases aliases
                 name = "elixirAtom";
                 description = "elixir atom";
                 check = isElixirType "atom";
+              });
+
+              charlist = elixirOr (mkOptionType {
+                name = "elixirCharlist";
+                description = "elixir charlist";
+                check = isElixirType "charlist";
               });
 
               tuple = elixirOr (mkOptionType {


### PR DESCRIPTION
These are needed for defining strings that reach through to Erlang code


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
