### PR TITLE
send-lxmf: init at 0-unstable-2026-05-15

### DIFF
--- a/pkgs/by-name/se/send-lxmf/env-vars.patch
+++ b/pkgs/by-name/se/send-lxmf/env-vars.patch
@@ -1,0 +1,40 @@
+diff --git a/send_lxmf/lib.py b/send_lxmf/lib.py
+index 8312c22fd2..1b671e3bb7 100644
+--- a/send_lxmf/lib.py
++++ b/send_lxmf/lib.py
+@@ -2,17 +2,30 @@
+
+ import os
+ import time
++from pathlib import Path
+ from typing import Any, Optional
+
+ import filelock
+ import LXMF
+ import RNS
+
+-SYSTEM_IDENTITY_PATH = "/var/lib/send-lxmf/identity"
+-SYSTEM_STORAGE_PATH = "/var/lib/send-lxmf/storage"
+-SYSTEM_LOCK_PATH = "/var/lib/send-lxmf/sending.lock"
+-SYSTEM_CONFIG_PATH = "/var/lib/send-lxmf/config"
+-
++home = Path.home()
++
++state_home = os.environ.get(
++    "XDG_STATE_HOME",
++    os.path.join(home, ".local", "state"),
++)
++
++config_home = os.environ.get(
++    "XDG_CONFIG_HOME",
++    os.path.join(home, ".config"),
++)
++
++SYSTEM_STATE_PATH = os.path.join(state_home, "send-lxmf")
++SYSTEM_IDENTITY_PATH = os.path.join(SYSTEM_STATE_PATH, "identity")
++SYSTEM_STORAGE_PATH = os.path.join(SYSTEM_STATE_PATH, "storage")
++SYSTEM_LOCK_PATH = os.path.join(SYSTEM_STATE_PATH, "sending.lock")
++SYSTEM_CONFIG_PATH = os.path.join(config_home, "send-lxmf", "config")
+
+ class LXMFError(Exception):
+     """Base exception for LXMF sending errors."""

--- a/pkgs/by-name/se/send-lxmf/package.nix
+++ b/pkgs/by-name/se/send-lxmf/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitea,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "send-lxmf";
+  version = "0-unstable-2026-05-15";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "melsner";
+    repo = "send-lxmf";
+    rev = "c8b28d5390d7ac334e48d5fe9fd16a864ae73abe";
+    hash = "sha256-bTBYHU4gbm9W1t93Ig5SiTFcMwa+J33cf4RsRZbclaA=";
+  };
+
+  patches = [
+    # Don't use a static directory in `/var/lib/send-lxmf`,
+    # as this is not writable for unpriviledged users and thus prevents the
+    # program from running without additional configuration.
+    # This patch allow the user to specify environment variables to configure
+    # the directories used for storing the program's state, and falls back to a
+    # directory in the user's home directory if the environment variables are
+    # not set.
+    # The environment variables are XDG_STATE_HOME and XDG_CONFIG_HOME.
+    ./env-vars.patch
+  ];
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    rns
+    filelock
+    lxmf
+    markdownify
+  ];
+
+  optional-dependencies = with python3Packages; {
+    dev = [
+      pytest
+    ];
+    integration = [
+      pytest
+      requests
+    ];
+  };
+
+  pythonImportsCheck = [
+    "send_lxmf"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Send LXMF messages over the Reticulum network from the command line";
+    homepage = "https://codeberg.org/melsner/send-lxmf";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ drupol ];
+    mainProgram = "send-lxmf";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
