### PR TITLE
nixos/rustical: fix unix domain socket support

### DIFF
--- a/nixos/modules/services/web-apps/rustical.nix
+++ b/nixos/modules/services/web-apps/rustical.nix
@@ -149,6 +149,8 @@ in
         EnvironmentFile = cfg.environmentFiles;
         Restart = "on-failure";
         StateDirectory = "rustical";
+        RuntimeDirectory = "rustical";
+        RuntimeDirectoryMode = "0750";
 
         CapabilityBoundingSet = "";
         DevicePolicy = "closed";
@@ -172,6 +174,7 @@ in
         RestrictAddressFamilies = [
           "AF_INET"
           "AF_INET6"
+          "AF_UNIX"
         ];
         RestrictNamespaces = true;
         RestrictRealtime = true;
@@ -181,7 +184,7 @@ in
           "~@privileged @resources"
         ];
         SystemCallErrorNumber = "EPERM";
-        UMask = "0077";
+        UMask = "0007";
       };
     };
   };

--- a/nixos/tests/web-apps/rustical.nix
+++ b/nixos/tests/web-apps/rustical.nix
@@ -4,10 +4,6 @@
   ...
 }:
 
-let
-  port = "4000";
-in
-
 {
   name = "rustical";
 
@@ -15,14 +11,21 @@ in
 
   containers.machine =
     {
+      config,
       pkgs,
       ...
     }:
     {
-      services.rustical = {
+      services.rustical.enable = true;
+      services.nginx = {
         enable = true;
-        settings.http.bind = "[::]:${port}";
+        virtualHosts."localhost" = {
+          locations."/" = {
+            proxyPass = "http://${config.services.rustical.settings.http.bind}";
+          };
+        };
       };
+      systemd.services.nginx.serviceConfig.SupplementaryGroups = [ "rustical" ];
       environment.systemPackages = with pkgs; [ calendar-cli ];
     };
 
@@ -32,8 +35,6 @@ in
       ...
     }:
     let
-      url = "http://localhost:${toString port}";
-
       createPrincipalScript = pkgs.writeScript "rustical-create-principal" ''
         #!${lib.getExe pkgs.expect}
         spawn rustical principals create alice --password
@@ -45,30 +46,31 @@ in
       calendarCliConfig = (pkgs.formats.json { }).generate "rustical-test-calendar-cli.json" {
         default = {
           caldav_user = "alice";
-          caldav_url = "${url}/caldav/";
-          calendar_url = "${url}/caldav/principal/alice";
+          caldav_url = "http://localhost/caldav/";
+          calendar_url = "http://localhost/caldav/principal/alice";
         };
         testcal = {
           inherits = "default";
-          calendar_url = "${url}/caldav/principal/alice/testcal";
+          calendar_url = "http://localhost/caldav/principal/alice/testcal";
         };
       };
     in
     # python
     ''
       machine.wait_for_unit("rustical.service")
-      machine.wait_for_open_port(${port})
+      machine.wait_for_file("${lib.removePrefix "unix:" containers.machine.services.rustical.settings.http.bind}")
+      machine.wait_for_open_port(80)
 
       with subtest("Smoketest"):
-        machine.succeed("curl --fail ${url}")
+        machine.succeed("curl --fail http://localhost")
 
       with subtest("Create principal"):
         machine.succeed("${createPrincipalScript}")
         machine.succeed("rustical principals list | grep alice")
 
       with subtest("Generate token for principal"):
-        machine.succeed("curl -f -c cookies.txt -d 'username=alice&password=foobar' ${url}/frontend/login")
-        machine.succeed("curl -f -b cookies.txt -d 'name=mytoken' ${url}/frontend/user/alice/app_token > token.txt")
+        machine.succeed("curl -f -c cookies.txt -d 'username=alice&password=foobar' http://localhost/frontend/login")
+        machine.succeed("curl -f -b cookies.txt -d 'name=mytoken' http://localhost/frontend/user/alice/app_token > token.txt")
 
       with subtest("Interact with caldav"):
         machine.succeed('calendar-cli --config-file ${calendarCliConfig} --caldav-pass "$(cat token.txt)" calendar create testcal')


### PR DESCRIPTION
While the config supported UNIX domain sockets, the runtime environment did not. For this to work we need to relax the UMask, which is not great and will be fixed once Rustical gains socket activation.

https://github.com/lennart-k/rustical/pull/213


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
