### PR TITLE
dua: 2.34.0 -> 2.35.0

### DIFF
--- a/pkgs/by-name/du/dua/package.nix
+++ b/pkgs/by-name/du/dua/package.nix
@@ -8,13 +8,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "dua";
-  version = "2.34.0";
+  version = "2.35.0";
 
   src = fetchFromGitHub {
     owner = "Byron";
     repo = "dua-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-F09Ne+2Ospw44L97nwHXp/ELM9B3G2Mt0Crau//zV/c=";
+    hash = "sha256-dlm8jp7Bh0DgUN4ztalE6uPSzeJy+JDfai39xZKiptw=";
     # Remove unicode file names which leads to different checksums on HFS+
     # vs. other filesystems because of unicode normalisation.
     postFetch = ''
@@ -22,12 +22,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
     '';
   };
 
-  cargoHash = "sha256-g92G/4mfHH7zW14eoodL7j179Iah5iAH78zlmcxM/AM=";
+  cargoHash = "sha256-620Emfkuzyc8/LVr8codB1/IAemxDBOnhS/rL6gR8R8=";
 
   checkFlags = [
     # Skip interactive tests
     "--skip=interactive::app::tests::journeys_readonly::quit_instantly_when_nothing_marked"
     "--skip=interactive::app::tests::journeys_readonly::quit_requires_two_presses_when_items_marked"
+    "--skip=interactive::app::tests::journeys_readonly::once_allows_replayed_quit_to_exit stdout"
     "--skip=interactive::app::tests::journeys_readonly::simple_user_journey_read_only"
     "--skip=interactive::app::tests::journeys_with_writes::basic_user_journey_with_deletion"
     "--skip=interactive::app::tests::unit::it_can_handle_ending_traversal_reaching_top_but_skipping_levels"


### PR DESCRIPTION
Changelog: https://github.com/Byron/dua-cli/releases/tag/v2.35.0
Diff: https://github.com/Byron/dua-cli/compare/v2.34.0...v2.35.0

skip another interactive test

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
