### PR TITLE
python3Packages.correctionlib: 2.8.0 -> 2.9.0

### DIFF
--- a/pkgs/development/python-modules/correctionlib/default.nix
+++ b/pkgs/development/python-modules/correctionlib/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -13,6 +14,8 @@
   ninja,
 
   # buildInputs
+  boost,
+  eigen,
   zlib,
 
   # dependencies
@@ -30,19 +33,29 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "correctionlib";
-  version = "2.8.0";
+  version = "2.9.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "cms-nanoAOD";
     repo = "correctionlib";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-zIKxMulID6JomaSDuI57cHA7xAZIfGBOOYCKS7Xrkaw=";
+    hash = "sha256-jxn5AYqHPtEPE9C5Gv9s556UH6KE1liC8JDw00vMaLg=";
   };
 
   postPatch = ''
-    substituteInPlace CMakeLists.txt --replace-fail "-Wall -Wextra -Wpedantic -Werror" ""
+    substituteInPlace CMakeLists.txt \
+      --replace-fail \
+        "-Wall -Wextra -Wpedantic -Werror" \
+        "" \
+      --replace-fail \
+        "set(BUILTIN_BOOST ON)" \
+        "set(BUILTIN_BOOST OFF)" \
+      --replace-fail \
+        "set(BUILTIN_EIGEN ON)" \
+        "set(BUILTIN_EIGEN OFF)"
   '';
 
   build-system = [
@@ -57,7 +70,11 @@ buildPythonPackage (finalAttrs: {
   ];
   dontUseCmakeConfigure = true;
 
-  buildInputs = [ zlib ];
+  buildInputs = [
+    boost
+    eigen
+    zlib
+  ];
 
   dependencies = [
     numpy
@@ -65,6 +82,8 @@ buildPythonPackage (finalAttrs: {
     pydantic
     rich
   ];
+
+  pythonImportsCheck = [ "correctionlib" ];
 
   nativeCheckInputs = [
     # One test requires running the produced `correctionlib` binary
@@ -75,7 +94,10 @@ buildPythonPackage (finalAttrs: {
     scipy
   ];
 
-  pythonImportsCheck = [ "correctionlib" ];
+  disabledTests = lib.optionals stdenv.hostPlatform.isAarch64 [
+    # AssertionError: assert 0.9518682535564676 == 0.9518682535564679
+    "test_lwtnn_example"
+  ];
 
   meta = {
     description = "Provides a well-structured JSON data format for a wide variety of ad-hoc correction factors encountered in a typical HEP analysis";


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/cms-nanoAOD/correctionlib/compare/v2.8.0...v2.9.0
Changelog: https://github.com/cms-nanoAOD/correctionlib/releases/tag/v2.9.0

cc @veprbl

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test