### PR TITLE
prmt: 0.2.6 -> 0.6.0

### DIFF
--- a/pkgs/by-name/pr/prmt/package.nix
+++ b/pkgs/by-name/pr/prmt/package.nix
@@ -7,34 +7,38 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "prmt";
-  version = "0.2.6";
+  version = "0.6.0";
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     repo = "prmt";
     owner = "3axap4eHko";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/B+Z+m9xpCK04f3/p2URzM0J66OGDX6mB/Zcede+XSo=";
+    hash = "sha256-pLxWArZzGU1vjS2DOJ6PyrhYC2XbkAD5SfiFjHTaQfI=";
   };
 
-  cargoHash = "sha256-Oui5po+She93GmcTNjHMt3syYULBVchcndOuDYgWwME=";
+  cargoHash = "sha256-hmtKmnSnSGgivY+dmC4WlMuCJGTVM6GI5k0pZcfzYso=";
 
   # Fail to run in sandbox environment
   checkFlags = map (t: "--skip=${t}") [
-    "modules::path::tests::relative_path_inside_home_renders_tilde"
-    "modules::path::tests::relative_path_with_shared_prefix_is_not_tilde"
     "test_git_module"
+    "modules::git::tests::empty_dir_tree_not_reported_as_untracked"
+    "modules::git::tests::empty_repo_has_no_untracked_status_in_gix_path"
+    "modules::git::tests::empty_repo_has_no_untracked_status_in_slow_path"
+    "modules::git::tests::untracked_file_sets_untracked_status_in_gix_path"
+    "modules::git::tests::xdg_ignored_progress_dir_does_not_set_untracked_status"
+    "modules::git::tests::xdg_ignored_progress_dir_stays_clean_in_gix_path"
   ];
 
-  nativeInstallCheckInputs = [ versionCheckHook ];
-
   doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Ultra-fast, customizable shell prompt generator";
     homepage = "https://github.com/3axap4eHko/prmt";
-    changelog = "https://github.com/3axap4eHko/prmt/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/3axap4eHko/prmt/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ nartsiss ];
     mainProgram = "prmt";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Update to [v0.6.0](https://github.com/3axap4eHko/prmt/releases/tag/v0.6.0) [(diff)](https://github.com/3axap4eHko/prmt/compare/v0.2.6...v0.6.0)

## Things done


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
