### PR TITLE
python3Packages.jupyterlab: 4.5.7 -> 4.5.8

### DIFF
--- a/pkgs/development/python-modules/jupyterlab/default.nix
+++ b/pkgs/development/python-modules/jupyterlab/default.nix
@@ -21,16 +21,16 @@
   traitlets,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "jupyterlab";
-  version = "4.5.7";
+  version = "4.5.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jupyterlab";
     repo = "jupyterlab";
-    tag = "v${version}";
-    hash = "sha256-kJ9DWfb9VWEPfpG17E3KIvGqWlr0iO2a094Ne7LS1U8=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OtytFZdgGzbQF3icglwRpAn0HhJNyjI6oNS01gfpzkA=";
   };
 
   nativeBuildInputs = [
@@ -43,9 +43,9 @@ buildPythonPackage rec {
   '';
 
   offlineCache = yarn-berry_3.fetchYarnBerryDeps {
-    inherit src;
-    sourceRoot = "${src.name}/jupyterlab/staging";
-    hash = "sha256-2YGs0clj44BSEGdp3wChw97jFSMiAeMnCv3PNhdnEeA=";
+    inherit (finalAttrs) src;
+    sourceRoot = "${finalAttrs.src.name}/jupyterlab/staging";
+    hash = "sha256-wgqwEl01VinYU5haL1X8Na1lNNcyqCfRaRBze4ypPPo=";
   };
 
   preBuild = ''
@@ -85,11 +85,11 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "jupyterlab" ];
 
   meta = {
-    changelog = "https://github.com/jupyterlab/jupyterlab/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/jupyterlab/jupyterlab/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "Jupyter lab environment notebook server extension";
     license = lib.licenses.bsd3;
     homepage = "https://jupyter.org/";
     teams = [ lib.teams.jupyter ];
     mainProgram = "jupyter-lab";
   };
-}
+})

--- a/pkgs/development/python-modules/jupyterlab/default.nix
+++ b/pkgs/development/python-modules/jupyterlab/default.nix
@@ -25,6 +25,7 @@ buildPythonPackage (finalAttrs: {
   pname = "jupyterlab";
   version = "4.5.8";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "jupyterlab";


### PR DESCRIPTION
Upstream release: https://github.com/jupyterlab/jupyterlab/releases/tag/v4.5.8

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
