### PR TITLE
swipe-card: init

### DIFF
--- a/pkgs/servers/home-assistant/custom-lovelace-modules/swipe-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/swipe-card/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/bramkragten/swipe-card";
     changelog = "https://github.com/bramkragten/swipe-card/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ gambled23 ];
+    maintainers = with lib.maintainers; [ Gambled23 ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/swipe-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/swipe-card/package.nix
@@ -33,8 +33,8 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    mkdir $out
-    cp ./dist/swipe-card.js $out
+    mkdir -p $out/bin
+    cp ./dist/swipe-card.js $out/bin
 
     runHook postInstall
   '';

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/swipe-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/swipe-card/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchYarnDeps,
+  fetchFromGitHub,
+  yarnBuildHook,
+  yarnConfigHook,
+  nodejs,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "swipe-card";
+  version = "5.0.0";
+
+  src = fetchFromGitHub {
+    owner = "bramkragten";
+    repo = "swipe-card";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-UC4Oz+2pRdZsNSwjb21jNrTBa+txtXf0CAoJKi2SLXo=";
+  };
+
+  offlineCache = fetchYarnDeps {
+    inherit (finalAttrs) src;
+    hash = "sha256-rtc5vAPWmPYiORf4LkPpa4IB8Oi0VQpS+1kWhXiUMo8=";
+  };
+
+  nativeBuildInputs = [
+    yarnConfigHook
+    yarnBuildHook
+    nodejs
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    cp ./dist/swipe-card.js $out
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Card that allows you to swipe throught multiple cards for Home Assistant Lovelace";
+    homepage = "https://github.com/bramkragten/swipe-card";
+    changelog = "https://github.com/bramkragten/swipe-card/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gambled23 ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
