### PR TITLE
stats: 2.12.7 -> 3.0.3

### DIFF
--- a/pkgs/by-name/st/stats/package.nix
+++ b/pkgs/by-name/st/stats/package.nix
@@ -24,6 +24,7 @@ let
     "Bluetooth"
     "Sensors"
     "Clock"
+    "Remote"
   ];
   modules = lib.tail frameworks;
 
@@ -53,7 +54,7 @@ let
       # CFBundleVersion is extracted from upstream's Info.plist at build time
       Description = "Simple macOS system monitor in your menu bar";
       LSApplicationCategoryType = "public.app-category.utilities";
-      LSMinimumSystemVersion = "11.0";
+      LSMinimumSystemVersion = "12.0";
       LSUIElement = true;
       NSAppTransportSecurity = {
         NSAllowsArbitraryLoads = true;
@@ -67,13 +68,16 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "stats";
-  version = "2.12.7";
+  version = "3.0.3";
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "exelban";
     repo = "Stats";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qx4FI+MnFknIrTOPP+8wyy1wqFMWyaunmags023ay6A=";
+    hash = "sha256-HYuS0mFzzln+EjYUmQgjCPFsF4aGP+4QWalDL0vt3OA=";
   };
 
   nativeBuildInputs = [
@@ -204,7 +208,7 @@ stdenv.mkDerivation (finalAttrs: {
     buildFramework CPU "Modules/CPU/bridge.h" \
       -lKit -framework IOKit
 
-    buildFramework GPU "" \
+    buildFramework GPU "Modules/GPU/bridge.h" \
       -lKit -framework IOKit -framework Metal
 
     buildFramework RAM "" \
@@ -256,6 +260,9 @@ stdenv.mkDerivation (finalAttrs: {
       -o "$buildDir/libSensors.dylib"
 
     buildFramework Clock "" \
+      -lKit
+
+    buildFramework Remote "" \
       -lKit
 
     echo "=== Building Stats app ==="
@@ -312,12 +319,6 @@ stdenv.mkDerivation (finalAttrs: {
       --app-icon AppIcon \
       "Stats/Supporting Files/Assets.xcassets"
 
-    actool \
-      --compile "$app/Contents/Frameworks/Kit.framework/Resources" \
-      --platform macosx \
-      --minimum-deployment-target 14.0 \
-      "Kit/Supporting Files/Assets.xcassets"
-
     # Copy localization files
     find "Stats/Supporting Files" -name '*.lproj' -type d -exec cp -r {} "$app/Contents/Resources/" \;
 
@@ -336,7 +337,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
-    changelog = "https://github.com/exelban/stats/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/exelban/stats/releases/tag/${finalAttrs.src.tag}";
     description = "macOS system monitor in your menu bar";
     homepage = "https://github.com/exelban/stats";
     license = lib.licenses.mit;


### PR DESCRIPTION
## Things done

Diff: https://github.com/exelban/stats/compare/v2.12.7...v3.0.3
Changelog: https://github.com/exelban/stats/releases/tag/v3.0.3

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
