### PR TITLE
nixos/plymouth: add showDelay option

### DIFF
--- a/nixos/modules/system/boot/plymouth.nix
+++ b/nixos/modules/system/boot/plymouth.nix
@@ -68,7 +68,7 @@ let
 
   configFile = pkgs.writeText "plymouthd.conf" ''
     [Daemon]
-    ShowDelay=0
+    ShowDelay=${toString cfg.showDelay}
     DeviceTimeout=8
     Theme=${cfg.theme}
     ${cfg.extraConfig}
@@ -163,6 +163,15 @@ in
         description = ''
           Logo which is displayed on the splash screen.
           Currently supports PNG file format only.
+        '';
+      };
+
+      showDelay = mkOption {
+        type = types.numbers.nonnegative;
+        default = 0;
+        example = 0.5;
+        description = ''
+          Time (in seconds) to delay the splash screen.
         '';
       };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
This commit just adds a `boot.plymouth.showDelay` option to set the `ShowDelay` parameter in `plymouthd.conf`.  This parameter is nice for when your system boots so fast that it ends up flashing Plymouth for a split second before switching to the display manager.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

##### Reviewed points

- [x] changes are backward compatible
- [x] removed options are declared with `mkRemovedOptionModule`
- [x] changes that are not backward compatible are documented in release notes
- [ ] module tests succeed on ARCHITECTURE
- [x] options types are appropriate
- [x] options description is set
- [x] options example is provided
- [x] documentation affected by the changes is updated

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
