### PR TITLE
nixos/release: remove tests.allDrivers

### DIFF
--- a/nixos/release.nix
+++ b/nixos/release.nix
@@ -54,27 +54,6 @@ let
               ${system} = hydraJob test;
             }
         );
-    }
-    // {
-      # for typechecking of the scripts and evaluation of
-      # the nodes, without running VMs.
-      allDrivers = import ./tests/all-tests.nix {
-        inherit system;
-        pkgs = import ./.. { inherit system; };
-        callTest =
-          config:
-          let
-            inherit (config) driver;
-          in
-          lib.optionalAttrs (builtins.elem system (getPlatforms driver)) (
-            if attrNamesOnly then
-              hydraJob driver
-            else
-              {
-                ${system} = hydraJob driver;
-              }
-          );
-      };
     };
 
   allTests = foldAttrs recursiveUpdate { } (


### PR DESCRIPTION
We discussed in #staging:nixos.org (Matrix) that the drivers itself are helpful for development, but that executing them in Hydra don't provide a benefit over executing the tests themself.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I checked that a partial eval of `tests` in `nixos/release.nix` still works

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
