### PR TITLE
xquartz: Fix (nontrusted) X forwarding and crashloop

### DIFF
--- a/pkgs/by-name/xo/xorg-server/package.nix
+++ b/pkgs/by-name/xo/xorg-server/package.nix
@@ -152,8 +152,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dxkb_bin_dir=${xkbcomp}/bin"
     "-Dxkb_dir=${xkeyboard-config}/share/X11/xkb"
     "-Dxkb_output_dir=$out/share/X11/xkb/compiled"
-  ]
-  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+
     "-Dxcsecurity=true"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/by-name/xo/xorg-server/package.nix
+++ b/pkgs/by-name/xo/xorg-server/package.nix
@@ -176,6 +176,9 @@ stdenv.mkDerivation (finalAttrs: {
       --subst-var-by XQUARTZ_APP "$out/Applications/XQuartz.app"
   '';
 
+  # avoid linux rebuilds
+  ${if stdenv.hostPlatform.isDarwin then "hardeningDisable" else null} = [ "strictflexarrays1" ];
+
   # default X install symlinks this to Xorg, we want XQuartz
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     ln -sf $out/bin/Xquartz $out/bin/X

--- a/pkgs/by-name/xq/xquartz/package.nix
+++ b/pkgs/by-name/xq/xquartz/package.nix
@@ -240,12 +240,12 @@ stdenv.mkDerivation {
     cp ${fontsConf} $fontsConfPath
 
     substituteInPlace $out/bin/startx \
-      --replace "bindir=${xinit}/bin" "bindir=$out/bin" \
-      --replace 'defaultserver=${xorg-server}/bin/X' "defaultserver=$out/bin/Xquartz" \
-      --replace "${xinit}" "$out" \
-      --replace "${xorg-server}" "$out" \
-      --replace "eval xinit" "eval $out/bin/xinit" \
-      --replace "sysclientrc=/etc/X11/xinit/xinitrc" "sysclientrc=$out/etc/X11/xinit/xinitrc"
+      --replace-fail "${xinit}" "$out" \
+      --replace-fail "xserver=\"${xorg-server}/bin/X\"" "xserver=\"$out/bin/Xquartz\"" \
+      --replace-fail 'xinit="xinit"' "xinit=$out/bin/xinit" \
+      --replace-fail '"xauth"' "${lib.getExe xauth}" \
+      --replace-fail "xauth " '"$xauth" ' \
+      --replace-fail "sysclientrc=/etc/X11/xinit/xinitrc" "sysclientrc=$out/etc/X11/xinit/xinitrc"
 
     wrapProgram $out/bin/Xquartz \
       --set XQUARTZ_APP $out/Applications/XQuartz.app
@@ -262,9 +262,9 @@ stdenv.mkDerivation {
     EOF
 
     substituteInPlace $out/etc/X11/xinit/xinitrc \
-      --replace ${xinit} $out \
-      --replace xmodmap ${xmodmap}/bin/xmodmap \
-      --replace xrdb ${xrdb}/bin/xrdb
+      --replace-fail ${xinit} $out \
+      --replace-fail '"xmodmap"' ${xmodmap}/bin/xmodmap \
+      --replace-fail '"xrdb"' ${xrdb}/bin/xrdb
 
     mkdir -p $out/etc/X11/xinit/xinitrc.d
 
@@ -281,7 +281,7 @@ stdenv.mkDerivation {
     chmod +x $out/etc/X11/xinit/xinitrc.d/99-quartz-wm.sh
 
     substituteInPlace $out/etc/X11/xinit/privileged_startx.d/20-font_cache \
-      --replace ${xinit} $out
+      --replace-fail ${xinit} $out
 
     cp ${./font_cache} $out/bin/font_cache
     substituteInPlace $out/bin/font_cache \


### PR DESCRIPTION
The two main changes are building xorg-server with the SECURITY module unconditionally (there didn't seem to be any reason to make it conditional in the first place and it works fine on Darwin) and fixing an infinite crashloop in XQuartz caused by an overzealous buffer overflow check (see #504784 for a similar issue).
I also made some changes to fix program paths in xinitrc and startx that were not quite correct; these errors may not have been fatal before this but I think it's generally a good idea to fix them.

With these changes `ssh -X` works properly for X forwarding from a headless Linux system running `xserver`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
