### PR TITLE
insomnia: 12.2.0 -> 13.0.0

### DIFF
--- a/pkgs/by-name/in/insomnia/package.nix
+++ b/pkgs/by-name/in/insomnia/package.nix
@@ -7,22 +7,22 @@
 }:
 let
   pname = "insomnia";
-  version = "12.2.0";
+  version = "13.0.0";
 
   src =
     fetchurl
       {
         aarch64-darwin = {
           url = "https://github.com/Kong/insomnia/releases/download/core%40${version}/Insomnia.Core-${version}.dmg";
-          hash = "sha256-ISQVIhR5TWY/Xk6sXeL89/srxppqBS7wdoRINwuoQqg=";
+          hash = "sha256-sPl7KXC8Z13LFZvxuKg02iDbtrCxn//Yrr8AOOf3VD4=";
         };
         x86_64-darwin = {
           url = "https://github.com/Kong/insomnia/releases/download/core%40${version}/Insomnia.Core-${version}.dmg";
-          hash = "sha256-ISQVIhR5TWY/Xk6sXeL89/srxppqBS7wdoRINwuoQqg=";
+          hash = "sha256-sPl7KXC8Z13LFZvxuKg02iDbtrCxn//Yrr8AOOf3VD4=";
         };
         x86_64-linux = {
           url = "https://github.com/Kong/insomnia/releases/download/core%40${version}/Insomnia.Core-${version}.AppImage";
-          hash = "sha256-/0fJmbXhjrcVVSFvxd847mSKrzrZRK3Sqi6rjyaBOUw=";
+          hash = "sha256-PlcKBQnkmgU/SsLRKX7ohrGHm7B4hK9FMkplwlbFolI=";
         };
       }
       .${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");


### PR DESCRIPTION
##### Motivation

Version bump for Insomnia from 12.2.0 to 13.0.0.

This replaces #524112, an unfinished bump to 12.6.0. 12.6.0 introduced a Linux regression where the main-process logger crashes with `write EPIPE` on desktop-file launch (Kong/insomnia#9951), so that bump was never completed. Kong fixed the crash in the 13.0.0 beta line and the issue reporter confirmed it resolved, so this goes to 13.0.0 and skips 12.6.0.

##### Changelog

Release notes: https://github.com/Kong/insomnia/releases/tag/core@13.0.0

13.0.0 promotes the 13.0.0 beta line to stable. Changes since 12.2.0 include:

- Fix for the Linux `write EPIPE` main-process crash on desktop-file launch (Kong/insomnia#9951)
- Konnect sync integration behind a feature flag, with proxy URL/regex, expressions, and nunjucks template sanitization
- Git Sync: credential validation, auto-resolve of non-YAML conflicts to remote during merge, canonical repository output, and a downgrade to upgrade path
- Custom npm registry mirror setting for plugin installation (INS-1269)
- Default user-agent for cURL imports and a deep-link import login experience (INS-2416)
- Pin and unpin support for WebSocket and Socket.IO requests
- Reworked pre and post-request scripting sandbox

##### Checklist

- [x] Built on platform(s): x86_64-linux
- ~~[ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside nixos/tests)~~ N/A (no tests exist for insomnia)
- [x] Tested basic functionality of the built binary (`./result/bin/insomnia` launches, reports version 13.0.0)
- [x] Built in the Nix sandbox
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

##### Notes

- Updated hashes for all three platforms: the x86_64-linux AppImage and the x86_64-darwin / aarch64-darwin DMG.
- Builds on x86_64-linux and the binary reports 13.0.0. Insomnia is a leaf package with no dependents, so there is nothing else to rebuild.
- Supersedes #524112.
