### PR TITLE
CloudReverb: init to v0.5

### DIFF
--- a/pkgs/by-name/cl/cloud_reverb/package.nix
+++ b/pkgs/by-name/cl/cloud_reverb/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  alsa-lib,
+  freetype,
+  fontconfig,
+  libGL,
+  libx11,
+  libxcursor,
+  libxext,
+  libxinerama,
+  libxrandr,
+  nix-update-script,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cloudreverb";
+  version = "0.5";
+
+  src = fetchFromGitHub {
+    owner = "xunil-cloud";
+    repo = "CloudReverb";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-erpJlS9VYvYyqYyKjyDuob7Jup+zLuj93j+BRAjPtl4=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    alsa-lib
+    freetype
+    fontconfig
+    libGL
+    libx11
+    libxcursor
+    libxext
+    libxinerama
+    libxrandr
+  ];
+
+  # JUCE dlopen's these at runtime, crashes without them
+  env.NIX_LDFLAGS = toString [
+    "-lX11"
+    "-lXext"
+    "-lXcursor"
+    "-lXinerama"
+    "-lXrandr"
+  ];
+
+  # Disable LTO to avoid optimization mismatch issues
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-fno-lto"
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    cp -r CloudReverb_artefacts/Release/LV2 $out/lib/lv2
+    cp -r CloudReverb_artefacts/Release/VST3 $out/lib/vst3
+    install -Dm755 "CloudReverb_artefacts/Release/Standalone/CloudReverb" $out/bin/cloud_reverb
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Algorithmic reverb plugin based on CloudSeed";
+    homepage = "https://github.com/xunil-cloud/CloudReverb";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ crop ];
+    platforms = lib.platforms.linux;
+    mainProgram = "cloud_reverb";
+  };
+})


### PR DESCRIPTION
Adding  CloudReverb an algorithmic reverb plugin based on CloudSeed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
