### PR TITLE
gitlab-workhorse: remove erroned attribute

### DIFF
--- a/pkgs/by-name/gi/gitlab/gitlab-workhorse/default.nix
+++ b/pkgs/by-name/gi/gitlab/gitlab-workhorse/default.nix
@@ -22,11 +22,12 @@ buildGoModule (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/workhorse";
 
-  vendorHash = "sha256-X1+neA2g61BR1VRKXzeqNath0+SYXRbU4vzEg1KD2sY=";
+  vendorHash = "sha256-6/50YxOW3NK5qzy0ALERCMK3JpLJflnw8ePAvNXANxQ=";
+
   buildInputs = [ git ];
   ldflags = [ "-X main.Version=${finalAttrs.version}" ];
   doCheck = false;
-  prodyVendor = true;
+  proxyVendor = true;
 
   meta = {
     homepage = "http://www.gitlab.com/";


### PR DESCRIPTION
When `proxdyVendor` is correted to `proxyVendor`, build fails.
```
error: Cannot build '/nix/store/5404c0zsk1ipfp2qhi54qqgqwvj6vhv9-gitlab-workhorse-18.11.5.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/ml70jvlr7bzvjj5pl57cqbgwm96jpwdy-gitlab-workhorse-18.11.5
       Last 10 log lines:
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/w2n4vq62fq5mwpbp53z9c98gm4y84z5b-source
       > source root is source/workhorse
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > Running phase: buildPhase
       > Building subPackage ./cmd/gitlab-resize-image
       > go: downloading golang.org/x/image v0.28.0
       > cmd/gitlab-resize-image/image.go:11:2: golang.org/x/image@v0.28.0: reading file:///nix/store/qyik1hlypgdc9aafbfmmx0p63lq529p1-gitlab-workhorse-18.11.5-go-modules/golang.org/x/image/@v/v0.28.0.zip: no such file or directory
       For full logs, run:
         nix log /nix/store/5404c0zsk1ipfp2qhi54qqgqwvj6vhv9-gitlab-workhorse-18.11.5.drv
```

## Things done

- part of #532401

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
