### PR TITLE
sampo: 0.17.4 -> 0.18.0

### DIFF
--- a/pkgs/by-name/sa/sampo/package.nix
+++ b/pkgs/by-name/sa/sampo/package.nix
@@ -9,20 +9,21 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sampo";
-  version = "0.17.4";
+  version = "0.18.0";
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "bruits";
     repo = "sampo";
-    tag = "sampo-v${finalAttrs.version}";
-    hash = "sha256-P+CekuDM3u+iG2HmCNWxZoTCaKtAUMnrNre4zeGNPrQ=";
+    tag = "cargo-sampo-v${finalAttrs.version}";
+    hash = "sha256-LPgY/UA2AF871bid8wqxzIhTDnsHsQ7IhY/eNYE6Npk=";
   };
+
+  cargoHash = "sha256-U52xGXJlz7cM1fJWZMp51iNgYQRA8AKJ0OkbxlAB5C8=";
 
   nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [ openssl ];
-
-  cargoHash = "sha256-udMpH0LWNqPTORSb1/c686stgvti5shx/O9rcH7YZNs=";
 
   cargoBuildFlags = [
     "-p"
@@ -35,12 +36,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
 
-  passthru.updateScript = nix-update-script { extraArgs = [ "--version-regex=sampo-v([0-9\\.]*)" ]; };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex=cargo-sampo-v([0-9\\.]*)" ];
+  };
 
   meta = {
     description = "Automate changelogs, versioning, and publishing—even for monorepos across multiple package registries";
     homepage = "https://github.com/bruits/sampo";
-    changelog = "https://github.com/bruits/sampo/blob/sampo-v${finalAttrs.version}/crates/sampo/CHANGELOG.md";
+    changelog = "https://github.com/bruits/sampo/blob/${finalAttrs.src.tag}/crates/sampo/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ nartsiss ];
     mainProgram = "sampo";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- Update to [v0.18.0](https://github.com/bruits/sampo/releases/tag/cargo-sampo-v0.18.0) [(diff)](https://github.com/bruits/sampo/compare/sampo-v0.17.4...cargo-sampo-v0.18.0)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
