### PR TITLE
zabbix-cli: 3.6.2 -> 3.6.3

### DIFF
--- a/pkgs/by-name/za/zabbix-cli/package.nix
+++ b/pkgs/by-name/za/zabbix-cli/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   python3Packages,
   testers,
   zabbix-cli,
@@ -10,24 +9,15 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "zabbix-cli";
-  version = "3.6.2";
+  version = "3.6.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "unioslo";
     repo = "zabbix-cli";
     tag = finalAttrs.version;
-    hash = "sha256-Y4IR/le+7X3MYmrVnZMr+Gu59LkCB5UfMJ2s9ovSjLM=";
+    hash = "sha256-FbLKU8pjnKpVLE85zkxOmvc6rbhc3x6JdKiI7SdSn1w=";
   };
-
-  patches = [
-    # Fix MarkupMode import with Typer >= 0.20.1
-    # https://github.com/unioslo/zabbix-cli/pull/333
-    (fetchpatch {
-      url = "https://github.com/unioslo/zabbix-cli/commit/b68f672f557ccb06fef3fd5a2d724633f1eb3c68.patch";
-      hash = "sha256-wc59c28aT8IsI4nvEH+CxfdvPAsN2R1uoLgN8tx+mBE=";
-    })
-  ];
 
   build-system = with python3Packages; [
     hatchling


### PR DESCRIPTION
Bumped version and removed now-upstream patch (unioslo/zabbix-cli#333).

Changelog: https://github.com/unioslo/zabbix-cli/releases/tag/3.6.3
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
