### PR TITLE
kiro-cli: workaround the embedded bun - fixes #516857

### DIFF
--- a/pkgs/by-name/ki/kiro-cli/kiro-cli-wrapper.sh
+++ b/pkgs/by-name/ki/kiro-cli/kiro-cli-wrapper.sh
@@ -1,0 +1,29 @@
+#!@shell@
+# Pre-populate the kiro-cli data dir with assets pinned by this package so
+# kiro-cli-chat skips its built-in extraction on every run. The embedded
+# bun is a glibc-linked binary that fails on NixOS (issue #516857); we
+# redirect to nixpkgs bun via a symlink the runtime accepts because we
+# also drop in the bun.sha256 the runtime expects.
+set -e
+
+# Skip data-dir setup if we have no usable HOME (e.g. version-check / --help).
+# kiro-cli-chat only needs the assets when actually entering the TUI.
+if [ -n "${KIRO_DATA_DIR:-}" ]; then
+    dataDir="$KIRO_DATA_DIR"
+elif [ -n "${XDG_DATA_HOME:-}" ]; then
+    dataDir="$XDG_DATA_HOME/kiro-cli"
+elif [ -n "${HOME:-}" ]; then
+    dataDir="$HOME/.local/share/kiro-cli"
+else
+    dataDir=
+fi
+
+if [ -n "$dataDir" ]; then
+    @coreutils@/bin/mkdir -p "$dataDir"
+    @coreutils@/bin/ln -sfn "@bun@"           "$dataDir/bun"
+    @coreutils@/bin/ln -sfn "@share@/tui.js"  "$dataDir/tui.js"
+    @coreutils@/bin/install -m 0644 "@share@/bun.sha256"    "$dataDir/bun.sha256"
+    @coreutils@/bin/install -m 0644 "@share@/tui.js.sha256" "$dataDir/tui.js.sha256"
+fi
+
+exec "@libexec@" "$@"

--- a/pkgs/by-name/ki/kiro-cli/package.nix
+++ b/pkgs/by-name/ki/kiro-cli/package.nix
@@ -7,6 +7,10 @@
   versionCheckHook,
   xz,
   bzip2,
+  bun,
+  coreutils,
+  python3,
+  runtimeShell,
 }:
 
 let
@@ -44,6 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs =
     lib.optionals stdenv.hostPlatform.isLinux [
       autoPatchelfHook
+      python3
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       undmg
@@ -65,9 +70,9 @@ stdenv.mkDerivation (finalAttrs: {
     runHook preInstall
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
-    install -Dm755 bin/kiro-cli -t $out/bin
-    install -Dm755 bin/kiro-cli-chat $out/bin/kiro-cli-chat
-    install -Dm755 bin/kiro-cli-term $out/bin/kiro-cli-term
+    install -Dm755 bin/kiro-cli      $out/libexec/kiro-cli/kiro-cli
+    install -Dm755 bin/kiro-cli-chat $out/libexec/kiro-cli/kiro-cli-chat
+    install -Dm755 bin/kiro-cli-term $out/libexec/kiro-cli/kiro-cli-term
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir -p $out/bin $out/Applications
@@ -81,6 +86,84 @@ stdenv.mkDerivation (finalAttrs: {
   ''
   + ''
     runHook postInstall
+  '';
+
+  # On Linux, kiro-cli-chat embeds a generic-Linux-glibc bun (101 MiB) and a
+  # tui.js bundle. On first --tui run it self-extracts those to
+  # ~/.local/share/kiro-cli/ and exec()s the extracted bun, which fails on
+  # NixOS because the dynamic loader path /lib64/ld-linux-x86-64.so.2 doesn't
+  # exist (issue #516857). To fix this without an FHS env we:
+  #
+  #   1. Run the (autopatchelf'd) kiro-cli-chat once at build time to extract
+  #      the embedded assets.
+  #   2. Stash bun.sha256, tui.js, and tui.js.sha256 under $out/share/kiro-cli/
+  #      and discard the extracted bun.
+  #   3. Zero out the embedded bun bytes inside kiro-cli-chat in-place. The
+  #      extraction-skip check only compares the on-disk bun.sha256 file to
+  #      the embedded hash; the bun bytes themselves are never re-read once
+  #      we pre-populate the data dir, so zeroing them is safe and lets the
+  #      Nix store binary cache compress that 101 MiB region to almost nothing.
+  #   4. Wrap kiro-cli, kiro-cli-chat, and kiro-cli-term so each invocation
+  #      pre-populates the user's ~/.local/share/kiro-cli/ with a symlink to
+  #      ${bun}/bin/bun and the build-time bun.sha256/tui.js/tui.js.sha256.
+  #      kiro-cli-chat then sees its assets are up-to-date, skips extraction,
+  #      and exec()s the nixpkgs bun.
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    # autoPatchelfHook normally runs at the end of fixupPhase, after our
+    # postFixup. We need the binaries patched first so we can execute
+    # kiro-cli-chat to trigger asset extraction. Run it explicitly here.
+    autoPatchelfPostFixup
+
+    extractDir=$(mktemp -d)
+    mkdir -p "$extractDir/.local/share/kiro-cli"
+
+    # kiro-cli-chat opens an interactive TUI and waits for input. Closing
+    # stdin and using a short timeout lets it run far enough to extract the
+    # embedded assets before we kill it.
+    HOME="$extractDir" \
+    XDG_DATA_HOME="$extractDir/.local/share" \
+    KIRO_DISABLE_TELEMETRY=1 \
+    KIRO_NO_AUTO_UPDATE=1 \
+    KIRO_DISABLE_TRUECOLOR=1 \
+    KIRO_API_KEY=nixpkgs-build-extract-only \
+      timeout --preserve-status --signal=TERM 30s \
+        $out/libexec/kiro-cli/kiro-cli-chat chat --tui --agent-engine=v2 \
+        < /dev/null > "$extractDir/extract.log" 2>&1 \
+      || true
+
+    for f in bun bun.sha256 tui.js tui.js.sha256; do
+      if [[ ! -s "$extractDir/.local/share/kiro-cli/$f" ]]; then
+        echo "kiro-cli build-time extraction did not produce $f" >&2
+        ls -la "$extractDir/.local/share/kiro-cli/" >&2
+        echo "--- extraction log: ---" >&2
+        cat "$extractDir/extract.log" >&2 || true
+        echo "--- end log ---" >&2
+        exit 1
+      fi
+    done
+
+    install -d $out/share/kiro-cli
+    install -m 0644 "$extractDir/.local/share/kiro-cli/bun.sha256"    $out/share/kiro-cli/bun.sha256
+    install -m 0644 "$extractDir/.local/share/kiro-cli/tui.js"        $out/share/kiro-cli/tui.js
+    install -m 0644 "$extractDir/.local/share/kiro-cli/tui.js.sha256" $out/share/kiro-cli/tui.js.sha256
+
+    python3 ${./zero-embedded-bun.py} \
+      $out/libexec/kiro-cli/kiro-cli-chat \
+      "$extractDir/.local/share/kiro-cli/bun" \
+      "$extractDir/.local/share/kiro-cli/bun.sha256"
+
+    rm -rf "$extractDir"
+
+    mkdir -p $out/bin
+    for binname in kiro-cli kiro-cli-chat kiro-cli-term; do
+      substitute ${./kiro-cli-wrapper.sh} $out/bin/$binname \
+        --subst-var-by shell ${runtimeShell} \
+        --subst-var-by coreutils ${coreutils} \
+        --subst-var-by bun ${lib.getExe bun} \
+        --subst-var-by share $out/share/kiro-cli \
+        --subst-var-by libexec $out/libexec/kiro-cli/$binname
+      chmod 0755 $out/bin/$binname
+    done
   '';
 
   passthru.updateScript = ./update.sh;

--- a/pkgs/by-name/ki/kiro-cli/zero-embedded-bun.py
+++ b/pkgs/by-name/ki/kiro-cli/zero-embedded-bun.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""
+Zero out the embedded bun ELF inside kiro-cli-chat in-place.
+
+kiro-cli-chat embeds:
+  [...]
+  [bun ELF bytes]                (binary data, 100MB+)
+  [bun.sha256 hex string]        (64 ASCII chars, the expected hash)
+  [tui.js bytes]
+  [tui.js.sha256 hex string]
+  [...]
+
+The runtime extraction logic verifies the on-disk bun.sha256 against the
+embedded hash, but does NOT verify the bun bytes themselves. Combined with
+a wrapper that pre-creates ~/.local/share/kiro-cli/bun -> ${bun}/bin/bun
+and writes the embedded bun.sha256, the embedded bun bytes are never
+extracted to disk and are dead weight inside kiro-cli-chat. We zero them
+out so they compress to nothing in the binary cache.
+
+Usage:
+  zero-embedded-bun.py <kiro-cli-chat> <extracted_bun> <bun.sha256_file>
+
+The bun.sha256 string is unique inside kiro-cli-chat, so we use it as a
+locator: bun_end = position of sha string, bun_start = bun_end - bun_size.
+"""
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        sys.stderr.write(
+            f"usage: {sys.argv[0]} <chat_binary> <extracted_bun> <bun_sha_file>\n"
+        )
+        return 2
+
+    chat_path, bun_path, sha_path = sys.argv[1:4]
+
+    with open(bun_path, "rb") as f:
+        bun_bytes = f.read()
+    with open(sha_path, "rb") as f:
+        sha_str = f.read().rstrip(b"\n")
+
+    if len(sha_str) != 64 or not all(c in b"0123456789abcdef" for c in sha_str):
+        sys.stderr.write(f"unexpected sha format: {sha_str!r}\n")
+        return 1
+
+    with open(chat_path, "rb") as f:
+        data = f.read()
+
+    positions = []
+    pos = -1
+    while True:
+        pos = data.find(sha_str, pos + 1)
+        if pos < 0:
+            break
+        positions.append(pos)
+    if len(positions) != 1:
+        sys.stderr.write(
+            f"expected exactly one occurrence of {sha_str.decode()} "
+            f"in {chat_path}, found {len(positions)}: "
+            f"{[hex(p) for p in positions]}\n"
+        )
+        return 1
+
+    sha_pos = positions[0]
+    bun_start = sha_pos - len(bun_bytes)
+    if bun_start < 0:
+        sys.stderr.write(
+            f"computed bun_start {bun_start:#x} is negative\n"
+        )
+        return 1
+
+    actual = data[bun_start:sha_pos]
+    if actual != bun_bytes:
+        sys.stderr.write(
+            f"bytes at offset {bun_start:#x} do not match extracted bun\n"
+        )
+        return 1
+
+    sys.stdout.write(
+        f"zeroing {len(bun_bytes):,} bytes of embedded bun "
+        f"at offset {bun_start:#x} in {chat_path}\n"
+    )
+    with open(chat_path, "r+b") as f:
+        f.seek(bun_start)
+        f.write(b"\x00" * len(bun_bytes))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
package.nix — moved the three real binaries to $out/libexec/kiro-cli/, then in
  postFixup:
  
  1. Force autoPatchelfPostFixup to run early (it normally runs after our hook),
  so kiro-cli-chat is patched and runnable.
  2. Run kiro-cli-chat chat --tui --agent-engine=v2 once with a 30s timeout and
  KIRO_API_KEY=dummy so it skips OAuth and reaches the asset-extraction step.
  3. Stash bun.sha256, tui.js, tui.js.sha256 under $out/share/kiro-cli/. Discard
  the extracted bun.
  4. Run zero-embedded-bun.py to zero the 101 MiB bun blob in-place inside
  kiro-cli-chat.
  5. Generate three thin wrappers in $out/bin/ from the template.
  
  zero-embedded-bun.py — locates the bun blob deterministically by searching for
  the unique 64-char bun.sha256 hex string (the byte right after bun's last
  byte) and computes bun_start = sha_pos − bun_size. After verifying the bytes
  match the extracted bun, it overwrites them with zeros.
  
  kiro-cli-wrapper.sh — single template used for all three wrappers. Each
  invocation:
  
  - Resolves dataDir from $KIRO_DATA_DIR, $XDG_DATA_HOME, or $HOME (graceful
  no-op when none are set, so --version/--help work in restricted environments).
  - ln -sfn bun → ${pkgs.bun}/bin/bun and tui.js → $out/share/kiro-cli/tui.js.
  - Copies the two .sha256 files.
  - execs the real binary in libexec.
  
  Why this works
  
  The runtime extraction-skip check in kiro-cli-chat compares the on-disk
  bun.sha256 content to an embedded hash, but never re-hashes the bun bytes
  themselves. Our wrapper drops in the matching .sha256 and a symlink to
  nixpkgs' bun (also 1.3.13). kiro-cli-chat sees its assets are up-to-date,
  skips extraction, and execs the symlinked nixpkgs bun, which is autopatchelf'd
  and works on NixOS.
  
  Verification
  
  - nix-build succeeds.
  - kiro-cli --version and kiro-cli chat --tui --agent-engine=v2 both work;
  strace confirms nixpkgs bun is exec'd.
  - The 101 MiB bun region in kiro-cli-chat is fully zeroed (sampled at start
  and 50 MiB in).
  - Cache-compressed NAR (zstd -19): 83 MB → 57 MB (~26 MB less to download from
  cache.nixos.org).
  - Runtime closure picks up bun, coreutils, bash, glibc correctly.


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
