### PR TITLE
zoneminder: 1.36.38 -> 1.38.3 + a number of fixes

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -59,3 +59,5 @@
 - `security.polkit.settings` added for RFC42 style configuration of the polkitd daemon.
 
 - The `newuidmap` and `newgidmap` security wrappers are now installed with `cap_setuid`/`cap_setgid` file capabilities instead of the setuid-root bit, matching shadow's `--with-fcaps` install mode and other major distributions. Rootless containers (podman, docker-rootless, unprivileged user namespaces) are unaffected. The only behavioural change is that mapping host uid 0 via `/etc/subuid` (which NixOS never configures by default) additionally requires `cap_setfcap`; users who explicitly grant uid 0 in a subuid range can restore the previous behaviour with `security.wrappers.newuidmap.capabilities = lib.mkForce "cap_setuid,cap_setfcap+ep";`.
+
+- `zoneminder` has been updated to 1.38.x release. See [upstream release note](https://github.com/ZoneMinder/zoneminder/releases/tag/1.38.0). While database migration should happen automatically, it's recommended that you make a backup of the database before upgrading your system.

--- a/pkgs/by-name/zo/zoneminder/0001-Don-t-use-file-timestamp-in-cache-filename.patch
+++ b/pkgs/by-name/zo/zoneminder/0001-Don-t-use-file-timestamp-in-cache-filename.patch
@@ -1,4 +1,4 @@
-From 8823e48b055b7e574c08069048ba21ffa4393699 Mon Sep 17 00:00:00 2001
+From f722b5f1c9d71542305f024c9769c9efb6793551 Mon Sep 17 00:00:00 2001
 From: Daniel Fullmer <danielrf12@gmail.com>
 Date: Fri, 21 Feb 2020 21:52:00 -0500
 Subject: [PATCH] Don't use file timestamp in cache filename
@@ -9,23 +9,26 @@ This would mean that newer versions would use the existing symlink to an
 older version of the source file.  We replace SRC_HASH in nix with a
 hash of the source used to build zoneminder to ensure this filename is
 unique.
+
+[peathot@hotmail.com: update for ZoneMinder 1.38.3]
 ---
  web/includes/functions.php | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/web/includes/functions.php b/web/includes/functions.php
-index 89d2cc8ad..52cbb6f38 100644
+index 1b03a4ddd..5ba311691 100644
 --- a/web/includes/functions.php
 +++ b/web/includes/functions.php
-@@ -1941,7 +1941,8 @@ function cache_bust($file) {
+@@ -1904,7 +1904,8 @@ function cache_bust($file) {
    $parts = pathinfo($file);
    global $css;
    $dirname = str_replace('/', '_', $parts['dirname']);
 -  $cacheFile = $dirname.'_'.$parts['filename'].'-'.$css.'-'.filemtime($file).'.'.$parts['extension'];
 +  $srcHash = '@srcHash@';
 +  $cacheFile = $dirname.'_'.$parts['filename'].'-'.$css.'-'.$srcHash.'.'.$parts['extension'];
-   if ( file_exists(ZM_DIR_CACHE.'/'.$cacheFile) or symlink(ZM_PATH_WEB.'/'.$file, ZM_DIR_CACHE.'/'.$cacheFile) ) {
-     return 'cache/'.$cacheFile;
-   } else {
+   if (
+     @symlink(ZM_PATH_WEB.'/'.$file, ZM_DIR_CACHE.'/'.$cacheFile)
+     or
 -- 
-2.32.0
+2.53.0
+

--- a/pkgs/by-name/zo/zoneminder/package.nix
+++ b/pkgs/by-name/zo/zoneminder/package.nix
@@ -270,7 +270,7 @@ stdenv.mkDerivation rec {
     description = "Video surveillance software system";
     homepage = "https://zoneminder.com";
     license = lib.licenses.gpl3;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ peat-psuwit ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/zo/zoneminder/package.nix
+++ b/pkgs/by-name/zo/zoneminder/package.nix
@@ -6,19 +6,23 @@
   cmake,
   makeWrapper,
   pkg-config,
+  arp-scan,
   curl,
   ffmpeg,
   glib,
+  iproute2,
   libjpeg,
   libselinux,
   libsepol,
   mp4v2,
   libmysqlclient,
   mariadb,
+  nlohmann_json,
   pcre2,
   perl,
   perlPackages,
   polkit,
+  systemd,
   util-linuxMinimal,
   x264,
   zlib,
@@ -68,6 +72,7 @@
 let
   addons = [
     {
+      # XXX: not tested with 1.38.x.
       path = "scripts/ZoneMinder/lib/ZoneMinder/Control/Xiaomi.pm";
       src = fetchurl {
         url = "https://gist.githubusercontent.com/joshstrange/73a2f24dfaf5cd5b470024096ce2680f/raw/e964270c5cdbf95e5b7f214f7f0fc6113791530e/Xiaomi.pm";
@@ -83,13 +88,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "zoneminder";
-  version = "1.36.38";
+  version = "1.38.3";
 
   src = fetchFromGitHub {
     owner = "ZoneMinder";
     repo = "zoneminder";
     tag = version;
-    hash = "sha256-c/Q+h0ntJ4XUuvgrLSlWfue4GL4nGARgmXt0En334Y4=";
+    hash = "sha256-Hko5ViEevcKp0kiSFK9DBcSoYkZY3KttazhEexv4klI=";
     fetchSubmodules = true;
   };
 
@@ -107,22 +112,29 @@ stdenv.mkDerivation rec {
       '') addons
     )}
 
-    for d in scripts/ZoneMinder onvif/{modules,proxy} ; do
+    for d in scripts/ZoneMinder onvif/modules ; do
       substituteInPlace $d/CMakeLists.txt \
-        --replace 'DESTDIR="''${CMAKE_CURRENT_BINARY_DIR}/output"' "PREFIX=$out INSTALLDIRS=site"
+        --replace-fail 'DESTDIR="''${CMAKE_CURRENT_BINARY_DIR}/output"' "PREFIX=$out INSTALLDIRS=site"
+      sed -i '/^install/d' $d/CMakeLists.txt
+    done
+
+    # Slightly different quoting.
+    for d in onvif/proxy ; do
+      substituteInPlace $d/CMakeLists.txt \
+        --replace-fail 'DESTDIR=''${CMAKE_CURRENT_BINARY_DIR}/output' "PREFIX=$out INSTALLDIRS=site"
       sed -i '/^install/d' $d/CMakeLists.txt
     done
 
     substituteInPlace misc/CMakeLists.txt \
-      --replace '"''${PC_POLKIT_PREFIX}/''${CMAKE_INSTALL_DATAROOTDIR}' "\"$out/share"
+      --replace-fail '"''${PC_POLKIT_PREFIX}/''${CMAKE_INSTALL_DATAROOTDIR}' "\"$out/share"
 
-    for f in misc/*.policy.in \
-             scripts/*.pl* \
+    for f in scripts/*.pl* \
              scripts/ZoneMinder/lib/ZoneMinder/Memory.pm.in ; do
       substituteInPlace $f \
-        --replace '/usr/bin/perl' '${perlBin}' \
-        --replace '/bin:/usr/bin' "$out/bin:${
+        --replace-quiet '/usr/bin/perl' '${perlBin}' \
+        --replace-quiet '/bin:/usr/bin' "$out/bin:${
           lib.makeBinPath [
+            arp-scan
             coreutils
             procps
             psmisc
@@ -130,47 +142,52 @@ stdenv.mkDerivation rec {
         }"
     done
 
+    substituteInPlace misc/com.zoneminder.systemctl.policy.in \
+      --replace-fail '/usr/bin/perl' '${perlBin}'
+
+    substituteInPlace misc/com.zoneminder.dnsmasq.policy.in \
+      --replace-fail '/bin/systemctl' '${systemd}/bin/systemctl'
+
+    substituteInPlace misc/com.zoneminder.arp-scan.policy.in \
+      --replace-fail '/usr/sbin/arp-scan' '${arp-scan}/bin/arp-scan'
+
     substituteInPlace scripts/zmdbbackup.in \
-      --replace /usr/bin/mysqldump ${mariadb.client}/bin/mysqldump
+      --replace-fail /usr/bin/mysqldump ${mariadb.client}/bin/mysqldump
 
     substituteInPlace scripts/zmupdate.pl.in \
-      --replace "'mysql'" "'${mariadb.client}/bin/mysql'" \
-      --replace "'mysqldump'" "'${mariadb.client}/bin/mysqldump'"
+      --replace-fail "'mysql'" "'${mariadb.client}/bin/mysql'" \
+      --replace-fail "'mysqldump'" "'${mariadb.client}/bin/mysqldump'"
 
     for f in scripts/ZoneMinder/lib/ZoneMinder/Config.pm.in \
              scripts/zmupdate.pl.in \
              src/zm_config_data.h.in \
              web/api/app/Config/bootstrap.php.in \
              web/includes/config.php.in ; do
-      substituteInPlace $f --replace @ZM_CONFIG_SUBDIR@ /etc/zoneminder
+      substituteInPlace $f --replace-fail @ZM_CONFIG_SUBDIR@ /etc/zoneminder
     done
 
-    for f in includes/Event.php views/image.php ; do
-      substituteInPlace web/$f \
-        --replace "'ffmpeg " "'${ffmpeg}/bin/ffmpeg "
-    done
-
-    for f in scripts/ZoneMinder/lib/ZoneMinder/Event.pm \
-             scripts/ZoneMinder/lib/ZoneMinder/Storage.pm ; do
-      substituteInPlace $f \
-        --replace '/bin/rm' "${coreutils}/bin/rm"
-    done
+    substituteInPlace scripts/ZoneMinder/lib/ZoneMinder/Storage.pm \
+      --replace-fail '/bin/rm' "${coreutils}/bin/rm"
 
     substituteInPlace web/includes/functions.php \
-      --replace "'date " "'${coreutils}/bin/date " \
+      --replace-fail "'date " "'${coreutils}/bin/date " \
+      --replace-fail "'rm " "'${coreutils}/bin/rm " \
       --subst-var-by srcHash "`basename $out`"
   '';
 
   buildInputs = [
+    arp-scan
     curl
     ffmpeg
     glib
+    iproute2
     libjpeg
     libselinux
     libsepol
     mp4v2
     libmysqlclient
     mariadb
+    nlohmann_json
     pcre2
     perl
     polkit
@@ -212,6 +229,7 @@ stdenv.mkDerivation rec {
     "-DZM_SOCKDIR=/run/${dirName}"
     "-DZM_TMPDIR=/tmp/${dirName}"
     "-DZM_CONFIG_DIR=${placeholder "out"}/etc/zoneminder"
+    "-DZM_PATH_SHUTDOWN=${systemd}/bin/shutdown"
     "-DZM_WEB_USER=${user}"
     "-DZM_WEB_GROUP=${user}"
   ];
@@ -238,6 +256,14 @@ stdenv.mkDerivation rec {
     done
 
     ln -s $out/share/zoneminder/www $out/share/zoneminder/www/zm
+
+    # Combine configs under $out/etc/zoneminder/conf.d/ into
+    # $out/etc/zoneminder/zm.conf, because we patch so that we read from
+    # /etc/zoneminder/conf.d instead of $out/zoneminder/conf.d.
+    for f in $out/etc/zoneminder/conf.d/*.conf; do
+      cat $f >>$out/etc/zoneminder/zm.conf
+      rm $f
+    done
   '';
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Refresh patch.
- Add new dependencies.
- Make substitutions use --replace-fail or --replace-quiet. This catches
  a number of substitution mistakes which is also fixed.
- Add executable dependencies into buildInputs for autodetection.
- Fix configs under $out/etc/zoneminder/conf.d not being read.
- Set path for `shutdown` binary.

While we're at it, volunteer myself to be a maintainer for this package.

Changelogs:
- https://github.com/ZoneMinder/zoneminder/releases/tag/1.38.0
- https://github.com/ZoneMinder/zoneminder/releases/tag/1.38.1
- https://github.com/ZoneMinder/zoneminder/releases/tag/1.38.3

(1.38.2 has been skipped upstream due to release process error)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
  - I mentioned major version update in NixOS release note rather than Nixpkgs as this is a system service.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
