### PR TITLE
quake3arena: flag broken with a friendly message when pak0.pk3 is unavailable

### DIFF
--- a/pkgs/games/quake3/content/arena.nix
+++ b/pkgs/games/quake3/content/arena.nix
@@ -1,39 +1,20 @@
 {
   lib,
   stdenv,
-  fetchzip,
   requireFile,
 }:
 
-let
-  version = "1.32c";
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "quake3arenadata";
-  inherit version;
+  version = "1.32c";
 
-  src = requireFile rec {
+  src = requireFile {
     name = "pak0.pk3";
     hash = "sha256-fOizkQYgzVCgnk8RAPQm6MYYD2iJXVifgOa9la9UvK4=";
-    message = ''
-      Quake 3 Arena requires the original ${name} file, from any legal source of the game.
-
-      This could be an old CD-ROM you have lying around or you can try to buy the game.
-
-      To my knowledge the Steam Quake-Collection-Package, is about the last legal way to get it.
-
-      Please note, there are plenty of versions of this file online like:
-
-      - https://github.com/nrempel/q3-server/raw/master/baseq3/pak0.pk3
-      - https://archive.org/details/quake-3-arena
-
-      However, none of these have the blessing of ID-Software and thus do not qualify.
-
-      Once you download a version or checked your old CD-ROM, locate the ${name} file
-      inside the baseq3 folder and then run the following command on it:
-
-      nix-prefetch-url file:///path/to/baseq3/${name}
-    '';
+    # The actionable guidance lives in meta.problems.broken below; this only
+    # satisfies requireFile's API and is not reached in practice, since the
+    # broken problem refuses evaluation before this builder would run.
+    message = "pak0.pk3 has not been added to the Nix store.";
   };
 
   buildCommand = ''
@@ -60,6 +41,45 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.idsoftware.com/";
     license = lib.licenses.unfreeRedistributable;
     platforms = lib.platforms.all;
+    # pak0.pk3 cannot be fetched automatically; it must be added to the store by
+    # hand. Until the store path exists the package cannot be built, so flag it
+    # as a broken problem. This both keeps automated evaluation (Hydra,
+    # nixpkgs-review, ...) from tripping over the build failure and shows the
+    # user a friendly, actionable message instead of a generic "broken" error.
+    # Providing the file makes the store path exist and clears the problem.
+    #
+    # tryEval guards against restrictive configs: reading the unfree src's store
+    # path throws an "unfree license" error under e.g. Hydra's tarball job,
+    # which would otherwise abort meta evaluation. Context is discarded so the
+    # probe never realises the file; the only catchable error is that guard, in
+    # which case we simply treat the data as unavailable.
+    problems =
+      let
+        probe = builtins.tryEval (
+          builtins.pathExists (builtins.unsafeDiscardStringContext finalAttrs.src.outPath)
+        );
+      in
+      lib.optionalAttrs (!(probe.success && probe.value)) {
+        broken.message = ''
+          Quake 3 Arena requires the original ${finalAttrs.src.name} file, from any legal source of the game.
+
+          This could be an old CD-ROM you have lying around or you can try to buy the game.
+
+          To my knowledge the Steam Quake-Collection-Package, is about the last legal way to get it.
+
+          Please note, there are plenty of versions of this file online like:
+
+          - https://github.com/nrempel/q3-server/raw/master/baseq3/pak0.pk3
+          - https://archive.org/details/quake-3-arena
+
+          However, none of these have the blessing of ID-Software and thus do not qualify.
+
+          Once you download a version or checked your old CD-ROM, locate the ${finalAttrs.src.name} file
+          inside the baseq3 folder and then run the following command on it:
+
+          nix-prefetch-url file:///path/to/baseq3/${finalAttrs.src.name}
+        '';
+      };
     maintainers = [ ];
   };
 })

--- a/pkgs/games/quake3/wrapper/default.nix
+++ b/pkgs/games/quake3/wrapper/default.nix
@@ -73,5 +73,8 @@ stdenv.mkDerivation {
       license
       ;
     inherit (ioquake3.meta) platforms;
+    # Surface any content pack's problems (e.g. quake3arena's missing pak0.pk3)
+    # on the wrapper too, so building it shows the same actionable message.
+    problems = lib.mergeAttrsList (map (pak: pak.meta.problems or { }) paks);
   };
 }


### PR DESCRIPTION
Follow-up to the discussion in https://github.com/NixOS/nixpkgs/pull/530537#issuecomment-4723247678.

`quake3arena`'s `pak0.pk3` cannot be fetched automatically — it must be obtained from a legal copy of the game and added to the store by hand (`requireFile`). Until then the package fails to build, which shows up as noise during automated evaluation (Hydra, `nixpkgs-review`).

As suggested in review, the package should be `broken` conditional on its data being present — but without losing the helpful instructions a user needs to obtain the file.

## What changed

- `quake3arenadata` gains a **conditional** `meta.problems.broken` entry, present only while the required store path is missing. This:
  - marks the package unavailable (`meta.available = false`) so automated evaluation skips it instead of hitting a build failure, and
  - shows the user the actionable `pak0.pk3` instructions (via the custom `problems` message) rather than a generic "this package is broken" error.
- The `quake3` wrapper merges its content packs' `meta.problems`, so building the runnable `quake3arena` / `quake3arena-hires` surfaces the same message.
- The store-path probe is wrapped in `builtins.tryEval`: reading the unfree `src`'s `outPath` throws an "unfree license" error under restrictive configs (e.g. Hydra's tarball job), which would otherwise abort `meta` evaluation. String context is discarded so the probe never realises the file.
- Providing the file makes the store path exist and clears the problem — no `NIXPKGS_ALLOW_BROKEN` needed.
- The demo variants (`quake3demo`, `quake3demo-hires`) use ordinary `fetchurl` content and are unaffected.

## Things done

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] Without the file: `quake3arena` / `quake3arenadata` are `meta.available = false` and refuse to evaluate with the friendly `pak0.pk3` instructions.
  - [x] Under a restrictive config (`allowUnfree = false`): `meta` evaluation no longer throws (regression that previously broke the tarball/eval CI job).
  - [x] After `nix-prefetch-url … pak0.pk3` (matching the declared hash): `meta.available` flips to `true` and `nix-build -A quake3arena` produces a working wrapper whose `baseq3/` contains the real game data.
  - [x] `quake3demo` still builds, confirming buildable variants are unaffected.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md

Assisted-by: claude-code with claude-opus-4-8[1m]-high
