### PR TITLE
wargus: provide interface for supplying game assets

### DIFF
--- a/pkgs/by-name/wa/wargus/package.nix
+++ b/pkgs/by-name/wa/wargus/package.nix
@@ -3,12 +3,7 @@
   lib,
   callPackage,
   fetchFromGitHub,
-  fetchurl,
   fetchpatch,
-  runCommand,
-  unzip,
-  bchunk,
-  p7zip,
   cmake,
   pkg-config,
   makeWrapper,
@@ -16,35 +11,51 @@
   bzip2,
   libpng,
   ffmpeg,
+  requireFile,
+  gameAssets ? null,
 }:
-
 let
   stratagus = callPackage ./stratagus.nix { };
+  gameAssets' =
+    if gameAssets != null then
+      gameAssets
+    else
+      requireFile {
+        name = "wargus-assets";
+        hash = lib.fakeHash;
+        message = ''
+          No game assets were provided to wargus! Use an override to provide a 'runCommand' to unpack them.
 
-  dataDownload = fetchurl {
-    url = "https://archive.org/download/warcraft-ii-tides-of-darkness_202105/Warcess.zip";
-    sha256 = "0yxgvf8xpv1w2bjmny4a38pa3xcdgqckk9abj21ilkc5zqzqmm9b";
-  };
+          Your override will look something like this:
 
-  data =
-    runCommand "warcraft2"
-      {
-        buildInputs = [
-          unzip
-          bchunk
-          p7zip
-        ];
-        meta.license = lib.licenses.unfree;
-      }
-      ''
-        unzip ${dataDownload} "Warcraft.II.Tides.of.Darkness/Warcraft II - Tides of Darkness (1995)/games/WarcrafD/cd/"{WC2BTDP.img,WC2BTDP.cue}
-        bchunk "Warcraft.II.Tides.of.Darkness/Warcraft II - Tides of Darkness (1995)/games/WarcrafD/cd/"{WC2BTDP.img,WC2BTDP.cue} WC2BTDP
-        rm -r Warcraft.II.Tides.of.Darkness
-        7z x WC2BTDP01.iso
-        rm WC2BTDP*.{iso,cdr}
-        cp -r DATA $out
-      '';
-
+          wargus.override {
+            gameAssets =
+              let
+                assetsSrc = requireFile {
+                  name = "...";
+                  hash = "...";
+                };
+              in
+              runCommand "warcraft2"
+                {
+                  buildInputs = [
+                    unzip
+                    bchunk
+                    p7zip
+                  ];
+                  meta.license = lib.licenses.unfree;
+                }
+                \'\'
+                  unzip ''${assetsSrc} "Warcraft.II.Tides.of.Darkness/Warcraft II - Tides of Darkness (1995)/games/WarcrafD/cd/"{WC2BTDP.img,WC2BTDP.cue}
+                  bchunk "Warcraft.II.Tides.of.Darkness/Warcraft II - Tides of Darkness (1995)/games/WarcrafD/cd/"{WC2BTDP.img,WC2BTDP.cue} WC2BTDP
+                  rm -r Warcraft.II.Tides.of.Darkness
+                  7z x WC2BTDP01.iso
+                  rm WC2BTDP*.{iso,cdr}
+                  cp -r DATA $out
+                \'\';
+          }
+        '';
+      };
 in
 stdenv.mkDerivation rec {
   pname = "wargus";
@@ -85,7 +96,7 @@ stdenv.mkDerivation rec {
     substituteInPlace $out/share/applications/wargus.desktop \
       --replace $out/games/wargus $out/bin/wargus
 
-    $out/bin/wartool -v -r ${data} $out/share/games/stratagus/wargus
+    $out/bin/wartool -v -r ${gameAssets'} $out/share/games/stratagus/wargus
     ln -s $out/share/games/stratagus/wargus/{contrib/black_title.png,graphics/ui/black_title.png}
   '';
 

--- a/pkgs/by-name/wa/wargus/package.nix
+++ b/pkgs/by-name/wa/wargus/package.nix
@@ -15,9 +15,6 @@
   zlib,
   bzip2,
   libpng,
-  dialog,
-  python3,
-  cdparanoia,
   ffmpeg,
 }:
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This is my attempt to resolve #208078.

It is not the most beautiful solution, but I think the message is descriptive enough that it should be okay. Especially since people using this should have a sense of how these CD-ROMs are usually handled. 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
