### PR TITLE
ci/eval: name base branch in the performance comparison summary

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -15,6 +15,9 @@ on:
       targetSha:
         required: true
         type: string
+      baseBranch:
+        required: true
+        type: string
       systems:
         required: true
         type: string
@@ -291,6 +294,7 @@ jobs:
       - name: Compare against the target branch
         env:
           TARGET_SHA: ${{ inputs.mergedSha }}
+          BASE_BRANCH: ${{ fromJSON(inputs.baseBranch).branch }}
         run: |
           git -C nixpkgs/trusted diff --name-only "$TARGET_SHA" \
             | jq --raw-input --slurp 'split("\n")[:-1]' > touched-files.json
@@ -299,6 +303,7 @@ jobs:
           nix-build nixpkgs/trusted/ci --arg nixpkgs ./nixpkgs/trusted-pinned -A eval.compare \
             --arg combinedDir ./combined \
             --arg touchedFilesJson ./touched-files.json \
+            --argstr baseBranch "$BASE_BRANCH" \
             --out-link comparison
 
           cat comparison/step-summary.md >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/merge-group.yml
+++ b/.github/workflows/merge-group.yml
@@ -97,6 +97,7 @@ jobs:
       artifact-prefix: ${{ inputs.artifact-prefix }}
       mergedSha: ${{ needs.prepare.outputs.mergedSha }}
       targetSha: ${{ needs.prepare.outputs.targetSha }}
+      baseBranch: ${{ needs.prepare.outputs.baseBranch }}
       systems: ${{ needs.prepare.outputs.systems }}
 
   build:

--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -110,6 +110,7 @@ jobs:
       mergedSha: ${{ needs.prepare.outputs.mergedSha }}
       headSha: ${{ github.event.pull_request.head.sha }}
       targetSha: ${{ needs.prepare.outputs.targetSha }}
+      baseBranch: ${{ needs.prepare.outputs.baseBranch }}
       systems: ${{ needs.prepare.outputs.systems }}
       testVersions: ${{ contains(fromJSON(needs.prepare.outputs.touched), 'pinned') && !contains(fromJSON(needs.prepare.outputs.headBranch).type, 'development') }}
 

--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -49,6 +49,7 @@ in
 {
   combinedDir,
   touchedFilesJson,
+  baseBranch,
   ownersFile ? ../../OWNERS,
 }:
 let
@@ -242,7 +243,7 @@ runCommand "compare"
       echo
       echo "# Performance comparison"
       echo
-      echo "This compares the performance of this branch against its pull request base branch (e.g., 'master')"
+      echo "This compares the performance of this branch against the \`${baseBranch}\` branch."
       echo
     } >> $out/step-summary.md
 

--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -288,6 +288,9 @@ let
       #   | jq --raw-input --slurp 'split("\n")[:-1]' > touched-files.json
       # ```
       touchedFilesJson ? builtins.toFile "touched-files.json" "[ ]",
+      # The branch the local comparison is made against; matches the `master`
+      # used in the touched-files expression above.
+      baseBranch ? "master",
     }:
     let
       diffs = symlinkJoin {
@@ -305,7 +308,7 @@ let
       };
       comparisonReport = compare {
         combinedDir = combine { diffDir = diffs; };
-        inherit touchedFilesJson;
+        inherit touchedFilesJson baseBranch;
       };
     in
     comparisonReport;


### PR DESCRIPTION
The performance comparison summary previously stated it compared against "its pull request base branch (e.g., 'master')" regardless of the actual base branch.

Plumb the base branch classification computed in prepare.js through the eval workflow to the `compare` derivation so the summary names the real base branch (e.g. "staging-25.11"). The local `eval.full` helper defaults to "master", matching its touched-files convention.

Assisted-by: claude-code with claude-opus-4-8[1m]-high

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
