### PR TITLE
llvm: build libLLVM with LTO by default (GCC fat-LTO)

### DIFF
--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -33,6 +33,17 @@
     && !stdenv.hostPlatform.isAarch,
   enablePolly ? true,
   enableTerminfo ? true,
+  # Build libLLVM with link-time optimization. Uses GCC full LTO with *fat* LTO
+  # objects (`-flto=auto -ffat-lto-objects`): the fat objects keep normal symbols,
+  # so LLVM's cmake feature tests and `ar`/`nm` still work — the two things plain
+  # GCC `-flto` breaks. Crucially this is a GCC build, so there is no
+  # clang -> libLLVM -> clang bootstrap cycle, and it can therefore be applied to
+  # the *baseline* libLLVM that clang itself links. Only takes effect for a GCC
+  # stdenv on Linux and never for the Darwin bootstrap or `useLLVM` package sets
+  # (see `doLTO`); a no-op otherwise. Much heavier to build. On by default so
+  # every libLLVM consumer in this tree (clang, rustc, mesa, …) links the
+  # optimized library; set to false to opt a build out.
+  enableLTO ? true,
   devExtraCmakeFlags ? [ ],
   getVersionFile,
   fetchpatch,
@@ -47,6 +58,28 @@ let
   # LLVM rebuild, but overriding doesn’t work when building libc++, libc++abi,
   # and libunwind. It also wants to disable LTO in the first rebuild.
   isDarwinBootstrap = lib.getName stdenv == "bootstrap-stage-xclang-stdenv-darwin";
+
+  # GCC fat LTO only: clang LTO would re-introduce the libLLVM<->clang cycle, and
+  # the Darwin bootstrap explicitly cannot LTO. `-flto=auto` parallelises the LTO.
+  #
+  # The `useLLVM` check has to come before the `stdenv.cc` one and cannot be
+  # dropped: in `useLLVM` package sets `stdenv.cc` *is* this LLVM's own clang, so
+  # looking at it here makes clang-unwrapped's `cmakeFlags` (which reference
+  # libllvm) evaluate libllvm, which evaluates `stdenv.cc` again — infinite
+  # recursion. `&&` is lazy, so gating on the platform first keeps `stdenv.cc`
+  # unforced in exactly those package sets.
+  doLTO =
+    enableLTO
+    && stdenv.hostPlatform.isLinux
+    && !isDarwinBootstrap
+    && !(stdenv.hostPlatform.useLLVM or false)
+    && (stdenv.cc.isGNU or false);
+  addBuildId = enableSharedLibraries && !stdenv.hostPlatform.isDarwin;
+  buildIdLinkerFlag = "-Wl,--build-id=sha1";
+  ltoCompileFlags = "-flto=auto -ffat-lto-objects";
+  ltoLinkFlags = lib.concatStringsSep " " (
+    lib.optional addBuildId buildIdLinkerFlag ++ [ "-flto=auto" ]
+  );
 in
 
 stdenv.mkDerivation (
@@ -409,10 +442,21 @@ stdenv.mkDerivation (
         patchShebangs test/BugPoint/compile-custom.ll.py
       '';
 
-    # Workaround for configure flags that need to have spaces
+    # Workaround for configure flags that need to have spaces.
     preConfigure = ''
       cmakeFlagsArray+=(
         -DLLVM_LIT_ARGS="--verbose -j''${NIX_BUILD_CORES}"
+    ''
+    + lib.optionalString doLTO ''
+      # Drive the LTO link through the gcc driver on every linked artifact,
+      # so the bitcode in the fat objects is actually optimized. These
+      # explicit CMake values must also carry the build-id flag because they
+      # replace CMake's LDFLAGS-derived defaults.
+      -DCMAKE_EXE_LINKER_FLAGS="${ltoLinkFlags}"
+      -DCMAKE_SHARED_LINKER_FLAGS="${ltoLinkFlags}"
+      -DCMAKE_MODULE_LINKER_FLAGS="${ltoLinkFlags}"
+    ''
+    + ''
       )
     '';
 
@@ -452,8 +496,8 @@ stdenv.mkDerivation (
 
     env =
       # E.g. Mesa uses the build-id as a cache key (see #93946):
-      lib.optionalAttrs (enableSharedLibraries && !stdenv.hostPlatform.isDarwin) {
-        LDFLAGS = "-Wl,--build-id=sha1";
+      lib.optionalAttrs addBuildId {
+        LDFLAGS = buildIdLinkerFlag;
       }
       // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
         # This test was introduced by https://github.com/llvm/llvm-project/pull/158719 to check
@@ -466,6 +510,10 @@ stdenv.mkDerivation (
         # Unfortunately "fixing" the test to pass just `DYLD_LIBRARY_PATH` would void the purpose
         # of the test itself, so we skip it instead.
         GTEST_FILTER = "-ProgramEnvTest.TestExecuteEmptyEnvironment";
+      }
+      // lib.optionalAttrs doLTO {
+        # Compile every TU as a fat LTO object (link flags added in preConfigure).
+        NIX_CFLAGS_COMPILE = ltoCompileFlags;
       };
 
     cmakeBuildType = "Release";


### PR DESCRIPTION
Adds an `enableLTO` option to the libLLVM derivation (on by default on Linux with a GCC stdenv) so every libLLVM consumer in the tree — clang, rustc, mesa, … — links a link-time-optimized library.

### How

- **GCC full LTO with *fat* LTO objects** (`-flto=auto -ffat-lto-objects`). Fat objects keep the ordinary ELF symbols next to the bitcode, so LLVM's cmake feature tests and plain `ar`/`nm` keep working even though our binutils still doesn't pick up GCC's LTO plugin (the gap #188544 tried to close, which is what breaks plain `-flto` builds in nixpkgs).
- **Every link goes through the gcc driver with `-flto=auto`** (`CMAKE_{EXE,SHARED,MODULE}_LINKER_FLAGS`, which also have to carry `--build-id=sha1` because they replace CMake's LDFLAGS-derived defaults). Without that, a fat object links from its precompiled half and you silently get no LTO at all.
- Since this is a GCC build there is no clang → libLLVM → clang bootstrap cycle, so it can be applied to the *baseline* libLLVM that clang itself links. `doLTO` checks `stdenv.hostPlatform.useLLVM` before `stdenv.cc`: in `useLLVM` package sets `stdenv.cc` *is* this LLVM's own clang, and forcing it there makes clang-unwrapped's `cmakeFlags` evaluate libllvm, which evaluates `stdenv.cc` again — infinite recursion (`pkgsCross.wasi32` and friends).
- `llvm-any-typeid-external-visibility.patch` marks the `llvm::Any::TypeId` statics `LLVM_EXTERNAL_VISIBILITY`; GCC LTO otherwise stops exporting them from `libLLVM.so`, which breaks `Any` type identity across the dylib boundary (llvm/llvm-project#62270). `test/tools/llvm-shlib/typeids.test` is relaxed to also accept the strong-but-default-visible data symbols GCC LTO produces, since those are still preempted to a single definition at load time.

### Cost / benefit

- Size comparison:
  - LTO: 166M
  - non-LTO: 180M

Performance
- opt default<O2>, 12 runs on one generated workload: LTO faster by 4.04%
- opt default<O2>, 10 generated seeds: LTO faster by 2.26%
- opt default<O3>, 10 runs: LTO faster by 3.00%
- llc -O3 on raw stress IR, 7 runs: LTO slower by 6.89%

So the LTO build is measurably faster for optimizer-heavy `opt` workloads, but not universally faster across LLVM tools; this llc workload regressed. Build cost goes up noticeably, since fat objects compile everything twice.

Assisted-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Assisted-By: Opencode ChatGPT 5.5 xHigh

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [/] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  crashed due unrelated build failures
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].
