### PR TITLE
flux9s: track upstream from GitHub

### DIFF
--- a/pkgs/by-name/fl/flux9s/package.nix
+++ b/pkgs/by-name/fl/flux9s/package.nix
@@ -1,5 +1,5 @@
 {
-  fetchCrate,
+  fetchFromGitHub,
   lib,
   openssl,
   pkg-config,
@@ -11,9 +11,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "flux9s";
   version = "0.10.2";
 
-  src = fetchCrate {
-    inherit (finalAttrs) pname version;
-    hash = "sha256-a+kGFxhqeo8Na5T4IZkyhFyPqT6FvOLP3oiuJUuJIOY=";
+  src = fetchFromGitHub {
+    owner = "dgunzy";
+    repo = "flux9s";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pphw27LHz+TrU5QcUZZ7zS5k02AaFWBEEHsiV+I+05E=";
   };
 
   cargoHash = "sha256-M2UCpSwKVFGXACcYkxJ8TzRHYgTLqt29RBMMdRvHZv8=";


### PR DESCRIPTION
Previously this package used `fetchCrate`, but this is causing issues with the `nix-update` script (as can be seen in the [nixpkgs-update logs](https://nixpkgs-update-logs.nix-community.org/flux9s/2026-06-13.log)).
This PR switches to `fetchFromGitHub`, and then updates the package to the most recent version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
