### PR TITLE
byedpi: add darwin support

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10466,6 +10466,12 @@
     github = "hacker1024";
     githubId = 20849728;
   };
+  hadal84 = {
+    name = "hadal84";
+    email = "business.masses555@passinbox.com";
+    github = "hadal84";
+    githubId = 143954694;
+  };
   hadilq = {
     name = "Hadi Lashkari Ghouchani";
     email = "hadilq.dev@gmail.com";

--- a/pkgs/by-name/by/byedpi/package.nix
+++ b/pkgs/by-name/by/byedpi/package.nix
@@ -30,8 +30,11 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/hufrea/byedpi";
     changelog = "https://github.com/hufrea/byedpi/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ averyanalex ];
-    platforms = with lib.platforms; linux ++ windows;
+    maintainers = with lib.maintainers; [
+      averyanalex
+      hadal84
+    ];
+    platforms = with lib.platforms; linux ++ windows ++ darwin;
     mainProgram = "ciadpi";
   };
 })


### PR DESCRIPTION
The install phase for byedpi is very simple and efficient, and it can easily be supported by Darwin with little to no changes to the original package expression. Compiled and tested on aarch64 Darwin.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].