### PR TITLE
flent: 2.2.0 -> 2.3.0, qt5 -> qt6, add binaries

### DIFF
--- a/pkgs/by-name/fl/flent/package.nix
+++ b/pkgs/by-name/fl/flent/package.nix
@@ -2,18 +2,21 @@
   lib,
   python3Packages,
   fetchPypi,
+  qt6,
+  irtt,
+  iputils,
+  netperf,
   procps,
-  qt5,
   nix-update-script,
 }:
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "flent";
-  version = "2.2.0";
+  version = "2.3.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
-    hash = "sha256-BPwh3oWIY1YEI+ecgi9AUiX4Ka/Y5dYikwmfvvNB+eg=";
+    hash = "sha256-qy+BvMpBDBtBqEEM9yEko/Gb2pusxF/LqiutSKlS2eE=";
   };
 
   build-system = with python3Packages; [
@@ -21,11 +24,23 @@ python3Packages.buildPythonApplication (finalAttrs: {
     sphinx
   ];
 
-  nativeBuildInputs = [ qt5.wrapQtAppsHook ];
+  nativeBuildInputs = [ qt6.wrapQtAppsHook ];
+  buildInputs = [ qt6.qtbase ];
+  makeWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.makeBinPath [
+      iputils
+      irtt
+      netperf
+      procps
+    ])
+  ];
 
   dependencies = with python3Packages; [
     matplotlib
-    pyqt5
+    pyqt6
     qtpy
   ];
 
@@ -36,15 +51,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
     sed -i 's|self.skip|pass; #&|' unittests/test_gui.py
 
     # Dummy qt setup for gui tests
-    export QT_PLUGIN_PATH="${qt5.qtbase.bin}/${qt5.qtbase.qtPluginPrefix}"
+    export QT_PLUGIN_PATH="${qt6.qtbase}/${qt6.qtbase.qtPluginPrefix}"
     export QT_QPA_PLATFORM=offscreen
-  '';
-
-  preFixup = ''
-    makeWrapperArgs+=(
-      "''${qtWrapperArgs[@]}"
-      --prefix PATH : ${lib.makeBinPath [ procps ]}
-    )
   '';
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
Upgraded flent 2.2.0 -> 2.3.0 and upgraded from qt5 to qt6. See [changelog](https://github.com/tohojo/flent/releases/tag/v2.3.0)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
