### PR TITLE
syncpack: init at 15.3.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7891,6 +7891,11 @@
     githubId = 183738665;
     name = "Marcell Tóth";
   };
+  ELHart05 = {
+    name = "Okba Allaoua";
+    github = "ELHart05";
+    githubId = 96151694;
+  };
   eliandoran = {
     email = "contact@eliandoran.me";
     name = "Elian Doran";

--- a/pkgs/by-name/sy/syncpack/package.nix
+++ b/pkgs/by-name/sy/syncpack/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "syncpack";
+  version = "15.3.2";
+
+  src = fetchFromGitHub {
+    owner = "JamieMason";
+    repo = "syncpack";
+    tag = finalAttrs.version;
+    hash = "sha256-hpTVubKPuRtVxjaWetpFaK71UJXMAfOvWCZ4SqgOi0Y=";
+  };
+
+  cargoHash = "sha256-sjHyifhKU7FxwxrrAPuMwcUEw0lDGV83mOxXzLZul88=";
+
+  __structuredAttrs = true;
+
+  # This test asserts that a nested .gitignore excludes a build directory, but
+  # the `ignore` crate only applies gitignore rules inside a real git repository.
+  # The sandbox builds from a source tarball with no .git, so it is skipped here.
+  checkFlags = [
+    "--skip=issue_334_nested_gitignore_excludes_build_directory"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "Consistent dependency versions in large JavaScript monorepos";
+    homepage = "https://syncpack.dev";
+    changelog = "https://github.com/JamieMason/syncpack/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ELHart05 ];
+    mainProgram = "syncpack";
+  };
+})


### PR DESCRIPTION
Adds syncpack, a CLI that keeps dependency versions consistent across large
JavaScript monorepos (https://syncpack.dev). Upstream is written in Rust, so
this packages it with rustPlatform.buildRustPackage. I'm adding myself as the
maintainer.

One test, issue_334_nested_gitignore_excludes_build_directory, is skipped: it
expects a nested .gitignore to take effect, which the `ignore` crate only
honours inside a real git repository. The sandbox builds from a source tarball
with no .git, so that rule never applies. The rest of the suite runs.

###### Things done

- Built on x86_64-linux.
- Ran the binary: `syncpack --version` prints `syncpack 15.3.2` (wired up via
  versionCheckHook, so it runs in the sandbox too).
- Formatted with nixfmt-rfc-style.
- Added myself to maintainers/maintainer-list.nix in its own commit.
- Package has meta.description, meta.homepage, meta.license (MIT),
  meta.mainProgram, and a maintainer.
