### PR TITLE
nixos/specialisation: add `specialisation.<name>.toplevel` option

### DIFF
--- a/nixos/modules/system/activation/bootspec.nix
+++ b/nixos/modules/system/activation/bootspec.nix
@@ -11,9 +11,7 @@
 }:
 let
   cfg = config.boot.bootspec;
-  children = lib.mapAttrs (
-    childName: childConfig: childConfig.configuration.system.build.toplevel
-  ) config.specialisation;
+  children = lib.mapAttrs (_: childConfig: childConfig.toplevel) config.specialisation;
   hasAtLeastOneInitrdSecret = lib.length (lib.attrNames config.boot.initrd.secrets) > 0;
   schemas = {
     v1 = rec {

--- a/nixos/modules/system/activation/specialisation.nix
+++ b/nixos/modules/system/activation/specialisation.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   extendModules,
   noUserModules,
   ...
@@ -24,9 +23,7 @@ let
   # you can provide an easy way to boot the same configuration
   # as you use, but with another kernel
   # !!! fix this
-  children = mapAttrs (
-    childName: childConfig: childConfig.configuration.system.build.toplevel
-  ) config.specialisation;
+  children = mapAttrs (_: childConfig: childConfig.toplevel) config.specialisation;
 
 in
 {
@@ -63,7 +60,13 @@ in
             options.inheritParentConfig = mkOption {
               type = types.bool;
               default = true;
-              description = "Include the entire system's configuration. Set to false to make a completely differently configured system.";
+              description = ''
+                Include the entire system's configuration. Set to false to make a
+                completely differently configured system.
+
+                Only applies when `configuration` is built. It has no effect when
+                `toplevel` is set to an externally-built system.
+              '';
             };
 
             options.configuration = mkOption {
@@ -74,9 +77,29 @@ in
                 Anything you can add to a normal NixOS configuration, you can add
                 here, including imports and config values, although nested
                 specialisations will be ignored.
+
+                This is built and used as the specialisation's `toplevel` unless
+                `toplevel` is set explicitly, in which case this is ignored.
               '';
               visible = "shallow";
               inherit (extend { modules = [ ./no-clone.nix ]; }) type;
+            };
+
+            options.toplevel = mkOption {
+              type = types.package;
+              default = local.config.configuration.system.build.toplevel;
+              defaultText = lib.literalExpression "config.configuration.system.build.toplevel";
+              description = ''
+                The top-level system derivation symlinked into
+                `specialisation/<name>` and whose bootspec is embedded into the
+                parent system's `boot.json`. Defaults to this specialisation's
+                built NixOS `configuration`.
+
+                Override it to point at a system built outside the NixOS module
+                system, as long as it produces an RFC-0125 bootspec
+                (a `boot.json`) of its own. When overridden, `configuration` is
+                not evaluated, so the specialisation need not be a NixOS system.
+              '';
             };
           }
         )

--- a/nixos/tests/bootspec.nix
+++ b/nixos/tests/bootspec.nix
@@ -166,6 +166,60 @@ in
     '';
   };
 
+  # Check that a specialisation can boot an externally-built toplevel supplied
+  # via `specialisation.<name>.toplevel`, instead of a NixOS `configuration`.
+  specialisation-toplevel =
+    let
+      # A system built outside this machine's module system, standing in for a
+      # non-NixOS system that emits its own RFC-0125 bootspec.
+      externalSystem =
+        (pkgs.nixos {
+          fileSystems."/" = {
+            device = "/dev/sda1";
+            fsType = "ext4";
+          };
+          boot.loader.grub.enable = false;
+          boot.kernelParams = [ "external_specialisation_marker" ];
+          system.stateVersion = pkgs.lib.trivial.release;
+        }).toplevel;
+    in
+    makeTest {
+      name = "bootspec-with-specialisation-toplevel";
+      meta.maintainers = with pkgs.lib.maintainers; [ aanderse ];
+
+      nodes.machine = {
+        imports = [ standard ];
+        environment.systemPackages = [ pkgs.jq ];
+        specialisation.external.toplevel = externalSystem;
+      };
+
+      testScript = ''
+        import json
+
+        machine.start()
+        machine.wait_for_unit("multi-user.target")
+
+        machine.succeed("test -e /run/current-system/boot.json")
+        machine.succeed("test -e /run/current-system/specialisation/external/boot.json")
+
+        # The specialisation symlink points at the externally-built toplevel,
+        # not at a configuration derived from this machine.
+        target = machine.succeed("readlink -f /run/current-system/specialisation/external").strip()
+        assert target == "${externalSystem}", f"specialisation points at {target}, expected ${externalSystem}"
+
+        # The external system's bootspec is embedded into the parent boot.json.
+        sp_in_parent = json.loads(machine.succeed("jq -r '.\"org.nixos.specialisation.v1\".external' /run/current-system/boot.json"))
+        sp_in_fs = json.loads(machine.succeed("cat /run/current-system/specialisation/external/boot.json"))
+        assert sp_in_parent['org.nixos.bootspec.v1'] == sp_in_fs['org.nixos.bootspec.v1'], "Bootspecs of the same specialisation are different!"
+
+        # It really is the external system: its unique kernel param is embedded
+        # for the specialisation but absent from the parent's own bootspec.
+        parent = json.loads(machine.succeed("jq -r '.\"org.nixos.bootspec.v1\"' /run/current-system/boot.json"))
+        assert "external_specialisation_marker" in sp_in_parent['org.nixos.bootspec.v1']['kernelParams']
+        assert "external_specialisation_marker" not in parent['kernelParams']
+      '';
+    };
+
   # Check that extensions are propagated.
   extensions = makeTest {
     name = "bootspec-with-extensions";


### PR DESCRIPTION
useful for including specialisations built outside of the nixos module system

this could allow you to do something like this in the context of a `flake.nix`:

```nix
nixosConfigurations.config-a = nixpkgs.nix.nixosSystem {
  system = "x86_64-linux";
  modules = nixpkgs.lib.singleton {
    specialisation.test.toplevel = self.nixosConfigurations.config-b.config.system.build.toplevel;
  };
```

or iunno... maybe something like:

```nix
nixosConfigurations.mymachine = nixpkgs.lib.nixosSystem {
  system = "x86_64-linux";
  modules = nixpkgs.lib.singleton {
    specialisation.test.toplevel = self.nixosConfigurations.finix-specialisation-so-i-can-run-both-nixos-and-finix-on-this-machine.config.system.build.toplevel;
  };
```

... just sayin :man_shrugging:

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

---

**automation disclosure:** i wrote all the code myself, but i had `Opus 4.8` write the comments and modify some of the `description` values... because code easy, words hard

_since i wrote all the code myself i'm not sure if this is required, but thought i would include it in case_

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
