### PR TITLE
vpinball: init at 10.8.1-unstable-2026-06-15

### DIFF
--- a/pkgs/by-name/vp/vpinball/externals.nix
+++ b/pkgs/by-name/vp/vpinball/externals.nix
@@ -1,0 +1,477 @@
+{
+  lib,
+  stdenv,
+  autoconf,
+  automake,
+  bison,
+  cmake,
+  libtool,
+  nasm,
+  patchelf,
+  perl,
+  pkg-config,
+  alsa-lib,
+  dbus,
+  freetype,
+  harfbuzz,
+  libGL,
+  libdrm,
+  libjpeg,
+  libpng,
+  libpulseaudio,
+  libtiff,
+  libusb1,
+  libx11,
+  libxcursor,
+  libxext,
+  libxi,
+  libxrandr,
+  libxrender,
+  libxscrnsaver,
+  libxtst,
+  libxcb,
+  libxkbcommon,
+  systemd,
+  wayland,
+  wayland-protocols,
+  zlib,
+  sources,
+}:
+
+let
+  runtimeLibraryPath = lib.makeLibraryPath [
+    alsa-lib
+    dbus
+    freetype
+    harfbuzz
+    libGL
+    libdrm
+    libjpeg
+    libpng
+    libpulseaudio
+    libtiff
+    libusb1
+    libx11
+    libxcursor
+    libxext
+    libxi
+    libxrandr
+    libxrender
+    libxscrnsaver
+    libxtst
+    libxcb
+    libxkbcommon
+    systemd
+    wayland
+    zlib
+  ];
+in
+stdenv.mkDerivation {
+  pname = "vpinball-externals";
+  version = "10.8.1-unstable-2026-06-15";
+
+  dontUnpack = true;
+  dontConfigure = true;
+
+  nativeBuildInputs = [
+    autoconf
+    automake
+    bison
+    cmake
+    libtool
+    nasm
+    patchelf
+    perl
+    pkg-config
+  ];
+
+  buildInputs = [
+    alsa-lib
+    dbus
+    freetype
+    harfbuzz
+    libGL
+    libdrm
+    libjpeg
+    libpng
+    libpulseaudio
+    libtiff
+    libusb1
+    libx11
+    libxcursor
+    libxext
+    libxi
+    libxrandr
+    libxrender
+    libxscrnsaver
+    libxtst
+    libxcb
+    libxkbcommon
+    systemd
+    wayland
+    wayland-protocols
+    zlib
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    cp -R --no-preserve=mode ${sources.sdl} SDL
+    cp -R --no-preserve=mode ${sources.sdl-image} SDL_image
+    cp -R --no-preserve=mode ${sources.sdl-ttf} SDL_ttf
+    cp -R --no-preserve=mode ${sources.freeimage} freeimage
+    tar xzf ${sources.bgfx-cmake}
+    cp -R --no-preserve=mode ${sources.bgfx} bgfx-patched
+    rm -rf bgfx.cmake/bgfx
+    mv bgfx-patched bgfx.cmake/bgfx
+    cp -R --no-preserve=mode ${sources.pinmame} pinmame
+    cp -R --no-preserve=mode ${sources.libaltsound} libaltsound
+    cp -R --no-preserve=mode ${sources.ffmpeg} ffmpeg
+    cp -R --no-preserve=mode ${sources.libzip} libzip
+    cp -R --no-preserve=mode ${sources.libwinevbs} libwinevbs
+    cp -R --no-preserve=mode ${sources.libdof} libdof
+    cp -R --no-preserve=mode ${sources.libdof-libusb} libdof-libusb
+    cp -R --no-preserve=mode ${sources.libdof-libserialport} libdof-libserialport
+    cp -R --no-preserve=mode ${sources.libdof-hidapi} libdof-hidapi
+    cp -R --no-preserve=mode ${sources.libdof-libftdi} libdof-libftdi
+    cp -R --no-preserve=mode ${sources.libdmdutil} libdmdutil
+    cp -R --no-preserve=mode ${sources.libdmdutil-libzedmd} libzedmd
+    cp -R --no-preserve=mode ${sources.libdmdutil-libserum} libserum
+    cp -R --no-preserve=mode ${sources.libdmdutil-libpupdmd} libpupdmd
+    cp -R --no-preserve=mode ${sources.libdmdutil-libvni} libvni
+    cp -R --no-preserve=mode ${sources.libdmdutil-cargs} cargs
+    cp -R --no-preserve=mode ${sources.libdmdutil-libframeutil} libframeutil
+    cp -R --no-preserve=mode ${sources.libdmdutil-sockpp} sockpp
+
+    cmake -S SDL -B SDL/build \
+      -DSDL_SHARED=ON \
+      -DSDL_STATIC=OFF \
+      -DSDL_TEST_LIBRARY=OFF \
+      -DSDL_OPENGLES=OFF \
+      -DCMAKE_BUILD_TYPE=Release
+    cmake --build SDL/build --parallel "$NIX_BUILD_CORES"
+
+    cmake -S SDL_image -B SDL_image/build \
+      -DBUILD_SHARED_LIBS=ON \
+      -DSDLIMAGE_SAMPLES=OFF \
+      -DSDLIMAGE_DEPS_SHARED=ON \
+      -DSDLIMAGE_VENDORED=OFF \
+      -DSDLIMAGE_AVIF=OFF \
+      -DSDLIMAGE_WEBP=OFF \
+      -DSDLIMAGE_JXL=OFF \
+      -DSDL3_DIR="$PWD/SDL/build" \
+      -DCMAKE_BUILD_TYPE=Release
+    cmake --build SDL_image/build --parallel "$NIX_BUILD_CORES"
+
+    cmake -S SDL_ttf -B SDL_ttf/build \
+      -DBUILD_SHARED_LIBS=ON \
+      -DSDLTTF_SAMPLES=OFF \
+      -DSDLTTF_VENDORED=OFF \
+      -DSDLTTF_HARFBUZZ=ON \
+      -DSDL3_DIR="$PWD/SDL/build" \
+      -DCMAKE_BUILD_TYPE=Release
+    cmake --build SDL_ttf/build --parallel "$NIX_BUILD_CORES"
+
+    cmake -S freeimage -B freeimage/build \
+      -DPLATFORM=linux \
+      -DARCH=x64 \
+      -DBUILD_STATIC=OFF \
+      -DCMAKE_BUILD_TYPE=Release
+    cmake --build freeimage/build --parallel "$NIX_BUILD_CORES"
+
+    cmake -S bgfx.cmake -B bgfx.cmake/build \
+      -DBGFX_LIBRARY_TYPE=SHARED \
+      -DBGFX_BUILD_TOOLS=OFF \
+      -DBGFX_BUILD_EXAMPLES=OFF \
+      -DBGFX_CONFIG_MULTITHREADED=ON \
+      -DBGFX_CONFIG_MAX_FRAME_BUFFERS=256 \
+      -DCMAKE_BUILD_TYPE=Release
+    cmake --build bgfx.cmake/build --parallel "$NIX_BUILD_CORES"
+
+    cp pinmame/cmake/libpinmame/CMakeLists.txt pinmame/CMakeLists.txt
+    cmake -S pinmame -B pinmame/build \
+      -DPLATFORM=linux \
+      -DARCH=x64 \
+      -DBUILD_STATIC=OFF \
+      -DCMAKE_BUILD_TYPE=Release
+    cmake --build pinmame/build --parallel "$NIX_BUILD_CORES"
+
+    cmake -S libaltsound -B libaltsound/build \
+      -DPLATFORM=linux \
+      -DARCH=x64 \
+      -DBUILD_STATIC=OFF \
+      -DCMAKE_BUILD_TYPE=Release
+    cmake --build libaltsound/build --parallel "$NIX_BUILD_CORES"
+
+    find ffmpeg -name '*.sh' -exec chmod +x {} +
+    chmod +x ffmpeg/configure
+    (cd ffmpeg && \
+      LDFLAGS=-Wl,-rpath,'$$$$ORIGIN' bash ./configure \
+        --enable-shared \
+        --disable-static \
+        --disable-programs \
+        --disable-doc && \
+      make -j"$NIX_BUILD_CORES")
+
+    cmake -S libzip -B libzip/build \
+      -DBUILD_SHARED_LIBS=ON \
+      -DENABLE_ZSTD=OFF \
+      -DENABLE_BZIP2=OFF \
+      -DENABLE_LZMA=OFF \
+      -DBUILD_TOOLS=OFF \
+      -DBUILD_REGRESS=OFF \
+      -DBUILD_OSSFUZZ=OFF \
+      -DBUILD_EXAMPLES=OFF \
+      -DBUILD_DOC=OFF \
+      -DCMAKE_BUILD_TYPE=Release
+    cmake --build libzip/build --parallel "$NIX_BUILD_CORES"
+
+    perl -0pi -e '
+      s{(^set\(LIBWINEVBS_COMPILE_OPTIONS\s*\n(?![^)]*-Wno-error=format-security)\s*-Wno-format)}{$1\n   -Wno-error=format-security}m;
+    ' libwinevbs/CMakeLists.txt
+    cmake -S libwinevbs -B libwinevbs/build \
+      -DPLATFORM=linux \
+      -DARCH=x64 \
+      -DCMAKE_BUILD_TYPE=Release
+    cmake --build libwinevbs/build --parallel "$NIX_BUILD_CORES"
+
+    mkdir -p \
+      libdof/third-party/include/libusb-1.0 \
+      libdof/third-party/build-libs/linux/x64 \
+      libdof/third-party/runtime-libs/linux/x64
+
+    (cd libdof-libusb && \
+      find . -name '*.sh' -exec chmod +x {} + && \
+      ./autogen.sh && \
+      chmod +x configure && \
+      ./configure --enable-shared && \
+      make -j"$NIX_BUILD_CORES")
+    cp libdof-libusb/libusb/libusb.h libdof/third-party/include/libusb-1.0/
+    cp -a libdof-libusb/libusb/.libs/libusb-1.0.so* libdof/third-party/runtime-libs/linux/x64/
+
+    (cd libdof-libserialport && \
+      find . -name '*.sh' -exec chmod +x {} + && \
+      ./autogen.sh && \
+      chmod +x configure && \
+      ./configure && \
+      make -j"$NIX_BUILD_CORES")
+    cp libdof-libserialport/libserialport.h libdof/third-party/include/
+    cp libdof-libserialport/.libs/libserialport.a libdof/third-party/build-libs/linux/x64/
+    cp -a libdof-libserialport/.libs/libserialport.so* libdof/third-party/runtime-libs/linux/x64/
+
+    cmake -S libdof-hidapi -B libdof-hidapi/build \
+      -DHIDAPI_WITH_LIBUSB=OFF \
+      -DCMAKE_BUILD_TYPE=Release
+    cmake --build libdof-hidapi/build --parallel "$NIX_BUILD_CORES"
+    cp -r libdof-hidapi/hidapi libdof/third-party/include/
+    cp -a libdof-hidapi/build/src/linux/libhidapi-hidraw.so* libdof/third-party/runtime-libs/linux/x64/
+
+    perl -0pi -e 's{cmake_minimum_required\([^)]*\)}{cmake_minimum_required(VERSION 3.10)}' libdof-libftdi/CMakeLists.txt
+    cmake -S libdof-libftdi -B libdof-libftdi/build \
+      -DFTDI_EEPROM=OFF \
+      -DEXAMPLES=OFF \
+      -DSTATICLIBS=OFF \
+      -DLIBUSB_INCLUDE_DIR="$PWD/libdof-libusb/libusb" \
+      -DLIBUSB_LIBRARIES="$PWD/libdof-libusb/libusb/.libs/libusb-1.0.so" \
+      -DCMAKE_INSTALL_RPATH='\$ORIGIN' \
+      -DCMAKE_BUILD_WITH_INSTALL_RPATH=TRUE \
+      -DCMAKE_BUILD_TYPE=Release
+    cmake --build libdof-libftdi/build --parallel "$NIX_BUILD_CORES"
+    mkdir -p libdof/third-party/include/libftdi1
+    cp libdof-libftdi/src/ftdi.h libdof/third-party/include/libftdi1/
+    cp -a libdof-libftdi/build/src/libftdi1.so* libdof/third-party/runtime-libs/linux/x64/
+
+    cmake -S libdof -B libdof/build \
+      -DPLATFORM=linux \
+      -DARCH=x64 \
+      -DBUILD_STATIC=OFF \
+      -DCMAKE_BUILD_TYPE=Release
+    cmake --build libdof/build --parallel "$NIX_BUILD_CORES"
+
+    mkdir -p \
+      libzedmd/third-party/include \
+      libzedmd/third-party/build-libs/linux/x64 \
+      libzedmd/third-party/runtime-libs/linux/x64
+
+    cmake -S cargs -B cargs/build \
+      -DBUILD_SHARED_LIBS=ON \
+      -DCMAKE_BUILD_TYPE=Release
+    cmake --build cargs/build --parallel "$NIX_BUILD_CORES"
+    cp cargs/include/cargs.h libzedmd/third-party/include/
+    cp cargs/build/libcargs.so* libzedmd/third-party/runtime-libs/linux/x64/
+
+    cp libdof-libserialport/libserialport.h libzedmd/third-party/include/
+    cp libdof-libserialport/.libs/libserialport.a libzedmd/third-party/build-libs/linux/x64/
+    cp -a libdof-libserialport/.libs/libserialport.so* libzedmd/third-party/runtime-libs/linux/x64/
+
+    cp libframeutil/include/* libzedmd/third-party/include/
+
+    cmake -S sockpp -B sockpp/build \
+      -DCMAKE_BUILD_TYPE=Release
+    cmake --build sockpp/build --parallel "$NIX_BUILD_CORES"
+    cp -r sockpp/include/sockpp libzedmd/third-party/include/
+    cp -a sockpp/build/libsockpp.so* libzedmd/third-party/runtime-libs/linux/x64/
+
+    cmake -S libzedmd -B libzedmd/build \
+      -DPLATFORM=linux \
+      -DARCH=x64 \
+      -DBUILD_SHARED=ON \
+      -DBUILD_STATIC=OFF \
+      -DCMAKE_BUILD_TYPE=Release
+    cmake --build libzedmd/build --parallel "$NIX_BUILD_CORES"
+
+    mkdir -p \
+      libdmdutil/third-party/include/libusb-1.0 \
+      libdmdutil/third-party/build-libs/linux/x64 \
+      libdmdutil/third-party/runtime-libs/linux/x64
+
+    cp libdof-libusb/libusb/libusb.h libdmdutil/third-party/include/libusb-1.0/
+    cp -a libdof-libusb/libusb/.libs/libusb-1.0.so* libdmdutil/third-party/runtime-libs/linux/x64/
+
+    cp libzedmd/src/ZeDMD.h libdmdutil/third-party/include/
+    cp libzedmd/third-party/include/libserialport.h libdmdutil/third-party/include/
+    cp libzedmd/third-party/include/cargs.h libdmdutil/third-party/include/
+    cp -r libzedmd/third-party/include/komihash libdmdutil/third-party/include/
+    cp -r libzedmd/third-party/include/sockpp libdmdutil/third-party/include/
+    cp libzedmd/third-party/include/FrameUtil.h libdmdutil/third-party/include/
+    cp libzedmd/third-party/runtime-libs/linux/x64/libcargs.so* libdmdutil/third-party/runtime-libs/linux/x64/
+    cp -a libzedmd/third-party/runtime-libs/linux/x64/libserialport.so* libdmdutil/third-party/runtime-libs/linux/x64/
+    cp -a libzedmd/third-party/runtime-libs/linux/x64/libsockpp.so* libdmdutil/third-party/runtime-libs/linux/x64/
+    cp -a libzedmd/build/libzedmd.so* libdmdutil/third-party/runtime-libs/linux/x64/
+
+    cmake -S libserum -B libserum/build \
+      -DPLATFORM=linux \
+      -DARCH=x64 \
+      -DBUILD_SHARED=ON \
+      -DBUILD_STATIC=OFF \
+      -DCMAKE_BUILD_TYPE=Release
+    cmake --build libserum/build --parallel "$NIX_BUILD_CORES"
+    cp -r libserum/third-party/include/lz4 libdmdutil/third-party/include/
+    cp libserum/src/LZ4Stream.h libdmdutil/third-party/include/
+    cp libserum/src/SceneGenerator.h libdmdutil/third-party/include/
+    cp libserum/src/serum.h libdmdutil/third-party/include/
+    cp libserum/src/TimeUtils.h libdmdutil/third-party/include/
+    cp libserum/src/serum-decode.h libdmdutil/third-party/include/
+    cp -a libserum/build/libserum.so* libdmdutil/third-party/runtime-libs/linux/x64/
+
+    cmake -S libpupdmd -B libpupdmd/build \
+      -DPLATFORM=linux \
+      -DARCH=x64 \
+      -DBUILD_SHARED=ON \
+      -DBUILD_STATIC=OFF \
+      -DCMAKE_BUILD_TYPE=Release
+    cmake --build libpupdmd/build --parallel "$NIX_BUILD_CORES"
+    cp libpupdmd/src/pupdmd.h libdmdutil/third-party/include/
+    cp -a libpupdmd/build/libpupdmd.so* libdmdutil/third-party/runtime-libs/linux/x64/
+
+    mkdir -p libvni/third-party/include
+    cp libframeutil/include/* libvni/third-party/include/
+    cmake -S libvni -B libvni/build \
+      -DPLATFORM=linux \
+      -DARCH=x64 \
+      -DBUILD_SHARED=ON \
+      -DBUILD_STATIC=OFF \
+      -DCMAKE_BUILD_TYPE=Release
+    cmake --build libvni/build --parallel "$NIX_BUILD_CORES"
+    cp libvni/src/vni.h libdmdutil/third-party/include/
+    cp -a libvni/build/libvni.so* libdmdutil/third-party/runtime-libs/linux/x64/
+
+    cmake -S libdmdutil -B libdmdutil/build \
+      -DPLATFORM=linux \
+      -DARCH=x64 \
+      -DBUILD_STATIC=OFF \
+      -DCMAKE_BUILD_TYPE=Release
+    cmake --build libdmdutil/build --parallel "$NIX_BUILD_CORES"
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/third-party/include" "$out/third-party/runtime-libs/linux-x64"
+
+    cp -a SDL/build/libSDL3.so* "$out/third-party/runtime-libs/linux-x64/"
+    cp -r SDL/include/SDL3 "$out/third-party/include/"
+
+    cp -a SDL_image/build/libSDL3_image.so* "$out/third-party/runtime-libs/linux-x64/"
+    cp -r SDL_image/include/SDL3_image "$out/third-party/include/"
+
+    cp -a SDL_ttf/build/libSDL3_ttf.so* "$out/third-party/runtime-libs/linux-x64/"
+    cp -r SDL_ttf/include/SDL3_ttf "$out/third-party/include/"
+
+    cp -a freeimage/build/libfreeimage.so* "$out/third-party/runtime-libs/linux-x64/"
+    cp freeimage/Source/FreeImage.h "$out/third-party/include/"
+
+    cp -a bgfx.cmake/build/cmake/bgfx/libbgfx.so* "$out/third-party/runtime-libs/linux-x64/"
+    cp -r bgfx.cmake/bgfx/include/bgfx "$out/third-party/include/"
+    cp -r bgfx.cmake/bimg/include/bimg "$out/third-party/include/"
+    cp -r bgfx.cmake/bx/include/bx "$out/third-party/include/"
+
+    cp -a pinmame/build/libpinmame.so* "$out/third-party/runtime-libs/linux-x64/"
+    cp pinmame/src/libpinmame/libpinmame.h "$out/third-party/include/"
+
+    cp -a libaltsound/build/libaltsound.so* "$out/third-party/runtime-libs/linux-x64/"
+    cp libaltsound/src/altsound.h "$out/third-party/include/"
+
+    for ffmpegLibrary in libavcodec libavdevice libavfilter libavformat libavutil libswresample libswscale; do
+      cp -a "ffmpeg/$ffmpegLibrary/$ffmpegLibrary".so* "$out/third-party/runtime-libs/linux-x64/"
+      mkdir -p "$out/third-party/include/$ffmpegLibrary"
+      cp "ffmpeg/$ffmpegLibrary"/*.h "$out/third-party/include/$ffmpegLibrary/"
+    done
+
+    cp -a libzip/build/lib/libzip.so* "$out/third-party/runtime-libs/linux-x64/"
+    cp libzip/build/zipconf.h "$out/third-party/include/"
+    cp libzip/lib/zip.h "$out/third-party/include/"
+
+    cp -a libwinevbs/build/libwinevbs.so* "$out/third-party/runtime-libs/linux-x64/"
+    mkdir -p \
+      "$out/third-party/include/libwinevbs/wine/include" \
+      "$out/third-party/include/libwinevbs/atl/include" \
+      "$out/third-party/include/libwinevbs/atlmfc/include"
+    cp libwinevbs/include/libwinevbs.h "$out/third-party/include/libwinevbs/"
+    cp -r libwinevbs/wine/include/. "$out/third-party/include/libwinevbs/wine/include/"
+    cp -r libwinevbs/atl/include/. "$out/third-party/include/libwinevbs/atl/include/"
+    cp -r libwinevbs/atlmfc/include/. "$out/third-party/include/libwinevbs/atlmfc/include/"
+
+    cp -a libdof/build/libdof.so* "$out/third-party/runtime-libs/linux-x64/"
+    cp -r libdof/include/DOF "$out/third-party/include/"
+    cp -a libdof/third-party/runtime-libs/linux/x64/libusb*.so* "$out/third-party/runtime-libs/linux-x64/"
+    cp -a libdof/third-party/runtime-libs/linux/x64/libserialport*.so* "$out/third-party/runtime-libs/linux-x64/"
+    cp -a libdof/third-party/runtime-libs/linux/x64/libhidapi-hidraw.so* "$out/third-party/runtime-libs/linux-x64/"
+    cp -a libdof/third-party/runtime-libs/linux/x64/libftdi1*.so* "$out/third-party/runtime-libs/linux-x64/"
+
+    cp -a libdmdutil/build/libdmdutil.so* "$out/third-party/runtime-libs/linux-x64/"
+    cp -r libdmdutil/include/DMDUtil "$out/third-party/include/"
+    cp -a libdmdutil/third-party/runtime-libs/linux/x64/libzedmd.so* "$out/third-party/runtime-libs/linux-x64/"
+    cp libdmdutil/third-party/include/ZeDMD.h "$out/third-party/include/"
+    cp -a libdmdutil/third-party/runtime-libs/linux/x64/libserum.so* "$out/third-party/runtime-libs/linux-x64/"
+    cp libdmdutil/third-party/include/serum.h "$out/third-party/include/"
+    cp libdmdutil/third-party/include/serum-decode.h "$out/third-party/include/"
+    cp -a libdmdutil/third-party/runtime-libs/linux/x64/libpupdmd.so* "$out/third-party/runtime-libs/linux-x64/"
+    cp libdmdutil/third-party/include/pupdmd.h "$out/third-party/include/"
+    cp -a libdmdutil/third-party/runtime-libs/linux/x64/libsockpp.so* "$out/third-party/runtime-libs/linux-x64/"
+    cp libdmdutil/third-party/runtime-libs/linux/x64/libcargs.so "$out/third-party/runtime-libs/linux-x64/"
+    cp libdmdutil/third-party/include/vni.h "$out/third-party/include/"
+    cp -a libdmdutil/third-party/runtime-libs/linux/x64/libvni.so* "$out/third-party/runtime-libs/linux-x64/"
+
+    for library in "$out"/third-party/runtime-libs/linux-x64/*.so*; do
+      if [ -f "$library" ]; then
+        patchelf --set-rpath "\$ORIGIN:${runtimeLibraryPath}" "$library"
+      fi
+    done
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Visual Pinball third-party dependency bundle for Linux x64";
+    license = with lib.licenses; [
+      gpl3Plus
+      unfreeRedistributable
+    ];
+    platforms = [ "x86_64-linux" ];
+    # The bundle combines dependencies with different licenses. Track these
+    # precisely as the individual build blocks are ported.
+  };
+}

--- a/pkgs/by-name/vp/vpinball/package.nix
+++ b/pkgs/by-name/vp/vpinball/package.nix
@@ -1,0 +1,158 @@
+{
+  lib,
+  stdenv,
+  callPackage,
+  fetchFromGitHub,
+  runCommand,
+  cmake,
+  pkg-config,
+  makeWrapper,
+  perl,
+  addDriverRunpath,
+  zlib,
+  libdrm,
+  libGL,
+  libGLU,
+  libglvnd,
+  vulkan-loader,
+  wayland,
+  wayland-protocols,
+  libxkbcommon,
+  systemd,
+  alsa-lib,
+  pipewire,
+  libx11,
+  libxext,
+  libxcursor,
+  libxcb,
+  libxi,
+  libxscrnsaver,
+  libxtst,
+  libxrandr,
+  libxrender,
+  libxfixes,
+}:
+
+let
+  version = "10.8.1-unstable-2026-06-15";
+
+  sources = callPackage ./sources.nix { };
+  externals = callPackage ./externals.nix { inherit sources; };
+
+  runtimeLibraryPath = lib.makeLibraryPath [
+    vulkan-loader
+    libglvnd
+    libx11
+    libxcb
+    pipewire
+    alsa-lib
+    wayland
+  ];
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vpinball";
+  inherit version;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "vpinball";
+    repo = "vpinball";
+    rev = "2c83fd2249c4406f15232ce6b6d6d4f913fd7883";
+    hash = "sha256-xh8IQknCvZAta3Lv6yuwq7yxsbgOBjRgMduBNGxQdTM=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    makeWrapper
+    perl
+  ];
+
+  buildInputs = [
+    zlib
+    libdrm
+    libGL
+    libGLU
+    libglvnd
+    vulkan-loader
+    wayland
+    wayland-protocols
+    libxkbcommon
+    systemd
+    alsa-lib
+    pipewire
+    libx11
+    libxext
+    libxcursor
+    libxcb
+    libxi
+    libxscrnsaver
+    libxtst
+    libxrandr
+    libxrender
+    libxfixes
+  ];
+
+  preConfigure = ''
+    cp make/CMakeLists_bgfx-linux-x64.txt CMakeLists.txt
+
+    if [ ! -d "${externals}/third-party/include" ]; then
+      echo "vpinball externals are missing: ${externals}" >&2
+      exit 1
+    fi
+
+    chmod -R u+w third-party
+    cp -a "${externals}/third-party/." third-party/
+  '';
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin" "$out/lib/vpinball"
+
+    cp -a VPinballX_BGFX "$out/lib/vpinball/"
+    cp -a ./*.so ./*.so.* "$out/lib/vpinball/"
+    cp -a assets scripts docs plugins "$out/lib/vpinball/"
+
+    makeWrapper "$out/lib/vpinball/VPinballX_BGFX" "$out/bin/vpinball" \
+      --set-default SDL_AUDIODRIVER alsa \
+      --prefix LD_LIBRARY_PATH : "${addDriverRunpath.driverLink}/lib:${runtimeLibraryPath}:$out/lib/vpinball"
+
+    runHook postInstall
+  '';
+
+  passthru.tests.smoke =
+    runCommand "${finalAttrs.pname}-smoke-test" { nativeBuildInputs = [ finalAttrs.finalPackage ]; }
+      ''
+        export HOME="$TMPDIR/home"
+        export XDG_CONFIG_HOME="$TMPDIR/config"
+        export XDG_DATA_HOME="$TMPDIR/share"
+        export SDL_AUDIODRIVER=dummy
+        export SDL_VIDEODRIVER=dummy
+
+        mkdir -p "$HOME" "$XDG_CONFIG_HOME" "$XDG_DATA_HOME"
+
+        vpinball -h > "$out"
+        grep -q "Visual Pinball Usage" "$out"
+      '';
+
+  meta = {
+    description = "Visual Pinball standalone player";
+    homepage = "https://github.com/vpinball/vpinball";
+    # Upstream is migrating from an old MAME-like noncommercial license to
+    # GPLv3+, while bundled third-party components retain their own licenses.
+    license = with lib.licenses; [
+      gpl3Plus
+      unfreeRedistributable
+    ];
+    mainProgram = "vpinball";
+    maintainers = with lib.maintainers; [ nmoya ];
+    platforms = [ "x86_64-linux" ];
+  };
+})

--- a/pkgs/by-name/vp/vpinball/sources.nix
+++ b/pkgs/by-name/vp/vpinball/sources.nix
@@ -1,0 +1,170 @@
+{ fetchFromGitHub, fetchurl }:
+
+{
+  # Versions mirror the sources used by platforms/linux-x64/external.sh.
+  sdl = fetchFromGitHub {
+    owner = "libsdl-org";
+    repo = "SDL";
+    rev = "8e37db5e797b6167f3a00d697d816a684bd259c7";
+    hash = "sha256-6Dph2eLiJUmpQzPWe8EuY5LrWhrFwde2f2dwfgCcWNw=";
+  };
+
+  sdl-image = fetchFromGitHub {
+    owner = "libsdl-org";
+    repo = "SDL_image";
+    rev = "96a73a551a857b7c8d0ca3cc553a266eabbab6a7";
+    hash = "sha256-LNEbXhUDB6OKk3HxwV+jANnskS82ewhQe8pDy+P6L40=";
+  };
+
+  sdl-ttf = fetchFromGitHub {
+    owner = "libsdl-org";
+    repo = "SDL_ttf";
+    rev = "a1ce3670aec736ecbf0936c43f2f0cc53aa61e5b";
+    hash = "sha256-g7LfLxs7yr7bezQWPWn8arNuPxCfYLCO4kzXmLRUUSY=";
+  };
+
+  freeimage = fetchFromGitHub {
+    owner = "toxieainc";
+    repo = "freeimage";
+    rev = "b1613452a0c3849d43ac877b154cf51ff9e078d3";
+    hash = "sha256-3dd5uEkcrK4mLZT58ZhZaTYzvSI4QBsSflcR4dBzz5g=";
+  };
+
+  bgfx-cmake = fetchurl {
+    url = "https://github.com/bkaradzic/bgfx.cmake/releases/download/v1.143.9262-545/bgfx.cmake.v1.143.9262-545.tar.gz";
+    hash = "sha256-t4u6ZuH6soUc8HJr/AMQBHXLJQWOXpfwv6EAvPA2+y4=";
+  };
+
+  bgfx = fetchFromGitHub {
+    owner = "vbousquet";
+    repo = "bgfx";
+    rev = "66fbca4dfe93da62b0f145bec872ee96df326afa";
+    hash = "sha256-2h7ZBO7rV/ra6fryqxEfrB3k/nWr6yu8wk+hPuKXxMk=";
+  };
+
+  pinmame = fetchFromGitHub {
+    owner = "vbousquet";
+    repo = "pinmame";
+    rev = "8b143198c4f07645db39a4cb4cf7f332702673d0";
+    hash = "sha256-UfEIechtJBFHExM+HGXW9Phxqdl0IhN9jdJlriBreOM=";
+  };
+
+  libdmdutil = fetchFromGitHub {
+    owner = "vpinball";
+    repo = "libdmdutil";
+    rev = "5879c321e75c2ca3c5dd9cde5d7c49f0075d1f16";
+    hash = "sha256-NkcC90DmExmK1sgIOZFyCBTqYrxx3GpSGdzEPXd+TiA=";
+  };
+
+  libdmdutil-libzedmd = fetchFromGitHub {
+    owner = "PPUC";
+    repo = "libzedmd";
+    rev = "5c44646f2af4b1419b4cdcaed3a2799ca9439221";
+    hash = "sha256-8oU7LzMcnVBff+35nfgUogsW9pag4VOGPpAXbhoBib4=";
+  };
+
+  libdmdutil-libserum = fetchFromGitHub {
+    owner = "PPUC";
+    repo = "libserum";
+    rev = "21b28325c4272724e719ab2d17481d851eaf9fd8";
+    hash = "sha256-Vf18gnz6sTHU5VM+mOY9ktR/auE5vSBap4fmTBjvN1Y=";
+  };
+
+  libdmdutil-libpupdmd = fetchFromGitHub {
+    owner = "PPUC";
+    repo = "libpupdmd";
+    rev = "4a1123220e6dce73c87cc584494df2ac82cb6f4c";
+    hash = "sha256-HGRODeS/dhtjTu0b5Ufbs0qxLmTbHOxxeTv0+RiIrvM=";
+  };
+
+  libdmdutil-libvni = fetchFromGitHub {
+    owner = "PPUC";
+    repo = "libvni";
+    rev = "7258e2fa0d086e1224d6510d44a61879e6b344b1";
+    hash = "sha256-pC5tmLVuXvyOJO5hLXpcEtVbMEYt/s6MiY9o65CRu1E=";
+  };
+
+  libdmdutil-cargs = fetchFromGitHub {
+    owner = "likle";
+    repo = "cargs";
+    rev = "0698c3f90333446d0fc2745c1e9ce10dd4a9497a";
+    hash = "sha256-DpUeKFVtbpD2lqW10q91zCFmm4AQKAYSHXUp5B1YNM8=";
+  };
+
+  libdmdutil-libframeutil = fetchFromGitHub {
+    owner = "ppuc";
+    repo = "libframeutil";
+    rev = "28f2bae0dabcbd5c599e6f62211f009e078c1f96";
+    hash = "sha256-Bk8pnSCtB7R157+gLHhnE4eM8UwN0JmD4o44aTiQTNw=";
+  };
+
+  libdmdutil-sockpp = fetchFromGitHub {
+    owner = "fpagliughi";
+    repo = "sockpp";
+    rev = "e6c4688a576d95f42dd7628cefe68092f6c5cd0f";
+    hash = "sha256-eIgYam/iQXjT3/Fu6ptNGSUVutLMG5Z1tmLsKLFOD/Q=";
+  };
+
+  libaltsound = fetchFromGitHub {
+    owner = "vpinball";
+    repo = "libaltsound";
+    rev = "f4b790a19ae45a9f93ae0051df6933800c7a6446";
+    hash = "sha256-Y4VxGeLi3GTPWuN0nXUtMQG/1hm2Hpkm4X9Y8HrageM=";
+  };
+
+  libdof = fetchFromGitHub {
+    owner = "vpinball";
+    repo = "libdof";
+    rev = "50af22e1909132993c5106cc64a6834710212da0";
+    hash = "sha256-vDeQa7BDGae0yL6eNjgy0Z92lubJDpvLgO6nV9gF91g=";
+  };
+
+  libdof-libusb = fetchFromGitHub {
+    owner = "libusb";
+    repo = "libusb";
+    rev = "15a7ebb4d426c5ce196684347d2b7cafad862626";
+    hash = "sha256-m1w+uF8+2WCn72LvoaGUYa+R0PyXHtFFONQjdRfImYY=";
+  };
+
+  libdof-libserialport = fetchFromGitHub {
+    owner = "sigrokproject";
+    repo = "libserialport";
+    rev = "21b3dfe5f68c205be4086469335fd2fc2ce11ed2";
+    hash = "sha256-zxHCJTC12kkbKB3UCTblNbNZZRhTuyhC9MR5iVXqYWc=";
+  };
+
+  libdof-hidapi = fetchFromGitHub {
+    owner = "libusb";
+    repo = "hidapi";
+    rev = "d6b2a974608dec3b76fb1e36c189f22b9cf3650c";
+    hash = "sha256-o6IZRG42kTa7EQib9eaV1HGyjaGgeCabk+8fyQTm/0s=";
+  };
+
+  libdof-libftdi = fetchFromGitHub {
+    owner = "jsm174";
+    repo = "libftdi";
+    rev = "5c2c58e03ea999534e8cb64906c8ae8b15536c30";
+    hash = "sha256-RmD40HVsx1fyBwHkYPmG+FZBfPcOGj87lH+tCfx4N24=";
+  };
+
+  ffmpeg = fetchFromGitHub {
+    owner = "FFmpeg";
+    repo = "FFmpeg";
+    rev = "239f2c733de417201d7ad3b3b8b0d9b63285b2b1";
+    hash = "sha256-WPGfjTZjsgpR5QiANRWF4g6LF2ejGzFQUrLjhzw9cfQ=";
+  };
+
+  libzip = fetchFromGitHub {
+    owner = "nih-at";
+    repo = "libzip";
+    rev = "6f8a0cdd24a0dc6cce9dac4a7679da784ab124ea";
+    hash = "sha256-+ekbD3PWAGhBJGIqqa9AnWcG7hToeFPRr6kkmxJHOaY=";
+  };
+
+  libwinevbs = fetchFromGitHub {
+    owner = "vpinball";
+    repo = "libwinevbs";
+    rev = "8ce73e202a4971ad3e08d91c694ea7ca0fe81ed6";
+    hash = "sha256-3kGx35IAICIgS0D1I5UTrDxfC1lrwPaSWwBOydFCy9E=";
+  };
+}


### PR DESCRIPTION
Adds `vpinball`, the Linux Visual Pinball X standalone player.
This package builds the Linux BGFX backend from source and installs one public executable: `vpinball`.
Tables and ROMs are not packaged. Users must provide their own `.vpx` tables and PinMAME ROMs. PinMAME ROMs can be provided under `~/.pinmame/roms` or a table-local `pinmame/roms` directory.
The wrapper defaults `SDL_AUDIODRIVER=alsa`, which was runtime-tested on NixOS. Vulkan runtime access is handled through the standard NixOS OpenGL driver link via `addDriverRunpath.driverLink`.
The upstream source is pinned to tested commit `2c83fd2249c4406f15232ce6b6d6d4f913fd7883`.
Upstream is migrating Visual Pinball from an old MAME-like noncommercial license to GPLv3+. Some files may still be under the older license, and bundled third-party components retain their own licenses, so the package is marked with mixed licensing: `gpl3Plus` and `unfreeRedistributable`.
## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`: `NIXPKGS_ALLOW_UNFREE=1 nix-build -A vpinball.passthru.tests.smoke --no-out-link`
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality: `nix-build lib/tests/maintainers.nix --no-out-link`
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`: `SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy ./result/bin/vpinball -h`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].