### PR TITLE
libaio: pull src from codeberg

### DIFF
--- a/pkgs/by-name/li/libaio/package.nix
+++ b/pkgs/by-name/li/libaio/package.nix
@@ -1,16 +1,18 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromCodeberg,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   version = "0.3.113";
   pname = "libaio";
 
-  src = fetchurl {
-    url = "https://pagure.io/libaio/archive/libaio-${finalAttrs.version}/libaio-libaio-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-cWxwWXAyRzROsGa1TsvDyiE08BAzBxkubCt9q1+VKKs=";
+  src = fetchFromCodeberg {
+    owner = "jmoyer";
+    repo = "libaio";
+    tag = "libaio-${finalAttrs.version}";
+    hash = "sha256-8TofYbwsnenv5GuC6FjkUt9rBTULEb5nhknuxr2ckQg=";
   };
 
   postPatch = ''
@@ -33,6 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Library for asynchronous I/O in Linux";
     homepage = "https://lse.sourceforge.net/io/aio.html";
+    downloadPage = "https://codeberg.org/jmoyer/libaio";
     platforms = lib.platforms.linux;
     license = lib.licenses.lgpl21;
     maintainers = [ ];


### PR DESCRIPTION
https://lore.kernel.org/distributions/ajH6hjJ9X6PcLET3@thunder.hadrons.org/T/#u


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
