### PR TITLE
whisper-cpp: 1.8.5 -> 1.8.7

### DIFF
--- a/pkgs/by-name/wh/whisper-cpp/package.nix
+++ b/pkgs/by-name/wh/whisper-cpp/package.nix
@@ -31,7 +31,7 @@
 
   withSDL ? true,
 
-  withFFmpegSupport ? false,
+  withFFmpegSupport ? stdenv.hostPlatform.isLinux,
 }:
 
 assert metalSupport -> stdenv.hostPlatform.isDarwin;
@@ -81,13 +81,13 @@ let
 in
 effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "whisper-cpp";
-  version = "1.8.5";
+  version = "1.8.7";
 
   src = fetchFromGitHub {
     owner = "ggml-org";
     repo = "whisper.cpp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-wZYSk0IVCL8bt00HVo6iqXS31GZJ2C8Z2be6wiMs7l8=";
+    hash = "sha256-hzgO2IqV1+JQjiYBBmFSOLfp1BgH0DgU0TZyO7OzFHE=";
   };
 
   # The upstream download script tries to download the models to the
@@ -135,7 +135,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     (cmakeBool "BUILD_SHARED_LIBS" (!isStatic))
   ]
   ++ optionals isLinux [
-    (cmakeBool "WHISPER_FFMPEG" withFFmpegSupport)
+    (cmakeBool "WHISPER_COMMON_FFMPEG" withFFmpegSupport)
   ]
   ++ optionals (isx86 && !isStatic) [
     (cmakeBool "GGML_BACKEND_DL" true)
@@ -186,6 +186,11 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     runHook preInstallCheck
     "$out/bin/whisper-cli" --help >/dev/null
     runHook postInstallCheck
+  '';
+
+  postFixup = ''
+    substituteInPlace $out/lib/pkgconfig/whisper.pc \
+      --replace-fail '//' '/'
   '';
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* bump version: 1.8.5 -> 1.8.7
* postFixup is necessary to fix malformed .pc file
* `WHISPER_FFMPEG` is deprecated, use `WHISPER_COMMON_FFMPEG` instead
* make `withFFmpegSupport` the default (PR #463682 made `withFFmpegSupport` optional so that whisper-server could run without the `--convert` flag. However, this is no longer necessary. FFmpeg is only used as a fallback when miniaudio fails. As a result, if whisper-server already works without `withFFmpegSupport`, enabling `withFFmpegSupport` will have no effect because the ffmpeg fallback path will never be used.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
