### PR TITLE
rh: init at 0.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3646,6 +3646,11 @@
     githubId = 23124539;
     name = "Błażej Sowa";
   };
+  bkaney = {
+    github = "bkaney";
+    githubId = 5303;
+    name = "Brian Kaney";
+  };
   bkchr = {
     email = "nixos@kchr.de";
     github = "bkchr";

--- a/pkgs/by-name/rh/rh/package.nix
+++ b/pkgs/by-name/rh/rh/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rh";
+  version = "0.2.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "reason-healthcare";
+    repo = "rh";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-XpAAkjPNtcirEIm772jth3vu9h9Rjr/zcZ83EvxylME=";
+  };
+
+  cargoHash = "sha256-8yR1nb6aJ9DrgN3DP/bSZjWTo5luskS/QgxNG35zIgM=";
+
+  cargoBuildFlags = [
+    "-p"
+    "rh-cli"
+  ];
+  cargoTestFlags = [
+    "-p"
+    "rh-cli"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "High-performance FHIR toolkit and CLI written in Rust";
+    longDescription = ''
+      Rust Health (rh) is a modern, high-performance toolkit for working with
+      HL7® FHIR®, purpose-built in Rust. Ships as a cross-platform CLI, Rust
+      library crates, and WebAssembly-backed npm packages.
+
+      Features include:
+      - FHIR resource validation
+      - FHIRPath expression evaluation
+      - FHIR Shorthand (FSH) compilation
+      - CQL to ELM translation
+      - FHIR package management
+      - VCL (Value Set Composition Language) support
+    '';
+    homepage = "https://github.com/reason-healthcare/rh";
+    changelog = "https://github.com/reason-healthcare/rh/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ bkaney ];
+    mainProgram = "rh";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
## Description

Add `rh` (Rust Health), a high-performance FHIR toolkit and CLI written in Rust.

## Package Info
- **Homepage**: https://github.com/reason-healthcare/rh
- **Crates.io**: https://crates.io/crates/rh-cli
- **License**: MIT OR Apache-2.0
- **MSRV**: Rust 1.91+

## Details

Rust Health (rh) is a modern, high-performance toolkit for working with HL7® FHIR®, purpose-built in Rust. Ships as a cross-platform CLI, Rust library crates, and WebAssembly-backed npm packages.

### Features
- **FHIR resource validation** — Validate FHIR resources against specifications
- **FHIRPath evaluation** — Query FHIR resources using FHIRPath expressions
- **FHIR Shorthand (FSH)** — Compile FSH source files to FHIR JSON profiles
- **CQL support** — Translate Clinical Quality Language to ELM format
- **FHIR package management** — Download and manage FHIR packages
- **VCL support** — Value Set Composition Language expressions

### Build Notes
- This package builds the rh-cli crate from a Cargo workspace monorepo
- Only the CLI binary is included; Rust library crates are separate
- WebAssembly packages are npm packages (separate PR)

### Testing
The package was tested locally with verification of hashes against the GitHub repository.

## Checklist
- [x] Package builds successfully
- [x] Binary executes and outputs expected help
- [x] Hashes verified against GitHub releases
- [x] License field correct
- [x] Meta fields populated