### PR TITLE
cliproxyapi: init at 7.2.146

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -68,6 +68,18 @@
   "module-boot-plymouth-tpm2-totp-quick-start-enable": [
     "index.html#module-boot-plymouth-tpm2-totp-quick-start-enable"
   ],
+  "module-services-cliproxyapi": [
+    "index.html#module-services-cliproxyapi"
+  ],
+  "module-services-cliproxyapi-authentication": [
+    "index.html#module-services-cliproxyapi-authentication"
+  ],
+  "module-services-cliproxyapi-authentication-cli": [
+    "index.html#module-services-cliproxyapi-authentication-cli"
+  ],
+  "module-services-cliproxyapi-authentication-management-api": [
+    "index.html#module-services-cliproxyapi-authentication-management-api"
+  ],
   "module-services-keycloak-unix-socket": [
     "index.html#module-services-keycloak-unix-socket"
   ],

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -68,6 +68,8 @@
 
 - [Freescout](https://freescout.net/), a free, open source Helpdesk and shared mailbox. Available as [services.freescout](#opt-services.freescout.enable).
 
+- [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI), a proxy that provides OpenAI/Gemini/Claude/Codex/Grok compatible API interfaces from OAuth-based AI CLI subscriptions. Available as [services.cliproxyapi](#opt-services.cliproxyapi.enable).
+
 - [Lix TOML remote builders](https://docs.lix.systems/manual/lix/stable/advanced-topics/distributed-builds.html#using-a-toml-configuration), remote builder configuration using lix's TOML format. Available as [lix.buildMachines](#opt-lix.buildMachines). Note: incompatible with `nix.buildMachines`.
 
 - [Forgejo Runner](https://forgejo.org/docs/latest/admin/actions/), a daemon for Forgejo Actions. Available as [services.forgejo-runner](#opt-services.forgejo-runner.instances).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -870,6 +870,7 @@
   ./services/misc/cgminer.nix
   ./services/misc/clipcat.nix
   ./services/misc/clipmenu.nix
+  ./services/misc/cliproxyapi.nix
   ./services/misc/comfyui.nix
   ./services/misc/confd.nix
   ./services/misc/conman.nix

--- a/nixos/modules/services/misc/cliproxyapi.md
+++ b/nixos/modules/services/misc/cliproxyapi.md
@@ -1,0 +1,55 @@
+# CLIProxyAPI {#module-services-cliproxyapi}
+
+[CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) exposes OAuth-based subscription CLIs (Claude Code, Codex, Gemini, Qwen, Grok, Antigravity) behind OpenAI/Gemini/Anthropic-compatible HTTP APIs.
+
+Enable it with:
+
+```nix
+{
+  services.cliproxyapi.enable = true;
+}
+```
+
+The service runs as a dedicated `cliproxyapi` user and keeps its configuration and OAuth tokens under `/var/lib/cliproxyapi`.
+
+## Authentication {#module-services-cliproxyapi-authentication}
+
+Provider logins use OAuth and must land in the service's `auth-dir` (`/var/lib/cliproxyapi`), which is owned by the `cliproxyapi` user. Either of the approaches below writes the token with the correct ownership, and the running service picks it up without a restart.
+
+### Management API {#module-services-cliproxyapi-authentication-management-api}
+
+Set a management key in [](#opt-services.cliproxyapi.settings):
+
+```nix
+{
+  services.cliproxyapi.settings.remote-management.secret-key._secret =
+    "/run/secrets/cliproxyapi-mgmt-key";
+}
+```
+
+Then request an authentication URL for the desired provider and open it in a browser:
+
+```bash
+curl -H "Authorization: Bearer <management-key>" \
+  http://127.0.0.1:8317/v0/management/anthropic-auth-url
+```
+
+The daemon completes the OAuth flow itself and stores the token in its `auth-dir`. Authentication endpoints are available for the `anthropic`, `codex`, `xai`, `antigravity`, and `kimi` providers.
+
+### Command-line login {#module-services-cliproxyapi-authentication-cli}
+
+Add the package so the `cliproxyapi` binary is on `PATH`:
+
+```nix
+{
+  environment.systemPackages = [ config.services.cliproxyapi.package ];
+}
+```
+
+Then run the login as the service user, pointing at the managed configuration:
+
+```bash
+sudo -u cliproxyapi cliproxyapi -config /var/lib/cliproxyapi/config.yaml --claude-login
+```
+
+Other providers use their matching flags, for example `--codex-login` or `--xai-login`. On a headless host, pass `-no-browser` to print the OAuth URL instead of launching a browser.

--- a/nixos/modules/services/misc/cliproxyapi.nix
+++ b/nixos/modules/services/misc/cliproxyapi.nix
@@ -1,0 +1,153 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+let
+  cfg = config.services.cliproxyapi;
+  format = pkgs.formats.yaml { };
+  stateDir = "/var/lib/cliproxyapi";
+  configPath = "${stateDir}/config.yaml";
+  settings = {
+    auth-dir = stateDir;
+  }
+  // cfg.settings;
+  secretsReplacement = utils.genJqSecretsReplacement {
+    loadCredential = true;
+  } settings configPath;
+  port = cfg.settings.port or 8317;
+in
+{
+  options.services.cliproxyapi = {
+    enable = lib.mkEnableOption "CLIProxyAPI";
+
+    package = lib.mkPackageOption pkgs "cliproxyapi" { };
+
+    settings = lib.mkOption {
+      type = format.type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          host = "127.0.0.1";
+          port = 8317;
+          api-keys = [ { _secret = "/run/secrets/cliproxyapi-api-key"; } ];
+          remote-management.secret-key._secret = "/run/secrets/cliproxyapi-management-key";
+        }
+      '';
+      description = ''
+        Configuration for CLIProxyAPI. See the
+        [example configuration](https://github.com/router-for-me/CLIProxyAPI/blob/main/config.example.yaml)
+        for available options. Secret values can be loaded from files using
+        `._secret = "/path/to/secret";`.
+      '';
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/run/secrets/cliproxyapi.env";
+      description = "Environment file as defined in {manpage}`systemd.exec(5)`.";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether to open the firewall for the specified port.";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "cliproxyapi";
+      description = "User account under which CLIProxyAPI runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "cliproxyapi";
+      description = "Group under which CLIProxyAPI runs.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.users = lib.mkIf (cfg.user == "cliproxyapi") {
+      cliproxyapi = {
+        isSystemUser = true;
+        group = cfg.group;
+        home = stateDir;
+        description = "CLIProxyAPI service user";
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == "cliproxyapi") {
+      cliproxyapi = { };
+    };
+
+    systemd.services.cliproxyapi = {
+      description = "Proxy that provides OpenAI/Gemini/Claude/Codex/Grok compatible API interfaces";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      preStart = secretsReplacement.script;
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        StateDirectory = "cliproxyapi";
+        StateDirectoryMode = "0700";
+        WorkingDirectory = stateDir;
+        ExecStart = "${lib.getExe cfg.package} -config ${configPath}";
+        Restart = "on-failure";
+        RestartSec = 5;
+        LoadCredential = secretsReplacement.credentials;
+        EnvironmentFile = lib.mkIf (cfg.environmentFile != null) [ cfg.environmentFile ];
+
+        # Hardening
+        CapabilityBoundingSet = "";
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        PrivateUsers = true;
+        ProtectHostname = true;
+        ProtectClock = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        ProtectProc = "invisible";
+        ProcSubset = "pid";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        RestrictSUIDSGID = true;
+        RestrictRealtime = true;
+        RemoveIPC = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@resources"
+        ];
+        UMask = "0077";
+      };
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [ port ];
+    };
+  };
+
+  meta = {
+    doc = ./cliproxyapi.md;
+    maintainers = [ lib.maintainers.anish ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -386,6 +386,7 @@ in
     inherit runTest;
     package = pkgs.clickhouse-lts;
   };
+  cliproxyapi = runTest ./cliproxyapi.nix;
   cloud-init = runTest ./cloud-init.nix;
   cloud-init-hostname = runTest ./cloud-init-hostname.nix;
   cloudcompare = import ./cloudcompare.nix { inherit pkgs runTest; };

--- a/nixos/tests/cliproxyapi.nix
+++ b/nixos/tests/cliproxyapi.nix
@@ -1,0 +1,41 @@
+{ lib, ... }:
+{
+  name = "cliproxyapi";
+
+  meta.maintainers = [ lib.maintainers.anish ];
+
+  containers.machine =
+    { pkgs, ... }:
+    {
+      services.cliproxyapi = {
+        enable = true;
+        settings = {
+          host = "127.0.0.1";
+          port = 8317;
+          api-keys = [ { _secret = "/etc/cliproxyapi-api-key"; } ];
+        };
+      };
+
+      environment.etc."cliproxyapi-api-key".text = "test-key";
+      environment.systemPackages = [ pkgs.curl ];
+    };
+
+  testScript = ''
+    machine.wait_for_unit("cliproxyapi.service")
+    machine.wait_for_open_port(8317)
+
+    # The API key secret must be substituted into config.yaml.
+    machine.succeed("grep -q test-key /var/lib/cliproxyapi/config.yaml")
+
+    # Requests without a valid API key are rejected.
+    status = machine.succeed(
+        "curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8317/v1/models"
+    ).strip()
+    assert status == "401", f"expected 401 for unauthenticated /v1/models, got {status}"
+
+    # Requests carrying the configured API key are accepted.
+    machine.succeed(
+        "curl -sf -H 'Authorization: Bearer test-key' http://127.0.0.1:8317/v1/models"
+    )
+  '';
+}

--- a/pkgs/by-name/cl/cliproxyapi/package.nix
+++ b/pkgs/by-name/cl/cliproxyapi/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "cliproxyapi";
+  version = "7.2.146";
+
+  src = fetchFromGitHub {
+    owner = "router-for-me";
+    repo = "CLIProxyAPI";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6A01jfwnydP5ww+Kr47TS6KHAt05enOiaHc9rYQEswU=";
+  };
+
+  vendorHash = "sha256-CrDp7MOr+AwJUhTovklXx3F1yaktQlvD7VYhYSY6VvY=";
+
+  subPackages = [ "cmd/server" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=${finalAttrs.version}"
+    "-X main.Commit=v${finalAttrs.version}"
+    "-X main.BuildDate=1970-01-01"
+  ];
+
+  postInstall = ''
+    mv $out/bin/server $out/bin/cliproxyapi
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Proxy that provides OpenAI/Gemini/Claude/Codex/Grok compatible API interfaces";
+    homepage = "https://github.com/router-for-me/CLIProxyAPI";
+    changelog = "https://github.com/router-for-me/CLIProxyAPI/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ anish ];
+    mainProgram = "cliproxyapi";
+  };
+})


### PR DESCRIPTION
[CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI) exposes OAuth-based subscription CLIs (Claude Code, Codex, Gemini, Qwen, Grok, Antigravity) behind OpenAI/Gemini/Anthropic-compatible HTTP APIs.  

This PR includes a package, for the upstream Go binary, `services.cliproxyapi`, and a VM test for startup and API-key auth.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
