### PR TITLE
maintainers: rename niksingh710 to semi710

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19830,12 +19830,6 @@
     githubId = 70602908;
     github = "nikolaizombie1";
   };
-  niksingh710 = {
-    email = "nik.singh710@gmail.com";
-    name = "Nikhil Singh";
-    github = "niksingh710";
-    githubId = 60490474;
-  };
   nikstur = {
     email = "nikstur@outlook.com";
     name = "nikstur";
@@ -25007,6 +25001,12 @@
     github = "sellout";
     githubId = 33031;
     name = "Greg Pfeil";
+  };
+  semi710 = {
+    email = "nik.singh710@gmail.com";
+    name = "Nikhil Singh";
+    github = "semi710";
+    githubId = 60490474;
   };
   sempiternal-aurora = {
     email = "myrialsarvay@gmail.com";

--- a/pkgs/by-name/ch/choose-gui/package.nix
+++ b/pkgs/by-name/ch/choose-gui/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/chipsenkbeil/choose/blob/${version}/CHANGELOG.md";
     maintainers = with lib.maintainers; [
       heywoodlh
-      niksingh710
+      semi710
     ];
     mainProgram = "choose";
   };

--- a/pkgs/by-name/fz/fzf-preview/package.nix
+++ b/pkgs/by-name/fz/fzf-preview/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
   version = "0-unstable-2026-02-22";
 
   src = fetchFromGitHub {
-    owner = "niksingh710";
+    owner = "semi710";
     repo = "fzf-preview";
     rev = "5e5a5a5c4258fa86300cb56224e31416ff7401b5";
     hash = "sha256-ZjBoTsZ2ymfhmUbMpMWT1MB20kLf0BILnCDu75F6WEQ=";
@@ -79,10 +79,10 @@ stdenv.mkDerivation {
       be simple, fast, and highly compatible, making it a useful tool for anyone
       leveraging fzf for file navigation or search.
     '';
-    homepage = "https://github.com/niksingh710/fzf-preview";
+    homepage = "https://github.com/semi710/fzf-preview";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
-      niksingh710
+      semi710
     ];
     mainProgram = "fzf-preview";
     platforms = lib.platforms.unix;

--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -521,7 +521,7 @@ in
     rtpFilePath = "minimal.tmux";
     version = "0-unstable-2025-06-04";
     src = fetchFromGitHub {
-      owner = "niksingh710";
+      owner = "semi710";
       repo = "minimal-tmux-status";
       rev = "de2bb049a743e0f05c08531a0461f7f81da0fc72";
       hash = "sha256-0gXtFVan+Urb79AjFOjHdjl3Q73m8M3wFSo3ZhjxcBA=";
@@ -534,10 +534,10 @@ in
         quickly identify the prefix state. Designed to be minimal in appearance and dependencies, it is ideal for users
         who want essential information without clutter.
       '';
-      homepage = "https://github.com/niksingh710/minimal-tmux-status.git";
+      homepage = "https://github.com/semi710/minimal-tmux-status.git";
       license = lib.licenses.mit;
       maintainers = with lib.maintainers; [
-        niksingh710
+        semi710
       ];
       platforms = lib.platforms.unix;
     };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
