### PR TITLE
ocamlPackages.{camlpdf,cpdf}: 2.9 -> 2.9.1; add ngi team

### DIFF
--- a/pkgs/development/ocaml-modules/camlpdf/default.nix
+++ b/pkgs/development/ocaml-modules/camlpdf/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   ocaml,
   findlib,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -28,11 +29,15 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/stublibs
   '';
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "OCaml library for reading, writing and modifying PDF files";
     homepage = "https://github.com/johnwhitington/camlpdf";
+    changelog = "https://github.com/johnwhitington/camlpdf/blob/${finalAttrs.src.rev}/Changes.txt";
     license = lib.licenses.lgpl21Plus;
     maintainers = with lib.maintainers; [ vbgl ];
+    teams = with lib.teams; [ ngi ];
     broken = lib.versionOlder ocaml.version "4.10";
   };
 })

--- a/pkgs/development/ocaml-modules/camlpdf/default.nix
+++ b/pkgs/development/ocaml-modules/camlpdf/default.nix
@@ -7,14 +7,14 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "2.9";
+  version = "2.9.1";
   pname = "ocaml${ocaml.version}-camlpdf";
 
   src = fetchFromGitHub {
     owner = "johnwhitington";
     repo = "camlpdf";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-8xBna7GDFbFf48069/ct71uFxLJU0eBfKVRWDnyYocs=";
+    hash = "sha256-f3Bm64T27eiIzOY2nwdzMRH68VlyNp2jXpOPyBouSCs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/ocaml-modules/cpdf/default.nix
+++ b/pkgs/development/ocaml-modules/cpdf/default.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ocaml${ocaml.version}-cpdf";
-  version = "2.9";
+  version = "2.9.1";
 
   src = fetchFromGitHub {
     owner = "johnwhitington";
     repo = "cpdf-source";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-b6fGKFM9Q2YxW8FoyewGNTkF9XBtjdq0Bur6KgVi5T4=";
+    hash = "sha256-P3CQwYp23URVBDcdnrRAg7gAsOMIifwraIcFSJh8pd0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/ocaml-modules/cpdf/default.nix
+++ b/pkgs/development/ocaml-modules/cpdf/default.nix
@@ -5,6 +5,7 @@
   ocaml,
   findlib,
   camlpdf,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -35,11 +36,15 @@ stdenv.mkDerivation (finalAttrs: {
     cp cpdfmanual.pdf $out/share/doc/cpdf/
   '';
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "PDF Command Line Tools";
     homepage = "https://www.coherentpdf.com/";
+    changelog = "https://github.com/johnwhitington/cpdf-source/blob/${finalAttrs.src.rev}/Changes.txt";
     license = lib.licenses.agpl3Only;
-    maintainers = [ lib.maintainers.vbgl ];
+    maintainers = with lib.maintainers; [ vbgl ];
+    teams = with lib.teams; [ ngi ];
     mainProgram = "cpdf";
     inherit (ocaml.meta) platforms;
     broken = lib.versionOlder ocaml.version "4.10";


### PR DESCRIPTION
- **camlpdf**:
    - diff: https://github.com/johnwhitington/camlpdf/compare/v2.9...v2.9.1
    - changelog: https://github.com/johnwhitington/camlpdf/blob/refs/tags/v2.9.1/Changes.txt
- **cpdf**:
    - diff: https://github.com/johnwhitington/cpdf-source/compare/v2.9...v2.9.1
    - changelog: https://github.com/johnwhitington/cpdf-source/blob/refs/tags/v2.9.1/Changes.txt

**PS:** I'm adding the NGI team since [`cpdf`](https://nlnet.nl/project/Cpdf-redaction) is an NGI project.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
