### PR TITLE
mangowc: 0.12.8 -> 0.14.4

### DIFF
--- a/pkgs/by-name/ma/mangowc/package.nix
+++ b/pkgs/by-name/ma/mangowc/package.nix
@@ -1,4 +1,5 @@
 {
+  cjson,
   lib,
   libx11,
   libinput,
@@ -23,13 +24,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "mangowc";
-  version = "0.12.8";
+  version = "0.14.4";
 
   src = fetchFromGitHub {
     owner = "mangowm";
     repo = "mango";
     tag = finalAttrs.version;
-    hash = "sha256-k9qFn9I+eeAq1kBfw6QRLRMDb6sIV+pgd5zpKNoc1ck=";
+    hash = "sha256-WfQNALT+8ZbjZG2co1tz2dZZZw1tcU5ynuFe+vVMbV0=";
   };
 
   nativeBuildInputs = [
@@ -40,6 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    cjson
     libinput
     libxcb
     libxkbcommon

--- a/pkgs/by-name/ma/mangowc/package.nix
+++ b/pkgs/by-name/ma/mangowc/package.nix
@@ -74,7 +74,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Lightweight and feature-rich Wayland compositor based on dwl";
     homepage = "https://mangowm.github.io";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ hustlerone ];
+    maintainers = with lib.maintainers; [
+      hustlerone
+      yvnth
+    ];
     platforms = lib.platforms.linux;
   };
 })


### PR DESCRIPTION
Bump mangowc from 0.12.8 to 0.14.4. Release notes: https://github.com/mangowm/mango/releases

This version introduces a new dependency on `libcjson`, so added `cjson` to `buildInputs`.

Also adding myself as a maintainer, since I use and test this package regularly.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [[NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)] in [[nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)].
  - [ ] [[Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)] at `passthru.tests`.
  - [ ] Tests in [[lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests)] or [[pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [[nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [[CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)], [[pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md)], [[maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md)] and other READMEs.
- [x] Follows the [[automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy)].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test