### PR TITLE
nixos/security/wrappers: avoid linux-headers in closure

### DIFF
--- a/nixos/modules/security/wrappers/wrapper.nix
+++ b/nixos/modules/security/wrappers/wrapper.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   stdenv,
   unsecvars,
   linuxHeaders,
@@ -31,5 +32,11 @@ stdenv.mkDerivation {
   installPhase = ''
     mkdir -p $out/bin
     $CC $CFLAGS ${./wrapper.c} -I${unsecvars} -o $out/bin/security-wrapper
+  '';
+
+  # HACK: Avoid leaking all of `buildInputs` into runtime closure
+  # FIXME when/if https://github.com/NixOS/nixpkgs/issues/83667 is resolved
+  postFixup = lib.optionalString stdenv.hostPlatform.isStatic ''
+    rm $out/nix-support/propagated-build-inputs
   '';
 }


### PR DESCRIPTION
Previously - due to https://github.com/NixOS/nixpkgs/issues/83667 - `linuxHeaders` in our `buildInputs` would be propagated in static builds. This results in (what I assume to be) almost every NixOS system having an unnecessary static version of linux-headers installed :(

Before:

```
$ nix-build nixos/ --arg configuration '{}' -A config.systemd.services.suid-sgid-wrappers.runner | xargs nix-store -qR | grep linux-headers
/nix/store/mjgmwddklgk1j6m7g4djsfmphwfs56wp-linux-headers-static-6.18.7
```

After:

```
$ nix-build nixos/ --arg configuration '{}' -A config.systemd.services.suid-sgid-wrappers.runner | xargs nix-store -qR | grep linux-headers

```


For reference, this is the same workaround used by [Nix itself](https://github.com/NixOS/nix/blob/00485422690332cd1fc96dc6aac6f6da14834bab/packaging/components.nix#L201-L206) following https://github.com/NixOS/nix/pull/13275

A mentioned workaround is also having a `dev` output, but I'm not sure that's really worth it here when that information is incorrect in any case

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
