### PR TITLE
flyway: 12.0.0 -> 12.8.1

### DIFF
--- a/pkgs/by-name/fl/flyway/package.nix
+++ b/pkgs/by-name/fl/flyway/package.nix
@@ -9,10 +9,10 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "flyway";
-  version = "12.0.0";
+  version = "12.8.1";
   src = fetchurl {
     url = "https://github.com/flyway/flyway/releases/download/flyway-${finalAttrs.version}/flyway-commandline-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-aBAbpNL+wJ+XOS7g8Af94iCylJTE7DmlbViVxA/yV1M=";
+    sha256 = "sha256-cJLyBFM4Q1WsvB7YP0uCt/IjLK7T2b326IvFW7ePVEA=";
   };
   nativeBuildInputs = [ makeWrapper ];
   dontBuild = true;
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
     done
     makeWrapper "${jre_headless}/bin/java" $out/bin/flyway \
       --add-flags "-Djava.security.egd=file:/dev/../dev/urandom" \
-      --add-flags "-classpath '$out/share/flyway/lib/*:$out/share/flyway/lib/flyway/*:$out/share/flyway/lib/aad/*:$out/share/flyway/lib/netty/*:$out/share/flyway/drivers/*'" \
+      --add-flags "-classpath '$out/share/flyway/lib/*:$out/share/flyway/lib/aad/*:$out/share/flyway/lib/flyway/*:$out/share/flyway/lib/netty/*:$out/share/flyway/drivers/*:$out/share/flyway/drivers/aws/*:$out/share/flyway/drivers/gcp/*:$out/share/flyway/drivers/cassandra/*:$out/share/flyway/drivers/couchbase/*:$out/share/flyway/drivers/mongo/*'" \
       --add-flags "org.flywaydb.commandline.Main"
   '';
   passthru.tests = {


### PR DESCRIPTION
## Description of changes

Updates flyway from 12.0.0 to 12.8.1.

12.8.1 adds new native-connector database plugins (notably `flyway-database-nc-cassandra`) under `lib/flyway`. These are discovered via Java's `ServiceLoader`, but instantiating them requires their JDBC driver dependencies which live in driver subdirectories the wrapper classpath did not include (`drivers/cassandra`, `drivers/aws`, `drivers/gcp`, `drivers/couchbase`, `drivers/mongo`). Without them flyway crashes on **every** invocation (including `flyway version`) with:

```
java.util.ServiceConfigurationError: org.flywaydb.core.extensibility.Plugin:
  org.flywaydb.database.nc.cassandra.CassandraDatabase Unable to get public no-arg constructor
```

The wrapper classpath has been extended with those subdirectories to match the upstream launcher script. Verified that `flyway version` runs cleanly and `passthru.tests.version` passes.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Ran the package's `passthru.tests`
- [x] `flyway version` runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
