### PR TITLE
octave.pkgs.optim: 1.6.2 -> 1.6.3, unbreak

### DIFF
--- a/pkgs/development/octave-modules/optim/default.nix
+++ b/pkgs/development/octave-modules/optim/default.nix
@@ -10,11 +10,11 @@
 
 buildOctavePackage rec {
   pname = "optim";
-  version = "1.6.2";
+  version = "1.6.3";
 
   src = fetchurl {
     url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
-    sha256 = "sha256-VUqOGLtxla6GH1BZwU8aVXhEJlwa3bW/vzq5iFUkeH4=";
+    sha256 = "sha256-Wfs3caLSojE0R1MsWaLgAKanu3pnfz74GD+6qrVJOhQ=";
   };
 
   buildInputs = [
@@ -34,9 +34,10 @@ buildOctavePackage rec {
       publicDomain
     ];
     # Modified BSD code seems removed
-    maintainers = with lib.maintainers; [ ravenjoad ];
+    maintainers = with lib.maintainers; [
+      ravenjoad
+      lnk3
+    ];
     description = "Non-linear optimization toolkit";
-    # Hasn't been updated since 2022, and fails to build with octave >= 10.1.0
-    broken = true;
   };
 }


### PR DESCRIPTION
It was marked broken in 1dc27975d1c106ccefcce2b9d7f3f75f16c3970f (May 2025).
But the bug was fixed in October 2025 with:
https://sourceforge.net/p/octave/optim/ci/d8c28ab3f3f37d439bc2d961d79f4a8caa9830d1/

Since then there were new commits, but no release. I asked the upstream maintainer to push the 1.6.3 tag.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 2 packages marked as broken and skipped:</summary>
  <ul>
    <li>octavePackages.data-smoothing</li>
    <li>octavePackages.econometrics</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>octavePackages.optim</li>
  </ul>
</details>

- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
```bash
[nix-shell:~/.cache/nixpkgs-review/rev-1eef7430a454b7dfbb38ba93a40d50c6d1f61dfe-dirty]$ nix-shell -p "octave.withPackages (ps: [ ps.optim ])" --run 'octave --eval "pkg load optim; disp(\"Success!\")"'
these 2 derivations will be built:
  /nix/store/ri9f4sjh0vz1522dww0nsibh4f69sq08-octave-11.3.0-pkgs-setup-hook.drv
  /nix/store/saa3navm38c5q06iqbjfy2n4540rbqg1-octave-11.3.0-env.drv
this path will be fetched (0.2 KiB download, 0.5 KiB unpacked):
  /nix/store/529dplxi7hfrjk92fhqz9pwlq6bxywr6-locale-glibc-2.42-61
copying path '/nix/store/529dplxi7hfrjk92fhqz9pwlq6bxywr6-locale-glibc-2.42-61' from 'https://cache.nixos.org'/...
building '/nix/store/ri9f4sjh0vz1522dww0nsibh4f69sq08-octave-11.3.0-pkgs-setup-hook.drv'...
building '/nix/store/saa3navm38c5q06iqbjfy2n4540rbqg1-octave-11.3.0-env.drv'...
structuredAttrs is enabled
created 6 symlinks in user environment
For information about changes from previous versions of the optim package, run 'news optim'.
error: ignoring const execution_exception& while preparing to exit
For information about changes from previous versions of the struct package, run 'news struct'.
error: ignoring const execution_exception& while preparing to exit
For information about changes from previous versions of the statistics package, run 'news statistics'.
Please report any issues with the statistics package at "[https://github.com/gnu-octave/statistics/issues"](https://github.com/gnu-octave/statistics/issues%22)
error: ignoring const execution_exception& while preparing to exit
program_PATH to change to is: /nix/store/c0pdlpqx8j6llkbm6sx5j7whk2bykb3b-octave-11.3.0-env/bin:/nix/store/qqxwlm6446piw274ndq1vs5dhydw5aqn-octave-11.3.0/bin
Recurse to propagated-build-input: /nix/store/c0pdlpqx8j6llkbm6sx5j7whk2bykb3b-octave-11.3.0-env
Recurse to propagated-build-input: /nix/store/45x1kdlvfi1dfd97lqqj5s76293c3pa5-octave-11.3.0-optim-1.6.3
Recurse to propagated-build-input: /nix/store/sn26g0cb1qnrrg6wzh80k22prwp9chwm-octave-11.3.0-struct-1.0.18
Recurse to propagated-build-input: /nix/store/m97pjhaz4x6s8i2y4kdmc6vjypm6dkk1-octave-11.3.0-statistics-1.8.3
wrapping `/nix/store/c0pdlpqx8j6llkbm6sx5j7whk2bykb3b-octave-11.3.0-env/bin/octave-config'...
wrapping `/nix/store/c0pdlpqx8j6llkbm6sx5j7whk2bykb3b-octave-11.3.0-env/bin/octave-cli-11.3.0'...
wrapping `/nix/store/c0pdlpqx8j6llkbm6sx5j7whk2bykb3b-octave-11.3.0-env/bin/octave-11.3.0'...
wrapping `/nix/store/c0pdlpqx8j6llkbm6sx5j7whk2bykb3b-octave-11.3.0-env/bin/octave-cli'...
wrapping `/nix/store/c0pdlpqx8j6llkbm6sx5j7whk2bykb3b-octave-11.3.0-env/bin/octave-config-11.3.0'...
wrapping `/nix/store/c0pdlpqx8j6llkbm6sx5j7whk2bykb3b-octave-11.3.0-env/bin/octave'...
wrapping `/nix/store/c0pdlpqx8j6llkbm6sx5j7whk2bykb3b-octave-11.3.0-env/bin/mkoctfile-11.3.0'...
wrapping `/nix/store/c0pdlpqx8j6llkbm6sx5j7whk2bykb3b-octave-11.3.0-env/bin/mkoctfile'...
octave: X11 DISPLAY environment variable not set
octave: disabling GUI features
Success!
```

- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy]. No LLM

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
