### PR TITLE
nixos/lubelogger: add listenAddress option

### DIFF
--- a/nixos/modules/services/web-apps/lubelogger.nix
+++ b/nixos/modules/services/web-apps/lubelogger.nix
@@ -32,6 +32,12 @@ in
         type = lib.types.port;
       };
 
+      listenAddress = lib.mkOption {
+        description = "The address LubeLogger will listen on.";
+        default = "localhost";
+        type = lib.types.str;
+      };
+
       user = lib.mkOption {
         description = "User account under which LubeLogger runs.";
         default = "lubelogger";
@@ -91,7 +97,7 @@ in
       wantedBy = [ "multi-user.target" ];
 
       environment = {
-        Kestrel__Endpoints__Http__Url = "http://localhost:${toString cfg.port}";
+        Kestrel__Endpoints__Http__Url = "http://${cfg.listenAddress}:${toString cfg.port}";
       }
       // cfg.settings;
 


### PR DESCRIPTION
## Things done

Allows binding LubeLogger to addresses other than localhost.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests in nixos/tests.
  - [ ] Package tests at passthru.tests.
  - [ ] Tests in lib/tests or pkgs/test for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.

cc @Lyndeno