### PR TITLE
nixos/outline: allow DATABASE_URL override from environment

### DIFF
--- a/nixos/modules/services/web-apps/outline.nix
+++ b/nixos/modules/services/web-apps/outline.nix
@@ -836,14 +836,12 @@ in
           ${
             if (cfg.databaseUrl == "local") then
               ''
-                DATABASE_URL=${lib.escapeShellArg localPostgresqlUrl}
-                export DATABASE_URL
-                export PGSSLMODE=disable
+                export DATABASE_URL="''${DATABASE_URL:-${lib.escapeShellArg localPostgresqlUrl}}"
+                export PGSSLMODE="''${PGSSLMODE:-disable}"
               ''
             else
               ''
-                DATABASE_URL=${lib.escapeShellArg cfg.databaseUrl}
-                export DATABASE_URL
+                export DATABASE_URL="''${DATABASE_URL:-${lib.escapeShellArg cfg.databaseUrl}}"
               ''
           }
 


### PR DESCRIPTION
## Things done

Uses parameter expansion for `DATABASE_URL` to allow systemd `EnvironmentFile` to securely provide the connection string.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests in nixos/tests.
  - [ ] Package tests at passthru.tests.
  - [ ] Tests in lib/tests or pkgs/test for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.

cc @cab404 @e1mo @xanderio @yrd