### PR TITLE
nixos/maddy: allow string paths for secrets to support optional EnvironmentFiles

### DIFF
--- a/nixos/modules/services/mail/maddy.nix
+++ b/nixos/modules/services/mail/maddy.nix
@@ -350,11 +350,13 @@ in
       };
 
       secrets = lib.mkOption {
-        type = with lib.types; listOf path;
+        type = with lib.types; listOf (either str path);
         description = ''
           A list of files containing the various secrets. Should be in the format
           expected by systemd's `EnvironmentFile` directory. Secrets can be
           referenced in the format `{env:VAR}`.
+
+          Paths can be prefixed with `-` to ignore errors if the file does not exist.
         '';
         default = [ ];
       };


### PR DESCRIPTION
## Things done

Changes the `secrets` option type to `listOf (either str path)` to allow string paths, enabling the `-` prefix for optional systemd `EnvironmentFile`s.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests in nixos/tests.
  - [ ] Package tests at passthru.tests.
  - [ ] Tests in lib/tests or pkgs/test for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.

cc @NickCao