### PR TITLE
turnstone: init at 1.7.4, add nixos module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1004,6 +1004,7 @@
   ./services/misc/tp-auto-kbbl.nix
   ./services/misc/transfer-sh.nix
   ./services/misc/turn-rs.nix
+  ./services/misc/turnstone.nix
   ./services/misc/tuxclocker.nix
   ./services/misc/tzupdate.nix
   ./services/misc/uhub.nix

--- a/nixos/modules/services/misc/turnstone.md
+++ b/nixos/modules/services/misc/turnstone.md
@@ -1,0 +1,131 @@
+# Turnstone {#module-services-turnstone}
+
+[Turnstone](https://github.com/turnstonelabs/turnstone) is a multi-node AI orchestration platform with tool use, agent routing, and cluster simulation.
+
+## Basic Configuration {#module-services-turnstone-basic}
+
+To enable the Turnstone server and console, you can use the following basic configuration:
+
+```nix
+{
+  services.turnstone.server = {
+    enable = true;
+    port = 8080;
+    settings.database.backend = "sqlite";
+  };
+
+  services.turnstone.console = {
+    enable = true;
+    port = 8090;
+    settings.database.backend = "sqlite";
+  };
+}
+```
+
+## PostgreSQL Configuration {#module-services-turnstone-postgresql}
+
+For production deployments, PostgreSQL is recommended over SQLite. Setting
+`database.createLocally` (which is the default) automatically provisions
+PostgreSQL databases for the server and console and connects via Unix socket
+peer authentication—no passwords required:
+
+```nix
+{
+  services.turnstone = {
+    database.createLocally = true;
+
+    server = {
+      enable = true;
+      settings.database.backend = "postgresql";
+    };
+
+    console = {
+      enable = true;
+      settings.database.backend = "postgresql";
+    };
+  };
+}
+```
+
+## Secrets Management {#module-services-turnstone-secrets}
+
+Turnstone requires several secrets (API keys, encryption keys, JWT secrets) for full functionality.
+To prevent these secrets from leaking into the Nix store, they are passed via files loaded securely using systemd's `LoadCredential`.
+
+You must provision these files out-of-band and provide their paths in your configuration:
+
+```nix
+{
+  services.turnstone = {
+    # JWT signing secret (e.g., generated with `openssl rand -hex 32`)
+    jwtSecretFile = "/path/to/turnstone-jwt.secret";
+
+    # MCP encryption key (e.g., generated with `openssl rand -hex 32`)
+    mcpEncryptionKeyFile = "/path/to/turnstone-mcp.key";
+
+    server.models.gpt-4o = {
+      model = "gpt-4o";
+      provider = "openai";
+      apiKeyFile = "/path/to/openai.key";
+    };
+  };
+}
+```
+
+Alternatively, you can provide an `EnvironmentFile` containing environment variables.
+
+Tools like [sops-nix](https://github.com/Mic92/sops-nix) and
+[agenix](https://github.com/ryantm/agenix) integrate well here—they decrypt
+secrets at activation time and place them under `/run/secrets/`, which is where
+the `*File` options can point.
+
+## Model Configuration {#module-services-turnstone-models}
+
+Register LLM models under `services.turnstone.server.models`. Each model
+entry specifies the upstream model name, its provider, and a file containing
+the API key:
+
+```nix
+{
+  services.turnstone.server.models = {
+    gpt-4o = {
+      model = "gpt-4o";
+      provider = "openai";
+      apiKeyFile = "/run/secrets/openai-key";
+    };
+    claude-sonnet = {
+      model = "claude-sonnet-4-20250514";
+      provider = "anthropic";
+      apiKeyFile = "/run/secrets/anthropic-key";
+      contextWindow = 200000;
+    };
+  };
+}
+```
+
+## MCP Servers {#module-services-turnstone-mcp}
+
+External tool servers following the Model Context Protocol can be registered
+under `services.turnstone.server.mcpServers`:
+
+```nix
+{
+  services.turnstone.server.mcpServers.filesystem = {
+    command = "${pkgs.mcp-server-filesystem}/bin/mcp-server-filesystem";
+    args = [ "/var/lib/turnstone/workspace" ];
+  };
+}
+```
+
+> **Warning:** Do not place secrets directly in `services.turnstone.server.mcpServers.<name>.env`, as these values are written to `mcp.json` which is world-readable in the Nix store. Use an `EnvironmentFile` or `LoadCredential` instead.
+
+## Reverse Proxy {#module-services-turnstone-proxy}
+
+Both the server and console bind to `127.0.0.1` by default, so they are not
+reachable from the network without additional configuration. For public or
+LAN-facing deployments, place a reverse proxy such as nginx or Caddy in front
+of the services.
+
+The `services.turnstone.openFirewall` option opens the firewall for both
+services, but it is rarely needed—most setups should expose the services
+exclusively through a TLS-terminating reverse proxy.

--- a/nixos/modules/services/misc/turnstone.nix
+++ b/nixos/modules/services/misc/turnstone.nix
@@ -1,0 +1,622 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.turnstone;
+  settingsFormat = pkgs.formats.toml { };
+  jsonFormat = pkgs.formats.json { };
+
+  stateDir = "/var/lib/turnstone";
+
+
+  # Build the full merged settings attrset for a given component.
+  # Secrets are injected as @PLACEHOLDER@ markers; the setup script
+  # substitutes them at runtime so they never land in the Nix store.
+  mkMergedSettings =
+    {
+      extraSettings ? { },
+    }:
+    let
+      # Drop the auto-defaulted PostgreSQL URL for non-postgresql backends so
+      # config.toml never carries a misleading connection string. Reading the
+      # backend here (a plain value, not an mkIf condition on `settings`) avoids
+      # the module-merge infinite recursion that gating settings.database.url would cause.
+      filtered = lib.filterAttrsRecursive (_: v: v != null) cfg.settings;
+      base =
+        if cfg.settings.database.backend == "postgresql" then
+          filtered
+        else
+          lib.filterAttrsRecursive (_: v: v != null) (
+            lib.recursiveUpdate filtered {
+              database.url = null;
+            }
+          );
+      withExtra = lib.recursiveUpdate base extraSettings;
+      withSecurity = lib.recursiveUpdate withExtra (
+        lib.optionalAttrs (cfg.jwtSecretFile != null || cfg.mcpEncryptionKeyFile != null) {
+          security = lib.filterAttrs (_: v: v != null) {
+            jwt_secret = if cfg.jwtSecretFile != null then "@JWT_SECRET@" else null;
+            mcp_token_encryption_key =
+              if cfg.mcpEncryptionKeyFile != null then "@MCP_ENCRYPTION_KEY@" else null;
+          };
+        }
+      );
+    in
+    withSecurity;
+
+  # Build model entries for inclusion in the TOML config.
+  # API keys use placeholders; everything else is inlined.
+  modelEntries = lib.mapAttrs (
+    _alias: model:
+    lib.filterAttrs (_: v: v != null) {
+      inherit (model) model provider enabled;
+      base_url = if model.baseUrl != "" then model.baseUrl else null;
+      api_key = if model.apiKeyFile != null then "@MODEL_KEY_${model.model}@" else null;
+      context_window = model.contextWindow;
+      capabilities = model.capabilities;
+      temperature = model.temperature;
+      max_tokens = model.maxTokens;
+      reasoning_effort = model.reasoningEffort;
+    }
+  ) cfg.server.models;
+
+  # Substitute secret placeholders in a TOML file at runtime.
+  mkSecretSubstitutionScript =
+    configPath:
+    let
+      sedCmds = lib.concatStringsSep "\n" (
+        lib.optional (cfg.jwtSecretFile != null) ''
+          secret=$(cat ${cfg.jwtSecretFile})
+          ${pkgs.gnused}/bin/sed -i "s|@JWT_SECRET@|$secret|g" ${configPath}
+        ''
+        ++ lib.optional (cfg.mcpEncryptionKeyFile != null) ''
+          secret=$(cat ${cfg.mcpEncryptionKeyFile})
+          ${pkgs.gnused}/bin/sed -i "s|@MCP_ENCRYPTION_KEY@|$secret|g" ${configPath}
+        ''
+        ++ lib.concatLists (
+          lib.mapAttrsToList (
+            _alias: model:
+            lib.optional (model.apiKeyFile != null) ''
+              secret=$(cat ${model.apiKeyFile})
+              ${pkgs.gnused}/bin/sed -i "s|@MODEL_KEY_${model.model}@|$secret|g" ${configPath}
+            ''
+          ) cfg.server.models
+        )
+      );
+    in
+    sedCmds;
+
+  # Shared systemd hardening for both server and console services.
+  sharedServiceConfig = {
+    Type = "simple";
+    User = "turnstone";
+    Group = "turnstone";
+    StateDirectory = "turnstone";
+    WorkingDirectory = stateDir;
+    Restart = "on-failure";
+    RestartSec = 5;
+
+    NoNewPrivileges = true;
+    PrivateTmp = true;
+    ProtectSystem = "strict";
+    ProtectHome = true;
+    PrivateDevices = true;
+    ProtectKernelTunables = true;
+    ProtectKernelModules = true;
+    ProtectControlGroups = true;
+    RestrictNamespaces = true;
+    RestrictRealtime = true;
+    RestrictSUIDSGID = true;
+    LockPersonality = true;
+    MemoryDenyWriteExecute = false; # Python JIT needs W^X
+    SystemCallArchitectures = "native";
+    RestrictAddressFamilies = [
+      "AF_INET"
+      "AF_INET6"
+      "AF_UNIX"
+    ];
+  };
+
+in
+{
+  meta.maintainers = [ ];
+
+  options.services.turnstone = {
+    package = lib.mkPackageOption pkgs "turnstone" {
+      default = [ "turnstone" ];
+    };
+
+    # ── Shared settings (config.toml) ────────────────────────────────
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
+        options = {
+          database = {
+            backend = lib.mkOption {
+              type = lib.types.enum [
+                "sqlite"
+                "postgresql"
+              ];
+              default = "sqlite";
+              description = "Database backend to use.";
+            };
+            path = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = "${stateDir}/turnstone.db";
+              description = "Path to the SQLite database file. Defaults to /var/lib/turnstone/turnstone.db.";
+            };
+            url = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = "PostgreSQL connection URL. Required when backend is postgresql.";
+            };
+            pool_size = lib.mkOption {
+              type = lib.types.int;
+              default = 5;
+              description = "Database connection pool size.";
+            };
+          };
+        };
+      };
+      default = { };
+      description = ''
+        Shared Turnstone configuration written to config.toml.
+        Any key accepted by Turnstone's TOML config can be set here
+        via the freeform type. Secrets should use the dedicated
+        `*File` options instead.
+      '';
+    };
+
+    # ── Secrets (shared by server and console) ───────────────────────
+
+    jwtSecretFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Path to a file containing the JWT secret for authentication.
+        The contents are injected at runtime and never stored in the
+        Nix store.
+      '';
+    };
+
+    mcpEncryptionKeyFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Path to a file containing the MCP token encryption key.
+        The contents are injected at runtime and never stored in the
+        Nix store.
+      '';
+    };
+
+    oidcClientSecretFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Path to a file containing the OIDC client secret.
+        The contents are injected via environment variables.
+      '';
+    };
+
+    # ── Logging (shared defaults, per-component override) ────────────
+
+    logLevel = lib.mkOption {
+      type = lib.types.enum [
+        "DEBUG"
+        "INFO"
+        "WARNING"
+        "ERROR"
+      ];
+      default = "INFO";
+      description = "Default log level for both server and console.";
+    };
+
+    logFormat = lib.mkOption {
+      type = lib.types.enum [
+        "auto"
+        "json"
+        "text"
+      ];
+      default = "auto";
+      description = "Default log output format for both server and console.";
+    };
+
+    # ── Firewall ─────────────────────────────────────────────────────
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Whether to automatically open the firewall for the server and console ports.";
+    };
+
+    # ── Database provisioning ────────────────────────────────────────
+
+    database = {
+      createLocally = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Automatically provision a PostgreSQL database. Ignored when backend is sqlite.";
+      };
+      name = lib.mkOption {
+        type = lib.types.str;
+        default = "turnstone";
+        description = "PostgreSQL database name.";
+      };
+      user = lib.mkOption {
+        type = lib.types.str;
+        default = "turnstone";
+        description = "PostgreSQL user name.";
+      };
+    };
+
+    # ── Server ───────────────────────────────────────────────────────
+
+    server = {
+      enable = lib.mkEnableOption "Turnstone API server";
+
+      host = lib.mkOption {
+        type = lib.types.str;
+        default = "127.0.0.1";
+        description = "Address to bind the server to.";
+      };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 8080;
+        description = "Port the API server listens on.";
+      };
+
+      logLevel = lib.mkOption {
+        type = lib.types.enum [
+          "DEBUG"
+          "INFO"
+          "WARNING"
+          "ERROR"
+        ];
+        default = "INFO";
+        description = "Log level for the server.";
+      };
+
+      logFormat = lib.mkOption {
+        type = lib.types.enum [
+          "auto"
+          "json"
+          "text"
+        ];
+        default = "auto";
+        description = "Log format for the server.";
+      };
+
+      openrouterKeyFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = "Path to a file containing the OpenRouter API key.";
+      };
+
+      environmentFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = "Path to an environment file loaded by the systemd service.";
+      };
+
+      mcpServers = lib.mkOption {
+        type = lib.types.attrsOf (
+          lib.types.submodule {
+            options = {
+              command = lib.mkOption {
+                type = lib.types.str;
+                description = "Command to launch the MCP server.";
+              };
+              args = lib.mkOption {
+                type = lib.types.listOf lib.types.str;
+                default = [ ];
+                description = "Arguments passed to the MCP server command.";
+              };
+              env = lib.mkOption {
+                type = lib.types.attrsOf lib.types.str;
+                default = { };
+                description = "Environment variables for the MCP server process.";
+              };
+            };
+          }
+        );
+        default = { };
+        description = "MCP server definitions included in mcp.json.";
+      };
+
+      models = lib.mkOption {
+        type = lib.types.attrsOf (
+          lib.types.submodule {
+            options = {
+              model = lib.mkOption {
+                type = lib.types.str;
+                description = "Upstream model identifier (e.g. `gpt-4o`, `claude-3.5-sonnet`).";
+              };
+              provider = lib.mkOption {
+                type = lib.types.enum [
+                  "openai"
+                  "anthropic"
+                ];
+                default = "openai";
+                description = "LLM provider backend.";
+              };
+              baseUrl = lib.mkOption {
+                type = lib.types.str;
+                default = "";
+                description = "Custom API base URL. Leave empty to use the provider default.";
+              };
+              apiKeyFile = lib.mkOption {
+                type = lib.types.nullOr lib.types.path;
+                default = null;
+                description = "Path to a file containing the API key for this model.";
+              };
+              contextWindow = lib.mkOption {
+                type = lib.types.int;
+                default = 131072;
+                description = "Maximum context window size in tokens.";
+              };
+              capabilities = lib.mkOption {
+                type = lib.types.listOf lib.types.str;
+                default = [ "tool_call" ];
+                description = "List of model capabilities (e.g. `tool_call`, `tool_search`).";
+              };
+              enabled = lib.mkOption {
+                type = lib.types.bool;
+                default = true;
+                description = "Whether this model is active.";
+              };
+              temperature = lib.mkOption {
+                type = lib.types.nullOr lib.types.float;
+                default = null;
+                description = "Sampling temperature override.";
+              };
+              maxTokens = lib.mkOption {
+                type = lib.types.nullOr lib.types.int;
+                default = null;
+                description = "Maximum output tokens override.";
+              };
+              reasoningEffort = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+                description = "Reasoning effort level (provider-specific).";
+              };
+            };
+          }
+        );
+        default = { };
+        description = "Model definitions written to the `[models]` section of config.toml.";
+      };
+    };
+
+    # ── Console ──────────────────────────────────────────────────────
+
+    console = {
+      enable = lib.mkEnableOption "Turnstone Console (admin dashboard)";
+
+      host = lib.mkOption {
+        type = lib.types.str;
+        default = "127.0.0.1";
+        description = "Address to bind the console to.";
+      };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 8090;
+        description = "Port the console dashboard listens on.";
+      };
+
+      logLevel = lib.mkOption {
+        type = lib.types.enum [
+          "DEBUG"
+          "INFO"
+          "WARNING"
+          "ERROR"
+        ];
+        default = "INFO";
+        description = "Log level for the console.";
+      };
+
+      logFormat = lib.mkOption {
+        type = lib.types.enum [
+          "auto"
+          "json"
+          "text"
+        ];
+        default = "auto";
+        description = "Log format for the console.";
+      };
+    };
+  };
+
+  config = lib.mkMerge [
+    # ── Log level/format inheritance ─────────────────────────────────
+    (lib.mkIf cfg.server.enable {
+      services.turnstone.server.logLevel = lib.mkDefault cfg.logLevel;
+      services.turnstone.server.logFormat = lib.mkDefault cfg.logFormat;
+    })
+    (lib.mkIf cfg.console.enable {
+      services.turnstone.console.logLevel = lib.mkDefault cfg.logLevel;
+      services.turnstone.console.logFormat = lib.mkDefault cfg.logFormat;
+    })
+
+    # ── Assertions ─────────────────────────────────────────────────
+    (lib.mkIf (cfg.server.enable || cfg.console.enable) {
+      assertions = [
+        {
+          assertion = cfg.settings.database.backend == "sqlite" -> cfg.settings.database.path != null;
+          message = "services.turnstone.settings.database.path is required when using the SQLite backend.";
+        }
+        {
+          assertion = cfg.settings.database.backend == "postgresql" -> cfg.settings.database.url != null;
+          message = "services.turnstone.settings.database.url is required when using the PostgreSQL backend.";
+        }
+      ];
+    })
+
+    # ── PostgreSQL auto-provisioning ───────────────────────────────
+    (lib.mkIf
+      (
+        (cfg.server.enable || cfg.console.enable)
+        && cfg.database.createLocally
+        && cfg.settings.database.backend == "postgresql"
+      )
+      {
+        services.postgresql = {
+          enable = true;
+          ensureDatabases = [ cfg.database.name ];
+          ensureUsers = [
+            {
+              name = cfg.database.user;
+              ensureDBOwnership = true;
+            }
+          ];
+        };
+      }
+    )
+
+    # ── PostgreSQL default URL ──────────────────────────────────────
+    # Set unconditionally so the postgresql-backend assertion holds by default;
+    # mkMergedSettings drops it from config.toml for non-postgresql backends
+    # (gating it here with an mkIf on `settings.database.backend` would create a
+    # module-merge infinite recursion, since the body writes to `settings`).
+    (lib.mkIf (cfg.server.enable || cfg.console.enable) {
+      services.turnstone.settings.database.url =
+        lib.mkDefault "postgresql://${cfg.database.user}@localhost:5432/${cfg.database.name}";
+    })
+
+    # ── User / group ───────────────────────────────────────────────
+    (lib.mkIf (cfg.server.enable || cfg.console.enable) {
+      users.users.turnstone = {
+        isSystemUser = true;
+        group = "turnstone";
+        home = stateDir;
+      };
+      users.groups.turnstone = { };
+    })
+
+    # ── Firewall ───────────────────────────────────────────────────
+    (lib.mkIf cfg.openFirewall {
+      networking.firewall.allowedTCPPorts =
+        lib.optional cfg.server.enable cfg.server.port ++ lib.optional cfg.console.enable cfg.console.port;
+    })
+
+    # ── Server service ─────────────────────────────────────────────
+    (lib.mkIf cfg.server.enable {
+      systemd.services.turnstone-server =
+        let
+          mcpConfigFile = jsonFormat.generate "mcp.json" {
+            mcpServers = lib.mapAttrs (_: srv: {
+              inherit (srv) command args env;
+            }) cfg.server.mcpServers;
+          };
+
+          serverSettings = mkMergedSettings {
+            extraSettings = {
+              server = {
+                host = cfg.server.host;
+                port = cfg.server.port;
+              };
+              mcp.config_path = toString mcpConfigFile;
+              models = modelEntries;
+            };
+          };
+
+          serverConfigFile = settingsFormat.generate "turnstone-server-config.toml" serverSettings;
+
+          setupScript = pkgs.writeShellScript "turnstone-server-setup" ''
+            set -euo pipefail
+            install -o turnstone -g turnstone -m 600 ${serverConfigFile} ${stateDir}/config.toml
+            ${mkSecretSubstitutionScript "${stateDir}/config.toml"}
+          '';
+        in
+        {
+          description = "Turnstone AI Server";
+          after = [
+            "network.target"
+          ]
+          ++ lib.optional (cfg.settings.database.backend == "postgresql") "postgresql.service";
+          requires = lib.optional (cfg.settings.database.backend == "postgresql") "postgresql.service";
+          wantedBy = [ "multi-user.target" ];
+
+          serviceConfig = sharedServiceConfig // {
+            ExecStartPre = [ "+${setupScript}" ];
+            ReadWritePaths = [ stateDir ];
+            EnvironmentFile = lib.optional (cfg.server.environmentFile != null) cfg.server.environmentFile;
+          };
+
+          script = ''
+            ${lib.optionalString (cfg.jwtSecretFile != null) ''
+              export TURNSTONE_JWT_SECRET="$(cat ${cfg.jwtSecretFile})"
+            ''}
+            ${lib.optionalString (cfg.oidcClientSecretFile != null) ''
+              export TURNSTONE_OIDC_CLIENT_SECRET="$(cat ${cfg.oidcClientSecretFile})"
+            ''}
+            ${lib.optionalString (cfg.server.openrouterKeyFile != null) ''
+              export OPENROUTER_API_KEY="$(cat ${cfg.server.openrouterKeyFile})"
+            ''}
+            exec ${lib.getExe' cfg.package "turnstone-server"} \
+              --config "${stateDir}/config.toml" \
+              --host ${cfg.server.host} \
+              --port ${toString cfg.server.port} \
+              --log-level ${cfg.server.logLevel} \
+              --log-format ${cfg.server.logFormat}
+          '';
+        };
+    })
+
+    # ── Console service ────────────────────────────────────────────
+    (lib.mkIf cfg.console.enable {
+      systemd.services.turnstone-console =
+        let
+          consoleSettings = mkMergedSettings {
+            extraSettings = {
+              console = {
+                host = cfg.console.host;
+                port = cfg.console.port;
+              };
+            };
+          };
+
+          consoleConfigFile = settingsFormat.generate "turnstone-console-config.toml" consoleSettings;
+
+          setupScript = pkgs.writeShellScript "turnstone-console-setup" ''
+            set -euo pipefail
+            install -o turnstone -g turnstone -m 600 ${consoleConfigFile} ${stateDir}/console-config.toml
+            ${mkSecretSubstitutionScript "${stateDir}/console-config.toml"}
+          '';
+        in
+        {
+          description = "Turnstone Console (Admin Dashboard)";
+          after = [
+            "network.target"
+          ]
+          ++ lib.optional (cfg.settings.database.backend == "postgresql") "postgresql.service";
+          requires = lib.optional (cfg.settings.database.backend == "postgresql") "postgresql.service";
+          wantedBy = [ "multi-user.target" ];
+
+          serviceConfig = sharedServiceConfig // {
+            ExecStartPre = [ "+${setupScript}" ];
+            ReadWritePaths = [ stateDir ];
+          };
+
+          script = ''
+            ${lib.optionalString (cfg.jwtSecretFile != null) ''
+              export TURNSTONE_JWT_SECRET="$(cat ${cfg.jwtSecretFile})"
+            ''}
+            ${lib.optionalString (cfg.oidcClientSecretFile != null) ''
+              export TURNSTONE_OIDC_CLIENT_SECRET="$(cat ${cfg.oidcClientSecretFile})"
+            ''}
+            exec ${lib.getExe' cfg.package "turnstone-console"} \
+              --config "${stateDir}/console-config.toml" \
+              --log-level ${cfg.console.logLevel} \
+              --log-format ${cfg.console.logFormat}
+          '';
+        };
+    })
+  ];
+}

--- a/nixos/modules/services/misc/turnstone.nix
+++ b/nixos/modules/services/misc/turnstone.nix
@@ -10,52 +10,122 @@ let
   settingsFormat = pkgs.formats.toml { };
   jsonFormat = pkgs.formats.json { };
 
-  stateDir = "/var/lib/turnstone";
+  serverStateDir = "/var/lib/turnstone";
+  consoleStateDir = "/var/lib/turnstone-console";
 
+  # Per-model API-key entries that need runtime substitution. Each maps a
+  # unique placeholder (keyed by the model alias, so duplicate `model` strings
+  # can't collide) to a systemd credential id. The credential id is sanitised
+  # to be a valid filename; the placeholder is matched literally by
+  # `replace-secret`, so it may contain any characters.
+  modelKeyEntries =
+    let
+      sanitizeCredId =
+        s: lib.stringAsChars (c: if lib.match "[a-zA-Z0-9._-]" c != null then c else "_") s;
+    in
+    lib.mapAttrsToList (alias: model: {
+      placeholder = "@MODEL_KEY_${alias}@";
+      credId = "model-${sanitizeCredId alias}";
+      file = model.apiKeyFile;
+    }) (lib.filterAttrs (_: m: m.apiKeyFile != null) cfg.server.models);
+
+  # systemd LoadCredential entries. systemd reads each secret as root at unit
+  # start and re-exposes it read-only under $CREDENTIALS_DIRECTORY, so the
+  # source files do not need to be readable by the `turnstone` user.
+  mkLoadCredentials =
+    {
+      isServer ? false,
+    }:
+    lib.optional (cfg.jwtSecretFile != null) "jwt-secret:${toString cfg.jwtSecretFile}"
+    ++ lib.optional (
+      cfg.mcpEncryptionKeyFile != null
+    ) "mcp-encryption-key:${toString cfg.mcpEncryptionKeyFile}"
+    ++ lib.optional (
+      cfg.oidcClientSecretFile != null
+    ) "oidc-client-secret:${toString cfg.oidcClientSecretFile}"
+    ++ lib.optionals isServer (
+      lib.optional (
+        cfg.server.openrouterKeyFile != null
+      ) "openrouter-key:${toString cfg.server.openrouterKeyFile}"
+      ++ (map (e: "${e.credId}:${toString e.file}") modelKeyEntries)
+    );
+
+  # Build the `replace-secret` invocation lines that substitute the
+  # @PLACEHOLDER@ tokens in a generated config file. `pkgs.replace-secret`
+  # performs a *literal* string replacement (no regex/sed metacharacters) and
+  # reads the secret from a file rather than argv, so secrets are never leaked
+  # through /proc/<pid>/cmdline and secret values can't inject config.
+  mkReplaceSecretLines =
+    {
+      isServer ? false,
+      target,
+    }:
+    let
+      common =
+        lib.optional (cfg.mcpEncryptionKeyFile != null)
+          "${lib.getExe pkgs.replace-secret} '@MCP_ENCRYPTION_KEY@' \"$CREDENTIALS_DIRECTORY/mcp-encryption-key\" ${target}";
+      models = lib.optionals isServer (
+        map (
+          e:
+          "${lib.getExe pkgs.replace-secret} '${e.placeholder}' \"$CREDENTIALS_DIRECTORY/${e.credId}\" ${target}"
+        ) modelKeyEntries
+      );
+    in
+    lib.concatLines (common ++ models);
 
   # Build the full merged settings attrset for a given component.
-  # Secrets are injected as @PLACEHOLDER@ markers; the setup script
+  # Secrets are injected as @PLACEHOLDER@ markers; the ExecStartPre script
   # substitutes them at runtime so they never land in the Nix store.
   mkMergedSettings =
     {
+      settings,
+      dbName,
       extraSettings ? { },
     }:
     let
-      # Drop the auto-defaulted PostgreSQL URL for non-postgresql backends so
-      # config.toml never carries a misleading connection string. Reading the
-      # backend here (a plain value, not an mkIf condition on `settings`) avoids
-      # the module-merge infinite recursion that gating settings.database.url would cause.
-      filtered = lib.filterAttrsRecursive (_: v: v != null) cfg.settings;
-      base =
-        if cfg.settings.database.backend == "postgresql" then
-          filtered
+      filtered = lib.filterAttrsRecursive (_: v: v != null) settings;
+      # Effective PostgreSQL URL: an explicit value wins; otherwise, when
+      # locally provisioning PostgreSQL, default to the Unix socket so peer
+      # auth maps the `turnstone` OS user to its role without a password. For
+      # non-postgresql backends the URL is dropped. Computing this here (rather
+      # than via mkIf on `settings.database.url`) avoids a module-merge
+      # infinite recursion, since the body writes into `settings`.
+      effectiveUrl =
+        if settings.database.backend != "postgresql" then
+          null
+        else if settings.database.url != null then
+          settings.database.url
+        else if cfg.database.createLocally then
+          "postgresql:///${dbName}?host=/run/postgresql"
         else
-          lib.filterAttrsRecursive (_: v: v != null) (
-            lib.recursiveUpdate filtered {
-              database.url = null;
-            }
-          );
-      withExtra = lib.recursiveUpdate base extraSettings;
+          null;
+      base = lib.filterAttrsRecursive (_: v: v != null) (
+        lib.recursiveUpdate filtered { database.url = effectiveUrl; }
+      );
+      # extraSettings provides defaults (host, port, models); user `settings`
+      # win because they are the second argument to recursiveUpdate.
+      withExtra = lib.recursiveUpdate extraSettings base;
+      # Only MCP token encryption lives in config.toml's [security] section.
+      # The JWT signing secret is NOT read from config.toml — turnstone's
+      # load_jwt_secret() reads TURNSTONE_JWT_SECRET (env) first, then
+      # [auth] jwt_secret — so it is delivered exclusively via the env var
+      # exported in the service script below.
       withSecurity = lib.recursiveUpdate withExtra (
-        lib.optionalAttrs (cfg.jwtSecretFile != null || cfg.mcpEncryptionKeyFile != null) {
-          security = lib.filterAttrs (_: v: v != null) {
-            jwt_secret = if cfg.jwtSecretFile != null then "@JWT_SECRET@" else null;
-            mcp_token_encryption_key =
-              if cfg.mcpEncryptionKeyFile != null then "@MCP_ENCRYPTION_KEY@" else null;
-          };
+        lib.optionalAttrs (cfg.mcpEncryptionKeyFile != null) {
+          security.mcp_token_encryption_key = "@MCP_ENCRYPTION_KEY@";
         }
       );
     in
     withSecurity;
 
-  # Build model entries for inclusion in the TOML config.
-  # API keys use placeholders; everything else is inlined.
+  # Model entries written to the [models] section. API keys are placeholder
+  # tokens keyed by the model alias (unique), resolved at runtime.
   modelEntries = lib.mapAttrs (
-    _alias: model:
+    alias: model:
     lib.filterAttrs (_: v: v != null) {
       inherit (model) model provider enabled;
       base_url = if model.baseUrl != "" then model.baseUrl else null;
-      api_key = if model.apiKeyFile != null then "@MODEL_KEY_${model.model}@" else null;
+      api_key = if model.apiKeyFile != null then "@MODEL_KEY_${alias}@" else null;
       context_window = model.contextWindow;
       capabilities = model.capabilities;
       temperature = model.temperature;
@@ -64,75 +134,14 @@ let
     }
   ) cfg.server.models;
 
-  # Substitute secret placeholders in a TOML file at runtime.
-  mkSecretSubstitutionScript =
-    configPath:
-    let
-      sedCmds = lib.concatStringsSep "\n" (
-        lib.optional (cfg.jwtSecretFile != null) ''
-          secret=$(cat ${cfg.jwtSecretFile})
-          ${pkgs.gnused}/bin/sed -i "s|@JWT_SECRET@|$secret|g" ${configPath}
-        ''
-        ++ lib.optional (cfg.mcpEncryptionKeyFile != null) ''
-          secret=$(cat ${cfg.mcpEncryptionKeyFile})
-          ${pkgs.gnused}/bin/sed -i "s|@MCP_ENCRYPTION_KEY@|$secret|g" ${configPath}
-        ''
-        ++ lib.concatLists (
-          lib.mapAttrsToList (
-            _alias: model:
-            lib.optional (model.apiKeyFile != null) ''
-              secret=$(cat ${model.apiKeyFile})
-              ${pkgs.gnused}/bin/sed -i "s|@MODEL_KEY_${model.model}@|$secret|g" ${configPath}
-            ''
-          ) cfg.server.models
-        )
-      );
-    in
-    sedCmds;
-
-  # Shared systemd hardening for both server and console services.
-  sharedServiceConfig = {
-    Type = "simple";
-    User = "turnstone";
-    Group = "turnstone";
-    StateDirectory = "turnstone";
-    WorkingDirectory = stateDir;
-    Restart = "on-failure";
-    RestartSec = 5;
-
-    NoNewPrivileges = true;
-    PrivateTmp = true;
-    ProtectSystem = "strict";
-    ProtectHome = true;
-    PrivateDevices = true;
-    ProtectKernelTunables = true;
-    ProtectKernelModules = true;
-    ProtectControlGroups = true;
-    RestrictNamespaces = true;
-    RestrictRealtime = true;
-    RestrictSUIDSGID = true;
-    LockPersonality = true;
-    MemoryDenyWriteExecute = false; # Python JIT needs W^X
-    SystemCallArchitectures = "native";
-    RestrictAddressFamilies = [
-      "AF_INET"
-      "AF_INET6"
-      "AF_UNIX"
-    ];
-  };
-
-in
-{
-  meta.maintainers = [ ];
-
-  options.services.turnstone = {
-    package = lib.mkPackageOption pkgs "turnstone" {
-      default = [ "turnstone" ];
-    };
-
-    # ── Shared settings (config.toml) ────────────────────────────────
-
-    settings = lib.mkOption {
+  # Shared, parameterised settings submodule so server and console stay in
+  # sync. Only the default SQLite path differs between the two.
+  mkSettingsOption =
+    {
+      defaultDbPath,
+      configFileName,
+    }:
+    lib.mkOption {
       type = lib.types.submodule {
         freeformType = settingsFormat.type;
         options = {
@@ -147,13 +156,17 @@ in
             };
             path = lib.mkOption {
               type = lib.types.nullOr lib.types.str;
-              default = "${stateDir}/turnstone.db";
-              description = "Path to the SQLite database file. Defaults to /var/lib/turnstone/turnstone.db.";
+              default = defaultDbPath;
+              description = "Path to the SQLite database file.";
             };
             url = lib.mkOption {
               type = lib.types.nullOr lib.types.str;
               default = null;
-              description = "PostgreSQL connection URL. Required when backend is postgresql.";
+              description = ''
+                PostgreSQL connection URL. Required when backend is postgresql,
+                unless `services.turnstone.database.createLocally` is enabled or
+                the URL is supplied to the service via an environment variable.
+              '';
             };
             pool_size = lib.mkOption {
               type = lib.types.int;
@@ -165,12 +178,95 @@ in
       };
       default = { };
       description = ''
-        Shared Turnstone configuration written to config.toml.
-        Any key accepted by Turnstone's TOML config can be set here
-        via the freeform type. Secrets should use the dedicated
-        `*File` options instead.
+        Turnstone configuration written to ${configFileName}. Any key accepted
+        by Turnstone's TOML config can be set here via the freeform type.
+        Secrets must use the dedicated `*File` options instead.
       '';
     };
+
+  # Shared systemd hardening for both server and console services.
+  sharedServiceConfig = {
+    Type = "simple";
+    Restart = "on-failure";
+    RestartSec = 5;
+
+    NoNewPrivileges = true;
+    PrivateTmp = true;
+    ProtectSystem = "strict";
+    ProtectHome = true;
+    PrivateDevices = true;
+    ProtectKernelTunables = true;
+    ProtectKernelModules = true;
+    ProtectKernelLogs = true;
+    ProtectClock = true;
+    ProtectHostname = true;
+    ProtectControlGroups = true;
+    RestrictNamespaces = true;
+    RestrictRealtime = true;
+    RestrictSUIDSGID = true;
+    LockPersonality = true;
+    UMask = "0077";
+    ProtectProc = "invisible";
+    ProcSubset = "pid";
+    PrivateUsers = true;
+    RemoveIPC = true;
+    # Disabled: the Python runtime needs writable+executable memory.
+    MemoryDenyWriteExecute = false;
+    SystemCallArchitectures = "native";
+    SystemCallFilter = [
+      "@system-service"
+      "~@privileged"
+      "~@resources"
+      "~@mount"
+    ];
+    CapabilityBoundingSet = "";
+    AmbientCapabilities = "";
+    RestrictAddressFamilies = [
+      "AF_INET"
+      "AF_INET6"
+      "AF_UNIX"
+    ];
+  };
+
+  # Heuristic check for environment-variable names that look like secrets, used
+  # to warn when MCP server `env` values would leak into the world-readable store.
+  looksSecretish =
+    k:
+    let
+      lk = lib.toLower k;
+    in
+    lib.hasInfix "secret" lk
+    || lib.hasInfix "token" lk
+    || lib.hasInfix "password" lk
+    || lib.hasInfix "passwd" lk
+    || lib.hasInfix "apikey" lk
+    || lib.hasInfix "api_key" lk
+    || lib.hasSuffix "_key" lk
+    || lk == "key";
+
+  leakedMcpKeys = lib.unique (
+    lib.flatten (
+      lib.mapAttrsToList (
+        _n: srv: lib.attrNames (lib.filterAttrs (k: _v: looksSecretish k) srv.env)
+      ) cfg.server.mcpServers
+    )
+  );
+
+  bothComponentsPgLocal =
+    cfg.database.createLocally
+    && cfg.server.enable
+    && cfg.server.settings.database.backend == "postgresql"
+    && cfg.console.enable
+    && cfg.console.settings.database.backend == "postgresql"
+    && cfg.server.database.name == cfg.console.database.name;
+
+in
+{
+  meta.maintainers = [ lib.maintainers.timvherpen ];
+  meta.doc = ./turnstone.md;
+
+  options.services.turnstone = {
+    package = lib.mkPackageOption pkgs "turnstone" { };
 
     # ── Secrets (shared by server and console) ───────────────────────
 
@@ -178,9 +274,9 @@ in
       type = lib.types.nullOr lib.types.path;
       default = null;
       description = ''
-        Path to a file containing the JWT secret for authentication.
-        The contents are injected at runtime and never stored in the
-        Nix store.
+        Path to a file containing the JWT secret for authentication. Loaded via
+        systemd `LoadCredential`; the file need not be readable by the
+        `turnstone` user. Its contents never enter the Nix store.
       '';
     };
 
@@ -188,9 +284,8 @@ in
       type = lib.types.nullOr lib.types.path;
       default = null;
       description = ''
-        Path to a file containing the MCP token encryption key.
-        The contents are injected at runtime and never stored in the
-        Nix store.
+        Path to a file containing the MCP token encryption key. Loaded via
+        systemd `LoadCredential`. Its contents never enter the Nix store.
       '';
     };
 
@@ -198,8 +293,8 @@ in
       type = lib.types.nullOr lib.types.path;
       default = null;
       description = ''
-        Path to a file containing the OIDC client secret.
-        The contents are injected via environment variables.
+        Path to a file containing the OIDC client secret. Exposed to the service
+        via systemd `LoadCredential`.
       '';
     };
 
@@ -231,7 +326,12 @@ in
     openFirewall = lib.mkOption {
       type = lib.types.bool;
       default = false;
-      description = "Whether to automatically open the firewall for the server and console ports.";
+      description = ''
+        Whether to open the firewall for the server and/or console ports.
+        The services bind to `127.0.0.1` by default, so this is only useful
+        when binding to a public interface; most deployments should rely on a
+        reverse proxy instead.
+      '';
     };
 
     # ── Database provisioning ────────────────────────────────────────
@@ -240,17 +340,13 @@ in
       createLocally = lib.mkOption {
         type = lib.types.bool;
         default = true;
-        description = "Automatically provision a PostgreSQL database. Ignored when backend is sqlite.";
-      };
-      name = lib.mkOption {
-        type = lib.types.str;
-        default = "turnstone";
-        description = "PostgreSQL database name.";
-      };
-      user = lib.mkOption {
-        type = lib.types.str;
-        default = "turnstone";
-        description = "PostgreSQL user name.";
+        description = ''
+          Automatically provision local PostgreSQL databases and connect via
+          the Unix socket (peer auth, no password). Ignored when the backend is
+          sqlite. When disabled, the connection URL must be provided via
+          `services.turnstone.<component>.settings.database.url` or an
+          environment variable.
+        '';
       };
     };
 
@@ -259,16 +355,29 @@ in
     server = {
       enable = lib.mkEnableOption "Turnstone API server";
 
+      database = {
+        name = lib.mkOption {
+          type = lib.types.str;
+          default = "turnstone";
+          description = "PostgreSQL database name for the server.";
+        };
+        user = lib.mkOption {
+          type = lib.types.str;
+          default = "turnstone";
+          description = "PostgreSQL user name for the server.";
+        };
+      };
+
       host = lib.mkOption {
         type = lib.types.str;
         default = "127.0.0.1";
-        description = "Address to bind the server to.";
+        description = "Address to bind the server to (written to config.toml).";
       };
 
       port = lib.mkOption {
         type = lib.types.port;
         default = 8080;
-        description = "Port the API server listens on.";
+        description = "Port the API server listens on (written to config.toml).";
       };
 
       logLevel = lib.mkOption {
@@ -295,13 +404,16 @@ in
       openrouterKeyFile = lib.mkOption {
         type = lib.types.nullOr lib.types.path;
         default = null;
-        description = "Path to a file containing the OpenRouter API key.";
+        description = ''
+          Path to a file containing the OpenRouter API key. Loaded via systemd
+          `LoadCredential`.
+        '';
       };
 
       environmentFile = lib.mkOption {
         type = lib.types.nullOr lib.types.path;
         default = null;
-        description = "Path to an environment file loaded by the systemd service.";
+        description = "Path to an EnvironmentFile loaded by the systemd service. Useful for providing secrets. The file is not added to the Nix store.";
       };
 
       mcpServers = lib.mkOption {
@@ -320,7 +432,12 @@ in
               env = lib.mkOption {
                 type = lib.types.attrsOf lib.types.str;
                 default = { };
-                description = "Environment variables for the MCP server process.";
+                description = ''
+                  Environment variables for the MCP server process. These are
+                  written to `mcp.json`, which lives in the world-readable Nix
+                  store, so do not place secrets here — provide them at runtime
+                  (e.g. via `services.turnstone.server.environmentFile`) instead.
+                '';
               };
             };
           }
@@ -353,7 +470,10 @@ in
               apiKeyFile = lib.mkOption {
                 type = lib.types.nullOr lib.types.path;
                 default = null;
-                description = "Path to a file containing the API key for this model.";
+                description = ''
+                  Path to a file containing the API key for this model. Loaded
+                  via systemd `LoadCredential`.
+                '';
               };
               contextWindow = lib.mkOption {
                 type = lib.types.int;
@@ -391,6 +511,11 @@ in
         default = { };
         description = "Model definitions written to the `[models]` section of config.toml.";
       };
+
+      settings = mkSettingsOption {
+        defaultDbPath = "${serverStateDir}/turnstone.db";
+        configFileName = "config.toml";
+      };
     };
 
     # ── Console ──────────────────────────────────────────────────────
@@ -398,16 +523,29 @@ in
     console = {
       enable = lib.mkEnableOption "Turnstone Console (admin dashboard)";
 
+      database = {
+        name = lib.mkOption {
+          type = lib.types.str;
+          default = "turnstone-console";
+          description = "PostgreSQL database name for the console.";
+        };
+        user = lib.mkOption {
+          type = lib.types.str;
+          default = "turnstone-console";
+          description = "PostgreSQL user name for the console.";
+        };
+      };
+
       host = lib.mkOption {
         type = lib.types.str;
         default = "127.0.0.1";
-        description = "Address to bind the console to.";
+        description = "Address to bind the console to (written to console-config.toml).";
       };
 
       port = lib.mkOption {
         type = lib.types.port;
         default = 8090;
-        description = "Port the console dashboard listens on.";
+        description = "Port the console dashboard listens on (written to console-config.toml).";
       };
 
       logLevel = lib.mkOption {
@@ -430,6 +568,17 @@ in
         default = "auto";
         description = "Log format for the console.";
       };
+
+      environmentFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = "Path to an EnvironmentFile loaded by the systemd service. Useful for providing secrets. The file is not added to the Nix store.";
+      };
+
+      settings = mkSettingsOption {
+        defaultDbPath = "${consoleStateDir}/turnstone-console.db";
+        configFileName = "console-config.toml";
+      };
     };
   };
 
@@ -445,58 +594,144 @@ in
     })
 
     # ── Assertions ─────────────────────────────────────────────────
-    (lib.mkIf (cfg.server.enable || cfg.console.enable) {
+    (lib.mkIf cfg.server.enable {
       assertions = [
         {
-          assertion = cfg.settings.database.backend == "sqlite" -> cfg.settings.database.path != null;
-          message = "services.turnstone.settings.database.path is required when using the SQLite backend.";
+          assertion =
+            cfg.server.settings.database.backend != "sqlite" || cfg.server.settings.database.path != null;
+          message = "services.turnstone.server.settings.database.path is required when using the SQLite backend.";
+        }
+      ];
+    })
+    (lib.mkIf cfg.console.enable {
+      assertions = [
+        {
+          assertion =
+            cfg.console.settings.database.backend != "sqlite" || cfg.console.settings.database.path != null;
+          message = "services.turnstone.console.settings.database.path is required when using the SQLite backend.";
         }
         {
-          assertion = cfg.settings.database.backend == "postgresql" -> cfg.settings.database.url != null;
-          message = "services.turnstone.settings.database.url is required when using the PostgreSQL backend.";
+          assertion =
+            !(
+              cfg.server.enable
+              && cfg.console.enable
+              && cfg.server.settings.database.backend == "sqlite"
+              && cfg.console.settings.database.backend == "sqlite"
+              && cfg.server.settings.database.path == cfg.console.settings.database.path
+            );
+          message = "services.turnstone: server and console must not share the same SQLite database path.";
         }
       ];
     })
 
-    # ── PostgreSQL auto-provisioning ───────────────────────────────
-    (lib.mkIf
-      (
-        (cfg.server.enable || cfg.console.enable)
-        && cfg.database.createLocally
-        && cfg.settings.database.backend == "postgresql"
-      )
-      {
-        services.postgresql = {
-          enable = true;
-          ensureDatabases = [ cfg.database.name ];
-          ensureUsers = [
-            {
-              name = cfg.database.user;
-              ensureDBOwnership = true;
-            }
-          ];
-        };
-      }
-    )
-
-    # ── PostgreSQL default URL ──────────────────────────────────────
-    # Set unconditionally so the postgresql-backend assertion holds by default;
-    # mkMergedSettings drops it from config.toml for non-postgresql backends
-    # (gating it here with an mkIf on `settings.database.backend` would create a
-    # module-merge infinite recursion, since the body writes to `settings`).
+    # ── Warnings ───────────────────────────────────────────────────
     (lib.mkIf (cfg.server.enable || cfg.console.enable) {
-      services.turnstone.settings.database.url =
-        lib.mkDefault "postgresql://${cfg.database.user}@localhost:5432/${cfg.database.name}";
+      warnings =
+        lib.optional
+          (
+            cfg.server.enable
+            && cfg.server.settings.database.backend == "postgresql"
+            && cfg.server.settings.database.url == null
+            && !cfg.database.createLocally
+          )
+          "services.turnstone.server: PostgreSQL backend is selected but no database.url is set and database.createLocally is false. Provide the connection URL via services.turnstone.server.settings.database.url or an environment file."
+        ++
+          lib.optional
+            (
+              cfg.console.enable
+              && cfg.console.settings.database.backend == "postgresql"
+              && cfg.console.settings.database.url == null
+              && !cfg.database.createLocally
+            )
+            "services.turnstone.console: PostgreSQL backend is selected but no database.url is set and database.createLocally is false. Provide the connection URL via services.turnstone.console.settings.database.url or an environment file."
+        ++ lib.optional (cfg.server.enable && leakedMcpKeys != [ ]) (
+          "services.turnstone.server.mcpServers: environment keys that look like secrets ("
+          + lib.concatStringsSep ", " leakedMcpKeys
+          + ") are written to mcp.json in the world-readable Nix store. Provide such values at runtime instead."
+        )
+        ++
+          lib.optional
+            (
+              cfg.server.enable
+              && cfg.server.settings.database.backend == "postgresql"
+              && cfg.server.settings.database.url != null
+              && cfg.database.createLocally
+            )
+            "services.turnstone.server: a custom database.url is set but database.createLocally is also true. The locally provisioned database will be created but not used."
+        ++
+          lib.optional
+            (
+              cfg.console.enable
+              && cfg.console.settings.database.backend == "postgresql"
+              && cfg.console.settings.database.url != null
+              && cfg.database.createLocally
+            )
+            "services.turnstone.console: a custom database.url is set but database.createLocally is also true. The locally provisioned database will be created but not used."
+        ++ lib.optional bothComponentsPgLocal (
+          "services.turnstone: both server and console use PostgreSQL with database.createLocally; they share a single database/user ('"
+          + cfg.server.database.name
+          + "'). Ensure their schemas are compatible."
+        );
     })
 
+    # ── PostgreSQL auto-provisioning ───────────────────────────────
+    (lib.mkIf cfg.database.createLocally (
+      lib.mkMerge [
+        (lib.mkIf (cfg.server.enable && cfg.server.settings.database.backend == "postgresql") {
+          assertions = [
+            {
+              assertion = cfg.server.database.user == cfg.server.database.name;
+              message = "services.turnstone.server.database.user must equal database.name when database.createLocally is true.";
+            }
+          ];
+          services.postgresql = {
+            enable = true;
+            ensureDatabases = [ cfg.server.database.name ];
+            ensureUsers = [
+              {
+                name = cfg.server.database.user;
+                ensureDBOwnership = true;
+              }
+            ];
+          };
+        })
+        (lib.mkIf (cfg.console.enable && cfg.console.settings.database.backend == "postgresql") {
+          assertions = [
+            {
+              assertion = cfg.console.database.user == cfg.console.database.name;
+              message = "services.turnstone.console.database.user must equal database.name when database.createLocally is true.";
+            }
+          ];
+          services.postgresql = {
+            enable = true;
+            ensureDatabases = [ cfg.console.database.name ];
+            ensureUsers = [
+              {
+                name = cfg.console.database.user;
+                ensureDBOwnership = true;
+              }
+            ];
+          };
+        })
+      ]
+    ))
+
     # ── User / group ───────────────────────────────────────────────
-    (lib.mkIf (cfg.server.enable || cfg.console.enable) {
+    (lib.mkIf cfg.server.enable {
       users.users.turnstone = {
         isSystemUser = true;
         group = "turnstone";
-        home = stateDir;
+        home = serverStateDir;
       };
       users.groups.turnstone = { };
+    })
+    (lib.mkIf cfg.console.enable {
+      users.users."turnstone-console" = {
+        isSystemUser = true;
+        group = "turnstone-console";
+        home = consoleStateDir;
+      };
+      users.groups."turnstone-console" = { };
     })
 
     # ── Firewall ───────────────────────────────────────────────────
@@ -516,12 +751,12 @@ in
           };
 
           serverSettings = mkMergedSettings {
+            settings = cfg.server.settings;
+            dbName = cfg.server.database.name;
             extraSettings = {
               server = {
-                host = cfg.server.host;
-                port = cfg.server.port;
+                inherit (cfg.server) host port;
               };
-              mcp.config_path = toString mcpConfigFile;
               models = modelEntries;
             };
           };
@@ -530,8 +765,11 @@ in
 
           setupScript = pkgs.writeShellScript "turnstone-server-setup" ''
             set -euo pipefail
-            install -o turnstone -g turnstone -m 600 ${serverConfigFile} ${stateDir}/config.toml
-            ${mkSecretSubstitutionScript "${stateDir}/config.toml"}
+            install -m 0600 ${serverConfigFile} ${serverStateDir}/config.toml
+            ${mkReplaceSecretLines {
+              isServer = true;
+              target = "${serverStateDir}/config.toml";
+            }}
           '';
         in
         {
@@ -539,32 +777,51 @@ in
           after = [
             "network.target"
           ]
-          ++ lib.optional (cfg.settings.database.backend == "postgresql") "postgresql.service";
-          requires = lib.optional (cfg.settings.database.backend == "postgresql") "postgresql.service";
+          ++ lib.optional (
+            cfg.server.settings.database.backend == "postgresql" && cfg.database.createLocally
+          ) "postgresql.service";
+          requires = lib.optional (
+            cfg.server.settings.database.backend == "postgresql" && cfg.database.createLocally
+          ) "postgresql.service";
           wantedBy = [ "multi-user.target" ];
 
           serviceConfig = sharedServiceConfig // {
-            ExecStartPre = [ "+${setupScript}" ];
-            ReadWritePaths = [ stateDir ];
+            User = "turnstone";
+            Group = "turnstone";
+            StateDirectory = "turnstone";
+            WorkingDirectory = serverStateDir;
+            LoadCredential = mkLoadCredentials { isServer = true; };
+            ExecStartPre = [ "${setupScript}" ];
             EnvironmentFile = lib.optional (cfg.server.environmentFile != null) cfg.server.environmentFile;
           };
 
           script = ''
+            set -euo pipefail
             ${lib.optionalString (cfg.jwtSecretFile != null) ''
-              export TURNSTONE_JWT_SECRET="$(cat ${cfg.jwtSecretFile})"
+              export TURNSTONE_JWT_SECRET="$(cat "$CREDENTIALS_DIRECTORY/jwt-secret")"
             ''}
             ${lib.optionalString (cfg.oidcClientSecretFile != null) ''
-              export TURNSTONE_OIDC_CLIENT_SECRET="$(cat ${cfg.oidcClientSecretFile})"
+              export TURNSTONE_OIDC_CLIENT_SECRET="$(cat "$CREDENTIALS_DIRECTORY/oidc-client-secret")"
             ''}
             ${lib.optionalString (cfg.server.openrouterKeyFile != null) ''
-              export OPENROUTER_API_KEY="$(cat ${cfg.server.openrouterKeyFile})"
+              export OPENROUTER_API_KEY="$(cat "$CREDENTIALS_DIRECTORY/openrouter-key")"
             ''}
-            exec ${lib.getExe' cfg.package "turnstone-server"} \
-              --config "${stateDir}/config.toml" \
-              --host ${cfg.server.host} \
-              --port ${toString cfg.server.port} \
-              --log-level ${cfg.server.logLevel} \
-              --log-format ${cfg.server.logFormat}
+            exec ${lib.getExe' cfg.package "turnstone-server"} ${
+              lib.escapeShellArgs (
+                [
+                  "--config"
+                  "${serverStateDir}/config.toml"
+                  "--log-level"
+                  cfg.server.logLevel
+                  "--log-format"
+                  cfg.server.logFormat
+                ]
+                ++ lib.optionals (cfg.server.mcpServers != { }) [
+                  "--mcp-config"
+                  (toString mcpConfigFile)
+                ]
+              )
+            }
           '';
         };
     })
@@ -574,10 +831,11 @@ in
       systemd.services.turnstone-console =
         let
           consoleSettings = mkMergedSettings {
+            settings = cfg.console.settings;
+            dbName = cfg.console.database.name;
             extraSettings = {
               console = {
-                host = cfg.console.host;
-                port = cfg.console.port;
+                inherit (cfg.console) host port;
               };
             };
           };
@@ -586,8 +844,11 @@ in
 
           setupScript = pkgs.writeShellScript "turnstone-console-setup" ''
             set -euo pipefail
-            install -o turnstone -g turnstone -m 600 ${consoleConfigFile} ${stateDir}/console-config.toml
-            ${mkSecretSubstitutionScript "${stateDir}/console-config.toml"}
+            install -m 0600 ${consoleConfigFile} ${consoleStateDir}/console-config.toml
+            ${mkReplaceSecretLines {
+              isServer = false;
+              target = "${consoleStateDir}/console-config.toml";
+            }}
           '';
         in
         {
@@ -595,26 +856,42 @@ in
           after = [
             "network.target"
           ]
-          ++ lib.optional (cfg.settings.database.backend == "postgresql") "postgresql.service";
-          requires = lib.optional (cfg.settings.database.backend == "postgresql") "postgresql.service";
+          ++ lib.optional (
+            cfg.console.settings.database.backend == "postgresql" && cfg.database.createLocally
+          ) "postgresql.service";
+          requires = lib.optional (
+            cfg.console.settings.database.backend == "postgresql" && cfg.database.createLocally
+          ) "postgresql.service";
           wantedBy = [ "multi-user.target" ];
 
           serviceConfig = sharedServiceConfig // {
-            ExecStartPre = [ "+${setupScript}" ];
-            ReadWritePaths = [ stateDir ];
+            User = "turnstone-console";
+            Group = "turnstone-console";
+            StateDirectory = "turnstone-console";
+            WorkingDirectory = consoleStateDir;
+            LoadCredential = mkLoadCredentials { isServer = false; };
+            ExecStartPre = [ "${setupScript}" ];
+            EnvironmentFile = lib.optional (cfg.console.environmentFile != null) cfg.console.environmentFile;
           };
 
           script = ''
+            set -euo pipefail
             ${lib.optionalString (cfg.jwtSecretFile != null) ''
-              export TURNSTONE_JWT_SECRET="$(cat ${cfg.jwtSecretFile})"
+              export TURNSTONE_JWT_SECRET="$(cat "$CREDENTIALS_DIRECTORY/jwt-secret")"
             ''}
             ${lib.optionalString (cfg.oidcClientSecretFile != null) ''
-              export TURNSTONE_OIDC_CLIENT_SECRET="$(cat ${cfg.oidcClientSecretFile})"
+              export TURNSTONE_OIDC_CLIENT_SECRET="$(cat "$CREDENTIALS_DIRECTORY/oidc-client-secret")"
             ''}
-            exec ${lib.getExe' cfg.package "turnstone-console"} \
-              --config "${stateDir}/console-config.toml" \
-              --log-level ${cfg.console.logLevel} \
-              --log-format ${cfg.console.logFormat}
+            exec ${lib.getExe' cfg.package "turnstone-console"} ${
+              lib.escapeShellArgs [
+                "--config"
+                "${consoleStateDir}/console-config.toml"
+                "--log-level"
+                cfg.console.logLevel
+                "--log-format"
+                cfg.console.logFormat
+              ]
+            }
           '';
         };
     })

--- a/nixos/tests/turnstone.nix
+++ b/nixos/tests/turnstone.nix
@@ -1,0 +1,92 @@
+import ./make-test-python.nix (
+  { pkgs, lib, ... }:
+  {
+    name = "turnstone";
+    meta.maintainers = with lib.maintainers; [ timvherpen ];
+
+    nodes.sqlite =
+      { pkgs, ... }:
+      {
+        virtualisation.cores = 4;
+        virtualisation.memorySize = 4096;
+
+        services.turnstone = {
+          # This intentionally places the secret in the Nix store, which is
+          # world-readable. That is acceptable for VM-based integration tests.
+          jwtSecretFile = "${pkgs.writeText "jwt-secret" "0000000000000000000000000000000000000000000000000000000000000000"}";
+
+          server = {
+            enable = true;
+            port = 8080;
+            settings.database.backend = "sqlite";
+          };
+
+          console = {
+            enable = true;
+            port = 8090;
+            settings.database.backend = "sqlite";
+          };
+        };
+      };
+
+    nodes.postgresql =
+      { pkgs, ... }:
+      {
+        virtualisation.cores = 4;
+        virtualisation.memorySize = 4096;
+
+        services.turnstone = {
+          # This intentionally places the secret in the Nix store, which is
+          # world-readable. That is acceptable for VM-based integration tests.
+          jwtSecretFile = "${pkgs.writeText "jwt-secret" "0000000000000000000000000000000000000000000000000000000000000000"}";
+
+          server = {
+            enable = true;
+            port = 8080;
+            settings.database.backend = "postgresql";
+          };
+        };
+      };
+
+    testScript = ''
+      start_all()
+
+      # --- SQLite node ---
+
+      with subtest("sqlite: wait for services to start"):
+          sqlite.wait_for_unit("turnstone-server.service")
+          sqlite.wait_for_open_port(8080)
+
+          sqlite.wait_for_unit("turnstone-console.service")
+          sqlite.wait_for_open_port(8090)
+
+      with subtest("sqlite: check if server is responding"):
+          sqlite.succeed("curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8080 | grep -E '^(200|401|403|404)$'")
+
+      with subtest("sqlite: check if console is responding"):
+          sqlite.succeed("curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8090 | grep -E '^(200|401|403|404)$'")
+
+      with subtest("sqlite: service user exists"):
+          sqlite.succeed("id turnstone")
+
+      with subtest("sqlite: config file permissions"):
+          sqlite.succeed("stat -c '%a' /var/lib/turnstone/config.toml | grep -q '600'")
+
+      with subtest("sqlite: state directory ownership"):
+          sqlite.succeed("stat -c '%U:%G' /var/lib/turnstone | grep -q 'turnstone:turnstone'")
+
+      # --- PostgreSQL node ---
+
+      with subtest("postgresql: wait for services to start"):
+          postgresql.wait_for_unit("postgresql.service")
+          postgresql.wait_for_unit("turnstone-server.service")
+          postgresql.wait_for_open_port(8080)
+
+      with subtest("postgresql: check if server is responding"):
+          postgresql.succeed("curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8080 | grep -E '^(200|401|403|404)$'")
+
+      with subtest("postgresql: database exists"):
+          postgresql.succeed("sudo -u postgres psql -lqt | grep -q turnstone")
+    '';
+  }
+)

--- a/pkgs/by-name/tu/turnstone/package.nix
+++ b/pkgs/by-name/tu/turnstone/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  python3Packages,
+  fetchPypi,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "turnstone";
+  version = "1.6.8";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1axaic8053xh1a0fya0y24f8knrwxx2lz6pnqk570cb071pcr4dm";
+  };
+
+  nativeBuildInputs = with python3Packages; [
+    pythonRelaxDepsHook
+    hatchling
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "hatchling>=1.29" "hatchling>=1.28"
+  '';
+
+  pythonRelaxDeps = [
+    "anthropic"
+    "cryptography"
+    "mcp"
+    "openai"
+    "starlette"
+  ];
+
+  dependencies = with python3Packages; [
+    alembic
+    anthropic
+    bcrypt
+    croniter
+    cryptography
+    httpx
+    httpx-sse
+    lacme
+    mcp
+    openai
+    pillow
+    psycopg
+    pydantic
+    pydantic-settings
+    pyjwt
+    pypdfium2
+    python-frontmatter
+    sqlalchemy
+    sse-starlette
+    starlette
+    structlog
+    uvicorn
+  ];
+
+  doCheck = false;
+
+  meta = {
+    description = "Self-hosted AI orchestration platform with tool use and agent routing";
+    homepage = "https://github.com/turnstonelabs/turnstone";
+    license = lib.licenses.asl20;
+    mainProgram = "turnstone-server";
+    maintainers = [ ];
+  };
+}

--- a/pkgs/by-name/tu/turnstone/package.nix
+++ b/pkgs/by-name/tu/turnstone/package.nix
@@ -9,6 +9,8 @@ python3Packages.buildPythonApplication rec {
   version = "1.6.8";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
     inherit pname version;
     sha256 = "1axaic8053xh1a0fya0y24f8knrwxx2lz6pnqk570cb071pcr4dm";

--- a/pkgs/by-name/tu/turnstone/package.nix
+++ b/pkgs/by-name/tu/turnstone/package.nix
@@ -1,14 +1,15 @@
-{ lib
-, python3Packages
-, fetchPypi
-, nixosTests
-,
+{
+  lib,
+  python3Packages,
+  fetchPypi,
+  nixosTests,
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "turnstone";
   version = "1.7.4";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchPypi {
     inherit pname version;
@@ -75,7 +76,6 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/turnstonelabs/turnstone";
     license = lib.licenses.asl20;
     mainProgram = "turnstone-server";
-    platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ timvherpen ];
   };
 }

--- a/pkgs/by-name/tu/turnstone/package.nix
+++ b/pkgs/by-name/tu/turnstone/package.nix
@@ -1,23 +1,25 @@
-{
-  lib,
-  python3Packages,
-  fetchPypi,
+{ lib
+, python3Packages
+, fetchPypi
+, nixosTests
+,
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "turnstone";
-  version = "1.6.8";
+  version = "1.7.4";
   pyproject = true;
-
-  __structuredAttrs = true;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1axaic8053xh1a0fya0y24f8knrwxx2lz6pnqk570cb071pcr4dm";
+    hash = "sha256-+QKBufoklp4HgNdhFQ7mq0AoBN8P7xUXBjov/hK+LL0=";
   };
 
-  nativeBuildInputs = with python3Packages; [
-    pythonRelaxDepsHook
+  nativeBuildInputs = [
+    python3Packages.pythonRelaxDepsHook
+  ];
+
+  build-system = with python3Packages; [
     hatchling
   ];
 
@@ -31,11 +33,13 @@ python3Packages.buildPythonApplication rec {
     "cryptography"
     "mcp"
     "openai"
+    "pydantic-settings"
     "starlette"
   ];
 
   dependencies = with python3Packages; [
     alembic
+    altair
     anthropic
     bcrypt
     croniter
@@ -57,15 +61,21 @@ python3Packages.buildPythonApplication rec {
     starlette
     structlog
     uvicorn
+    vl-convert-python
   ];
 
-  doCheck = false;
+  doCheck = false; # tests require a running LLM backend
+
+  passthru.tests = {
+    inherit (nixosTests) turnstone;
+  };
 
   meta = {
     description = "Self-hosted AI orchestration platform with tool use and agent routing";
     homepage = "https://github.com/turnstonelabs/turnstone";
     license = lib.licenses.asl20;
     mainProgram = "turnstone-server";
-    maintainers = [ ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ timvherpen ];
   };
 }

--- a/pkgs/development/python-modules/lacme/default.nix
+++ b/pkgs/development/python-modules/lacme/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+  cryptography,
+  acme,
+  httpx,
+}:
+
+buildPythonPackage rec {
+  pname = "lacme";
+  version = "1.0.5";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "1375hprc5fy9lr0crg84y2nd03rp9z8zpmzpk8k1r7wah1kbgkf1";
+  };
+
+  build-system = [ hatchling ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "hatchling>=1.29" "hatchling>=1.28"
+  '';
+
+  dependencies = [
+    cryptography
+    acme
+    httpx
+  ];
+
+  doCheck = false;
+
+  meta = {
+    description = "A lightweight ACME client for Python";
+    homepage = "https://github.com/turnstonelabs/lacme";
+    license = lib.licenses.asl20;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8944,6 +8944,8 @@ self: super: with self; {
 
   laces = callPackage ../development/python-modules/laces { };
 
+  lacme = callPackage ../development/python-modules/lacme { };
+
   lacrosse-view = callPackage ../development/python-modules/lacrosse-view { };
 
   lacuscore = callPackage ../development/python-modules/lacuscore { };


### PR DESCRIPTION
## Things done

Adds the Turnstone package and NixOS module. Extracted `lacme` into its own package.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests in nixos/tests.
  - [ ] Package tests at passthru.tests.
  - [ ] Tests in lib/tests or pkgs/test for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR.
- [ ] Tested basic functionality of all binary files.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.