### PR TITLE
nixos/userborn: manage /etc/sub{u,g}id

### DIFF
--- a/nixos/modules/services/system/userborn-import-auto-subuid-map.py
+++ b/nixos/modules/services/system/userborn-import-auto-subuid-map.py
@@ -1,0 +1,27 @@
+"""Seed sub{u,g}id from /var/lib/nixos/auto-subuid-map once."""
+
+import json
+import sys
+from pathlib import Path
+
+LEGACY_MAP = Path("/var/lib/nixos/auto-subuid-map")
+SENTINEL = Path("/var/lib/userborn/auto-subuid-map-imported")
+
+directory = Path(sys.argv[1] if len(sys.argv) > 1 else "/etc")
+directory.mkdir(parents=True, exist_ok=True)
+SENTINEL.parent.mkdir(parents=True, exist_ok=True)
+
+if LEGACY_MAP.exists():
+    auto = json.loads(LEGACY_MAP.read_text())
+    for fname in ("subuid", "subgid"):
+        path = directory / fname
+        text = path.read_text() if path.exists() else ""
+        seen = {ln.split(":", 1)[0] for ln in text.splitlines() if ":" in ln}
+        with path.open("a") as f:
+            for name, start in sorted(auto.items()):
+                if name not in seen:
+                    line = f"{name}:{start}:65536"
+                    f.write(line + "\n")
+                    print(f"<6>seeded {fname}: {line}", file=sys.stderr)
+
+SENTINEL.touch()

--- a/nixos/modules/services/system/userborn.nix
+++ b/nixos/modules/services/system/userborn.nix
@@ -31,6 +31,15 @@ let
         ;
       isNormal = opts.isNormalUser;
       shell = utils.toShellPath opts.shell;
+      autoSubIdRange = opts.autoSubUidGidRange;
+      subUidRanges = map (r: {
+        start = r.startUid;
+        inherit (r) count;
+      }) opts.subUidRanges;
+      subGidRanges = map (r: {
+        start = r.startGid;
+        inherit (r) count;
+      }) opts.subGidRanges;
     }) (lib.filterAttrs (_: u: u.enable) config.users.users);
   };
 
@@ -47,6 +56,54 @@ let
     "passwd"
     "shadow"
   ];
+  # newuidmap from shadow-utils opens these with O_NOFOLLOW, so they cannot
+  # be exposed in /etc as symlinks like the other files. When
+  # passwordFilesLocation is not /etc they are bind-mounted instead.
+  subIdFiles = [
+    "subuid"
+    "subgid"
+  ];
+  needsSubIdBind = !cfg.static && cfg.passwordFilesLocation != "/etc";
+
+  # Refresh the /etc/sub{u,g}id bind mounts gaplessly. The existing bind
+  # points at a now-deleted inode after userborn's atomic rename, so move a
+  # fresh bind beneath it and pop the stale one off the top, mirroring how
+  # the /etc overlay remount swaps in a new generation.
+  refreshSubIdBinds = pkgs.writeShellApplication {
+    name = "userborn-refresh-subid-binds";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.util-linux
+    ];
+    text = ''
+      for f in ${lib.escapeShellArgs subIdFiles}; do
+        src=${lib.escapeShellArg cfg.passwordFilesLocation}/$f
+        dst=/etc/$f
+        [ -e "$src" ] || continue
+        if mountpoint --quiet "$dst"; then
+          tmp=$(TMPDIR=/run mktemp --directory -t userborn-subids.XXXXXXXXXX)
+          mount --bind --make-private "$tmp" "$tmp"
+          touch "$tmp/$f"
+          mount --bind "$src" "$tmp/$f"
+          mount --move --beneath "$tmp/$f" "$dst"
+          umount --lazy "$dst"
+          umount --lazy "$tmp"
+          rm -rf "$tmp"
+        else
+          # On a writable /etc the target may not exist yet on first run.
+          # On an immutable overlay it is provided as a baked-in placeholder.
+          if [ ! -e "$dst" ]; then
+            touch "$dst"
+          fi
+          mount --bind "$src" "$dst"
+        fi
+      done
+    '';
+  };
+
+  importLegacySubIdMap = pkgs.writers.writePython3 "userborn-import-auto-subuid-map" { } (
+    builtins.readFile ./userborn-import-auto-subuid-map.py
+  );
 
 in
 {
@@ -181,22 +238,56 @@ in
 
             # Make the source files writable before executing userborn.
             (lib.mkIf (!userCfg.mutableUsers) (
-              lib.map (file: "-${pkgs.util-linux}/bin/umount ${cfg.passwordFilesLocation}/${file}") passwordFiles
+              lib.map (file: "-${pkgs.util-linux}/bin/umount ${cfg.passwordFilesLocation}/${file}") (
+                passwordFiles ++ subIdFiles
+              )
             ))
           ];
 
-          ExecStartPost =
-            if userCfg.mutableUsers then
-              # Store the config somewhere for the next invocation
-              [
-                "${pkgs.coreutils}/bin/ln -sf ${userbornConfigJson} ${previousConfigPath}"
-              ]
-            else
+          ExecStartPost = lib.mkMerge [
+            (lib.mkIf userCfg.mutableUsers [
+              # Store the config somewhere for the next invocation.
+              "${pkgs.coreutils}/bin/ln -sf ${userbornConfigJson} ${previousConfigPath}"
+            ])
+
+            (lib.mkIf (!userCfg.mutableUsers) (
               # Make the source files read-only after userborn has finished.
-              (lib.map (
+              lib.map (
                 file:
                 "${pkgs.util-linux}/bin/mount --bind -o ro ${cfg.passwordFilesLocation}/${file} ${cfg.passwordFilesLocation}/${file}"
-              ) passwordFiles);
+              ) (passwordFiles ++ subIdFiles)
+            ))
+
+            (lib.mkIf needsSubIdBind [ (lib.getExe refreshSubIdBinds) ])
+          ];
+        };
+      };
+
+      # One-shot seed of sub{u,g}id from update-users-groups.pl's state so
+      # that allocations made by the perl script survive the switch to
+      # userborn. Gated by ConditionPathExists, no-op on fresh installs.
+      services.userborn-import-auto-subuid-map = lib.mkIf (!cfg.static) {
+        wantedBy = [ "sysinit.target" ];
+        requiredBy = [ "userborn.service" ];
+        before = [
+          "userborn.service"
+          "shutdown.target"
+        ];
+        after = [ "systemd-remount-fs.service" ];
+        conflicts = [ "shutdown.target" ];
+        unitConfig = {
+          Description = "Seed /etc/sub{u,g}id from legacy auto-subuid-map";
+          DefaultDependencies = false;
+          ConditionPathExists = [
+            "/var/lib/nixos/auto-subuid-map"
+            "!/var/lib/userborn/auto-subuid-map-imported"
+          ];
+        };
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          StateDirectory = "userborn";
+          ExecStart = "${importLegacySubIdMap} ${cfg.passwordFilesLocation}";
         };
       };
     };
@@ -211,7 +302,7 @@ in
               source = "${userbornStaticFiles}/${file}";
               mode = if file == "shadow" then "0000" else "0644";
             }
-          ) passwordFiles
+          ) (passwordFiles ++ subIdFiles)
         )
       ))
 
@@ -227,6 +318,22 @@ in
               mode = "direct-symlink";
             }
           ) passwordFiles
+        )
+      ))
+
+      (lib.mkIf (needsSubIdBind && immutableEtc) (
+        # Empty regular-file placeholders to bind-mount the real subuid/subgid
+        # onto. Symlinks would be rejected by newuidmap (O_NOFOLLOW). Only
+        # needed when /etc is read-only, otherwise the refresh script creates
+        # the target itself.
+        lib.listToAttrs (
+          lib.map (
+            file:
+            lib.nameValuePair file {
+              text = "";
+              mode = "0644";
+            }
+          ) subIdFiles
         )
       ))
     ];

--- a/nixos/modules/services/system/userborn.nix
+++ b/nixos/modules/services/system/userborn.nix
@@ -90,8 +90,8 @@ let
           umount --lazy "$tmp"
           rm -rf "$tmp"
         else
-          # On a writable /etc the target may not exist yet on first run.
-          # On an immutable overlay it is provided as a baked-in placeholder.
+          # The target is provided via environment.etc; this is just a
+          # safety net for a manually-deleted file on a writable /etc.
           if [ ! -e "$dst" ]; then
             touch "$dst"
           fi
@@ -321,11 +321,9 @@ in
         )
       ))
 
-      (lib.mkIf (needsSubIdBind && immutableEtc) (
-        # Empty regular-file placeholders to bind-mount the real subuid/subgid
-        # onto. Symlinks would be rejected by newuidmap (O_NOFOLLOW). Only
-        # needed when /etc is read-only, otherwise the refresh script creates
-        # the target itself.
+      (lib.mkIf needsSubIdBind (
+        # Empty regular-file bind targets for the real subuid/subgid.
+        # Symlinks would be rejected by newuidmap (O_NOFOLLOW).
         lib.listToAttrs (
           lib.map (
             file:

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1762,6 +1762,9 @@ in
   userborn-mutable-etc = runTest ./userborn-mutable-etc.nix;
   userborn-mutable-users = runTest ./userborn-mutable-users.nix;
   userborn-static = runTest ./userborn-static.nix;
+  userborn-subids = runTest ./userborn-subids.nix;
+  userborn-subids-custom-location = runTest ./userborn-subids-custom-location.nix;
+  userborn-subids-immutable-etc = runTest ./userborn-subids-immutable-etc.nix;
   ustreamer = runTest ./ustreamer.nix;
   utils = import ./utils { inherit runTest; };
   uwsgi = runTest ./uwsgi.nix;

--- a/nixos/tests/userborn-subids-custom-location.nix
+++ b/nixos/tests/userborn-subids-custom-location.nix
@@ -1,0 +1,61 @@
+{ lib, ... }:
+
+# /etc/sub{u,g}id with userborn writing to a custom passwordFilesLocation
+# while /etc itself is mutable (no overlay). Exercises the bind-mount path
+# without relying on the etc-overlay placeholder mechanism.
+
+{
+  name = "userborn-subids-custom-location";
+
+  meta.maintainers = with lib.maintainers; [ rvdp ];
+
+  nodes.machine =
+    { ... }:
+    {
+      services.userborn = {
+        enable = true;
+        passwordFilesLocation = "/var/lib/nixos";
+      };
+
+      users.users.alice.isNormalUser = true;
+
+      specialisation.with-bob.configuration = {
+        users.users.bob.isNormalUser = true;
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("userborn.service")
+
+    with subtest("/etc/subuid is a regular file backed by passwordFilesLocation"):
+        assert machine.succeed("stat -c '%F' /etc/subuid").strip() == "regular file"
+        machine.succeed("mountpoint -q /etc/subuid")
+        a = machine.succeed("stat -c %d:%i /etc/subuid").strip()
+        b = machine.succeed("stat -c %d:%i /var/lib/nixos/subuid").strip()
+        assert a == b
+
+    with subtest("newuidmap accepts the bind-mounted file"):
+        machine.succeed("runuser -u alice -- unshare --user --map-auto -- true")
+
+    before = machine.succeed("cat /etc/subuid")
+    machine.succeed(
+        "/run/current-system/specialisation/with-bob/bin/switch-to-configuration switch"
+    )
+
+    with subtest("bind is refreshed across activations without stacking"):
+        n = machine.succeed("grep -c ' /etc/subuid ' /proc/self/mountinfo").strip()
+        assert n == "1", f"expected 1 mount on /etc/subuid, got {n}"
+        a = machine.succeed("stat -c %d:%i /etc/subuid").strip()
+        b = machine.succeed("stat -c %d:%i /var/lib/nixos/subuid").strip()
+        assert a == b
+
+    with subtest("alice's range survived and bob was added"):
+        after = machine.succeed("cat /etc/subuid")
+        assert "alice:" in after and "bob:" in after
+        for line in before.splitlines():
+            assert line in after
+
+    with subtest("newuidmap still works after the swap"):
+        machine.succeed("runuser -u alice -- unshare --user --map-auto -- true")
+  '';
+}

--- a/nixos/tests/userborn-subids-immutable-etc.nix
+++ b/nixos/tests/userborn-subids-immutable-etc.nix
@@ -1,0 +1,93 @@
+{ lib, pkgs, ... }:
+
+# /etc/sub{u,g}id with userborn on an immutable /etc.
+# The files are written to passwordFilesLocation and bind-mounted into
+# /etc so that newuidmap (which opens with O_NOFOLLOW) accepts them.
+
+let
+  common = {
+    services.userborn.enable = true;
+    boot.initrd.systemd.enable = true;
+    networking.useNetworkd = true;
+    system.etc.overlay = {
+      enable = true;
+      mutable = false;
+    };
+  };
+in
+{
+  name = "userborn-subids-immutable-etc";
+
+  meta.maintainers = with lib.maintainers; [ rvdp ];
+
+  nodes.machine =
+    { ... }:
+    {
+      imports = [ common ];
+
+      users.users.alice.isNormalUser = true;
+
+      specialisation.with-bob = {
+        inheritParentConfig = false;
+        configuration = {
+          nixpkgs = { inherit pkgs; };
+          imports = [ common ];
+          users.users.alice.isNormalUser = true;
+          users.users.bob.isNormalUser = true;
+        };
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("userborn.service")
+
+    def parse(path):
+        out = {}
+        for line in machine.succeed(f"cat {path}").splitlines():
+            name, start, count = line.split(":")
+            out.setdefault(name, []).append((int(start), int(count)))
+        return out
+
+    with subtest("/etc/subuid is a regular file, not a symlink"):
+        assert machine.succeed("stat -c '%F' /etc/subuid").strip() == "regular file"
+        assert machine.succeed("stat -c '%F' /etc/subgid").strip() == "regular file"
+
+    with subtest("/etc/subuid is bind-mounted from passwordFilesLocation"):
+        machine.succeed("mountpoint -q /etc/subuid")
+        # Same inode as the backing file proves the bind is in place.
+        a = machine.succeed("stat -c %d:%i /etc/subuid").strip()
+        b = machine.succeed("stat -c %d:%i /var/lib/nixos/subuid").strip()
+        assert a == b, f"/etc/subuid {a} != /var/lib/nixos/subuid {b}"
+
+    subuid = parse("/etc/subuid")
+    with subtest("alice has an auto range"):
+        (start, count), = subuid["alice"]
+        assert count == 65536
+
+    with subtest("newuidmap accepts the bind-mounted file"):
+        machine.succeed("runuser -u alice -- unshare --user --map-auto -- true")
+
+    alice_before = subuid["alice"]
+    machine.succeed(
+        "/run/current-system/specialisation/with-bob/bin/switch-to-configuration switch"
+    )
+
+    with subtest("bind mount is refreshed gaplessly across generations"):
+        assert machine.succeed("stat -c '%F' /etc/subuid").strip() == "regular file"
+        # Exactly one mount stacked on /etc/subuid (refresh popped the old).
+        n = machine.succeed("grep -c ' /etc/subuid ' /proc/self/mountinfo").strip()
+        assert n == "1", f"expected 1 mount on /etc/subuid, got {n}"
+
+    subuid = parse("/etc/subuid")
+    with subtest("alice's range survived the generation switch"):
+        assert subuid["alice"] == alice_before
+
+    with subtest("bob has a non-overlapping range"):
+        (bstart, bcount), = subuid["bob"]
+        assert not (bstart < alice_before[0][0] + alice_before[0][1]
+                    and alice_before[0][0] < bstart + bcount)
+
+    with subtest("newuidmap still works after the swap"):
+        machine.succeed("runuser -u alice -- unshare --user --map-auto -- true")
+  '';
+}

--- a/nixos/tests/userborn-subids.nix
+++ b/nixos/tests/userborn-subids.nix
@@ -1,0 +1,156 @@
+{ lib, pkgs, ... }:
+
+# /etc/sub{u,g}id management via userborn.
+
+{
+  name = "userborn-subids";
+
+  meta.maintainers = with lib.maintainers; [ rvdp ];
+
+  nodes.machine =
+    { ... }:
+    {
+      services.userborn.enable = true;
+
+      users.users = {
+        alice.isNormalUser = true;
+
+        explicit = {
+          isNormalUser = true;
+          subUidRanges = [
+            {
+              startUid = 700000;
+              count = 65536;
+            }
+          ];
+          subGidRanges = [
+            {
+              startGid = 700000;
+              count = 65536;
+            }
+          ];
+        };
+
+        # Huge root range as set by the incus module. Auto allocations must
+        # avoid it.
+        root = {
+          subUidRanges = [
+            {
+              startUid = 1000000;
+              count = 1000000000;
+            }
+          ];
+          subGidRanges = [
+            {
+              startGid = 1000000;
+              count = 1000000000;
+            }
+          ];
+        };
+      };
+
+      environment.systemPackages = [ pkgs.util-linux ];
+
+      specialisation = {
+        with-bob.configuration = {
+          users.users.bob.isNormalUser = true;
+        };
+
+        # carol has no entry in /etc/subuid yet, but a synthesised legacy
+        # auto-subuid-map records an old allocation that must be reused.
+        with-carol.configuration = {
+          users.users.carol.isNormalUser = true;
+        };
+
+        # An explicit range that necessarily covers alice's auto allocation
+        # must fail the service before writing.
+        conflict.configuration = {
+          users.users.mallory = {
+            isNormalUser = true;
+            subUidRanges = [
+              {
+                startUid = 100000;
+                count = 200000;
+              }
+            ];
+          };
+        };
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("userborn.service")
+
+    def switch_to(spec):
+        machine.succeed(
+            f"/run/booted-system/specialisation/{spec}/bin/switch-to-configuration switch"
+        )
+
+    def parse(path):
+        out = {}
+        for line in machine.succeed(f"cat {path}").splitlines():
+            name, start, count = line.split(":")
+            out.setdefault(name, []).append((int(start), int(count)))
+        return out
+
+    def overlaps(a, b):
+        return a[0] < b[0] + b[1] and b[0] < a[0] + a[1]
+
+    with subtest("/etc/subuid is a regular file (newuidmap O_NOFOLLOW)"):
+        assert machine.succeed("stat -c '%F' /etc/subuid").strip() == "regular file"
+        assert machine.succeed("stat -c '%a' /etc/subuid").strip() == "644"
+
+    subuid = parse("/etc/subuid")
+    subgid = parse("/etc/subgid")
+
+    with subtest("explicit ranges are honoured verbatim"):
+        assert subuid["explicit"] == [(700000, 65536)]
+        assert subuid["root"] == [(1000000, 1000000000)]
+
+    with subtest("alice gets an auto range below the root range"):
+        (start, count), = subuid["alice"]
+        assert count == 65536
+        assert start >= 100000
+        assert not overlaps((start, count), (1000000, 1000000000))
+        assert subgid["alice"] == subuid["alice"]
+
+    with subtest("newuidmap accepts the file"):
+        machine.succeed(
+            "runuser -u alice -- unshare --user --map-auto -- true"
+        )
+
+    alice_before = subuid["alice"]
+    switch_to("with-bob")
+    subuid = parse("/etc/subuid")
+
+    with subtest("alice's range is preserved across generations"):
+        assert subuid["alice"] == alice_before
+
+    with subtest("bob's range does not overlap anything"):
+        (bstart, bcount), = subuid["bob"]
+        for owner, ranges in subuid.items():
+            if owner == "bob":
+                continue
+            for r in ranges:
+                assert not overlaps((bstart, bcount), r), f"bob overlaps {owner}"
+
+    with subtest("legacy auto-subuid-map is imported once"):
+        machine.succeed("mkdir -p /var/lib/nixos")
+        machine.succeed(
+            """echo '{"carol": 424242}' > /var/lib/nixos/auto-subuid-map"""
+        )
+        # Force the import unit to be eligible again for the test.
+        machine.succeed("rm -f /var/lib/userborn/auto-subuid-map-imported")
+        switch_to("with-carol")
+        subuid = parse("/etc/subuid")
+        assert (424242, 65536) in subuid["carol"]
+        assert machine.succeed("test -e /var/lib/userborn/auto-subuid-map-imported && echo ok").strip() == "ok"
+
+    with subtest("overlapping ranges fail the service"):
+        machine.fail(
+            "/run/booted-system/specialisation/conflict/bin/switch-to-configuration switch"
+        )
+        # File must be unchanged (no mallory entry written).
+        assert "mallory" not in machine.succeed("cat /etc/subuid")
+  '';
+}


### PR DESCRIPTION
Wire the existing `users.users.<name>.{autoSubUidGidRange,subUidRanges,subGidRanges}` options into userborn so it writes `/etc/subuid` and `/etc/subgid`, and handle the resulting files alongside `passwd`/`group`/`shadow`.
When `passwordFilesLocation != /etc` the subid files are bind-mounted (not symlinked) because `newuidmap` opens them with `O_NOFOLLOW`.

A one-shot service seeds the files from `/var/lib/nixos/auto-subuid-map` on the first activation after switching from `update-users-groups.pl`, so existing auto allocations survive the migration.

Depends on https://github.com/nikstur/userborn/pull/48 and a userborn release containing it.

Alternative to #508608 that keeps the allocation logic inside userborn instead of a separate tool.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
