### PR TITLE
t3: 1.0.9 -> 1.1.0

### DIFF
--- a/pkgs/by-name/t3/t3/package.nix
+++ b/pkgs/by-name/t3/t3/package.nix
@@ -8,13 +8,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "t3";
-  version = "1.0.9";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "flox";
     repo = "t3";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-42T0qQ3zK1jTRU+gcBzEet5rHZ6QuknCbPdbGPNlETI=";
+    hash = "sha256-49nmFvyA5HtX0rTqG4vrCdQPo78HMF7wIN4StItShB4=";
+    postFetch = "rm -f $out/.flox/env/manifest.lock";
   };
 
   makeFlags = [


### PR DESCRIPTION
Manual update of t3 to v1.1.0.

This is being done manually on this occasion because the Nixpkgs merge bot is unable to fetch the source on account of a lockfile containing references to store paths. This patch adds a `postFetch` action to remove the lockfile, so automatic updates should be possible going forward.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
