### PR TITLE
minimal-bootstrap: Add supporting packages for gcc-ng refactor

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -322,6 +322,12 @@ lib.makeScope
           gnumake = gnumake-musl;
         };
 
+        musl-headers = callPackage ./musl/headers.nix {
+          gcc = gcc46;
+          gnumake = gnumake-musl;
+          gnutar = gnutar-latest;
+        };
+
         musl-static = callPackage ./musl/static.nix {
           libgcc = gcc-latest-unwrapped;
           gcc = gcc-latest;

--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -490,6 +490,13 @@ lib.makeScope
           gnutar = gnutar-latest;
           gnugrep = gnugrep-static;
         };
+
+        glibc-headers = callPackage ./glibc/headers.nix {
+          gcc = gcc-latest;
+          binutils-build = binutils;
+          gnumake = gnumake-musl;
+          gnutar = gnutar-latest;
+        };
       }
     )
   )

--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -281,6 +281,12 @@ lib.makeScope
           gnutar = gnutar-latest;
         };
 
+        libmpfr = callPackage ./gcc/mpfr.nix {
+          gcc = gcc-latest;
+          gnumake = gnumake-musl;
+          gnutar = gnutar-latest;
+        };
+
         linux-headers = callPackage ./linux-headers {
           gcc = gcc-latest;
           gnumake = gnumake-musl;

--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -274,6 +274,13 @@ lib.makeScope
 
         heirloom-devtools = callPackage ./heirloom-devtools { tinycc = tinycc-mes; };
 
+        libgmp = callPackage ./gcc/gmp.nix {
+          gcc-buildbuild = gcc-latest;
+          gcc = gcc-latest;
+          gnumake = gnumake-musl;
+          gnutar = gnutar-latest;
+        };
+
         linux-headers = callPackage ./linux-headers {
           gcc = gcc-latest;
           gnumake = gnumake-musl;

--- a/pkgs/os-specific/linux/minimal-bootstrap/default.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/default.nix
@@ -281,6 +281,12 @@ lib.makeScope
           gnutar = gnutar-latest;
         };
 
+        libmpc = callPackage ./gcc/mpc.nix {
+          gcc = gcc-latest;
+          gnumake = gnumake-musl;
+          gnutar = gnutar-latest;
+        };
+
         libmpfr = callPackage ./gcc/mpfr.nix {
           gcc = gcc-latest;
           gnumake = gnumake-musl;

--- a/pkgs/os-specific/linux/minimal-bootstrap/gcc/gmp.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gcc/gmp.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  buildPlatform,
+  hostPlatform,
+  fetchurl,
+  bash,
+  coreutils,
+  gcc-buildbuild,
+  gcc,
+  binutils,
+  gnumake,
+  gnused,
+  gnugrep,
+  gawk,
+  diffutils,
+  findutils,
+  gnutar,
+  gzip,
+  bzip2,
+  xz,
+}:
+let
+  pname = "gmp";
+  version = "6.3.0";
+
+  src = fetchurl {
+    url = "mirror://gnu/gmp/gmp-${version}.tar.xz";
+    hash = "sha256-o8K4AgG4nmhhb0rTC8Zq7kknw85Q4zkpyoGdXENTiJg=";
+  };
+in
+bash.runCommand "${pname}-${version}"
+  {
+    inherit pname version;
+
+    nativeBuildInputs = [
+      gcc
+      gcc-buildbuild
+      binutils
+      gnumake
+      gnused
+      gnugrep
+      gawk
+      diffutils
+      findutils
+      gnutar
+      gzip
+      bzip2
+      xz
+    ];
+
+    meta = {
+      description = "The GNU Multiple Precision Arithmetic Library, version ${version}";
+      homepage = "https://gmplib.org/";
+      license = with lib.licenses; [
+        lgpl3Only
+        gpl2Only
+      ];
+      teams = [ lib.teams.minimal-bootstrap ];
+      platforms = lib.platforms.unix;
+    };
+  }
+  ''
+    # Unpack
+    tar xf ${src}
+    cd gmp-${version}
+
+    # Configure
+    bash ./configure \
+      --prefix=$out \
+      --build=${buildPlatform.config} \
+      --host=${hostPlatform.config} \
+      --disable-dependency-tracking \
+      --with-pic \
+      --disable-assembly \
+      CFLAGS=-std=c99 \
+      M4=false
+
+    # Build
+    make -j $NIX_BUILD_CORES
+
+    # Install
+    make -j $NIX_BUILD_CORES install-strip
+  ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/gcc/mpc.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gcc/mpc.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  buildPlatform,
+  hostPlatform,
+  fetchurl,
+  bash,
+  coreutils,
+  gcc,
+  binutils,
+  gnumake,
+  gnused,
+  gnugrep,
+  gawk,
+  diffutils,
+  findutils,
+  gnutar,
+  gzip,
+  bzip2,
+  xz,
+  libgmp,
+  libmpfr,
+}:
+let
+  pname = "mpc";
+  version = "1.3.1";
+  src = fetchurl {
+    url = "mirror://gnu/mpc/mpc-${version}.tar.gz";
+    hash = "sha256-q2QkkvXPiCt0qgy3MM1BCoHtzb7IlRg86TDnBsHHWbg=";
+  };
+in
+bash.runCommand "${pname}-${version}"
+  {
+    inherit pname version;
+
+    nativeBuildInputs = [
+      gcc
+      binutils
+      gnumake
+      gnused
+      gnugrep
+      gawk
+      diffutils
+      findutils
+      gnutar
+      gzip
+      bzip2
+      xz
+    ];
+
+    meta = {
+      description = "GNU Multiple Precision Complex Library, version ${version}";
+      homepage = "https://www.multiprecision.org/";
+      license = lib.licenses.lgpl3Plus;
+      teams = [ lib.teams.minimal-bootstrap ];
+      platforms = lib.platforms.unix;
+    };
+  }
+  ''
+    # Unpack
+    tar xf ${src}
+    cd mpc-${version}
+
+    # Configure
+    bash ./configure \
+      --prefix=$out \
+      --build=${buildPlatform.config} \
+      --host=${hostPlatform.config} \
+      --disable-dependency-tracking \
+      --with-gmp=${libgmp} \
+      --with-mpfr=${libmpfr}
+
+    # Build
+    make -j $NIX_BUILD_CORES
+
+    # Install
+    make -j $NIX_BUILD_CORES install-strip
+  ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/gcc/mpfr.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/gcc/mpfr.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  buildPlatform,
+  hostPlatform,
+  fetchurl,
+  bash,
+  gcc,
+  binutils,
+  gnumake,
+  gnused,
+  gnugrep,
+  gawk,
+  diffutils,
+  findutils,
+  gnutar,
+  xz,
+  libgmp,
+}:
+let
+  pname = "mpfr";
+  version = "4.2.2";
+
+  src = fetchurl {
+    url = "mirror://gnu/mpfr/mpfr-${version}.tar.xz";
+    hash = "sha256-tnugOD736KhWNzTi6InvXsPDuJigHQD6CmhprYHGzgE=";
+  };
+in
+bash.runCommand "${pname}-${version}"
+  {
+    inherit pname version;
+
+    nativeBuildInputs = [
+      gcc
+      binutils
+      gnumake
+      gnused
+      gnugrep
+      gawk
+      diffutils
+      findutils
+      gnutar
+      xz
+    ];
+
+    meta = {
+      description = "The GNU Multiple Precision Floating-Point Reliable Library, version ${version}";
+      homepage = "https://www.mpfr.org/";
+      license = lib.licenses.lgpl3Plus;
+      teams = [ lib.teams.minimal-bootstrap ];
+      platforms = lib.platforms.unix;
+    };
+  }
+  ''
+    # Unpack
+    tar xf ${src}
+    cd mpfr-${version}
+
+    # Configure
+    bash ./configure \
+      --prefix=$out \
+      --build=${buildPlatform.config} \
+      --host=${hostPlatform.config} \
+      --disable-dependency-tracking \
+      --with-gmp=${libgmp}
+
+    # Build
+    make -j $NIX_BUILD_CORES
+
+    # Install
+    make -j $NIX_BUILD_CORES install-strip
+  ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/glibc/headers.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/glibc/headers.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  buildPlatform,
+  hostPlatform,
+  fetchurl,
+  bash,
+  gcc,
+  binutils,
+  binutils-build,
+  linux-headers,
+  gnumake,
+  gnused,
+  gnugrep,
+  gawk,
+  diffutils,
+  findutils,
+  python,
+  bison,
+  gnutar,
+  xz,
+}:
+let
+  pname = "glibc-headers";
+  version = "2.42";
+
+  src = fetchurl {
+    url = "mirror://gnu/libc/glibc-${version}.tar.xz";
+    hash = "sha256-0XdeMuRijmTvkw9DW2e7Y691may2viszW58Z8WUJ8X8=";
+  };
+in
+bash.runCommand "${pname}-${version}"
+  {
+    inherit pname version;
+
+    nativeBuildInputs = [
+      gcc
+      binutils
+      binutils-build
+      gnumake
+      gnused
+      gnugrep
+      gawk
+      diffutils
+      findutils
+      python
+      bison
+      gnutar
+      xz
+    ];
+
+    meta = {
+      description = "The GNU C Library";
+      homepage = "https://www.gnu.org/software/libc/";
+      license = lib.licenses.lgpl2Plus;
+      platforms = lib.platforms.linux;
+      teams = [ lib.teams.minimal-bootstrap ];
+    };
+  }
+  ''
+    # Unpack
+    tar xf ${src}
+    cd glibc-${version}
+
+    # Configure
+    mkdir build
+    cd build
+    # libstdc++.so is built against musl and fails to link
+    export CXX=false
+    bash ../configure \
+      --prefix=$out \
+      --build=${buildPlatform.config} \
+      --host=${hostPlatform.config} \
+      --with-headers=${linux-headers}/include \
+      --disable-dependency-tracking
+
+    # Install
+    make -j $NIX_BUILD_CORES INSTALL_UNCOMPRESSED=yes install-headers install-bootstrap-headers=yes
+    ln -s $(ls -d ${linux-headers}/include/* | grep -v scsi\$) $out/include/
+
+    # https://sources.debian.org/patches/glibc/2.43-1/any/local-bootstrap-headers.diff/
+    touch $out/include/gnu/stubs.h
+  ''

--- a/pkgs/os-specific/linux/minimal-bootstrap/musl/headers.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/musl/headers.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildPlatform,
+  hostPlatform,
+  fetchurl,
+  bash,
+  gcc,
+  binutils,
+  gnumake,
+  gnugrep,
+  gnused,
+  gnutar,
+  gzip,
+}:
+let
+  inherit (import ./common.nix { inherit lib; }) pname meta;
+  version = "1.2.6";
+
+  src = fetchurl {
+    url = "https://musl.libc.org/releases/musl-${version}.tar.gz";
+    hash = "sha256-1YX9O2E8ZhUfwySejtRPdwIMtebB5jWmFtP5+CRgUSo=";
+  };
+in
+bash.runCommand "${pname}-${version}"
+  {
+    inherit pname version meta;
+
+    nativeBuildInputs = [
+      gcc
+      binutils
+      gnumake
+      gnused
+      gnugrep
+      gnutar
+      gzip
+    ];
+  }
+  ''
+    # Unpack
+    tar xzf ${src}
+    cd musl-${version}
+
+    # Patch
+    # https://github.com/ZilchOS/bootstrap-from-tcc/blob/2e0c68c36b3437386f786d619bc9a16177f2e149/using-nix/2a3-intermediate-musl.nix
+    sed -i 's|/bin/sh|${bash}/bin/bash|' \
+      tools/*.sh
+
+    # Configure
+    # Use build-gcc, since we won't be compiling anything
+    bash ./configure \
+      --prefix=$out \
+      --build=${buildPlatform.config} \
+      --host=${hostPlatform.config} \
+      --syslibdir=$out/lib \
+      --enable-wrapper \
+      CC=gcc
+
+    # Install
+    make -j $NIX_BUILD_CORES install-headers
+  ''


### PR DESCRIPTION
Add supporting packages for splitting gcc into gcc-ng in minimal-bootstrap, to consume less build time once cross-compilation within minimal-bootstrap is setup.

These packages are not yet used, but will be used in #532618

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
