### PR TITLE
libnice: fix build for musl

### DIFF
--- a/pkgs/by-name/li/libnice/musl.patch
+++ b/pkgs/by-name/li/libnice/musl.patch
@@ -1,0 +1,178 @@
+From a7310137cf09e382e2642e39d4ade88942d564c3 Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Fri, 19 Jun 2026 17:21:47 +0200
+Subject: [PATCH 1/3] tests: treat Glibc-style sendmmsg as default case
+
+As requested.
+
+Link: https://gitlab.freedesktop.org/libnice/libnice/-/merge_requests/353#note_3526962
+Signed-off-by: Alyssa Ross <hi@alyssa.is>
+---
+ tests/instrument-send.c | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/tests/instrument-send.c b/tests/instrument-send.c
+index 3f79de87..65576dea 100644
+--- a/tests/instrument-send.c
++++ b/tests/instrument-send.c
+@@ -190,23 +190,23 @@ sendmsg (int sockfd, const struct msghdr *msg, int flags)
+   }
+ }
+ 
+-#ifndef __FreeBSD__
+-int
+-sendmmsg (int sockfd, struct mmsghdr *msgvec, unsigned int vlen, int flags)
+-#else
++#ifdef __FreeBSD__
+ ssize_t
+ sendmmsg (int sockfd, struct mmsghdr *msgvec, size_t vlen, int flags)
++#else
++int
++sendmmsg (int sockfd, struct mmsghdr *msgvec, unsigned int vlen, int flags)
+ #endif
+ {
+   if (should_inject_ewouldblock ()) {
+     errno = EWOULDBLOCK;
+     return -1;
+   } else {
+-#ifndef __FreeBSD__
+-    int ret = ((int (*) (int sockfd, struct mmsghdr *msgvec, unsigned int vlen, int flags)) (
++#ifdef __FreeBSD__
++    ssize_t ret = ((int (*) (int sockfd, struct mmsghdr *msgvec, size_t vlen, int flags)) (
+         dlsym (RTLD_NEXT, "sendmmsg"))) (sockfd, msgvec, vlen, flags);
+ #else
+-    ssize_t ret = ((int (*) (int sockfd, struct mmsghdr *msgvec, size_t vlen, int flags)) (
++    int ret = ((int (*) (int sockfd, struct mmsghdr *msgvec, unsigned int vlen, int flags)) (
+         dlsym (RTLD_NEXT, "sendmmsg"))) (sockfd, msgvec, vlen, flags);
+ #endif
+     if (ret != -1) {
+-- 
+GitLab
+
+
+From 145c542b442f4deb89e1cc8bb92e1ca02456f918 Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Mon, 15 Jun 2026 17:54:12 +0200
+Subject: [PATCH 2/3] tests: check sendmmsg prototype in Meson
+
+Checking the actual prototype we have rather than using hardcoded libc
+checks improves portability by being compatible with libcs that aren't
+explictly handled, but use the same prototype as a known libc.  For
+example, uClibc-ng uses the same prototype as FreeBSD, but wouldn't
+have been caught be the __FreeBSD__ check.
+---
+ tests/instrument-send.c |  4 ++--
+ tests/meson.build       | 18 +++++++++++++++++-
+ 2 files changed, 19 insertions(+), 3 deletions(-)
+
+diff --git a/tests/instrument-send.c b/tests/instrument-send.c
+index 65576dea..9903619a 100644
+--- a/tests/instrument-send.c
++++ b/tests/instrument-send.c
+@@ -190,7 +190,7 @@ sendmsg (int sockfd, const struct msghdr *msg, int flags)
+   }
+ }
+ 
+-#ifdef __FreeBSD__
++#if defined(HAVE_FREEBSD_STYLE_SENDMMSG)
+ ssize_t
+ sendmmsg (int sockfd, struct mmsghdr *msgvec, size_t vlen, int flags)
+ #else
+@@ -202,7 +202,7 @@ sendmmsg (int sockfd, struct mmsghdr *msgvec, unsigned int vlen, int flags)
+     errno = EWOULDBLOCK;
+     return -1;
+   } else {
+-#ifdef __FreeBSD__
++#if defined(HAVE_FREEBSD_STYLE_SENDMMSG)
+     ssize_t ret = ((int (*) (int sockfd, struct mmsghdr *msgvec, size_t vlen, int flags)) (
+         dlsym (RTLD_NEXT, "sendmmsg"))) (sockfd, msgvec, vlen, flags);
+ #else
+diff --git a/tests/meson.build b/tests/meson.build
+index 7a4ce651..29888c29 100644
+--- a/tests/meson.build
++++ b/tests/meson.build
+@@ -102,9 +102,25 @@ if gst_dep.found() and not static_build
+     ]
+     gst_env = environment()
+     dl_dep = cc.find_library('dl')
++
++    instrument_send_lib_c_args = ['-DG_LOG_DOMAIN="libnice-instrument-send"']
++    if cc.compiles('''
++      #include <sys/socket.h>
++      static int (*f) (int, struct mmsghdr *, unsigned int, int) = &sendmmsg;
++    ''', args: ['-D_GNU_SOURCE', '-Werror=incompatible-pointer-types'], name: 'Glibc-style sendmmsg')
++      # We consider this the default.
++    elif cc.compiles('''
++      #include <sys/socket.h>
++      static ssize_t (*f) (int, struct mmsghdr *, size_t, int) = &sendmmsg;
++    ''', args: ['-D_GNU_SOURCE', '-Werror=incompatible-pointer-types'], name: 'FreeBSD-style sendmmsg')
++      instrument_send_lib_c_args += ['-DHAVE_FREEBSD_STYLE_SENDMMSG']
++    else
++      error('sendmmsg not present or has unknown prototype')
++    endif
++
+     instrument_send_lib = shared_library('instrument-send',
+       'instrument-send.c',
+-      c_args: '-DG_LOG_DOMAIN="libnice-instrument-send"',
++      c_args: instrument_send_lib_c_args,
+       dependencies: [dl_dep, gio_deps],
+     )
+     gst_env.append('LD_PRELOAD', instrument_send_lib.full_path())
+-- 
+GitLab
+
+
+From 4565af6fe9fe01164b072710ad18e537608d3a40 Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Wed, 17 Jun 2026 11:53:11 +0200
+Subject: [PATCH 3/3] tests: support NetBSD/musl-style sendmmsg
+
+Fixes compilation for these platforms.
+---
+ tests/instrument-send.c | 6 ++++++
+ tests/meson.build       | 5 +++++
+ 2 files changed, 11 insertions(+)
+
+diff --git a/tests/instrument-send.c b/tests/instrument-send.c
+index 9903619a..20c02b30 100644
+--- a/tests/instrument-send.c
++++ b/tests/instrument-send.c
+@@ -193,6 +193,9 @@ sendmsg (int sockfd, const struct msghdr *msg, int flags)
+ #if defined(HAVE_FREEBSD_STYLE_SENDMMSG)
+ ssize_t
+ sendmmsg (int sockfd, struct mmsghdr *msgvec, size_t vlen, int flags)
++#elif defined(HAVE_NETBSD_STYLE_SENDMMSG)
++int
++sendmmsg (int sockfd, struct mmsghdr *msgvec, unsigned int vlen, unsigned int flags)
+ #else
+ int
+ sendmmsg (int sockfd, struct mmsghdr *msgvec, unsigned int vlen, int flags)
+@@ -205,6 +208,9 @@ sendmmsg (int sockfd, struct mmsghdr *msgvec, unsigned int vlen, int flags)
+ #if defined(HAVE_FREEBSD_STYLE_SENDMMSG)
+     ssize_t ret = ((int (*) (int sockfd, struct mmsghdr *msgvec, size_t vlen, int flags)) (
+         dlsym (RTLD_NEXT, "sendmmsg"))) (sockfd, msgvec, vlen, flags);
++#elif defined(HAVE_NETBSD_STYLE_SENDMMSG)
++    int ret = ((int (*) (int sockfd, struct mmsghdr *msgvec, unsigned int vlen, unsigned int flags)) (
++        dlsym (RTLD_NEXT, "sendmmsg"))) (sockfd, msgvec, vlen, flags);
+ #else
+     int ret = ((int (*) (int sockfd, struct mmsghdr *msgvec, unsigned int vlen, int flags)) (
+         dlsym (RTLD_NEXT, "sendmmsg"))) (sockfd, msgvec, vlen, flags);
+diff --git a/tests/meson.build b/tests/meson.build
+index 29888c29..3827dc2b 100644
+--- a/tests/meson.build
++++ b/tests/meson.build
+@@ -114,6 +114,11 @@ if gst_dep.found() and not static_build
+       static ssize_t (*f) (int, struct mmsghdr *, size_t, int) = &sendmmsg;
+     ''', args: ['-D_GNU_SOURCE', '-Werror=incompatible-pointer-types'], name: 'FreeBSD-style sendmmsg')
+       instrument_send_lib_c_args += ['-DHAVE_FREEBSD_STYLE_SENDMMSG']
++    elif cc.compiles('''
++      #include <sys/socket.h>
++      static int (*f) (int, struct mmsghdr *, unsigned int, unsigned int) = &sendmmsg;
++    ''', args: ['-D_GNU_SOURCE', '-Werror=incompatible-pointer-types'], name: 'NetBSD-style sendmmsg')
++      instrument_send_lib_c_args += ['-DHAVE_NETBSD_STYLE_SENDMMSG']
+     else
+       error('sendmmsg not present or has unknown prototype')
+     endif
+-- 
+GitLab
+

--- a/pkgs/by-name/li/libnice/package.nix
+++ b/pkgs/by-name/li/libnice/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   meson,
   ninja,
   pkg-config,
@@ -37,6 +38,15 @@ stdenv.mkDerivation (finalAttrs: {
     # Bumps the gupnp_igd_dep version requested to 1.6
     # https://gitlab.freedesktop.org/libnice/libnice/-/merge_requests/255
     ./gupnp-igd-bump.patch
+
+    (fetchpatch {
+      name = "freebsd.patch";
+      url = "https://gitlab.freedesktop.org/libnice/libnice/-/commit/479f0813a571ff035bf00de679db452a0441125b.patch";
+      hash = "sha256-rr8pAb8TjU85jYWUjsMMKkLxxXVE3B+IjfAyOw9suo0=";
+    })
+
+    # https://gitlab.freedesktop.org/libnice/libnice/-/merge_requests/353
+    ./musl.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
Backported the FreeBSD fix as well to get the musl one to apply cleanly.  Dependencies don't all build for FreeBSD but it wasn't hard to get that to work so I have fixes in the pipeline.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
