### PR TITLE
{d2, tala}: init and add support for tala layout engine

### DIFF
--- a/pkgs/by-name/d2/d2/package.nix
+++ b/pkgs/by-name/d2/d2/package.nix
@@ -11,7 +11,9 @@
   libgbm,
   makeWrapper,
   playwright-driver,
+  tala,
   withImageSupport ? lib.meta.availableOn stdenv.hostPlatform libdrm,
+  withTala ? false,
 }:
 
 assert lib.assertMsg (
@@ -55,10 +57,13 @@ buildGoModule (finalAttrs: {
   postInstall = ''
     installManPage ci/release/template/man/d2.1
   ''
-  # Wrap the d2 executable to set LD_LIBRARY_PATH for Playwright
-  + lib.optionalString withImageSupport ''
-    wrapProgram $out/bin/d2 \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath finalAttrs.buildInputs}
+  # Wrap the d2 executable to set LD_LIBRARY_PATH for Playwright and add tala to PATH
+  + lib.optionalString (withImageSupport || withTala) ''
+    makeWrapperArgs=(
+      ${lib.optionalString withImageSupport "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath finalAttrs.buildInputs}"}
+      ${lib.optionalString withTala "--prefix PATH : ${lib.makeBinPath [ tala ]}"}
+    )
+    wrapProgram $out/bin/d2 "''${makeWrapperArgs[@]}"
   '';
 
   preCheck = ''

--- a/pkgs/by-name/ta/tala/package.nix
+++ b/pkgs/by-name/ta/tala/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  installShellFiles,
+  autoPatchelfHook,
+  testers,
+  tala,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "tala";
+  version = "0.4.3";
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src =
+    {
+      x86_64-linux = fetchurl {
+        url = "https://github.com/terrastruct/TALA/releases/download/v${finalAttrs.version}/tala-v${finalAttrs.version}-linux-amd64.tar.gz";
+        hash = "sha256-xc3ZVjK+dgyFRvMNhg7jWGmBgESPggl6WZB4NzclCiY=";
+      };
+      aarch64-linux = fetchurl {
+        url = "https://github.com/terrastruct/TALA/releases/download/v${finalAttrs.version}/tala-v${finalAttrs.version}-linux-arm64.tar.gz";
+        hash = "sha256-Jo4ABZJIakGHQDgiM+uh08qnlAH1LjRGlhRdgvr3iU0=";
+      };
+      x86_64-darwin = fetchurl {
+        url = "https://github.com/terrastruct/TALA/releases/download/v${finalAttrs.version}/tala-v${finalAttrs.version}-macos-amd64.tar.gz";
+        hash = "sha256-IUUxkZXl5rZjlF02SSjo4Jh/jZa6zpo0wCY5fdX4LMg=";
+      };
+      aarch64-darwin = fetchurl {
+        url = "https://github.com/terrastruct/TALA/releases/download/v${finalAttrs.version}/tala-v${finalAttrs.version}-macos-arm64.tar.gz";
+        hash = "sha256-4dYb0jrSpwtG+tIypHFo/IK10hz+VydOAotgm5hdAiY=";
+      };
+    }
+    .${stdenvNoCC.hostPlatform.system};
+
+  nativeBuildInputs = [
+    installShellFiles
+  ]
+  ++ lib.optional stdenvNoCC.hostPlatform.isLinux autoPatchelfHook;
+
+  dontBuild = true;
+  dontStrip = stdenvNoCC.hostPlatform.isDarwin;
+
+  unpackPhase = ''
+    tar xf $src --strip-components=1 --exclude='._*'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 bin/d2plugin-tala -t $out/bin/
+    installManPage man/d2plugin-tala.1 man/tala.1
+
+    runHook postInstall
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = tala;
+    version = "v${finalAttrs.version}";
+  };
+
+  meta = {
+    description = "Proprietary layout engine plugin for D2";
+    homepage = "https://d2lang.com/tour/tala/";
+    changelog = "https://github.com/terrastruct/TALA/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ kashw2 ];
+    mainProgram = "d2plugin-tala";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This introduces tala as a package and adds support for it in d2. D2 can specify the tala layout engine via passing `--layout tala`. Previously this didn't work because Tala wasn't on it's path

https://github.com/terrastruct/TALA

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
