### PR TITLE
python3Packages.mcp: 1.26.0 -> 1.27.0; python3Packages.fastmcp: 3.2.3 -> 3.2.4

### DIFF
--- a/pkgs/development/python-modules/fastmcp/default.nix
+++ b/pkgs/development/python-modules/fastmcp/default.nix
@@ -15,6 +15,7 @@
   azure-identity,
   cyclopts,
   exceptiongroup,
+  griffelib,
   httpx,
   jsonref,
   jsonschema-path,
@@ -49,20 +50,21 @@
   opentelemetry-sdk,
   psutil,
   pytest-asyncio,
+  pytest-examples,
   pytest-httpx,
   pytestCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "fastmcp";
-  version = "3.2.3";
+  version = "3.2.4";
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "jlowin";
+    owner = "PrefectHQ";
     repo = "fastmcp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-YfFAJvfKLOgfGFWyQmR4FGHrRc066Y0mAYhXJqJ9vyw=";
+    hash = "sha256-rJpxPvqAaa6/vXhG1+R9dI32cY/54e6I+F/zyBVoqBM=";
   };
 
   build-system = [
@@ -78,6 +80,7 @@ buildPythonPackage (finalAttrs: {
     authlib
     cyclopts
     exceptiongroup
+    griffelib
     httpx
     jsonref
     jsonschema-path
@@ -129,6 +132,7 @@ buildPythonPackage (finalAttrs: {
     opentelemetry-sdk
     psutil
     pytest-asyncio
+    pytest-examples
     pytest-httpx
     pytestCheckHook
     writableTmpDirAsHomeHook
@@ -165,6 +169,7 @@ buildPythonPackage (finalAttrs: {
 
     # Requires prefab-ui (optional dependency)
     "test_auto_registers_renderer_resource"
+    "test_auto_synthesizes_renderer_resource"
     "test_equivalent_to_app_true"
 
     # Requires pydocket (tasks optional dependency, not in test inputs)
@@ -202,6 +207,7 @@ buildPythonPackage (finalAttrs: {
   disabledTestPaths = [
     # Requires prefab-ui (optional dependency)
     "tests/apps"
+    "tests/docs/test_doc_examples.py"
     "tests/test_apps_prefab.py"
     "tests/test_fastmcp_app.py"
     # Subprocess crash recovery tests are flaky in sandbox
@@ -224,8 +230,8 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "Fast, Pythonic way to build MCP servers and clients";
-    changelog = "https://github.com/jlowin/fastmcp/releases/tag/${finalAttrs.src.tag}";
-    homepage = "https://github.com/jlowin/fastmcp";
+    changelog = "https://github.com/PrefectHQ/fastmcp/releases/tag/${finalAttrs.src.tag}";
+    homepage = "https://github.com/PrefectHQ/fastmcp";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ GaetanLepage ];
   };

--- a/pkgs/development/python-modules/fastmcp/default.nix
+++ b/pkgs/development/python-modules/fastmcp/default.nix
@@ -59,6 +59,7 @@ buildPythonPackage (finalAttrs: {
   pname = "fastmcp";
   version = "3.2.4";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "PrefectHQ";

--- a/pkgs/development/python-modules/mcp/default.nix
+++ b/pkgs/development/python-modules/mcp/default.nix
@@ -42,14 +42,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "mcp";
-  version = "1.26.0";
+  version = "1.27.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "modelcontextprotocol";
     repo = "python-sdk";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-TGkAyuBcIstL2BCZYBWoi7PhnhoBvap67sLWGe0QUoU=";
+    hash = "sha256-qvbGyF0PVC626yCgUqOYmA1zOmvI3/bC7l7HhfOtKH8=";
   };
 
   # time.sleep(0.1) feels a bit optimistic and it has been flaky whilst
@@ -139,6 +139,7 @@ buildPythonPackage (finalAttrs: {
     # Flaky: httpx.ConnectError: All connection attempts failed
     "test_sse_security_"
     "test_streamable_http_"
+    "test_streamablehttp_"
 
     # This just feels a bit optimistic...
     #     	assert duration < 3 * _sleep_time_seconds

--- a/pkgs/development/python-modules/mcp/default.nix
+++ b/pkgs/development/python-modules/mcp/default.nix
@@ -44,6 +44,7 @@ buildPythonPackage (finalAttrs: {
   pname = "mcp";
   version = "1.27.0";
   pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "modelcontextprotocol";


### PR DESCRIPTION
Update Python dependencies needed to add Atlassian MCP (new package).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
