### PR TITLE
numberstation: 1.4.0 -> 1.5.0

### DIFF
--- a/pkgs/by-name/nu/numberstation/package.nix
+++ b/pkgs/by-name/nu/numberstation/package.nix
@@ -2,6 +2,7 @@
   lib,
   python3,
   fetchFromSourcehut,
+  fetchurl,
   desktop-file-utils,
   glib,
   gobject-introspection,
@@ -16,16 +17,23 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "numberstation";
-  version = "1.4.0";
+  version = "1.5.0";
 
   pyproject = false;
 
   src = fetchFromSourcehut {
     owner = "~martijnbraam";
     repo = "numberstation";
-    rev = finalAttrs.version;
-    hash = "sha256-0T/Dc2i6auuZiWjcPR72JT8yOrzmdEmbW2PS5YhmEwI=";
+    tag = finalAttrs.version;
+    hash = "sha256-N8hTXlJcekg/+dCK/tp2EhbNBtj8n9K3LHURRI5ruQQ=";
   };
+
+  patches = [
+    (fetchurl {
+      url = "https://src.fedoraproject.org/rpms/numberstation/raw/05cb9e58d879cd9d224862bb72c373374de63943/f/0001-Fix-if-statement-after-b32decode-removal.patch";
+      hash = "sha256-grTSKdXl1WIK+n4rOe/g4lczc8eIuCU1ZqHI1VNkJ8w=";
+    })
+  ];
 
   postPatch = ''
     patchShebangs build-aux/meson


### PR DESCRIPTION
Changelog: https://git.sr.ht/~martijnbraam/numberstation/refs/1.5.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
