### PR TITLE
libxmlxx5: 5.4 -> 5.6.1

### DIFF
--- a/pkgs/by-name/li/libxmlxx5/package.nix
+++ b/pkgs/by-name/li/libxmlxx5/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   pkg-config,
   libxml2,
   glibmm,
@@ -11,11 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libxmlxx5";
-  version = "5.4";
+  version = "5.6.1";
 
-  src = fetchurl {
-    url = "mirror://gnome/sources/libxml++/${finalAttrs.version}/libxml++-${lib.versions.pad 3 finalAttrs.version}.tar.xz";
-    hash = "sha256-6aI8Q2aGqUaY0hOOa8uvhJEh1jv6D1DcNP77/XlWaEg=";
+  src = fetchFromGitHub {
+    owner = "libxmlplusplus";
+    repo = "libxmlplusplus";
+    tag = finalAttrs.version;
+    hash = "sha256-f8R2T5A7C/HqydhZOlbWIKj6Q9oc97f2PfV8ef70G0I=";
   };
 
   nativeBuildInputs = [
@@ -31,9 +33,10 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
   meta = {
+    changelog = "https://github.com/libxmlplusplus/libxmlplusplus/blob/${finalAttrs.src.tag}/NEWS";
     description = "C++ wrapper for the libxml2 XML parser library";
-    homepage = "https://libxmlplusplus.sourceforge.net/";
-    license = lib.licenses.lgpl2Plus;
+    homepage = "https://libxmlplusplus.github.io/libxmlplusplus";
+    license = lib.licenses.lgpl21Plus;
     maintainers = [ ];
     platforms = lib.platforms.unix;
   };


### PR DESCRIPTION
Diff: https://github.com/libxmlplusplus/libxmlplusplus/compare/5.4...5.6.1

Changelog: https://github.com/libxmlplusplus/libxmlplusplus/blob/5.6.1/NEWS


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
