### PR TITLE
octavePackages: drop mesa dependencies

### DIFF
--- a/pkgs/development/octave-modules/image/default.nix
+++ b/pkgs/development/octave-modules/image/default.nix
@@ -2,7 +2,6 @@
   buildOctavePackage,
   lib,
   fetchurl,
-  mesa,
   gnuplot,
   makeFontsConf,
   writableTmpDirAsHomeHook,
@@ -18,7 +17,6 @@ buildOctavePackage rec {
   };
 
   nativeOctavePkgTestInputs = [
-    mesa
     gnuplot
     writableTmpDirAsHomeHook
   ];

--- a/pkgs/development/octave-modules/statistics/default.nix
+++ b/pkgs/development/octave-modules/statistics/default.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   io,
   datatypes,
-  mesa,
   gnuplot,
   makeFontsConf,
   writableTmpDirAsHomeHook,
@@ -27,7 +26,6 @@ buildOctavePackage rec {
   ];
 
   nativeOctavePkgTestInputs = [
-    mesa
     gnuplot
     writableTmpDirAsHomeHook
   ];

--- a/pkgs/top-level/octave-packages.nix
+++ b/pkgs/top-level/octave-packages.nix
@@ -118,7 +118,6 @@ makeScope newScope (
 
     image = callPackage ../development/octave-modules/image {
       inherit (pkgs)
-        mesa
         gnuplot
         makeFontsConf
         writableTmpDirAsHomeHook


### PR DESCRIPTION
Those don't do anything. statistics tests still pass, image tests also pass but the hook doesn't know how to handle xfail so the build fails.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
