### PR TITLE
samba: add Prometheus exporter support

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1307,6 +1307,9 @@
   "module-services-samba-configuring-file-share": [
     "index.html#module-services-samba-configuring-file-share"
   ],
+  "module-services-samba-prometheus-exporter": [
+    "index.html#module-services-samba-prometheus-exporter"
+  ],
   "module-services-tandoor-recipes": [
     "index.html#module-services-tandoor-recipes"
   ],

--- a/nixos/modules/services/network-filesystems/samba.md
+++ b/nixos/modules/services/network-filesystems/samba.md
@@ -37,3 +37,20 @@ which is read-only and accessible without authentication:
   };
 }
 ```
+
+### Prometheus metrics exporter {#module-services-samba-prometheus-exporter}
+
+Samba can expose profiling metrics in Prometheus format using the
+`smb_prometheus_endpoint` utility:
+
+```nix
+{
+  services.samba = {
+    enable = true;
+    prometheusExporter.enable = true;
+  };
+}
+```
+
+The exporter listens on `127.0.0.1:9922` by default and serves metrics at
+`/metrics`.

--- a/nixos/modules/services/network-filesystems/samba.nix
+++ b/nixos/modules/services/network-filesystems/samba.nix
@@ -79,6 +79,33 @@ in
 
       openFirewall = lib.mkEnableOption "opening the default ports in the firewall for Samba";
 
+      prometheusExporter = {
+        enable = lib.mkEnableOption "Samba Prometheus metrics exporter";
+
+        listenAddress = lib.mkOption {
+          type = lib.types.str;
+          default = "127.0.0.1";
+          example = "0.0.0.0";
+          description = "Address the Samba Prometheus metrics exporter listens on.";
+        };
+
+        port = lib.mkOption {
+          type = lib.types.port;
+          default = 9922;
+          example = 9000;
+          description = "Port the Samba Prometheus metrics exporter listens on.";
+        };
+
+        profileTdb = lib.mkOption {
+          type = lib.types.str;
+          default = "/var/cache/samba/smbprofile.tdb";
+          example = "/var/lock/samba/smbprofile.tdb";
+          description = "Path to Samba's profiling database.";
+        };
+
+        openFirewall = lib.mkEnableOption "opening the Samba Prometheus metrics exporter port in the firewall";
+      };
+
       smbd = {
         enable = lib.mkOption {
           type = lib.types.bool;
@@ -216,6 +243,10 @@ in
           assertion = cfg.nsswins -> cfg.winbindd.enable;
           message = "If services.samba.nsswins is enabled, then services.samba.winbindd.enable must also be enabled";
         }
+        {
+          assertion = cfg.prometheusExporter.enable -> cfg.smbd.enable;
+          message = "If services.samba.prometheusExporter is enabled, then services.samba.smbd.enable must also be enabled";
+        }
       ];
     }
 
@@ -262,6 +293,29 @@ in
       networking.firewall.allowedUDPPorts = lib.mkIf cfg.openFirewall [
         137
         138
+      ];
+    })
+
+    (lib.mkIf (cfg.enable && cfg.prometheusExporter.enable) {
+      services.samba.settings.global."smbd profiling level" = lib.mkDefault "on";
+
+      systemd.services.samba-prometheus-exporter = {
+        description = "Samba Prometheus Metrics Exporter";
+        documentation = [ "man:smb_prometheus_endpoint(8)" ];
+
+        after = [ "samba-smbd.service" ];
+        partOf = [ "samba.target" ];
+        wantedBy = [ "samba.target" ];
+
+        serviceConfig = {
+          ExecStart = "${lib.getExe' cfg.package "smb_prometheus_endpoint"} -a ${lib.escapeShellArg cfg.prometheusExporter.listenAddress} -p ${toString cfg.prometheusExporter.port} ${lib.escapeShellArg cfg.prometheusExporter.profileTdb}";
+          Restart = "on-failure";
+          Slice = "system-samba.slice";
+        };
+      };
+
+      networking.firewall.allowedTCPPorts = lib.mkIf cfg.prometheusExporter.openFirewall [
+        cfg.prometheusExporter.port
       ];
     })
 

--- a/nixos/tests/samba.nix
+++ b/nixos/tests/samba.nix
@@ -1,4 +1,7 @@
-{ lib, ... }:
+{ config, lib, ... }:
+let
+  pkgs = config.node.pkgs;
+in
 {
   name = "samba";
 
@@ -23,6 +26,7 @@
         services.samba = {
           enable = true;
           openFirewall = true;
+          prometheusExporter.enable = true;
           settings = {
             "public" = {
               "path" = "/public";
@@ -39,10 +43,14 @@
   testScript = ''
     server.start()
     server.wait_for_unit("samba.target")
+    server.wait_for_unit("samba-prometheus-exporter.service")
     server.succeed("mkdir -p /public; echo bar > /public/foo")
 
     client.start()
     client.wait_for_unit("remote-fs.target")
     client.succeed("[[ $(cat /public/foo) = bar ]]")
+
+    server.wait_until_succeeds("test -e /var/cache/samba/smbprofile.tdb")
+    server.wait_until_succeeds("${lib.getExe pkgs.curl} -fsS http://127.0.0.1:9922/metrics | grep -q smb_worker_smbd_num")
   '';
 }

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   buildPackages,
+  runCommand,
   fetchurl,
   fetchpatch,
   wafHook,
@@ -18,6 +19,7 @@
   dbus,
   libbsd,
   libarchive,
+  libevent,
   zlib,
   liburing,
   gnutls,
@@ -46,6 +48,7 @@
   enablePrinting ? false,
   cups,
   enableProfiling ? true,
+  enablePrometheusExporter ? true,
   enableMDNS ? false,
   avahi,
   enableDomainController ? false,
@@ -64,6 +67,10 @@
   enablePam ? (!stdenv.hostPlatform.isDarwin),
   pam,
 }:
+
+assert lib.assertMsg (
+  enablePrometheusExporter -> enableProfiling
+) "samba: enablePrometheusExporter requires enableProfiling";
 
 let
   inherit (lib) optional optionals;
@@ -181,6 +188,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ optional enablePrinting cups
   ++ optional enableMDNS avahi
+  ++ optional enablePrometheusExporter libevent
   ++ optionals enableDomainController [
     gpgme
     python3Packages.dnspython
@@ -258,6 +266,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ optional enableLibunwind "--with-libunwind"
   ++ optional enableProfiling "--with-profiling-data"
+  ++ optional enablePrometheusExporter "--with-prometheus-exporter"
   ++ optional (!enableAcl) "--without-acl-support"
   ++ optional (!enablePam) "--without-pam"
   ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
@@ -330,7 +339,7 @@ stdenv.mkDerivation (finalAttrs: {
   + ''
     EOF
     find $out -type f -regex '.*\${stdenv.hostPlatform.extensions.sharedLibrary}\(\..*\)?' -exec $SHELL -c "$SCRIPT" \;
-    find $out/bin -type f -exec $SHELL -c "$SCRIPT" \;
+    find $out/bin $out/sbin -type f -exec $SHELL -c "$SCRIPT" \;
 
     # Fix PYTHONPATH for some tools
     wrapPythonPrograms
@@ -351,6 +360,20 @@ stdenv.mkDerivation (finalAttrs: {
       command = "${finalAttrs.finalPackage}/bin/smbd -V";
       package = finalAttrs.finalPackage;
     };
+  }
+  // lib.optionalAttrs enablePrometheusExporter {
+    prometheus-exporter = runCommand "samba-prometheus-exporter-test" { } ''
+      test -x ${lib.getExe' finalAttrs.finalPackage "smb_prometheus_endpoint"}
+      test -f ${lib.getOutput "man" finalAttrs.finalPackage}/share/man/man8/smb_prometheus_endpoint.8.gz
+
+      if ${lib.getExe' finalAttrs.finalPackage "smb_prometheus_endpoint"} 2>stderr; then
+        echo "smb_prometheus_endpoint unexpectedly succeeded without a tdb filename" >&2
+        exit 1
+      fi
+
+      grep -q "Missing tdb filename" stderr
+      touch $out
+    '';
   }
   // lib.optionalAttrs enableDomainController {
     versionSambaTool = testers.testVersion {


### PR DESCRIPTION
Samba 4.23 added `smb_prometheus_endpoint`, but the nixpkgs package did not pass `--with-prometheus-exporter`, so the binary and manpage were not installed.

This change enables the upstream build flag, adds the required `libevent` dependency, and adds NixOS module support to run it as a managed metrics service.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
