### PR TITLE
redisinsight: 3.4.2 -> 3.6.0

### DIFF
--- a/pkgs/by-name/re/redisinsight/package.nix
+++ b/pkgs/by-name/re/redisinsight/package.nix
@@ -9,27 +9,28 @@
   copyDesktopItems,
   dart-sass,
   makeWrapper,
-  nodejs-slim_20,
+  nodejs-slim_24,
   pkg-config,
   yarnConfigHook,
 
-  electron,
+  electron_41,
   libsecret,
   sqlite,
 }:
 
 let
-  nodejs = nodejs-slim_20;
+  electron = electron_41;
+  nodejs = nodejs-slim_24;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "redisinsight";
-  version = "3.4.2";
+  version = "3.6.0";
 
   src = fetchFromGitHub {
     owner = "redis";
     repo = "RedisInsight";
     rev = finalAttrs.version;
-    hash = "sha256-QV1xxpr8aMgkxWitJPVjXB/G2UaAYrV2wMM1FbltZpE=";
+    hash = "sha256-YnBy++KshDVNw3p1gf7gHydQyyh03fkSULhnZsqZMxs=";
   };
 
   patches = [
@@ -42,21 +43,21 @@ stdenv.mkDerivation (finalAttrs: {
   baseOfflineCache = fetchYarnDeps {
     name = "redisinsight-${finalAttrs.version}-base-offline-cache";
     inherit (finalAttrs) src patches;
-    hash = "sha256-hU8/ycljmRxqQEx0neezQmJPaianJhL0IyVOJEfLy5o=";
+    hash = "sha256-lfCasq3C0jD4wNpguxSOxwrR0Sx3ZfwK95Ib31TShSQ=";
   };
 
   innerOfflineCache = fetchYarnDeps {
     name = "redisinsight-${finalAttrs.version}-inner-offline-cache";
     inherit (finalAttrs) src patches;
     postPatch = "cd redisinsight";
-    hash = "sha256-s4JTgqXT+5P/C5e3/c30/VZHt8MRct3KViZOD1Fekqc=";
+    hash = "sha256-vdBSquVsIeMh5eZMRxYdVz3iuhM27RgEtI6FZqjCP74=";
   };
 
   apiOfflineCache = fetchYarnDeps {
     name = "redisinsight-${finalAttrs.version}-api-offline-cache";
     inherit (finalAttrs) src patches;
     postPatch = "cd redisinsight/api";
-    hash = "sha256-GsdKJjQltpHKDZmGRF60M1TLTbnwyHt9e5ayrXgbFOU=";
+    hash = "sha256-8u4igcegknwydNsVLcPv6E5/uwQJpwNWhIpCujfoXqk=";
   };
 
   nativeBuildInputs = [
@@ -101,6 +102,7 @@ stdenv.mkDerivation (finalAttrs: {
     npm rebuild --verbose --no-progress
     cd redisinsight
     npm rebuild --verbose --no-progress
+    export npm_config_nodedir=${nodejs}
     cd api
     npm rebuild --verbose --no-progress
     cd ../..
@@ -115,6 +117,7 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace node_modules/sass/dist/lib/src/compiler-path.js \
       --replace-fail 'compilerCommand = (() => {' 'compilerCommand = (() => { return ["${lib.getExe dart-sass}"];'
 
+    yarn --cwd redisinsight/api generate:api-client
     yarn --offline build:prod
 
     # TODO: Generate defaults. Currently broken because it requires network access.


### PR DESCRIPTION
changelog: https://github.com/redis/RedisInsight/releases/tag/3.6.0
diff: https://github.com/redis/RedisInsight/compare/3.4.2...3.6.0

Building the desktop app now requires the generated `api-client`. There seem to have been some header symbol issues where it couldn't use the sqlite3 module correctly so those had to be adjusted for the API client deps to use the `nodejs` ones (I know too little about nodejs so there might be a better solution, just LMK).

This package could also probably take some cleanup, e.g. setting things like `meta.mainProgram` but that can be done in a follow-up.

Supersedes #524452 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
