### PR TITLE
openvino: 2026.2.0 -> 2026.2.1; openvino-genai 2026.2.0.0 -> 2026.2.1.0; openvino-tokenizers: 2026.2.0.0 -> 2026.2.1.0

### DIFF
--- a/pkgs/by-name/op/openvino-genai/package.nix
+++ b/pkgs/by-name/op/openvino-genai/package.nix
@@ -164,7 +164,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeCheckInputs = [ openvino-tokenizers ];
 
-  doCheck = true;
+  # C++ exception with description "Exception from src/inference/src/cpp/core.cpp:272:
+  # Exception from src/inference/src/dev/core_impl.cpp:706:
+  # Device with "CPU" name is not registered in the OpenVINO Runtime
+  doCheck = !stdenv.hostPlatform.isAarch64;
 
   preCheck = ''
     mkdir -p tests/cpp/data

--- a/pkgs/by-name/op/openvino-genai/package.nix
+++ b/pkgs/by-name/op/openvino-genai/package.nix
@@ -42,6 +42,14 @@ let
   };
 
   python = python3Packages.python.withPackages (ps: [ ps.pybind11 ]);
+
+  # How the build system calls the different platforms
+  archName =
+    {
+      "aarch64-linux" = "aarch64";
+      "x86_64-linux" = "intel64";
+    }
+    .${stdenv.hostPlatform.system};
 in
 
 stdenv.mkDerivation (finalAttrs: {
@@ -147,7 +155,11 @@ stdenv.mkDerivation (finalAttrs: {
         "\''${_IMPORT_PREFIX}/runtime/include" "$dev/include"
     substituteInPlace $dev/lib/cmake/OpenVINOGenAITargets-release.cmake \
       --replace-fail \
-        "\''${_IMPORT_PREFIX}/runtime/lib/intel64/" "$out/lib/"
+        "\''${_IMPORT_PREFIX}/runtime/lib/${archName}/" "$out/lib/"
+  '';
+
+  preFixup = ''
+    addAutoPatchelfSearchPath ${lib.getLib openvino}/runtime/lib/${archName}
   '';
 
   postFixup = ''

--- a/pkgs/by-name/op/openvino-genai/package.nix
+++ b/pkgs/by-name/op/openvino-genai/package.nix
@@ -46,7 +46,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "openvino-genai";
-  version = "2026.2.0.0";
+  version = "2026.2.1.0";
 
   __structuredAttrs = true;
 
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
       owner = "openvinotoolkit";
       repo = "openvino.genai";
       tag = finalAttrs.version;
-      hash = "sha256-C60e4F+NuUPA4pQ/o2+EekOmp47QH1fTGDyXYqPJ57s=";
+      hash = "sha256-M8xxOsNvtIYIKvkrmOUnKv6gL/RAGuBfTBu3OPm3zRk=";
     };
 
   outputs = [

--- a/pkgs/by-name/op/openvino-tokenizers/package.nix
+++ b/pkgs/by-name/op/openvino-tokenizers/package.nix
@@ -17,7 +17,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "openvino-tokenizers";
-  version = "2026.2.0.0";
+  version = "2026.2.1.0";
 
   __structuredAttrs = true;
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
       owner = "openvinotoolkit";
       repo = "openvino_tokenizers";
       tag = finalAttrs.version;
-      hash = "sha256-J138ungdkkq1qa5/eEQTgKKtGyx9KHCrQwUsIGkf3mI=";
+      hash = "sha256-K0Zdo9er+s9/PWvBmVJTsWOSgzzZ5De7sRLMNEpxf/U=";
     };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/op/openvino/package.nix
+++ b/pkgs/by-name/op/openvino/package.nix
@@ -56,14 +56,14 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "openvino";
-  version = "2026.2.0";
+  version = "2026.2.1";
 
   src = fetchFromGitHub {
     owner = "openvinotoolkit";
     repo = "openvino";
     tag = finalAttrs.version;
     fetchSubmodules = true;
-    hash = "sha256-/JbaWeW4MgIylhEhA///febE9OCooONKgz1zTn0tb90=";
+    hash = "sha256-66g+v+L0BPNW6HvmWMHAHoNEFn9SUPrmZDyDjES6K1I=";
   };
 
   outputs = [


### PR DESCRIPTION
https://github.com/openvinotoolkit/openvino/releases/tag/2026.2.1  
https://github.com/openvinotoolkit/openvino.genai/releases/tag/2026.2.1.0  
https://github.com/openvinotoolkit/openvino_tokenizers/releases/tag/2026.2.1.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
