### PR TITLE
nixos/sabnzbd: offload config format to pkgs.formats.configobj

### DIFF
--- a/nixos/modules/services/networking/sabnzbd/default.nix
+++ b/nixos/modules/services/networking/sabnzbd/default.nix
@@ -29,71 +29,24 @@ let
 
   cfg = config.services.sabnzbd;
 
+  # Sabnzbd expects 0/1 instead of true/false
+  fixupSettings = lib.mapAttrsRecursive (
+    path: value:
+    if value == true then
+      1
+    else if value == false then
+      0
+    else
+      value
+  );
+
   mandatoryGlobalSettings = {
     "__version__" = 19;
     "__encoding__" = "utf-8";
   };
-  allSettings = mandatoryGlobalSettings // cfg.settings;
+  allSettings = fixupSettings (mandatoryGlobalSettings // cfg.settings);
 
-  # sabnzbd uses configobj type inis, which support
-  # nested sections specified by increasing numbers
-  # of square brackets (but not toml style dotted paths)
-  configObjAtom = types.oneOf [
-    types.str
-    types.int
-    types.bool
-  ];
-
-  configObjValue =
-    let
-      valueType =
-        types.oneOf [
-          types.str
-          types.int
-          types.bool
-          (types.listOf configObjAtom)
-          (types.attrsOf valueType)
-        ]
-        // {
-          description = "ConfigObj type";
-        };
-    in
-    valueType;
-
-  configObjIni =
-    { }:
-    let
-      extractAtoms = lib.filterAttrs (k: v: v != null && !lib.isAttrs v);
-      extractSections = lib.filterAttrs (k: v: lib.isAttrs v);
-      mkValueString = (
-        v:
-        if true == v then
-          "1"
-        else if false == v then
-          "0"
-        else
-          mkValueStringDefault { } v
-      );
-      mkKeyValue = mkKeyValueDefault { inherit mkValueString; } "=";
-      mkSection = (
-        depth: attrs:
-        let
-          sections = extractSections attrs;
-          sectionHeadingLeft = lib.concatStrings (lib.replicate (depth + 1) "[");
-          sectionHeadingRight = lib.concatStrings (lib.replicate (depth + 1) "]");
-          mkSectionHeading =
-            name: "${sectionHeadingLeft}${lib.escape [ "[" "]" ] name}${sectionHeadingRight}";
-          mkSubsection = name: attrs: (mkSectionHeading name) + "\n" + (mkSection (depth + 1) attrs) + "\n";
-        in
-        toKeyValue { inherit mkKeyValue; } (extractAtoms attrs)
-        + "\n"
-        + lib.concatStrings (lib.mapAttrsToList mkSubsection sections)
-      );
-    in
-    {
-      type = types.attrsOf configObjValue;
-      generate = name: attrs: pkgs.writeText name (mkSection 0 attrs);
-    };
+  configObjIni = pkgs.formats.configobj;
 
   publicSettingsIni =
     if cfg.configFile != null then


### PR DESCRIPTION
Now that #531952 is merged, we can stop handrolling our own configobj ini format.