### PR TITLE
leftwm-theme: unstable-2024-03-05 -> 0.1.3

### DIFF
--- a/pkgs/by-name/le/leftwm-theme/package.nix
+++ b/pkgs/by-name/le/leftwm-theme/package.nix
@@ -6,18 +6,18 @@
   pkg-config,
 }:
 
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "leftwm-theme";
-  version = "unstable-2024-03-05";
+  version = "0.1.3";
 
   src = fetchFromGitHub {
     owner = "leftwm";
     repo = "leftwm-theme";
-    rev = "b394824ff874b269a90c29e2d45b0cacc4d209f5";
-    hash = "sha256-cV4tY1qKNluSSGf+WwKFK3iVE7cMevafl6qQvhy1flE=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TPzmopH9RBM/BBrEL9/NWO3qjVa6SSWCp34tHxjLtBI=";
   };
 
-  cargoHash = "sha256-v3PHMaXJCEBiCd+78b/BXRooZC4Py82gDcvA/efNJ7w=";
+  cargoHash = "sha256-ZfNVpepTm6/JgJJB+qDVI2gVz36PRBpUL8/ba20xQhk=";
 
   checkFlags = [
     # direct writing /tmp
@@ -40,4 +40,4 @@ rustPlatform.buildRustPackage {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ denperidge ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/leftwm/leftwm-theme/compare/b394824ff874b269a90c29e2d45b0cacc4d209f5...v0.1.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
