### PR TITLE
neovim/wrapper: remove python3Env and rubyEnv from derivation attrs

### DIFF
--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -168,6 +168,13 @@ pkgs.lib.recurseIntoAttrs rec {
       "${./init-single-lines.vim}"
   '';
 
+  nvim_with_providers = neovim.override {
+    withPython3 = true;
+    withRuby = true;
+    withNodeJs = true;
+    withPerl = true;
+  };
+
   nvim_via_override = neovim.override {
     extraName = "-via-override";
     configure = {

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -206,7 +206,7 @@ let
           lib.concatStringsSep ";" [
             (genProviderCommand "node" finalAttrs.withNodeJs "${neovim-node-client}/bin/neovim-node-host")
             (genProviderCommand "perl" finalAttrs.withPerl "${perlEnv}/bin/perl")
-            (genProviderCommand "ruby" finalAttrs.withRuby "${finalAttrs.rubyEnv}/bin/neovim-ruby-host")
+            (genProviderCommand "ruby" finalAttrs.withRuby "${rubyEnv}/bin/neovim-ruby-host")
             (genProviderCommand "python3" finalAttrs.withPython3 "${hostPython3}/bin/nvim-python3")
           ];
 
@@ -265,7 +265,6 @@ let
           providerLuaRc
           packpathDirs
           ;
-        inherit python3Env rubyEnv;
         inherit wrapperArgs generatedWrapperArgs;
 
         runtimeDeps =


### PR DESCRIPTION
Remove python3Env and rubyEnv from derivation attrs. This prevents them from being built as dependencies of the wrapped neovim derivation even when withPython or withRuby are set to false.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
