### PR TITLE
python3Packages.exa-py: 2.13.1-unstable-2026-06-03 -> 2.14.0

### DIFF
--- a/pkgs/development/python-modules/exa-py/default.nix
+++ b/pkgs/development/python-modules/exa-py/default.nix
@@ -20,14 +20,11 @@
   pytest-cov-stub,
   pytest-mock,
   pytestCheckHook,
-
-  # passthru
-  unstableGitUpdater,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "exa-py";
-  version = "2.13.1-unstable-2026-06-03";
+  version = "2.14.0";
   pyproject = true;
   __structuredAttrs = true;
 
@@ -35,8 +32,8 @@ buildPythonPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "exa-labs";
     repo = "exa-py";
-    rev = "42fde906ecd069c15ad4888e1585b395a0db7edf";
-    hash = "sha256-6o4SKAeP5q+57LCbbw5vP7r/dEA1HiQNa9CkopbTlxg=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pL5d79KdKlfv4l/M7PF8fs0gUEk4DYEKPm8PJ+pwFMc=";
   };
 
   build-system = [
@@ -66,11 +63,10 @@ buildPythonPackage (finalAttrs: {
 
   pytestFlags = [ "tests/" ];
 
-  passthru.updateScript = unstableGitUpdater { };
-
   meta = {
     description = "Official Python SDK for Exa, the web search API for AI";
     homepage = "https://github.com/exa-labs/exa-py/";
+    changelog = "https://github.com/exa-labs/exa-py/releases/tag/v${finalAttrs.version}";
     maintainers = with lib.maintainers; [ ethancedwards8 ];
     license = lib.licenses.mit;
   };


### PR DESCRIPTION
This work is sponsored by exa.ai

Changelog: https://github.com/exa-labs/exa-py/releases/tag/v2.14.0

Only took some internal begging to get tags :)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
