### PR TITLE
tuxedo: 2026.6.2 -> 2026.6.3

### DIFF
--- a/pkgs/by-name/tu/tuxedo/package.nix
+++ b/pkgs/by-name/tu/tuxedo/package.nix
@@ -8,17 +8,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tuxedo";
-  version = "2026.6.2";
+  version = "2026.6.3";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "webstonehq";
     repo = "tuxedo";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-0ulyr7AbB6KZbAAvxc/s0NJTPBYS42UCbEXYREJTWMo=";
+    hash = "sha256-1uTa+S1bUyBsWy5FpmXFbggFc7lMbnDKul0h1O4NvMI=";
   };
 
-  cargoHash = "sha256-Sd3O/bw3/FZeas2eWAvSV3HWcDQg8Cla2hagWVYRKsc=";
+  cargoHash = "sha256-PIhtD0/0hxFOn51PwOWCtz82a2dvhS+2jbd8Wvr/JUM=";
 
   preCheck = ''
     export HOME="$TMPDIR/home"

--- a/pkgs/by-name/tu/tuxedo/package.nix
+++ b/pkgs/by-name/tu/tuxedo/package.nix
@@ -23,15 +23,17 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeCheckInputs = [ writableTmpDirAsHomeHook ];
 
-  passthru.updateScript = nix-update-script { };
-
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
+
+  __darwinAllowLocalNetworking = true;
 
   checkFlags = [
     # Failure
     "--skip=insert_dialog_after_nl_parse"
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "fast, keyboard-driven terminal UI for todo.txt";

--- a/pkgs/by-name/tu/tuxedo/package.nix
+++ b/pkgs/by-name/tu/tuxedo/package.nix
@@ -2,6 +2,7 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  writableTmpDirAsHomeHook,
   nix-update-script,
   versionCheckHook,
 }:
@@ -20,18 +21,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-PIhtD0/0hxFOn51PwOWCtz82a2dvhS+2jbd8Wvr/JUM=";
 
-  preCheck = ''
-    export HOME="$TMPDIR/home"
-    export XDG_CONFIG_HOME="$TMPDIR/config"
-    export XDG_CACHE_HOME="$TMPDIR/cache"
-    export XDG_STATE_HOME="$TMPDIR/state"
-
-    mkdir -p \
-      "$HOME" \
-      "$XDG_CONFIG_HOME" \
-      "$XDG_CACHE_HOME" \
-      "$XDG_STATE_HOME"
-  '';
+  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
 
   passthru.updateScript = nix-update-script { };
 
@@ -42,6 +32,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     # Failure
     "--skip=insert_dialog_after_nl_parse"
   ];
+
   meta = {
     description = "fast, keyboard-driven terminal UI for todo.txt";
     homepage = "https://github.com/webstonehq/tuxedo";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
