### PR TITLE
ungoogled-chromium: 149.0.7827.114-1 -> 149.0.7827.155-1

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -823,7 +823,7 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "149.0.7827.114",
+    "version": "149.0.7827.155",
     "deps": {
       "depot_tools": {
         "rev": "45dedc4c3b87c982fd846b3dc599b233ed3aff90",
@@ -835,16 +835,16 @@
         "hash": "sha256-oFs7fZAZEs/gQ7X1A4uigo9+Y+iEN9sMMQYwAjEuD04="
       },
       "ungoogled-patches": {
-        "rev": "149.0.7827.114-1",
-        "hash": "sha256-F0pIlZM/EBPLIZxD8jyLX7HWe0vFn2HXs2vkM5+Xplg="
+        "rev": "149.0.7827.155-1",
+        "hash": "sha256-+DviTrU7mdY3YQIIUzFh0DbFKUokQI8+lmQslUZdNSU="
       },
       "npmHash": "sha256-pF0JtwFpPC4/fodbhSJnQKkczA9WlDg4VqEAy9aDVLg="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "5be7af702aa73ed64f47858cecc86290e42f2a20",
-        "hash": "sha256-R2vnW3Wa+REar23OhyFWzOo44F8NN9IqH7GjWJ1g1lo=",
+        "rev": "07b52360cc15066f987c910ab34dfbcd4a8778d2",
+        "hash": "sha256-D9RKH0kzEfaMsCDnFFIGCGLyfhghnGMOLA0XmOa9MtI=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -914,8 +914,8 @@
       },
       "src/third_party/angle": {
         "url": "https://chromium.googlesource.com/angle/angle.git",
-        "rev": "4b8c7f0f321952bba4f81056b4aa57d0d6428642",
-        "hash": "sha256-ADG0WfkeFRq4NF0m+s3a/N5+u3q4ApExuWUnV3m5uAI="
+        "rev": "591ee1999d950f2bc54be89651eb62c8d7925314",
+        "hash": "sha256-crooDCkJ6voJyDBIUvtjmXnA4xOx7YmGltuf2ulTLIk="
       },
       "src/third_party/angle/third_party/glmark2/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glmark2/glmark2",
@@ -954,8 +954,8 @@
       },
       "src/third_party/dawn": {
         "url": "https://dawn.googlesource.com/dawn.git",
-        "rev": "c1179de12ec3ed8feb91e922f12a90ae33f4a8cf",
-        "hash": "sha256-VFEBqbSsn/3jqRGJgTM/r5DEtfhvTOIfS9fGIKzYo9I="
+        "rev": "5f4c5ef509c5ffa65822302341cf9b2ccad471f9",
+        "hash": "sha256-h+0Gep+RWTTEVoRrXCRDCtHdbYlSYdNK1botahtqUX0="
       },
       "src/third_party/dawn/third_party/glfw3/src": {
         "url": "https://chromium.googlesource.com/external/github.com/glfw/glfw",
@@ -1014,8 +1014,8 @@
       },
       "src/third_party/breakpad/breakpad": {
         "url": "https://chromium.googlesource.com/breakpad/breakpad.git",
-        "rev": "afa2870e449ef33ad41545e7670c574cf70926a4",
-        "hash": "sha256-+N6FPtSiLQmNqf5+x5XDSksrRq/YDVSMVx5Rv1PGjfI="
+        "rev": "8ef5673404a3bbc192b0997e1c2df559cc5bd79d",
+        "hash": "sha256-NplvLz9oET6mhTuBkHH6pZc8qdfhqI7g69eZRCyae0A="
       },
       "src/third_party/cast_core/public/src": {
         "url": "https://chromium.googlesource.com/cast_core/public",
@@ -1359,8 +1359,8 @@
       },
       "src/third_party/libvpx/source/libvpx": {
         "url": "https://chromium.googlesource.com/webm/libvpx.git",
-        "rev": "640d4ce27ba918783e28a0da46a8a37abe4a65b6",
-        "hash": "sha256-uCa/MEfw2s05kK91uubi/TqztHulwattzt1vfr0LR4E="
+        "rev": "d1268a5f3f3553ad7735911c614e8548381ca3cd",
+        "hash": "sha256-6IZTDhtjVWiqTv+jUC6Wr/tSqvql3thi9+mt+M3ixt4="
       },
       "src/third_party/libwebm/source": {
         "url": "https://chromium.googlesource.com/webm/libwebm.git",
@@ -1424,8 +1424,8 @@
       },
       "src/third_party/pdfium": {
         "url": "https://pdfium.googlesource.com/pdfium.git",
-        "rev": "74d747ce1d383caca3ec0e604d77bac35ccd1e58",
-        "hash": "sha256-qMY6L93hlnMgGZ5Blk5ldDnI/LUXYyuk+b7FXCiVV6s="
+        "rev": "be702d63baba7507bb1f6f6ff2d35be9c133c08c",
+        "hash": "sha256-hXqSJn1C0ISLWx68UicggiL8xzgQX2Y8l75vtpJgHeU="
       },
       "src/third_party/perfetto": {
         "url": "https://chromium.googlesource.com/external/github.com/google/perfetto.git",
@@ -1474,8 +1474,8 @@
       },
       "src/third_party/skia": {
         "url": "https://skia.googlesource.com/skia.git",
-        "rev": "92a56ebeef43061f4878aa869aa1f2160265c24c",
-        "hash": "sha256-QEY9Wy2guRuS4CXeXHUhUNigCJWWndnNCbWQmaSYJ/A="
+        "rev": "75c589e1f436688fca8f5b7f7a8affeafaa4f923",
+        "hash": "sha256-x0jEek7iJv7WBNdkOUPc5VvIYJw9QPzzTChFUofqErM="
       },
       "src/third_party/smhasher/src": {
         "url": "https://chromium.googlesource.com/external/smhasher.git",
@@ -1609,8 +1609,8 @@
       },
       "src/third_party/webrtc": {
         "url": "https://webrtc.googlesource.com/src.git",
-        "rev": "e8b4d4c5952a8fb7b35c2a6cba4e8c3de2ea2e1e",
-        "hash": "sha256-94U9URlFGLYe94KCFU0giY9bBbrHNDCBr9GEwbRbOK4="
+        "rev": "28311abc149a9bb7e6761a3d54f362a8d77e6793",
+        "hash": "sha256-WuaxKrbISJ1nwyoj2sPAhGCNz33xEYSX1WlDiM+zxpw="
       },
       "src/third_party/wuffs/src": {
         "url": "https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git",
@@ -1639,8 +1639,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "16ef80c1f5d3cfade812bd1743952a4cfd480a31",
-        "hash": "sha256-GI0NWA0XYGocxZp3+lPen6BkwaG7X3EDaEWM9rejgkI="
+        "rev": "6511f6cfab1f24c360d0fb737d205c27da48a623",
+        "hash": "sha256-Dpe0Z/zjdPlOlqi85c9QSr7rLs7dww+a/BY68B2MTCw="
       }
     }
   }


### PR DESCRIPTION
Same underlying changes as #532650

https://chromereleases.googleblog.com/2026/06/stable-channel-update-for-desktop_01750511403.html

This update includes 33 security fixes.

CVEs:
CVE-2026-12437 CVE-2026-12438 CVE-2026-12439 CVE-2026-12440
CVE-2026-12441 CVE-2026-12442 CVE-2026-12443 CVE-2026-12444
CVE-2026-12445 CVE-2026-12446 CVE-2026-12447 CVE-2026-12448
CVE-2026-12449 CVE-2026-12450 CVE-2026-12451 CVE-2026-12452
CVE-2026-12453 CVE-2026-12454 CVE-2026-12455 CVE-2026-12456
CVE-2026-12457 CVE-2026-12458 CVE-2026-12459 CVE-2026-12460
CVE-2026-12461 CVE-2026-12462 CVE-2026-12463 CVE-2026-12464
CVE-2026-12465 CVE-2026-12466 CVE-2026-12467 CVE-2026-12468
CVE-2026-12469

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
