### PR TITLE
nixos/nix-remote-build: permit non-integer speed factors

### DIFF
--- a/nixos/modules/config/nix-remote-build.nix
+++ b/nixos/modules/config/nix-remote-build.nix
@@ -159,12 +159,12 @@ in
                 '';
               };
               speedFactor = mkOption {
-                type = types.int;
+                type = types.numbers.positive;
                 default = 1;
                 description = ''
-                  The relative speed of this builder. This is an arbitrary integer
-                  that indicates the speed of this builder, relative to other
-                  builders. Higher is faster.
+                  The relative speed of this builder. This is an arbitrary
+                  positive number that indicates the speed of this builder,
+                  relative to other builders. Higher is faster.
                 '';
               };
               mandatoryFeatures = mkOption {

--- a/nixos/modules/config/nix-remote-build.nix
+++ b/nixos/modules/config/nix-remote-build.nix
@@ -159,12 +159,12 @@ in
                 '';
               };
               speedFactor = mkOption {
-                type = types.int;
+                type = types.numbers.nonnegative;
                 default = 1;
                 description = ''
-                  The relative speed of this builder. This is an arbitrary integer
-                  that indicates the speed of this builder, relative to other
-                  builders. Higher is faster.
+                  The relative speed of this builder. This is an arbitrary
+                  positive number that indicates the speed of this builder,
+                  relative to other builders. Higher is faster.
                 '';
               };
               mandatoryFeatures = mkOption {


### PR DESCRIPTION
Nix doesn't require the speed factor for a remote builder to be an
integer, so NixOS shouldn't either.

See also NixOS/nix#16034, which is the corresponding pull request for
Nix's own documentation.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
