### PR TITLE
kdePackages.kdenetwork-filesharing: fix recognizing smbd service

### DIFF
--- a/pkgs/kde/gear/kdenetwork-filesharing/default.nix
+++ b/pkgs/kde/gear/kdenetwork-filesharing/default.nix
@@ -17,6 +17,8 @@ mkKdeDerivation {
 
     # Provide a more NixOS specific Samba hint
     ./samba-hint.patch
+    # Add samba-smbd.service to systemd unit candidates
+    ./samba-service.patch
   ];
 
   extraBuildInputs = [

--- a/pkgs/kde/gear/kdenetwork-filesharing/samba-service.patch
+++ b/pkgs/kde/gear/kdenetwork-filesharing/samba-service.patch
@@ -1,0 +1,26 @@
+diff --git a/samba/filepropertiesplugin/kauth/authhelper.cpp b/samba/filepropertiesplugin/kauth/authhelper.cpp
+index 9192d51..10e4196 100644
+--- a/samba/filepropertiesplugin/kauth/authhelper.cpp
++++ b/samba/filepropertiesplugin/kauth/authhelper.cpp
+@@ -27,7 +27,7 @@ static QString findAvailableService()
+     // The smb service can be named "smbd.service" on some systems, e.g. Debian.
+     // Ensure the correct service name is used.
+     OrgFreedesktopSystemd1ManagerInterface manager(DBUS_SYSTEMD_SERVICE, DBUS_SYSTEMD_PATH, QDBusConnection::systemBus());
+-    auto candidates = {QStringLiteral("smb.service"), QStringLiteral("smbd.service")};
++    auto candidates = {QStringLiteral("smb.service"), QStringLiteral("smbd.service"), QStringLiteral("samba-smbd.service")};
+ 
+     for (const QString &candidate : candidates) {
+         // If this call doesn't return an error, it means the unit file exists, even if it's disabled.
+diff --git a/samba/filepropertiesplugin/servicehelper.cpp b/samba/filepropertiesplugin/servicehelper.cpp
+index d8ea4ea..8d50e67 100644
+--- a/samba/filepropertiesplugin/servicehelper.cpp
++++ b/samba/filepropertiesplugin/servicehelper.cpp
+@@ -33,7 +33,7 @@ QCoro::Task<QString> findAvailableService()
+     // The smb service can be named "smbd.service" on some systems, e.g. Debian.
+     // Ensure the correct service name is used.
+     OrgFreedesktopSystemd1ManagerInterface manager(DBUS_SYSTEMD_SERVICE, DBUS_SYSTEMD_PATH, QDBusConnection::systemBus());
+-    auto candidates = {QStringLiteral("smb.service"), QStringLiteral("smbd.service")};
++    auto candidates = {QStringLiteral("smb.service"), QStringLiteral("smbd.service"), QStringLiteral("samba-smbd.service")};
+ 
+     for (const QString &candidate : candidates) {
+         // If this call doesn't return an error, it means the unit file exists, even if it's disabled.


### PR DESCRIPTION
The kdenetwork-filesharing plugin fails to detect an available Samba service on NixOS because it only probes for standard systemd unit names like `smbd.service`.

This patch adds [`samba-smbd.service`](https://github.com/NixOS/nixpkgs/blob/2c26fd269b1bebf5c3f9e6277f682cf41808f3c0/nixos/modules/services/network-filesystems/samba.nix#L304) to the plugin's list of candidate unit names.

Fixes discourse issue: https://discourse.nixos.org/t/samba-dolphin-share-error/77571


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
