### PR TITLE
nixos/prometheus-exporters: add mastodon exporter

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -87,6 +87,7 @@ let
         "mail"
         "mailman3"
         "mail-tlsa-check"
+        "mastodon"
         "mikrotik"
         "modemmanager"
         "mongodb"

--- a/nixos/modules/services/monitoring/prometheus/exporters/mastodon.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/mastodon.nix
@@ -1,0 +1,65 @@
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.prometheus.exporters.mastodon;
+  package = config.services.mastodon.package;
+  inherit (lib)
+    mkOption
+    types
+    mkMerge
+    mkIf
+    ;
+in
+{
+  port = 9394;
+
+  extraOpts = {
+    prefix = mkOption {
+      type = types.str;
+      default = "mastodon_";
+      description = ''
+        The prefix for Mastodon metrics
+      '';
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = config.services.mastodon.user;
+      defaultText = "config.services.mastodon.user";
+      description = ''
+        Mastodon user
+      '';
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = config.services.mastodon.group;
+      defaultText = "config.services.mastodon.group";
+      description = ''
+        Mastodon group
+      '';
+    };
+  };
+
+  serviceOpts = mkMerge [
+    {
+      serviceConfig = {
+        ExecStart = ''
+          ${package}/bin/prometheus_exporter \
+            -p '${toString cfg.port}' \
+            -b '${cfg.listenAddress}' \
+            --prefix '${cfg.prefix}'
+        '';
+      };
+    }
+
+    (mkIf config.services.mastodon.enable {
+      after = [ "mastodon.target" ];
+      requires = [ "mastodon.target" ];
+    })
+  ];
+}

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -931,6 +931,26 @@ let
         '';
       };
 
+    mastodon = { ... }: {
+      exporterConfig = {
+        enable = true;
+      };
+      metricProvider = {
+        services.mastodon = {
+          enable = true;
+          localDomain = "example.org";
+          streamingProcesses = 2;
+          smtp.fromAddress = "from@example.org";
+          extraConfig.MASTODON_PROMETHEUS_EXPORTER_ENABLED = "true";
+        };
+      };
+      exporterTest = ''
+        wait_for_unit("prometheus-mastodon-exporter.service")
+        wait_for_open_port(9394)
+        wait_until_succeeds("curl -sSf http://localhost:9394/metrics | grep 'mastodon_collector_working 1'")
+      '';
+    };
+
     mikrotik =
       { ... }:
       {


### PR DESCRIPTION
Mastodon already comes with its own prometheus exporter


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
