### PR TITLE
i-dot-ming: fetch all fonts, fix update script, use installFonts

### DIFF
--- a/pkgs/by-name/i-/i-dot-ming/package.nix
+++ b/pkgs/by-name/i-/i-dot-ming/package.nix
@@ -1,47 +1,27 @@
 {
   lib,
   stdenvNoCC,
-  fetchurl,
-  writeScript,
+  fetchFromGitHub,
+  installFonts,
+  nix-update-script,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "i.ming";
   version = "8.10";
 
-  src = fetchurl {
-    url = "https://raw.githubusercontent.com/ichitenfont/I.Ming/${version}/${version}/I.Ming-${version}.ttf";
-    hash = "sha256-y6E7dbBQ1nG2EdAGMUcmLkIeFDWa1FMJSLBw9WER8PM=";
+  src = fetchFromGitHub {
+    owner = "ichitenfont";
+    repo = "I.Ming";
+    tag = finalAttrs.version;
+    hash = "sha256-TutIcX/DoeO5cwjD0o1IaXErStY73Cqk00NDKbXw39I=";
+    rootDir = finalAttrs.version;
   };
 
-  dontUnpack = true;
-
-  installPhase = ''
-    runHook preInstall
-
-    install -DT -m444 $src $out/share/fonts/truetype/I.Ming/I.Ming.ttf
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   passthru = {
-    updateScript = writeScript "updater" ''
-      #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl gnused
-      set -e
-      version=$(curl -i -s https://github.com/ichitenfont/I.Ming/releases/latest | sed -n -E 's|^location.*releases/tag/([0-9.]+).*$|\1|p')
-      if [[ $version != ${version} ]]; then
-        tmp=$(mktemp -d)
-        curl -Lo $tmp/I.Ming.ttf https://raw.githubusercontent.com/ichitenfont/I.Ming/$version/$version/I.Ming-$version.ttf
-        install -DT -m444 $tmp/I.Ming.ttf $tmp/share/fonts/truetype/I.Ming/I.Ming.ttf
-        rm $tmp/I.Ming.ttf
-        hash=$(nix --extra-experimental-features nix-command hash path --type sha256 --base32 --sri $tmp)
-        sed -i -E \
-          -e "s/version = \"[0-9.]+\"/version = \"$version\"/" \
-          -e "s|hash = \".*\"|hash = \"$hash\"|" \
-          pkgs/data/fonts/i-dot-ming/default.nix
-      fi
-    '';
+    updateScript = nix-update-script { };
   };
 
   meta = {
@@ -51,4 +31,4 @@ stdenvNoCC.mkDerivation rec {
     platforms = lib.platforms.all;
     maintainers = [ lib.maintainers.linsui ];
   };
-}
+})


### PR DESCRIPTION
Part of #495640
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
