### PR TITLE
keylights: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29882,6 +29882,11 @@
     githubId = 168610;
     name = "Ricardo M. Correia";
   };
+  wjohnsto = {
+    name = "Will Johnston";
+    github = "wjohnsto";
+    githubId = 785258;
+  };
   wkral = {
     email = "william.kral@gmail.com";
     github = "wkral";

--- a/pkgs/by-name/ke/keylights/package.nix
+++ b/pkgs/by-name/ke/keylights/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  fetchFromCodeberg,
+  installShellFiles,
+  rustPlatform,
+  stdenv,
+  testers,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "keylights";
+  version = "0.1.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "wjohnsto";
+    repo = "keylights";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-cl/IRkQMowrWOt0yLEFZC1J2MM6Fr68J6YaakUXwxTQ=";
+  };
+
+  cargoHash = "sha256-ns+EppqGP19P+xzevgZcovPKwYkMkWTcu5L0bovuQuk=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    keylightsBin="target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/keylights"
+
+    "$keylightsBin" completions bash > keylights.bash
+    "$keylightsBin" completions fish > keylights.fish
+    "$keylightsBin" completions zsh > _keylights
+
+    installShellCompletion --cmd keylights \
+      --bash keylights.bash \
+      --fish keylights.fish \
+      --zsh _keylights
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "keylights --version";
+  };
+
+  meta = {
+    description = "Daemonless CLI for discovering and controlling Elgato Key Light devices";
+    homepage = "https://codeberg.org/wjohnsto/keylights";
+    changelog = "https://codeberg.org/wjohnsto/keylights/releases/tag/v${finalAttrs.version}";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ wjohnsto ];
+    mainProgram = "keylights";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Add `keylights` at 0.1.0.

`keylights` is a daemonless, script-friendly Rust CLI for discovering, adopting, grouping, and controlling Elgato Key Light devices on a local network.

Homepage: https://codeberg.org/wjohnsto/keylights

Also add `wjohnsto` as a nixpkgs maintainer.

Automation disclosure: this PR was prepared with assistance from OpenAI gpt-5.5. I reviewed the changes and verified them locally.

## Things done

- Built on platform:
    - [x] x86_64-linux
    - [ ] aarch64-linux
    - [ ] x86_64-darwin
    - [ ] aarch64-darwin
- Tested, as applicable:
    - [ ] [NixOS tests] in [nixos/tests].
    - [x] [Package tests] at `passthru.tests`.
    - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
    - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
    - [ ] Module addition: when adding a new NixOS module.
    - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

Validation run:

```sh
nix-build -A keylights
nix-build -A keylights.tests.version
nix-build lib/tests/maintainers.nix
nix shell nixpkgs#nixfmt -c nixfmt --check pkgs/by-name/ke/keylights/package.nix maintainers/maintainer-list.nix
nix shell nixpkgs#nixpkgs-review -c nixpkgs-review rev HEAD --run 'keylights --version'
```

nixpkgs-review result:

```sh
1 package added:
keylights (init at 0.1.0)

1 package built:
keylights
```