### PR TITLE
lightworks: 2025.1 -> 2025.2

### DIFF
--- a/pkgs/by-name/li/lightworks/package.nix
+++ b/pkgs/by-name/li/lightworks/package.nix
@@ -27,6 +27,7 @@
   gmp,
   libdrm,
   libpulseaudio,
+  sndio,
 }:
 let
   fullPath = lib.makeLibraryPath [
@@ -53,18 +54,19 @@ let
     gmp
     libdrm
     libpulseaudio
+    sndio
   ];
 
   lightworks = stdenv.mkDerivation rec {
-    version = "2025.1";
-    rev = "148287";
+    version = "2025.2";
+    rev = "56356";
     pname = "lightworks";
 
     src =
       if stdenv.hostPlatform.system == "x86_64-linux" then
         fetchurl {
-          url = "https://cdn.lwks.com/releases/${version}/lightworks_${version}_r${rev}.deb";
-          sha256 = "sha256-opYbWzZYim5wqSaxDeGmc10XxFkkE521PDB8OULh7Jc=";
+          url = "https://cdn.lwks.com/releases/${version}/Lightworks-${version}-${rev}.deb";
+          sha256 = "sha256-MQsXl10I85qHiOosBEpdrLPq3iIiFlzumQv2R2sXNn8=";
         }
       else
         throw "${pname}-${version} is not supported on ${stdenv.hostPlatform.system}";
@@ -125,6 +127,7 @@ buildFHSEnv {
       antonxy
       vojta001
       kashw2
+      tombert
     ];
     platforms = [ "x86_64-linux" ];
   };


### PR DESCRIPTION
Bumped the version of Lightworks to the latest. 

Additionally added myself as a maintainer since I have been the one doing the last few updates. 



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
