### PR TITLE
atopile: 0.12.5 -> 0.15.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27476,6 +27476,12 @@
     githubId = 3512122;
     keys = [ { fingerprint = "5F29 132D EFA8 5DA0 B598  5BF2 5941 754C 1CDE 33BB"; } ];
   };
+  thecodedkid = {
+    email = "samuel.raumin@gmail.com";
+    github = "TheCodedKid";
+    githubId = 15819181;
+    name = "Samuel";
+  };
   TheColorman = {
     name = "colorman";
     email = "nixpkgs@colorman.me";

--- a/pkgs/development/python-modules/atopile-kicad-python/default.nix
+++ b/pkgs/development/python-modules/atopile-kicad-python/default.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  poetry-core,
+  protoletariat,
+  mypy-protobuf_3_6,
+  pkgs,
+  protobuf,
+  pynng,
+  pytestCheckHook,
+  gitMinimal,
+  pythonOlder,
+  typing-extensions,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "atopile-kicad-python";
+  version = "0.5.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "atopile";
+    repo = "kicad-python";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Qs0xnq+dcgm6U4i2vvyC05Am76/njwgk8P7zeXoawqg=";
+    fetchSubmodules = true;
+  };
+
+  build-system = [
+    poetry-core
+    protoletariat
+  ];
+
+  dependencies = [
+    protobuf
+    pynng
+  ]
+  ++ (lib.optional (pythonOlder "3.13") typing-extensions);
+
+  nativeBuildInputs = [
+    pkgs.protobuf
+    mypy-protobuf_3_6
+    gitMinimal
+  ];
+
+  pythonRelaxDeps = [ "protobuf" ];
+
+  # The repo declares itself as "kicad-python" 0.6.0.dev0; atopile only renames
+  # it to atopile-kicad-python ${finalAttrs.version} at PyPI publish time. Match
+  # that so dependents resolving "atopile-kicad-python" find it.
+  # Also fixes: FileExistsError: File already exists .../kipy/__init__.py
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'name = "kicad-python"' 'name = "atopile-kicad-python"' \
+      --replace-fail 'version = "0.6.0.dev0"' 'version = "${finalAttrs.version}"' \
+      --replace-fail 'script =' "#"
+  '';
+
+  preBuild = ''
+    python build.py
+  '';
+
+  pythonImportsCheck = [ "kipy" ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = {
+    description = "KiCad API Python Bindings (atopile fork)";
+    homepage = "https://github.com/atopile/kicad-python";
+    downloadPage = "https://github.com/atopile/kicad-python";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+  };
+})

--- a/pkgs/development/python-modules/atopile/default.nix
+++ b/pkgs/development/python-modules/atopile/default.nix
@@ -1,41 +1,52 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
-  fetchpatch,
+  fetchPypi,
 
   cmake,
   ninja,
+  zig_0_16,
   # build-system
   hatchling,
   scikit-build-core,
   hatch-vcs,
   nanobind,
   # deps
+  anthropic,
   antlr4-python3-runtime,
   atopile-easyeda2kicad,
+  atopile-kicad-python,
   black,
   case-converter,
   cookiecutter,
   dataclasses-json,
   deprecated,
+  fastapi,
   fastapi-github-oidc,
   freetype-py,
   gitpython,
-  kicad-python,
+  httpx,
+  jinja2,
+  keyring,
   kicadcliwrapper,
   matplotlib,
   mcp,
   more-itertools,
   natsort,
   numpy,
+  openai,
   ordered-set,
   pathvalidate,
   pint,
+  platformdirs,
   posthog,
+  prompt-toolkit,
   psutil,
+  pyaaf2,
   pydantic-settings,
   pygls,
+  pytest,
+  pyyaml,
   questionary,
   requests,
   rich,
@@ -46,35 +57,38 @@
   shapely,
   truststore,
   typer,
+  typing-extensions,
   urllib3,
+  uvicorn,
+  watchdog,
+  websockets,
   zstd,
   pythonOlder,
 
   # tests
-  pytestCheckHook,
-
-  pytest-benchmark,
-  pytest-timeout,
-  pytest-datafiles,
-  pytest-xdist,
-  hypothesis,
-  writableTmpDirAsHomeHook,
   versionCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "atopile";
-  version = "0.12.5";
+  version = "0.15.7";
   pyproject = true;
 
-  disabled = pythonOlder "3.13";
+  disabled = pythonOlder "3.14";
 
-  src = fetchFromGitHub {
-    owner = "atopile";
-    repo = "atopile";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-/1vkYGG3OHyeFpzbvRoAxUtLQLePKE2jwQx8o/CTErQ=";
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-HGYDkFm6Hic69pZTF+aEtJ0beeUyW4/QKcmtL+Q7O1U=";
   };
+
+  # Upstream pins a fork of scikit-build-core (editable-mode patch) we don't need.
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail \
+        'scikit-build-core @ git+https://github.com/atopile/scikit-build-core.git@feature/allow_editable' \
+        'scikit-build-core' \
+      --replace-fail '"ziglang==0.16.0",' ""
+  '';
 
   build-system = [
     hatchling
@@ -85,36 +99,59 @@ buildPythonPackage (finalAttrs: {
 
   dontUseCmakeConfigure = true; # skip cmake configure invocation
 
+  # The CMake build shells out to `python -m ziglang ...` (the ziglang pip
+  # wheel, not packaged in nixpkgs). Provide a shim module that execs the real
+  # zig, and give zig a writable cache dir.
+  preBuild = ''
+    mkdir -p zigshim/ziglang
+    touch zigshim/ziglang/__init__.py
+    printf 'import os, sys\nos.execv("%s/bin/zig", ["zig", *sys.argv[1:]])\n' "${zig_0_16}" > zigshim/ziglang/__main__.py
+    export PYTHONPATH="$PWD/zigshim:$PYTHONPATH"
+    export ZIG_GLOBAL_CACHE_DIR="$TMPDIR/zig-cache"
+  '';
+
   nativeBuildInputs = [
     cmake
     ninja
+    zig_0_16 # replaces the ziglang pip build-dep; build calls zig to compile faebryk core
   ];
 
   dependencies = [
+    anthropic
     antlr4-python3-runtime
     atopile-easyeda2kicad
+    atopile-kicad-python
     black # used as a dependency
     case-converter
     cookiecutter
     dataclasses-json
     deprecated
+    fastapi
     fastapi-github-oidc
     freetype-py
     gitpython
-    kicad-python
+    httpx
+    jinja2
+    keyring
     kicadcliwrapper
     matplotlib
     mcp
     more-itertools
     natsort
     numpy
+    openai
     ordered-set
     pathvalidate
     pint
+    platformdirs
     posthog
+    prompt-toolkit
     psutil
+    pyaaf2
     pydantic-settings
     pygls
+    pytest # imported at runtime
+    pyyaml
     questionary
     requests
     rich
@@ -125,121 +162,47 @@ buildPythonPackage (finalAttrs: {
     shapely
     truststore
     typer
+    typing-extensions
     urllib3
+    uvicorn
+    watchdog
+    websockets
     zstd
   ];
 
   pythonRelaxDeps = [
+    "atopile-easyeda2kicad" # nixpkgs has 0.9.7, atopile wants >=0.9.9
     "deprecated"
+    "more-itertools" # nixpkgs has 10.8.0, atopile wants >=11
     "posthog"
     "prompt-toolkit"
+    "ruff"
   ];
 
   pythonImportsCheck = [ "atopile" ];
 
+  # The 0.15 test suite was restructured (tests moved under src/, top-level
+  # test/ dir removed) and most of it needs network access (JLCPCB part picker),
+  # KiCad, and example builds that don't work in the sandbox. Rely on the import
+  # check and `ato --version` for smoke testing instead.
+  doCheck = false;
+
   nativeCheckInputs = [
-    writableTmpDirAsHomeHook
-    pytestCheckHook
-    pytest-xdist
-    pytest-benchmark
-    pytest-datafiles
-    pytest-timeout
-    hypothesis
     versionCheckHook
   ];
+  doInstallCheck = true;
   versionCheckProgramArg = "--version";
-
-  preCheck = ''
-    # do not report worker logs to filee
-    substituteInPlace test/conftest.py \
-      --replace-fail "worker_id =" "worker_id = None #"
-
-    # unrecognized flags
-    substituteInPlace pyproject.toml \
-      --replace-fail "--html=artifacts/test-report.html" "" \
-      --replace-fail "--self-contained-html" "" \
-      --replace-fail "--numprocesses=auto" "" \
-
-    # Replace this function call that cause test to hang
-    substituteInPlace            \
-      test/cli/test_packages.py  \
-      test/library/test_names.py \
-      test/test_examples.py      \
-      test/test_parse_utils.py   \
-        --replace-fail "_repo_root()" "Path('$(pwd)')"
-
-    # Fix crash due to empty list in fixture tests
-    substituteInPlace            \
-      test/test_examples.py      \
-      test/test_parse_utils.py   \
-        --replace-fail "p.stem" "p.stem if isinstance(p, Path) else p"
-  '';
-
-  disabledTestPaths = [
-    # timouts
-    "test/test_cli.py"
-    "test/cli/test_packages.py"
-    "test/end_to_end/test_net_naming.py"
-    "test/end_to_end/test_pcb_export.py"
-    "test/exporters/bom/test_bom.py"
-    "test/front_end/test_front_end_pick.py"
-    "test/libs/picker/test_pickers.py"
-  ];
-
-  disabledTests = [
-    # Timeout (>10.0s) from pytest-timeout.
-    "test_build_error_logging"
-    "test_can_evaluate_literals"
-    "test_examples_build"
-    "test_net_names_deterministic"
-    "test_performance_mifs_bus_params"
-    "test_regression_rp2040_usb_diffpair"
-    "test_reserved_attrs"
-    "test_resistor"
-    "test_loooooong_chain"
-    "test_parser_netlist"
-    "test_dump_load_equality"
-    "test_performance_mifs_connect_check"
-
-    # requires internet
-    "test_simple_pick"
-    "test_simple_negative_pick"
-    "test_jlcpcb_pick_resistor"
-    "test_jlcpcb_pick_capacitor"
-    "test_regression_rp2040_usb_diffpair_full"
-    "test_model_translations"
-
-    # FileNotFoundError: [Errno 2] No such file or directory: '/build/source/build/logs/latest'
-    "test_muster_diamond_dependencies"
-    "test_muster_disconnected_components"
-    "test_muster_register_decorator"
-    "test_muster_select_skips_targets_with_failed_dependencies"
-    "test_muster_select_skips_targets_with_partial_failed_dependencies"
-    "test_muster_select_yields_targets_with_all_successful_dependencies"
-    "test_muster_specific_targets_with_dependencies"
-  ];
-
-  disabledTestMarks = [
-    "slow"
-    "not_in_ci"
-    "regression"
-  ];
-
-  pytestFlags = [
-    "--timeout=10" # any test taking long, timouts with more than 60s
-    "--benchmark-disable"
-    "--tb=line"
-  ];
-
-  doCheck = true;
 
   meta = {
     description = "Design circuit boards with code";
     homepage = "https://atopile.io";
     downloadPage = "https://github.com/atopile/atopile";
-    changelog = "https://github.com/atopile/atopile/releases/tag/${finalAttrs.src.tag}";
+    changelog = "https://github.com/atopile/atopile/releases/tag/v${finalAttrs.version}";
     license = with lib.licenses; [ mit ];
-    maintainers = with lib.maintainers; [ sigmanificient ];
+    maintainers = with lib.maintainers; [
+      sigmanificient
+      thecodedkid
+    ];
     mainProgram = "ato";
   };
 })

--- a/pkgs/development/python-modules/pyaaf2/default.nix
+++ b/pkgs/development/python-modules/pyaaf2/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "pyaaf2";
+  version = "1.7.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-4Y5ahLyk6hjBueg4SVji9tKWGVyQGkSPcfgwsiuJwiU=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "aaf2" ];
+
+  # The test suite relies on sample .aaf files that are not distributed with
+  # the sdist on PyPI.
+  doCheck = false;
+
+  meta = {
+    description = "Module for reading and writing Advanced Authoring Format (AAF) files";
+    homepage = "https://github.com/markreidvfx/pyaaf2";
+    changelog = "https://github.com/markreidvfx/pyaaf2/releases/tag/${version}";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1210,6 +1210,8 @@ self: super: with self; {
 
   atopile-easyeda2kicad = callPackage ../development/python-modules/atopile-easyeda2kicad { };
 
+  atopile-kicad-python = callPackage ../development/python-modules/atopile-kicad-python { };
+
   atproto = callPackage ../development/python-modules/atproto { };
 
   atpublic = callPackage ../development/python-modules/atpublic { };
@@ -13542,6 +13544,8 @@ self: super: with self; {
   py65 = callPackage ../development/python-modules/py65 { };
 
   py7zr = callPackage ../development/python-modules/py7zr { };
+
+  pyaaf2 = callPackage ../development/python-modules/pyaaf2 { };
 
   pyabpoa = toPythonModule (
     pkgs.abpoa.override {


### PR DESCRIPTION
Updates atopile 0.12.5 -> 0.15.7. Also adds me (TheCodedKid) as maintainer.  

Switch src to fetchPypi: upstream stopped tagging GitHub releases at
  v0.14.3, and hatch-vcs needs the version baked in PKG-INFO.

  - needs Python 3.14; build under python314
  - compiles Zig now: add zig_0_16 + ziglang shim, un-pin scikit-build-core fork
  - init deps atopile-kicad-python (0.5.1) and pyaaf2 (1.7.1)
  - relax more-itertools and atopile-easyeda2kicad (nixpkgs versions lag)
  - doCheck off: 0.15 test suite restructured and needs network/KiCad

Ran nixpkgs-review on x86_64-linux: 5 packages built, 0 failed.
_Note_: atopile now requires Python 3.14, so it moves from python313Packages to python314Packages.

Assisted-by: Claude Code (Claude Opus 4.8)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
