### PR TITLE
ha-mcp: 7.7.0 -> 7.8.0; home-assistant-custom-components.ha_mcp_tools: inherit src & version from ha-mcp

### DIFF
--- a/pkgs/by-name/ha/ha-mcp/package.nix
+++ b/pkgs/by-name/ha/ha-mcp/package.nix
@@ -7,14 +7,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "ha-mcp";
-  version = "7.7.0";
+  version = "7.8.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "homeassistant-ai";
     repo = "ha-mcp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Gp4C3SRNkgv9GfLkVx/VCMp4/kCORHsp87IHcCaCPKk=";
+    hash = "sha256-+HhtHeSQlK1jd/4/x1d54Etvrs8e+pQkIGvJV39ZZBw=";
   };
 
   build-system = with python3Packages; [

--- a/pkgs/servers/home-assistant/custom-components/ha_mcp_tools/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/ha_mcp_tools/package.nix
@@ -1,22 +1,15 @@
 {
   lib,
   buildHomeAssistantComponent,
-  fetchFromGitHub,
+  ha-mcp,
   nix-update-script,
   ruamel-yaml,
 }:
 
 buildHomeAssistantComponent rec {
-  owner = "homeassistant-ai";
   domain = "ha_mcp_tools";
-  version = "7.7.0";
-
-  src = fetchFromGitHub {
-    owner = "homeassistant-ai";
-    repo = "ha-mcp";
-    tag = "v${version}";
-    hash = "sha256-Gp4C3SRNkgv9GfLkVx/VCMp4/kCORHsp87IHcCaCPKk=";
-  };
+  inherit (ha-mcp) version src;
+  inherit (ha-mcp.src) owner;
 
   dependencies = [
     ruamel-yaml


### PR DESCRIPTION
Diff: https://github.com/homeassistant-ai/ha-mcp/compare/v7.7.0...v7.8.0

Changelog: https://github.com/homeassistant-ai/ha-mcp/releases/tag/v7.8.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
