### PR TITLE
Revert "texlive: add historic TeX mirrors to mirrors.nix"

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -332,17 +332,6 @@
     "https://test.pypi.io/packages/source/"
   ];
 
-  # TeX historic archive (see https://tug.org/historic/)
-  texhistoric = [
-    "https://ftp.math.utah.edu/pub/tex/historic/"
-    "https://texlive.info/historic/"
-    "https://ftp.tu-chemnitz.de/pub/tug/historic/"
-    "https://pi.kwarc.info/historic/"
-    "https://mirrors.tuna.tsinghua.edu.cn/tex-historic-archive/"
-    "https://mirror.nju.edu.cn/tex-historic/"
-    "ftp://tug.org/texlive/historic/"
-  ];
-
   ### Linux distros
 
   # CentOS

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -143,7 +143,10 @@ let
   common = {
     # initial TeX Live 2025 release
     # src = fetchurl {
-    #   url = "mirror://texhistoric/systems/texlive/${year}/texlive-${year}0308-source.tar.xz";
+    #   urls = [
+    #     "http://ftp.math.utah.edu/pub/tex/historic/systems/texlive/${year}/texlive-${year}0308-source.tar.xz"
+    #     "ftp://tug.ctan.org/pub/tex/historic/systems/texlive/${year}/texlive-${year}0308-source.tar.xz"
+    #   ];
     #   hash = "sha256-//2xo9FDwXekOYoiKaQNaojxgJjl9tz9V2SMnyQXSQ8=";
     # };
 

--- a/pkgs/tools/typesetting/tex/texlive/default.nix
+++ b/pkgs/tools/typesetting/tex/texlive/default.nix
@@ -156,7 +156,8 @@ let
         [
           # tlnet-final snapshot; used when texlive.tlpdb is frozen
           # the TeX Live yearly freeze typically happens in mid-March
-          "mirror://texhistoric/systems/texlive/${toString version.texliveYear}/tlnet-final"
+          "http://ftp.math.utah.edu/pub/tex/historic/systems/texlive/${toString version.texliveYear}/tlnet-final"
+          "ftp://tug.org/texlive/historic/${toString version.texliveYear}/tlnet-final"
         ]
       else
         [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#518480

Touching the mirror list for fetchurl causes a world rebuild.

```
$ git checkout 77456b834919be3e6e8ed00bd26eebd32046dc8e
$ nix-instantiate -A hello
/nix/store/rkpd5n618zqd8q5f4d0qxgjr64i4z586-hello-2.12.3.drv
$ git checkout HEAD~1
$ nix-instantiate -A hello
/nix/store/rd86bi6mw84brmj6yxdf4ihd1x7qhri6-hello-2.12.3.drv
```