### PR TITLE
pfixtools: pcre -> pcre2

### DIFF
--- a/pkgs/by-name/pf/pfixtools/0002-libcommon-pcre2.patch
+++ b/pkgs/by-name/pf/pfixtools/0002-libcommon-pcre2.patch
@@ -1,0 +1,82 @@
+diff --git a/regexp.c b/regexp.c
+index f9b4e55..cbe17d5 100644
+--- a/common/regexp.c
++++ b/common/regexp.c
+@@ -42,8 +42,8 @@ regexp_t *regexp_new(void)
+ 
+ void regexp_wipe(regexp_t *re)
+ {
+-    pcre_free(re->re);
+-    pcre_free(re->extra);
++    pcre2_code_free(re->re);
++    re->re = NULL;
+ }
+ 
+ void regexp_delete(regexp_t **re)
+@@ -56,21 +56,20 @@ void regexp_delete(regexp_t **re)
+ 
+ bool regexp_compile(regexp_t *re, const char *str, bool cs)
+ {
+-    const char *error = NULL;
+-    int erroffset = 0;
++    int errcode = 0;
++    PCRE2_SIZE erroffset = 0;
++    PCRE2_UCHAR errbuf[256];
+ 
+-    int flags = (cs ? 0 : PCRE_CASELESS);
++    uint32_t flags = (cs ? 0 : PCRE2_CASELESS);
+ 
+     debug("compiling regexp: %s", str);
+-    re->re = pcre_compile(str, flags, &error, &erroffset, NULL);
++    re->re = pcre2_compile((PCRE2_SPTR)str, PCRE2_ZERO_TERMINATED,
++                           flags, &errcode, &erroffset, NULL);
+     if (re->re == NULL) {
+-        err("cannot compile regexp: %s (at %d)", error, erroffset);
++        pcre2_get_error_message(errcode, errbuf, sizeof(errbuf));
++        err("cannot compile regexp: %s (at %zu)", errbuf, erroffset);
+         return false;
+     }
+-    re->extra = pcre_study(re->re, 0, &error);
+-    if (re->extra == NULL && error != NULL) {
+-        warn("regexp inspection failed: %s", error);
+-    }
+     return true;
+ }
+ 
+@@ -89,8 +88,12 @@ bool regexp_compile_str(regexp_t *re, const clstr_t *str, bool cs)
+ 
+ bool regexp_match_str(const regexp_t *re, const clstr_t *str)
+ {
+-    return 0 == pcre_exec(re->re, re->extra, str->str, str->len,
+-                          0, 0, NULL, 0);
++    pcre2_match_data *md =
++        pcre2_match_data_create_from_pattern(re->re, NULL);
++    int rc = pcre2_match(re->re, (PCRE2_SPTR)str->str, str->len,
++                         0, 0, md, NULL);
++    pcre2_match_data_free(md);
++    return rc >= 0;
+ }
+ 
+ bool regexp_match(const regexp_t *re, const char *str)
+diff --git a/regexp.h b/regexp.h
+index 488f38b..2f49ab5 100644
+--- a/common/regexp.h
++++ b/common/regexp.h
+@@ -36,14 +36,14 @@
+ #ifndef PFIXTOOLS_REGEXP_H
+ #define PFIXTOOLS_REGEXP_H
+ 
+-#include <pcre.h>
++#define PCRE2_CODE_UNIT_WIDTH 8
++#include <pcre2.h>
+ #include "str.h"
+ #include "array.h"
+ #include "buffer.h"
+ 
+ struct regexp_t {
+-    pcre *re;
+-    pcre_extra *extra;
++    pcre2_code *re;
+ };
+ 
+ typedef struct regexp_t regexp_t;

--- a/pkgs/by-name/pf/pfixtools/0003-pfixtools-pcre2.patch
+++ b/pkgs/by-name/pf/pfixtools/0003-pfixtools-pcre2.patch
@@ -1,0 +1,26 @@
+diff --git a/postlicyd/Makefile b/postlicyd/Makefile
+index 4f9f87e..5843bac 100644
+--- a/postlicyd/Makefile
++++ b/postlicyd/Makefile
+@@ -55,7 +55,7 @@ libpostlicyd_SOURCES = filter.c config.c query.c resources.c db.c dns.c \
+ 					   spf-proto.c $(FILTERS) $(GENERATED)
+ 
+ postlicyd_SOURCES = main-postlicyd.c libpostlicyd.a ../common/lib.a
+-postlicyd_LIBADD  = $(TC_LIBS) -lev -lpcre -lunbound -lsrs2
++postlicyd_LIBADD  = $(TC_LIBS) -lev -lpcre2-8 -lunbound -lsrs2
+ 
+ all:
+ 
+diff --git a/tests/Makefile b/tests/Makefile
+index ba734fb..12e9d93 100644
+--- a/tests/Makefile
++++ b/tests/Makefile
+@@ -36,7 +36,7 @@
+ include ../common/mk/tc.mk
+ 
+ TESTS = trie regexp spf rbl filters greylist qf
+-TESTLIBS=$(TC_LIBS) -lunbound -lev -lpcre -lsrs2
++TESTLIBS=$(TC_LIBS) -lunbound -lev -lpcre2-8 -lsrs2
+ 
+ all:
+ 

--- a/pkgs/by-name/pf/pfixtools/package.nix
+++ b/pkgs/by-name/pf/pfixtools/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   git,
   gperf,
-  pcre,
+  pcre2,
   unbound,
   libev,
   tokyocabinet,
@@ -40,13 +40,17 @@ stdenv.mkDerivation {
 
   src = pfixtoolsSrc;
 
-  patches = [ ./0001-Fix-build-with-unbound-1.6.1.patch ];
+  patches = [
+    ./0001-Fix-build-with-unbound-1.6.1.patch
+    ./0002-libcommon-pcre2.patch
+    ./0003-pfixtools-pcre2.patch
+  ];
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     git
     gperf
-    pcre
+    pcre2
     unbound
     libev
     tokyocabinet

--- a/pkgs/by-name/pf/pfixtools/package.nix
+++ b/pkgs/by-name/pf/pfixtools/package.nix
@@ -61,10 +61,10 @@ stdenv.mkDerivation {
 
   postPatch = ''
     substituteInPlace postlicyd/policy_tokens.sh \
-                      --replace /bin/bash ${bash}/bin/bash;
+                      --replace-fail /bin/bash ${bash}/bin/bash;
 
     substituteInPlace postlicyd/*_tokens.sh \
-      --replace "unsigned int" "size_t"
+      --replace-fail "unsigned int" "size_t"
   '';
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error=unused-result -Wno-error=nonnull-compare -Wno-error=format-truncation";
@@ -73,6 +73,21 @@ stdenv.mkDerivation {
     "DESTDIR=$(out)"
     "prefix="
   ];
+
+  doCheck = true;
+  checkPhase = ''
+    (
+      cd tests;
+      for t in tst-*; do
+        if [ "$t" == "tst-spf" ]; then
+          echo skipping $t due to known glibc malloc assertion error
+        else
+          echo running test $t;
+          ./$t;
+        fi
+      done
+    )
+  '';
 
   meta = {
     description = "Collection of postfix-related tools";


### PR DESCRIPTION
#356387

these patches were constructed by Claude from the following prompts:

> Can you scope out what would be involved in migrating
  https://github.com/Fruneau/pfixtools and
  https://github.com/Fruneau/libcommon to use pcre2?

> tell me more about the code unit width definition.

> okay, that makes sense.  please prepare a patch against libcommon
  that carries out this migration.

> please prepare a patch for the pfixtools repo as well.

the key bit of explanation from the 2nd prompt was:

> For this codebase, 8 is the only sensible choice. The strings being
  matched are email addresses and SMTP protocol data — plain
  ASCII/UTF-8 byte strings, exactly what PCRE1 was already treating
  them as.

the changes look plausible to me, but I have not done any real C programming since college 25+ years ago.  link to full chat session: https://claude.ai/share/9ec35d1c-e9fe-442a-ab33-3ecf4468c015

no attempt is being made to upstream these changes, as neither repo has seen any activity in 10 years.

Assisted-by: Claude:claude-4.6-sonnet

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
