### PR TITLE
yacreader: use libarchive decompression backend for RAR5 support

### DIFF
--- a/pkgs/by-name/ya/yacreader/package.nix
+++ b/pkgs/by-name/ya/yacreader/package.nix
@@ -6,6 +6,7 @@
   pkg-config,
   ctestCheckHook,
   libGLU,
+  libarchive,
   libunarr,
   expat,
   libdeflate,
@@ -19,6 +20,12 @@
 }:
 let
   qtPackages = qt6Packages;
+
+  # libarchive reads RAR5 under a free license and already ships in nixpkgs core,
+  # so it is the Linux backend; it is Linux-only upstream, so Darwin keeps unarr.
+  # (YACReader's 7zip backend also reads RAR5, but only via a runtime 7z.so built
+  #  with the unfree unRAR codec, which would make this package unfree.)
+  useLibarchive = stdenv.hostPlatform.isLinux;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "yacreader";
@@ -50,10 +57,9 @@ stdenv.mkDerivation (finalAttrs: {
   __structuredAttrs = true;
 
   cmakeFlags = [
-    # force unarr backend on all platforms
     (lib.cmakeBool "BUILD_SERVER_STANDALONE" onlyServer)
     (lib.cmakeFeature "PDF_BACKEND" "poppler")
-    (lib.cmakeFeature "DECOMPRESSION_BACKEND" "unarr")
+    (lib.cmakeFeature "DECOMPRESSION_BACKEND" (if useLibarchive then "libarchive" else "unarr"))
   ];
 
   nativeBuildInputs = [
@@ -64,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     libGLU
-    libunarr
+    (if useLibarchive then libarchive else libunarr)
     expat
     libdeflate
     lerc


### PR DESCRIPTION
The yacreader derivation forces DECOMPRESSION_BACKEND=unarr on all platforms. libunarr 1.1.x does not support RAR5, so RAR5-compressed .cbr archives fail to open.
YACReader 10.0.0 supports a libarchive backend, and nixpkgs already provides libarchive with RAR5 read support compiled into core. Upstream restricts the libarchive backend to Linux, so Darwin should retain unarr.

Flathub made a similar change when upgrading yacreader:
https://github.com/flathub/com.yacreader.YACReader/pull/21

Using libunarr creates a lot of complaints for Linux users of YACReader, for example see this Reddit thread where someone mentions the issue to the lead developer of YACReader:
https://www.reddit.com/r/comicbooks/comments/1t0yp4e/comment/ojezxms/

AI disclosure:
I prepared these changes and this PR description with help from Claude Opus 4.8

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
