### PR TITLE
patchance: Fix startup failure

### DIFF
--- a/pkgs/by-name/pa/patchance/package.nix
+++ b/pkgs/by-name/pa/patchance/package.nix
@@ -53,6 +53,12 @@ python3Packages.buildPythonApplication (finalAttrs: {
     done
   '';
 
+  postPatch = ''
+    # Fix startup with Python 3.13: cgitb was removed and this import is unused.
+    substituteInPlace src/patchbay/patchcanvas/portgroup_widget.py \
+      --replace-fail 'from cgitb import text' ""
+  '';
+
   meta = {
     homepage = "https://github.com/Houston4444/Patchance";
     description = "JACK Patchbay GUI";


### PR DESCRIPTION
`cgitb` was removed since Python 3.13. Patchance was broken in `nixos-25.05` and also broken in `nixos-26.11`. It fails to start with

> ModuleNotFoundError: No module named 'cgitb'

That `cgitb` import is unused anyway. Just adding a patch removing it.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test