### PR TITLE
lan-mouse: 0.10.0 -> 0.11.0

### DIFF
--- a/pkgs/by-name/la/lan-mouse/package.nix
+++ b/pkgs/by-name/la/lan-mouse/package.nix
@@ -14,24 +14,13 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "lan-mouse";
-  version = "0.10.0";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
     owner = "feschber";
     repo = "lan-mouse";
     rev = "v${version}";
-    hash = "sha256-ofiNgJbmf35pfRvZB3ZmMkCJuM7yYgNL+Dd5mZZqyNk=";
-  };
-
-  # lan-mouse uses `git` to determine the version at build time and
-  # has Cargo set the `GIT_DESCRIBE` environment variable. To improve
-  # build reproducibility, we define the variable based on the package
-  # version instead.
-  prePatch = ''
-    rm build.rs
-  '';
-  env = {
-    GIT_DESCRIBE = "${version}-nixpkgs";
+    hash = "sha256-6EqA9WfiukOymUT4FkNdMvzmFKByW0LLoI/9sv4TzBU=";
   };
 
   nativeBuildInputs = [
@@ -47,7 +36,7 @@ rustPlatform.buildRustPackage rec {
     libxtst
   ];
 
-  cargoHash = "sha256-+UXRBYfbkb114mwDGj36oG5ZT3TQtcEzsbyZvtWTMxM=";
+  cargoHash = "sha256-Lxs0qWvNAv4KCeJ+cDBYBzwlbJfQJshcxPRdg9w0szc=";
 
   postInstall = ''
     install -Dm444 de.feschber.LanMouse.desktop -t $out/share/applications


### PR DESCRIPTION
Changelist: https://github.com/feschber/lan-mouse/releases/tag/v0.11.0

The git build dependency was removed here: https://github.com/feschber/lan-mouse/pull/255 and no longer uses `GIT_DESCRIBE`.

`lan-mouse --version` now reports:

```
lan-mouse 0.11.0
branch:
commit_hash:
build_time:1980-01-01 00:00:00 +00:00
build_env:rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball),
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
