### PR TITLE
ceph: enable tests

### DIFF
--- a/pkgs/by-name/ce/ceph/ceph.nix
+++ b/pkgs/by-name/ce/ceph/ceph.nix
@@ -94,6 +94,11 @@
   libxfs,
   liburing,
   withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
+
+  # Test Dependencies
+  net-tools,
+
+  enableTests ? true,
 }:
 
 # We must have one crypto library
@@ -306,7 +311,7 @@ stdenv.mkDerivation {
     # So it's probably not worth trying to fix that for this Ceph version,
     # and instead just disable Ceph's Jaeger support.
     (lib.cmakeBool "WITH_JAEGER" false)
-    (lib.cmakeBool "WITH_TESTS" false)
+    (lib.cmakeBool "WITH_TESTS" enableTests)
 
     # Use our own libraries, where possible
     (lib.cmakeBool "WITH_SYSTEM_ARROW" true) # Only used if other options enable Arrow support.
@@ -379,7 +384,20 @@ stdenv.mkDerivation {
     "man"
   ];
 
-  doCheck = false; # uses pip to install things from the internet
+  nativeCheckInputs = [
+    net-tools # for unittest_hostname
+  ];
+
+  doCheck = enableTests;
+
+  # The CMake setup hook enables parallel building at runtime, but it does not
+  # enable parallel *checking*. Without this, the generic `checkPhase` runs
+  # `make check` without `-j`, and since Ceph's `check` target first builds the
+  # `tests` target (compiling every test executable), the test compilation ends
+  # up single-threaded. Setting this at the Nix level ensures `enableParallelChecking`
+  # is exported (see pkgs/stdenv/generic/make-derivation.nix), so `checkPhase`
+  # compiles the tests with `-j$NIX_BUILD_CORES`.
+  enableParallelBuilding = true;
 
   # Takes 7+h to build with 2 cores.
   requiredSystemFeatures = [ "big-parallel" ];

--- a/pkgs/by-name/ce/ceph/patches/skip-unsandboxable-tests.patch
+++ b/pkgs/by-name/ce/ceph/patches/skip-unsandboxable-tests.patch
@@ -1,0 +1,39 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 46a0efc680d..28076431d58 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -860,9 +860,18 @@ add_custom_target(tests
+   COMMENT "Building tests")
+ enable_testing()
+ set(CMAKE_CTEST_COMMAND ctest)
++# The following tests cannot run in a network- and privilege-isolated build
++# sandbox (e.g. nix): the run-tox-*/*-venv-for-* and run-cli-tests targets need
++# to pip-install from PyPI / clone from GitHub; unittest_mon_monmap performs DNS
++# resolution; and unittest_rgw_posix_driver requires user extended attributes on
++# the filesystem. Exclude them by name so `make check` stays green in the sandbox.
++# VERBATIM is required so the '|' regex characters are passed to ctest as a
++# single argument rather than being interpreted as shell pipes.
+ add_custom_target(check
+-  COMMAND ${CMAKE_CTEST_COMMAND}
+-  DEPENDS tests)
++  COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
++    -E "run-tox-|-venv-for-|run-cli-tests|unittest_mon_monmap|unittest_rgw_posix_driver"
++  DEPENDS tests
++  VERBATIM)
+ 
+ option(WITH_SYSTEMD "build with systemd support" ON)
+ 
+diff --git a/src/test/run-rbd-unit-tests.sh b/src/test/run-rbd-unit-tests.sh
+index af33e058347..8840fd56e66 100755
+--- a/src/test/run-rbd-unit-tests.sh
++++ b/src/test/run-rbd-unit-tests.sh
+@@ -14,6 +14,9 @@ GTEST_FILTER+=":TestLibRBD.QuiesceWatchError"
+ GTEST_FILTER+=":TestLibRBD.ConcurrentOperations"
+ # https://tracker.ceph.com/issues/70847
+ GTEST_FILTER+=":TestMigration.Stress*"
++# requires a working DNS resolver (expects EAI_NONAME); fails in network-isolated
++# build sandboxes (e.g. nix) where resolution yields EAI_AGAIN instead
++GTEST_FILTER+=":TestMockMigrationHttpClient.OpenResolveFail"
+ 
+ # exclude tests that are prone to sporadic failures
+ export GTEST_FILTER

--- a/pkgs/by-name/ce/ceph/src.nix
+++ b/pkgs/by-name/ce/ceph/src.nix
@@ -26,5 +26,6 @@ applyPatches (final: {
     # fixes issues when python3 is not on the PATH
     # See: https://github.com/ceph/ceph/pull/67904
     ./patches/0001-mgr-python-interpreter.patch
+    ./patches/skip-unsandboxable-tests.patch
   ];
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Turn on Ceph tests except the Python ones and the ones that don't work in the sandbox.

Pending https://github.com/ceph/ceph/pull/69560

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
