### PR TITLE
lore, nixos/loreserver, nixosTests.loreserver: init at 0.8.4

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -30,6 +30,8 @@
 
 - [Matrix Authentication Service](https://github.com/element-hq/matrix-authentication-service) is an OAuth2.0 and OpenID Connect provider for Matrix homeservers (such as Synapse). It replaces standard password authentication with modern OpenID Connect flows, and can delegate authentication to upstream OIDC providers. Available as [services.matrix-authentication-service](#opt-services.matrix-authentication-service.enable).
 
+- [Lore](https://lore.org/), open source version control system for projects combining code with large binary assets. Available as [services.loreserver](#opt-services.loreserver.enable).
+
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1282,6 +1282,7 @@
   ./services/networking/lldpd.nix
   ./services/networking/logmein-hamachi.nix
   ./services/networking/lokinet.nix
+  ./services/networking/loreserver.nix
   ./services/networking/lxd-image-server.nix
   ./services/networking/magic-wormhole-mailbox-server.nix
   ./services/networking/matterbridge.nix

--- a/nixos/modules/services/networking/loreserver.nix
+++ b/nixos/modules/services/networking/loreserver.nix
@@ -1,0 +1,245 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.loreserver;
+
+  tomlFormat = pkgs.formats.toml { };
+
+  stateDir = "/var/lib/${cfg.stateDirectoryName}";
+  certDir = "${stateDir}/certs";
+  storeDir = "${stateDir}/store";
+
+  userCert = (cfg.settings.server.quic.certificate or null) != null;
+
+  managedDefaults = {
+    immutable_store.local.path = storeDir;
+    mutable_store.local.path = storeDir;
+  }
+  // lib.optionalAttrs (cfg.generateSelfSignedCert && !userCert) {
+    server.quic.certificate = {
+      cert_file = "${certDir}/cert.pem";
+      pkey_file = "${certDir}/key.pem";
+    };
+  };
+
+  mergedSettings = lib.recursiveUpdate managedDefaults cfg.settings;
+
+  configDir = pkgs.runCommand "loreserver-config" { } ''
+    mkdir -p "$out"
+    cp ${tomlFormat.generate "local.toml" mergedSettings} "$out/local.toml"
+  '';
+
+  quicPort = mergedSettings.server.quic.port or 41337;
+  grpcPort = mergedSettings.server.grpc.port or 41337;
+  httpPort = mergedSettings.server.http.port or 41339;
+
+  quicInternalEnabled = mergedSettings.server.quic_internal.enabled or false;
+  quicInternalPort = mergedSettings.server.quic_internal.port or 41340;
+  replicationEnabled = mergedSettings.server.replication.enabled or false;
+  replicationPort = mergedSettings.server.replication.port or 41340;
+in
+{
+  options.services.loreserver = {
+    enable = lib.mkEnableOption "the Lore version control server";
+
+    package = lib.mkPackageOption pkgs "lore" { };
+
+    environment = lib.mkOption {
+      type = lib.types.str;
+      default = "local";
+      description = ''
+        Environment name passed as `--env`. Selects which `<environment>.toml`
+        overlay the server layers over its built-in defaults. The module always
+        writes its configuration to `local.toml`, which is applied last
+        regardless of this value.
+      '';
+    };
+
+    settings = lib.mkOption {
+      type = tomlFormat.type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          server.http.port = 41339;
+          server.quic.idle_timeout = 60000;
+          telemetry.logger.format = "text";
+        }
+      '';
+      description = ''
+        Free-form configuration rendered to the server's `local.toml`. See the
+        [Lore Server configuration reference](https://epicgames.github.io/lore/reference/lore-server-config/).
+      '';
+    };
+
+    generateSelfSignedCert = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Generate and maintain a stable self-signed certificate for the public
+        QUIC endpoint, if a certificate is not supplied under settings. This
+        will be stored in the state directory.
+      '';
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "loreserver";
+      description = "User account under which loreserver runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "loreserver";
+      description = "Group under which loreserver runs.";
+    };
+
+    stateDirectoryName = lib.mkOption {
+      type = lib.types.str;
+      default = "loreserver";
+      description = ''
+        Name of the systemd `StateDirectory` (under `/var/lib`) that holds the
+        stores and the module-managed certificate.
+      '';
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Open the firewall for the server's listening ports: TCP for gRPC and
+        HTTP, UDP for QUIC.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.user == "loreserver" || config.users.users ? ${cfg.user};
+        message = ''
+          services.loreserver.user is set to "${cfg.user}", which does not
+          exist. Define it in users.users (or unset this option).
+        '';
+      }
+      {
+        assertion = cfg.group == "loreserver" || config.users.groups ? ${cfg.group};
+        message = ''
+          services.loreserver.group is set to "${cfg.group}", which does not
+          exist. Define it in users.groups (or unset this option).
+        '';
+      }
+    ];
+
+    users.users = lib.mkIf (cfg.user == "loreserver") {
+      loreserver = {
+        isSystemUser = true;
+        group = cfg.group;
+        home = stateDir;
+        description = "Lore version control server";
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == "loreserver") {
+      loreserver = { };
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = lib.unique (
+        [
+          grpcPort
+          httpPort
+        ]
+        ++ lib.optional replicationEnabled replicationPort
+      );
+      allowedUDPPorts = lib.unique ([ quicPort ] ++ lib.optional quicInternalEnabled quicInternalPort);
+    };
+
+    systemd.services.loreserver = {
+      description = "Lore version control server";
+      documentation = [ "https://epicgames.github.io/lore/" ];
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      # openssl is needed only for the optional self-signed certificate.
+      path = lib.optional (cfg.generateSelfSignedCert && !userCert) pkgs.openssl;
+
+      preStart = ''
+        # Ensure the store directory exists.
+        mkdir -p "${storeDir}"
+      ''
+      + lib.optionalString (cfg.generateSelfSignedCert && !userCert) ''
+        if [ ! -s "${certDir}/cert.pem" ] || [ ! -s "${certDir}/key.pem" ]; then
+          mkdir -p "${certDir}"
+          openssl req -x509 -newkey rsa:2048 -nodes \
+            -keyout "${certDir}/key.pem" \
+            -out "${certDir}/cert.pem" \
+            -days 3650 -subj "/CN=localhost" \
+            -addext "subjectAltName=IP:127.0.0.1,IP:::1,DNS:localhost"
+          chmod 600 "${certDir}/key.pem"
+        fi
+      '';
+
+      serviceConfig = {
+        ExecStart = lib.escapeShellArgs [
+          (lib.getExe' cfg.package "loreserver")
+          "--config"
+          "${configDir}"
+          "--env"
+          cfg.environment
+        ];
+
+        User = cfg.user;
+        Group = cfg.group;
+
+        StateDirectory = cfg.stateDirectoryName;
+        StateDirectoryMode = "0750";
+        WorkingDirectory = stateDir;
+
+        Restart = "on-failure";
+        RestartSec = 5;
+        TimeoutStopSec = 45;
+
+        DynamicUser = false;
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        ProtectClock = true;
+        ProtectHostname = true;
+        ProtectProc = "invisible";
+        ProcSubset = "pid";
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        RemoveIPC = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged @resources"
+        ];
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        CapabilityBoundingSet = [ "" ];
+        AmbientCapabilities = [ "" ];
+        UMask = "0077";
+      };
+    };
+  };
+
+  meta.maintainers = [ lib.maintainers.jchw ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -970,6 +970,7 @@ in
   lomiri-mediaplayer-app = runTest ./lomiri-mediaplayer-app.nix;
   lomiri-music-app = runTest ./lomiri-music-app.nix;
   lomiri-system-settings = runTest ./lomiri-system-settings.nix;
+  loreserver = runTest ./loreserver.nix;
   lorri = handleTest ./lorri/default.nix { };
   luks = runTest ./luks.nix;
   lvm2 = import ./lvm2 { inherit pkgs runTest; };

--- a/nixos/tests/loreserver.nix
+++ b/nixos/tests/loreserver.nix
@@ -1,0 +1,238 @@
+{ pkgs, lib, ... }:
+
+let
+  # Quick'n'dirty CA just for testing purposes.
+  testCerts =
+    pkgs.runCommand "lore-test-certs"
+      {
+        nativeBuildInputs = [ pkgs.openssl ];
+      }
+      ''
+        mkdir -p "$out"
+        openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \
+          -keyout "$out/ca.key" -out "$out/ca.crt" -subj "/CN=Lore Test CA"
+        openssl req -newkey rsa:2048 -nodes \
+          -keyout "$out/server.key" -out server.csr -subj "/CN=tlsserver"
+        printf 'subjectAltName=DNS:tlsserver,DNS:localhost,IP:127.0.0.1\n' > san.ext
+        openssl x509 -req -in server.csr -CA "$out/ca.crt" -CAkey "$out/ca.key" \
+          -CAcreateserial -days 3650 -extfile san.ext -out "$out/server.crt"
+      '';
+in
+{
+  name = "loreserver";
+  meta.maintainers = [ lib.maintainers.jchw ];
+
+  nodes.server = {
+    services.loreserver = {
+      enable = true;
+      openFirewall = true;
+      settings = {
+        immutable_store.local.flush_delay_seconds = 1;
+        mutable_store.local.flush_delay_seconds = 1;
+        telemetry.logger.format = "text";
+      };
+    };
+
+    environment.systemPackages = [
+      pkgs.lore
+      pkgs.curl
+    ];
+
+    virtualisation.memorySize = 3072;
+    virtualisation.cores = 2;
+  };
+
+  nodes.client = {
+    environment.systemPackages = [
+      pkgs.lore
+      pkgs.curl
+    ];
+
+    # Disable IPv6; Happy Eyeballs isn't doing what it is supposed to.
+    networking.enableIPv6 = false;
+
+    # Trust the test CA so the client can verify tlsserver's cert over lores://.
+    security.pki.certificateFiles = [ "${testCerts}/ca.crt" ];
+    virtualisation.memorySize = 1024;
+  };
+
+  # Node running a loreserver that uses TLS for QUIC and gRPC.
+  nodes.tlsserver = {
+    services.loreserver = {
+      enable = true;
+      openFirewall = true;
+      settings = {
+        immutable_store.local.flush_delay_seconds = 1;
+        mutable_store.local.flush_delay_seconds = 1;
+        telemetry.logger.format = "text";
+        server.quic.certificate = {
+          cert_file = "${testCerts}/server.crt";
+          pkey_file = "${testCerts}/server.key";
+        };
+        server.grpc.certificate = {
+          cert_file = "${testCerts}/server.crt";
+          pkey_file = "${testCerts}/server.key";
+        };
+      };
+    };
+
+    virtualisation.memorySize = 2048;
+    virtualisation.cores = 2;
+  };
+
+  # Node running a loreserver using JWT authentication.
+  nodes.authserver = {
+    services.nginx = {
+      enable = true;
+      virtualHosts.jwks = {
+        listen = [
+          {
+            addr = "127.0.0.1";
+            port = 8080;
+          }
+        ];
+        # This is enough for our test.
+        locations."= /jwks.json".extraConfig = ''
+          default_type application/json;
+          return 200 '{"keys":[]}';
+        '';
+      };
+    };
+
+    services.loreserver = {
+      enable = true;
+      settings = {
+        immutable_store.local.flush_delay_seconds = 1;
+        mutable_store.local.flush_delay_seconds = 1;
+        telemetry.logger.format = "text";
+        server.auth.jwk.endpoint = "http://127.0.0.1:8080/jwks.json";
+      };
+    };
+
+    # The server fetches the JWKS at startup, so it must come up after nginx.
+    systemd.services.loreserver = {
+      after = [ "nginx.service" ];
+      wants = [ "nginx.service" ];
+    };
+
+    environment.systemPackages = [
+      pkgs.lore
+      pkgs.curl
+    ];
+    virtualisation.memorySize = 2048;
+    virtualisation.cores = 2;
+  };
+
+  testScript = ''
+    start_all()
+
+    with subtest("server starts and reports healthy"):
+        client.wait_for_unit("multi-user.target")
+        server.wait_for_unit("loreserver.service")
+        server.wait_for_open_port(41337)
+        server.wait_for_open_port(41339)
+        server.wait_until_succeeds(
+            "curl -fsS -o /dev/null -w '%{http_code}' http://127.0.0.1:41339/health_check | grep -qx 200",
+            timeout=60,
+        )
+
+    with subtest("module-managed self-signed certificate is persisted"):
+        server.succeed("test -s /var/lib/loreserver/certs/cert.pem")
+        server.succeed("test -s /var/lib/loreserver/certs/key.pem")
+
+    with subtest("create a repository, stage, commit and push"):
+        server.succeed("mkdir -p /root/my-project")
+        server.succeed(
+            "cd /root/my-project && lore repository create lore://127.0.0.1:41337/my-project"
+        )
+        server.succeed("test -d /root/my-project/.lore")
+        server.succeed("echo 'Hello, Lore' > /root/my-project/hello.txt")
+        # Woah, binary files!
+        server.succeed("head -c 256 /dev/urandom > /root/my-project/sample.bin")
+        server.succeed("cd /root/my-project && lore stage hello.txt sample.bin")
+        server.succeed("cd /root/my-project && lore status --scan")
+        server.succeed("cd /root/my-project && lore commit 'Initial revision'")
+        server.succeed("cd /root/my-project && lore push")
+
+    with subtest("clone into a second working tree"):
+        server.succeed("cd /root && lore clone lore://127.0.0.1:41337/my-project my-project-b")
+        server.succeed("test -f /root/my-project-b/hello.txt")
+        server.succeed("test -f /root/my-project-b/sample.bin")
+        server.succeed("grep -q 'Hello, Lore' /root/my-project-b/hello.txt")
+
+    with subtest("branch, commit, merge into main and push"):
+        server.succeed("cd /root/my-project && lore branch create my-first-branch")
+        server.succeed("echo 'Notes added on a branch.' > /root/my-project/notes.txt")
+        server.succeed("cd /root/my-project && lore stage notes.txt")
+        server.succeed("cd /root/my-project && lore commit 'Add notes on a branch'")
+        server.succeed("cd /root/my-project && lore branch switch main")
+        server.succeed("test ! -e /root/my-project/notes.txt")
+        server.succeed(
+            "cd /root/my-project && lore branch merge my-first-branch "
+            "--message 'Merge my-first-branch into main'"
+        )
+        server.succeed("test -f /root/my-project/notes.txt")
+        server.succeed("cd /root/my-project && lore push")
+
+    with subtest("sync the merged revision into the clone"):
+        server.succeed("cd /root/my-project-b && lore sync")
+        server.succeed("test -f /root/my-project-b/notes.txt")
+        server.succeed("grep -q 'Notes added on a branch.' /root/my-project-b/notes.txt")
+
+    with subtest("server survives a restart with the store intact"):
+        server.systemctl("restart loreserver.service")
+        server.wait_until_succeeds(
+            "curl -fsS -o /dev/null -w '%{http_code}' http://127.0.0.1:41339/health_check | grep -qx 200",
+            timeout=60,
+        )
+        server.succeed("cd /root && rm -rf verify && lore clone lore://127.0.0.1:41337/my-project verify")
+        server.succeed("test -f /root/verify/notes.txt")
+
+    with subtest("remote client reaches the server over the network"):
+        client.wait_until_succeeds(
+            "curl -fsS -o /dev/null -w '%{http_code}' http://server:41339/health_check | grep -qx 200",
+            timeout=60,
+        )
+        client.succeed("cd /root && lore clone lore://server:41337/my-project remote-clone")
+        client.succeed("test -f /root/remote-clone/notes.txt")
+        client.succeed("grep -q 'Notes added on a branch.' /root/remote-clone/notes.txt")
+
+    with subtest("remote client can create and push a new repository"):
+        client.succeed("mkdir -p /root/remoteproject")
+        client.succeed("cd /root/remoteproject && lore repository create lore://server:41337/remoteproject")
+        client.succeed("echo 'from the client node' > /root/remoteproject/remote.txt")
+        client.succeed("cd /root/remoteproject && lore stage remote.txt")
+        client.succeed("cd /root/remoteproject && lore commit 'Remote client commit'")
+        client.succeed("cd /root/remoteproject && lore push")
+        server.succeed("cd /root && rm -rf remoteproject-check && lore clone lore://127.0.0.1:41337/remoteproject remoteproject-check")
+        server.succeed("grep -q 'from the client node' /root/remoteproject-check/remote.txt")
+
+    with subtest("verifies TLS when using custom CA certificate"):
+        tlsserver.wait_for_unit("loreserver.service")
+        tlsserver.wait_for_open_port(41337)
+        tlsserver.wait_for_open_port(41339)
+        tlsserver.succeed("test ! -e /var/lib/loreserver/certs/cert.pem")
+        client.succeed("mkdir -p /root/secureproject")
+        client.succeed("cd /root/secureproject && lore repository create lores://tlsserver:41337/secureproject")
+        client.succeed("echo 'over verified TLS' > /root/secureproject/secure.txt")
+        client.succeed("cd /root/secureproject && lore stage secure.txt")
+        client.succeed("cd /root/secureproject && lore commit 'Secure commit'")
+        client.succeed("cd /root/secureproject && lore push")
+        client.succeed("cd /root && lore clone lores://tlsserver:41337/secureproject secureproject-clone")
+        client.succeed("grep -q 'over verified TLS' /root/secureproject-clone/secure.txt")
+
+    with subtest("rejects unauthenticated clients when using JWT"):
+        authserver.wait_for_unit("nginx.service")
+        authserver.wait_for_unit("loreserver.service")
+        authserver.wait_for_open_port(41337)
+        authserver.wait_until_succeeds(
+            "curl -fsS -o /dev/null -w '%{http_code}' http://127.0.0.1:41339/health_check | grep -qx 200",
+            timeout=60,
+        )
+        authserver.succeed("mkdir -p /root/jwtproject")
+        out = authserver.fail(
+            "cd /root/jwtproject && lore repository create lore://127.0.0.1:41337/jwtproject 2>&1"
+        )
+        assert "authorization header required" in out.lower(), f"expected an auth-related rejection, got:\n{out}"
+  '';
+}

--- a/pkgs/by-name/lo/lore/package.nix
+++ b/pkgs/by-name/lo/lore/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+  versionCheckHook,
+  nix-update-script,
+  stdenv,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "lore";
+  version = "0.8.4";
+
+  outputs = [
+    "out"
+    "lib"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "EpicGames";
+    repo = "lore";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RxeRjSfi0Waz7Sm4Ifu4eBhfnez/qAvgs+bP1BTYAS0=";
+  };
+
+  __structuredAttrs = true;
+
+  cargoHash = "sha256-kPow7EzpNXTUgkZW0guXgVcTxE645uPc0U9EEsrsFM8=";
+
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
+    installShellFiles
+  ];
+
+  cargoBuildFlags = [
+    "--package=lore-client"
+    "--package=lore-server"
+    "--package=lore"
+  ];
+
+  env = {
+    # This is a workaround; otherwise, these two --cfg flags get lost due to
+    # cargoSetupHook's rustflags logic.
+    RUSTFLAGS = "--cfg tokio_unstable --cfg uuid_unstable -Cforce-frame-pointers=yes";
+    VERGEN_IDEMPOTENT = "true";
+  };
+
+  # TODO: The tests seem to require some external setup to work.
+  doCheck = false;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "--version";
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    for shell in bash zsh fish; do
+      "$out/bin/lore" completions "$shell" > "lore.$shell"
+    done
+
+    installShellCompletion --cmd lore \
+      --bash lore.bash \
+      --zsh lore.zsh \
+      --fish lore.fish
+
+    mkdir -p "$lib"
+    mv "$out/lib" "$lib/lib"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Next-generation open source version control system";
+    longDescription = ''
+      Lore is a centralized, content-addressed version control system created
+      by Epic Games, optimized for projects that combine code with large
+      binary assets, including games and entertainment.
+    '';
+    homepage = "https://lore.org/";
+    changelog = "https://github.com/EpicGames/lore/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+    maintainers = [
+      lib.maintainers.jchw
+      lib.maintainers.griffi-gh
+    ];
+    mainProgram = "lore";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/lo/lore/package.nix
+++ b/pkgs/by-name/lo/lore/package.nix
@@ -6,6 +6,7 @@
   versionCheckHook,
   nix-update-script,
   stdenv,
+  nixosTests,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -67,7 +68,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mv "$out/lib" "$lib/lib"
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      server-test = nixosTests.loreserver;
+    };
+  };
 
   meta = {
     description = "Next-generation open source version control system";


### PR DESCRIPTION
This is [Lore](https://lore.org/), a brand new source control from Epic Games designed to handle video games well. Since this just released earlier today, I obviously have not had a lot of time for this to bake yet, but it seems fairly straightforward so I want to get some eyes on it sooner rather than later :) I'll be trying this out on my own machines. If it delivers on its promises, it's going to be pretty awesome and I'd love to have NixOS be early to the party.

Here's the broad overview:
- Added package `lore`, which gives you the client (`lore`) and server (`loreserver`).
    - Set it up with `nix-update-script` which I believe should be sufficient. Seems to work but you know, there's only one release, so I can't really test it properly.
    - Didn't bother wiring up Oodle support. I think this is needed if anyone wants to use this with Unreal Editor for Fortnite, but since Epic says they're moving away from Oodle here and since I don't personally have any interest in this I decided against trying to handle this case. (I don't have a license for Oodle to try this anyways, which I assume you need.)
- Added `nixos/loreserver`, a basic NixOS module for setting up the server. There isn't really all that much to it.
    - For convenience, the NixOS module supports setting up a self-signed certificate. This may seem a little pointless since loreserver will generate one on-the-fly, but it seems to be ephemeral, which isn't very useful for this context.
- Added `nixosTests.loreserver`, which mostly tests a few different modalities of authentication. I ran into some issues with memory but the knobs on each VM is not very carefully tweaked so it's possible I have oversized them a bit. I'll take another pass to make sure it makes sense.

I have not tested replication but it should work if you configure it right.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
