### PR TITLE
cargo-unused-workspace-deps: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2266,6 +2266,12 @@
     githubId = 1296771;
     name = "Anders Riutta";
   };
+  arizzo35 = {
+    email = "ajarizzo@gmail.com";
+    github = "ARizzo35";
+    githubId = 1613675;
+    name = "Adam Rizkalla";
+  };
   arjan-s = {
     email = "github@anymore.nl";
     github = "arjan-s";

--- a/pkgs/by-name/ca/cargo-unused-workspace-deps/package.nix
+++ b/pkgs/by-name/ca/cargo-unused-workspace-deps/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "cargo-unused-workspace-deps";
+  version = "0.1.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "JarredAllen";
+    repo = "cargo-unused-workspace-deps";
+    rev = "82ab3f57d6cc2b9d6dd7f0dd9f20f2b03cc9c9c8";
+    hash = "sha256-7xj4Xh2imvTRXzl6obVjziQqrgJfXZXhdV7hDbeYDTE=";
+  };
+
+  cargoHash = "sha256-KzfOztkLpP658G0J/AFLDh8qsdUNAOQpT4fReQ2fahU=";
+
+  meta = {
+    description = "Cargo tool that detects unused dependencies in workspace manifests";
+    mainProgram = "cargo-unused-workspace-deps";
+    homepage = "https://github.com/JarredAllen/cargo-unused-workspace-deps";
+    license = lib.licenses.gpl3;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/by-name/ca/cargo-unused-workspace-deps/package.nix
+++ b/pkgs/by-name/ca/cargo-unused-workspace-deps/package.nix
@@ -24,6 +24,8 @@ rustPlatform.buildRustPackage {
     mainProgram = "cargo-unused-workspace-deps";
     homepage = "https://github.com/JarredAllen/cargo-unused-workspace-deps";
     license = lib.licenses.gpl3;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      arizzo35
+    ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
