### PR TITLE
nebula-de-esser: 3.2.0 -> 3.3.0

### DIFF
--- a/pkgs/by-name/ne/nebula-de-esser/package.nix
+++ b/pkgs/by-name/ne/nebula-de-esser/package.nix
@@ -19,16 +19,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nebula-de-esser";
-  version = "3.2.0";
+  version = "3.3.0";
 
   src = fetchFromGitHub {
     owner = "subhankardas15071992-cloud";
     repo = "Nebula-De-Esser";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-N+tVlhGTBRXZDKGRYo2WUamiekTe1FXvpqm34lwu2Z8=";
+    hash = "sha256-vV7Qc5WxGvb6h3o1CXTLYZzpWSc3ASt8cq3opI3qjEg=";
   };
 
-  cargoHash = "sha256-+z6oFjmPr2bLf81F4Q3dJC+x+RWeZnnnMHrWLphTsq0=";
+  cargoHash = "sha256-swhj9JQsDCFYzB/+qKffcdcIOAZ1HXmrgZ/Iy/rxG1M=";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -65,16 +65,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    clapDir="${
-      if stdenv.hostPlatform.isDarwin then "$out/Library/Audio/Plug-Ins/CLAP" else "$out/lib/clap"
-    }"
     vst3Dir="${
       if stdenv.hostPlatform.isDarwin then "$out/Library/Audio/Plug-Ins/VST3" else "$out/lib/vst3"
     }"
 
-    mkdir -p "$clapDir" "$vst3Dir"
+    mkdir -p "$vst3Dir"
 
-    cp -r "target/bundled/Nebula De-Esser.clap" "$clapDir/"
     cp -r "target/bundled/Nebula De-Esser.vst3" "$vst3Dir/"
 
     runHook postInstall


### PR DESCRIPTION
replace #532769

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
