### PR TITLE
nixfmt-tree: fix passthru

### DIFF
--- a/pkgs/by-name/ni/nixfmt-tree/package.nix
+++ b/pkgs/by-name/ni/nixfmt-tree/package.nix
@@ -54,7 +54,7 @@ let
       '' allRuntimeInputs;
   };
 in
-treefmtWithConfig.overrideAttrs {
+treefmtWithConfig.overrideAttrs (prevAttrs: {
   meta = {
     mainProgram = "treefmt";
     description = "Official Nix formatter zero-setup starter using treefmt";
@@ -118,63 +118,65 @@ treefmtWithConfig.overrideAttrs {
     platforms = lib.platforms.all;
   };
 
-  passthru.tests.simple =
-    runCommand "nixfmt-tree-test-simple"
-      {
-        nativeBuildInputs = [
-          git
-          nixfmt-tree
-          writableTmpDirAsHomeHook
-        ];
-      }
-      ''
-        git config --global user.email "nix-builder@nixos.org"
-        git config --global user.name "Nix Builder"
+  passthru = prevAttrs.passthru // {
+    tests.simple =
+      runCommand "nixfmt-tree-test-simple"
+        {
+          nativeBuildInputs = [
+            git
+            nixfmt-tree
+            writableTmpDirAsHomeHook
+          ];
+        }
+        ''
+          git config --global user.email "nix-builder@nixos.org"
+          git config --global user.name "Nix Builder"
 
-        cat > unformatted.nix <<EOF
-        let to = "be formatted"; in to
-        EOF
+          cat > unformatted.nix <<EOF
+          let to = "be formatted"; in to
+          EOF
 
-        cat > formatted.nix <<EOF
-        let
-          to = "be formatted";
-        in
-        to
-        EOF
+          cat > formatted.nix <<EOF
+          let
+            to = "be formatted";
+          in
+          to
+          EOF
 
-        mkdir -p repo
-        (
-          cd repo
-          mkdir dir
-          cp ../unformatted.nix a.nix
-          cp ../unformatted.nix dir/b.nix
-
-          git init
-          git add .
-          git commit -m "Initial commit"
-
-          treefmt dir
-          if [[ "$(<dir/b.nix)" != "$(<../formatted.nix)" ]]; then
-            echo "File dir/b.nix was not formatted properly after dir was requested to be formatted"
-            exit 1
-          elif [[ "$(<a.nix)" != "$(<../unformatted.nix)" ]]; then
-            echo "File a.nix was formatted when only dir was requested to be formatted"
-            exit 1
-          fi
-
+          mkdir -p repo
           (
-            cd dir
-            treefmt
+            cd repo
+            mkdir dir
+            cp ../unformatted.nix a.nix
+            cp ../unformatted.nix dir/b.nix
+
+            git init
+            git add .
+            git commit -m "Initial commit"
+
+            treefmt dir
+            if [[ "$(<dir/b.nix)" != "$(<../formatted.nix)" ]]; then
+              echo "File dir/b.nix was not formatted properly after dir was requested to be formatted"
+              exit 1
+            elif [[ "$(<a.nix)" != "$(<../unformatted.nix)" ]]; then
+              echo "File a.nix was formatted when only dir was requested to be formatted"
+              exit 1
+            fi
+
+            (
+              cd dir
+              treefmt
+            )
+
+            if [[ "$(<a.nix)" != "$(<../formatted.nix)" ]]; then
+              echo "File a.nix was not formatted properly after running treefmt without arguments in dir"
+              exit 1
+            fi
           )
 
-          if [[ "$(<a.nix)" != "$(<../formatted.nix)" ]]; then
-            echo "File a.nix was not formatted properly after running treefmt without arguments in dir"
-            exit 1
-          fi
-        )
+          echo "Success!"
 
-        echo "Success!"
-
-        touch $out
-      '';
-}
+          touch $out
+        '';
+  };
+})


### PR DESCRIPTION
allows nixfmt-tree.check to be used


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
