### PR TITLE
notable: cleanup, fix icon location

### DIFF
--- a/pkgs/by-name/no/notable/package.nix
+++ b/pkgs/by-name/no/notable/package.nix
@@ -36,10 +36,12 @@ appimageTools.wrapType2 rec {
 
   extraInstallCommands = ''
     install -m 444 -D ${appimageContents}/notable.desktop $out/share/applications/notable.desktop
-    for size in 16 32 48 64 128 256 512 1024; do
+    for size in 16 32 48 64 128 256 512; do
       install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/''${size}x''${size}/apps/notable.png \
         $out/share/icons/hicolor/''${size}x''${size}/apps/notable.png
     done
+    install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/1024x1024/apps/notable.png \
+      $out/share/icons/notable.png
     substituteInPlace $out/share/applications/notable.desktop \
       --replace 'Exec=AppRun' 'Exec=${pname}'
     wrapProgram "$out/bin/${pname}" \

--- a/pkgs/by-name/no/notable/package.nix
+++ b/pkgs/by-name/no/notable/package.nix
@@ -19,7 +19,7 @@ let
     inherit pname version src;
   };
 in
-appimageTools.wrapType2 rec {
+appimageTools.wrapType2 {
 
   inherit pname version src;
 
@@ -43,8 +43,8 @@ appimageTools.wrapType2 rec {
     install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/1024x1024/apps/notable.png \
       $out/share/icons/notable.png
     substituteInPlace $out/share/applications/notable.desktop \
-      --replace 'Exec=AppRun' 'Exec=${pname}'
-    wrapProgram "$out/bin/${pname}" \
+      --replace-fail 'Exec=AppRun' 'Exec=notable'
+    wrapProgram "$out/bin/notable" \
       --add-flags "--disable-seccomp-filter-sandbox"
   '';
 


### PR DESCRIPTION
Related (ish): #428824
Closes #335160

I tested on gnome and can't reproduce, so I think this is solved, the WMCLASS is set correctly, which is the usual cause of problems. I took the opportunity while checking this to also move the large 1024x1024 icon to a directory that is fully supported.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
