### PR TITLE
v2ray-rules-dat: use finalAttrs; modernize; 202606122311 -> 202606172318

### DIFF
--- a/pkgs/by-name/v2/v2ray-rules-dat/package.nix
+++ b/pkgs/by-name/v2/v2ray-rules-dat/package.nix
@@ -1,37 +1,43 @@
 {
+  lib,
   stdenvNoCC,
   fetchurl,
-  lib,
 }:
-let
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "v2ray-rules-dat";
   version = "202606122311";
 
-  geoipDat = fetchurl {
-    url = "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/${version}/geoip.dat";
-    hash = "sha256-iGGpeUaWtIH7AEPueCssQOgL/Ia7nkLFvWnAj1SDsbU=";
-  };
-
-  geositeDat = fetchurl {
-    url = "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/${version}/geosite.dat";
-    hash = "sha256-/c/3OjfALveNnHS9NxonTeOiZyud6U/X4WHrGZSOs7Q=";
-  };
-in
-stdenvNoCC.mkDerivation {
-  pname = "v2ray-rules-dat";
-  inherit version;
   __structuredAttrs = true;
   strictDeps = true;
+
+  src = null;
   dontUnpack = true;
 
   installPhase = ''
-    install -Dm444 ${geoipDat} $out/share/v2ray/geoip.dat
-    install -Dm444 ${geositeDat} $out/share/v2ray/geosite.dat
+    runHook preInstall
+
+    install -Dm444 ${finalAttrs.passthru.geoipDat} $out/share/v2ray/geoip.dat
+    install -Dm444 ${finalAttrs.passthru.geositeDat} $out/share/v2ray/geosite.dat
+
+    runHook postInstall
   '';
+
+  passthru = {
+    geoipDat = fetchurl {
+      url = "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/${finalAttrs.version}/geoip.dat";
+      hash = "sha256-iGGpeUaWtIH7AEPueCssQOgL/Ia7nkLFvWnAj1SDsbU=";
+    };
+    geositeDat = fetchurl {
+      url = "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/${finalAttrs.version}/geosite.dat";
+      hash = "sha256-/c/3OjfALveNnHS9NxonTeOiZyud6U/X4WHrGZSOs7Q=";
+    };
+  };
 
   meta = {
     description = "Enhanced edition of V2Ray rules dat files";
     homepage = "https://github.com/Loyalsoldier/v2ray-rules-dat";
+    changelog = "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/tag/${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ nix-julia ];
   };
-}
+})

--- a/pkgs/by-name/v2/v2ray-rules-dat/package.nix
+++ b/pkgs/by-name/v2/v2ray-rules-dat/package.nix
@@ -31,7 +31,7 @@ stdenvNoCC.mkDerivation {
   meta = {
     description = "Enhanced edition of V2Ray rules dat files";
     homepage = "https://github.com/Loyalsoldier/v2ray-rules-dat";
-    license = lib.licenses.gpl3;
+    license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ nix-julia ];
   };
 }

--- a/pkgs/by-name/v2/v2ray-rules-dat/package.nix
+++ b/pkgs/by-name/v2/v2ray-rules-dat/package.nix
@@ -5,7 +5,7 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "v2ray-rules-dat";
-  version = "202606122311";
+  version = "202606172318";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -29,7 +29,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     };
     geositeDat = fetchurl {
       url = "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/${finalAttrs.version}/geosite.dat";
-      hash = "sha256-/c/3OjfALveNnHS9NxonTeOiZyud6U/X4WHrGZSOs7Q=";
+      hash = "sha256-DEhEZP7ijNudb6qhIArpRhUqzEzmG0OxJaoBuMFVacM=";
     };
     updateScript = ./update.sh;
   };

--- a/pkgs/by-name/v2/v2ray-rules-dat/package.nix
+++ b/pkgs/by-name/v2/v2ray-rules-dat/package.nix
@@ -31,6 +31,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       url = "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/${finalAttrs.version}/geosite.dat";
       hash = "sha256-/c/3OjfALveNnHS9NxonTeOiZyud6U/X4WHrGZSOs7Q=";
     };
+    updateScript = ./update.sh;
   };
 
   meta = {

--- a/pkgs/by-name/v2/v2ray-rules-dat/update.sh
+++ b/pkgs/by-name/v2/v2ray-rules-dat/update.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq nix common-updater-scripts
+
+set -euo pipefail
+
+version="$(
+  curl -fsSL ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "https://api.github.com/repos/Loyalsoldier/v2ray-rules-dat/releases/latest" \
+    | jq -r .tag_name
+)"
+
+if [[ "$UPDATE_NIX_OLD_VERSION" == "$version" ]]; then
+  echo "Already up to date!"
+  exit 0
+fi
+
+prefetch_hash() {
+  local name="$1"
+  nix --extra-experimental-features nix-command \
+    store prefetch-file \
+    --json \
+    --hash-type sha256 \
+    "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/$version/$name" \
+    | jq -r .hash
+}
+
+geoip_hash="$(prefetch_hash geoip.dat)"
+geosite_hash="$(prefetch_hash geosite.dat)"
+
+update-source-version "v2ray-rules-dat" "$version" "$geoip_hash" \
+  --source-key=passthru.geoipDat \
+  --ignore-same-version --ignore-same-hash
+
+update-source-version "v2ray-rules-dat" "$version" "$geosite_hash" \
+  --source-key=passthru.geositeDat \
+  --ignore-same-version --ignore-same-hash


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
