### PR TITLE
openafs: 1.8.15 → 1.8.16, patch for Linux kernel 7.1

### DIFF
--- a/pkgs/by-name/op/openafs/module.nix
+++ b/pkgs/by-name/op/openafs/module.nix
@@ -28,6 +28,16 @@ stdenv.mkDerivation {
   inherit src;
 
   patches = [
+    # Linux: pagevec.h renamed to folio_batch.h
+    (fetchpatch {
+      url = "https://github.com/openafs/openafs/commit/d47c438aec49e417066a7bef00bd82078014f5ea.patch";
+      hash = "sha256-LPURZovpl6KbigzP4mNjgHvPlXYKY5Pxh8sj9RT2W08=";
+    })
+    # Linux: Add comment for d_alias configure test
+    (fetchpatch {
+      url = "https://github.com/openafs/openafs/commit/fd157926f08d10afe981d85654395bbf083ea7a3.patch";
+      hash = "sha256-gJ+ylIEZwJcpTWc5hmIXS/QcxtICqjaEzZsl2QegjhY=";
+    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/op/openafs/module.nix
+++ b/pkgs/by-name/op/openafs/module.nix
@@ -28,69 +28,6 @@ stdenv.mkDerivation {
   inherit src;
 
   patches = [
-    # Linux: Use get_tree_nodev
-    (fetchpatch {
-      url = "https://github.com/openafs/openafs/commit/c02a8f451b48766aa163e729abe40d145751b2dc.patch";
-      hash = "sha256-9okSQLV4tW1wjoffQXPneZbu6tTRqrqVPbEOwZmaD+E=";
-    })
-    # LINUX: Re-dirty folio on writepages recursion
-    (fetchpatch {
-      url = "https://github.com/openafs/openafs/commit/11849e96820eca64d91742a8c521614e1e99d9fa.patch";
-      hash = "sha256-F2MOqEDaj4e0Xj1mvs7v61cutZY3cO22p9iIp2bLiRQ=";
-    })
-    # Linux: Introduce LINUX_WRITE_CACHE_PAGES_USES_FOLIOS
-    (fetchpatch {
-      url = "https://github.com/openafs/openafs/commit/63a3503240c06187fa87514e5ea421cece483422.patch";
-      hash = "sha256-ZWV8IZ8CeFQaEOamqKfkXuUccSxCRFNkZ7/kxKbEuis=";
-    })
-    # Linux: Avoid write_cache_pages() for ->writepages()
-    (fetchpatch {
-      url = "https://gerrit.openafs.org/changes/16704/revisions/d465a07a98c2b0b2c23780571a8fe70c2584473a/patch";
-      decode = "base64 -d";
-      hash = "sha256-2FOf+o36gbTHm90RxtOI7iXcgb6rv9nh9rSjZzL5O7A=";
-    })
-    # LINUX: Log warning on recursive folio writeback
-    (fetchpatch {
-      url = "https://gerrit.openafs.org/changes/16705/revisions/d66ca6372461840c6ecaaa46ec293640c8f22573/patch";
-      decode = "base64 -d";
-      hash = "sha256-A383wDMkwnGFatBDHUGV8FVqPMjzvhqUnIWrP2C+ym4=";
-    })
-    # Linux: Move afs_root()/afs_fill_super() in osi_vfsops
-    (fetchpatch {
-      url = "https://gerrit.openafs.org/changes/16706/revisions/988c70859f1d402022e9342e28f0c5a954760a72/patch";
-      decode = "base64 -d";
-      hash = "sha256-JsZwGGa7dRT43RIUUY3hYCbbqPObd5bkDOHl9QK/MhE=";
-    })
-    # Linux: Use sockaddr_unsized for socket->ops->bind
-    (fetchpatch {
-      url = "https://gerrit.openafs.org/changes/16707/revisions/e6069d6c35e848b5b388f4c47a2ecf0d72420198/patch";
-      decode = "base64 -d";
-      hash = "sha256-hTRaTqOc0njW/RIsNTrFZ5uWTrQq04Fuh/Sk7K2Q5e4=";
-    })
-    # Linux: Pass 3rd parameter to filemap_alloc_folio()
-    (fetchpatch {
-      url = "https://gerrit.openafs.org/changes/16708/revisions/48d2184ec95418cada68b70919b0afd9888bb945/patch";
-      decode = "base64 -d";
-      hash = "sha256-CSGlXYkkLSHQoWK2xLpUYJDOUP/mlsxkTru2qdmbeQo=";
-    })
-    # Linux: implement aops->migrate_folio
-    (fetchpatch {
-      url = "https://gerrit.openafs.org/changes/16709/revisions/2c51471aea08cc495a5d59fee6e651ba58c9d772/patch";
-      decode = "base64 -d";
-      hash = "sha256-TtcblVczSp8b1bfd0ajWjK2LffAkgYr2+KUL2nEe8hs=";
-    })
-    # Linux: Use set_default_d_op() to set dentry ops
-    (fetchpatch {
-      url = "https://gerrit.openafs.org/changes/16729/revisions/6d0a2107fcab28fc4ba64d365133d171b75bd3dc/patch";
-      decode = "base64 -d";
-      hash = "sha256-OKxR5zzVKSXPzudPl5jc7koObisQMMqq/d9kfrMem/M=";
-    })
-    # Linux: Use __getname()/__putname() to alloc name
-    (fetchpatch {
-      url = "https://gerrit.openafs.org/changes/16738/revisions/a1754489f382aabd087f14c325d13a36faa5bf5c/patch";
-      decode = "base64 -d";
-      hash = "sha256-JizLrwnujybCkcbDIltGfgVtCc5fL3ZxWvgVbI1kKto=";
-    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/op/openafs/srcs.nix
+++ b/pkgs/by-name/op/openafs/srcs.nix
@@ -1,16 +1,16 @@
 { fetchurl }:
 rec {
-  version = "1.8.15";
+  version = "1.8.16";
   src = fetchurl {
     url = "https://www.openafs.org/dl/openafs/${version}/openafs-${version}-src.tar.bz2";
-    hash = "sha256-MvEN0kG12LhG5CWrnL8nW1VroYgL9998RZzZ60kFg1U=";
+    hash = "sha256-7oEnaJdXy9lyOoU6EvrigcnenD6JSkvZAQf7b4UnBGk=";
   };
 
   srcs = [
     src
     (fetchurl {
       url = "https://www.openafs.org/dl/openafs/${version}/openafs-${version}-doc.tar.bz2";
-      hash = "sha256-kAGRw3T0VdJ/XMqqFjV0Z7gzKbWeyZWEsMsBJ+7ijsE=";
+      hash = "sha256-F9fyLe5Ofs6Ri4MXlO63wOZmhZuY8FAh2P/aoAX5wiQ=";
     })
   ];
 }


### PR DESCRIPTION
Upgrade OpenAFS from 1.8.15 to 1.8.16. Remove patches applied upstream, and apply new patches from `master` required to support building with Linux kernel 7.1.

- https://www.openafs.org/dl/openafs/1.8.16/RELNOTES-1.8.16
- https://www.openafs.org/dl/openafs/1.8.16/ChangeLog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
