### PR TITLE
strawberry-browser: init at 0.1.11

### DIFF
--- a/pkgs/by-name/st/strawberry-browser/package.nix
+++ b/pkgs/by-name/st/strawberry-browser/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  undmg,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "strawberry-browser";
+  version = "0.1.11";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchurl {
+    url = "https://strawberrybucket.com/strawberry-${finalAttrs.version}.dmg";
+    hash = "sha256-OwwBwJXfhPqPgF0TrZaxaju6+Mc4NygfzfEkSfh19qg=";
+  };
+
+  sourceRoot = "Strawberry.app";
+
+  nativeBuildInputs = [ undmg ];
+
+  # prebuilt, Developer ID signed, hardened-runtime bundle; leave it untouched so
+  # the signature stays valid
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/Applications/Strawberry.app"
+    cp -R . "$out/Applications/Strawberry.app"
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "AI-powered web browser";
+    homepage = "https://strawberrybrowser.com/";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ vmfunc ];
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    hydraPlatforms = [ ]; # unfree, prebuilt: nothing for Hydra to build
+  };
+})

--- a/pkgs/by-name/st/strawberry-browser/update.sh
+++ b/pkgs/by-name/st/strawberry-browser/update.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq common-updater-scripts
+set -euo pipefail
+
+# upstream publishes the current macOS build in a small json endpoint rather than
+# tagged releases, so read the version from there and let the templated url follow
+version=$(curl -fsSL https://strawberrybrowser.com/api/download/version-info | jq -r '.mac.version')
+
+update-source-version strawberry-browser "$version"


### PR DESCRIPTION
adds strawberry-browser, an ai-powered electron browser for macos.

proprietary, shipped as a notarized developer id dmg, so this installs the
prebuilt Strawberry.app into $out/Applications and leaves the bundle untouched
(dontFixup) to keep the signature valid. universal, both darwin arches.

version comes from upstream's version-info json endpoint, not tagged releases,
so updateScript reads it from there.

homepage: https://strawberrybrowser.com/

## Things done
- Built on platform:
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] nixpkgs-review: 1 package built (strawberry-browser)
- [x] launches and runs from the store path; gatekeeper accepts (notarized
      developer id), codesign --verify --deep --strict passes
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md
