### PR TITLE
pkgs/nixos-render-docs: introduce sidebar navigation

### DIFF
--- a/doc/style.css
+++ b/doc/style.css
@@ -34,7 +34,7 @@ body {
   }
 }
 
-.book .list-of-examples {
+.list-of-examples {
   display: none;
 }
 
@@ -392,8 +392,7 @@ div.appendix .toc dt {
   margin-top: 0;
 }
 
-div.book .list-of-examples dt,
-div.appendix .list-of-examples dt {
+.list-of-examples dt {
   margin-top: 0;
 }
 
@@ -450,6 +449,7 @@ div.appendix .variablelist .term {
 }
 
 :root {
+  --sidebar-width: 20rem;
   --background: #fff;
   --main-text-color: #000;
   --link-color: #405d99;
@@ -495,4 +495,69 @@ div.appendix .variablelist .term {
 
 .chapter {
   content-visibility: auto;
+}
+
+.navheader {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background-color: var(--background);
+}
+
+nav.toc-sidebar {
+  height: 100%;
+  overflow-y: none;
+  padding: 0 1rem 2rem;
+  border-bottom: 0.0625rem solid #d8d8d8;
+}
+
+nav.toc-sidebar .toc {
+  margin-bottom: 0;
+}
+
+nav.toc-sidebar .toc dl {
+  margin: 0;
+}
+
+nav.toc-sidebar .toc dd {
+  margin-left: 1em;
+}
+
+@media screen and (min-width: 768px) {
+  body {
+    height: 100vh;
+    min-height: 0;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto minmax(0, 1fr);
+  }
+
+  body:has(> nav.toc-sidebar) {
+    grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
+  }
+
+  .navheader {
+    grid-column: 1 / -1;
+    grid-row: 1;
+  }
+
+  nav.toc-sidebar {
+    grid-column: 1;
+    grid-row: 2;
+    max-height: none;
+    overflow-y: auto;
+    border-bottom: none;
+    border-right: 0.0625rem solid #d8d8d8;
+  }
+
+  main.content {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    overflow-y: auto;
+    padding: 0 1rem;
+  }
+
+  body:has(> nav.toc-sidebar) main.content {
+    grid-column: 2;
+  }
 }

--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manual.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manual.py
@@ -307,7 +307,7 @@ class ManualHTMLRenderer(RendererMixin, HTMLRenderer):
 
         toc = TocEntry.of(tokens[0])
         return "\n".join([
-            self._file_header(toc),
+            self._file_header(toc, sidebar=self._build_toc(tokens, 0)),
             ' <div class="book">',
             '  <div class="titlepage">',
             '   <div>',
@@ -316,13 +316,12 @@ class ManualHTMLRenderer(RendererMixin, HTMLRenderer):
             '   </div>',
             "   <hr />",
             '  </div>',
-            self._build_toc(tokens, 0),
             super(HTMLRenderer, self).render(tokens[6:]),
             ' </div>',
             self._file_footer(toc),
         ])
 
-    def _file_header(self, toc: TocEntry) -> str:
+    def _file_header(self, toc: TocEntry, sidebar: str = "") -> str:
         prev_link, up_link, next_link = "", "", ""
         prev_a, next_a, parent_title = "", "", "&nbsp;"
         nav_html = ""
@@ -384,6 +383,8 @@ class ManualHTMLRenderer(RendererMixin, HTMLRenderer):
             ' </head>',
             ' <body>',
             nav_html,
+            f'  <nav class="toc-sidebar">{sidebar}</nav>' if sidebar else "",
+            '  <main class="content">',
         ])
 
     def _file_footer(self, toc: TocEntry) -> str:
@@ -424,6 +425,7 @@ class ManualHTMLRenderer(RendererMixin, HTMLRenderer):
             ])
         return "\n".join([
             nav_html,
+            '  </main>',
             ' </body>',
             '</html>',
         ])


### PR DESCRIPTION
As discussed in our last [documentation team meeting](https://discourse.nixos.org/t/2026-06-10-documentation-team-meeting-notes/78195)

Things changed:

- slight structural change of the rendered toc
- added little css that adds a sidebar
- mobile 

Not done yet:

- anchor following (needs a javascript intersectionObserver) -> next pr if desired.

-> Which of them should be done within this PR, which can be done in a follow up?

Noteworthy

-  Current css rules match elements by html structure. If we want more sophisticated custom components (dropdowns/search/tree-views/tabs etc. this will get very painful and breakages will be silent) 

Desktop (> 768px)
<img width="1507" height="873" alt="image" src="https://github.com/user-attachments/assets/4fbc1bc8-2b80-428d-b0e7-44d203e2f4ed" />

Mobile (<= 768px )

<img width="468" height="738" alt="image" src="https://github.com/user-attachments/assets/476bc428-fee5-4f46-857e-c04f546a0820" />


#### New (schematic) html structure:

Introduces new `nav` and  `main` tags which are individually scrollable.

- scroll content 
- scroll sidebar

```html
<head>
   <meta>
   ...
   <link>
</head>

<body>
nav_html,
  <nav class="toc-sidebar">{sidebar}</nav> 
  <main class="content">
    ... manual content
  </main>
</body>
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
