### PR TITLE
ty: 0.0.49 -> 0.0.50

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -10,6 +10,7 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- Paths under `/etc/xdg/` from packages in `environment.systemPackages` are no longer linked into the global `/etc/` by default. Modules depending on such directories must declare them explicitly using `environment.pathsToLink`.
 - `databricks-cli` has been updated from `0.290.2` to `1.x.x`, the first major release. OAuth tokens for interactive logins (`auth_type = databricks-cli`) are now stored in the OS-native secure store by default (Secret Service on Linux) instead of `~/.databricks/token-cache.json`; cached tokens from older versions are not migrated, so run `databricks auth login` once per profile after upgrading. To keep the previous file-backed storage, set `DATABRICKS_AUTH_STORAGE=plaintext` or add `auth_storage = plaintext` under `[__settings__]` in `~/.databrickscfg`. Additionally, the `vector_search_endpoints` DABs resource renamed `min_qps` to `target_qps` (and the `vector-search-endpoints` command renamed `--min-qps` to `--target-qps`). See the [upstream changelog](https://github.com/databricks/cli/blob/main/CHANGELOG.md) for details.
 
 - `hurl` has been updated to `8.x.x` which has some breaking changes. See [upstream changelog](https://github.com/Orange-OpenSource/hurl/releases/tag/8.0.0) for details.

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6205,7 +6205,7 @@
     name = "Daniel Șerbănescu";
   };
   daskladas = {
-    email = "xvzrsm@tutanota.de";
+    email = "mail@daskladas.de";
     github = "daskladas";
     githubId = 155686186;
     name = "Eric Heinemann";

--- a/nixos/modules/config/system-path.nix
+++ b/nixos/modules/config/system-path.nix
@@ -187,7 +187,6 @@ in
 
     environment.pathsToLink = [
       "/bin"
-      "/etc/xdg"
       "/etc/gtk-2.0"
       "/etc/gtk-3.0"
       "/lib" # FIXME: remove and update debug-info.nix

--- a/nixos/modules/config/xdg/autostart.nix
+++ b/nixos/modules/config/xdg/autostart.nix
@@ -22,8 +22,6 @@
   };
 
   config = {
-    # FIXME this does not actually work because "/etc/xdg" is linked
-    # unconditionally in `nixos/modules/config/system-path.nix`
     environment.pathsToLink = lib.mkIf config.xdg.autostart.install [
       "/etc/xdg/autostart"
     ];

--- a/nixos/modules/services/web-apps/davis.nix
+++ b/nixos/modules/services/web-apps/davis.nix
@@ -189,7 +189,7 @@ in
       name = lib.mkOption {
         type = lib.types.nullOr lib.types.str;
         default = "davis";
-        description = "Database name, only used when the databse is created locally.";
+        description = "Database name, only used when the database is created locally.";
       };
       createLocally = lib.mkOption {
         type = lib.types.bool;

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -763,12 +763,21 @@ in
           ];
         };
         serviceConfig.Type = "oneshot";
+        serviceConfig.EnvironmentFile = "-/etc/switch-root.conf";
         description = "NixOS Activation";
 
         script = # bash
           ''
             set -uo pipefail
             export PATH="/bin:${cfg.package.util-linux}/bin"
+
+            # A non-NixOS closure (e.g. init=/bin/sh) has no prepare-root;
+            # initrd-find-nixos-closure records this as a non-empty NEW_INIT.
+            # Skip activation and let initrd-switch-root hand over to it directly.
+            if [ -n "''${NEW_INIT:-}" ]; then
+              echo "$NEW_INIT is not a NixOS system - not activating"
+              exit 0
+            fi
 
             closure="$(realpath /nixos-closure)"
 

--- a/nixos/modules/system/etc/etc-activation.nix
+++ b/nixos/modules/system/etc/etc-activation.nix
@@ -71,6 +71,10 @@
               RequiresMountsFor = [
                 "/sysroot/nix/store"
               ];
+              # find-etc only creates this symlink for a NixOS init. For a
+              # non-NixOS init= (e.g. init=/bin/sh) it is absent, so skip the
+              # mount instead of failing the whole initrd.
+              ConditionPathExists = "/etc-metadata-image";
             };
             requires = [
               config.boot.initrd.systemd.services.initrd-find-etc.name
@@ -123,6 +127,8 @@
                 "/run/nixos-etc-metadata"
               ];
               DefaultDependencies = false;
+              # Skip for a non-NixOS init=, see the metadata mount above.
+              ConditionPathExists = "/etc-basedir";
             };
           }
         ];
@@ -140,6 +146,8 @@
                   # before the overlay is mounted.
                   "/run/nixos-etc-metadata"
                 ];
+                # Skip for a non-NixOS init=, see the metadata mount above.
+                ConditionPathExists = "/etc-metadata-image";
               };
               serviceConfig = {
                 Type = "oneshot";

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1631,6 +1631,7 @@ in
     "i686-linux"
   ] ./initrd-network-openvpn { systemdStage1 = true; };
   systemd-initrd-networkd-ssh = runTest ./systemd-initrd-networkd-ssh.nix;
+  systemd-initrd-non-nixos = runTest ./systemd-initrd-non-nixos.nix;
   systemd-initrd-shutdown = runTest {
     imports = [ ./systemd-shutdown.nix ];
     _module.args.systemdStage1 = true;

--- a/nixos/tests/systemd-initrd-non-nixos.nix
+++ b/nixos/tests/systemd-initrd-non-nixos.nix
@@ -1,0 +1,53 @@
+{ lib, pkgs, ... }:
+let
+  marker = "REACHED NON-NIXOS INIT AS PID 1";
+
+  # A non-NixOS init (no prepare-root). We use a store path, not literal
+  # /bin/sh: a fresh disk has no /bin/sh yet (it is created by the activation a
+  # non-NixOS init skips), while the store is always mounted; init=/bin/sh works
+  # the same on a real system. Writes a marker, then stays alive so PID 1 lives.
+  nonNixosInit = pkgs.writeShellScriptBin "non-nixos" ''
+    echo "${marker}" > /dev/console
+    exec ${pkgs.coreutils}/bin/sleep infinity
+  '';
+in
+{
+  name = "systemd-initrd-non-nixos";
+
+  nodes.machine = {
+    boot.initrd.systemd.enable = true;
+
+    virtualisation = {
+      # tmpfs root, like real non-NixOS closure init= microvm consumers.
+      diskImage = null;
+
+      graphics = false;
+    };
+
+    # Speed up wait_for_console.
+    boot.consoleLogLevel = lib.mkForce 3;
+    boot.initrd.systemd.managerEnvironment.SYSTEMD_LOG_LEVEL = "warning";
+
+    # switch-root needs an os-release on the target root. A real system has one
+    # on disk; our fresh tmpfs does not, so create it.
+    boot.initrd.systemd.tmpfiles.settings."10-os-release"."/sysroot/etc/os-release".f = {
+      mode = "0644";
+      argument = "ID=test-non-nixos";
+    };
+  };
+
+  testScript = ''
+    import os
+
+    # The last init= on the cmdline wins; QEMU_KERNEL_PARAMS is appended after
+    # the default one, so this boots our non-NixOS init.
+    os.environ["QEMU_KERNEL_PARAMS"] = "init=${lib.getExe nonNixosInit}"
+
+    machine.start()
+
+    # If activation does not skip the non-NixOS init, switch-root is blocked and
+    # the machine drops to emergency mode: the marker never appears and this
+    # times out.
+    machine.wait_for_console_text("${marker}", timeout=300)
+  '';
+}

--- a/nixos/tests/systemd-initrd-non-nixos.nix
+++ b/nixos/tests/systemd-initrd-non-nixos.nix
@@ -10,11 +10,8 @@ let
     echo "${marker}" > /dev/console
     exec ${pkgs.coreutils}/bin/sleep infinity
   '';
-in
-{
-  name = "systemd-initrd-non-nixos";
 
-  nodes.machine = {
+  common = {
     boot.initrd.systemd.enable = true;
 
     virtualisation = {
@@ -35,6 +32,20 @@ in
       argument = "ID=test-non-nixos";
     };
   };
+in
+{
+  name = "systemd-initrd-non-nixos";
+
+  nodes = {
+    bashActivation = common;
+
+    nixosInit = {
+      imports = [ common ];
+      system.nixos-init.enable = true;
+      system.etc.overlay.enable = true;
+      services.userborn.enable = true;
+    };
+  };
 
   testScript = ''
     import os
@@ -43,11 +54,15 @@ in
     # the default one, so this boots our non-NixOS init.
     os.environ["QEMU_KERNEL_PARAMS"] = "init=${lib.getExe nonNixosInit}"
 
-    machine.start()
+    start_all()
 
-    # If activation does not skip the non-NixOS init, switch-root is blocked and
-    # the machine drops to emergency mode: the marker never appears and this
+    # If a code path does not skip the non-NixOS init, switch-root is blocked and
+    # the machine drops to emergency mode: the marker never appears and the wait
     # times out.
-    machine.wait_for_console_text("${marker}", timeout=300)
+    with subtest("bash initrd-nixos-activation skips a non-NixOS init"):
+        bashActivation.wait_for_console_text("${marker}", timeout=300)
+
+    with subtest("nixos-init switches to a non-NixOS init directly"):
+        nixosInit.wait_for_console_text("${marker}", timeout=300)
   '';
 }

--- a/pkgs/by-name/co/code-cursor/sources.json
+++ b/pkgs/by-name/co/code-cursor/sources.json
@@ -1,22 +1,22 @@
 {
-  "version": "3.7.19",
+  "version": "3.7.42",
   "vscodeVersion": "1.105.1",
   "sources": {
     "x86_64-linux": {
-      "url": "https://downloads.cursor.com/production/80c653c2c3528e65016a0d304b54486084b470bb/linux/x64/Cursor-3.7.19-x86_64.AppImage",
-      "hash": "sha256-qlNQwaDqPL1/wsxwyUXPWvoeXuWoVahibnk0H0h6KZ4="
+      "url": "https://downloads.cursor.com/production/5702c9cfca656d8710fad58402fe37f14345e3ac/linux/x64/Cursor-3.7.42-x86_64.AppImage",
+      "hash": "sha256-o7c220esGj2qrLDt88zQ+XpAMbhJGoky5iNFB/qhvtU="
     },
     "aarch64-linux": {
-      "url": "https://downloads.cursor.com/production/80c653c2c3528e65016a0d304b54486084b470bb/linux/arm64/Cursor-3.7.19-aarch64.AppImage",
-      "hash": "sha256-JqFyV6OORi1IywBsTqCcamiyBojA7wFgMbcvD2PXjrQ="
+      "url": "https://downloads.cursor.com/production/5702c9cfca656d8710fad58402fe37f14345e3ac/linux/arm64/Cursor-3.7.42-aarch64.AppImage",
+      "hash": "sha256-PjVgVemRY66zY/gXcgYCVzSwkC5aCJeMsNreceQzWI4="
     },
     "x86_64-darwin": {
-      "url": "https://downloads.cursor.com/production/80c653c2c3528e65016a0d304b54486084b470bb/darwin/x64/Cursor-darwin-x64.dmg",
-      "hash": "sha256-nHewB1kn7wJDlzWWzuFD6yV6/LpcGGANHDQHTUgL6Ks="
+      "url": "https://downloads.cursor.com/production/5702c9cfca656d8710fad58402fe37f14345e3ac/darwin/x64/Cursor-darwin-x64.dmg",
+      "hash": "sha256-AiS0Iswdp8DAZV6cFA7uIYSE24ystuqJRz0YGJkkmDE="
     },
     "aarch64-darwin": {
-      "url": "https://downloads.cursor.com/production/80c653c2c3528e65016a0d304b54486084b470bb/darwin/arm64/Cursor-darwin-arm64.dmg",
-      "hash": "sha256-Dj2JQmL5VDT7WpejNX4wQi4wOrx7pt22oryycY9BXj0="
+      "url": "https://downloads.cursor.com/production/5702c9cfca656d8710fad58402fe37f14345e3ac/darwin/arm64/Cursor-darwin-arm64.dmg",
+      "hash": "sha256-e6VrLs/tj+FkEbUJN4RpQKNAbWCS/mEo1drVQFErXU0="
     }
   }
 }

--- a/pkgs/by-name/dn/dnsrecon/package.nix
+++ b/pkgs/by-name/dn/dnsrecon/package.nix
@@ -6,15 +6,20 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "dnsrecon";
-  version = "1.6.0";
+  version = "1.6.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "darkoperator";
     repo = "dnsrecon";
     tag = finalAttrs.version;
-    hash = "sha256-3o3UOEvaUVtfqZNAXzos7mtsAeUxJXtwNDw1MCKZ0YM=";
+    hash = "sha256-l10U8lRTSxT0ciZxLy+ZZBWhssUP9kSvVnPinzJ1SdQ=";
   };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools>=82.0.1" "setuptools"
+  '';
 
   pythonRelaxDeps = true;
 
@@ -45,9 +50,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     homepage = "https://github.com/darkoperator/dnsrecon";
     changelog = "https://github.com/darkoperator/dnsrecon/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [
-      fab
-    ];
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "dnsrecon";
   };
 })

--- a/pkgs/by-name/fa/fakeroot/add-missing-wrapawk.patch
+++ b/pkgs/by-name/fa/fakeroot/add-missing-wrapawk.patch
@@ -1,0 +1,98 @@
+--- /dev/null	2026-06-10 18:10:25.546025717 +0200
++++ b/wrapawk	1970-01-01 01:00:01.000000000 +0100
+@@ -0,0 +1,95 @@
++#Saluton Emacson! Bonvolu elekti -*- mode: awk; -*-. Dankon.
++
++BEGIN{
++  headerfile="wrapped.h";
++  deffile="wrapdef.h";
++  structfile="wrapstruct.h";
++  tmpffile="wraptmpf.h";
++  FS=";";
++  WARNING="/* Automatically generated file. Do not edit. Edit wrapawk/wrapfunc.inp. */";
++  print WARNING > headerfile;
++  print "#ifndef WRAPPED_H" > headerfile;
++  print "#define WRAPPED_H" > headerfile;
++  print WARNING > deffile;
++  print "#ifndef WRAPDEF_H" > deffile;
++  print "#define WRAPDEF_H" > deffile;
++  print WARNING > tmpffile;
++  print "#ifndef WRAPTMPF_H" > tmpffile;
++  print "#define WRAPTMPF_H" > tmpffile;
++  print WARNING > structfile;
++  print "#ifndef WRAPSTRUCT_H" > structfile;
++  print "#define WRAPSTRUCT_H" > structfile;
++  print "struct next_wrap_st next_wrap[]= {" > structfile;
++}
++
++/\/\*/{
++}
++/^(\#)/{
++  print $0 > structfile;
++  print $0 > tmpffile;
++  print $0 > deffile;
++  print $0 > headerfile;
++
++}
++/^[^\/].*;.*;.*;/{
++  name=$1;
++  ret=$2;
++  argtype=$3;
++  argname=$4;
++  MACRO=$5;
++  openat_extra=$6;
++  if(openat_extra){
++    print "  {(void(*))&next_" name ", \"" name "\"},"  > structfile;
++    print "extern " ret " (*next_" name ")" openat_extra ";" > headerfile;
++    print ret " (*next_" name ")" openat_extra "=tmp_" name ";"> deffile;
++
++    print ret " tmp_" name,  openat_extra "{"           > tmpffile;
++    print "  mode_t mode = 0;"                          > tmpffile;
++    print "  if (flags & O_CREAT) {"                    > tmpffile;
++    print "    va_list args;"                           > tmpffile;
++    print "    va_start(args, flags);"                  > tmpffile;
++    print "    mode = va_arg(args, int);"               > tmpffile;
++    print "    va_end(args);"                           > tmpffile;
++    print "  }"                                         > tmpffile;
++    print "  load_library_symbols();"                   > tmpffile;
++    print "  return  next_" name,  argname ";"          > tmpffile;
++    print "}"                                           > tmpffile;
++    print ""                                            > tmpffile;
++  } else if(MACRO){
++    print "  {(void(*))&NEXT_" MACRO "_NOARG, " name "_QUOTE},"  > structfile;
++    print "extern " ret " (*NEXT_" MACRO "_NOARG)" argtype ";" > headerfile;
++    print ret " (*NEXT_" MACRO "_NOARG)" argtype "=TMP_" MACRO ";"> deffile;
++    
++    print ret " TMP_" MACRO,  argtype "{"                 > tmpffile;
++    print "  load_library_symbols();"                   > tmpffile;
++    print "  return  NEXT_" MACRO "_NOARG "  argname ";"           > tmpffile;
++    print "}"                                           > tmpffile;
++    print ""                                            > tmpffile;
++  } else {
++    print "  {(void(*))&next_" name ", \"" name "\"},"  > structfile;
++    print "extern " ret " (*next_" name ")" argtype ";" > headerfile;
++    print ret " (*next_" name ")" argtype "=tmp_" name ";"> deffile;
++    
++    print ret " tmp_" name,  argtype "{"                 > tmpffile;
++    print "  load_library_symbols();"                   > tmpffile;
++    print "  return  next_" name,  argname ";"           > tmpffile;
++    print "}"                                           > tmpffile;
++    print ""                                            > tmpffile;
++  }
++}
++
++/^ *$/{
++  print > structfile;
++  print > headerfile;
++  print > deffile;  
++  print > tmpffile;
++}
++
++END{
++  print "  {NULL, NULL}," > structfile;
++  print "};"              > structfile;
++  print "#endif"          > structfile;
++  print "#endif"          > tmpffile;
++  print "#endif"          > deffile;
++  print "#endif"          > headerfile;
++}

--- a/pkgs/by-name/fa/fakeroot/package.nix
+++ b/pkgs/by-name/fa/fakeroot/package.nix
@@ -22,10 +22,11 @@ stdenv.mkDerivation (finalAttrs: {
     repo = "fakeroot";
     rev = "upstream/${finalAttrs.version}";
     domain = "salsa.debian.org";
-    hash = "sha256-1Xmb8OPZSVP4xtSBGuwwKwdVQXixEugMgQfvAJueJAg=";
+    hash = "sha256-sAzXeONjDT753lbu7amQY6yXpaTNCa4wFOzB01SRbCs=";
   };
 
   patches = lib.optionals stdenv.hostPlatform.isLinux [
+    ./add-missing-wrapawk.patch
     ./einval.patch
   ];
 

--- a/pkgs/by-name/fe/ferron/package.nix
+++ b/pkgs/by-name/fe/ferron/package.nix
@@ -10,13 +10,14 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ferron";
-  version = "2.7.0";
+  version = "2.8.1";
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "ferronweb";
     repo = "ferron";
     tag = finalAttrs.version;
-    hash = "sha256-nh3dq8s+lH+WbFviFZ9L+4MF4YhGPaJWTYtH12HfXoI=";
+    hash = "sha256-69rCgyUjEbInTmgZMU6uNuahaqSVcaIOWFVSGC9in28=";
   };
 
   # ../../ is cargoDepsCopy, and obviously does not contain monoio's README.md
@@ -25,9 +26,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail '#![doc = include_str!("../../README.md")]' ""
   '';
 
-  strictDeps = true;
-
-  cargoHash = "sha256-ft7Ewv56u31iPCH3LJKE4Mt68KTfHtIiYMRjeGcwSQQ=";
+  cargoHash = "sha256-H6AMHYlUdlCFAzOcso5V7uagB1Is304TuXR6+IrqWOU=";
 
   nativeBuildInputs = [
     pkg-config
@@ -53,7 +52,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Fast, memory-safe web server written in Rust";
     homepage = "https://github.com/ferronweb/ferron";
-    changelog = "https://github.com/ferronweb/ferron/releases/tag/${finalAttrs.version}";
+    changelog = "https://github.com/ferronweb/ferron/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       _0x4A6F

--- a/pkgs/by-name/fi/firewalld/package.nix
+++ b/pkgs/by-name/fi/firewalld/package.nix
@@ -132,6 +132,9 @@ stdenv.mkDerivation (finalAttrs: {
   ''
   + lib.optionalString (!withGui) ''
     rm $out/bin/firewall-{applet,config}
+    rm $out/etc/xdg/autostart/firewall-applet.desktop
+    rm $out/share/applications/firewall-config.desktop
+    rm $out/share/metainfo/org.firewalld.firewall-config.metainfo.xml
   '';
 
   dontWrapGApps = true;

--- a/pkgs/by-name/fo/folly/package.nix
+++ b/pkgs/by-name/fo/folly/package.nix
@@ -174,6 +174,7 @@ stdenv.mkDerivation (finalAttrs: {
     "singleton_thread_local_test.SingletonThreadLocalDeathTest.Overload"
 
     # very strict timing constraints, will fail under load
+    "logging_async_file_writer_test.AsyncFileWriter.discard"
     "io_async_hh_wheel_timer_test.HHWheelTimerTest.CancelTimeout"
     "io_async_hh_wheel_timer_test.HHWheelTimerTest.DefaultTimeout"
     "io_async_hh_wheel_timer_test.HHWheelTimerTest.DeleteWheelInTimeout"

--- a/pkgs/by-name/fr/frida-tools/package.nix
+++ b/pkgs/by-name/fr/frida-tools/package.nix
@@ -6,13 +6,13 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "frida-tools";
-  version = "14.9.0";
+  version = "14.10.2";
   pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) version;
     pname = "frida_tools";
-    hash = "sha256-9S/PtdcyFV/9c3pNrmhpqBg8hXtGkqtUyoX1SzXHxtE=";
+    hash = "sha256-DGv5zyOkxQHXhFFrbcG4zVkNhOosymmEZdX2Aphdh/0=";
   };
 
   build-system = with python3Packages; [

--- a/pkgs/by-name/ge/geant4/package.nix
+++ b/pkgs/by-name/ge/geant4/package.nix
@@ -38,12 +38,12 @@ let
 in
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "11.4.1";
+  version = "11.4.2";
   pname = "geant4";
 
   src = fetchurl {
     url = "https://cern.ch/geant4-data/releases/geant4-v${finalAttrs.version}.tar.gz";
-    hash = "sha256-HG3ymOw5hFlDgP/jRJ48I80jKZsX4QZz5pI7jmuNIBc=";
+    hash = "sha256-VyDyu6aSECfiBq1PCgb5vMNIras2JA6LJ3EPIM4+lxo=";
   };
 
   # Fix broken paths in a .pc

--- a/pkgs/by-name/gi/gitte/package.nix
+++ b/pkgs/by-name/gi/gitte/package.nix
@@ -22,7 +22,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "gitte";
-  version = "0.7.1";
+  version = "0.7.2";
 
   __structuredAttrs = true;
 
@@ -30,12 +30,12 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "ckruse";
     repo = "Gitte";
     tag = finalAttrs.version;
-    hash = "sha256-R2Y/nmj509yo0ueh0nMxUsoqdJBaGUdSHj69QHZBVTQ=";
+    hash = "sha256-ZnJhObVZgseUz4cb/poaUmxfV+v11SC4xlNQDkff/fs=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-QTnstnFJYlasY9JSXT+OMjxWYawQbNpQzI0FDpLWknM=";
+    hash = "sha256-Ouz9foDYXzK3UH6mjrM2T55U63FqOLLgCljNKSKIA/E=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/gs/gsoap/package.nix
+++ b/pkgs/by-name/gs/gsoap/package.nix
@@ -18,11 +18,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gsoap";
-  version = "2.8.142";
+  version = "2.8.143";
 
   src = fetchurl {
     url = "mirror://sourceforge/gsoap2/gsoap_${finalAttrs.version}.zip";
-    hash = "sha256-bXGWvWWR7Cl3R0xoHjUbSjPrXC1kyeLmcnsATzMLN1I=";
+    hash = "sha256-tTgVhMvIWRB4szmtoVn7BgWGwOHkZmtotKOVjvLisek=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/js/jsoncons/package.nix
+++ b/pkgs/by-name/js/jsoncons/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "jsoncons";
-  version = "1.8.0";
+  version = "1.8.1";
 
   src = fetchFromGitHub {
     owner = "danielaparker";
     repo = "jsoncons";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-QSTT/wpc9EaQOF8aItqqtVQl2TjQA2iiw4vYmSjK7Tk=";
+    hash = "sha256-+5vglrmmJ6jb33Mlp+VnIMG2yHqzKFHPQUqTBezDNCw=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/lx/lxmf-rs/package.nix
+++ b/pkgs/by-name/lx/lxmf-rs/package.nix
@@ -13,17 +13,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "lxmf-rs";
-  version = "0.2.0";
+  version = "0.4.1";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "FreeTAKTeam";
     repo = "LXMF-rs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2bxSBw4ISb7xOQiazrSVytvW9cW4i7azB7U8sos7+yA=";
+    hash = "sha256-GCN4HpqbCM2xCBpBRpUALmHGfhOm1qZScdYgBqJqLQU=";
   };
 
-  cargoHash = "sha256-EqRL1JoAdyh46Ev8S/Ta6RsbhhaNH6dlisudpO2D1Rw=";
+  cargoHash = "sha256-a6O1VslizDom6AuJKF5xZgKNSgrw1EfvJRWpG9J7Le8=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/lx/lxmf-rs/package.nix
+++ b/pkgs/by-name/lx/lxmf-rs/package.nix
@@ -52,6 +52,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=transport::announce_limits::tests::ingress_limiting_is_scoped_per_interface"
     # multicast listener expected to see the Broadcast tx within 500ms
     "--skip=broadcast_tx_reaches_multicast_listeners"
+    "--skip=direct_link_proof_targeting_multicast_iface_falls_back_to_broadcast"
   ];
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/ma/matterjs-server/package.nix
+++ b/pkgs/by-name/ma/matterjs-server/package.nix
@@ -12,7 +12,7 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "matterjs-server";
-  version = "1.0.0";
+  version = "1.1.0";
   __structuredAttrs = true;
   strictDeps = true;
 
@@ -20,10 +20,10 @@ buildNpmPackage (finalAttrs: {
     owner = "matter-js";
     repo = "matterjs-server";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-c/jhQfenRgE0qHisGM1TOtqWjDy/RcwGa04RE0FzR/U=";
+    hash = "sha256-LNSj9y+FDCsz4xiP8pL4xs7TVg2Cl5FOtWLTclewVbU=";
   };
 
-  npmDepsHash = "sha256-7Anz+Foz5jKP8u9jmpw1wn/LgknR1LWyozamBs83v1A=";
+  npmDepsHash = "sha256-bvmh6Jv0KDOZOY7Ti0TgbSdVcyYHhX0YOY/8PB7pebs=";
 
   nativeBuildInputs = [
     makeBinaryWrapper

--- a/pkgs/by-name/mo/monocypher/package.nix
+++ b/pkgs/by-name/mo/monocypher/package.nix
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "monocypher";
-  version = "4.0.2";
+  version = "4.0.3";
 
   src = fetchurl {
     url = "https://monocypher.org/download/monocypher-${finalAttrs.version}.tar.gz";
-    hash = "sha256-ONBxeXOMDJBnfbo863p7hJa8/qdYuhpT6AP+0wrgh5w=";
+    hash = "sha256-jMm8NBpmJJAW25vXDpFC2NCu+ZRZc3RLGsBdvFXY7mY=";
   };
 
   installFlags = [ "PREFIX=$(out)" ];

--- a/pkgs/by-name/mu/mu/package.nix
+++ b/pkgs/by-name/mu/mu/package.nix
@@ -19,7 +19,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mu";
-  version = "1.14.1";
+  version = "1.14.2";
 
   outputs = [
     "out"
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "djcb";
     repo = "mu";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-P2b0JuzgoZkWXSkJWUrjkcfW9oGVPeH1p/hVKfA9Yjc=";
+    hash = "sha256-0svY7XhhimIgsYUbHcNT4OCmpmhE4otRxqoasABEIA4=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/ne/nerva/package.nix
+++ b/pkgs/by-name/ne/nerva/package.nix
@@ -6,13 +6,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "nerva";
-  version = "1.18.1";
+  version = "1.19.1";
 
   src = fetchFromGitHub {
     owner = "praetorian-inc";
     repo = "nerva";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-bsa4dZZbxm3MzHhyqTLuxzsK7nQoTxY0Qeoa2TsdqHg=";
+    hash = "sha256-qz689RHDBoCJ8NsOooXtkkHQ2G1T1oL4+D3rgpqHZDE=";
   };
 
   vendorHash = "sha256-j+8KZxHnYrtxwdBxpAXZ+Q5Sm1REluUEmD69tKYTCag=";

--- a/pkgs/by-name/ni/nixos-init/src/find_etc.rs
+++ b/pkgs/by-name/ni/nixos-init/src/find_etc.rs
@@ -3,7 +3,7 @@ use std::{os::unix, path::Path};
 use anyhow::{Context, Result};
 
 use crate::config::Config;
-use crate::{SYSROOT_PATH, find_toplevel_in_prefix, resolve_in_prefix};
+use crate::{SYSROOT_PATH, find_init_in_prefix, resolve_in_prefix, verify_init_is_nixos};
 
 /// Entrypoint for the `find-etc` binary.
 ///
@@ -12,7 +12,20 @@ use crate::{SYSROOT_PATH, find_toplevel_in_prefix, resolve_in_prefix};
 /// This avoids needing a reference to the toplevel embedded in the initrd and thus reduces the
 /// need to re-build it.
 pub fn find_etc() -> Result<()> {
-    let toplevel = find_toplevel_in_prefix(SYSROOT_PATH)?;
+    let init_in_sysroot =
+        find_init_in_prefix(SYSROOT_PATH).context("Failed to find init in sysroot")?;
+
+    // A non-NixOS init= (e.g. init=/bin/sh) has no etc metadata image. Skip
+    // without creating the symlinks: the etc-overlay mounts are gated on them
+    // and so skip too, and initrd-init switches root to the init directly.
+    let Ok(toplevel) = verify_init_is_nixos(SYSROOT_PATH, &init_in_sysroot) else {
+        log::info!(
+            "{} is not a NixOS system - not setting up the etc overlay.",
+            init_in_sysroot.display()
+        );
+        return Ok(());
+    };
+
     let config = Config::from_toplevel(&toplevel, SYSROOT_PATH)?;
 
     let basedir = config

--- a/pkgs/by-name/ni/nixos-init/src/lib.rs
+++ b/pkgs/by-name/ni/nixos-init/src/lib.rs
@@ -27,16 +27,6 @@ pub use crate::{
 
 pub const SYSROOT_PATH: &str = "/sysroot";
 
-/// Find the path to the toplevel closure of the system in a prefix.
-///
-/// Uses the `init=` parameter on the kernel command-line.
-///
-/// Returns the relative path of the init to the prefix, e.g. without the `/sysroot` prefix.
-pub fn find_toplevel_in_prefix(prefix: &str) -> Result<PathBuf> {
-    let init_in_sysroot = find_init_in_prefix(prefix)?;
-    verify_init_is_nixos(prefix, init_in_sysroot)
-}
-
 /// Verify that an init path is inside a `NixOS` toplevel directory.
 ///
 /// If the path is verified, returns the path to the toplevel.

--- a/pkgs/by-name/ni/nixos-init/src/lib.rs
+++ b/pkgs/by-name/ni/nixos-init/src/lib.rs
@@ -87,20 +87,16 @@ pub fn find_init_in_prefix(prefix: &str) -> Result<PathBuf> {
 }
 
 /// Extract the value of the `init` parameter from the given kernel `cmdline`.
+///
+/// If `init=` appears multiple times the last one wins, matching the kernel.
+/// This is what makes appending `init=/bin/sh` at the boot prompt work even
+/// though the boot entry already has an `init=`.
 fn extract_init(cmdline: &str) -> Result<PathBuf> {
-    let init_params: Vec<&str> = cmdline
+    let init = cmdline
         .split_ascii_whitespace()
-        .filter(|p| p.starts_with("init="))
-        .collect();
-
-    if init_params.len() != 1 {
-        bail!("Expected exactly one init param on kernel cmdline: {cmdline}")
-    }
-
-    let init = init_params
-        .first()
-        .and_then(|s| s.split('=').next_back())
-        .context("Failed to extract init path from kernel cmdline: {cmdline}")?;
+        .filter_map(|p| p.strip_prefix("init="))
+        .next_back()
+        .with_context(|| format!("No init= parameter on kernel cmdline: {cmdline}"))?;
 
     Ok(PathBuf::from(init))
 }
@@ -128,5 +124,26 @@ mod tests {
         verify_init_is_nixos(prefix.path().to_str().unwrap(), "/toplevel/init")?;
 
         Ok(())
+    }
+
+    #[test]
+    fn test_extract_init_single() {
+        assert_eq!(
+            extract_init("root=fstab init=/nix/store/xxx-nixos/init quiet").unwrap(),
+            PathBuf::from("/nix/store/xxx-nixos/init")
+        );
+    }
+
+    #[test]
+    fn test_extract_init_last_wins() {
+        assert_eq!(
+            extract_init("init=/nix/store/xxx-nixos/init init=/bin/sh").unwrap(),
+            PathBuf::from("/bin/sh")
+        );
+    }
+
+    #[test]
+    fn test_extract_init_missing() {
+        assert!(extract_init("root=fstab quiet").is_err());
     }
 }

--- a/pkgs/by-name/op/openvino-genai/package.nix
+++ b/pkgs/by-name/op/openvino-genai/package.nix
@@ -164,7 +164,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeCheckInputs = [ openvino-tokenizers ];
 
-  doCheck = true;
+  # C++ exception with description "Exception from src/inference/src/cpp/core.cpp:272:
+  # Exception from src/inference/src/dev/core_impl.cpp:706:
+  # Device with "CPU" name is not registered in the OpenVINO Runtime
+  doCheck = !stdenv.hostPlatform.isAarch64;
 
   preCheck = ''
     mkdir -p tests/cpp/data

--- a/pkgs/by-name/op/openvino-genai/package.nix
+++ b/pkgs/by-name/op/openvino-genai/package.nix
@@ -42,6 +42,14 @@ let
   };
 
   python = python3Packages.python.withPackages (ps: [ ps.pybind11 ]);
+
+  # How the build system calls the different platforms
+  archName =
+    {
+      "aarch64-linux" = "aarch64";
+      "x86_64-linux" = "intel64";
+    }
+    .${stdenv.hostPlatform.system};
 in
 
 stdenv.mkDerivation (finalAttrs: {
@@ -147,7 +155,11 @@ stdenv.mkDerivation (finalAttrs: {
         "\''${_IMPORT_PREFIX}/runtime/include" "$dev/include"
     substituteInPlace $dev/lib/cmake/OpenVINOGenAITargets-release.cmake \
       --replace-fail \
-        "\''${_IMPORT_PREFIX}/runtime/lib/intel64/" "$out/lib/"
+        "\''${_IMPORT_PREFIX}/runtime/lib/${archName}/" "$out/lib/"
+  '';
+
+  preFixup = ''
+    addAutoPatchelfSearchPath ${lib.getLib openvino}/runtime/lib/${archName}
   '';
 
   postFixup = ''

--- a/pkgs/by-name/op/openvino-genai/package.nix
+++ b/pkgs/by-name/op/openvino-genai/package.nix
@@ -46,7 +46,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "openvino-genai";
-  version = "2026.2.0.0";
+  version = "2026.2.1.0";
 
   __structuredAttrs = true;
 
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
       owner = "openvinotoolkit";
       repo = "openvino.genai";
       tag = finalAttrs.version;
-      hash = "sha256-C60e4F+NuUPA4pQ/o2+EekOmp47QH1fTGDyXYqPJ57s=";
+      hash = "sha256-M8xxOsNvtIYIKvkrmOUnKv6gL/RAGuBfTBu3OPm3zRk=";
     };
 
   outputs = [

--- a/pkgs/by-name/op/openvino-tokenizers/package.nix
+++ b/pkgs/by-name/op/openvino-tokenizers/package.nix
@@ -17,7 +17,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "openvino-tokenizers";
-  version = "2026.2.0.0";
+  version = "2026.2.1.0";
 
   __structuredAttrs = true;
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
       owner = "openvinotoolkit";
       repo = "openvino_tokenizers";
       tag = finalAttrs.version;
-      hash = "sha256-J138ungdkkq1qa5/eEQTgKKtGyx9KHCrQwUsIGkf3mI=";
+      hash = "sha256-K0Zdo9er+s9/PWvBmVJTsWOSgzzZ5De7sRLMNEpxf/U=";
     };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/op/openvino/package.nix
+++ b/pkgs/by-name/op/openvino/package.nix
@@ -56,14 +56,14 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "openvino";
-  version = "2026.2.0";
+  version = "2026.2.1";
 
   src = fetchFromGitHub {
     owner = "openvinotoolkit";
     repo = "openvino";
     tag = finalAttrs.version;
     fetchSubmodules = true;
-    hash = "sha256-/JbaWeW4MgIylhEhA///febE9OCooONKgz1zTn0tb90=";
+    hash = "sha256-66g+v+L0BPNW6HvmWMHAHoNEFn9SUPrmZDyDjES6K1I=";
   };
 
   outputs = [

--- a/pkgs/by-name/or/orbiton/package.nix
+++ b/pkgs/by-name/or/orbiton/package.nix
@@ -12,13 +12,13 @@
 
 buildGoModule rec {
   pname = "orbiton";
-  version = "2.74.3";
+  version = "2.74.4";
 
   src = fetchFromGitHub {
     owner = "xyproto";
     repo = "orbiton";
     tag = "v${version}";
-    hash = "sha256-+Q3+YuyD95U4UGD6FrdsYHSQYOOZFsmIP2R4Ccs1z1U=";
+    hash = "sha256-LwwHwi1NyKqyzJou4sh+gM2NxNdYvpBN2Zx8SIOHX40=";
   };
 
   vendorHash = null;

--- a/pkgs/by-name/pa/parallel-launcher/package.nix
+++ b/pkgs/by-name/pa/parallel-launcher/package.nix
@@ -55,13 +55,13 @@ stdenv.mkDerivation (
   in
   {
     pname = "parallel-launcher";
-    version = "9.0.4"; # Check ./parallel-n64-next.nix for updates when updating, too
+    version = "9.0.5"; # Check ./parallel-n64-next.nix for updates when updating, too
 
     src = fetchFromGitLab {
       owner = "parallel-launcher";
       repo = "parallel-launcher";
       tag = reformatVersion finalAttrs.version;
-      hash = "sha256-j+fblgE891Ji+aCl3CcX0QjAAKdGiSivOVWa+KDrDoY=";
+      hash = "sha256-D+4vPSimIVNY8y7k0QsKZ/47ojgjR8aWBhDqBxY15Zk=";
     };
 
     patches =

--- a/pkgs/by-name/re/renovate/package.nix
+++ b/pkgs/by-name/re/renovate/package.nix
@@ -20,13 +20,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "renovate";
-  version = "43.150.1";
+  version = "43.214.1";
 
   src = fetchFromGitHub {
     owner = "renovatebot";
     repo = "renovate";
     tag = finalAttrs.version;
-    hash = "sha256-yCkwlPf6jLM906U7BdY1h5IcaOSe6aureYIKXQk+re0=";
+    hash = "sha256-S5ixP4Dp/YDv23kE5lvmp/Px6GrF9B6/wwSiKUwVWhA=";
   };
 
   postPatch = ''
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_10;
     fetcherVersion = 3;
-    hash = "sha256-ldxhP+I455PEfBrkJIlHudNvAsI4EN34ZkQXMBciOo4=";
+    hash = "sha256-A8aL5ZF0tFKi0uCXxOQMzxByAIVyt76wnLvolFVYKuI=";
   };
 
   env.COREPACK_ENABLE_STRICT = 0;
@@ -78,12 +78,6 @@ stdenv.mkDerivation (finalAttrs: {
     export npm_config_nodedir=${nodejs}
     npm run rebuild
     rm -rf build/Release/{obj.target,.deps} vendor
-
-    popd
-
-    pushd node_modules/.pnpm/better-sqlite3*/node_modules/better-sqlite3
-    npm run build-release
-    rm -rf build/Release/{obj.target,sqlite3.a,.deps} deps
 
     popd
 

--- a/pkgs/by-name/se/seaweedfs/package.nix
+++ b/pkgs/by-name/se/seaweedfs/package.nix
@@ -9,7 +9,7 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "seaweedfs";
-  version = "4.31";
+  version = "4.34";
 
   src = fetchFromGitHub {
     owner = "seaweedfs";
@@ -22,10 +22,10 @@ buildGoModule (finalAttrs: {
       find "$out" -name .git -print0 | xargs -0 rm -rf
       popd
     '';
-    hash = "sha256-jhhLOjA+CXhtNyVHePT7dN3T5u5K3dHJj1gmxOh+RJU=";
+    hash = "sha256-lKpNBdiynDEnqCujgDRFUXvyVops4Q5l6n9P/7pm8hc=";
   };
 
-  vendorHash = "sha256-eB5fkFDGOqw4q2iHe4acLfIx2/a1Ys1EmARGX/vIN84=";
+  vendorHash = "sha256-MF8aLFKUFq0io7CL1EGZp+TUB2co/Hf0fwK2wZybx8Y=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/so/songrec/package.nix
+++ b/pkgs/by-name/so/songrec/package.nix
@@ -19,16 +19,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "songrec";
-  version = "0.7.3";
+  version = "0.7.4";
 
   src = fetchFromGitHub {
     owner = "marin-m";
     repo = "songrec";
     tag = finalAttrs.version;
-    hash = "sha256-6DT5KY6Y3CPTFLNG+EostAlMgZ35SLv8r9EXtRadC2U=";
+    hash = "sha256-U7THM8fagZREkleH6DWiusP3KcAtu/OrAg9USdCGRec=";
   };
 
-  cargoHash = "sha256-9R7HwTwjeCBIxX2xHs++9Zl0SMRmHPHDD1OHNa4q+jI=";
+  cargoHash = "sha256-O0YjeZCOe+cXjxUAgMT1l621rid4pexMZ3MbLDGxQsM=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/st/strace/package.nix
+++ b/pkgs/by-name/st/strace/package.nix
@@ -11,11 +11,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "strace";
-  version = "7.0";
+  version = "7.1";
 
   src = fetchurl {
     url = "https://strace.io/files/${finalAttrs.version}/strace-${finalAttrs.version}.tar.xz";
-    hash = "sha256-bJJBm+Py7FYLMXKKRlIhfFmGTIZCunsbN3GxsBOtB0s=";
+    hash = "sha256-gXQ+zypbRBhrL1A4r9yL7aflxwrtFbT7+8xuns4kSQ8=";
   };
 
   separateDebugInfo = true;

--- a/pkgs/by-name/ty/ty/package.nix
+++ b/pkgs/by-name/ty/ty/package.nix
@@ -17,7 +17,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ty";
-  version = "0.0.49";
+  version = "0.0.50";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     repo = "ty";
     tag = finalAttrs.version;
     fetchSubmodules = true;
-    hash = "sha256-IKeoskueujGYFjhUd3V7iwKwZjFZqG3OYfe36S6J2aw=";
+    hash = "sha256-dIl/iNBKHDpoDKv0Kw2MTsjboEbxkKZOqab9Y1mV4T0=";
   };
 
   # For Darwin platforms, remove the integration test for file notifications,
@@ -39,7 +39,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoBuildFlags = [ "--package=ty" ];
 
-  cargoHash = "sha256-y1sKf+KXya/K+WUiIE357U6DXh/d+AQgj0SQIi1gpUw=";
+  cargoHash = "sha256-gfCriBU7VDni+H+VwedEvRd/Rr4CvT9wKDO0JzLqDcs=";
 
   nativeBuildInputs = [ installShellFiles ];
   buildInputs = [ rust-jemalloc-sys ];

--- a/pkgs/by-name/v2/v2ray-rules-dat/package.nix
+++ b/pkgs/by-name/v2/v2ray-rules-dat/package.nix
@@ -1,37 +1,43 @@
 {
+  lib,
   stdenvNoCC,
   fetchurl,
-  lib,
 }:
-let
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "v2ray-rules-dat";
   version = "202606122311";
 
-  geoipDat = fetchurl {
-    url = "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/${version}/geoip.dat";
-    hash = "sha256-iGGpeUaWtIH7AEPueCssQOgL/Ia7nkLFvWnAj1SDsbU=";
-  };
-
-  geositeDat = fetchurl {
-    url = "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/${version}/geosite.dat";
-    hash = "sha256-/c/3OjfALveNnHS9NxonTeOiZyud6U/X4WHrGZSOs7Q=";
-  };
-in
-stdenvNoCC.mkDerivation {
-  pname = "v2ray-rules-dat";
-  inherit version;
   __structuredAttrs = true;
   strictDeps = true;
+
+  src = null;
   dontUnpack = true;
 
   installPhase = ''
-    install -Dm444 ${geoipDat} $out/share/v2ray/geoip.dat
-    install -Dm444 ${geositeDat} $out/share/v2ray/geosite.dat
+    runHook preInstall
+
+    install -Dm444 ${finalAttrs.passthru.geoipDat} $out/share/v2ray/geoip.dat
+    install -Dm444 ${finalAttrs.passthru.geositeDat} $out/share/v2ray/geosite.dat
+
+    runHook postInstall
   '';
+
+  passthru = {
+    geoipDat = fetchurl {
+      url = "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/${finalAttrs.version}/geoip.dat";
+      hash = "sha256-iGGpeUaWtIH7AEPueCssQOgL/Ia7nkLFvWnAj1SDsbU=";
+    };
+    geositeDat = fetchurl {
+      url = "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/${finalAttrs.version}/geosite.dat";
+      hash = "sha256-/c/3OjfALveNnHS9NxonTeOiZyud6U/X4WHrGZSOs7Q=";
+    };
+  };
 
   meta = {
     description = "Enhanced edition of V2Ray rules dat files";
     homepage = "https://github.com/Loyalsoldier/v2ray-rules-dat";
+    changelog = "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/tag/${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ nix-julia ];
   };
-}
+})

--- a/pkgs/by-name/v2/v2ray-rules-dat/package.nix
+++ b/pkgs/by-name/v2/v2ray-rules-dat/package.nix
@@ -31,7 +31,7 @@ stdenvNoCC.mkDerivation {
   meta = {
     description = "Enhanced edition of V2Ray rules dat files";
     homepage = "https://github.com/Loyalsoldier/v2ray-rules-dat";
-    license = lib.licenses.gpl3;
+    license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ nix-julia ];
   };
 }

--- a/pkgs/by-name/v2/v2ray-rules-dat/package.nix
+++ b/pkgs/by-name/v2/v2ray-rules-dat/package.nix
@@ -5,7 +5,7 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "v2ray-rules-dat";
-  version = "202606122311";
+  version = "202606172318";
 
   __structuredAttrs = true;
   strictDeps = true;
@@ -29,7 +29,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     };
     geositeDat = fetchurl {
       url = "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/${finalAttrs.version}/geosite.dat";
-      hash = "sha256-/c/3OjfALveNnHS9NxonTeOiZyud6U/X4WHrGZSOs7Q=";
+      hash = "sha256-DEhEZP7ijNudb6qhIArpRhUqzEzmG0OxJaoBuMFVacM=";
     };
     updateScript = ./update.sh;
   };

--- a/pkgs/by-name/v2/v2ray-rules-dat/package.nix
+++ b/pkgs/by-name/v2/v2ray-rules-dat/package.nix
@@ -31,6 +31,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       url = "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/${finalAttrs.version}/geosite.dat";
       hash = "sha256-/c/3OjfALveNnHS9NxonTeOiZyud6U/X4WHrGZSOs7Q=";
     };
+    updateScript = ./update.sh;
   };
 
   meta = {

--- a/pkgs/by-name/v2/v2ray-rules-dat/update.sh
+++ b/pkgs/by-name/v2/v2ray-rules-dat/update.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq nix common-updater-scripts
+
+set -euo pipefail
+
+version="$(
+  curl -fsSL ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} "https://api.github.com/repos/Loyalsoldier/v2ray-rules-dat/releases/latest" \
+    | jq -r .tag_name
+)"
+
+if [[ "$UPDATE_NIX_OLD_VERSION" == "$version" ]]; then
+  echo "Already up to date!"
+  exit 0
+fi
+
+prefetch_hash() {
+  local name="$1"
+  nix --extra-experimental-features nix-command \
+    store prefetch-file \
+    --json \
+    --hash-type sha256 \
+    "https://github.com/Loyalsoldier/v2ray-rules-dat/releases/download/$version/$name" \
+    | jq -r .hash
+}
+
+geoip_hash="$(prefetch_hash geoip.dat)"
+geosite_hash="$(prefetch_hash geosite.dat)"
+
+update-source-version "v2ray-rules-dat" "$version" "$geoip_hash" \
+  --source-key=passthru.geoipDat \
+  --ignore-same-version --ignore-same-hash
+
+update-source-version "v2ray-rules-dat" "$version" "$geosite_hash" \
+  --source-key=passthru.geositeDat \
+  --ignore-same-version --ignore-same-hash

--- a/pkgs/by-name/vi/victorialogs/package.nix
+++ b/pkgs/by-name/vi/victorialogs/package.nix
@@ -10,13 +10,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "VictoriaLogs";
-  version = "1.50.0";
+  version = "1.51.0";
 
   src = fetchFromGitHub {
     owner = "VictoriaMetrics";
     repo = "VictoriaLogs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-hlRHTTwGPXAMVscIeHxac7KCNWEdBy7WS/KbxwMTl7w=";
+    hash = "sha256-8rUDMV7bxMxyU0NYIMFSqGzSMwGogKFDliGXf4VSoCI=";
   };
 
   vendorHash = null;

--- a/pkgs/by-name/we/werf/package.nix
+++ b/pkgs/by-name/we/werf/package.nix
@@ -10,13 +10,13 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "werf";
-  version = "2.69.1";
+  version = "2.70.0";
 
   src = fetchFromGitHub {
     owner = "werf";
     repo = "werf";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-w3H+SwCNkAg8MfA1FbSOTrG6pHDBMhkoaBlsuwERBNM=";
+    hash = "sha256-3Oe/IjmzD7+LE6OVLACDgknrl4cb9yJ/lDvKBjrvFNQ=";
   };
 
   proxyVendor = true;

--- a/pkgs/by-name/wi/wireplumber/package.nix
+++ b/pkgs/by-name/wi/wireplumber/package.nix
@@ -25,7 +25,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wireplumber";
-  version = "0.5.14";
+  version = "0.5.15";
 
   outputs = [
     "out"
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "pipewire";
     repo = "wireplumber";
     tag = finalAttrs.version;
-    hash = "sha256-Ap7vrkSxVQFzAJoBN8wWer4gOFc8iknN1A9KyRfdImc=";
+    hash = "sha256-28JrX8V23VpTe6GPI6g/JlN7412yJLMcwEre2Jv77qg=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/za/zammad/gemset.nix
+++ b/pkgs/by-name/za/zammad/gemset.nix
@@ -267,10 +267,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0cl2qpvwiffym62z991ynks7imsm87qmgxf0yfsmlwzkgi9qcaa6";
+      sha256 = "1by7h2lwziiblizpd5yx87jsq8ppdhzvwf08ga34wzqgcv1nmpvz";
       type = "gem";
     };
-    version = "2.8.7";
+    version = "2.9.0";
   };
   aes_key_wrap = {
     groups = [ "default" ];
@@ -330,6 +330,17 @@
     };
     version = "1.0.2";
   };
+  auth-sanitizer = {
+    dependencies = [ "version_gem" ];
+    groups = [ "default" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "0xy5gjb12kv6zjn4zyd16yfv4bygd02ykbr6cz10d6sqyw0wyzci";
+      type = "gem";
+    };
+    version = "0.2.1";
+  };
   autodiscover = {
     dependencies = [
       "httpclient"
@@ -374,10 +385,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1zi3nhm572awpjkcbziadsjq640g8dmdyll5ys0w8gwbiy33n504";
+      sha256 = "0asrqg47gp087wvx1cvhy1s7rpqx7r9q8kxnndfpggg3jp8dxrg6";
       type = "gem";
     };
-    version = "1.1210.0";
+    version = "1.1244.0";
   };
   aws-sdk-core = {
     dependencies = [
@@ -393,10 +404,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1zg44q9bykznxdp4l130qkvmhx4n3hhalh3cgc781aafqalcnb54";
+      sha256 = "1k6xqkipjli9vl40d4wqxcl7035lav9f9hnczilhwmj8i7n68f1r";
       type = "gem";
     };
-    version = "3.241.4";
+    version = "3.246.0";
   };
   aws-sdk-kms = {
     dependencies = [
@@ -407,10 +418,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1q015l5gm3f230jz9l6si9s3hlw7ra76q8biqvxlwxdmnk7w2qym";
+      sha256 = "0z7k84m1wqf2zra9pm5xb8lndwj6npfd02r743b9zr6p0svhml20";
       type = "gem";
     };
-    version = "1.121.0";
+    version = "1.124.0";
   };
   aws-sdk-s3 = {
     dependencies = [
@@ -422,10 +433,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "03g5k3jl0sgp60ppmxa267qflxlj174mrs8hnrnl10j5ak7nqndg";
+      sha256 = "0z4cl87lbyw9qgp1l52sbjnysw63zmxih9wfhjfdvv67d9gdlzr3";
       type = "gem";
     };
-    version = "1.213.0";
+    version = "1.220.0";
   };
   aws-sigv4 = {
     dependencies = [ "aws-eventstream" ];
@@ -437,6 +448,24 @@
       type = "gem";
     };
     version = "1.12.1";
+  };
+  bake = {
+    dependencies = [
+      "bigdecimal"
+      "samovar"
+    ];
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1izlqnz0828mgdq04s1w291ky912w6jzcg5iwch7gc8l2pkcgylb";
+      type = "gem";
+    };
+    version = "0.24.1";
   };
   base64 = {
     groups = [
@@ -478,10 +507,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "19y406nx17arzsbc515mjmr6k5p59afprspa1k423yd9cp8d61wb";
+      sha256 = "1g9zi8c4i7g8zz0c3hxrw6mblrjvgn7akys60clb9si7c1k1gljk";
       type = "gem";
     };
-    version = "4.0.1";
+    version = "4.1.2";
   };
   bindata = {
     groups = [ "default" ];
@@ -499,10 +528,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "16mjj15ks5ws53v2y31hxcmf46d0qjdvdaadpk7xsij2zymh4a9b";
+      sha256 = "05yma8qd0c53dalkh2b9iddvi7j1wy1kmd77xmx5i1ca8bwfngp5";
       type = "gem";
     };
-    version = "1.0.1";
+    version = "2.0.0";
   };
   biz = {
     dependencies = [
@@ -524,10 +553,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0gkrfpkmlf6994218l7r7cig24f5pn258mp6psaz1zif5kacj82q";
+      sha256 = "071dihwrx2bnz9cplhidqr40g0i0bgjvbnh3klndd22hly2hz46j";
       type = "gem";
     };
-    version = "1.22.0";
+    version = "1.24.2";
   };
   brakeman = {
     dependencies = [ "racc" ];
@@ -538,10 +567,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0sj2haki5a9jd9awi5abch73gsz8g2nz5lzgkja97pmix1f0c0kv";
+      sha256 = "0vyg9l6xivamb49r4kzkcw12r9x943kv79wsvwslhm1qjvx23ybv";
       type = "gem";
     };
-    version = "8.0.2";
+    version = "8.0.4";
   };
   browser = {
     groups = [ "default" ];
@@ -567,17 +596,6 @@
       type = "gem";
     };
     version = "3.3.0";
-  };
-  byebug = {
-    dependencies = [ "reline" ];
-    groups = [ "default" ];
-    platforms = [ ];
-    source = {
-      remotes = [ "https://rubygems.org" ];
-      sha256 = "0pg05blj56sxdxq9d54386y9rlvj36vl95x21x9clh8rfpz3w9nj";
-      type = "gem";
-    };
-    version = "13.0.0";
   };
   byk = {
     groups = [ "default" ];
@@ -627,20 +645,20 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1w3d5dhx4vjd707ihkcmq7fy78p5fgawcjdqw2byxnfw32gzgkbr";
+      sha256 = "0b65lw8a5s0x7g6c4h0mfzhqn83nwaql2m2hwqii321clvvh8lfz";
       type = "gem";
     };
-    version = "0.5.10.1";
+    version = "0.5.10.2";
   };
   cgi = {
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1njrjznc2j5xqqw71sp9130b9hyv59h2gfrf6yaf4in1n9dzd6gy";
+      sha256 = "1s8qdw1nfh3njd47q154njlfyc2llcgi4ik13vz39adqd7yclgz9";
       type = "gem";
     };
-    version = "0.5.0";
+    version = "0.5.1";
   };
   childprocess = {
     dependencies = [ "logger" ];
@@ -795,10 +813,29 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1b8nlxr5z843ii7hfk6igpr5acw3k2ih9yjrgkyz2gbmallgjkz5";
+      sha256 = "02ifws3c4x7b54fv17sm4cca18d2pfw1saxpdji2lbd1f6xgbzrk";
       type = "gem";
     };
-    version = "2.5.5";
+    version = "3.0.2";
+  };
+  console = {
+    dependencies = [
+      "fiber-annotation"
+      "fiber-local"
+      "json"
+    ];
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1k0dxi072mz8j72r32kkzpky825hn092hb8hdxh4rz3yd5sbv7w6";
+      type = "gem";
+    };
+    version = "1.34.3";
   };
   cose = {
     dependencies = [
@@ -877,10 +914,24 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "10wdhy00rwvm9jjhp07ig2ybyh40vchz6p0iqn7p5aggy48l20h6";
+      sha256 = "0jc7k9g0hd2nz7lfayaqahah20nlfnpcapn67zddkkcsgci6k141";
       type = "gem";
     };
-    version = "4.3.1";
+    version = "5.0.2";
+  };
+  dartsass-rails = {
+    dependencies = [
+      "railties"
+      "sass-embedded"
+    ];
+    groups = [ "assets" ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "06is62xl51f6sy6ndz5nagb0mlpi2pb58sd074bnrir93gxi15gi";
+      type = "gem";
+    };
+    version = "0.5.1";
   };
   date = {
     groups = [
@@ -980,10 +1031,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1lsh9lzrglqlwm9icmn0ggrwjc9iy9308f9m59z1w2srmyp0fgd7";
+      sha256 = "0dk37d3fcg34g4ii5cmycf4a5yz76crl5z4164ggasyb7lxhbbgd";
       type = "gem";
     };
-    version = "5.8.2";
+    version = "5.9.0";
   };
   drb = {
     groups = [
@@ -1005,10 +1056,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "113f4b01pf6igzmb7zkbcd3zgp118gfsqc35ggw9p3bzkmgp2jlq";
+      sha256 = "0x6qlxk6zp3jw748k6x3zkpywx9yjyagdyinb9qai2khdjvmn0dq";
       type = "gem";
     };
-    version = "1.3.0";
+    version = "1.4.1";
   };
   dry-core = {
     dependencies = [
@@ -1020,20 +1071,20 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "15di39ssfkwigyyqla65n4x6cfhgwa4cv8j5lmyrlr07jwd840q9";
+      sha256 = "18cn9s2p7cbgacy0z41h3sf9jvl75vjfmvj774apyffzi3dagi8c";
       type = "gem";
     };
-    version = "1.1.0";
+    version = "1.2.0";
   };
   dry-inflector = {
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0blgyg9l4gpzhb7rs9hqq9j7br80ngiigjp2ayp78w6m1ysx1x92";
+      sha256 = "1k1dd35sqqqg2abd2g2w78m94pa3mcwvmrsjbkr3hxpn0jxw5c3z";
       type = "gem";
     };
-    version = "1.2.0";
+    version = "1.3.1";
   };
   dry-logic = {
     dependencies = [
@@ -1062,10 +1113,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0ri9iqxknxvvhpbshf6jn7bq581k8l67iv23mii69yr4k5aqphvl";
+      sha256 = "1wc07v0qm8zbblr74w3iy2s74sxpifyfpw9b2x01a9259icnhf03";
       type = "gem";
     };
-    version = "1.8.0";
+    version = "1.8.1";
   };
   dry-types = {
     dependencies = [
@@ -1122,10 +1173,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "01ikhhinsna2dmq6maa0dmcyyad85h2ijccyny39h2kby90hsc5n";
+      sha256 = "0kf058q3mdq4nch8x0qgy9hf761hj0k3hbsxygag4h0qg67ygsjy";
       type = "gem";
     };
-    version = "8.4.1";
+    version = "8.5.1";
   };
   elasticsearch = {
     dependencies = [
@@ -1136,10 +1187,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1z8c1mmnj3jzwv5mpypq244px4av8czyvd4lxgxpmpqzkhvnqkgn";
+      sha256 = "097a46f3921y72fy0s2izsxlcfqmr41fcjz7a56l7xgmn1rznffa";
       type = "gem";
     };
-    version = "9.3.0";
+    version = "9.3.1";
   };
   elasticsearch-api = {
     dependencies = [
@@ -1150,10 +1201,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "101brzg04fwvr8yqc1ba7ifzz3lczgi0hx05grfljgfzd8ipm3gi";
+      sha256 = "0wm61n1v7syry78lmvs1vp7024r8s1qag37vw07hrgywapnl96lw";
       type = "gem";
     };
-    version = "9.3.0";
+    version = "9.3.1";
   };
   em-websocket = {
     dependencies = [
@@ -1178,10 +1229,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "15hdy1si19jssk4qc3cvw67waimcig2yc8rcm08bazx6zb7p6p8f";
+      sha256 = "1si81641108bf0cl06j4yj1k1ad5azskbmh676d0xmk8f5mpsxnn";
       type = "gem";
     };
-    version = "0.2.8";
+    version = "0.2.9";
   };
   email_validator = {
     dependencies = [ "activemodel" ];
@@ -1204,10 +1255,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0x9pwh2zl0cjrmhddfml8jb2ghnlsl5vffshg9bagyhx3dxfpdm3";
+      sha256 = "1ncmbdjf2bwmk0jf5cxywns9zbxyfiy4h4p3pzi7yddyjhv81qrq";
       type = "gem";
     };
-    version = "5.0.3";
+    version = "6.0.4";
   };
   erubi = {
     groups = [
@@ -1239,10 +1290,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "03a590q16nhqvfms0lh42mp6a1i41w41qpdnf39zjbq5y3l8pjvb";
+      sha256 = "1wbkbskyaz1vh4yq0zmf39lnm1q79n9yn508q4q8xsv7hh1axq5b";
       type = "gem";
     };
-    version = "2.10.0";
+    version = "2.10.1";
   };
   factory_bot = {
     dependencies = [ "activesupport" ];
@@ -1254,10 +1305,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1gpgcr5dfrq7hs3wafxaqrkx84zm2rlfwbwamd6p1d71mrfjjnff";
+      sha256 = "0xz02xlnfhj418g51w06asfpcjccf7b66dx6ly3c1k2d45rv7ghj";
       type = "gem";
     };
-    version = "6.5.5";
+    version = "6.5.6";
   };
   factory_bot_rails = {
     dependencies = [
@@ -1285,10 +1336,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0jj6via2mqccr8vngy10qkm60bc6py86cnf5ykzvn2cd3kwhps2c";
+      sha256 = "1z1yfmqwml3gr1hjnjx6qbchmvr29j6z317wlhkhzabkvw4b6iy1";
       type = "gem";
     };
-    version = "3.6.0";
+    version = "3.8.0";
   };
   faraday = {
     dependencies = [
@@ -1304,10 +1355,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "077n5ss3z3ds4vj54w201kd12smai853dp9c9n7ii7g3q7nwwg54";
+      sha256 = "1b930ag8nh99v8n9645ac1wcah9fx0mclbp323q4i1ly9acvkk3k";
       type = "gem";
     };
-    version = "2.14.1";
+    version = "2.14.2";
   };
   faraday-follow_redirects = {
     dependencies = [ "faraday" ];
@@ -1315,10 +1366,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1y87p3yk15bjbk0z9mf01r50lzxvp7agr56lbm9gxiz26mb9fbfr";
+      sha256 = "1b8hgpci3wjm3rm41bzpasvsc5j253ljyg5rsajl62dkjk497pjw";
       type = "gem";
     };
-    version = "0.3.0";
+    version = "0.5.0";
   };
   faraday-mashify = {
     dependencies = [
@@ -1333,10 +1384,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0bsly35pakjpzmbwizc94mj5jqna3jfgmwgpz89rkd6bzmm6111n";
+      sha256 = "1sfjmpkvd3gybw0w577dg8lix86dggy6gnf3315rmbq7z2rr7p7b";
       type = "gem";
     };
-    version = "1.0.0";
+    version = "1.0.2";
   };
   faraday-multipart = {
     dependencies = [ "multipart-post" ];
@@ -1348,10 +1399,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "00w9imp55hi81q0wsgwak90ldkk7gbyb8nzmmv8hy0s907s8z8bp";
+      sha256 = "0mzp9rlqiryyi99bm9ii80hfsbbafh9wl8r3c5pif51pd54sk2bx";
       type = "gem";
     };
-    version = "1.1.1";
+    version = "1.2.0";
   };
   faraday-net_http = {
     dependencies = [ "net-http" ];
@@ -1363,23 +1414,20 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0v4hfmc7d4lrqqj2wl366rm9551gd08zkv2ppwwnjlnkc217aizi";
+      sha256 = "125m3qri52vwh5v9dhq0dkqxf8629cxrf99yyc01pva72wasyy0f";
       type = "gem";
     };
-    version = "3.4.2";
+    version = "3.4.4";
   };
   ffi = {
-    groups = [
-      "assets"
-      "default"
-    ];
+    groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0k1xaqw2jk13q3ss7cnyvkp8fzp75dk4kazysrxgfd1rpgvkk7qf";
+      sha256 = "1kqasqvy8d7r09ri4n6bkdwbk63j7afd9ilsw34nzlgh0qp69ldw";
       type = "gem";
     };
-    version = "1.17.3";
+    version = "1.17.4";
   };
   ffi-compiler = {
     dependencies = [
@@ -1390,13 +1438,46 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1844j58cdg2q6g0rqfwg4rrambnhf059h4yg9rfmrbrcs60kskx9";
+      sha256 = "0vhjv98f9rjdzdxfsyyk19sfb45dcxc57ynsdmvn8vzdkifrvmm9";
       type = "gem";
     };
-    version = "1.3.2";
+    version = "1.4.2";
+  };
+  fiber-annotation = {
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "00vcmynyvhny8n4p799rrhcx0m033hivy0s1gn30ix8rs7qsvgvs";
+      type = "gem";
+    };
+    version = "0.2.0";
+  };
+  fiber-local = {
+    dependencies = [ "fiber-storage" ];
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "01lz929qf3xa90vra1ai1kh059kf2c8xarfy6xbv1f8g457zk1f8";
+      type = "gem";
+    };
+    version = "1.1.0";
   };
   fiber-storage = {
-    groups = [ "default" ];
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
@@ -1426,10 +1507,27 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1sbw6b66r7cwdx3jhs46s4lr991969hvigkjpbdl7y3i31qpdgvh";
+      sha256 = "04gzhqvsm4z4l12r9dkac9a75ah45w186ydhl0i4andldsnkkih5";
       type = "gem";
     };
-    version = "1.2.1";
+    version = "1.3.0";
+  };
+  google-protobuf = {
+    dependencies = [
+      "bigdecimal"
+      "rake"
+    ];
+    groups = [
+      "assets"
+      "default"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "1p3cg5sf7if5vf17glhsm58ydk6cr68kgyi8y1h9qrcd5da82w9l";
+      type = "gem";
+    };
+    version = "4.34.1";
   };
   graphql = {
     dependencies = [
@@ -1441,10 +1539,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "16d2bwxdy314kgrw4z1abaj6h5qqkml2k4k7zchjkl77rd0wyw3c";
+      sha256 = "0rqrwkviv3vkszxrx6zh0r71kqk7xvsar37k5nxcz7rhv86jkd74";
       type = "gem";
     };
-    version = "2.5.19";
+    version = "2.6.1";
   };
   graphql-batch = {
     dependencies = [
@@ -1506,10 +1604,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0rp0xq5x1n1sf7jwh2kczc4y4xb6k3nca5spr14lgw5czgankskl";
+      sha256 = "17gj43jwjiy56sag0zy0gpwkxd9kf2giqngn71yxjl6397dvf30g";
       type = "gem";
     };
-    version = "0.26.4";
+    version = "0.28.0";
   };
   htmlentities = {
     groups = [ "default" ];
@@ -1526,10 +1624,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1gj4fmls0mf52dlr928gaq0c0cb0m3aqa9kaa6l0ikl2zbqk42as";
+      sha256 = "0yh924g697spcv4hfigyxgidhyy6a7b9007rnac57airbcadzs4s";
       type = "gem";
     };
-    version = "0.8.0";
+    version = "0.8.1";
   };
   httparty = {
     dependencies = [
@@ -1680,6 +1778,7 @@
   irb = {
     dependencies = [
       "pp"
+      "prism"
       "rdoc"
       "reline"
     ];
@@ -1692,10 +1791,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1aja320qnimlnfc80wf2i2x8i99kl5sdzfacsfzzfzzs3vzysja3";
+      sha256 = "1qs8a9vprg7s8krgq4s0pygr91hclqqyz98ik15p0m1sf2h5956y";
       type = "gem";
     };
-    version = "1.15.3";
+    version = "1.18.0";
   };
   jmespath = {
     groups = [ "default" ];
@@ -1716,10 +1815,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1kw39sqnr0lprwsd2h0zx1ic96skhqf88i14xv7c8drcicqvvqg7";
+      sha256 = "1anz6a6n33x4s3906s0bz6x161kk1ns3h7xxsn3rpxkfsw7k2m33";
       type = "gem";
     };
-    version = "2.19.2";
+    version = "2.19.8";
   };
   json-jwt = {
     dependencies = [
@@ -1745,10 +1844,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1x64l31nkqjwfv51s2vsm0yqq4cwzrlnji12wvaq761myx3fxq9i";
+      sha256 = "1mqps8z4ly74hpksfajcfamqk1wb79biy187pn10knmi6zzb26al";
       type = "gem";
     };
-    version = "2.10.2";
+    version = "3.2.0";
   };
   koala = {
     dependencies = [
@@ -1824,6 +1923,7 @@
     version = "1.1.4";
   };
   localhost = {
+    dependencies = [ "bake" ];
     groups = [
       "development"
       "test"
@@ -1831,10 +1931,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0zslqi1xj21pzlm4lr7gnq0p8lb2n7x9bid7y36lr4bzaccjicq9";
+      sha256 = "0097kdsp2fwkps57f8ypc12dqzf4dg4glzn1i32ljjgnnhjshznz";
       type = "gem";
     };
-    version = "1.7.0";
+    version = "1.8.0";
   };
   logger = {
     groups = [
@@ -1879,10 +1979,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0dx316q03x6rpdbl610rdaj2vfd5s8fanixk21j4gv3h5f230nk5";
+      sha256 = "011fdngxzr1p9dq2hxqz7qq1glj2g44xnhaadjqlf48cplywfdnl";
       type = "gem";
     };
-    version = "2.24.1";
+    version = "2.25.1";
   };
   macaddr = {
     dependencies = [ "systemu" ];
@@ -1897,6 +1997,7 @@
   };
   mail = {
     dependencies = [
+      "logger"
       "mini_mime"
       "net-imap"
       "net-pop"
@@ -1906,20 +2007,34 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1bf9pysw1jfgynv692hhaycfxa8ckay1gjw5hz3madrbrynryfzc";
+      sha256 = "0ha9sgkfqna62c1basc17dkx91yk7ppgjq32k4nhrikirlz6g9kg";
       type = "gem";
     };
-    version = "2.8.1";
+    version = "2.9.0";
+  };
+  mapping = {
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "18jdbz3x6cvprhsw7jiv44xi6wklric0rq6iznm6xm7c40fr6x12";
+      type = "gem";
+    };
+    version = "1.1.3";
   };
   marcel = {
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "190n2mk8m1l708kr88fh6mip9sdsh339d2s6sgrik3sbnvz4jmhd";
+      sha256 = "1vhb1sbzlq42k2pzd9v0w5ws4kjx184y8h4d63296bn57jiwzkzx";
       type = "gem";
     };
-    version = "1.0.4";
+    version = "1.1.0";
   };
   matrix = {
     groups = [
@@ -1979,10 +2094,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0f05x8mm7p1dpmchpfx2393nyb4wnqizximq9wq904zsjrl4551v";
+      sha256 = "1k28j6ww8rf43r5i8278jvm2cq3pnzsvqm7yqpb4p93kadjlq726";
       type = "gem";
     };
-    version = "3.2025.0812";
+    version = "3.2026.0414";
   };
   mini_mime = {
     groups = [
@@ -2023,10 +2138,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1qyda32pf9jivaw2m7yymxshqxxd0fhjn7zpbagvmfc5c65128gh";
+      sha256 = "1mbpz92ml19rcxxfjrj91gmkif9khb1xpzyw38f81rvglgw1ffrd";
       type = "gem";
     };
-    version = "5.26.2";
+    version = "5.27.0";
   };
   msgpack = {
     groups = [ "default" ];
@@ -2043,10 +2158,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1drisvysgvnjlz49a0qcbs294id6mvj3i8iik5rvym68ybwfzvvs";
+      sha256 = "0a14g7qzbp32f4q3y1x8ifnxl9yfprqic33q75mpkx6f2hc7csfx";
       type = "gem";
     };
-    version = "1.19.1";
+    version = "1.21.0";
   };
   multi_xml = {
     dependencies = [ "bigdecimal" ];
@@ -2058,10 +2173,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0nnzdswa9l6w8k5ndgbv5al9f0jkg14dqwzyic4fjd5c1cls1nxd";
+      sha256 = "0msflv26i6i3jr9w761k4qdl7cp9zbhymjkn57b1w90pkjsndrvw";
       type = "gem";
     };
-    version = "0.8.1";
+    version = "0.9.1";
   };
   multipart-post = {
     groups = [
@@ -2121,10 +2236,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1imc50a9ic3ynsl3k0japhmb0ggrgp2c186cfqbcclv892nsrjh8";
+      sha256 = "03ga2h4i5hsk8pdlicyfvqfsbh55vrbikb0nkx9x7vx7fl6kdw19";
       type = "gem";
     };
-    version = "0.6.2";
+    version = "0.6.4.1";
   };
   net-ldap = {
     dependencies = [
@@ -2210,10 +2325,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1lss1nh526n3h1qsig2kjchi8vlsjwc8pdjpplm1f2yz6rzk52sr";
+      sha256 = "1s30b7h7qpyim30m8060xs415mbr3ci7i5hdg09chh1aqfx2qcbq";
       type = "gem";
     };
-    version = "1.19.1";
+    version = "1.19.3";
   };
   nori = {
     dependencies = [ "bigdecimal" ];
@@ -2228,6 +2343,9 @@
   };
   oauth = {
     dependencies = [
+      "auth-sanitizer"
+      "base64"
+      "cgi"
       "oauth-tty"
       "snaky_hash"
       "version_gem"
@@ -2236,24 +2354,29 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1syx3hfimaqycy21kn8gmal1cb3bw3hzalv3in2ixnay1xzjp41q";
+      sha256 = "107i702qlyirqh243zan4lpl6ki599brw31fhhvq47z413ih7p8r";
       type = "gem";
     };
-    version = "1.1.0";
+    version = "1.1.6";
   };
   oauth-tty = {
-    dependencies = [ "version_gem" ];
+    dependencies = [
+      "auth-sanitizer"
+      "cgi"
+      "version_gem"
+    ];
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "05wb5n36i4h23hh9dx2m2cwjxx5vj0vgyrn2xr6rsl54glq5rqil";
+      sha256 = "01qylh3rskdpvjkd2dkm6sdf2klf2w99zib8z0bjbhhpmxkkp9nr";
       type = "gem";
     };
-    version = "1.0.5";
+    version = "1.0.8";
   };
   oauth2 = {
     dependencies = [
+      "auth-sanitizer"
       "faraday"
       "jwt"
       "logger"
@@ -2266,10 +2389,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "11rj80dgjz05x5xx93y4bfk9rcn7fl56srj8fgqn7ffzf3j13kxs";
+      sha256 = "19igd2jv3vqrqpqqdf36740g1sln16ibv1npgvdzcsfyr3q6jilg";
       type = "gem";
     };
-    version = "2.0.18";
+    version = "2.0.22";
   };
   omniauth = {
     dependencies = [
@@ -2340,10 +2463,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1pdf3bx036l6ggz6lkkykv77m9k4jypwsiw1q7874czwh2v50768";
+      sha256 = "04dyy57rlgvrv69pq2pm4rsj658zbaqjy2a6i29qy10w4b8g7hvl";
       type = "gem";
     };
-    version = "1.2.1";
+    version = "1.2.2";
   };
   omniauth-linkedin-oauth2 = {
     dependencies = [ "omniauth-oauth2" ];
@@ -2422,10 +2545,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1sznc4d2qhqmkw1vhpx2v5i9ndfb4k25cazhz74cbv18wyp4bk2s";
+      sha256 = "0ndbsyhdalpijj8bri3imkrrr06y07c0m7hnzl6iywadarjd8ajm";
       type = "gem";
     };
-    version = "2.2.4";
+    version = "2.2.5";
   };
   omniauth-twitter = {
     dependencies = [
@@ -2498,10 +2621,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "14gfk3j88gcfk2mzp4ingm7y1pq2nbnsgzkfvflwksfljgni2mqq";
+      sha256 = "0zazkk5q3p2ldd23ka04wypsz2g8gqwwainf3d58j0kvdc9p8yg2";
       type = "gem";
     };
-    version = "4.0.0";
+    version = "4.0.1";
   };
   openssl-signature_algorithm = {
     dependencies = [ "openssl" ];
@@ -2541,10 +2664,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1l68phk7kixncc13db5yqgkryf69gc3h63vj7l5f2970i1ix5g5z";
+      sha256 = "15w69xzvbzjadcl5lppmjf7jjw3p5cz9859y19wcn17bb0jh828m";
       type = "gem";
     };
-    version = "0.68.0";
+    version = "0.69.0";
   };
   parallel = {
     groups = [
@@ -2555,10 +2678,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0c719bfgcszqvk9z47w2p8j2wkz5y35k48ywwas5yxbbh3hm3haa";
+      sha256 = "0mlkn1vhh9lr7vljibpgspwsswk7mzm8nw6bbr616c9fbj35hlmk";
       type = "gem";
     };
-    version = "1.27.0";
+    version = "2.1.0";
   };
   parser = {
     dependencies = [
@@ -2573,10 +2696,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1256ws3w3gnfqj7r3yz2i9y1y7k38fhjphxpybkyb4fds8jsgxh6";
+      sha256 = "0m2xqvn1la62hji1mn04y59giikww95p2hs0r4y2rrz3mdxcwyni";
       type = "gem";
     };
-    version = "3.3.10.1";
+    version = "3.3.11.1";
   };
   pg = {
     groups = [ "postgres" ];
@@ -2608,10 +2731,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "08y3bc9f0jbrlbnrqs98y2xzai4695j6h595dlrmgsmqbfw13db3";
+      sha256 = "00s1sfjak8w3f12g66ldb61xjavr5p2wvkflziiyhx6c2rkqgscc";
       type = "gem";
     };
-    version = "2.0.5";
+    version = "3.0.1";
   };
   pp = {
     dependencies = [ "prettyprint" ];
@@ -2646,6 +2769,7 @@
   };
   prism = {
     groups = [
+      "assets"
       "default"
       "development"
       "test"
@@ -2686,20 +2810,6 @@
       type = "gem";
     };
     version = "0.16.0";
-  };
-  pry-byebug = {
-    dependencies = [
-      "byebug"
-      "pry"
-    ];
-    groups = [ "default" ];
-    platforms = [ ];
-    source = {
-      remotes = [ "https://rubygems.org" ];
-      sha256 = "1dyi2dr5zp08s4bp9ik44v84wc0kdvinmcy7six0lfd8x150jkjr";
-      type = "gem";
-    };
-    version = "3.12.0";
   };
   pry-doc = {
     dependencies = [
@@ -2766,10 +2876,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0h7kp99r8vpvpbvia079i58932qjz2ci9qhwbk7h1bf48ydymnx2";
+      sha256 = "1413005yb8h1g48bzb17gzs554ch9mxa8gkhd7xa67n4mwy4q51z";
       type = "gem";
     };
-    version = "0.6.1";
+    version = "0.6.3";
   };
   pry-theme = {
     dependencies = [ "coderay" ];
@@ -2796,10 +2906,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0vii1xc7x81hicdbp7dlllhmbw5w3jy20shj696n0vfbbnm2hhw1";
+      sha256 = "0x0r3gc66abv8i4dw0x0370b5hrshjfp6kpp7wbp178cy775fypb";
       type = "gem";
     };
-    version = "5.2.6";
+    version = "5.3.1";
   };
   public_suffix = {
     groups = [
@@ -2810,10 +2920,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1543ap9w3ydhx39ljcd675cdz9cr948x9mp00ab8qvq6118wv9xz";
+      sha256 = "08znfv30pxmdkjyihvbjqbvv874dj3nybmmyscl958dy3f7v12qs";
       type = "gem";
     };
-    version = "6.0.2";
+    version = "7.0.5";
   };
   puma = {
     dependencies = [ "nio4r" ];
@@ -2821,10 +2931,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1a3jd9qakasizrf7dkq5mqv51fjf02r2chybai2nskjaa6mz93mz";
+      sha256 = "1yw6nvkvddriacmva8hm0za0961d6j96dm7zm6748rmyzcfqgvf8";
       type = "gem";
     };
-    version = "7.2.0";
+    version = "8.0.2";
   };
   pundit = {
     dependencies = [ "activesupport" ];
@@ -2881,10 +2991,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0hj5yq200wlq1clpdvh44pqwllbxll0k3gjajxnrcn95hxzhpky5";
+      sha256 = "1hhjy9gcp52dzij05gmidqac8g28ski5xm67prwmdqmjfcgqxmsy";
       type = "gem";
     };
-    version = "2.2.22";
+    version = "3.2.6";
   };
   rack-attack = {
     dependencies = [ "rack" ];
@@ -2910,24 +3020,25 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "19fi42hi9l474ki89y6cs8vrpfmc1h8zpd02iwjy4hw0a1yahfn7";
+      sha256 = "0cn6a9v8nry9fx4zrzp1xakfp2n5xv5075j90q56m20k7zvjrq23";
       type = "gem";
     };
-    version = "2.2.1";
+    version = "2.3.0";
   };
   rack-protection = {
     dependencies = [
       "base64"
+      "logger"
       "rack"
     ];
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1zzvivmdb4dkscc58i3gmcyrnypynsjwp6xgc4ylarlhqmzvlx1w";
+      sha256 = "1b4bamcbpk29i7jvly3i7ayfj69yc1g03gm4s7jgamccvx12hvng";
       type = "gem";
     };
-    version = "3.2.0";
+    version = "4.2.1";
   };
   rack-proxy = {
     dependencies = [ "rack" ];
@@ -2941,7 +3052,10 @@
     version = "0.7.7";
   };
   rack-session = {
-    dependencies = [ "rack" ];
+    dependencies = [
+      "base64"
+      "rack"
+    ];
     groups = [
       "assets"
       "default"
@@ -2951,10 +3065,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0xhxhlsz6shh8nm44jsmd9276zcnyzii364vhcvf0k8b8bjia8d0";
+      sha256 = "1s7zcxlmg88a6dam4aqbgk9xkpy6dkdfqmmcszkkliy3q3w38m2r";
       type = "gem";
     };
-    version = "1.0.2";
+    version = "2.1.2";
   };
   rack-test = {
     dependencies = [ "rack" ];
@@ -2973,10 +3087,7 @@
     version = "2.2.0";
   };
   rackup = {
-    dependencies = [
-      "rack"
-      "webrick"
-    ];
+    dependencies = [ "rack" ];
     groups = [
       "assets"
       "default"
@@ -2986,10 +3097,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0jf2ncj2nx56vh96hh2nh6h4r530nccxh87z7c2f37wq515611ms";
+      sha256 = "0s48d2a0z5f0cg4npvzznf933vipi6j7gmk16yc913kpadkw4ybc";
       type = "gem";
     };
-    version = "1.0.1";
+    version = "2.3.1";
   };
   rails = {
     dependencies = [
@@ -3067,10 +3178,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0q55i6mpad20m2x1lg5pkqfpbmmapk0sjsrvr1sqgnj2hb5f5z1m";
+      sha256 = "128y5g3fyi8fds41jasrr4va1jrs7hcamzklk1523k7rxb64bc98";
       type = "gem";
     };
-    version = "1.6.2";
+    version = "1.7.0";
   };
   railties = {
     dependencies = [
@@ -3121,16 +3232,13 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "175iisqb211n0qbfyqd8jz2g01q6xj038zjf4q0nm8k6kz88k7lc";
+      sha256 = "009p524zl0p0kfa65nii8wdmaigkmawv9pbvlcffky7islmmp0nb";
       type = "gem";
     };
-    version = "13.3.1";
+    version = "13.4.2";
   };
   rb-fsevent = {
-    groups = [
-      "assets"
-      "default"
-    ];
+    groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
@@ -3141,10 +3249,7 @@
   };
   rb-inotify = {
     dependencies = [ "ffi" ];
-    groups = [
-      "assets"
-      "default"
-    ];
+    groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
@@ -3167,6 +3272,7 @@
     dependencies = [
       "erb"
       "psych"
+      "tsort"
     ];
     groups = [
       "assets"
@@ -3177,10 +3283,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "09lj8d16wx5byj0nbcb9wc6v9farsvgn98n91kknm18g2ggl9pcz";
+      sha256 = "14iiyb4yi1chdzrynrk74xbhmikml3ixgdayjma3p700singfl46";
       type = "gem";
     };
-    version = "6.14.2";
+    version = "7.2.0";
   };
   redis = {
     dependencies = [ "redis-client" ];
@@ -3199,10 +3305,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "083i9ig39bc249mv24nsb2jlfwcdgmp9kbpy5ph569nsypphpmrs";
+      sha256 = "0jw2xjzz24dwn85y8v1jf1vzzpsnypsvs06f1qfa91w7rpwr5248";
       type = "gem";
     };
-    version = "0.26.4";
+    version = "0.28.0";
   };
   regexp_parser = {
     groups = [
@@ -3213,10 +3319,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "192mzi0wgwl024pwpbfa6c2a2xlvbh3mjd75a0sakdvkl60z64ya";
+      sha256 = "1fwfw26a32rps78920nn29shqg2zmqv72i89j1fap41isshida9m";
       type = "gem";
     };
-    version = "2.11.3";
+    version = "2.12.0";
   };
   reline = {
     dependencies = [ "io-console" ];
@@ -3268,10 +3374,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "18sgga9zjrd5579m9rpb78l7yn9a0bjzwz51z5kiq4y6jwl6hgxb";
+      sha256 = "0bcbh9yv6cs6pv299zs4bvalr8yxa51kcdd1pjl60yv625j3r0m8";
       type = "gem";
     };
-    version = "3.13.5";
+    version = "3.13.6";
   };
   rspec-expectations = {
     dependencies = [
@@ -3304,10 +3410,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "10gajm8iscl7gb8q926hyna83bw3fx2zb4sqdzjrznjs51pqlcz4";
+      sha256 = "0iqxmw0knjiz5nf6pgr8ihs6cjzh89f0ppj3fqiz8cvms79x6sh8";
       type = "gem";
     };
-    version = "3.13.5";
+    version = "3.13.8";
   };
   rspec-rails = {
     dependencies = [
@@ -3326,10 +3432,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1kis8dfxlvi6gdzrv9nsn3ckw0c2z7armhni917qs1jx7yjkjc8i";
+      sha256 = "1pr29snnnlgkqv80vbi4795l6rxq3l47x5rl7lyni4h8zj95c8q6";
       type = "gem";
     };
-    version = "8.0.2";
+    version = "8.0.4";
   };
   rspec-retry = {
     dependencies = [ "rspec-core" ];
@@ -3354,10 +3460,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1gwz4ykvj69n7dm6n5w64z8zmzc7z4gb96i0y4c4plaxafplbmxd";
+      sha256 = "0z64h5rznm2zv21vjdjshz4v0h7bxvg02yc6g7yzxakj11byah06";
       type = "gem";
     };
-    version = "3.13.5";
+    version = "3.13.7";
   };
   rszr = {
     groups = [ "default" ];
@@ -3389,10 +3495,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "06ncdg69d42mfq53f9lvccqbn4vbsrl0mhakxyigahai6mpn5k0l";
+      sha256 = "0ca5inh368d4l24a2v2nbd3p4xc6s0pqs91j27h226nh04zmyha4";
       type = "gem";
     };
-    version = "1.84.1";
+    version = "1.86.1";
   };
   rubocop-ast = {
     dependencies = [
@@ -3407,10 +3513,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1zbikzd6237fvlzjfxdlhwi2vbmavg1cc81y6cyr581365nnghs9";
+      sha256 = "0dahfpnzz63hyqxa03x8rypnrxzwyvh4i5a8ri34bzpnf3pg64j4";
       type = "gem";
     };
-    version = "1.49.0";
+    version = "1.49.1";
   };
   rubocop-capybara = {
     dependencies = [
@@ -3424,10 +3530,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "030wymq0jrblrdswl1lncj60dhcg5wszz6708qzsbziyyap8rn6f";
+      sha256 = "0mz3mvjh09awggp0bwsmf4rfaz2irrwc6vzpiklfh7jnlyiipspr";
       type = "gem";
     };
-    version = "2.22.1";
+    version = "2.23.0";
   };
   rubocop-factory_bot = {
     dependencies = [
@@ -3476,10 +3582,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1fml8mngnwgzpynm9z664cmhndq56wqal1pkxmw9djqls0wmgcjv";
+      sha256 = "1ki8lx0x76jrb8kibkjnqc023s0jh1g0v2cmjzzlyf5qrdvqwxv0";
       type = "gem";
     };
-    version = "1.5.6";
+    version = "1.6.0";
   };
   rubocop-inflector = {
     dependencies = [
@@ -3654,10 +3760,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "05an0wz87vkmqwcwyh5rjiaavydfn5f4q1lixcsqkphzvj7chxw5";
+      sha256 = "0d50hcsix6zrmmijwjx60y4f9n2k0dr6p47cr05qqkrai5kzqwm3";
       type = "gem";
     };
-    version = "2.4.1";
+    version = "3.3.0";
   };
   safety_net_attestation = {
     dependencies = [ "jwt" ];
@@ -3670,8 +3776,29 @@
     };
     version = "0.5.0";
   };
-  sass = {
-    dependencies = [ "sass-listen" ];
+  samovar = {
+    dependencies = [
+      "console"
+      "mapping"
+    ];
+    groups = [
+      "default"
+      "development"
+      "test"
+    ];
+    platforms = [ ];
+    source = {
+      remotes = [ "https://rubygems.org" ];
+      sha256 = "104y60zqn1mznv1smbzzvhljam193w8w2886c2yf6w87b381vff3";
+      type = "gem";
+    };
+    version = "2.4.1";
+  };
+  sass-embedded = {
+    dependencies = [
+      "google-protobuf"
+      "rake"
+    ];
     groups = [
       "assets"
       "default"
@@ -3679,44 +3806,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0p95lhs0jza5l7hqci1isflxakz83xkj97lkvxl919is0lwhv2w0";
+      sha256 = "1qbqaldw9d7l937kr9370q318lrx3lyd95l1d0sz793xvhlj5531";
       type = "gem";
     };
-    version = "3.7.4";
-  };
-  sass-listen = {
-    dependencies = [
-      "rb-fsevent"
-      "rb-inotify"
-    ];
-    groups = [
-      "assets"
-      "default"
-    ];
-    platforms = [ ];
-    source = {
-      remotes = [ "https://rubygems.org" ];
-      sha256 = "0xw3q46cmahkgyldid5hwyiwacp590zj2vmswlll68ryvmvcp7df";
-      type = "gem";
-    };
-    version = "4.0.0";
-  };
-  sass-rails = {
-    dependencies = [
-      "railties"
-      "sass"
-      "sprockets"
-      "sprockets-rails"
-      "tilt"
-    ];
-    groups = [ "assets" ];
-    platforms = [ ];
-    source = {
-      remotes = [ "https://rubygems.org" ];
-      sha256 = "14vlfwdwzn308xhzgicwmhhryigis43gxfxlwb1d3mcixj3aqa4p";
-      type = "gem";
-    };
-    version = "5.1.0";
+    version = "1.99.0";
   };
   securerandom = {
     groups = [
@@ -3748,10 +3841,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0nsys7ghl99zn2n4zjw3bi697qqnm6pmmi7aaafln79whnlpmvqn";
+      sha256 = "0p56552x321hgvasdsbz3qgfqd7s10xcw2d0q1m1qw2bjrxkfd56";
       type = "gem";
     };
-    version = "4.40.0";
+    version = "4.43.0";
   };
   shoulda-matchers = {
     dependencies = [ "activesupport" ];
@@ -3827,25 +3920,25 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0mnllrwhs7psw6xxs8x5yx85k12qjfdgs8zs0bxm70bfascx58r5";
+      sha256 = "1p9cnbz0fxkfqgpjb5xwwj5pfm969ndbp8shg43fz2kksqvl3rvh";
       type = "gem";
     };
-    version = "2.0.3";
+    version = "2.0.5";
   };
   sprockets = {
     dependencies = [
-      "base64"
       "concurrent-ruby"
+      "logger"
       "rack"
     ];
     groups = [ "assets" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "10ykzsa76cf8kvbfkszlvbyn4ckcx1mxjhfvwxzs7y28cljhzhkj";
+      sha256 = "1car3fpzhn1l06x2zmanz2l4bj346mv3jcgpcd3p1262y54ml7kn";
       type = "gem";
     };
-    version = "3.7.5";
+    version = "4.2.2";
   };
   sprockets-rails = {
     dependencies = [
@@ -3853,10 +3946,7 @@
       "activesupport"
       "sprockets"
     ];
-    groups = [
-      "assets"
-      "default"
-    ];
+    groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
@@ -3875,10 +3965,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "08aii379my5zvk0jb3nb50yx321pz7n5a9mwlfbangm7sc9sy4f1";
+      sha256 = "1q92y9627yisykyscv0bdsrrgyaajc2qr56dwlzx7ysgigjv4z63";
       type = "gem";
     };
-    version = "3.1.9";
+    version = "3.2.0";
   };
   swd = {
     dependencies = [
@@ -3902,10 +3992,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "023lbh48fcn72gwyh1x52ycs1wx1bnhdajmv0qvkidmdsmxnxzjd";
+      sha256 = "0wklh86rhpiff34ja0hda5pwdfywybjvb50hqhz90wpyhblqmhy4";
       type = "gem";
     };
-    version = "0.3.0";
+    version = "0.4.0";
   };
   systemu = {
     groups = [ "default" ];
@@ -3941,10 +4031,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "15jiw8hh2d9lryxaxl9c2zfba9j5k3kn8gg8cv95fx4nrjkbgi1s";
+      sha256 = "0w8k5620n68axdkrdijcsdyyvlpsx1ag2p7dilb1an0kx1hwhxcw";
       type = "gem";
     };
-    version = "2.5.0";
+    version = "2.7.0";
   };
   telephone_number = {
     groups = [ "default" ];
@@ -3962,10 +4052,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1arp7z8yp9i2k5fs328g9ymaf3yp9kklkcdrw83mn0gp7nwh1pvd";
+      sha256 = "06xaqs2gz304x37vmfzi6ns4mzr8i6rqad5cr92arbcxfr4yn4hv";
       type = "gem";
     };
-    version = "1.2.6";
+    version = "1.2.7";
   };
   test-unit = {
     dependencies = [ "power_assert" ];
@@ -3996,28 +4086,15 @@
     };
     version = "1.5.0";
   };
-  tilt = {
-    groups = [
-      "assets"
-      "default"
-    ];
-    platforms = [ ];
-    source = {
-      remotes = [ "https://rubygems.org" ];
-      sha256 = "0w27v04d7rnxjr3f65w1m7xyvr6ch6szjj2v5wv1wz6z5ax9pa9m";
-      type = "gem";
-    };
-    version = "2.6.1";
-  };
   timeout = {
     groups = [ "default" ];
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1jwhj5y89j5c6pk5hjw8jmrm3iila0krn2c31lnlrn217z8yyal5";
+      sha256 = "1jxcji88mh6xsqz0mfzwnxczpg7cyniph7wpavnavfz7lxl77xbq";
       type = "gem";
     };
-    version = "0.5.0";
+    version = "0.6.1";
   };
   tpm-key_attestation = {
     dependencies = [
@@ -4059,10 +4136,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "12lfc7rxpja5qc5qsksfsqwgwff6qficyjxjkm6ijxirgxfwlcg6";
+      sha256 = "0ammns6wi0d8xv95wbx6yljnqazar1b4fp7z78ivx0083rsi21mg";
       type = "gem";
     };
-    version = "7.10.1";
+    version = "7.10.5";
   };
   twitter_cldr = {
     dependencies = [
@@ -4102,10 +4179,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0qlm97fqcwhvfa7jg2gnq8la3mnk617b5bwsc460mi75wpqy4imm";
+      sha256 = "1g0hmv2axxjvk7m5ksql9q0a6mnhqv4cqgqqzh0pd39vsp9x7c3x";
       type = "gem";
     };
-    version = "1.2025.3";
+    version = "1.2026.2";
   };
   unicode-display_width = {
     dependencies = [ "unicode-emoji" ];
@@ -4198,10 +4275,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "195r5qylwxwqbllnpli9c2pzin0lky6h3fw912h88g2lmri0j6hc";
+      sha256 = "15wwjmzk8y63v1w11lzc6y0pqlb2j040wvjgdfbxrcv2913gcpb9";
       type = "gem";
     };
-    version = "1.1.9";
+    version = "1.1.11";
   };
   viewpoint = {
     dependencies = [
@@ -4230,10 +4307,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "10p6jrfzkliqg9xsb5y598w1ggd99wmqc5wcljqdkd637fmgjasq";
+      sha256 = "0md8zry4dvcj436mssd4mf4fmi6n7xsvk9aldyz3yz6xl4db32bf";
       type = "gem";
     };
-    version = "3.0.20";
+    version = "3.11.0";
   };
   vite_ruby = {
     dependencies = [
@@ -4247,10 +4324,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0wj9ia0s7vywn66pf2jn49pfsy5h5rncjjwhaymwq32r3f2pq2p1";
+      sha256 = "11lsr9c9v7xpyz0z6yxvw992aaqxcxivm5pmh7fbn2hqxd8m8inv";
       type = "gem";
     };
-    version = "3.9.2";
+    version = "3.10.2";
   };
   webauthn = {
     dependencies = [
@@ -4299,25 +4376,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1mqw7ca931zmqgad0fq4gw7z3gwb0pwx9cmd1b12ga4hgjsnysag";
+      sha256 = "142cbab47mjxmg8gc89d94sd3h7an9ligh38r9n88wb3xbr5cibp";
       type = "gem";
     };
-    version = "3.26.1";
-  };
-  webrick = {
-    groups = [
-      "assets"
-      "default"
-      "development"
-      "test"
-    ];
-    platforms = [ ];
-    source = {
-      remotes = [ "https://rubygems.org" ];
-      sha256 = "0ca1hr2rxrfw7s613rp4r4bxb454i3ylzniv9b9gxpklqigs3d5y";
-      type = "gem";
-    };
-    version = "1.9.2";
+    version = "3.26.2";
   };
   websocket = {
     groups = [
@@ -4367,10 +4429,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "0gcykkmk89zpp8js5hs9cmfamn8qyivzpkrd5jrqpxjw6cbxyp53";
+      sha256 = "0sq9kj9w828yaqfik5gygbzpnph4mkp32ym1jhh2r3b9kv0kg286";
       type = "gem";
     };
-    version = "1.0.5";
+    version = "1.1.0";
   };
   write_xlsx = {
     dependencies = [
@@ -4381,10 +4443,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1mlpl8bd4gb8i7m9vdbf0pba0j5q3y7szgr9wsf5y7isjzj9ii0w";
+      sha256 = "16j37cvk4w2zaha9kdsfi9w8rp5d0bn5rvydi1h2x031fg6c3kv7";
       type = "gem";
     };
-    version = "1.12.3";
+    version = "1.15.0";
   };
   xpath = {
     dependencies = [ "nokogiri" ];
@@ -4410,10 +4472,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "03q1hf12csqy5q2inafzi44179zaq9n5yrb0k2j2llqhzcmbh7vj";
+      sha256 = "08aq3im74b20ixmhkpi2dlgsc59231grnzljcahz4pa8y2l371yg";
       type = "gem";
     };
-    version = "0.9.38";
+    version = "0.9.43";
   };
   zeitwerk = {
     groups = [
@@ -4425,10 +4487,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "12zcvhzfnlghzw03czy2ifdlyfpq0kcbqcmxqakfkbxxavrr1vrb";
+      sha256 = "1pbkiwwla5gldgb3saamn91058nl1sq1344l5k36xsh9ih995nnq";
       type = "gem";
     };
-    version = "2.7.4";
+    version = "2.7.5";
   };
   zendesk_api = {
     dependencies = [

--- a/pkgs/by-name/za/zammad/package.nix
+++ b/pkgs/by-name/za/zammad/package.nix
@@ -23,7 +23,7 @@
 
 let
   pname = "zammad";
-  version = "7.0.1";
+  version = "7.1.0";
 
   src = applyPatches {
     src = fetchFromGitHub (lib.importJSON ./source.json);
@@ -87,7 +87,7 @@ stdenvNoCC.mkDerivation {
     pnpm = pnpm_10;
 
     fetcherVersion = 3;
-    hash = "sha256-BhkKCo9fVkG7G2er/NVyEP17T8P1rLqCQdJlcjHsSxQ=";
+    hash = "sha256-JG1VhG56L1bDyrVOjP4MFB5h//dVchgnrHiqhGNIuw4=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/za/zammad/source.json
+++ b/pkgs/by-name/za/zammad/source.json
@@ -1,8 +1,8 @@
 {
   "owner": "zammad",
   "repo": "zammad",
-  "rev": "6a5ac49588022c610896a50516dc5876ac1f24b9",
-  "hash": "sha256-E2hDdl32C4dQOZqnbAOsJ12zJsC9bJ9qFPadm4rEeKA=",
+  "rev": "ecbb861ce33908e4b52bb2c78d816a0eef69e6a6",
+  "hash": "sha256-5mK120Oo8LEIA7yY9erc57WRUeCwzsIamTiAxPgePIQ=",
   "fetchSubmodules": true
 }
 

--- a/pkgs/development/python-modules/boto3-stubs/default.nix
+++ b/pkgs/development/python-modules/boto3-stubs/default.nix
@@ -358,13 +358,13 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "boto3-stubs";
-  version = "1.43.31";
+  version = "1.43.32";
   pyproject = true;
 
   src = fetchPypi {
     pname = "boto3_stubs";
     inherit (finalAttrs) version;
-    hash = "sha256-/b2tYnqU0wMzJ2TK1K4ms12MSWOvJuuqODUOWA2VTxU=";
+    hash = "sha256-1jpnmxnBJCJpiLHbomnLWCgBdax0NWcyEsEJBPz/rug=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/boto3-stubs/default.nix
+++ b/pkgs/development/python-modules/boto3-stubs/default.nix
@@ -358,13 +358,13 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "boto3-stubs";
-  version = "1.43.29";
+  version = "1.43.31";
   pyproject = true;
 
   src = fetchPypi {
     pname = "boto3_stubs";
     inherit (finalAttrs) version;
-    hash = "sha256-TXgp7KEfAqZS1ys1P72BpRkq5V2fdCW4HRAqUfAdjlg=";
+    hash = "sha256-/b2tYnqU0wMzJ2TK1K4ms12MSWOvJuuqODUOWA2VTxU=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/cloudflare/default.nix
+++ b/pkgs/development/python-modules/cloudflare/default.nix
@@ -14,12 +14,12 @@
 
 buildPythonPackage rec {
   pname = "cloudflare";
-  version = "5.2.0";
+  version = "5.4.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-3PXLS1T1Q7AApoCVKXvMFqnGGLmMCXR9e3jlnj2GUpI=";
+    hash = "sha256-hj8qI0p9LM6ff/nErgt+YvOfWFBElLxJ2QI6IT0prOs=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/cyclonedx-python-lib/default.nix
+++ b/pkgs/development/python-modules/cyclonedx-python-lib/default.nix
@@ -22,14 +22,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "cyclonedx-python-lib";
-  version = "11.10.0";
+  version = "11.11.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "CycloneDX";
     repo = "cyclonedx-python-lib";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-8iZWIiLLMWJsLbl3ayPTcLYbpxT9ccCpgxIRd7d3Bkk=";
+    hash = "sha256-P6TJHxETBazn+zfrDYUuzCH2DHhYVtn1ceBharxCXRo=";
   };
 
   pythonRelaxDeps = [ "py-serializable" ];

--- a/pkgs/development/python-modules/homematicip/default.nix
+++ b/pkgs/development/python-modules/homematicip/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "homematicip";
-  version = "2.12.0";
+  version = "2.13.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "hahn-th";
     repo = "homematicip-rest-api";
     tag = finalAttrs.version;
-    hash = "sha256-bxoEHk4624Wk4rhSDzRaweWp+wgYo4O0cfpLTNAcdCk=";
+    hash = "sha256-gy9s2w8zbNqED6MXzoMLEERGk3E9Zz/gWC7NzhPRiPw=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/iamdata/default.nix
+++ b/pkgs/development/python-modules/iamdata/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "iamdata";
-  version = "0.1.202606171";
+  version = "0.1.202606181";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "cloud-copilot";
     repo = "iam-data-python";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/ObglIjoGPf96vD6BCweXvwHE7yvqSSdqZPSUmn5jwg=";
+    hash = "sha256-m0GxNjaPA4XTjpysgAv5FQ+zw4hjyEdgt/NSJoRDMj0=";
   };
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/python-modules/lookyloo-models/default.nix
+++ b/pkgs/development/python-modules/lookyloo-models/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "lookyloo-models";
-  version = "0.2.7";
+  version = "0.2.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Lookyloo";
     repo = "lookyloo-models";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-iIeC7+RBITENUpTM0PuHG8fPtWoEUoq4+40XqwvCVvc=";
+    hash = "sha256-LvGKzwi6zz+lvYoe3ybf8EARAXG/SX71jMl4b5hpUn8=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/mypy-boto3/default.nix
+++ b/pkgs/development/python-modules/mypy-boto3/default.nix
@@ -459,8 +459,8 @@ in
       "sha256-02BUkAFhr9sT8ohkJJFPYNni0O9/UI/G0GUee/Kx5Dw=";
 
   mypy-boto3-ecs =
-    buildMypyBoto3Package "ecs" "1.43.27"
-      "sha256-wdq6dIF6tbjhIBVRUY8GKbOwkJVyKNFGPniisK7uzVU=";
+    buildMypyBoto3Package "ecs" "1.43.32"
+      "sha256-pMGBaM4f26LMyu+uU4/TA7B9Mfh2PDSrH0RmKturmf8=";
 
   mypy-boto3-efs =
     buildMypyBoto3Package "efs" "1.43.23"
@@ -571,8 +571,8 @@ in
       "sha256-vMz4YKm78XMavlPUNiSVAYmAbyUBrJhUXbFrhxIvUJA=";
 
   mypy-boto3-glue =
-    buildMypyBoto3Package "glue" "1.43.29"
-      "sha256-y9RO80gAmBTVUy/QHeWfGcIVMsoZjC6UuZPA3Br1n/I=";
+    buildMypyBoto3Package "glue" "1.43.32"
+      "sha256-wV0hi33q2UoKY4LiXQmplnsMuJzf2QGhj1m77Lir08U=";
   mypy-boto3-grafana =
     buildMypyBoto3Package "grafana" "1.43.11"
       "sha256-XJOSLyL1+uEweZ9zER7IhH3DFLaLtpJKvuRIn8Ri+P4=";

--- a/pkgs/development/python-modules/mypy-boto3/default.nix
+++ b/pkgs/development/python-modules/mypy-boto3/default.nix
@@ -399,8 +399,8 @@ in
       "sha256-4VGCEZbno4w3H5+bc+2/f4ZkgefUDgWOOBkuGTVqvWk=";
 
   mypy-boto3-directconnect =
-    buildMypyBoto3Package "directconnect" "1.43.0"
-      "sha256-qoADzGwSCK2RXSaZKirR5g8SQBmDUuQtUGRdCv69Irw=";
+    buildMypyBoto3Package "directconnect" "1.43.31"
+      "sha256-DFq9baDdB2vDM7G4ifvBEim7Tztrq8MjyjK+xwCLNho=";
 
   mypy-boto3-discovery =
     buildMypyBoto3Package "discovery" "1.43.0"

--- a/pkgs/development/python-modules/mypy-boto3/default.nix
+++ b/pkgs/development/python-modules/mypy-boto3/default.nix
@@ -1170,8 +1170,8 @@ in
       "sha256-T+JIJpHxD7IzAwq8yxgq6zbVMj/btpbhKnylMyfFvvU=";
 
   mypy-boto3-sagemaker =
-    buildMypyBoto3Package "sagemaker" "1.43.27"
-      "sha256-UnNJiqfI7G5hN3QkTIzKEcL1gwJPVsTUgUCAce3mmCs=";
+    buildMypyBoto3Package "sagemaker" "1.43.31"
+      "sha256-S2uL8thh/cyWkxeyZMBBL/BFlky0MFsuYKdNkT3JROw=";
 
   mypy-boto3-sagemaker-a2i-runtime =
     buildMypyBoto3Package "sagemaker-a2i-runtime" "1.43.0"

--- a/pkgs/development/python-modules/mypy-boto3/default.nix
+++ b/pkgs/development/python-modules/mypy-boto3/default.nix
@@ -1394,8 +1394,8 @@ in
       "sha256-zwxwpve6uEpXNyMQzaFPIEqDI/JoP5ks2wmO5gqLf7c=";
 
   mypy-boto3-wafv2 =
-    buildMypyBoto3Package "wafv2" "1.43.0"
-      "sha256-aaKxHvrUbUJfJyVAhohJNqOp5fpGPuR5x/11z2dGKz0=";
+    buildMypyBoto3Package "wafv2" "1.43.30"
+      "sha256-Jcj10R0SolupyI7VQNYpH3P6U7mM6mT4Zia/RH7Gtxc=";
 
   mypy-boto3-wellarchitected =
     buildMypyBoto3Package "wellarchitected" "1.43.0"

--- a/pkgs/development/python-modules/mypy-boto3/default.nix
+++ b/pkgs/development/python-modules/mypy-boto3/default.nix
@@ -926,8 +926,8 @@ in
       "sha256-Xn8quvaU8HAJKLiUuh7vGqy6j/VYWrrdwAEuMnFSdzw=";
 
   mypy-boto3-mq =
-    buildMypyBoto3Package "mq" "1.43.0"
-      "sha256-fZFP/qF24Wssjh0RDXx4jBfCIGZn0OF8AMJ8e8P2yfU=";
+    buildMypyBoto3Package "mq" "1.43.32"
+      "sha256-8O4z5OB5E/NbmM+hLvtJ6MmArl/Nub9HwkYmaWiGb6s=";
 
   mypy-boto3-mturk =
     buildMypyBoto3Package "mturk" "1.43.0"

--- a/pkgs/development/python-modules/mypy-boto3/default.nix
+++ b/pkgs/development/python-modules/mypy-boto3/default.nix
@@ -1422,8 +1422,8 @@ in
       "sha256-2glzIKBlui8YPvzI74bT4ADqEZ0lH9CuZqHtwz64Z3k=";
 
   mypy-boto3-workspaces =
-    buildMypyBoto3Package "workspaces" "1.43.23"
-      "sha256-0BG0twdq8/ghYauhcpGvUSs4FeQidWuIFbYqNG0di7E=";
+    buildMypyBoto3Package "workspaces" "1.43.30"
+      "sha256-1OsfLVGw+V5J8nV343HEp8JOHpk81UawKRmAoE/eBNc=";
 
   mypy-boto3-workspaces-web =
     buildMypyBoto3Package "workspaces-web" "1.43.0"

--- a/pkgs/development/python-modules/mypy-boto3/default.nix
+++ b/pkgs/development/python-modules/mypy-boto3/default.nix
@@ -906,8 +906,8 @@ in
       "sha256-V6xgiUn87wqIlWJGOpc7Zu24EDzROAspAn3qkRifsFU=";
 
   mypy-boto3-mgn =
-    buildMypyBoto3Package "mgn" "1.43.25"
-      "sha256-fMcbT83WHYMmKgH5KSJ5maSLjkYaXdcj/x8wXhGNTAk=";
+    buildMypyBoto3Package "mgn" "1.43.30"
+      "sha256-d1/mHOsc6SdCbRm+xSAOmwSntYZP/jWDm4aJw1qY0A4=";
 
   mypy-boto3-migration-hub-refactor-spaces =
     buildMypyBoto3Package "migration-hub-refactor-spaces" "1.43.0"

--- a/pkgs/development/python-modules/mypy-boto3/default.nix
+++ b/pkgs/development/python-modules/mypy-boto3/default.nix
@@ -806,8 +806,8 @@ in
       "sha256-EunrKwNaYp0CDiwp8frI7zASilMF4wYHjDSuCsJ6aJM=";
 
   mypy-boto3-logs =
-    buildMypyBoto3Package "logs" "1.43.9"
-      "sha256-z/0+HjEaoSPjLVQRXBjOShaU7xbj6ztQKdLFEqF/PXc=";
+    buildMypyBoto3Package "logs" "1.43.30"
+      "sha256-9orJ4i+E+GKPxvvpJzAbKrrVIOBQqahx6gsUv1KCbV4=";
 
   mypy-boto3-lookoutequipment =
     buildMypyBoto3Package "lookoutequipment" "1.43.0"

--- a/pkgs/development/python-modules/mypy-boto3/default.nix
+++ b/pkgs/development/python-modules/mypy-boto3/default.nix
@@ -990,8 +990,8 @@ in
       "sha256-0rAEnU+3VsESGKlu8OTnY//rzwRqvROhRFga+vnwd1k=";
 
   mypy-boto3-outposts =
-    buildMypyBoto3Package "outposts" "1.43.26"
-      "sha256-GWsZ1RZyTt8A04O9s1HeakDhUpOmdGRSGjXy2lIXxKo=";
+    buildMypyBoto3Package "outposts" "1.43.31"
+      "sha256-pCoCP49nPBy/qhPn4gYGiDdQSp4/4e6WlUCKv6q7uog=";
 
   mypy-boto3-panorama =
     buildMypyBoto3Package "panorama" "1.43.0"

--- a/pkgs/development/python-modules/mypy-boto3/default.nix
+++ b/pkgs/development/python-modules/mypy-boto3/default.nix
@@ -1082,8 +1082,8 @@ in
       "sha256-ZmYC3YQujmfSUK0pOGCGFwT7LrSa3oJfo9juUb+2Xpk=";
 
   mypy-boto3-rds =
-    buildMypyBoto3Package "rds" "1.43.0"
-      "sha256-ZKRhSBcrpdi3T2Qdw5v8WFg7dDbGCUlZBgIrmgHSUFs=";
+    buildMypyBoto3Package "rds" "1.43.30"
+      "sha256-VEWtNjsbdzYKdYufG0PrdMi9+kb4JxLvzsPo9DombYc=";
 
   mypy-boto3-rds-data =
     buildMypyBoto3Package "rds-data" "1.43.18"

--- a/pkgs/development/python-modules/mypy-boto3/default.nix
+++ b/pkgs/development/python-modules/mypy-boto3/default.nix
@@ -1150,8 +1150,8 @@ in
       "sha256-F1xhitFa4Eac9VlCpfqjCObUH+YvLz7TYDYfI/bPYbc=";
 
   mypy-boto3-route53resolver =
-    buildMypyBoto3Package "route53resolver" "1.43.18"
-      "sha256-IoIpgRY94hxtu0keb2KrqrL/mUmY4Cun0JPNpdEVwF0=";
+    buildMypyBoto3Package "route53resolver" "1.43.31"
+      "sha256-MXTtc6xvYB6K8S4XSt916G5jjv5y7Zzjp6HnxdfIdZ0=";
 
   mypy-boto3-rum =
     buildMypyBoto3Package "rum" "1.43.0"

--- a/pkgs/development/python-modules/mypy-boto3/default.nix
+++ b/pkgs/development/python-modules/mypy-boto3/default.nix
@@ -966,8 +966,8 @@ in
       "sha256-dlZYG0M6H1b3SyocmFc+HQYn9MX1fryNJo6cIu6paBA=";
 
   mypy-boto3-opensearch =
-    buildMypyBoto3Package "opensearch" "1.43.16"
-      "sha256-vo4FbTnm7vHPgBKlvGl7qZ/H/tuRkzrdzwBI82ewchQ=";
+    buildMypyBoto3Package "opensearch" "1.43.32"
+      "sha256-fLNaflt1AOYy8OKGiX+MvnDOgYcnFtTP6/h8zi/Eqy0=";
 
   mypy-boto3-opensearchserverless =
     buildMypyBoto3Package "opensearchserverless" "1.43.17"

--- a/pkgs/development/python-modules/mypy-boto3/default.nix
+++ b/pkgs/development/python-modules/mypy-boto3/default.nix
@@ -1158,8 +1158,8 @@ in
       "sha256-8or7NMBfeq9jZRzAu0Q1ShoTXTm8GCXR4kov0kaJCcE=";
 
   mypy-boto3-s3 =
-    buildMypyBoto3Package "s3" "1.43.14"
-      "sha256-c9VMHQmZxzxAPcmpo9pKlyJxWroRZZWvCMDUZ1+LxnA=";
+    buildMypyBoto3Package "s3" "1.43.31"
+      "sha256-+4Z0Bj86SR8TZMAlNxwxVQd814C9BBdkl/izG1qN008=";
 
   mypy-boto3-s3control =
     buildMypyBoto3Package "s3control" "1.43.17"

--- a/pkgs/development/python-modules/mypy-boto3/update.sh
+++ b/pkgs/development/python-modules/mypy-boto3/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl jq nixpkgs-fmt nix-update xmlstarlet
+#!nix-shell -i bash -p curl jq nixfmt-tree nix-update xmlstarlet
 
 set -eu -o pipefail
 
@@ -383,7 +383,7 @@ for package in "${packages[@]}"; do
       { print }
     ' ${source_file}
 
-    nixfmt ${source_file}
+    treefmt ${source_file}
 
     git commit ${source_file} -m "python3Packages.${package}: ${old_version} -> ${version}"
   fi

--- a/pkgs/development/python-modules/pyfaup-rs/default.nix
+++ b/pkgs/development/python-modules/pyfaup-rs/default.nix
@@ -8,19 +8,19 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pyfaup-rs";
-  version = "0.4.10";
+  version = "0.4.11";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ail-project";
     repo = "faup-rs";
     tag = "pyfaup-rs-v${finalAttrs.version}";
-    hash = "sha256-cbKmvUoqID87mtVM9AocUviyzZvWT18Qoxot23qFdJM=";
+    hash = "sha256-bfUMOuG8wqCoB+32NKApuPPPIZIBvmlMLGD30Wf5hWM=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-maMMuuH7GIpRCRe1GoKXpFrOntdsnM8gHJg0lWC3kZ0=";
+    hash = "sha256-s8JwFAERQXWpu84aseI+L+pB3JEafX81HMydjOcwcgE=";
   };
 
   buildAndTestSubdir = "python";

--- a/pkgs/development/python-modules/pylamarzocco/default.nix
+++ b/pkgs/development/python-modules/pylamarzocco/default.nix
@@ -16,14 +16,14 @@
 
 buildPythonPackage rec {
   pname = "pylamarzocco";
-  version = "2.2.5";
+  version = "2.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "zweckj";
     repo = "pylamarzocco";
     tag = "v${version}";
-    hash = "sha256-Pcuhg48j/sbGKzk5sbMAFY9I3NDkKNt2nNn+O4dMjvw=";
+    hash = "sha256-DNlUdnJjaYUfz8X8UmzqjHwj+WGmRQZQGDkHUjrAJ7E=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/pylamarzocco/default.nix
+++ b/pkgs/development/python-modules/pylamarzocco/default.nix
@@ -14,7 +14,7 @@
   syrupy,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pylamarzocco";
   version = "2.3.0";
   pyproject = true;
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "zweckj";
     repo = "pylamarzocco";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-DNlUdnJjaYUfz8X8UmzqjHwj+WGmRQZQGDkHUjrAJ7E=";
   };
 
@@ -48,8 +48,8 @@ buildPythonPackage rec {
   meta = {
     description = "Library to interface with La Marzocco's cloud";
     homepage = "https://github.com/zweckj/pylamarzocco";
-    changelog = "https://github.com/zweckj/pylamarzocco/releases/tag/${src.tag}";
+    changelog = "https://github.com/zweckj/pylamarzocco/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/textblob/default.nix
+++ b/pkgs/development/python-modules/textblob/default.nix
@@ -21,7 +21,9 @@ buildPythonPackage rec {
 
   dependencies = [ nltk ];
 
-  doCheck = true;
+  # Test process requires pytestCheckHook and network access to download wordnet
+  # Error: 'wordnet not found' 'Attempted to load corpora/wordnet'
+  doCheck = false;
 
   pythonImportsCheck = [ "textblob" ];
 


### PR DESCRIPTION
Changelog: https://github.com/astral-sh/ty/releases/tag/0.0.50
Diff: https://github.com/astral-sh/ty/compare/0.0.49...0.0.50

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
