### PR TITLE
mistral-rs: 0.8.4 -> 0.9.0

### DIFF
--- a/pkgs/by-name/mi/mistral-rs/no-native-cpu.patch
+++ b/pkgs/by-name/mi/mistral-rs/no-native-cpu.patch
@@ -1,20 +1,10 @@
 diff --git a/.cargo/config.toml b/.cargo/config.toml
-index 0ab50ad46..3f5fe0788 100644
+index d3e3031e1..96b624fb3 100644
 --- a/.cargo/config.toml
 +++ b/.cargo/config.toml
-@@ -1,15 +1,10 @@
+@@ -1,5 +1,2 @@
 -[build]
 -rustflags = ["-C", "target-cpu=native"]
 -
- [target.aarch64-apple-darwin]
- rustflags = [
--  "-C", "target-cpu=native",
-   "-C", "target-feature=+aes,+sha2,+fp16,+i8mm",
- ]
- 
- [target.x86_64-apple-darwin]
- rustflags = [
--  "-C", "target-cpu=native",
-   "-C", "target-feature=-avx,-avx2",
- ]
- 
+ [target.wasm32-unknown-unknown]
+ rustflags = ["-C", "target-feature=+simd128"]

--- a/pkgs/by-name/mi/mistral-rs/package.nix
+++ b/pkgs/by-name/mi/mistral-rs/package.nix
@@ -73,14 +73,14 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mistral-rs";
-  version = "0.8.4";
+  version = "0.9.0";
   __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "EricLBuehler";
     repo = "mistral.rs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-BSP8fi4grbEzGOfR4tGCJVjIom/1d2mnFrK8O6BRWL4=";
+    hash = "sha256-3p/e7UZ8BLwT+dpb61NmzX2Z1QxxEgkgjlNzv5lWybM=";
   };
 
   patches = [
@@ -100,16 +100,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
     + lib.optionalString cudaSupport ''
       substituteInPlace mistralrs-flash-attn/build.rs \
         --replace-fail \
-          ".with_cutlass(Some(CUTLASS_COMMIT))" \
+          ".with_cutlass(Some(&cutlass_commit))" \
           ""
 
       substituteInPlace mistralrs-quant/build.rs \
         --replace-fail \
-          'builder = builder.with_cutlass(Some("7d49e6c7e2f8896c47f586706e67e1fb215529dc"));' \
+          "builder = builder.with_cutlass(Some(&cutlass_commit));" \
           ""
     '';
 
-  cargoHash = "sha256-T4TPm31fihx9ZvQ6jme67yrc0osl4c9CiAm4+rISgFs=";
+  cargoHash = "sha256-TULJ3mEAWp1ktPDPeBbUJGHhsEuo5T2qh3/JpS+8+ds=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION

## Things done

Diff: https://github.com/EricLBuehler/mistral.rs/compare/v0.8.4...v0.9.0
Changelog: https://github.com/EricLBuehler/mistral.rs/releases/tag/v0.9.0

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test