### PR TITLE
util-linux: 2.42.1 -> 2.42.2

### DIFF
--- a/pkgs/by-name/ut/util-linux/package.nix
+++ b/pkgs/by-name/ut/util-linux/package.nix
@@ -43,11 +43,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "util-linux" + lib.optionalString isMinimal "-minimal";
-  version = "2.42.1";
+  version = "2.42.2";
 
   src = fetchurl {
     url = "mirror://kernel/linux/utils/util-linux/v${lib.versions.majorMinor finalAttrs.version}/util-linux-${finalAttrs.version}.tar.xz";
-    hash = "sha256-gukVjrEqmwtWnYThaH/tndGP6JzNjvWsNCchinwNf38=";
+    hash = "sha256-A6BdOt+WAu8Sjy2gW4SzIFzmDDUeVzfANw90AAZ5zoo=";
   };
 
   # Note: fetchpatch/fetchpatch2 cause infinite recursion with util-linuxMinimal.


### PR DESCRIPTION
https://www.kernel.org/pub/linux/utils/util-linux/v2.42/v2.42.2-ReleaseNotes

Fix some CVEs in mount(8) and a UAF in libblkid.

Build testing:

- [x] pkgs.util-linuxMinimal (x86_64-linux)
- [x] pkgsMusl.util-linuxMinimal (x86_64-linux)
- [x] pkgs.util-linuxMinimal (aarch64-darwin)

Compat note:

```
Backward incompatible changes:

 The security fixes above harden the SUID mount(8) against TOCTOU
 attacks.  As a side effect, the following features are restricted
 for non-root users:

 X-mount.subdir=
   Restricted to Linux >= 6.15 for non-root users.  The old-kernel
   implementation uses namespace unsharing and string-based
   move_mount() which is unsafe (TOCTOU).  The safe detached subdir
   open is available only on Linux >= 6.15.

 X-mount.nocanonicalize
   Ignored for non-root users.  Paths must always be canonicalized
   in restricted mode to ensure safe target resolution before
   fd pinning.
```

I found only one place we use X-mount in nixos/ and it's not relevant:

```
$ grep -Ri X-mount nixos
nixos/modules/system/boot/zram-as-tmp.nix:          default = "X-mount.mode=1777,discard";
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
