### PR TITLE
libwebsockets: fix plugin search path

### DIFF
--- a/pkgs/by-name/li/libwebsockets/package.nix
+++ b/pkgs/by-name/li/libwebsockets/package.nix
@@ -59,6 +59,9 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace lib/CMakeLists.txt \
       --replace-fail '=\''${exec_prefix}/''${LWS_INSTALL_LIB_DIR}' '=''${CMAKE_INSTALL_FULL_LIBDIR}' \
       --replace-fail '=\''${prefix}/''${LWS_INSTALL_INCLUDE_DIR}' '=''${CMAKE_INSTALL_FULL_INCLUDEDIR}'
+
+    substituteInPlace cmake/lws_config.h.in \
+      --replace-fail '"''${CMAKE_INSTALL_PREFIX}/''${LWS_INSTALL_LIB_DIR}"' '"''${CMAKE_INSTALL_FULL_LIBDIR}"'
   ''
   # Remove after https://github.com/warmcat/libwebsockets/pull/3567 has been merged or otherwise addressed
   + lib.optionalString stdenv.hostPlatform.isStatic ''


### PR DESCRIPTION
The update of libwebsockets from 4.4.1 to 4.4.5[^1] introduced a regression where plugins could no longer be found.[^2]  This could be traced back to a change in how the installation directory is computed since libwebsockets 4.4.2[^3] and we patch it here with the correct path.

Fixes https://github.com/NixOS/nixpkgs/issues/532638

[^1]: https://github.com/NixOS/nixpkgs/pull/529620
[^2]: https://github.com/NixOS/nixpkgs/issues/532638
[^3]: https://github.com/warmcat/libwebsockets/commit/bdbebaa3b5f89bd31128fceb72a4133c0a2f738d

Tested using
```bash
cat <<-'EOF' | gdb --quiet --args ttyd -p 7681 bash
start
break lws_create_context
continue
catch syscall openat
commands 3
    x/s $rsi
    continue
end
continue
quit
EOF
```

<details>
<summary>Before</summary>

```
[...omitted...]
[2026/06/18 11:04:09:7248] N: ttyd 1.7.7 (libwebsockets 4.4.5-no_hash)
[2026/06/18 11:04:09:7248] N: tty configuration:
[2026/06/18 11:04:09:7248] N:   start command: bash
[2026/06/18 11:04:09:7248] N:   close signal: SIGHUP (1)
[2026/06/18 11:04:09:7248] N:   terminal type: xterm-256color
[2026/06/18 11:04:09:7248] N: The --writable option is not set, will start in readonly mode

Breakpoint 2, 0x00007ffff7f18fea in lws_create_context ()
   from /nix/store/l744pzvpq36rjwcz85qh10q7ci50vr2k-libwebsockets-4.4.5/lib/libwebsockets.so.20
=> 0x00007ffff7f18fea <lws_create_context+10>:	4c 8d 2d 6b 2c 06 00	lea    r13,[rip+0x62c6b]        # 0x7ffff7f7bc5c
(gdb) Catchpoint 3 (syscall 'openat' [257])
(gdb) >>>(gdb) Continuing.

Catchpoint 3 (call to syscall openat), 0x00007ffff7318bf6 in __open_nocancel
    ()
   from /nix/store/57iz36553175g3178pvxjij8z5rcsd4n-glibc-2.42-61/lib/libc.so.6
=> 0x00007ffff7318bf6 <__open_nocancel+70>:	48 3d 00 f0 ff ff  	cmp    rax,0xfffffffffffff000
0x7ffff7f7fafb:	"."

Catchpoint 3 (returned from syscall openat), 0x00007ffff7318bf6 in __open_nocancel ()
   from /nix/store/57iz36553175g3178pvxjij8z5rcsd4n-glibc-2.42-61/lib/libc.so.6
=> 0x00007ffff7318bf6 <__open_nocancel+70>:	48 3d 00 f0 ff ff  	cmp    rax,0xfffffffffffff000
0x7ffff7f7fafb:	"."

Catchpoint 3 (call to syscall openat), 0x00007ffff7318bf6 in __open_nocancel
    ()
   from /nix/store/57iz36553175g3178pvxjij8z5rcsd4n-glibc-2.42-61/lib/libc.so.6
=> 0x00007ffff7318bf6 <__open_nocancel+70>:	48 3d 00 f0 ff ff  	cmp    rax,0xfffffffffffff000
0x7ffff7f81a20:	"/nix/store/l744pzvpq36rjwcz85qh10q7ci50vr2k-libwebsockets-4.4.5//nix/store/l744pzvpq36rjwcz85qh10q7ci50vr2k-libwebsockets-4.4.5/lib"

Catchpoint 3 (returned from syscall openat), 0x00007ffff7318bf6 in __open_nocancel ()
   from /nix/store/57iz36553175g3178pvxjij8z5rcsd4n-glibc-2.42-61/lib/libc.so.6
=> 0x00007ffff7318bf6 <__open_nocancel+70>:	48 3d 00 f0 ff ff  	cmp    rax,0xfffffffffffff000
0x7ffff7f81a20:	"/nix/store/l744pzvpq36rjwcz85qh10q7ci50vr2k-libwebsockets-4.4.5//nix/store/l744pzvpq36rjwcz85qh10q7ci50vr2k-libwebsockets-4.4.5/lib"
[2026/06/18 11:04:09:7282] E: lws_create_context: failed to load evlib_uv
[2026/06/18 11:04:09:7282] E: libwebsockets context creation failed
[Inferior 1 (process 2389612) exited with code 01]
```

</details>

<details>
<summary>After</summary>

```
[...omitted...]
[2026/06/18 11:07:57:0258] N: ttyd 1.7.7 (libwebsockets 4.4.5-no_hash)
[2026/06/18 11:07:57:0258] N: tty configuration:
[2026/06/18 11:07:57:0258] N:   start command: bash
[2026/06/18 11:07:57:0258] N:   close signal: SIGHUP (1)
[2026/06/18 11:07:57:0258] N:   terminal type: xterm-256color
[2026/06/18 11:07:57:0258] N: The --writable option is not set, will start in readonly mode

Breakpoint 2, 0x00007ffff7f18fea in lws_create_context ()
   from /nix/store/grqrvcq4hm159fk80w93hnvwsf2z3giq-libwebsockets-4.4.5/lib/libwebsockets.so.20
=> 0x00007ffff7f18fea <lws_create_context+10>:	4c 8d 2d 6b 2c 06 00	lea    r13,[rip+0x62c6b]        # 0x7ffff7f7bc5c
(gdb) Catchpoint 3 (syscall 'openat' [257])
(gdb) >>>(gdb) Continuing.

Catchpoint 3 (call to syscall openat), 0x00007ffff7318bf6 in __open_nocancel
    ()
   from /nix/store/57iz36553175g3178pvxjij8z5rcsd4n-glibc-2.42-61/lib/libc.so.6
=> 0x00007ffff7318bf6 <__open_nocancel+70>:	48 3d 00 f0 ff ff  	cmp    rax,0xfffffffffffff000
0x7ffff7f7fafb:	"."

Catchpoint 3 (returned from syscall openat), 0x00007ffff7318bf6 in __open_nocancel ()
   from /nix/store/57iz36553175g3178pvxjij8z5rcsd4n-glibc-2.42-61/lib/libc.so.6
=> 0x00007ffff7318bf6 <__open_nocancel+70>:	48 3d 00 f0 ff ff  	cmp    rax,0xfffffffffffff000
0x7ffff7f7fafb:	"."

Catchpoint 3 (call to syscall openat), 0x00007ffff7318bf6 in __open_nocancel
    ()
   from /nix/store/57iz36553175g3178pvxjij8z5rcsd4n-glibc-2.42-61/lib/libc.so.6
=> 0x00007ffff7318bf6 <__open_nocancel+70>:	48 3d 00 f0 ff ff  	cmp    rax,0xfffffffffffff000
0x7ffff7f81a20:	"/nix/store/grqrvcq4hm159fk80w93hnvwsf2z3giq-libwebsockets-4.4.5/lib"

Catchpoint 3 (returned from syscall openat), 0x00007ffff7318bf6 in __open_nocancel ()
   from /nix/store/57iz36553175g3178pvxjij8z5rcsd4n-glibc-2.42-61/lib/libc.so.6
=> 0x00007ffff7318bf6 <__open_nocancel+70>:	48 3d 00 f0 ff ff  	cmp    rax,0xfffffffffffff000
0x7ffff7f81a20:	"/nix/store/grqrvcq4hm159fk80w93hnvwsf2z3giq-libwebsockets-4.4.5/lib"

Catchpoint 3 (call to syscall openat), 0x00007ffff7fe9fe5 in __open_nocancel
    ()
   from /nix/store/57iz36553175g3178pvxjij8z5rcsd4n-glibc-2.42-61/lib/ld-linux-x86-64.so.2
=> 0x00007ffff7fe9fe5 <__open_nocancel+53>:	48 3d 00 f0 ff ff  	cmp    rax,0xfffffffffffff000
0x555555590410:	"/nix/store/grqrvcq4hm159fk80w93hnvwsf2z3giq-libwebsockets-4.4.5/lib/libwebsockets-evlib_uv.so"

Catchpoint 3 (returned from syscall openat), 0x00007ffff7fe9fe5 in __open_nocancel ()
   from /nix/store/57iz36553175g3178pvxjij8z5rcsd4n-glibc-2.42-61/lib/ld-linux-x86-64.so.2
=> 0x00007ffff7fe9fe5 <__open_nocancel+53>:	48 3d 00 f0 ff ff  	cmp    rax,0xfffffffffffff000
0x555555590410:	"/nix/store/grqrvcq4hm159fk80w93hnvwsf2z3giq-libwebsockets-4.4.5/lib/libwebsockets-evlib_uv.so"
[2026/06/18 11:07:57:0313] N: lws_create_context: LWS: 4.4.5-no_hash, NET CLI SRV H1 H2 WS SS-JSON-POL ConMon IPV6-off
[...omitted...]
```

</details>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
