### PR TITLE
python3Packages.python-statemachine: 3.0.0 -> 3.2.0

### DIFF
--- a/pkgs/development/python-modules/python-statemachine/default.nix
+++ b/pkgs/development/python-modules/python-statemachine/default.nix
@@ -11,11 +11,14 @@
   pytest-timeout,
   pytest-django,
   pydot,
+  docutils,
+  pyyaml,
+  jsonschema,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "python-statemachine";
-  version = "3.0.0";
+  version = "3.2.0";
   pyproject = true;
 
   __structuredAttrs = true;
@@ -23,7 +26,7 @@ buildPythonPackage (finalAttrs: {
   src = fetchPypi {
     pname = "python_statemachine";
     inherit (finalAttrs) version;
-    hash = "sha256-kVI/nq1zwdb+zJddXG4L/jY/v1N8XwvzCbzQ+U+UQbI=";
+    hash = "sha256-RLmMubsQgYke9u+pB8gh0FyuUxSiuZcT5W1Wqcli3gg=";
   };
 
   build-system = [ hatchling ];
@@ -36,6 +39,9 @@ buildPythonPackage (finalAttrs: {
     pytest-timeout
     pytest-django
     pydot
+    docutils
+    pyyaml
+    jsonschema
   ];
 
   pytestFlags = [ "--benchmark-disable" ];
@@ -44,6 +50,9 @@ buildPythonPackage (finalAttrs: {
     # quite slow
     "tests/test_weighted_transitions.py"
     "tests/scxml/"
+
+    # requires sphinx, which is not worth pulling in for this relatively low-signal test
+    "statemachine/contrib/diagram/sphinx_ext.py"
   ];
 
   disabledTests = [


### PR DESCRIPTION
Closes #532929

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
