### PR TITLE
wasilibc: 27 -> 32

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25142,6 +25142,13 @@
     githubId = 35622998;
     name = "Suwon Park";
   };
+  sepointon = {
+     email = "sampointon@gmail.com";
+     github = "sepointon";
+     githubId = 209542026;
+     matrix = "sampointon:matrix.org";
+     name = "Sam Pointon";
+  };
   seppeljordan = {
     email = "sebastian.jordan.mail@googlemail.com";
     github = "seppeljordan";

--- a/pkgs/build-support/build-mozilla-mach/default.nix
+++ b/pkgs/build-support/build-mozilla-mach/default.nix
@@ -627,11 +627,12 @@ buildStdenv.mkDerivation {
 
   makeFlags = extraMakeFlags;
   separateDebugInfo = enableDebugSymbols;
-  enableParallelBuilding = true;
+  #enableParallelBuilding = true;
   env = {
     # if not explicitly set, wrong cc from buildStdenv would be used
     HOST_CC = "${llvmPackagesBuildBuild.stdenv.cc}/bin/cc";
     HOST_CXX = "${llvmPackagesBuildBuild.stdenv.cc}/bin/c++";
+    CARGO_BUILD_JOBS = "1";
   }
   // lib.optionalAttrs stdenv.hostPlatform.isMusl {
     # Firefox relies on nonstandard behavior of the glibc dynamic linker. It re-uses

--- a/pkgs/by-name/wa/wasilibc/0000-relax-version-bounds.patch
+++ b/pkgs/by-name/wa/wasilibc/0000-relax-version-bounds.patch
@@ -1,0 +1,39 @@
+Commit ID: bf0251709e0440ff00036298d94177a72382979d
+Change ID: nukukykqkzqunwukokzxwlxrpxptuwzm
+Author   : Sam Pointon <sampointon@gmail.com> (2026-06-17 09:26:00)
+Committer: Sam Pointon <sampointon@gmail.com> (2026-06-17 09:27:26)
+
+    Relax strict version bounds on tools
+
+    Nixpkgs has more recent versions of these, and they work fine.
+
+diff --git a/cmake/bindings.cmake b/cmake/bindings.cmake
+index a629ecd006..14fdb8aed3 100644
+--- a/cmake/bindings.cmake
++++ b/cmake/bindings.cmake
+@@ -15,10 +15,6 @@
+     OUTPUT_VARIABLE WIT_BINDGEN_VERSION
+     OUTPUT_STRIP_TRAILING_WHITESPACE)
+ 
+-  if (NOT (WIT_BINDGEN_VERSION MATCHES "0\\.53\\.1"))
+-    message(WARNING "wit-bindgen version 0.53.1 is required, found: ${WIT_BINDGEN_VERSION}")
+-    set(WIT_BINDGEN_EXECUTABLE "")
+-  endif()
+ endif()
+ 
+ if (NOT WIT_BINDGEN_EXECUTABLE)
+diff --git a/cmake/wasi-wits.cmake b/cmake/wasi-wits.cmake
+index e21ab0258d..d72ed9bcc2 100644
+--- a/cmake/wasi-wits.cmake
++++ b/cmake/wasi-wits.cmake
+@@ -12,10 +12,6 @@
+     OUTPUT_VARIABLE WKG_VERSION
+     OUTPUT_STRIP_TRAILING_WHITESPACE)
+ 
+-  if (NOT (WKG_VERSION MATCHES "0\\.13\\.0"))
+-    message(WARNING "wkg version 0.13.0 is required, found: ${WKG_VERSION}")
+-    set(WKG_EXECUTABLE "")
+-  endif()
+ endif()
+ 
+ if (NOT WKG_EXECUTABLE)

--- a/pkgs/by-name/wa/wasilibc/package.nix
+++ b/pkgs/by-name/wa/wasilibc/package.nix
@@ -1,23 +1,42 @@
 {
   stdenvNoLibc,
+  cmake,
   fetchFromGitHub,
   lib,
+  lld,
+  llvmPackages,
+  wasm-component-ld,
+  wasm-tools,
+  wit-bindgen,
+  wkg,
   firefox-unwrapped,
   firefox-esr-unwrapped,
-  enablePosixThreads ? false,
 }:
 
 stdenvNoLibc.mkDerivation (finalAttrs: {
   pname = "wasilibc";
-  version = "27";
+  version = "32";
 
   src = fetchFromGitHub {
     owner = "WebAssembly";
     repo = "wasi-libc";
     tag = "wasi-sdk-${finalAttrs.version}";
-    hash = "sha256-RIjph1XdYc1aGywKks5JApcLajbNFEuWm+Wy/GMHddg=";
+    hash = "sha256-iP/SFYvO8zQMwwbY4VvIboO+Kx195L9brpMq8cbsA7c=";
     fetchSubmodules = true;
   };
+
+  patches = [
+    ./0000-relax-version-bounds.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    lld
+    wasm-component-ld
+    wasm-tools
+    wit-bindgen
+    wkg
+  ];
 
   # These flags break pkgsCross.wasi32.llvmPackages.libcxx
   hardeningDisable = [
@@ -28,45 +47,36 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
   outputs = [
     "out"
     "dev"
-    "share"
   ];
 
-  # clang-13: error: argument unused during compilation: '-rtlib=compiler-rt' [-Werror,-Wunused-command-line-argument]
-  postPatch = ''
-    substituteInPlace Makefile \
-      --replace "-Werror" ""
-    patchShebangs scripts/
-  '';
-
-  preBuild = ''
-    export SYSROOT_LIB=${placeholder "out"}/lib
-    export SYSROOT_INC=${placeholder "dev"}/include
-    export SYSROOT_SHARE=${placeholder "share"}/share
-    mkdir -p "$SYSROOT_LIB" "$SYSROOT_INC" "$SYSROOT_SHARE"
-    makeFlagsArray+=(
-      "SYSROOT_LIB:=$SYSROOT_LIB"
-      "SYSROOT_INC:=$SYSROOT_INC"
-      "SYSROOT_SHARE:=$SYSROOT_SHARE"
-      "TARGET_TRIPLE:=${stdenvNoLibc.system}"
-      ${lib.strings.optionalString enablePosixThreads "THREAD_MODEL:=posix"}
-    )
-  '';
+  cmakeFlags = [
+    "-DBUILTINS_LIB=${llvmPackages.compiler-rt}/lib/wasi/libclang_rt.builtins-wasm32.a"
+    # CMake probes cc to try and detect brokenness, but it tries ordinary compilation that
+    # depends on having a libc... which isn't there, as we're building the libc that's to
+    # be used by the platform. Just skipping these checks makes the right thing happen.
+    "-DCMAKE_C_COMPILER_FORCED=TRUE"
+    "-DTARGET_TRIPLE=${stdenvNoLibc.system}"
+  ];
 
   enableParallelBuilding = true;
 
-  # We just build right into the install paths, per the `preBuild`.
-  dontInstall = true;
+  preFixup =
+    lib.optionalString (stdenvNoLibc.system != stdenvNoLibc.targetPlatform.rust.rustcTargetSpec)
+      ''
+        ln -s $out/lib/${stdenvNoLibc.system} $out/lib/${stdenvNoLibc.targetPlatform.rust.rustcTargetSpec}
+      '';
 
-  preFixup = ''
-    ln -s $share/share/undefined-symbols.txt $out/lib/wasi.imports
-    ln -s $out/lib $out/lib/${stdenvNoLibc.system}
-  ''
-  + lib.optionalString (stdenvNoLibc.system != stdenvNoLibc.targetPlatform.rust.rustcTargetSpec) ''
-    ln -s $out/lib $out/lib/${stdenvNoLibc.targetPlatform.rust.rustcTargetSpec}
-  '';
+  # TODO: run wasilibc tests. Nixpkgs never runs the check phase during cross compiles
+  # (sensibly), but this package is always cross compiled due to its nature, and the tests
+  # expect to be run in a cross-compilation environment. There are instructions on how to run
+  # them but I don't understand enough about Nixpkgs' CMake set-up to work out how to apply them.
 
-  passthru.tests = {
-    inherit firefox-unwrapped firefox-esr-unwrapped;
+  passthru = {
+    incdir = "/include/${stdenvNoLibc.system}";
+    libdir = "/lib/${stdenvNoLibc.system}";
+    tests = {
+      inherit firefox-unwrapped firefox-esr-unwrapped;
+    };
   };
 
   meta = {

--- a/pkgs/by-name/wa/wasm-component-ld/package.nix
+++ b/pkgs/by-name/wa/wasm-component-ld/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  fetchFromGitHub,
+  makeWrapper,
+  lld,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "wasm-component-ld";
+  version = "0.5.25";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "bytecodealliance";
+    repo = "wasm-component-ld";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-EQqNm3GRuMafbrOyzsdZ5e1pX4LH40wCyKVgSgm8A48=";
+  };
+
+  cargoHash = "sha256-1e54TLWGjfNORwr6uLIe/XhdDDOkbalw/6/0UGuBiPk=";
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  # We can't add the flag --wasm-ld-path, because wasm-ld-component rejects multiple instances
+  # of it (rather than letting the last one win), and wasilibc sets it during its build process.
+  # So, $PATH munging it is.
+  postFixup = ''
+    wrapProgram $out/bin/wasm-component-ld \
+      --set PATH ${lld}/bin
+  '';
+
+  # Tests require a rustc that can target wasm32-wasip1, including std. This is awkward for
+  # Nixpkgs to provide at the same time as providing a rustc that's targetting the actual target.
+  # TODO: work around by patching the test suite to invoke pkgsBuildTarget.rustc rather than just looking in PATH for any old rustc
+  doCheck = false;
+
+  meta = {
+    description = "Command line linker for creating WebAssembly components";
+    homepage = "https://github.com/bytecodealliance/wasm-component-ld";
+    license = with lib.licenses; [
+      asl20
+      llvm-exception
+      mit
+    ];
+    maintainers = with lib.maintainers; [
+      sepointon
+    ];
+    mainProgram = "wasm-component-ld";
+  };
+})


### PR DESCRIPTION
WIP until I can verify it's not broken Firefox.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
