### PR TITLE
bender: 0.28.2 -> 0.32.0

### DIFF
--- a/pkgs/by-name/be/bender/build-rs.patch
+++ b/pkgs/by-name/be/bender/build-rs.patch
@@ -1,0 +1,24 @@
+--- a/crates/bender-slang/build.rs
++++ b/crates/bender-slang/build.rs
+@@ -55,6 +55,9 @@
+         .define("CMAKE_DISABLE_FIND_PACKAGE_fmt", "ON")
+         .define("CMAKE_DISABLE_FIND_PACKAGE_mimalloc", "ON")
+         .define("CMAKE_DISABLE_FIND_PACKAGE_Boost", "ON")
++        .define("FETCHCONTENT_SOURCE_DIR_SLANG", "@slangSrc@")
++        .define("FETCHCONTENT_SOURCE_DIR_FMT", "@fmtSrc@")
++        .define("FETCHCONTENT_SOURCE_DIR_MIMALLOC", "@mimallocSrc@")
+         .profile(cmake_profile);
+
+     // Apply common defines and flags
+@@ -71,9 +74,9 @@
+     // With FetchContent, cmake builds slang in a _deps subdirectory rather than
+     // installing it. Point directly at the FetchContent build/source directories.
+     let slang_lib_dir = dst.join("build/_deps/slang-build/lib");
+-    let slang_include_dir = dst.join("build/_deps/slang-src/include");
++    let slang_include_dir = std::path::PathBuf::from("@slangSrc@").join("include");
+     let slang_generated_include_dir = dst.join("build/_deps/slang-build/source");
+-    let fmt_include_dir = dst.join("build/_deps/fmt-src/include");
++    let fmt_include_dir = std::path::PathBuf::from("@fmtSrc@").join("include");
+
+     // Generate cpp/compile_flags.txt for clangd IDE support
+     if !in_publish {

--- a/pkgs/by-name/be/bender/package.nix
+++ b/pkgs/by-name/be/bender/package.nix
@@ -10,21 +10,21 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "bender";
-  version = "0.28.2";
+  version = "0.31.0";
 
   src = fetchFromGitHub {
     owner = "pulp-platform";
     repo = "bender";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-OJWYhs5QmfUC1I5OkEJAeLTpklEQyQ6024wmhv1sSnA=";
+    hash = "sha256-91VS3cXscq2Lu2oP3b5WJ1sp7HhMhw+BgOVTFsC6pnc=";
   };
 
-  cargoHash = "sha256-nZ2gchifWSmDlVJIsPcvrnUxzhyXYoA1kE9f2pZDJzs=";
+  cargoHash = "sha256-lgEg9Sf5n3zbm/vbn+vLBGmqBOA1aTcCBCFYrzwPVCk=";
 
   nativeCheckInputs = [ gitMinimal ];
   postCheck = ''
     patchShebangs --build tests
-    BENDER="target/${target}/$cargoBuildType/bender" tests/run_all.sh
+    BENDER="$PWD/target/${target}/$cargoBuildType/bender" tests/run_all.sh
   '';
 
   meta = {

--- a/pkgs/by-name/be/bender/package.nix
+++ b/pkgs/by-name/be/bender/package.nix
@@ -3,28 +3,81 @@
   stdenv,
   rustPlatform,
   fetchFromGitHub,
+  replaceVars,
   gitMinimal,
+  cmake,
+  installShellFiles,
+  python3,
 }:
 let
   target = stdenv.hostPlatform.rust.cargoShortTarget;
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "bender";
-  version = "0.31.0";
+  version = "0.32.0";
 
   src = fetchFromGitHub {
     owner = "pulp-platform";
     repo = "bender";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-91VS3cXscq2Lu2oP3b5WJ1sp7HhMhw+BgOVTFsC6pnc=";
+    hash = "sha256-Pyx68NTlCNTGKXdEGG9YML5E+vJlLHlPQjjbSV2uOsE=";
   };
 
-  cargoHash = "sha256-lgEg9Sf5n3zbm/vbn+vLBGmqBOA1aTcCBCFYrzwPVCk=";
+  cargoHash = "sha256-XItTYqTTN8KBvyFmDSKIgVURox/1tmAFjDAM8Vq3zxo=";
+
+  patches = [
+    (replaceVars ./build-rs.patch {
+      # We will download them instead of cmake's fetchContent
+      #
+      # We manually build the dependencies as
+      # bender-slang builds slang as a private cmake dependency with specific
+      # compile-time defines (SLANG_USE_MIMALLOC, SLANG_BOOST_SINGLE_HEADER, etc.)
+      # that must match between the library and the cxx bridge to avoid ABI
+      # incompatibilities.
+      slangSrc = fetchFromGitHub {
+        owner = "MikePopoloski";
+        repo = "slang";
+        tag = "v11.0";
+        hash = "sha256-popHzwX0qwv2POAl7/qX3e//OwJRXGtSl9xogpSn2LI=";
+      };
+
+      fmtSrc = fetchFromGitHub {
+        owner = "fmtlib";
+        repo = "fmt";
+        tag = "12.1.0";
+        hash = "sha256-ZmI1Dv0ZabPlxa02OpERI47jp7zFfjpeWCy1WyuPYZ0=";
+      };
+
+      mimallocSrc = fetchFromGitHub {
+        owner = "microsoft";
+        repo = "mimalloc";
+        tag = "v3.3.2";
+        hash = "sha256-GZ37qQVDe9jgMb4Coe5oKvgaLTspZDlSkS5rdy1MfUU=";
+      };
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    installShellFiles
+    python3
+  ];
+
+  # owo-colors wraps test assertions in ANSI codes when TERM is set,
+  # causing string-matching tests to fail in the sandbox.
+  preCheck = "export NO_COLOR=1";
 
   nativeCheckInputs = [ gitMinimal ];
   postCheck = ''
     patchShebangs --build tests
     BENDER="$PWD/target/${target}/$cargoBuildType/bender" tests/run_all.sh
+  '';
+
+  postInstall = ''
+    installShellCompletion --cmd bender \
+      --bash <($out/bin/bender completion bash) \
+      --fish <($out/bin/bender completion fish) \
+      --zsh <($out/bin/bender completion zsh)
   '';
 
   meta = {


### PR DESCRIPTION
Updates bender from 0.28.2 to 0.32.0. Based on #511264 by @Liamolucko.

The main change in 0.32.0 is the new `bender-slang` crate, a C++ bridge to the
[slang](https://github.com/MikePopoloski/slang) SystemVerilog parser. It uses
cmake FetchContent to fetch slang, fmt, and mimalloc at build time, which is
blocked by the Nix sandbox.

The fix patches `crates/bender-slang/build.rs` to inject
`FETCHCONTENT_SOURCE_DIR_*` cmake variables pointing at pre-fetched Nix store
paths via `replaceVars`. The three sources are fetched separately from their
nixpkgs counterparts because `bender-slang` compiles slang with specific
compile-time defines (`SLANG_USE_MIMALLOC`, `SLANG_BOOST_SINGLE_HEADER`, etc.)
that must match between the library and the cxx bridge to avoid C++ ABI
incompatibilities.

Shell completions for bash, fish, and zsh are also added via `bender completion`.

Changelog: https://github.com/pulp-platform/bender/blob/main/CHANGELOG.md

This PR was authored with assistance from Claude Code (claude-sonnet-4-6).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test