### PR TITLE
uhub: unstable-2019-12-13 -> 0.7.1

### DIFF
--- a/nixos/modules/services/misc/uhub.nix
+++ b/nixos/modules/services/misc/uhub.nix
@@ -119,25 +119,21 @@ in
 
       systemd.services = lib.attrsets.mapAttrs' (name: cfg: {
         name = "uhub-${name}";
-        value =
-          let
-            pkg = pkgs.uhub.override { tlsSupport = cfg.enableTLS; };
-          in
-          {
-            description = "high performance peer-to-peer hub for the ADC network";
-            after = [ "network.target" ];
-            wantedBy = [ "multi-user.target" ];
-            reloadIfChanged = true;
-            serviceConfig = {
-              Type = "notify";
-              ExecStart = "${pkg}/bin/uhub -c /etc/uhub/${name}.conf -L";
-              ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
-              DynamicUser = true;
+        value = {
+          description = "high performance peer-to-peer hub for the ADC network";
+          after = [ "network.target" ];
+          wantedBy = [ "multi-user.target" ];
+          reloadIfChanged = true;
+          serviceConfig = {
+            Type = "notify";
+            ExecStart = "${lib.getExe pkgs.uhub} -c /etc/uhub/${name}.conf -L";
+            ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
+            DynamicUser = true;
 
-              AmbientCapabilities = "CAP_NET_BIND_SERVICE";
-              CapabilityBoundingSet = "CAP_NET_BIND_SERVICE";
-            };
+            AmbientCapabilities = "CAP_NET_BIND_SERVICE";
+            CapabilityBoundingSet = "CAP_NET_BIND_SERVICE";
           };
+        };
       }) hubs;
     };
 

--- a/pkgs/by-name/uh/uhub/package.nix
+++ b/pkgs/by-name/uh/uhub/package.nix
@@ -7,48 +7,61 @@
   sqlite,
   pkg-config,
   systemd,
-  tlsSupport ? false,
+  versionCheckHook,
+  perl,
 }:
 
-assert tlsSupport -> openssl != null;
-
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "uhub";
-  version = "unstable-2019-12-13";
+  version = "0.7.1";
 
   src = fetchFromGitHub {
     owner = "janvidar";
     repo = "uhub";
-    rev = "35d8088b447527f56609b85b444bd0b10cd67b5c";
-    hash = "sha256-CdTTf82opnpjd7I9TTY+JDEZSfdGFPE0bq/xsafwm/w=";
+    rev = finalAttrs.version;
+    hash = "sha256-TXE8/qBKeG/mQVydzus5ok8WnAOP+GoNavjgMslvYrI=";
   };
 
   nativeBuildInputs = [
     cmake
     pkg-config
+    perl
   ];
   buildInputs = [
+    openssl
     sqlite
     systemd
-  ]
-  ++ lib.optional tlsSupport openssl;
+  ];
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
       --replace-fail "/usr/lib/uhub/" "$out/plugins" \
-      --replace-fail "/etc/uhub" "$TMPDIR" \
-      --replace-fail "cmake_minimum_required (VERSION 2.8.2)" "cmake_minimum_required(VERSION 3.10)"
+      --replace-fail "/etc/uhub" "$out/share/doc/uhub"
   '';
 
   cmakeFlags = [
     "-DSYSTEMD_SUPPORT=ON"
-    "-DSSL_SUPPORT=${if tlsSupport then "ON" else "OFF"}"
   ];
+
+  # run generated autotest-bin for integration-testing
+  # skipped tests: fuzzing + stress tests
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    ./autotest-bin
+    runHook postCheck
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "-V";
+  doInstallCheck = true;
 
   meta = {
     description = "High performance peer-to-peer hub for the ADC network";
     homepage = "https://www.uhub.org/";
+    changelog = "https://github.com/janvidar/uhub/blob/${finalAttrs.src.rev}/ChangeLog";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.unix;
+    mainProgram = "uhub";
   };
-}
+})


### PR DESCRIPTION
uhub released a new version (new release after 12 years). The PR changes the unstable pinning to the new official release

related: janvidar/uhub#73


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

**Update**: i've de-scoped the vmtest for now, hoping the package bump will be merged more quickly

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
