### PR TITLE
datalab: init at 1.2.1

### DIFF
--- a/pkgs/by-name/da/datalab/package.nix
+++ b/pkgs/by-name/da/datalab/package.nix
@@ -1,0 +1,3 @@
+{ python3Packages }:
+
+python3Packages.toPythonApplication python3Packages.datalab-platform

--- a/pkgs/by-name/in/intersphinx-registry/package.nix
+++ b/pkgs/by-name/in/intersphinx-registry/package.nix
@@ -1,0 +1,3 @@
+{ python3Packages }:
+
+python3Packages.toPythonApplication python3Packages.intersphinx-registry

--- a/pkgs/by-name/ju/jupyterlite/package.nix
+++ b/pkgs/by-name/ju/jupyterlite/package.nix
@@ -1,0 +1,3 @@
+{ python3Packages }:
+
+python3Packages.toPythonApplication python3Packages.jupyterlite-core

--- a/pkgs/by-name/sp/sphinx-gallery/package.nix
+++ b/pkgs/by-name/sp/sphinx-gallery/package.nix
@@ -1,0 +1,3 @@
+{ python3Packages }:
+
+python3Packages.toPythonApplication python3Packages.sphinx-gallery

--- a/pkgs/development/python-modules/datalab-platform/default.nix
+++ b/pkgs/development/python-modules/datalab-platform/default.nix
@@ -1,0 +1,174 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-time
+  qt5,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  fastapi,
+  guidata,
+  numpy,
+  packaging,
+  pandas,
+  plotpy,
+  psutil,
+  pydantic,
+  pywavelets,
+  scikit-image,
+  scipy,
+  sigima,
+  uvicorn,
+
+  # optional-dependencies
+  babel,
+  build,
+  coverage,
+  pre-commit,
+  pylint,
+  ruff,
+  myst-parser,
+  pydata-sphinx-theme,
+  sphinx,
+  sphinx-copybutton,
+  sphinx-design,
+  sphinx-intl,
+  sphinx-sitemap,
+  sphinxcontrib-svg2pdfconverter,
+  opencv-python-headless,
+  pyinstaller,
+  pyqt5,
+  httpx,
+  pytest,
+  pytest-xvfb,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "datalab-platform";
+  version = "1.2.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "DataLab-Platform";
+    repo = "DataLab";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rJDA5qYv2LYMyrckxNy63Gqn8HYU62qG0OAioztKGtA=";
+  };
+
+  # NOTE: DataLab is compatible with qt6, but it's apparently not perfect as
+  # the executable segfaults on startup. For now, let's use qt5 which works and
+  # migrate in the future.
+  nativeBuildInputs = [
+    qt5.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt5.qtbase
+  ];
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    fastapi
+    guidata
+    numpy
+    packaging
+    pandas
+    plotpy
+    psutil
+    pydantic
+    pywavelets
+    scikit-image
+    scipy
+    sigima
+    uvicorn
+  ]
+  ++ finalAttrs.passthru.optional-dependencies.qt
+  # required for `bin/datalab-{demo,tests}`
+  ++ finalAttrs.passthru.optional-dependencies.test;
+
+  optional-dependencies = {
+    dev = [
+      babel
+      build
+      coverage
+      pre-commit
+      pylint
+      ruff
+    ];
+    doc = [
+      myst-parser
+      pydata-sphinx-theme
+      sphinx
+      sphinx-copybutton
+      sphinx-design
+      sphinx-intl
+      sphinx-sitemap
+      sphinxcontrib-svg2pdfconverter
+    ];
+    exe = [
+      opencv-python-headless
+      pyinstaller
+      pyqt5
+    ];
+    opencv = [
+      opencv-python-headless
+    ];
+    qt = [
+      pyqt5
+    ];
+    test = [
+      httpx
+      pytest
+      pytest-xvfb
+    ];
+  };
+
+  pythonRelaxDeps = [
+    "guidata"
+    "plotpy"
+    "scipy"
+  ];
+
+  pythonImportsCheck = [
+    "datalab"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ]
+  ++ finalAttrs.passthru.optional-dependencies.test;
+
+  pytestFlags = [
+    "--collect-only"
+  ];
+
+  dontWrapQtApps = true;
+
+  preFixup = ''
+    # Python scripts need to be manually wrapped
+    for exe in "$out/bin"/datalab*; do
+      wrapQtApp "$exe"
+    done
+  '';
+
+  meta = {
+    description = "Open-source Platform for Scientific and Technical Data Processing and Visualization";
+    homepage = "https://github.com/DataLab-Platform/DataLab";
+    changelog = "https://github.com/DataLab-Platform/DataLab/releases/tag/${finalAttrs.src.tag}";
+    mainProgram = "datalab";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/development/python-modules/intersphinx-registry/default.nix
+++ b/pkgs/development/python-modules/intersphinx-registry/default.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  flit-core,
+
+  # optional-dependencies
+  platformdirs,
+  requests,
+  requests-cache,
+  sphinx,
+  mypy,
+  pytest,
+  pytest-xdist,
+  types-requests,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "intersphinx-registry";
+  version = "0.2705.27";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Quansight-labs";
+    repo = "intersphinx_registry";
+    tag = finalAttrs.version;
+    hash = "sha256-yFpk3NZO2iCjuJ43WvssbDYxNJ6G6KfY5pcTCilsGQs=";
+  };
+
+  build-system = [
+    flit-core
+  ];
+
+  dependencies = finalAttrs.passthru.optional-dependencies.lookup;
+
+  optional-dependencies = {
+    lookup = [
+      platformdirs
+      requests
+      requests-cache
+      sphinx
+    ];
+    tests = [
+      mypy
+      pytest
+      pytest-xdist
+      types-requests
+    ];
+  };
+
+  nativeCheckInputs = [
+    mypy
+    pytestCheckHook
+  ]
+  ++ finalAttrs.passthru.optional-dependencies.tests;
+
+  # TODO: lots of failing tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "intersphinx_registry"
+  ];
+
+  meta = {
+    description = "Utility package that provides a default intersphinx mapping";
+    homepage = "https://github.com/Quansight-labs/intersphinx_registry";
+    mainProgram = "intersphinx-registry";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ eljamm ];
+  };
+})

--- a/pkgs/development/python-modules/jupyterlite-core/default.nix
+++ b/pkgs/development/python-modules/jupyterlite-core/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  doit,
+  jupyter-core,
+  pycparser,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "jupyterlite-core";
+  version = "0.7.6";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "jupyterlite";
+    repo = "jupyterlite";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TSy0GUI/7NLsLOayBwZ/raTtOtFgs/t4v1ByytVG960=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/py/jupyterlite-core";
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    doit
+    jupyter-core
+    pycparser
+  ];
+
+  # upstream has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "jupyterlite_core"
+  ];
+
+  meta = {
+    description = "Wasm powered Jupyter running in the browser";
+    homepage = "https://github.com/jupyterlite/jupyterlite";
+    changelog = "https://github.com/jupyterlite/jupyterlite/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    mainProgram = "jupyter-lite";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ eljamm ];
+  };
+})

--- a/pkgs/development/python-modules/jupyterlite-sphinx/default.nix
+++ b/pkgs/development/python-modules/jupyterlite-sphinx/default.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  docutils,
+  jupyter-server,
+  jupyterlab-server,
+  jupyterlite-core,
+  jupytext,
+  nbformat,
+  sphinx,
+
+  # optional-dependencies
+  hatch,
+  myst-parser,
+  pydata-sphinx-theme,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "jupyterlite-sphinx";
+  version = "0.22.1";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "jupyterlite";
+    repo = "jupyterlite-sphinx";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-eww/VyHbAp78Bz2jg43XHmetEDrXEqXK45cnXHElG80=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    docutils
+    jupyter-server
+    jupyterlab-server
+    jupyterlite-core
+    finalAttrs.passthru.deps.jupytext
+    nbformat
+    sphinx
+  ];
+
+  optional-dependencies = {
+    dev = [
+      hatch
+    ];
+    docs = [
+      #jupyterlite-xeus # missing, but not important
+      myst-parser
+      pydata-sphinx-theme
+    ];
+  };
+
+  # upstream has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "jupyterlite_sphinx"
+  ];
+
+  passthru.deps.jupytext = jupytext.overridePythonAttrs (oldAttrs: {
+    # FIX: lots of flaky tests
+    doCheck = false;
+  });
+
+  meta = {
+    description = "Sphinx extension that integrates JupyterLite within your Sphinx documentation";
+    homepage = "https://github.com/jupyterlite/jupyterlite-sphinx";
+    changelog = "https://github.com/jupyterlite/jupyterlite-sphinx/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ eljamm ];
+  };
+})

--- a/pkgs/development/python-modules/sigima/default.nix
+++ b/pkgs/development/python-modules/sigima/default.nix
@@ -1,0 +1,137 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  guidata,
+  makefun,
+  numpy,
+  packaging,
+  pandas,
+  pywavelets,
+  scikit-image,
+  scipy,
+  typing-extensions,
+
+  # optional-dependencies
+  babel,
+  build,
+  coverage,
+  pre-commit,
+  pylint,
+  ruff,
+  wheel,
+  matplotlib,
+  myst-nb,
+  myst-parser,
+  opencv-python-headless,
+  plotpy,
+  pydata-sphinx-theme,
+  pyqt5,
+  qtpy,
+  sphinx,
+  sphinx-copybutton,
+  sphinx-design,
+  sphinx-gallery,
+  sphinx-intl,
+  pytest,
+  pytest-xvfb,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "sigima";
+  version = "1.1.4";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "DataLab-Platform";
+    repo = "Sigima";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-AQrUn/WgWZ5W9Lrg4TJjerEZvGDH1wKL2WbeP3sGjrE=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    guidata
+    makefun
+    numpy
+    packaging
+    pandas
+    pywavelets
+    scikit-image
+    scipy
+    typing-extensions
+  ];
+
+  optional-dependencies = {
+    dev = [
+      babel
+      build
+      coverage
+      pre-commit
+      pylint
+      ruff
+      setuptools
+      wheel
+    ];
+    doc = [
+      matplotlib
+      myst-nb
+      myst-parser
+      opencv-python-headless
+      plotpy
+      pydata-sphinx-theme
+      pyqt5
+      qtpy
+      sphinx
+      sphinx-copybutton
+      sphinx-design
+      sphinx-gallery
+      sphinx-intl
+    ];
+    opencv = [
+      opencv-python-headless
+    ];
+    qt = [
+      plotpy
+      pyqt5
+      qtpy
+    ];
+    test = [
+      pytest
+      pytest-xvfb
+    ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonRelaxDeps = [
+    "scipy"
+  ];
+
+  pythonImportsCheck = [
+    "sigima"
+  ];
+
+  meta = {
+    description = "Scientific computing engine for 1D signals and 2D images";
+    homepage = "https://github.com/DataLab-Platform/Sigima";
+    changelog = "https://github.com/DataLab-Platform/Sigima/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ eljamm ];
+    teams = with lib.teams; [ ngi ];
+  };
+})

--- a/pkgs/development/python-modules/sphinx-gallery/default.nix
+++ b/pkgs/development/python-modules/sphinx-gallery/default.nix
@@ -1,0 +1,134 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  pillow,
+  sphinx,
+
+  # optional-dependencies
+  absl-py,
+  graphviz,
+  intersphinx-registry,
+  ipython,
+  joblib,
+  jupyterlite-sphinx,
+  lxml,
+  matplotlib,
+  mypy,
+  numpy,
+  packaging,
+  plotly,
+  pydata-sphinx-theme,
+  pytest,
+  pytest-cov,
+  seaborn,
+  sphinx-design,
+  statsmodels,
+  types-docutils,
+  types-pillow,
+  memory-profiler,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "sphinx-gallery";
+  version = "0.21.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "sphinx-gallery";
+    repo = "sphinx-gallery";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-eWU2xNnguyXi2AZ/PpBp0Pv3IsgL9wQMyPuQpNbn9cY=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    pillow
+    sphinx
+  ];
+
+  optional-dependencies = {
+    animations = [
+      #sphinxcontrib-video
+    ];
+    dev = [
+      absl-py
+      graphviz
+      intersphinx-registry
+      ipython
+      joblib
+      jupyterlite-sphinx
+      lxml
+      matplotlib
+      mypy
+      numpy
+      packaging
+      plotly
+      pydata-sphinx-theme
+      pytest
+      pytest-cov
+      seaborn
+      sphinx-design
+      #sphinxcontrib-video
+      statsmodels
+      types-docutils
+      types-pillow
+      #types-pygments
+    ];
+    jupyterlite = [
+      jupyterlite-sphinx
+    ];
+    parallel = [
+      joblib
+    ];
+    recommender = [
+      numpy
+    ];
+    show-api-usage = [
+      graphviz
+    ];
+    show-memory = [
+      memory-profiler
+    ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ]
+  ++ finalAttrs.passthru.optional-dependencies.dev;
+
+  # TODO:
+  disabledTests = [
+    # requires the sphinxcontrib.video package
+    "test_dummy_image"
+    # urllib.error.URLError: <urlopen error [Errno -3] Temporary failure in name resolution>
+    "test_embed_code_links_get_data"
+  ];
+
+  pythonImportsCheck = [
+    "sphinx_gallery"
+  ];
+
+  meta = {
+    description = "Sphinx extension for automatic generation of an example gallery";
+    homepage = "https://github.com/sphinx-gallery/sphinx-gallery";
+    changelog = "https://github.com/sphinx-gallery/sphinx-gallery/blob/${finalAttrs.src.rev}/CHANGES.rst";
+    mainProgram = "sphinx_gallery_py2jupyter";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ eljamm ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8311,6 +8311,8 @@ self: super: with self; {
 
   jupyterlab-widgets = callPackage ../development/python-modules/jupyterlab-widgets { };
 
+  jupyterlite-core = callPackage ../development/python-modules/jupyterlite-core { };
+
   jupytext = callPackage ../development/python-modules/jupytext { };
 
   justbackoff = callPackage ../development/python-modules/justbackoff { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18033,6 +18033,8 @@ self: super: with self; {
 
   sievelib = callPackage ../development/python-modules/sievelib { };
 
+  sigima = callPackage ../development/python-modules/sigima { };
+
   signalrcore = callPackage ../development/python-modules/signalrcore { };
 
   signalslot = callPackage ../development/python-modules/signalslot { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7743,6 +7743,8 @@ self: super: with self; {
 
   interruptingcow = callPackage ../development/python-modules/interruptingcow { };
 
+  intersphinx-registry = callPackage ../development/python-modules/intersphinx-registry { };
+
   intervals = callPackage ../development/python-modules/intervals { };
 
   intervaltree = callPackage ../development/python-modules/intervaltree { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18593,6 +18593,8 @@ self: super: with self; {
 
   sphinx-fortran = callPackage ../development/python-modules/sphinx-fortran { };
 
+  sphinx-gallery = callPackage ../development/python-modules/sphinx-gallery { };
+
   sphinx-inline-tabs = callPackage ../development/python-modules/sphinx-inline-tabs { };
 
   sphinx-intl = callPackage ../development/python-modules/sphinx-intl { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8313,6 +8313,8 @@ self: super: with self; {
 
   jupyterlite-core = callPackage ../development/python-modules/jupyterlite-core { };
 
+  jupyterlite-sphinx = callPackage ../development/python-modules/jupyterlite-sphinx { };
+
   jupytext = callPackage ../development/python-modules/jupytext { };
 
   justbackoff = callPackage ../development/python-modules/justbackoff { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3660,6 +3660,8 @@ self: super: with self; {
     protoc = pkgs.protobuf;
   };
 
+  datalab-platform = callPackage ../development/python-modules/datalab-platform { };
+
   datalad = callPackage ../development/python-modules/datalad { };
 
   datalad-gooey = callPackage ../development/python-modules/datalad-gooey { };


### PR DESCRIPTION
[DataLab](https://github.com/DataLab-Platform/DataLab) is an open-source platform for scientific and technical data processing and visualization.

This PR also adds the following dependencies:
- [sigima](https://github.com/DataLab-Platform/Sigima): scientific computing engine for 1D signals and 2D images
- [sphinx-gallery](https://github.com/sphinx-gallery/sphinx-gallery): Sphinx extension for automatic generation of an example gallery
- [intersphinx-registry](https://github.com/Quansight-labs/intersphinx_registry): utility package that provides a default intersphinx mapping
- [jupyterlite-sphinx](https://github.com/jupyterlite/jupyterlite-sphinx): Sphinx extension that integrates JupyterLite within your Sphinx documentation
- [jupyterlite-core](https://github.com/jupyterlite/jupyterlite): wasm powered Jupyter running in the browser

Tracking: https://github.com/ngi-nix/projects/issues/1092

**PS:** I've had issues running datalab with qt6, although it [should be compatible](https://datalab-platform.com/en/release_notes/release_1.01.html#:~:text=PyQt6%20compatibility) with it. For the time being, I've decided to just go with qt5 and leave any qt6 migration to a followup.

> [!NOTE]
> Work done as part of the [Nix@NGI](https://nixos.org/community/teams/ngi/) packaging effort 

[DataLab Demo.webm](https://github.com/user-attachments/assets/9c05e62b-247f-480d-a28a-76680ba0e950)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
