### PR TITLE
nfs-ganesha: 9.14 -> 9.16

### DIFF
--- a/pkgs/by-name/nf/nfs-ganesha/package.nix
+++ b/pkgs/by-name/nf/nfs-ganesha/package.nix
@@ -21,11 +21,12 @@
   ceph,
   useDbus ? true,
   dbus,
+  rdma-core,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nfs-ganesha";
-  version = "9.14";
+  version = "9.16";
 
   outputs = [
     "out"
@@ -37,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "nfs-ganesha";
     repo = "nfs-ganesha";
     tag = "V${finalAttrs.version}";
-    hash = "sha256-aeZDXr6vUFyFhVQO31ttZ04W8KP8iKN0u17McULtQUM=";
+    hash = "sha256-y5rsQjhmfhqZXQ7jXsItbNe/3Gq4lswIXUq7nnyQIcs=";
   };
 
   patches = lib.optional useDbus ./allow-bypassing-dbus-pkg-config-test.patch;
@@ -54,6 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"
     "-DUSE_MAN_PAGE=ON"
     "-DUSE_MONITORING=ON"
+    "-DUSE_NFS_RDMA=ON"
   ]
   ++ lib.optionals useCeph [
     "-DUSE_RADOS_RECOV=ON"
@@ -90,6 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
     liburcu
     nfs-utils
     prometheus-cpp-lite
+    rdma-core
   ]
   ++ lib.optional useCeph ceph;
 

--- a/pkgs/by-name/nt/ntirpc/package.nix
+++ b/pkgs/by-name/nt/ntirpc/package.nix
@@ -8,28 +8,30 @@
   libtirpc,
   libnsl,
   prometheus-cpp-lite,
+  rdma-core,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ntirpc";
-  version = "7.2";
+  version = "9.16";
 
   src = fetchFromGitHub {
     owner = "nfs-ganesha";
     repo = "ntirpc";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-4E6wDAwinCNn7arRgBulg7e0x9S/steh+mjwNY4X3Vc=";
+    hash = "sha256-ZpjP1ugT9gN3TW7roBfJJBA6Y6FCkaOl31WRoRqPvTU=";
   };
 
   outputs = [
     "out"
     "dev"
   ];
-  postPatch = ''
-    substituteInPlace CMakeLists.txt --replace-fail \
-      "cmake_minimum_required(VERSION 2.6.3)" \
-      "cmake_minimum_required(VERSION 3.10)"
 
+  patches = [
+    ./pkg-config.patch
+  ];
+
+  postPatch = ''
     substituteInPlace ntirpc/netconfig.h --replace-fail \
       "/etc/netconfig" "$out/etc/netconfig"
   '';
@@ -40,10 +42,12 @@ stdenv.mkDerivation (finalAttrs: {
     liburcu
     libnsl
     prometheus-cpp-lite
+    rdma-core
   ];
 
   cmakeFlags = [
     "-DUSE_MONITORING=ON"
+    "-DUSE_RPC_RDMA=ON"
   ];
 
   postInstall = ''

--- a/pkgs/by-name/nt/ntirpc/pkg-config.patch
+++ b/pkgs/by-name/nt/ntirpc/pkg-config.patch
@@ -1,0 +1,12 @@
+diff --git a/libntirpc.pc.in.cmake b/libntirpc.pc.in.cmake
+index 6650568..3aaea1d 100644
+--- a/libntirpc.pc.in.cmake
++++ b/libntirpc.pc.in.cmake
+@@ -1,6 +1,6 @@
+ prefix=@CMAKE_INSTALL_PREFIX@
+ exec_prefix=${prefix}
+-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
++libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+ includedir=${prefix}/include/ntirpc
+ 
+ Name: libntirpc


### PR DESCRIPTION
https://github.com/nfs-ganesha/nfs-ganesha/tags

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
