### PR TITLE
shader-slang: 2026.5.2 -> 2026.11

### DIFF
--- a/pkgs/by-name/sh/shader-slang/package.nix
+++ b/pkgs/by-name/sh/shader-slang/package.nix
@@ -21,13 +21,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "shader-slang";
-  version = "2026.5.2";
+  version = "2026.11";
 
   src = fetchFromGitHub {
     owner = "shader-slang";
     repo = "slang";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-kx1g7GrUX8ZPg/HGS6SpRYat/YLTJejxCM2UgcUkDgo=";
+    hash = "sha256-PnqnTd6ccOK6WWCEdan0l6NFy/0Iv0nIbfk3oywTQZU=";
     fetchSubmodules = true;
   };
 
@@ -101,6 +101,9 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "SLANG_RHI_ENABLE_VULKAN" false)
     (lib.cmakeBool "SLANG_RHI_ENABLE_METAL" false)
     (lib.cmakeBool "SLANG_RHI_ENABLE_WGPU" false)
+    # Disable DXC (DirectX Compiler) for now; wiring up directx-shader-compiler
+    # as a proper dependency is left for a future PR
+    (lib.cmakeBool "SLANG_ENABLE_DXIL" false)
   ]
   ++ lib.optionals withGlslang [
     (lib.cmakeBool "SLANG_USE_SYSTEM_SPIRV_TOOLS" true)


### PR DESCRIPTION
(https://github.com/shader-slang/slang/releases/tag/v2026.11)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].