### PR TITLE
mouser: darwin build is fixed

### DIFF
--- a/pkgs/by-name/mo/mouser/package.nix
+++ b/pkgs/by-name/mo/mouser/package.nix
@@ -39,6 +39,14 @@ python3Packages.buildPythonApplication (finalAttrs: {
       [
         evdev
       ]
+    )
+    ++ lib.optionals stdenv.hostPlatform.isDarwin (
+      with python3Packages;
+      [
+        pyobjc-core
+        pyobjc-framework-Cocoa
+        pyobjc-framework-Quartz
+      ]
     );
 
   installPhase = ''
@@ -51,6 +59,31 @@ python3Packages.buildPythonApplication (finalAttrs: {
     install -Dm644 images/logo_icon.png $out/share/pixmaps/mouser.png
     install -Dm444 packaging/linux/69-mouser-logitech.rules \
       -t $out/lib/udev/rules.d
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    appBundle="$out/Applications/Mouser.app"
+    mkdir -p "$appBundle/Contents/MacOS" "$appBundle/Contents/Resources"
+    install -Dm644 images/AppIcon.icns "$appBundle/Contents/Resources/AppIcon.icns"
+
+    cat > "$appBundle/Contents/Info.plist" <<'EOF'
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+    <dict>
+      <key>CFBundleName</key><string>Mouser</string>
+      <key>CFBundleDisplayName</key><string>Mouser</string>
+      <key>CFBundleExecutable</key><string>Mouser</string>
+      <key>CFBundleIdentifier</key><string>io.github.tombadash.mouser</string>
+      <key>CFBundleIconFile</key><string>AppIcon</string>
+      <key>CFBundleShortVersionString</key><string>${finalAttrs.version}</string>
+      <key>CFBundleVersion</key><string>${finalAttrs.version}</string>
+      <key>CFBundlePackageType</key><string>APPL</string>
+      <key>NSHighResolutionCapable</key><true/>
+      <key>LSUIElement</key><true/>
+      <key>LSMinimumSystemVersion</key><string>12.0</string>
+    </dict>
+    </plist>
+    EOF
   ''
   + ''
     runHook postInstall
@@ -70,6 +103,9 @@ python3Packages.buildPythonApplication (finalAttrs: {
   ''
   + ''
     --add-flags "$out/share/mouser/main_qml.py"
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    makeWrapper $out/bin/mouser $out/Applications/Mouser.app/Contents/MacOS/Mouser
   '';
 
   desktopItems = lib.optionals stdenv.hostPlatform.isLinux [


### PR DESCRIPTION
- Add missing Python libraries
- Wrap app so it could be launched by spotlight 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
