### PR TITLE
 prismlauncher-theme-oreui: init at 1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26286,6 +26286,12 @@
     githubId = 4061736;
     name = "Severen Redwood";
   };
+  ssnoer = {
+    email = "ssnoer@proton.me";
+    github = "Seba244c";
+    githubId = 23051740;
+    name = "Sebastian August Snoer";
+  };
   sstef = {
     email = "stephane@nix.frozenid.net";
     github = "haskelious";

--- a/pkgs/by-name/pr/prismlauncher-theme-oreui/package.nix
+++ b/pkgs/by-name/pr/prismlauncher-theme-oreui/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  prismlauncher,
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "prismlauncher-theme-oreui";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "ninsent";
+    repo = "Ore-UI-theme-pack";
+    tag = "${version}";
+    hash = "sha256-wkbqrPrDZjVZ0S/3125YPajqoyGccISZ6l5tVk0+Rvs=";
+  };
+
+  strictDeps = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/PrismLauncher/iconthemes
+    cp -r "Ore UI - Icon Pack" "$out/share/PrismLauncher/iconthemes/"
+
+    mkdir $out/share/PrismLauncher/themes
+    cp -r "Ore UI - Dark Amethyst" "$out/share/PrismLauncher/themes/"
+    cp -r "Ore UI - Dark Diamond" "$out/share/PrismLauncher/themes/"
+    cp -r "Ore UI - Dark Emerald" "$out/share/PrismLauncher/themes/"
+    cp -r "Ore UI - Light Amethyst" "$out/share/PrismLauncher/themes/"
+    cp -r "Ore UI - Dark Diamond" "$out/share/PrismLauncher/themes/"
+    cp -r "Ore UI - Dark Emerald" "$out/share/PrismLauncher/themes/"
+
+    runHook postInstall
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    inherit (prismlauncher.meta) platforms;
+    description = "Minecraft Bedrock inspired Ore UI theme for Prism Launcher.";
+    longDescription = ''
+      PrismLauncher theme and icon theme insipired by Minecraft Bedrock Ore UI.
+    '';
+    homepage = "https://github.com/ninsent/Ore-UI-theme-pack";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ssnoer ];
+  };
+}


### PR DESCRIPTION
PrismLauncher theme and icon theme inspired by Minecraft Bedrock Ore UI.

Original repo: https://github.com/ninsent/Ore-UI-theme-pack

This package is inspired by a similair package on the [AUR](https://aur.archlinux.org/packages/prismlauncher-ore-ui-themes).

## Things done
- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
