### PR TITLE
gradle: fix update script with structuredAttrs

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/update-deps.nix
+++ b/pkgs/development/tools/build-managers/gradle/update-deps.nix
@@ -37,6 +37,7 @@ lib.makeOverridable (
     ];
     gradleScript = writeShellScript "gradle-commands.sh" ''
       set -eo pipefail
+      if [ -e "''${NIX_ATTRS_SH_FILE:-}" ]; then . "$NIX_ATTRS_SH_FILE"; fi
       export http_proxy="$MITM_CACHE_ADDRESS"
       export https_proxy="$MITM_CACHE_ADDRESS"
       export SSL_CERT_FILE="$MITM_CACHE_CA"


### PR DESCRIPTION
Fixes an issue with the Gradle script to fetch updates failing when the main package has `__structuredAttrs = true`.

## Testing

To see the failure on `master`:

1. Pick a random Gradle package that uses `nix-update-script`. I used `coulomb`
2. Set the update script to run unconditionally (for testing) and enable `__structuredAttrs`, e.g.:
```diff
diff --git a/pkgs/by-name/co/coulomb/package.nix b/pkgs/by-name/co/coulomb/package.nix
index 66705cdd84e2..f73222cefdec 100644
--- a/pkgs/by-name/co/coulomb/package.nix
+++ b/pkgs/by-name/co/coulomb/package.nix
@@ -36,6 +36,8 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "languageVersion.set(JavaLanguageVersion.of(19))" "languageVersion.set(JavaLanguageVersion.of(21))"
   '';
 
+  __structuredAttrs = true;
+
   nativeBuildInputs = [
     gradle
     jdk21_headless
@@ -89,7 +91,9 @@ stdenv.mkDerivation (finalAttrs: {
     ''${gappsWrapperArgs[@]}
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=skip" ];
+  };
 
   meta = {
     description = "Simple and beautiful circuit simulator app";
```
3. Run the update script (`nix-shell maintainers/scripts/update.nix --argstr package coulomb`)

The script should fail relatively quickly, with an error like `/nix/store/1a2kgc1raikz7qlh2scs63z23kkdp3xs-gradle-commands.sh: line 14: /setup: No such file or directory`.

On this branch, the script should pass (it will take a few minutes, as it usually does for Gradle).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
