### PR TITLE
python3Packages.pysptk: migrate to pyproject, enable __structuredAttrs, use finalAttrs, enable tests

### DIFF
--- a/pkgs/development/python-modules/pysptk/default.nix
+++ b/pkgs/development/python-modules/pysptk/default.nix
@@ -10,13 +10,14 @@
   six,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pysptk";
   version = "1.0.1";
   format = "setuptools";
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) version;
+    pname = "pysptk";
     hash = "sha256-eLHJM4v3laQc3D/wP81GmcQBwyP1RjC7caGXEAeNCz8=";
   };
 
@@ -43,4 +44,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/pysptk/default.nix
+++ b/pkgs/development/python-modules/pysptk/default.nix
@@ -6,14 +6,13 @@
   fetchPypi,
   numpy,
   scipy,
-  setuptools,
-  six,
+  setuptools_80,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "pysptk";
   version = "1.0.1";
-  format = "setuptools";
+  pyproject = true;
 
   __structuredAttrs = true;
 
@@ -23,16 +22,16 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-eLHJM4v3laQc3D/wP81GmcQBwyP1RjC7caGXEAeNCz8=";
   };
 
-  env.PYSPTK_BUILD_VERSION = 0;
+  build-system = [
+    cython
+  ];
 
-  nativeBuildInputs = [ cython ];
-
-  propagatedBuildInputs = [
+  dependencies = [
     decorator
     numpy
     scipy
-    setuptools
-    six
+    # setuptools is a runtime dependency because util.py imports pkg_resources
+    setuptools_80
   ];
 
   # Tests are not part of the PyPI releases

--- a/pkgs/development/python-modules/pysptk/default.nix
+++ b/pkgs/development/python-modules/pysptk/default.nix
@@ -15,6 +15,8 @@ buildPythonPackage (finalAttrs: {
   version = "1.0.1";
   format = "setuptools";
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
     inherit (finalAttrs) version;
     pname = "pysptk";

--- a/pkgs/development/python-modules/pysptk/default.nix
+++ b/pkgs/development/python-modules/pysptk/default.nix
@@ -5,6 +5,7 @@
   decorator,
   fetchPypi,
   numpy,
+  pytestCheckHook,
   scipy,
   setuptools_80,
 }:
@@ -34,8 +35,20 @@ buildPythonPackage (finalAttrs: {
     setuptools_80
   ];
 
-  # Tests are not part of the PyPI releases
-  doCheck = false;
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  # Remove source to prevent the tests from trying to import it
+  preCheck = ''
+    rm -r pysptk
+  '';
+
+  disabledTests = [
+    # These tests rely on test data not present in the pypi release
+    "test_rapt_regression"
+    "test_swipe_regression"
+  ];
 
   pythonImportsCheck = [ "pysptk" ];
 

--- a/pkgs/development/python-modules/pysptk/default.nix
+++ b/pkgs/development/python-modules/pysptk/default.nix
@@ -1,19 +1,19 @@
 {
   lib,
   buildPythonPackage,
-  cython,
-  decorator,
   fetchPypi,
+  cython,
+  setuptools,
+  decorator,
   numpy,
   scipy,
-  setuptools,
-  six,
+  standard-pkg-resources,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "pysptk";
   version = "1.0.1";
-  format = "setuptools";
+  pyproject = true;
 
   __structuredAttrs = true;
 
@@ -23,16 +23,16 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-eLHJM4v3laQc3D/wP81GmcQBwyP1RjC7caGXEAeNCz8=";
   };
 
-  env.PYSPTK_BUILD_VERSION = 0;
+  build-system = [
+    cython
+    setuptools
+  ];
 
-  nativeBuildInputs = [ cython ];
-
-  propagatedBuildInputs = [
+  dependencies = [
     decorator
     numpy
     scipy
-    setuptools
-    six
+    standard-pkg-resources
   ];
 
   # Tests are not part of the PyPI releases

--- a/pkgs/development/python-modules/pysptk/default.nix
+++ b/pkgs/development/python-modules/pysptk/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchPypi,
   cython,
+  pytestCheckHook,
   setuptools,
   decorator,
   numpy,
@@ -35,8 +36,20 @@ buildPythonPackage (finalAttrs: {
     standard-pkg-resources
   ];
 
-  # Tests are not part of the PyPI releases
-  doCheck = false;
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  # Remove source to prevent the tests from trying to import it
+  preCheck = ''
+    rm -r pysptk
+  '';
+
+  disabledTests = [
+    # These tests rely on test data not present in the pypi release
+    "test_rapt_regression"
+    "test_swipe_regression"
+  ];
 
   pythonImportsCheck = [ "pysptk" ];
 


### PR DESCRIPTION
- https://github.com/NixOS/nixpkgs/issues/515974
- use `finalAttrs`
- enable `__structuredAttrs`
- enable tests

This is against staging to have access to `setuptools_80`
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
