### PR TITLE
folly: fix x86_64-darwin build

### DIFF
--- a/pkgs/by-name/fo/folly/memset-benchmark-darwin.patch
+++ b/pkgs/by-name/fo/folly/memset-benchmark-darwin.patch
@@ -1,0 +1,11 @@
+--- a/folly/test/MemsetBenchmark.cpp
++++ b/folly/test/MemsetBenchmark.cpp
+@@ -40,7 +40,7 @@
+ 
+ template <void* memset_impl(void*, int, size_t)>
+ void bmMemset(void* buf, size_t length, size_t iters) {
+-#if !defined(__aarch64__)
++#if !defined(__aarch64__) && !defined(__APPLE__)
+   __asm__ volatile(".align 64\n");
+ #endif
+ #pragma unroll(1)

--- a/pkgs/by-name/fo/folly/package.nix
+++ b/pkgs/by-name/fo/folly/package.nix
@@ -144,6 +144,11 @@ stdenv.mkDerivation (finalAttrs: {
     # https://github.com/facebook/folly/pull/2561
     ./memset-memcpy-aarch64.patch
 
+    # `.align 64` is invalid on x86_64 Mach-O, where `.align` takes a
+    # power-of-two exponent (64 means 2^64). The guard only excluded
+    # aarch64, so add !__APPLE__ to also skip x86_64-darwin.
+    ./memset-benchmark-darwin.patch
+
     # Use feature detection directly instead of private standard library
     # macros to detect the presence of ASAN and otherwise fallback to
     # _not_ having ASAN.


### PR DESCRIPTION
Follow up fix for `x86_64-darwin` build issues reported in #512802 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
