### PR TITLE
Firefox: 152.0 -> 152.0.1

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/release_sources.nix
@@ -1,1859 +1,1859 @@
 {
-  version = "152.0";
+  version = "152.0.1";
   sources = [
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/ach/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ach/firefox-152.0.1.tar.xz";
       locale = "ach";
       arch = "linux-x86_64";
-      sha256 = "3cc74a1cd00873f1562d5fd0db7d04664409a0ecca19b993b0b28559245d90df";
+      sha256 = "8de0b24eb92f17c27b5cf7b0005a13cc94d72ac05f1e557d8f4b491b449645f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/af/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/af/firefox-152.0.1.tar.xz";
       locale = "af";
       arch = "linux-x86_64";
-      sha256 = "922b94182cd99a93d5a7c642d235799a64707f0898ecb204c973137839443caa";
+      sha256 = "f67b2f9955513cf1a0281247ac1988f4306678ab0aa57ab2895f3db20d7eda10";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/an/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/an/firefox-152.0.1.tar.xz";
       locale = "an";
       arch = "linux-x86_64";
-      sha256 = "0764dad7d8c8bf3770c7d4e0b97b090a59c2003dfa62654a14dc922e219f184f";
+      sha256 = "c9a97857bb183d49c6385c831bd7f46f4ba2bc942ed78ea136053a047f1227af";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/ar/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ar/firefox-152.0.1.tar.xz";
       locale = "ar";
       arch = "linux-x86_64";
-      sha256 = "1f5117edcfcfebb85fe914cd681d46e9cc6eacf62252e5fd791cecce3ea87395";
+      sha256 = "fecd3068932f9d5886b4424cae645cb01e3f9875bad199b094afca23f9a601c6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/ast/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ast/firefox-152.0.1.tar.xz";
       locale = "ast";
       arch = "linux-x86_64";
-      sha256 = "09b246435a604797ec6605b0a443b7a8fa4cc330a50f5168a5a90e5230632c17";
+      sha256 = "c855a732862e2999b23c08886ea66e734d5e868c185e229a2458149dd2d196e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/az/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/az/firefox-152.0.1.tar.xz";
       locale = "az";
       arch = "linux-x86_64";
-      sha256 = "a9b8819957b7ec9a56273758113c1281a44be65d2ad449fefd87a43dce7e5476";
+      sha256 = "220f9bbbe8f2ee3c26edca52b2bec5bdfdadaf82431b6db808ef976e63ab4319";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/be/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/be/firefox-152.0.1.tar.xz";
       locale = "be";
       arch = "linux-x86_64";
-      sha256 = "055b5a2d75bbfeda12af0add90116e3473c365ad064303f1295653911c6f3fc2";
+      sha256 = "ef2c931aeed16f31118b92969faad1b2f173cbab7b74a55b37b5eba3a3e6d252";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/bg/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/bg/firefox-152.0.1.tar.xz";
       locale = "bg";
       arch = "linux-x86_64";
-      sha256 = "ebf64840ecce73e08a71c9bb7359e322e1b083d6540e4090e47c3b1c1c33b47a";
+      sha256 = "7920f2fcad9a5d9166175b1a609bf9a45cb903e460e69134ce72b33c6727f294";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/bn/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/bn/firefox-152.0.1.tar.xz";
       locale = "bn";
       arch = "linux-x86_64";
-      sha256 = "f4375e1141b80861678ad1facd9a993874364274c21aa1de403ecabf5c331121";
+      sha256 = "f5db6117e54029b05b508d4442ddfd05bb4f0ae0272c2c4124bc9cced3c0e3ef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/br/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/br/firefox-152.0.1.tar.xz";
       locale = "br";
       arch = "linux-x86_64";
-      sha256 = "e367fe3be236dd0a8c42cf11054b9ff7e7c8233e1a906e11037926716edcccb4";
+      sha256 = "e50cff8c75079d61c74991c55fca5db701bca5719ffc7e1692f4f338ece41752";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/bs/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/bs/firefox-152.0.1.tar.xz";
       locale = "bs";
       arch = "linux-x86_64";
-      sha256 = "1c194feab368daae4de9e7b36bbc68c2344c29024b43b329e98cdd6500651370";
+      sha256 = "d18fe74ce0bca7d44a2207abc2a739f349a15d76fc086147ec4b8e9c03bc9a45";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/ca-valencia/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ca-valencia/firefox-152.0.1.tar.xz";
       locale = "ca-valencia";
       arch = "linux-x86_64";
-      sha256 = "de0e9c8d8c31842bb5a8333cef709faac6cdf22d152b3273ce28b03de631486b";
+      sha256 = "104bc5a0e543ba9066f84efbf1328a335f6a46f22edba17dd9ddd8b85620b505";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/ca/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ca/firefox-152.0.1.tar.xz";
       locale = "ca";
       arch = "linux-x86_64";
-      sha256 = "0cf226d10a22e4bc28f2bef7221fd7fedd6a59247efe72e2ba9fe5b8ebb3714e";
+      sha256 = "aed5308e20d7aebf24746e4feb13753bbe404f735b0fcb3eb9d32c42bfa702d7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/cak/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/cak/firefox-152.0.1.tar.xz";
       locale = "cak";
       arch = "linux-x86_64";
-      sha256 = "30cc1f429738262e02867437201d455a028cbb8f865c0b6a60a3e69ab9d13d14";
+      sha256 = "b2ed0425c1ee90adbdbda303bb32eee07e139d70eaabe72da942d900ca876a0d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/cs/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/cs/firefox-152.0.1.tar.xz";
       locale = "cs";
       arch = "linux-x86_64";
-      sha256 = "3b92c45ff497813f48b106babe5dc5fbbd8ee0c577a719f59e295c43ea2fe7e5";
+      sha256 = "bee74b9ffaf355b3f0ac9e93739d508ccd7d41c075d9f652ff467cf11a4f3555";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/cy/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/cy/firefox-152.0.1.tar.xz";
       locale = "cy";
       arch = "linux-x86_64";
-      sha256 = "730dfcd8fd6cd87b2e7b4d203a9c837ee2e591eb4ab966b605ebee6b591dd2e8";
+      sha256 = "0b6c00902e26a2988db954cb1958ec06ac8abdc5c702d95b5af4989d4459ea89";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/da/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/da/firefox-152.0.1.tar.xz";
       locale = "da";
       arch = "linux-x86_64";
-      sha256 = "623f211424a2f71221e987b354daffe0cbba2423ae063b9bd79abe8dc7d3cd20";
+      sha256 = "9ffbc66f2ed0fdb17b3359036fa98e883bf088901393b353d9ac1684f665cfd0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/de/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/de/firefox-152.0.1.tar.xz";
       locale = "de";
       arch = "linux-x86_64";
-      sha256 = "14a929a0d17ac2de7cfdde74ddddeb8d5231cadc399cdb23d72d2b1d434d8324";
+      sha256 = "d7f8f2efea29ea2b9e4e17b6c49a16007eba724a8bebc1aca0fc4c268673c728";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/dsb/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/dsb/firefox-152.0.1.tar.xz";
       locale = "dsb";
       arch = "linux-x86_64";
-      sha256 = "380f8d3287a68eaee6edf2b7fcf54eb3dc2a65a78435da2a556e361e520a4661";
+      sha256 = "00c44e2a3c3986525f0035f3e64a609714ce5008bcc6a472b29e35d04e55495b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/el/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/el/firefox-152.0.1.tar.xz";
       locale = "el";
       arch = "linux-x86_64";
-      sha256 = "96eee2bee0d64781d6645d2552b977d453d0210cecac19b59e4a592d4fe93eb2";
+      sha256 = "d54b6c213bd208bf8eacc7d795763117747625f81a71ec0c29e55589bf7725fd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/en-CA/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/en-CA/firefox-152.0.1.tar.xz";
       locale = "en-CA";
       arch = "linux-x86_64";
-      sha256 = "2644684e96c1dc8bff8348aa9c90e446ac1ce33dfdbaef09109b32d0cb3499f9";
+      sha256 = "2f4f7e4b130da176e4a68e359359504e18fbcac635610280ce7fd6cdab76057a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/en-GB/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/en-GB/firefox-152.0.1.tar.xz";
       locale = "en-GB";
       arch = "linux-x86_64";
-      sha256 = "295a5e4a3b39d7f226b4dd8d4e057b4249d1afc8237b4058ab45871cb64f3997";
+      sha256 = "340ab737ea69010cc6153874d506d9a9ca0638bf5af29efabbc24d6f7da48e14";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/en-US/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/en-US/firefox-152.0.1.tar.xz";
       locale = "en-US";
       arch = "linux-x86_64";
-      sha256 = "748704b06ffaabc8bd2b3351c93c244db4e29bfe21af6ecb4d6c124c7bd4a234";
+      sha256 = "04efc89d4127bc4c9c56e471532be46606cb3776f2fd6252d459a83bc11c9b2d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/eo/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/eo/firefox-152.0.1.tar.xz";
       locale = "eo";
       arch = "linux-x86_64";
-      sha256 = "4f8bdb8e41179f06b3805cc2645af2b1d738ebee932cef4e2cebe2307079b82d";
+      sha256 = "0ccea386ae972d104bacb893607ea5da06bf45237ab94fcc08a3ba7aed51c0b4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/es-AR/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/es-AR/firefox-152.0.1.tar.xz";
       locale = "es-AR";
       arch = "linux-x86_64";
-      sha256 = "e1778aacf82f950e27f7f2663c3d3abfc82e20f30b08624be13726d5e27f409b";
+      sha256 = "a6814db65e8f1c2b0a98297d843871b91c9609284842d1b28acc489e37fef4c7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/es-CL/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/es-CL/firefox-152.0.1.tar.xz";
       locale = "es-CL";
       arch = "linux-x86_64";
-      sha256 = "c405ddb4320dfb13a102f982bfb64e579c4aeed18399bed721f9edd64c7d7157";
+      sha256 = "5e84ea6769266352ba9540d74baf428a518686e84b453864f9f0ba1e290c405d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/es-ES/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/es-ES/firefox-152.0.1.tar.xz";
       locale = "es-ES";
       arch = "linux-x86_64";
-      sha256 = "083c515b440b608f357e50061dd4fe88c7567636604efce0b2cbe13386b46ef9";
+      sha256 = "32378327f6771c99c93d9bc49958f8f04c8dad8e1107ac0f348723a76c93e14d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/es-MX/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/es-MX/firefox-152.0.1.tar.xz";
       locale = "es-MX";
       arch = "linux-x86_64";
-      sha256 = "5db5187a76252fa099e6a8bf3ad219e582a26ef01a3b166eccb8f16914098faa";
+      sha256 = "96ffa98bf3d78d15f32d0336e17ce0a2b9d1c183ea6a043090b36c3e2f9240e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/et/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/et/firefox-152.0.1.tar.xz";
       locale = "et";
       arch = "linux-x86_64";
-      sha256 = "c11b15b43186d5681602b24ff3664f6388ae7bd9063cc4a3073d727349661552";
+      sha256 = "e4083f3112ac0a5f79d9ed1790ad6e198d0d053603a1ef72896892b6fc78fb1d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/eu/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/eu/firefox-152.0.1.tar.xz";
       locale = "eu";
       arch = "linux-x86_64";
-      sha256 = "ec5f0adfbdb74104b985c3dc27694a23f4e6ebdb8c269ade980ba986034040d1";
+      sha256 = "541c5fcae2f8906dd919e2f776c64c0816618722132218a29d3d43df2b7feadf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/fa/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/fa/firefox-152.0.1.tar.xz";
       locale = "fa";
       arch = "linux-x86_64";
-      sha256 = "ee522582f27d4ce6b9cfeeb6d7f3777c71fd245980392af5f7073c7b90792c2e";
+      sha256 = "8483301e8b34c6300a32195272409a1897655afb6e54e2c1f8a85d29b9177208";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/ff/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ff/firefox-152.0.1.tar.xz";
       locale = "ff";
       arch = "linux-x86_64";
-      sha256 = "c6e1da362936ae28be93cfb82092be38f56612da0713e8785570c605625b8b7e";
+      sha256 = "ee18c36c7632efdba4696b667f4d86c4e4c6964f558d1b3337ea271cf9d65245";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/fi/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/fi/firefox-152.0.1.tar.xz";
       locale = "fi";
       arch = "linux-x86_64";
-      sha256 = "63527b76c129c33a26067a70ae584170a5c9ca692f1ba4604cb6cdf86d2db8dc";
+      sha256 = "90d243e68fc845dc5ad552c472e1b96b19cc2998029714f2aa3bc17816d59859";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/fr/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/fr/firefox-152.0.1.tar.xz";
       locale = "fr";
       arch = "linux-x86_64";
-      sha256 = "ecdbb057bfe0477e5f13213f472a0c11d0bc6499fd7527a07d3a23a99b4295bd";
+      sha256 = "e8ddabead201e6ff45cdc17268f783702508098b8a40e7b29cd8d29950a79b4a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/fur/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/fur/firefox-152.0.1.tar.xz";
       locale = "fur";
       arch = "linux-x86_64";
-      sha256 = "b42b46dda310d3b3df61aad2ae8bd365400b10626bd83079d99058dc1112923b";
+      sha256 = "be8c3a6be69494dd4912eaac8d1adff21f0883399db8ef7d847c5d8b79487b65";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/fy-NL/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/fy-NL/firefox-152.0.1.tar.xz";
       locale = "fy-NL";
       arch = "linux-x86_64";
-      sha256 = "985cb8898fbd06be9df66ec2e57d31bd7dd0d0118b127f2c52ee4832dd676206";
+      sha256 = "e58ac987ddf6a6b26eb28d0a19d68544fb190efc84982e9ef25736490d158cca";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/ga-IE/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ga-IE/firefox-152.0.1.tar.xz";
       locale = "ga-IE";
       arch = "linux-x86_64";
-      sha256 = "f866a51c2b7019474b5c2ae814ab0c26314d81cf878bb3a4343ccffdc32b85ef";
+      sha256 = "834ebee6b4c581d767232243aaa089380f8cab8a8dba48e179e402a29be0eb7f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/gd/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/gd/firefox-152.0.1.tar.xz";
       locale = "gd";
       arch = "linux-x86_64";
-      sha256 = "d4633e1df3ffcacd7b30f8b81d135082f62b59999eb6319430f6763f8ad53b7e";
+      sha256 = "0adff16834f86f6190510c77898e2068dee71c5cf9da03f6eebfaa3b36496143";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/gl/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/gl/firefox-152.0.1.tar.xz";
       locale = "gl";
       arch = "linux-x86_64";
-      sha256 = "0f93cb1b57dd9c5a7a4207b7d535b303fc0ec9577e8cf4ca573d8e6869d4bdb2";
+      sha256 = "6dc5a9c1c333e85bc7ebaa4d13972525f718166510121b658b061abd60f75735";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/gn/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/gn/firefox-152.0.1.tar.xz";
       locale = "gn";
       arch = "linux-x86_64";
-      sha256 = "e0bcdbd90cf200ee13cfa15be8aa05aa8dc716228112a2b1941341e2e6968a4e";
+      sha256 = "358a964bd788e3b62d460fb9fa5989de919e0a6dc478cc3047694bef6eb5fb16";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/gu-IN/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/gu-IN/firefox-152.0.1.tar.xz";
       locale = "gu-IN";
       arch = "linux-x86_64";
-      sha256 = "b9e467697619fda7240fff2732a19319a33f2aac708b8f7fbd6cadb0b2864d3e";
+      sha256 = "1498e53ce59a6bb9873b9e68af3e1b22db3b78f11018dc17fb930655a99ea6ae";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/he/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/he/firefox-152.0.1.tar.xz";
       locale = "he";
       arch = "linux-x86_64";
-      sha256 = "07fd7b894ee906b7a817867fdfabb396cd0a653322ee22ddff67d2eae4da6cd6";
+      sha256 = "65290c279ba969a0536242ee24f7572434a7e0478a987ebe6ab9c81a1591cb66";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/hi-IN/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/hi-IN/firefox-152.0.1.tar.xz";
       locale = "hi-IN";
       arch = "linux-x86_64";
-      sha256 = "82f46cbe3c4a0d1c06af3eb40d3f13637da0318c854cbb5ee1b62cb80386ae55";
+      sha256 = "465eaeeff57171447cfeaf2c1a4826eb28abe5c65ab8ab6bcbd6ccc1a0311084";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/hr/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/hr/firefox-152.0.1.tar.xz";
       locale = "hr";
       arch = "linux-x86_64";
-      sha256 = "b3b3310efe722d94fb24f8ce8d98b885c4a4a9231c1c443826d2306e3cfabb03";
+      sha256 = "0def94adcdf670eaaa89eba5c28d5fd675e9f33f38590bf767d8daa846502d36";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/hsb/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/hsb/firefox-152.0.1.tar.xz";
       locale = "hsb";
       arch = "linux-x86_64";
-      sha256 = "af5d8e6abd29d1de3f117d7d14ebcf48169c7dfdea72a98f8e6b07bafe487220";
+      sha256 = "e1a9663d8167c41064cff55baa6258ad18a185ddc53e1ad82a4b7191687aa380";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/hu/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/hu/firefox-152.0.1.tar.xz";
       locale = "hu";
       arch = "linux-x86_64";
-      sha256 = "bd8e07bea2d2bd8e1a0e65f0d330a567445bfccb1ad1286141deef66a9cb1d52";
+      sha256 = "29b7c76b30762879caa835c59c44c0667d6bfd60cb2f4149b3927950f9d0a190";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/hy-AM/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/hy-AM/firefox-152.0.1.tar.xz";
       locale = "hy-AM";
       arch = "linux-x86_64";
-      sha256 = "e3829f7d9eb2cb2204eb6366d2ab8227daa1ab247fc9a0f8b4f58caffa792be6";
+      sha256 = "d105eb9f6cbf181b44609c2077988f0e326bb3b81cffdd7a9c012c8494080cbc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/ia/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ia/firefox-152.0.1.tar.xz";
       locale = "ia";
       arch = "linux-x86_64";
-      sha256 = "adc9495e92921f3c36ff713b9a7b6dfb197c765d9aec55d97013bcec765cba81";
+      sha256 = "a89d1a5aa7398d7b1ed0c3028c05c223a72f652f1325ac7b7e78431dbbec5392";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/id/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/id/firefox-152.0.1.tar.xz";
       locale = "id";
       arch = "linux-x86_64";
-      sha256 = "adee38429c89941826fb02084055c0b0a1cd3af8dfbbdce46a65487b2f925e66";
+      sha256 = "47c458c089881ca9dc0427701a9ea642dfa21ff736018620d7bb64e2cc11958e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/is/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/is/firefox-152.0.1.tar.xz";
       locale = "is";
       arch = "linux-x86_64";
-      sha256 = "161885d75dabac339a58f7cc1eb517eb3c36da0a443394cb45b9f841dc0f816d";
+      sha256 = "1b2d991c14d7815dc60a553eb215bcf57ed4a6f60795810f9ae8b8949f3ed427";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/it/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/it/firefox-152.0.1.tar.xz";
       locale = "it";
       arch = "linux-x86_64";
-      sha256 = "686b703a37b8e2b25c50ff672d8fab5e07c443b485120e41657a6487f2e8257f";
+      sha256 = "f561803bbe77632c2bda29bbb44841cdd0c5a2382d4b96622d5ab1973ccb50a9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/ja/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ja/firefox-152.0.1.tar.xz";
       locale = "ja";
       arch = "linux-x86_64";
-      sha256 = "ddb724aa19e1855ff9f8de0922f417fa3feec96b6608cb08c99afaae20375062";
+      sha256 = "2c93ed744647df780518ed36598a5c757a41bab5ef5279a2e7bcf737ff44170f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/ka/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ka/firefox-152.0.1.tar.xz";
       locale = "ka";
       arch = "linux-x86_64";
-      sha256 = "c45233c0b2b18fbc15e594b2e685b057d16c2b3984d41d7f9434f945d108f292";
+      sha256 = "bdb1661d395d7f7a25b2a733699d5514b1809d43fe142bab13b5a4dedfc8f017";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/kab/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/kab/firefox-152.0.1.tar.xz";
       locale = "kab";
       arch = "linux-x86_64";
-      sha256 = "499589e4c0886f3ebbda57c72ffc9473be4a699b8a09e6af9b8aee22355fecea";
+      sha256 = "21b40bc284fbd3d28c714cad2caf8f0f9cdfd05bbed78063f5a61791ae717708";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/kk/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/kk/firefox-152.0.1.tar.xz";
       locale = "kk";
       arch = "linux-x86_64";
-      sha256 = "8cbed9e429f232f64634cbb1aa43a8fa86684344b90f6da5448b033713efb732";
+      sha256 = "d0bbfe1990a10af033b7e6e8bcec3cc944b87ccc5b1eb50692f3b17723a383ee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/km/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/km/firefox-152.0.1.tar.xz";
       locale = "km";
       arch = "linux-x86_64";
-      sha256 = "ccbc988478c10fc81c74abf433aeaa4a87bf16b1170d07278c2541bb95ae8d28";
+      sha256 = "0dd570c27ee5fc985ca87752b57fd718502f3cd3738a7b94a0e59510ce65afb8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/kn/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/kn/firefox-152.0.1.tar.xz";
       locale = "kn";
       arch = "linux-x86_64";
-      sha256 = "ffe0b8ec88d48be2c5f0c773f925d065b63b13b21c9ba732db739e7d876512ca";
+      sha256 = "010246daf4a3acf0052ffe79733162b86183d4d4b72951194b4959792e4ab768";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/ko/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ko/firefox-152.0.1.tar.xz";
       locale = "ko";
       arch = "linux-x86_64";
-      sha256 = "1c80a40f110c81a7fddc9a680d0ef24d3dacd67fb274778b027285c73c408eb9";
+      sha256 = "77c9e20756eb39c7482aea884963cab3195687f9c2daed73a710bc2f12c6a1ea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/lij/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/lij/firefox-152.0.1.tar.xz";
       locale = "lij";
       arch = "linux-x86_64";
-      sha256 = "e68adc7e4638b3f4400ef06312733835bfae45fd19fe9b73b9a694e5bd63d1db";
+      sha256 = "d91bb0643b565acfd6193200f4d9d4f08613ae2a46f1aa59aadf294c955638c4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/lt/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/lt/firefox-152.0.1.tar.xz";
       locale = "lt";
       arch = "linux-x86_64";
-      sha256 = "3459d0cfa8116fce6794e938040ad1d871de8b294079299ad25f41ce299cdb70";
+      sha256 = "9946c8b62469fb050d9c77bd232b328730b1ab50a312584a4a038e7aeb6cae6b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/lv/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/lv/firefox-152.0.1.tar.xz";
       locale = "lv";
       arch = "linux-x86_64";
-      sha256 = "bf6ff2e8e58c09aaa5aecb310e5c7290b0f05dbeb9b56484bc27fccb41267607";
+      sha256 = "d897427b87d345afbc5b783bcd336a130e425a7f34572ffa4ccec111d8f17475";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/mk/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/mk/firefox-152.0.1.tar.xz";
       locale = "mk";
       arch = "linux-x86_64";
-      sha256 = "959b166ed3c792791d14164fde75684ae9105390996c17732f1bea32443c74c4";
+      sha256 = "a865b32e2a533a5cb2e1326149d449038a23b3a97cbd725a6997d29d95435867";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/mr/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/mr/firefox-152.0.1.tar.xz";
       locale = "mr";
       arch = "linux-x86_64";
-      sha256 = "2d10d9dce046e3cd4d13ea890f9bb4bef949af7eca053f862063b38b56044ac6";
+      sha256 = "02919ffb5f9181870f2eab22177b49f3dc99406580045de2559df7a474963ebb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/ms/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ms/firefox-152.0.1.tar.xz";
       locale = "ms";
       arch = "linux-x86_64";
-      sha256 = "22158f0319996520864628b9b30a5c9f05f4ea0adca5a10d3fa6a36ca18ac98f";
+      sha256 = "026f2217d264af4acf30bef87be30361d2b8923a202779461268ea4423e85a01";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/my/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/my/firefox-152.0.1.tar.xz";
       locale = "my";
       arch = "linux-x86_64";
-      sha256 = "cf868111fc77a04d6d626ae48dc36953aeabf4d7f924c3db268e8dae2ea1cf99";
+      sha256 = "f9b18234026c92cfe22c99e41e4935676b7602faa8ca3277001d314c649e41eb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/nb-NO/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/nb-NO/firefox-152.0.1.tar.xz";
       locale = "nb-NO";
       arch = "linux-x86_64";
-      sha256 = "37fd26fdbe98a98c01b696d6f750c981b2d6cadd1ed9fd9527ba9b3f29487736";
+      sha256 = "33637a549d8aaeccd72fa88d14995de701e6dc43198942e1c0ec1ccbb0531ec5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/ne-NP/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ne-NP/firefox-152.0.1.tar.xz";
       locale = "ne-NP";
       arch = "linux-x86_64";
-      sha256 = "038a12d2da9abef5e0888bef21bf0fc80125f8de9a117e081540ed4e59ab4ec0";
+      sha256 = "e7df83acc744593d1285221e4650aba827a1e1ac32b5960eb1d04c2a9c9bb9cc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/nl/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/nl/firefox-152.0.1.tar.xz";
       locale = "nl";
       arch = "linux-x86_64";
-      sha256 = "c835e8b8553f53b8b70fb4710b4b0e36a688d54b597157b8f595acd80f3c8a8f";
+      sha256 = "803760a9411070680fcd4b24474eadf897d99813efd9020c153ca23ee03dcbe1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/nn-NO/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/nn-NO/firefox-152.0.1.tar.xz";
       locale = "nn-NO";
       arch = "linux-x86_64";
-      sha256 = "6c6c8a02645738526f6a2ebc5aefa81a9321960abfc8dec7c4aeb0496b767b8e";
+      sha256 = "30415eec15adbd6d249f1f35fc782bee66328da644bd75a0940f6de958e76cb2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/oc/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/oc/firefox-152.0.1.tar.xz";
       locale = "oc";
       arch = "linux-x86_64";
-      sha256 = "78dadb733b70f745241b036fd5d7860eede179ce9af1c8b7d499241d2faafbd6";
+      sha256 = "24673361cec55de24bcd69132e2abe7430a8057f00825f2563885f9f7c6acbbf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/pa-IN/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/pa-IN/firefox-152.0.1.tar.xz";
       locale = "pa-IN";
       arch = "linux-x86_64";
-      sha256 = "3e3c9b011d9378f43773a643050af9c3412613b096facc12bc22a8635c6e3bd4";
+      sha256 = "69df264baa6a758376f935e6c328def4cb9f40e88754bc3d5f3befe6a4f581b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/pl/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/pl/firefox-152.0.1.tar.xz";
       locale = "pl";
       arch = "linux-x86_64";
-      sha256 = "49b8d88e635e0fc2dbaca8d59e6b5406e094bc6271cff63394ad758fe9cacdba";
+      sha256 = "220a35c8baaf207c6d41e4935850ef0fd9cb78618ef7c1eff2b08be727745861";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/pt-BR/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/pt-BR/firefox-152.0.1.tar.xz";
       locale = "pt-BR";
       arch = "linux-x86_64";
-      sha256 = "bf00e252fb5a48490f6c21737712c63515d255efee1517412d52f1c601bd4284";
+      sha256 = "b735ca170d21fdbc848ca11bcdfae8155314ed152573f485edab8c8e1abd9c03";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/pt-PT/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/pt-PT/firefox-152.0.1.tar.xz";
       locale = "pt-PT";
       arch = "linux-x86_64";
-      sha256 = "2161edfb85bf7aa0cb4db134f777ef0241f56bcb08fbcb5d29f720ad8d45a842";
+      sha256 = "cf17cf2375c2b38837cec5282eb4533d4a3c36d2ae65b4dc6210d723f92b73c4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/rm/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/rm/firefox-152.0.1.tar.xz";
       locale = "rm";
       arch = "linux-x86_64";
-      sha256 = "ded6053492a6a445e205aaa64a5876ce377e092e41ceffe2809255540f56fc0d";
+      sha256 = "82d2752d5d87bd19ab209e5f64cfbc95c79d5c5d4209b63cd8a89b7d0f087526";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/ro/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ro/firefox-152.0.1.tar.xz";
       locale = "ro";
       arch = "linux-x86_64";
-      sha256 = "76c3a565d5d04d11635b2ef20899551d4e2bedc7e77e35435b26250033d0116a";
+      sha256 = "793add59809e638b981d67cdb8060f2fe2e22557eb547940564e185bd25399fa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/ru/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ru/firefox-152.0.1.tar.xz";
       locale = "ru";
       arch = "linux-x86_64";
-      sha256 = "b424c73df11768f104db43086d783e30e2f00078b476c6cdcc2a7e52ad6e292b";
+      sha256 = "446be317a9169760ab407eeb6734d3a01603aa88ae1c818f75caf47d7665ec00";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/sat/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/sat/firefox-152.0.1.tar.xz";
       locale = "sat";
       arch = "linux-x86_64";
-      sha256 = "35af32489aac43e7e5d45e21683fd5d0e211dcc3dfdecf6520be24b5453c2c96";
+      sha256 = "17e145189e3d53a4edf8c870e163501714e96907c42f3374e533ca47f3c89e4c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/sc/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/sc/firefox-152.0.1.tar.xz";
       locale = "sc";
       arch = "linux-x86_64";
-      sha256 = "9abf57e63ef34a22f3f61e0760c8f81c7fe32b47cabee7c5dab3e60a58b56e58";
+      sha256 = "ef652d448b9aab658c2872895b4105c961e7deeefc8eb1a4ea536638f2058e62";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/sco/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/sco/firefox-152.0.1.tar.xz";
       locale = "sco";
       arch = "linux-x86_64";
-      sha256 = "77a944814f42638263a76433b4a91ff3fbdf8d44fcb0429a4c7b14d38470db35";
+      sha256 = "2762a365a8fee59ecbb7dc86b1e32074a6cbf35a9f2c07276e68d7caeac209c4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/si/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/si/firefox-152.0.1.tar.xz";
       locale = "si";
       arch = "linux-x86_64";
-      sha256 = "4bcc4567b46906f35168acc9a8a07f8592b7ec8c3ee3bb2b0f5d6fe1eec779f4";
+      sha256 = "de60b474181495093e462b6da07b6ed2c96c5cb890c2c0f2df538e5852627981";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/sk/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/sk/firefox-152.0.1.tar.xz";
       locale = "sk";
       arch = "linux-x86_64";
-      sha256 = "ccf73179b40ce56e7dda4526113330519382d758d98f406b086d7bb976b32187";
+      sha256 = "aec21ad67da6ac2ffbc1f9bae1ca1e3cda450e17437924e322eaac09b6e492ba";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/skr/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/skr/firefox-152.0.1.tar.xz";
       locale = "skr";
       arch = "linux-x86_64";
-      sha256 = "7cf40d9783e6c6bac8f4fd74e62ce13e145ace277738e01c432b319dd56a2f20";
+      sha256 = "17c6224ffd937178d4d08dd7a07e35b1f7d6144a7b3414c0d54c92f4d6190570";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/sl/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/sl/firefox-152.0.1.tar.xz";
       locale = "sl";
       arch = "linux-x86_64";
-      sha256 = "d72857e11781fe56a69693794cd5aa8f4efdff74157fca8545be4505ff9daa09";
+      sha256 = "22d8b832db8ee333cd5685b57fdb684527797bd4a54e90657f80a9793d4fdfd0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/son/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/son/firefox-152.0.1.tar.xz";
       locale = "son";
       arch = "linux-x86_64";
-      sha256 = "f5963876922cbaa880d59f48411baeb4047b79610021ef33ad1c9f49e07e9e2b";
+      sha256 = "aa5b94d392ae293a319d507b913cb155b0ff14ce6b1f33f49a8509656931d5c8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/sq/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/sq/firefox-152.0.1.tar.xz";
       locale = "sq";
       arch = "linux-x86_64";
-      sha256 = "d3f76379829bb185267f4a571381966dbca4b3ced5ddbd3afa42f47e07033800";
+      sha256 = "f3a5c28d3be98ba1826449f2d0cc46b18640a282ff214b071a843232facf1c0e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/sr/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/sr/firefox-152.0.1.tar.xz";
       locale = "sr";
       arch = "linux-x86_64";
-      sha256 = "0dee6e4b5602a056be38a338029d59dcf0853493532fecb717b70b6f6e4b19a4";
+      sha256 = "c86697a64723325ff3f8c1ace45fe9507e46ef1231016e4995780b8c31de4353";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/sv-SE/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/sv-SE/firefox-152.0.1.tar.xz";
       locale = "sv-SE";
       arch = "linux-x86_64";
-      sha256 = "e364b3f9d2e5528314b4901ca9fcc2f94075398766e402df9429c253fa7327a1";
+      sha256 = "a4b6a1c0263874e1c67a03fb47955b61245fe1997166b0dbe48e8a7bb7a24599";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/szl/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/szl/firefox-152.0.1.tar.xz";
       locale = "szl";
       arch = "linux-x86_64";
-      sha256 = "0a377cfc98442c60443f28879fc9ddb467399d26c5c623442f0ed4065204d9b3";
+      sha256 = "2e426e9811518c3610fa00fee1c84bb85ea30754a3b1542ec49359b606d319c8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/ta/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ta/firefox-152.0.1.tar.xz";
       locale = "ta";
       arch = "linux-x86_64";
-      sha256 = "0b735a33501bf67cf904e180779b6ba375bb30a0f8a893fdd3b815c91f464b39";
+      sha256 = "5eedf2eb50c83271ae466f6dd6c2f5b1918c7b4a3caaf29f89b98dabfbd61883";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/te/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/te/firefox-152.0.1.tar.xz";
       locale = "te";
       arch = "linux-x86_64";
-      sha256 = "7ea315cb37ae0f29a83db8f54c611812b49390e77f547a29cc54e47913b388f3";
+      sha256 = "63b8e73b5a21738579193f572cea3bc990b74f8c98f0c89d06a80adfd8b35347";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/tg/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/tg/firefox-152.0.1.tar.xz";
       locale = "tg";
       arch = "linux-x86_64";
-      sha256 = "aa68b864d54eecdc625ab64fa4e0d5ed7fc5024c7aba1db75dd04b57c7a80997";
+      sha256 = "6f2992322d37bc9c90c53b5d7105c579e9a56408297ecf43f274f462954a8d98";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/th/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/th/firefox-152.0.1.tar.xz";
       locale = "th";
       arch = "linux-x86_64";
-      sha256 = "4bc336495dd8c3d6e140da05b9644e4710ab9f70dbe19c9dfc2985853041bbd2";
+      sha256 = "038092ec469134d437b07038aa32e341e06c493ee36c1d0a69b7fc3718ebf29b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/tl/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/tl/firefox-152.0.1.tar.xz";
       locale = "tl";
       arch = "linux-x86_64";
-      sha256 = "c50b1cd15e892de1dbfdcbdf6064120ef268aa1dbcdd48c2095838c32cbb9ac3";
+      sha256 = "39df25ee4835043bb86b97325b68311b9af3df25da04bb2971f69a69ff6d3059";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/tr/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/tr/firefox-152.0.1.tar.xz";
       locale = "tr";
       arch = "linux-x86_64";
-      sha256 = "0f40c5a5a9afc713a940c8d286bec44ab2d3f9ea6f03f15cae14e575fbf52720";
+      sha256 = "189fd0ca08eea2e76073279109d730cda4fab32a041d03dc18f95831de2bde45";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/trs/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/trs/firefox-152.0.1.tar.xz";
       locale = "trs";
       arch = "linux-x86_64";
-      sha256 = "c96f33e573b588a35675d6e17d620c420d9c9966c5b721bd0e166d444b5eec88";
+      sha256 = "5fed2d1e075070d797999d8a1d0033b3340b8faf280c56787749f2c7ff225c83";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/uk/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/uk/firefox-152.0.1.tar.xz";
       locale = "uk";
       arch = "linux-x86_64";
-      sha256 = "c20c4a39ad88750b2f205ffe356a8f9e900468554b6f87d3fa35a30443fdc091";
+      sha256 = "54f3ba58021c07316dd91f0353c14b53aae65e2752ca9116197f67df159a7b82";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/ur/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/ur/firefox-152.0.1.tar.xz";
       locale = "ur";
       arch = "linux-x86_64";
-      sha256 = "b9564c36e0c98f7199108ef2eadc93fc069d8414be12b602efcf43a28b817c47";
+      sha256 = "6981e1b54c4201f62e5d990398db23f89c6a401f5416aa6f2f81f3701a370ffb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/uz/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/uz/firefox-152.0.1.tar.xz";
       locale = "uz";
       arch = "linux-x86_64";
-      sha256 = "d3fc8aa175a0f29914073c824279fdbcef694d6679a91e511e435ebd723a9221";
+      sha256 = "f2c7996e943b9e75753d167e292bada86437c806ce0104e3e3084afa7e4b0066";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/vi/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/vi/firefox-152.0.1.tar.xz";
       locale = "vi";
       arch = "linux-x86_64";
-      sha256 = "c8838a6e6e35e09aa9b6a5f9c54f53f6696d0deee938b8315403100876c080db";
+      sha256 = "e726b116f8a2e87e456a428c202959c4c74a79918eff8bdad560ca8e43b1e9b3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/xh/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/xh/firefox-152.0.1.tar.xz";
       locale = "xh";
       arch = "linux-x86_64";
-      sha256 = "602acafeda5f3d8b794f59173b851a321e26d94fcd1b3261905a901de8e3f41d";
+      sha256 = "e0407be8198e01e1baa3df5cfddbfdd406089136167e2c45fb2f2eac29802ecf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/zh-CN/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/zh-CN/firefox-152.0.1.tar.xz";
       locale = "zh-CN";
       arch = "linux-x86_64";
-      sha256 = "7ae7b3b8030da9029686d28895da75c956b9338bb576721fa51d65afeca7a904";
+      sha256 = "c04aafa32bd08c9642d46429dc55123338c76d8d9ba247366472ded3e9a3a6d1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-x86_64/zh-TW/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-x86_64/zh-TW/firefox-152.0.1.tar.xz";
       locale = "zh-TW";
       arch = "linux-x86_64";
-      sha256 = "7f148fe7f331bb1a534d6aae9da78685bd9a4d2d13c08f02223d8ca599a59100";
+      sha256 = "b6802eab250e42f1e7251b130e367958463441111a9ff9ddf3e57d8bec1207b9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/ach/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ach/firefox-152.0.1.tar.xz";
       locale = "ach";
       arch = "linux-aarch64";
-      sha256 = "5da9a30a9e965312edf4fcccf19428e9e221f443ecf52f2f395a30a1a605fdae";
+      sha256 = "cbf19d4b84374c9ef2222e197b0246b3a812b6f861556742eec392e42690a635";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/af/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/af/firefox-152.0.1.tar.xz";
       locale = "af";
       arch = "linux-aarch64";
-      sha256 = "e074c10f378b23192f309f0790849ad2a20908eac59696cefdb2b8fbf8786a5a";
+      sha256 = "aa335bba462415b94d5dcb93ef88d2ed28711cc639fb7cc420bfb25d0253cf95";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/an/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/an/firefox-152.0.1.tar.xz";
       locale = "an";
       arch = "linux-aarch64";
-      sha256 = "f31adf793f665a4ea97460ed66f7c0bc32c56a6394ac75d0c673606397510701";
+      sha256 = "c26c15c32ad4e96f7e0f91917c6f87c6e1beaf0dbef1885a3fd047a75a016b66";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/ar/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ar/firefox-152.0.1.tar.xz";
       locale = "ar";
       arch = "linux-aarch64";
-      sha256 = "30d8b63fcb784d42942710f27d3617e2efab6a3fdc7fa21a67effe211f775167";
+      sha256 = "b3b027ce12fa13e4a9d2463fa82e05402c47b49d8a2fd63dbfb359ce9da3db5d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/ast/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ast/firefox-152.0.1.tar.xz";
       locale = "ast";
       arch = "linux-aarch64";
-      sha256 = "ef8fd00ef8fcab46fc077ac1da2e241191b4e42209c5f0e867fac232c49b1a2e";
+      sha256 = "fd6b397f98c1d6e36f3bd3aa0df1bf220ff9bd7e345efe3fa40ebc7b2b93a875";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/az/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/az/firefox-152.0.1.tar.xz";
       locale = "az";
       arch = "linux-aarch64";
-      sha256 = "50610c5fb899512b6eb5bc48038fa2909e815efecccfed40c6a8472d5d6d183f";
+      sha256 = "60b24f096dffcb89c306c923645c3cab1a92a3aa9ac8c234ab0f01b01d9f300e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/be/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/be/firefox-152.0.1.tar.xz";
       locale = "be";
       arch = "linux-aarch64";
-      sha256 = "57a75f77527374a3e8b3c03e8979fce08d787d79ac9fbdf7b14ac77e0c33f3bb";
+      sha256 = "35af196289becf2f0688272ddcbb70552e939bc37dcf064361058e257b4ab6db";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/bg/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/bg/firefox-152.0.1.tar.xz";
       locale = "bg";
       arch = "linux-aarch64";
-      sha256 = "f16082cc1ac0ccd6c6374cf828aa647709fdfa348a330c6c3c299e6ea2065c33";
+      sha256 = "fed7d6ae6cc31fe7bc4e545afb3c74dc38bc04d2bd4b04bf9012c6e4994292cc";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/bn/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/bn/firefox-152.0.1.tar.xz";
       locale = "bn";
       arch = "linux-aarch64";
-      sha256 = "f5a5b952ccad499b457440b2d04d91974979694b4b0bf79b0243a7ab6eb8aae2";
+      sha256 = "c3cbb79d0cab97ff162a08293eba1bf2eaa10610fd7ed8aa0a49f6c9305cc46f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/br/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/br/firefox-152.0.1.tar.xz";
       locale = "br";
       arch = "linux-aarch64";
-      sha256 = "dc9aba107d01d3ecec5968c625f68e4865c74257c61ec36031c48ca8f8f9a2ff";
+      sha256 = "a36e7359cacd21b1aef60bd6657f94bcaf818f66b8d96dc3e8e321cb4e0dcdcf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/bs/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/bs/firefox-152.0.1.tar.xz";
       locale = "bs";
       arch = "linux-aarch64";
-      sha256 = "ce7162c4d04e5026a5dea578acb6aebef91dcf4c311fef394819e3af6e857e76";
+      sha256 = "a9298e271de07dbdc5c17d0b938a1298e4a1f3ba9eae14127836a3f4ea314c81";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/ca-valencia/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ca-valencia/firefox-152.0.1.tar.xz";
       locale = "ca-valencia";
       arch = "linux-aarch64";
-      sha256 = "6a73f70971ae6616ad25e34134d83c619740c4f21c40ab8433741af6ceb22202";
+      sha256 = "8cfb78e6955c5c698446cf73cebea6685bec70658e76dae031477f75a2a4d530";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/ca/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ca/firefox-152.0.1.tar.xz";
       locale = "ca";
       arch = "linux-aarch64";
-      sha256 = "4e8d00fc9237f7aba48201c11ad9c468c6968aa905f218e68279ee2b1de2dff8";
+      sha256 = "b2b7c8c59e5a653c639bdcd2e9624f1d86501aa06a82f115400edd2e49343f8f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/cak/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/cak/firefox-152.0.1.tar.xz";
       locale = "cak";
       arch = "linux-aarch64";
-      sha256 = "22e51b36888622cac9942f3f2c5d26583c2d9c7d6e6c3325901ec3028c5a08b0";
+      sha256 = "472925fd62908977b8f1bf467a56145ab0a57c74249d0b110ff48a7d6892d265";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/cs/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/cs/firefox-152.0.1.tar.xz";
       locale = "cs";
       arch = "linux-aarch64";
-      sha256 = "801c627afc6d2feb8c136a197aed3c5f87d4a70eedbebfa83f7ba5036d8f670c";
+      sha256 = "9fd1f9e7622eb203df9c236dabc66fbd9ffdad55b9fa3ed683f09395a792ca85";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/cy/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/cy/firefox-152.0.1.tar.xz";
       locale = "cy";
       arch = "linux-aarch64";
-      sha256 = "dc60e6eb21c16d08adeddf7a39af650756d634ce7a379a9a6d8f44ddaa90061e";
+      sha256 = "26e6408f1b1d53a5b4a0203ca86a83c922b1259f8e0ccaf6dbc21d7098c186a2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/da/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/da/firefox-152.0.1.tar.xz";
       locale = "da";
       arch = "linux-aarch64";
-      sha256 = "cae383be235abf2a3b852325f5cd66b8117e05293ad69748f56bc9f5266e5135";
+      sha256 = "633b8f0774053f754e255c72a716a3f981c30ac2045b6093d55384540ae19b6b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/de/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/de/firefox-152.0.1.tar.xz";
       locale = "de";
       arch = "linux-aarch64";
-      sha256 = "bfa1070520e259655c3633aebc9657598ece47f141a9d4842462de8f155feada";
+      sha256 = "ae21e0dade3602d5ac0b41634e6b616ffe4006593ab65db4fab8e11ea2c02621";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/dsb/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/dsb/firefox-152.0.1.tar.xz";
       locale = "dsb";
       arch = "linux-aarch64";
-      sha256 = "99b88bcfa2c322ef70fe6afc5fdd612ad94d691fed5feadc84cd0df4d579fa1f";
+      sha256 = "95c4501fcff86da1f3a1d2f08402df723b0d95c5b0c00404a9f446a3c6848ee8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/el/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/el/firefox-152.0.1.tar.xz";
       locale = "el";
       arch = "linux-aarch64";
-      sha256 = "efffac5cd5ba891315d8ea8a6882a56fc2f83b85165e6831a719abba9012a3c1";
+      sha256 = "ebcadae6d4a85cf2b88f5b5d5623f2bb644aa2a907b9916d27484da47bd4d2f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/en-CA/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/en-CA/firefox-152.0.1.tar.xz";
       locale = "en-CA";
       arch = "linux-aarch64";
-      sha256 = "ba43d261c449391da2415bf38c8c65ce8ba785bef2d22803b5e0ec3474302596";
+      sha256 = "3adb7c37539e3ab2cd3211f3aa38cdbbb6edeab0e45a42445b5f352707b00cc8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/en-GB/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/en-GB/firefox-152.0.1.tar.xz";
       locale = "en-GB";
       arch = "linux-aarch64";
-      sha256 = "a22a5f64fba0ce95de83ac7b840c0d56b345aadd6da35c2bba5670d5d3c73367";
+      sha256 = "68e0e9717a345e017db81badd309fa67d9e646efcdf48106e8452d61105a61c8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/en-US/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/en-US/firefox-152.0.1.tar.xz";
       locale = "en-US";
       arch = "linux-aarch64";
-      sha256 = "c44a986475745e9ae292e3d6561b2c0d366e6ff0cca06a1bbc6e166cfb0eb2f1";
+      sha256 = "dd8e6c39a230af96082e89c963c93f36372f5875d33d38196f9f35fab597551f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/eo/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/eo/firefox-152.0.1.tar.xz";
       locale = "eo";
       arch = "linux-aarch64";
-      sha256 = "46cd7df1b9611363924e4bf10a88cc4c91ba724e93312281b23ecceee408a3de";
+      sha256 = "cefee603d9c6b739a263be8fc30447e26cee9089b23b721371078a8176b40645";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/es-AR/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/es-AR/firefox-152.0.1.tar.xz";
       locale = "es-AR";
       arch = "linux-aarch64";
-      sha256 = "1792fcbe7bc00ba94cde25bb22d26547f8d6cbd7b451135fcc93e1dc0ec641cc";
+      sha256 = "3d16ee897c28eb9cf32a6f43beca90a5cd52b9ee44733768c688017a20ef165a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/es-CL/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/es-CL/firefox-152.0.1.tar.xz";
       locale = "es-CL";
       arch = "linux-aarch64";
-      sha256 = "9bede420203ffb650f27038c1d48a08a670aa10aa29d18bb0685b0f1b4de6282";
+      sha256 = "3799e2f68522b7ab878aeabfb1cac6100c0f86481b23ce3c1160f24adb52ead7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/es-ES/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/es-ES/firefox-152.0.1.tar.xz";
       locale = "es-ES";
       arch = "linux-aarch64";
-      sha256 = "cb0319256a958d9e6d458c51a603dbbf82a1d074e9948674c1a5c34555d4e03b";
+      sha256 = "8d6cd840c12cf09e8d9296b2c01c917c09dc620ef43bebbe2be4c1b57a51c50a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/es-MX/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/es-MX/firefox-152.0.1.tar.xz";
       locale = "es-MX";
       arch = "linux-aarch64";
-      sha256 = "4510aadeebd532d0bc7a8f82fb0f65f93193623a3c428b42cb4290f6465a556d";
+      sha256 = "95448caa7b4af1e76651a707fe1c6626fc0982e4cb4086839c06ca70df1318c7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/et/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/et/firefox-152.0.1.tar.xz";
       locale = "et";
       arch = "linux-aarch64";
-      sha256 = "aa2b5f95577a2410c51c943f8b6dbd3d4d0d02eb84e7dda49945aa98608945c4";
+      sha256 = "0d32c6542345e323d902e7fee882bcbb930f2900fb361ecba00630d2b692bf8e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/eu/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/eu/firefox-152.0.1.tar.xz";
       locale = "eu";
       arch = "linux-aarch64";
-      sha256 = "4e564dcbe39408633e57cbc0f2738b7d77a69ab384f0f82343429132b0c1cff1";
+      sha256 = "76afb67dbec1aa876077f94ed5fff648c6c5274efd0e32ed7f3d0163ca6f0ae0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/fa/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/fa/firefox-152.0.1.tar.xz";
       locale = "fa";
       arch = "linux-aarch64";
-      sha256 = "8d185441ca9331d0667ea7235735a26cacbd58d4cf98b5ae4df0f0fb908a91a6";
+      sha256 = "7bedc5d92bb7c1731982ba6ceaf420912febdf08d82255b5661826b8f9e4be65";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/ff/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ff/firefox-152.0.1.tar.xz";
       locale = "ff";
       arch = "linux-aarch64";
-      sha256 = "257017279f70f4495d47aafbce2fcece01c0b52eed0c1ab9812b836a3ded14cd";
+      sha256 = "3049c5dcac5d87c61f62dc7ae22c0905a30b75eea32c1f30ee273c6d7c398485";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/fi/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/fi/firefox-152.0.1.tar.xz";
       locale = "fi";
       arch = "linux-aarch64";
-      sha256 = "78b562feee45b931bea8cc4e89ffc4c97d7141fb952c7d8171fe4131171f26b2";
+      sha256 = "c33af0ce2d62cd79831cd86a3117b04e4c8fec5f0dd6079355478dfea5b6acbf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/fr/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/fr/firefox-152.0.1.tar.xz";
       locale = "fr";
       arch = "linux-aarch64";
-      sha256 = "19f4072c0b82f17babd42b69cdfc12931777ec4ac703345d803f8c12582fcdc9";
+      sha256 = "65737f1b29ac6849c6a805db9d98f11d7ec7556c8ef467fc0dc1930f5cf4f745";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/fur/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/fur/firefox-152.0.1.tar.xz";
       locale = "fur";
       arch = "linux-aarch64";
-      sha256 = "e820815b893a8d9b93f86f351ae1d35aacb65976d1057e23305d6525ac8a4b43";
+      sha256 = "a981a1c5c37015ac879bf4d009ea6cd8767f4bc9c476821b92afcae9fc16b826";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/fy-NL/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/fy-NL/firefox-152.0.1.tar.xz";
       locale = "fy-NL";
       arch = "linux-aarch64";
-      sha256 = "828e3d5608b34ecca52a8a1dc7629fe31ecc41c3bf5c6340890201e8c7b13383";
+      sha256 = "9e8f4dc4cdfd80b7b97801b33e0eba58a422c92de5d17c21177b68770d3728c7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/ga-IE/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ga-IE/firefox-152.0.1.tar.xz";
       locale = "ga-IE";
       arch = "linux-aarch64";
-      sha256 = "06a6059a37757c3d56293a2ffd06498a4340ccf28870a2b8e9e2faf7e37f266d";
+      sha256 = "27b009a81c15593162649a1c6528c04e1825ae994da0303faf08c8df9862039e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/gd/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/gd/firefox-152.0.1.tar.xz";
       locale = "gd";
       arch = "linux-aarch64";
-      sha256 = "f13c0429da4a82308ebd181fd7e18642175457f35bb60e5b9999fe19ae88f339";
+      sha256 = "5a14ae1fdd939c216893c2a7e9f7cd383e46b8c69430bd0259a042bdb0e3a743";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/gl/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/gl/firefox-152.0.1.tar.xz";
       locale = "gl";
       arch = "linux-aarch64";
-      sha256 = "c7c5d2f53bf1fb513f6cab8c662d848e257bd874e4cac1309e0ca94e3ce47653";
+      sha256 = "3d149ecdfd300e59bb483cf783b216a461578ef1a81f445b40f7ade80b31edd5";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/gn/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/gn/firefox-152.0.1.tar.xz";
       locale = "gn";
       arch = "linux-aarch64";
-      sha256 = "b963dc1e8bebbf3d97bf2b0166931bf29130c4791907043e62fbf4c2cbb86ad3";
+      sha256 = "a0b8f3ae1ca6ee72b241ceba7ea0a0dfa1f9ab5f38c876953262cd2ea30c5d07";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/gu-IN/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/gu-IN/firefox-152.0.1.tar.xz";
       locale = "gu-IN";
       arch = "linux-aarch64";
-      sha256 = "5261b853dad177e93150c1cf35b96cd59e27f347087ed6dbec7d31a827f63f4f";
+      sha256 = "b517415e4e75e2f085410616069efa77f8710d47b1745fd584274127c2f942c2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/he/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/he/firefox-152.0.1.tar.xz";
       locale = "he";
       arch = "linux-aarch64";
-      sha256 = "2780b0478549f13c647bacd28bd65d2db0c5866b5658279719cc5eb69e85ea07";
+      sha256 = "f93c26df9b38f1c84726e62b72bf5b7d04e110ae1e86894e91663051d5ff6c35";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/hi-IN/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/hi-IN/firefox-152.0.1.tar.xz";
       locale = "hi-IN";
       arch = "linux-aarch64";
-      sha256 = "da6da3ee2787c848bd68a5d809b76650ceb248800930efa82bd026732305404f";
+      sha256 = "883c158dfb7c2b6f24a26cef2dc86536cfb153c5befbeaae2d5aba090625badf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/hr/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/hr/firefox-152.0.1.tar.xz";
       locale = "hr";
       arch = "linux-aarch64";
-      sha256 = "0528e8c4a688795a0450bac2ade9e2f8fd798408cf018922049ceeceea98f84c";
+      sha256 = "9fc54a2e04ee8680d4a2ba2e235fea47bdcd2aff6845c3c1e16f606fd2c7cb75";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/hsb/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/hsb/firefox-152.0.1.tar.xz";
       locale = "hsb";
       arch = "linux-aarch64";
-      sha256 = "c8dfaf8275eb9a152bc82d90553b92ca623a1d2aa7449f8ed22a318309a8ce4c";
+      sha256 = "90700a976b408a6e0649d95c556453670d89d647d97c56dadf33c0816c78d160";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/hu/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/hu/firefox-152.0.1.tar.xz";
       locale = "hu";
       arch = "linux-aarch64";
-      sha256 = "ba303dd2f5d80c7c0aa962c10f03fc46d9e37c69b5a14268ce6c7fcae6b92de0";
+      sha256 = "eba9b8baafa824e26eb33fc6c72bec40b9b82e58a03450ce02f6cfbd1cbdbe6d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/hy-AM/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/hy-AM/firefox-152.0.1.tar.xz";
       locale = "hy-AM";
       arch = "linux-aarch64";
-      sha256 = "6140d00ff9489d803d342c346d529e36ee869a2967b19493dd123b10255d24c0";
+      sha256 = "ce5d4fd77daf9f4ac902f33fa2db4c6bda51a407ff8e517f4f6f185bffb0e97d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/ia/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ia/firefox-152.0.1.tar.xz";
       locale = "ia";
       arch = "linux-aarch64";
-      sha256 = "4f67005959cbe8673215e3e22a3f872258e43e658bf344a79debd5bbd9aeda56";
+      sha256 = "3972561b5e66db727c7716dce79b19f8e67c474620e9df5834c27e1088b266ec";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/id/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/id/firefox-152.0.1.tar.xz";
       locale = "id";
       arch = "linux-aarch64";
-      sha256 = "57541c177f21d7733b1c08c374821ed1f6d901859469ebdea2744a553899c1b2";
+      sha256 = "9b9d4ef17d768d0d75af7ce03ef77f56c52e555306f93378631da9b12f037edb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/is/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/is/firefox-152.0.1.tar.xz";
       locale = "is";
       arch = "linux-aarch64";
-      sha256 = "108d450e69033e6db1d98824a3246131ce0e92f44fd7574c6cc92598e173a433";
+      sha256 = "be40bb39ba7e436e7cebe52e9fd5344f20decb94635550074139189f67a7b095";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/it/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/it/firefox-152.0.1.tar.xz";
       locale = "it";
       arch = "linux-aarch64";
-      sha256 = "758e641f897128b9275c7f50cdc47a71b657efe1994c169ccbbb08567e612d88";
+      sha256 = "ba55d271fb6fe06e89bebd837c2ec0b9649f185909499b9e2c75bd71805dad4c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/ja/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ja/firefox-152.0.1.tar.xz";
       locale = "ja";
       arch = "linux-aarch64";
-      sha256 = "a41a04d79755da9ea4dc021a5ef8c11fed2b2e70255c87f3ba9fb979c6572715";
+      sha256 = "48812299490107900054768d40d108980f61c3e0804586d0ae047cdd66d1f882";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/ka/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ka/firefox-152.0.1.tar.xz";
       locale = "ka";
       arch = "linux-aarch64";
-      sha256 = "682778a725a22dc0098af037731886117ccde474717e362003a4c2a354c63bdc";
+      sha256 = "44adc3bfd8e91ef9cb5eb43b5fa155a6610a72bd4fa77993d5600a1f7a2ef55d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/kab/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/kab/firefox-152.0.1.tar.xz";
       locale = "kab";
       arch = "linux-aarch64";
-      sha256 = "136ee1121f6ef1afe367d4b982bd8fe17214f15840299d316754ebcef595a313";
+      sha256 = "f10e380073984dd14bd4659d4ce55bd01f82855cf67b47e40a4a7a8fd93a17a3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/kk/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/kk/firefox-152.0.1.tar.xz";
       locale = "kk";
       arch = "linux-aarch64";
-      sha256 = "fa1e6d8c8c4eeda0e6ea9e6f85ba15f73fa650ba7774e3c9305f67e337274dfc";
+      sha256 = "8b17434115ff8a6f7ed8e733dcc6ac63350ed63ff06f1c70e81ec0ef02cb33cf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/km/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/km/firefox-152.0.1.tar.xz";
       locale = "km";
       arch = "linux-aarch64";
-      sha256 = "d455b27c31268b9bfab509936a71c188eaad83bf22bcf7b7acf8e94b281deac5";
+      sha256 = "22dd538f204296e6a4c54980091c5324facb3df0c4fc1ffa8cae8f1c8adfd3f9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/kn/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/kn/firefox-152.0.1.tar.xz";
       locale = "kn";
       arch = "linux-aarch64";
-      sha256 = "ec89f84e47c19b53d11838869ebd7fd255e5208779e9b783e2f97a0e84cc4c04";
+      sha256 = "2afb87474fccb51d6b7081bd7cf0a8195b55a5f6a45a895c77b09f308c8ced03";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/ko/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ko/firefox-152.0.1.tar.xz";
       locale = "ko";
       arch = "linux-aarch64";
-      sha256 = "b35046c773a3bbfaa80daffd5e0dae13e14213698135643005272c06a1bb9aa6";
+      sha256 = "69fbca523d4b00b3e8c8e28feb3f52a9bd9537d76dff0f12b950cdecb5c92aae";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/lij/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/lij/firefox-152.0.1.tar.xz";
       locale = "lij";
       arch = "linux-aarch64";
-      sha256 = "14519d473c829f18ca285860c1b471e0a6b24448363e02f91d3b870d78723148";
+      sha256 = "37c80be4eb4ac1cde954f5484a8eb8df07f46036286ae1b0688dbd2c44ebe138";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/lt/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/lt/firefox-152.0.1.tar.xz";
       locale = "lt";
       arch = "linux-aarch64";
-      sha256 = "ca61a6c95a97f2775195c036ce81f20ed13fdd6bbb5228190af99db0b20edb44";
+      sha256 = "ebfe550a9503aad363a174f3558333f80b2e7e5d2b81ccc563419762347e54c3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/lv/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/lv/firefox-152.0.1.tar.xz";
       locale = "lv";
       arch = "linux-aarch64";
-      sha256 = "b2069bf367e547ff75b6c84d4c71c858e2ecd0d9297b79aa93cdfd017a5a6b26";
+      sha256 = "9fb0653f1588ada25dbda0379b5dac709d717ae0fcbbf6321c490e44d8fb7bad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/mk/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/mk/firefox-152.0.1.tar.xz";
       locale = "mk";
       arch = "linux-aarch64";
-      sha256 = "b62b98a30f98be1ca3f5d30ef3c04c1c1fbe93f20603a0efe71e018f74d79d8e";
+      sha256 = "005c99cb5d681314651205380788d5954046d8d3380b86d2b4de2082457fcbe0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/mr/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/mr/firefox-152.0.1.tar.xz";
       locale = "mr";
       arch = "linux-aarch64";
-      sha256 = "e41a7a83bfc8202087095b3ade3ac3583f6b718e62d8b0d2260ee8db73bce898";
+      sha256 = "54fe2944d46a605a5d825be040b177ec75e99ec540e9e6125ff8a94c2abadca6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/ms/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ms/firefox-152.0.1.tar.xz";
       locale = "ms";
       arch = "linux-aarch64";
-      sha256 = "301d213e2262c106b9751f2fe206860d36172240a76071701dd5f8bdf8b5211b";
+      sha256 = "6de95bbb652b0651124fe4b51dc8c52c3feb093d61a73b2777272b0a02a8abb6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/my/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/my/firefox-152.0.1.tar.xz";
       locale = "my";
       arch = "linux-aarch64";
-      sha256 = "59bb43629f6cb041272c90aa13d855a3bffc025f71fe94350eed25c382d2c8ad";
+      sha256 = "49be133f51ec3f942f1d067f49475efb949c3b09335cc939f14e17af76cf72ce";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/nb-NO/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/nb-NO/firefox-152.0.1.tar.xz";
       locale = "nb-NO";
       arch = "linux-aarch64";
-      sha256 = "256db2764a655a3122e6db9d5bb16d3f7f2af0892ca5a0104848ba0c164a3321";
+      sha256 = "ac8eb102e83e5a44305e11dc8cf4189edc11e20acd3daf00a1aebb66c9775dd3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/ne-NP/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ne-NP/firefox-152.0.1.tar.xz";
       locale = "ne-NP";
       arch = "linux-aarch64";
-      sha256 = "5cc179df71b1917b47f179c73f69dbbac016b2b8ac411c45489ae7f45a012da0";
+      sha256 = "8977ce3abc7518ca40c80f84fcfad6bfa5bf150782e91d11ae7a5fe771cdb9e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/nl/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/nl/firefox-152.0.1.tar.xz";
       locale = "nl";
       arch = "linux-aarch64";
-      sha256 = "f408a8a1e31094f555cf75c451eecc31fdd413866476d9d9d954c2c9aae637c6";
+      sha256 = "76e7297bb504d691501f6c7d81db622772475eb4ed5104b76e7c34352199a000";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/nn-NO/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/nn-NO/firefox-152.0.1.tar.xz";
       locale = "nn-NO";
       arch = "linux-aarch64";
-      sha256 = "05d3ab1dabd6109a2d01fd1140a509b8e0177ed7f464c43f2739afccc5f59607";
+      sha256 = "02734dc117624965b3c858464d5706375f34b0cb87741d6004ff4aefddf545cb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/oc/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/oc/firefox-152.0.1.tar.xz";
       locale = "oc";
       arch = "linux-aarch64";
-      sha256 = "1255bfc151f783d9e2aaff3004b5901d24a3588800d28f51ed5131da3ede7a74";
+      sha256 = "a7e81e0be667523fa96b7ed8c07b6b66ae77ec0cba010f8b5936a5e63f405ff8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/pa-IN/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/pa-IN/firefox-152.0.1.tar.xz";
       locale = "pa-IN";
       arch = "linux-aarch64";
-      sha256 = "2e319330b5a631d37dc3830f49e717253cc6525471a83ec2df4cfb23c457f593";
+      sha256 = "c48272f218b59461103488b9c07d44727af63a3261243a6bc0671faaf5d6fd9d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/pl/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/pl/firefox-152.0.1.tar.xz";
       locale = "pl";
       arch = "linux-aarch64";
-      sha256 = "27e3807b57e3c6c98aa35a5af8c528c1d080b255e625a73749980a8d27114e66";
+      sha256 = "f24980d76399305a488fea9b877640f27be052686ca48b71dfcca35b7096ea5e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/pt-BR/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/pt-BR/firefox-152.0.1.tar.xz";
       locale = "pt-BR";
       arch = "linux-aarch64";
-      sha256 = "1434c27707aab5b9ba1c5228f13d68850e3c97605f5e8c128abffdbff73c1f00";
+      sha256 = "3c5d505fde21db9ba6ac0719526f33f6e4d3d618b9b99b897e2cf2c0bd598987";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/pt-PT/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/pt-PT/firefox-152.0.1.tar.xz";
       locale = "pt-PT";
       arch = "linux-aarch64";
-      sha256 = "29db42d5b19e494c2f28da697675b4b56a88bf8b10ee1ae476e7dda4f2596959";
+      sha256 = "3a8a45dbc8c4a856c244f92c5fef9d56638cdeeb9359d1aa879a1d66f4171c4e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/rm/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/rm/firefox-152.0.1.tar.xz";
       locale = "rm";
       arch = "linux-aarch64";
-      sha256 = "4b381be07cdf3ce4547b8e99e46d8a7a65c1a73492c29f3b24718df1bcab93d7";
+      sha256 = "1630108515d136b968710fecd66d89648134089add490b4d4119744bc674db8f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/ro/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ro/firefox-152.0.1.tar.xz";
       locale = "ro";
       arch = "linux-aarch64";
-      sha256 = "cab76c441baba03a2650280bbd44905f21ec2fece911cbb227692e0142664c80";
+      sha256 = "6a3026a5344729c83d9b365b007d7711914e26d8090a7a3c9888f0afa9667a64";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/ru/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ru/firefox-152.0.1.tar.xz";
       locale = "ru";
       arch = "linux-aarch64";
-      sha256 = "7277117f89c1f85156a9b94345e17547996811fe970860ea14cdb001e769441b";
+      sha256 = "a485f2f03e50e0c89ac36728afb4ba2eb3ca6616ec7fbd2f04d82b58d1bc33c7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/sat/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/sat/firefox-152.0.1.tar.xz";
       locale = "sat";
       arch = "linux-aarch64";
-      sha256 = "bcc39b492adf43120eb41ed999d931202e863d6fe98cd6b3045da9a7906e371d";
+      sha256 = "e8fd0de0e2d8409f4cec8ba11ae3e9bb16dafbc9406ce7bda3465dd30ccd92ef";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/sc/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/sc/firefox-152.0.1.tar.xz";
       locale = "sc";
       arch = "linux-aarch64";
-      sha256 = "89ea5069926c03f01904c4ae3108adac5caac4a80c68cd38a28c7c7758378263";
+      sha256 = "3591c1a32b4fd50556473ba1086c1706a2cc18e0001bf0a17aaeeccad41c4d8f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/sco/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/sco/firefox-152.0.1.tar.xz";
       locale = "sco";
       arch = "linux-aarch64";
-      sha256 = "6c21ba839fd20b4db30bd56581ebdd9b9d9657c12cce6ccc8e5a4c9e8fe1a63b";
+      sha256 = "e9b91e7272b69a0abb0a10194b14e9c884e3ee1623319d071fc634727d454efb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/si/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/si/firefox-152.0.1.tar.xz";
       locale = "si";
       arch = "linux-aarch64";
-      sha256 = "19ae3dbbaa5b82a90e37eb5ab446db4cc1525aa5200429a80b80dd66948f0248";
+      sha256 = "89ec2e862d27caf3fcce6c5c30d3599fea5a487f4911c39307791bec6b9f0f2e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/sk/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/sk/firefox-152.0.1.tar.xz";
       locale = "sk";
       arch = "linux-aarch64";
-      sha256 = "1872d2b234ab0f86c2ab1505ec4805a4a1d9ee482e517509f2e4f87a391cbfa5";
+      sha256 = "28f6032517668a3a55fba1b3b9f1a63cb4a3afd941d794c3c03d4dcbb0471e60";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/skr/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/skr/firefox-152.0.1.tar.xz";
       locale = "skr";
       arch = "linux-aarch64";
-      sha256 = "b8b205dd8ee3837613c07ed096c201332e2bed886aab129102699669e7a352d8";
+      sha256 = "441e6a75a599dea31f8823ecc108debbd3e87c7b0bc6cc0850330c1c83f01f0f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/sl/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/sl/firefox-152.0.1.tar.xz";
       locale = "sl";
       arch = "linux-aarch64";
-      sha256 = "cda751a8f2b63218e33ccc59ec3ca62a995cf20d778a85d61bce2b2d77522fd4";
+      sha256 = "b9dedf17bc7bdfca882d10bf15683d0e627f91266ec33f29e8f311a112027589";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/son/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/son/firefox-152.0.1.tar.xz";
       locale = "son";
       arch = "linux-aarch64";
-      sha256 = "aec53eb07b35204a071a3e599322cdf6b5c62dda49e99759b3cb2870269bc5b8";
+      sha256 = "b920c2b638577049afc6a192164d70c420fb9ea81f056287fcf1e831698d0e6c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/sq/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/sq/firefox-152.0.1.tar.xz";
       locale = "sq";
       arch = "linux-aarch64";
-      sha256 = "5ff6afd4ab0f271c7cf746c98ea3f80e15e20e38e247b2863f4be253c56765ec";
+      sha256 = "fbf12721ee02e4ed16f3c8ab70a4c7ee3103718dc76efa17f58cc4a87d60d4ee";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/sr/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/sr/firefox-152.0.1.tar.xz";
       locale = "sr";
       arch = "linux-aarch64";
-      sha256 = "8a5ad15dc4d4023e08dc5dcc390c36e6e276ee9241ab3c854db54d0c49541433";
+      sha256 = "7b353fcc0461ad730343ef8f4b63084dfeb149781feed1997e44f8b642e4a18a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/sv-SE/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/sv-SE/firefox-152.0.1.tar.xz";
       locale = "sv-SE";
       arch = "linux-aarch64";
-      sha256 = "0677614b60de1865636b8536c01914d11cefd75ac073742c7eed10b8474e5283";
+      sha256 = "17a9e13e0c81e87dfabee297045fe2cbea94237bcbdfae2589027a46b20855c8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/szl/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/szl/firefox-152.0.1.tar.xz";
       locale = "szl";
       arch = "linux-aarch64";
-      sha256 = "06014875d9c35480c9c631af472458ecf32aeb66acd7469a6808e77a8cf7f152";
+      sha256 = "75e12d6ddeb1412b654d29beacceaab6574bd36f46c953d86f99cbbe8a45ffb4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/ta/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ta/firefox-152.0.1.tar.xz";
       locale = "ta";
       arch = "linux-aarch64";
-      sha256 = "633f8d8416a365fc133233fbbc8725b1704a3ef67e1fc8615474adf4bfc7d826";
+      sha256 = "766be6f4a93a95567c1eb847300d42ffd2d7305a9cc854ea583fbf8d83e871e9";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/te/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/te/firefox-152.0.1.tar.xz";
       locale = "te";
       arch = "linux-aarch64";
-      sha256 = "651f6cb0ecb3551b1ec29f724e388fffa51401c99f17e8b337bedfb288dcbfcf";
+      sha256 = "aee899225e016f6a78206a95dd99361afaac02b6b6642a83ccab54642771d30d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/tg/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/tg/firefox-152.0.1.tar.xz";
       locale = "tg";
       arch = "linux-aarch64";
-      sha256 = "550e0e0a1e45962ca5cc433d47e7ebebca6baf2697083fc3f35a317927ff2ebc";
+      sha256 = "032cac36167b0e35be77ebe908fbbd76f06dfeeab887c253ec0f8e5cad97db57";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/th/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/th/firefox-152.0.1.tar.xz";
       locale = "th";
       arch = "linux-aarch64";
-      sha256 = "147645abbe140e55fe382cd50a589f1001498d13fdc13ed3aeb7e88d04faa082";
+      sha256 = "d2cda2d3247af69bdf708a8787a6699a10580eedbb444ff5eac6a6eb16971665";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/tl/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/tl/firefox-152.0.1.tar.xz";
       locale = "tl";
       arch = "linux-aarch64";
-      sha256 = "90427cd881dbefd19e882f4abe7c34f33f9d9e9e29c74272fc338d6970dfebee";
+      sha256 = "361586e1aaa289448a97076f4bb9a8cb89e1baafdc526f0cd03c2f2229322243";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/tr/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/tr/firefox-152.0.1.tar.xz";
       locale = "tr";
       arch = "linux-aarch64";
-      sha256 = "b3e45da6a0dd517aa1138958fd9800356c773659456d1afa6e29be855ba40bcf";
+      sha256 = "a757ed0cfa25d9d806b35551febf8bc47e79fc3a2fb4719cd54a8a2997635701";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/trs/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/trs/firefox-152.0.1.tar.xz";
       locale = "trs";
       arch = "linux-aarch64";
-      sha256 = "8f8d0cfc84d2fdd929145288aa40e9ca5a60eb207574fcc957375b2a69cb724d";
+      sha256 = "27ba01b45f17ab7bd8c0e8c252f96214bff4500b4fdda9efff75cecaf39a0fd0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/uk/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/uk/firefox-152.0.1.tar.xz";
       locale = "uk";
       arch = "linux-aarch64";
-      sha256 = "3a36800ac975cec25b6ac83fc22d1a3596f96b6ab2c13357f1d8a4ff37727ca2";
+      sha256 = "8b8b26441bfbdac02973eadd02e25266819601d4f100fa45ccc0851929e2c0b7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/ur/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/ur/firefox-152.0.1.tar.xz";
       locale = "ur";
       arch = "linux-aarch64";
-      sha256 = "e0638e9fbfb25ab78783b89b2c42106f7b3c2056e9a46f1dd15b33c7684f2566";
+      sha256 = "fe28ac18113f6b0f667f8db1fb4ed0dd29884a1fa9d8ecf87842c76a417bde33";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/uz/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/uz/firefox-152.0.1.tar.xz";
       locale = "uz";
       arch = "linux-aarch64";
-      sha256 = "8399295f391ae2b2552b7a532b686a76c5d4566c6235b1ccff3f76ca8a624061";
+      sha256 = "0dfde346dfa55439c80897e161f565e77bc9e6101d93ebb005ab27dc9b6f063d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/vi/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/vi/firefox-152.0.1.tar.xz";
       locale = "vi";
       arch = "linux-aarch64";
-      sha256 = "f7acf72677d2a3da7b347754cf3e3c60c563dcfa19dca89c1143ade4ed81e4de";
+      sha256 = "c02702bb99fc7c6e2901d680504f81737f865d4442ba144336112e440c2f74c2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/xh/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/xh/firefox-152.0.1.tar.xz";
       locale = "xh";
       arch = "linux-aarch64";
-      sha256 = "a3960e2de111e8762d2038953784dd9d93914d946ce5463897636ddf884fa4cf";
+      sha256 = "2077f484d03bcfe867a075bcaee2a0cf0ad80528dcfaa1e3ee477f1e24149f85";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/zh-CN/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/zh-CN/firefox-152.0.1.tar.xz";
       locale = "zh-CN";
       arch = "linux-aarch64";
-      sha256 = "33c3c5ecdebeb994220544e0614b093b4f86da5e4e12edc5f0a4f6ad3f1fca81";
+      sha256 = "a54b2d1404569808d014a550bdd23c8414b1e6fb13e77c9e03976ae49f8df42d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/linux-aarch64/zh-TW/firefox-152.0.tar.xz";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/linux-aarch64/zh-TW/firefox-152.0.1.tar.xz";
       locale = "zh-TW";
       arch = "linux-aarch64";
-      sha256 = "ef68aef218274008c2ee2c59b76362268f09602d06d956da6a40cb8882fb6443";
+      sha256 = "9a8e19704b97ad131891dc26e93766ccb24f8478826792e6c08ee25cd9d59afd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/ach/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ach/Firefox%20152.0.1.dmg";
       locale = "ach";
       arch = "mac";
-      sha256 = "cfb80daebd6fa035747c0c3c662d790a7e9917344e91f852ca62dd01a6507f53";
+      sha256 = "a14b9ca5cae670b5f42aab2f17df613865af9493e54bd164290e3c2bdf4c40b1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/af/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/af/Firefox%20152.0.1.dmg";
       locale = "af";
       arch = "mac";
-      sha256 = "e7b6904a441c542617dcce0d6731a368df539de6f0708e8142dd02f347c9077b";
+      sha256 = "31451bf4d3b7c6dd5ca888b5bb65321a19ee2058aa128cfbcb8d1b24fc4c530a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/an/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/an/Firefox%20152.0.1.dmg";
       locale = "an";
       arch = "mac";
-      sha256 = "efa9e4e6053867e397b81eb7622ecb963efdc2c7fccbb642ab7efa22817c772f";
+      sha256 = "08a9e820a09b870084d4a14964eda64cff12fc3f9c79a8d48d8086aeadfcd359";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/ar/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ar/Firefox%20152.0.1.dmg";
       locale = "ar";
       arch = "mac";
-      sha256 = "30412df0dd17ba85d217633e4a29d44a7641b59aff0917289db94454ce2811f6";
+      sha256 = "88429e89c9ae690844673b6aa4c1fc8bf2571b2a9ca4ca5f2d9232424f3bc385";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/ast/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ast/Firefox%20152.0.1.dmg";
       locale = "ast";
       arch = "mac";
-      sha256 = "1659cbe6ab716f351f7197cf5021ea56d60c0d8a02a214a902d777ff58645128";
+      sha256 = "d1e5f0dd0cb76ddcc463355faf3ccdd1631b40865c2ba52a6122ed35bb0e11d6";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/az/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/az/Firefox%20152.0.1.dmg";
       locale = "az";
       arch = "mac";
-      sha256 = "c014e7c5ffeea7116a4fb77feeca0f4dbce918bcbe5687ed612c4293aa308031";
+      sha256 = "1334ef16c5f736e35a3e0112c72090243bac4337492c779fe507a642298c1f98";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/be/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/be/Firefox%20152.0.1.dmg";
       locale = "be";
       arch = "mac";
-      sha256 = "fcf86cb4dd3e6d145e28a9cc24294dd45921a2d9e7fac6865c51855d66963df3";
+      sha256 = "b9b9ff3e1e7f4c0d37930385ce74b00a36d3562c12fe8fd0a2bba26c47f0714b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/bg/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/bg/Firefox%20152.0.1.dmg";
       locale = "bg";
       arch = "mac";
-      sha256 = "78f97690cb2f8cfdd8e596d6f256ed05d3802d24ad7f09e1a6c38ab7a14ff2c9";
+      sha256 = "5d3e088b8658b8f4218f69474eff22d3495bc81ec80a2324aac98437a7c305c1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/bn/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/bn/Firefox%20152.0.1.dmg";
       locale = "bn";
       arch = "mac";
-      sha256 = "0340b79ec48d7d2fbf9f6b5044f8065330397aa9a6b75a6dd1e9f4346e1b6206";
+      sha256 = "b3495a1bc5426ba1af223cdd46d4b42b0ddc425c6fb2442ccc1e9c28fb0e330d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/br/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/br/Firefox%20152.0.1.dmg";
       locale = "br";
       arch = "mac";
-      sha256 = "a49c394e97894364929f15858c961bd13429295e9c57f8e1f14ef6cda6e72de6";
+      sha256 = "961ccb269cd0e15bf58929194d30f16294cb74b43475700a77d9799b9d239b7a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/bs/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/bs/Firefox%20152.0.1.dmg";
       locale = "bs";
       arch = "mac";
-      sha256 = "b407332d745d8a9a8b72a9a91631236a6913a0d278164a6ac19e08ab35d23f28";
+      sha256 = "ae4560a9743e17d4682ab70a01de5addf8215c8351ef548ed87eb5ea13f8e3ca";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/ca-valencia/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ca-valencia/Firefox%20152.0.1.dmg";
       locale = "ca-valencia";
       arch = "mac";
-      sha256 = "4fcd512ef39174db6ae24b1fde3c33e2eb2accff77d1cae7c97e99b5e48d9483";
+      sha256 = "7cc75bc007f12a41e9b64ab522065ef652ac4c5716b471e627c498e0bf443c79";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/ca/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ca/Firefox%20152.0.1.dmg";
       locale = "ca";
       arch = "mac";
-      sha256 = "26e7305bb5b292894d7f6f6a7c7ac1a24bd93c3af27c215701bf5da30e9471dd";
+      sha256 = "687aaf217f80cfdd514491ce2d454b8ff8f1b70814d11687db79ad153a17449e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/cak/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/cak/Firefox%20152.0.1.dmg";
       locale = "cak";
       arch = "mac";
-      sha256 = "65c0f369899b35de654607b2e43ae34a7c48a84c25d0a8e9690a92f6492aeeac";
+      sha256 = "1959eb7a55f1e7f0fb24d6f17e47e20a80faabd8d3104a5fb4c1279889c450e2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/cs/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/cs/Firefox%20152.0.1.dmg";
       locale = "cs";
       arch = "mac";
-      sha256 = "aa9c47b07d3cce71e7e1e9489329571e5dc48d20c762d434b0b00e71ef4ff196";
+      sha256 = "20bd8c084bb1eab32d0b510f2e761f36606f37c898ea9a1bda69434c844eb4f1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/cy/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/cy/Firefox%20152.0.1.dmg";
       locale = "cy";
       arch = "mac";
-      sha256 = "e88600a034bc75ef10dee13b605c04789e8df309504ac411153d4df8a8460468";
+      sha256 = "7bf4f120fde633659785aa23dfaf9a4569089cc4fcc36e27649fbbd96541991c";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/da/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/da/Firefox%20152.0.1.dmg";
       locale = "da";
       arch = "mac";
-      sha256 = "a477ffa4f9e0866fb270d4c97fbe0206ea4962e680dbfefe3a9cd75d5a983db1";
+      sha256 = "f049e7934353c72e15cc72a2f35a596c79b512d20ebd999549c81fde151fafc7";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/de/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/de/Firefox%20152.0.1.dmg";
       locale = "de";
       arch = "mac";
-      sha256 = "c2006a6f21945d27b23203395b026fc4066096a50827bbf261eae808cad4bd96";
+      sha256 = "64b0d3d180b65fa34866289a1d004f91b7fe4f04592cb2563123209753168f18";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/dsb/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/dsb/Firefox%20152.0.1.dmg";
       locale = "dsb";
       arch = "mac";
-      sha256 = "46352ddb2c382da0894a1e3e80d423a330962c37035ca4066e9bfb3be5d3bf55";
+      sha256 = "1fdab7e1e68166b4a1998e168afd6a88cda89ba0911ad797fd71016f9fe9375f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/el/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/el/Firefox%20152.0.1.dmg";
       locale = "el";
       arch = "mac";
-      sha256 = "c0420046a9ad193162a003f2f37fd4af6efd1679398a5a5c187e6da8706b8832";
+      sha256 = "96ea89bc4fa2e86663117365acaa713030f7ddf63e3fd1fcecddc915c7994afa";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/en-CA/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/en-CA/Firefox%20152.0.1.dmg";
       locale = "en-CA";
       arch = "mac";
-      sha256 = "2a48c3782dbe491b3c34f9ed352007d6c1fced243710acfb35f6b4c0313d2fc2";
+      sha256 = "b43ddf56f63a8bd8c6644115fd882c0ffed775c5db10c3c58ffb1a827ee26404";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/en-GB/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/en-GB/Firefox%20152.0.1.dmg";
       locale = "en-GB";
       arch = "mac";
-      sha256 = "0df93140498602f2c95eacae2a4a2f2e73761adf83e1dd1a77f68ac60ffc2524";
+      sha256 = "f9c0d5236a17f77380cdb9a41a95dd487168c72ed4a2ca91e185552a17be97e8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/en-US/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/en-US/Firefox%20152.0.1.dmg";
       locale = "en-US";
       arch = "mac";
-      sha256 = "b8a46188850d2fb32f16ad3c0829b08cd689bc714b8ee18fd9b09bb60629004d";
+      sha256 = "3398cb6c17077f536bd534af3a98b66ef850689532f82ddc3df05533b8018ede";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/eo/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/eo/Firefox%20152.0.1.dmg";
       locale = "eo";
       arch = "mac";
-      sha256 = "588002709f8f3e337c862d14be9cf8341f3d88f539ea8bc237340bb5b738fddf";
+      sha256 = "a7560c946928764f2aac02ad8cd91d4f7db174d97cef586b9c33598b9b0309d0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/es-AR/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/es-AR/Firefox%20152.0.1.dmg";
       locale = "es-AR";
       arch = "mac";
-      sha256 = "0bc6b8218f6f3a4995dfb4758e0f1156394983daaa11075904fd4a139d7ea421";
+      sha256 = "77da7f3a78cc28509a335232cadda12582569f1272d44ad0a6837e92c46bc838";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/es-CL/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/es-CL/Firefox%20152.0.1.dmg";
       locale = "es-CL";
       arch = "mac";
-      sha256 = "9d631697b00d6b7c79393e5eadd27c139d36a09547b5b50bf050da2239a026e5";
+      sha256 = "d2e4dbd2369211ec367105137423feba3f1a8f927d528e79566f529b651e531a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/es-ES/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/es-ES/Firefox%20152.0.1.dmg";
       locale = "es-ES";
       arch = "mac";
-      sha256 = "6e76e461e33df7d6958b7e24f69a003c527c45cbb5916095c732ba600040722a";
+      sha256 = "424f7bc5a67176ebac2b22f0f9348eae8db0c0dbb415112809c5092d1f4e9cab";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/es-MX/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/es-MX/Firefox%20152.0.1.dmg";
       locale = "es-MX";
       arch = "mac";
-      sha256 = "fce3e43d50a2d592a1664ef3509348c97e2dbb070b0971c3fdbd9d66203ddcf8";
+      sha256 = "a2988c5ba9d4c2776e080142947538788ab1a098ea609d29e8945532813f6b5d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/et/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/et/Firefox%20152.0.1.dmg";
       locale = "et";
       arch = "mac";
-      sha256 = "212a31dd0620e01e5aacd08e91f3dc4c5e340eb2baf45ac0e04eddf44cba0bdf";
+      sha256 = "1d40f73e629682f568de6cbbf9473c349bec5c0d89112bfa7d88c2e1e51c1f02";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/eu/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/eu/Firefox%20152.0.1.dmg";
       locale = "eu";
       arch = "mac";
-      sha256 = "273cb1f5702ac5f90d45679528827d72d9219485b24ed486300824babfaa5b5e";
+      sha256 = "008a66a53f4749c58bbc8cdf22c04cdf11bc49123f694bacef3affdd96221673";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/fa/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/fa/Firefox%20152.0.1.dmg";
       locale = "fa";
       arch = "mac";
-      sha256 = "bc760b0039ed06130b3dea9d5ba5500b0652f6c4e8468e6d330c0dd81b2e34d8";
+      sha256 = "fa73a3e545e3e6c8fc9b1f0ef6b48fb684701e435721b527753ea254b6943e73";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/ff/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ff/Firefox%20152.0.1.dmg";
       locale = "ff";
       arch = "mac";
-      sha256 = "4e1fbab69307778303bb93ef8855ca9af7112f81e9140bd4dc9d23aef65b4ee5";
+      sha256 = "a50a98a681de12b15cc545b16cec96a97ac966a69a04adc5a8ce08345db27058";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/fi/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/fi/Firefox%20152.0.1.dmg";
       locale = "fi";
       arch = "mac";
-      sha256 = "96b98161eef2ea8bd2c681143640f28ded4aa8f86f50004b94c01e65f6b8492a";
+      sha256 = "bc3f9b1d838f7876c56b0a01daa69993ae66cf5202cc95d6c169bebb4f44f731";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/fr/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/fr/Firefox%20152.0.1.dmg";
       locale = "fr";
       arch = "mac";
-      sha256 = "aa2cee6319f7e0f62a5bebf7cc90c8daaedbfc435ea3fa18c924e07a5f6b849c";
+      sha256 = "6bee1ba2a8d1eceb237b123f0ee22214b28ffe5561088f1a20c25d2cdbabdb38";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/fur/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/fur/Firefox%20152.0.1.dmg";
       locale = "fur";
       arch = "mac";
-      sha256 = "9611b7bc46956820ca7b15adb808b518fa6b65e51e3460fa4a61685f41b0e7cc";
+      sha256 = "ee910621eaa5607d589c4f59ee7ae07108553ced001f706d185730e0f340cd2d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/fy-NL/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/fy-NL/Firefox%20152.0.1.dmg";
       locale = "fy-NL";
       arch = "mac";
-      sha256 = "6b6624a46b4cadca1ef9cd3b322ef0e57b443969fbdcf6a85f8f9406e33c9db0";
+      sha256 = "af4c465481d521aede69cfe160b396e45725dde511ae4ba46a768385b0e7cf49";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/ga-IE/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ga-IE/Firefox%20152.0.1.dmg";
       locale = "ga-IE";
       arch = "mac";
-      sha256 = "5c22887f48b1e09f20f1009a9d6fb0bc9c4ac19356a3f51e4e63efdaef1cfaa9";
+      sha256 = "051bb6d3ef6e63846f4c531a1a6dc48b5d669887309d1682983b71de68c71362";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/gd/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/gd/Firefox%20152.0.1.dmg";
       locale = "gd";
       arch = "mac";
-      sha256 = "8305a9b89ef4a89379612bcbbd4dd039e277f099e41acae73e1b6616af5aca94";
+      sha256 = "8da084fd9ca21e0c6e1b189b53b2f1caf84328695f5a8d057de5602691c5fad8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/gl/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/gl/Firefox%20152.0.1.dmg";
       locale = "gl";
       arch = "mac";
-      sha256 = "9b889d993147dde2f87522b3e7330c235136d1a3abc13d6bbead38afc0209cf9";
+      sha256 = "06c316481ed30b286c3bcbeb46880a7107c988bb929ce465c821cc473e204c79";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/gn/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/gn/Firefox%20152.0.1.dmg";
       locale = "gn";
       arch = "mac";
-      sha256 = "967ab00e4082137d56411f0625773cd8642ae05c0e66b9642b4f5130b953e731";
+      sha256 = "6978c956652808c21359680bfd79ff2ada3f6519750db40d3453dc2dd8c9ea27";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/gu-IN/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/gu-IN/Firefox%20152.0.1.dmg";
       locale = "gu-IN";
       arch = "mac";
-      sha256 = "87852a13e7d286292af9894a01f53eccc0d6fe554edc9ee88d131b417ee6661d";
+      sha256 = "e8abd879a56b3aec97c21c018e9e7b187d498ce4461c753048a178b6d266bfb2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/he/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/he/Firefox%20152.0.1.dmg";
       locale = "he";
       arch = "mac";
-      sha256 = "1e1f33e1165b2baa0f1edcfb841bfc628de1552d39bae27cd592e36a99112117";
+      sha256 = "030a5a8e9070f975e8ec57c9a45ed004a19acf9eaacb399e84c15d365d936a39";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/hi-IN/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/hi-IN/Firefox%20152.0.1.dmg";
       locale = "hi-IN";
       arch = "mac";
-      sha256 = "82160a5a82bc49ce1f490dc5ec3d8339d210df4980c773510fc66d9fb4332e6d";
+      sha256 = "d131e02724198992eaaf95c6c6dac27a04c4ad7cd8ef9ff7b3bb6ed7d04c329a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/hr/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/hr/Firefox%20152.0.1.dmg";
       locale = "hr";
       arch = "mac";
-      sha256 = "0fcccfa9a7db9d7fa4b3fbd4e1c55a66ce2d9410b83be593c86a3ddc7c37bf6b";
+      sha256 = "fe6533f418c3a496ac7230b85d868463e3e9dcdb77a72ec24ece9055be325a8a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/hsb/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/hsb/Firefox%20152.0.1.dmg";
       locale = "hsb";
       arch = "mac";
-      sha256 = "3d9959d778107d7e4c8fb127c22f8d5a7b5956c9b612e0150f881502db0e6a98";
+      sha256 = "fcc2be581e4e38991a51a4064bf4a46edd1dabdcaecaaef998eb43d7ee854880";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/hu/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/hu/Firefox%20152.0.1.dmg";
       locale = "hu";
       arch = "mac";
-      sha256 = "ce2d47afd3cc9b8690570293bb9865751bf7d91ff8e0ffa2ab2457ca6fbab5be";
+      sha256 = "f5cb59fb3b319c13608a1300ae451051342373519d8415affb1dd45c2c024fc3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/hy-AM/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/hy-AM/Firefox%20152.0.1.dmg";
       locale = "hy-AM";
       arch = "mac";
-      sha256 = "f55cfc03bf015fbbcd9417b05744fc0e58728ce010b832c6dda0c71801adcf66";
+      sha256 = "4ad1ab547a850093c2bbe169eb32c8a13ec9905700c9dce6c1e8939cf4f3d937";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/ia/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ia/Firefox%20152.0.1.dmg";
       locale = "ia";
       arch = "mac";
-      sha256 = "fe6835767af133503d98bb4bd5c1c2d6f652c747d3f797afae8ae3a5f6e7ad14";
+      sha256 = "e22fd59db4c8ea6f524d1fde11fbf702e5cd9f813e02c7b3c876032c26f2d172";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/id/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/id/Firefox%20152.0.1.dmg";
       locale = "id";
       arch = "mac";
-      sha256 = "d44f623563204273e72858bdd1432b7e33ff3c5cf4adc38da6ee7f7e85d7eab1";
+      sha256 = "671887fe4abac1e8dcd69d42cb127e1f6956ef7c489657260b2f8bcf455b7a38";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/is/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/is/Firefox%20152.0.1.dmg";
       locale = "is";
       arch = "mac";
-      sha256 = "e037e919c455d88b84a2dcb6c87f1b931684d478e128d3116f56290366d5a50a";
+      sha256 = "b3399c9ebe91b7bbd5483a167a342eb6ec666168ab8a9589e1731b18f8914942";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/it/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/it/Firefox%20152.0.1.dmg";
       locale = "it";
       arch = "mac";
-      sha256 = "3efcd309afcb4ad77dc3ccab835c94568c8aacfdd4de4532a1555bc5195263d1";
+      sha256 = "8162e4806e9c0a93583ae9dc047d3a5aaead053338b3002369fb29fdcb5d60cd";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/ja-JP-mac/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ja-JP-mac/Firefox%20152.0.1.dmg";
       locale = "ja-JP-mac";
       arch = "mac";
-      sha256 = "2fd7532c366451b6de02debd8159af16a383fea965a3c5f0e04444184bdac796";
+      sha256 = "5e33d8738784a5bd0834de6670383c789a5d722c1603757990e84602009eaa65";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/ka/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ka/Firefox%20152.0.1.dmg";
       locale = "ka";
       arch = "mac";
-      sha256 = "e1d0bff84565bc893bdef0b713a314b43b18860b6a304d1bccb072b5e99f5685";
+      sha256 = "96b40509b7a2cb74d2e195278c97d77f65c7fb22c95d47877eebe25a75005a40";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/kab/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/kab/Firefox%20152.0.1.dmg";
       locale = "kab";
       arch = "mac";
-      sha256 = "e654376356a13af90b73fe900eec03a51d1d017ef397829c94498e11ac76a27e";
+      sha256 = "297c7cbfb71ccd28babba5c9ea074ba9826fe82a116607316ffbec543cb3171f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/kk/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/kk/Firefox%20152.0.1.dmg";
       locale = "kk";
       arch = "mac";
-      sha256 = "9ad6378470e39a89af444498c1e2ad4f7a7fc1e86ac7b82ec306acf6d3a3e5c7";
+      sha256 = "118d04f727382f1c0f21e0756d07b04291ef4e74568fa34a93022d9ef123968d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/km/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/km/Firefox%20152.0.1.dmg";
       locale = "km";
       arch = "mac";
-      sha256 = "6f0dd00caab77a7199b72230425c17cec673b000168ae999893d72a9d51a99f1";
+      sha256 = "0c5a6a2946adc5713d86dceeedbfe81589d7294b70d110000db9e80105d63d38";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/kn/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/kn/Firefox%20152.0.1.dmg";
       locale = "kn";
       arch = "mac";
-      sha256 = "8bb119138a7268c1e6a0e9fb32dcd68373526a9287b4212e5974ab1437a7410e";
+      sha256 = "463d0641b1d8608916b30bef1a1cbe63dd0d41a307aa8af665340c7a0550ea2a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/ko/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ko/Firefox%20152.0.1.dmg";
       locale = "ko";
       arch = "mac";
-      sha256 = "a4f8234fd7ef374e8f890ef41ae5ce91f2da209e4795d92a9751b11275b29619";
+      sha256 = "69b4b6fd0b8f4e2eef40e5cf6d11553131ff01476a636e961c30e27133ef9aa8";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/lij/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/lij/Firefox%20152.0.1.dmg";
       locale = "lij";
       arch = "mac";
-      sha256 = "bf132de3ef4b381f0c2c6b41f8708186ec37e8d4ad29ff8a257a7be925ab8a89";
+      sha256 = "494f6a07f0f0c4721c2d7d267fa85962d82c97f1b86794d74201b5b9f48fad5d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/lt/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/lt/Firefox%20152.0.1.dmg";
       locale = "lt";
       arch = "mac";
-      sha256 = "b16eb1ba8c9dd347413970704bee3da3ac470fe249318417eba26968cfb8531c";
+      sha256 = "70ec6804ee7a7e267d4a51dafd9bb1bc1c6e99f177ef5b755d30cfeb12585581";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/lv/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/lv/Firefox%20152.0.1.dmg";
       locale = "lv";
       arch = "mac";
-      sha256 = "f128bfbf3b934f2bd86a40cb8ce82f61ff3c9eaa8d640e7b1febd1f76dc66613";
+      sha256 = "43997b69caef9546a9d1bf9de0a4bfa958007667374219b2a329cbdc6655c183";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/mk/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/mk/Firefox%20152.0.1.dmg";
       locale = "mk";
       arch = "mac";
-      sha256 = "4ccaf68c304f14f8c1b77a9abd966bfa93ea61615424ea8f90398c8a49e42d00";
+      sha256 = "a13a6dd71e40cb60c451bddb5ff25b804210ddf2b788e2ed63b87dfc5b898884";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/mr/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/mr/Firefox%20152.0.1.dmg";
       locale = "mr";
       arch = "mac";
-      sha256 = "7a7685ccbe78b99620664ef275d08f99169903a4e94df102a32d5117c428790e";
+      sha256 = "bceed32a96c98ef852a6af590d31f1d2892d5b57f420f8995700cec17eae9761";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/ms/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ms/Firefox%20152.0.1.dmg";
       locale = "ms";
       arch = "mac";
-      sha256 = "64c2ced0bb15646510288d00d9521200f13178acbb34d41271d033798272971d";
+      sha256 = "355962198e475d2bf92b1ed181870890cd3aa78e32b18bb85322d6c999f423a0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/my/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/my/Firefox%20152.0.1.dmg";
       locale = "my";
       arch = "mac";
-      sha256 = "e73ee1329c6cd911cd8d285947a550366af283ac71425e14fd9cbf0ec74d7f72";
+      sha256 = "37ed9a2b84bc87f69658ffbb109385e5d3d09e87ec453fc0822e4e8f59f4286d";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/nb-NO/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/nb-NO/Firefox%20152.0.1.dmg";
       locale = "nb-NO";
       arch = "mac";
-      sha256 = "69d26f349dc2102649800792e6159bc7522b4b7bac10af8b2b9e6b91c357c7e9";
+      sha256 = "f1156597d804b1f9fd0ea9691b11df0fa4c5316f67b6c45264d0991bfa0a83b4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/ne-NP/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ne-NP/Firefox%20152.0.1.dmg";
       locale = "ne-NP";
       arch = "mac";
-      sha256 = "03a1295bfd4837f3b5353d20ee021737a8f702584352e9ff4687040a69f56f3e";
+      sha256 = "d22c8f9eb0f6584b3f81ba2f1f37d61392aa02d3264e7f85c79396bf1ad1f686";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/nl/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/nl/Firefox%20152.0.1.dmg";
       locale = "nl";
       arch = "mac";
-      sha256 = "917e6f679e6b6622af079b4fe53ef8fec9daa5bd1d14088de7f932dab9d3971f";
+      sha256 = "7c522d4e607497c22926b1ede7f6ef62d942b9c6f70f885393e5ffafcd15c518";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/nn-NO/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/nn-NO/Firefox%20152.0.1.dmg";
       locale = "nn-NO";
       arch = "mac";
-      sha256 = "900725806f530259ef17212fd5f0777201ba4ef3e0e946601f720f9d704809fe";
+      sha256 = "7371b6c1e6968bf26041c16257aff045a024e7cb634e31223fec7f91befae417";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/oc/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/oc/Firefox%20152.0.1.dmg";
       locale = "oc";
       arch = "mac";
-      sha256 = "134380fead0819e01a2085f130bd4956d304123370d49cfbf9c9ffea098ed99f";
+      sha256 = "883e88183afc87a7dc671b25261d95d80b614671bca6ea6504e0c1502e0a7611";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/pa-IN/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/pa-IN/Firefox%20152.0.1.dmg";
       locale = "pa-IN";
       arch = "mac";
-      sha256 = "2a63bf8a34002bcc27900fc2b44aa4677627b16f5e5b4f0081517a27835092c4";
+      sha256 = "e04904260ca557b78dc77a3d004b6afb00f5f6725e67ea003c45cbf7d084cef0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/pl/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/pl/Firefox%20152.0.1.dmg";
       locale = "pl";
       arch = "mac";
-      sha256 = "b9c0ccda4703d36e5da0d3d8638adb3c4d5aaa66483f38baa04626e8bb91b179";
+      sha256 = "fdb11e4e2ad66d7fd6c4af50dee54dc62194f6af31d9413727206e9255aad775";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/pt-BR/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/pt-BR/Firefox%20152.0.1.dmg";
       locale = "pt-BR";
       arch = "mac";
-      sha256 = "b45f2d85ee02d1ca3dd3372c7283396ae70a845b924652abf3f6425577d2e6b8";
+      sha256 = "bdb18c290911a6b701d599be0afe8c1104ea5420d1b3e287db2d2294c8e065fe";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/pt-PT/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/pt-PT/Firefox%20152.0.1.dmg";
       locale = "pt-PT";
       arch = "mac";
-      sha256 = "d848fabffef4ce2c9cc9f9fb8b03e97c85f8db62695021c62a6a4f4ffc370d99";
+      sha256 = "0765f48eb00eaa1bffecf7887da20aa66bf546933d0ac546b4cdb816b57ebabf";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/rm/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/rm/Firefox%20152.0.1.dmg";
       locale = "rm";
       arch = "mac";
-      sha256 = "9fc0c7a6bfd63a23fd101c5282c655fb1de3eeb95fab10337a74d695e533bc62";
+      sha256 = "e602fd0ebff4e800c3d8cb96a1dc49250d27c6902fabf14e139e88a5fc1b448e";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/ro/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ro/Firefox%20152.0.1.dmg";
       locale = "ro";
       arch = "mac";
-      sha256 = "26b3ad72e9f8b86344a0d5096e5be81fbfb4c0503bbf097044724f9d6f1ffbe5";
+      sha256 = "8c6552a8aedaa17533c4bdd24b5a2270093fb17a72f0515c35b9968d3de75e3a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/ru/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ru/Firefox%20152.0.1.dmg";
       locale = "ru";
       arch = "mac";
-      sha256 = "bea7ef50fc8e43fb32bb391f35ac1c259ff377685e542ead87c700f8f8afd298";
+      sha256 = "32780f8c4526ba67785f1fb9f98d9bf434dc0c6080c74fc5d4deb4335fab8ecb";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/sat/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/sat/Firefox%20152.0.1.dmg";
       locale = "sat";
       arch = "mac";
-      sha256 = "7ceffca9692517e86004e8eb4bc8f9d1f162b23a1c41cfcf024061547c5b2d40";
+      sha256 = "9860aac9e342b26cddfcfdcb55e881af1690a258774fde2794b6c7c0a713db48";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/sc/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/sc/Firefox%20152.0.1.dmg";
       locale = "sc";
       arch = "mac";
-      sha256 = "f048452eef2d21511c337184ffb11020240f30a97d5208fe4f62528bc89bb2e5";
+      sha256 = "9e19dd61584eb7ec89a1003056e5c72acc44a1c314c0e9b5d4c4b50fb77f7df1";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/sco/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/sco/Firefox%20152.0.1.dmg";
       locale = "sco";
       arch = "mac";
-      sha256 = "23cd8585c84eea6436ce08a276bb9dae19a23828dff08c2b88100fa8b158e78e";
+      sha256 = "5dee3b6a01b46e53c7c1b0462c7769fe5ac975867c8b1d889e09537ec7f4ca0b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/si/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/si/Firefox%20152.0.1.dmg";
       locale = "si";
       arch = "mac";
-      sha256 = "19e7327cee11de5a4c54c8c1ddde57d7973b3b34cd8c249de75bcf00505f374b";
+      sha256 = "4bf126e6afbdb3e9ecade94db12f4fed11567d703de6b0ca238feaedb629937f";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/sk/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/sk/Firefox%20152.0.1.dmg";
       locale = "sk";
       arch = "mac";
-      sha256 = "88d4c7e388bcb71ea33845e5f416e6f9c86716f72295eddab1738b3fb57a968f";
+      sha256 = "e8050332ed989f92852326dfab12cbf744022594765fc6e3eb4ba22a02881010";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/skr/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/skr/Firefox%20152.0.1.dmg";
       locale = "skr";
       arch = "mac";
-      sha256 = "b57acbb4b8a1c7d23665d919d3924b78622c36f155aea7aa94877989ca7fa366";
+      sha256 = "d57c0bcc4666d90982d6c67c91d2c6ac66675619420931fa13bfa173bd2f1d6a";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/sl/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/sl/Firefox%20152.0.1.dmg";
       locale = "sl";
       arch = "mac";
-      sha256 = "480da06b36276042e01eaf4cb75b1ff3944ec3975cd87b40dce555d2e9100a5f";
+      sha256 = "10c93479689e79e51b067f502e767de517c02862d77a5366574defa306f036a2";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/son/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/son/Firefox%20152.0.1.dmg";
       locale = "son";
       arch = "mac";
-      sha256 = "c0437a89efbf4192c07514a482b95310632db80011c8bd2b0d70eab0883bfad2";
+      sha256 = "f41a956cb65c4d0f4e04fd4b8e224e091dd69e52e1dc19b4bf2d99921192e7a4";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/sq/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/sq/Firefox%20152.0.1.dmg";
       locale = "sq";
       arch = "mac";
-      sha256 = "f2335f43d0ca2e753802f93d732bd440acbb79aa239eb7371d0e6d1a15d560d9";
+      sha256 = "bbf8a9c86c4cdfce83e47d3ca8f161412efbe89cc9cf02d9ca3b37d447889f72";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/sr/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/sr/Firefox%20152.0.1.dmg";
       locale = "sr";
       arch = "mac";
-      sha256 = "72a7a443ae738d06053bbcbed3295ca71b686a2ea46072573f5db542d8dc9f58";
+      sha256 = "98bfbfdb40da834b722a18d2149feaab81dc52c52ea2876e225ba5f2f8712715";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/sv-SE/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/sv-SE/Firefox%20152.0.1.dmg";
       locale = "sv-SE";
       arch = "mac";
-      sha256 = "a2bd3dbfba397d957ae1cc6b6dc73ec8f008d2ed6380d8282c512e580c793a2d";
+      sha256 = "450d102a470ec808d46840c1d7bf21ce2af32ef4c586c9c19ecedc8d8d050820";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/szl/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/szl/Firefox%20152.0.1.dmg";
       locale = "szl";
       arch = "mac";
-      sha256 = "97b35336c17fbb5feafc58ae81bf21e50e787829ea6f7edbc48af2085a80c4ec";
+      sha256 = "c0971c39223876b35b7c6b05369f3cd2fe1caccc36bd34b25f7d3164c135ddf0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/ta/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ta/Firefox%20152.0.1.dmg";
       locale = "ta";
       arch = "mac";
-      sha256 = "d1911bd99fbfceb077f87a86a1dc04f4d375e05edcd189907e7c8f2f536e46fd";
+      sha256 = "8144df52424dffcb39ccfcc621ba64aa17f307bec142e40bbbca020cdd8d78a3";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/te/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/te/Firefox%20152.0.1.dmg";
       locale = "te";
       arch = "mac";
-      sha256 = "7e580f31320a55ea50e8802a17c64adc53b4c32e6cc7cfa7cfc56cf7a0e7f486";
+      sha256 = "477f540f219e125ffc110789d0af72d76f688bee804e46cbf075c9097efdf046";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/tg/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/tg/Firefox%20152.0.1.dmg";
       locale = "tg";
       arch = "mac";
-      sha256 = "06459f349a9cff064d2b9ea1f39cc38da8f321a7a797aeaae09f1363f3ec9c58";
+      sha256 = "c9620df254674dcdf004448737ec9b4a4d9d9a294ceca76bd255101e2db45a46";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/th/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/th/Firefox%20152.0.1.dmg";
       locale = "th";
       arch = "mac";
-      sha256 = "1e5229a0bcb2a09be614375f6deb6e3a89b27ee2ad67a0163edcfc80a48fea8d";
+      sha256 = "76ad3c53dab15158a0901f9c03c62e42b1caa40b1553cdb4eefdebc25be516ad";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/tl/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/tl/Firefox%20152.0.1.dmg";
       locale = "tl";
       arch = "mac";
-      sha256 = "e4e2c28fb5d8f529f5b3eb133470d1d69d3b41dd77fd9b4242daa607de258b3e";
+      sha256 = "509e2a5b10ec5ed32bbebc6a259747c8fb3234df2288ab07c88006f4d47bbe84";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/tr/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/tr/Firefox%20152.0.1.dmg";
       locale = "tr";
       arch = "mac";
-      sha256 = "a0f966ef8257b801d3838216d8da887e18d160d4b500bc5282a5da76cea3473f";
+      sha256 = "33ccbe2385a04937fd3e76b5c4fe0786721ffe10474cd1844752ad4c40dba2ea";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/trs/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/trs/Firefox%20152.0.1.dmg";
       locale = "trs";
       arch = "mac";
-      sha256 = "6d31ba0c843c95b05fe2b7a57b02aa57054e3e7664fdcf7bb6a652c994c8fb98";
+      sha256 = "82222fd6de57a53caded0bedfe4b83a63fb2a573e3c8b937e64d38d2d5202d19";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/uk/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/uk/Firefox%20152.0.1.dmg";
       locale = "uk";
       arch = "mac";
-      sha256 = "bafcb55c9db4676e6fc929d951e2ed50a94a02277bd0f90613afb9753aa4a981";
+      sha256 = "0a0efc3cb0045efaa6597b28f8d2ff0c7f1cb1664a14a9d89321f7fc871f4823";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/ur/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/ur/Firefox%20152.0.1.dmg";
       locale = "ur";
       arch = "mac";
-      sha256 = "e66467837b0992a3dd3335f87e42b60085a67fbec3f936951c31136528021154";
+      sha256 = "8672dd604d381d6c2f9e7ef130b2dcc7773d1619695e6ad79dc8953236483298";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/uz/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/uz/Firefox%20152.0.1.dmg";
       locale = "uz";
       arch = "mac";
-      sha256 = "ccb34e9750b0c31d49e10f2d75da151dc5a03c9fdb17fdac42e9e0dfd3b85d89";
+      sha256 = "4d64edd496224bac99d6e13b7901f54b87b770f0cba55544317261182665bb67";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/vi/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/vi/Firefox%20152.0.1.dmg";
       locale = "vi";
       arch = "mac";
-      sha256 = "0e846368518c4bc0ab96c7a7d38fe19747e4c64e13e482cc305cd4ad046bb4b7";
+      sha256 = "42465e83f7c0131dd2dddab0bbc1873171c823473484a11da7c1ef6b0c7e8cd0";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/xh/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/xh/Firefox%20152.0.1.dmg";
       locale = "xh";
       arch = "mac";
-      sha256 = "068df314fb733b79f57cd3e35f9f66d3c5fe324828de8f5ea92666cdef4a51e5";
+      sha256 = "81e3552691097d4b10b9180a6e71a5b61b4196a29aa51003478f1cef3c567f60";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/zh-CN/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/zh-CN/Firefox%20152.0.1.dmg";
       locale = "zh-CN";
       arch = "mac";
-      sha256 = "cd73fbaced1ca03ef69c94ce9bfb12231c9faf00959f7c447bb9b0f4233bf8b2";
+      sha256 = "31b89bfdb6293a8bb4f7be953a8f31a3ba89aeddb2ecf060cfe67dc091f3c39b";
     }
     {
-      url = "https://archive.mozilla.org/pub/firefox/releases/152.0/mac/zh-TW/Firefox%20152.0.dmg";
+      url = "https://archive.mozilla.org/pub/firefox/releases/152.0.1/mac/zh-TW/Firefox%20152.0.1.dmg";
       locale = "zh-TW";
       arch = "mac";
-      sha256 = "1f6daf4f8f8bbffb5f332e60bdc62c9aa6a102cd6ee76b2c51e63c8dbb0a7ca6";
+      sha256 = "d52aa6bf280e7aad52f83fd02551db207b51bdc8915f129aa21a6d355b68b663";
     }
   ];
 }

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox.nix
@@ -9,10 +9,10 @@
 
 buildMozillaMach rec {
   pname = "firefox";
-  version = "152.0";
+  version = "152.0.1";
   src = fetchurl {
     url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
-    sha512 = "2c7adf367004063ee9f3385e692f612d8e5c0c10662bf294996c118001e43dec12ca8cb4fd70e67a25a903dbf5adf83d22e487f04bf3f930da2a815c80378ceb";
+    sha512 = "9b2595148ed977040ea2b21e7d6ece70f0e53fac9b96b3115b113bea76ead6c0422f6e94b1540283b430fed5e8e9a227771a6357bf16f56d530a7fae7dc7553a";
   };
 
   meta = {


### PR DESCRIPTION
https://www.firefox.com/en-US/firefox/152.0.1/releasenotes/
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
