### PR TITLE
nixos/ratbagd: add extraDevices and verbose options, update libratbag and piper

### DIFF
--- a/nixos/modules/services/hardware/ratbagd.nix
+++ b/nixos/modules/services/hardware/ratbagd.nix
@@ -15,6 +15,34 @@ in
       enable = lib.mkEnableOption "ratbagd for configuring gaming mice";
 
       package = lib.mkPackageOption pkgs "libratbag" { };
+
+      verbose = lib.mkOption {
+        type = lib.types.enum [
+          "quiet"
+          "info"
+          "debug"
+          "raw"
+        ];
+        default = "info";
+        description = "Verbosity level";
+      };
+
+      extraDevices = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
+        example = lib.literalExpression ''
+          {
+            logitech-g700 = '''
+              [Device]
+              Name=Logitech G700
+              DeviceMatch=usb:046d:c06b
+              Driver=hidpp10
+              DeviceType=mouse
+            ''';
+          }
+        '';
+        description = "Additional device description files";
+      };
     };
   };
 
@@ -27,5 +55,40 @@ in
     services.dbus.packages = [ cfg.package ];
 
     systemd.packages = [ cfg.package ];
+
+    systemd.services.ratbagd = {
+      serviceConfig.ExecStart =
+        let
+          arg =
+            {
+              quiet = "--quiet";
+              info = "";
+              debug = "--verbose=debug";
+              raw = "--verbose=raw";
+            }
+            .${cfg.verbose};
+        in
+        # If stdout is not a TTY, ratbagd logging is not line buffered, so if
+        # it doesn't print a lot, you will never see anything. Run with
+        # stdbuf as a workaround.
+        [
+          ""
+          "${pkgs.coreutils}/bin/stdbuf -oL ${cfg.package}/bin/ratbagd ${arg}"
+        ];
+
+      environment.LIBRATBAG_DATA_DIR =
+        let
+          makeDev = name: text: lib.nameValuePair "${name}.device" (pkgs.writeText "${name}.device" text);
+        in
+        lib.mkIf (cfg.extraDevices != { }) (
+          pkgs.symlinkJoin {
+            name = "libratbag-devices";
+            paths = [
+              "${cfg.package}/share/libratbag"
+              (pkgs.linkFarm "libratbag-extra-devices" (lib.mapAttrs' makeDev cfg.extraDevices))
+            ];
+          }
+        );
+    };
   };
 }

--- a/pkgs/by-name/li/libratbag/package.nix
+++ b/pkgs/by-name/li/libratbag/package.nix
@@ -22,13 +22,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libratbag";
-  version = "0.18";
+  version = "0.18-unstable-2026-07-17";
 
   src = fetchFromGitHub {
     owner = "libratbag";
     repo = "libratbag";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-dAWKDF5hegvKhUZ4JW2J/P9uSs4xNrZLNinhAff6NSc=";
+    rev = "03afbe49f30a4fd18d830530685804eb3bd57c39";
+    hash = "sha256-vlo3RfpLJQTw7P5Bmopl8vi4nDrY9OwNM6tVja+scq8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pi/piper/package.nix
+++ b/pkgs/by-name/pi/piper/package.nix
@@ -18,15 +18,15 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "piper";
-  version = "0.8";
+  version = "0.8-unstable-2026-07-21";
 
   pyproject = false;
 
   src = fetchFromGitHub {
     owner = "libratbag";
     repo = "piper";
-    rev = finalAttrs.version;
-    hash = "sha256-j58fL6jJAzeagy5/1FmygUhdBm+PAlIkw22Rl/fLff4=";
+    rev = "452f46ce861948cacdf0f7948964e67a29d027b9";
+    hash = "sha256-0PLf8YZmEV1SQcEMEa0fm9GZkrD8jvtNG+iIeqRkJJw=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Added services.ratbagd.extraDevices to add extra device description files. Sometimes devices are supported but upstream has not made a new release yet, so this makes it easier for users to add their device quickly.

Added services.ratbagd.verbose to set log level.

Added stdbuf -oL to ExecStart as a workaround for ratbagd not line-buffering stdout.

Updated libratbag and Piper to support more devices.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
