### PR TITLE
oyui: init at 0.2.1

### DIFF
--- a/pkgs/by-name/oy/oyui/package.nix
+++ b/pkgs/by-name/oy/oyui/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "oyui";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "emilien-jegou";
+    repo = "oyui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Z69mBOZFHqslZLC2WutvkhcydxAmO9pppapJSTeHtiA=";
+  };
+
+  cargoHash = "sha256-3XzTbrEDFzCf2rsvJu/foiDYEoO4lLMsr+4t9nDYv34=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Modern TUI merge tool and interactive diff editor for Jujutsu (jj) and Git";
+    homepage = "https://github.com/emilien-jegou/oyui";
+    changelog = "https://github.com/emilien-jegou/oyui/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      adda
+    ];
+    mainProgram = "oyui";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Introduces `oyui`, a "modern TUI merge tool and interactive diff editor for Jujutsu (jj) and Git".

https://github.com/emilien-jegou/oyui

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
