### PR TITLE
roadrunner: fix ldflags; 2025.1.6 -> 2025.1.14

### DIFF
--- a/pkgs/by-name/ro/roadrunner/package.nix
+++ b/pkgs/by-name/ro/roadrunner/package.nix
@@ -9,18 +9,19 @@
 
 buildGoModule (finalAttrs: {
   pname = "roadrunner";
-  version = "2025.1.6";
+  version = "2025.1.14";
 
   src = fetchFromGitHub {
-    repo = "roadrunner";
     owner = "roadrunner-server";
+    repo = "roadrunner";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qoPQxJbZ1BH9Gy06qmp9LGWF6YPJL0gRZX3+S5ej6XY=";
+    hash = "sha256-0Mfu/De28tWCygJ5/QJnOzxk88aajx4Oq/Xm0TOXR0M=";
   };
 
-  nativeBuildInputs = [
-    installShellFiles
-  ];
+  vendorHash = "sha256-KuATz7rVsDuGiyILvILaEpznI63sCHx0G+9D2vR+dx0=";
+  env.GOWORK = "off";
+
+  subPackages = [ "cmd/rr" ];
 
   # Flags as provided by the build automation of the project:
   # https://github.com/roadrunner-server/roadrunner/blob/3853ad693522e82d53d62950e5f1315402c910f2/.github/workflows/release.yml#L82
@@ -28,6 +29,10 @@ buildGoModule (finalAttrs: {
     "-s"
     "-X=github.com/roadrunner-server/roadrunner/v${lib.versions.major finalAttrs.version}/internal/meta.version=${finalAttrs.version}"
     "-X=github.com/roadrunner-server/roadrunner/v${lib.versions.major finalAttrs.version}/internal/meta.buildTime=1970-01-01T00:00:00Z"
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
   ];
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
@@ -49,8 +54,6 @@ buildGoModule (finalAttrs: {
   '';
 
   __darwinAllowLocalNetworking = true;
-
-  vendorHash = "sha256-LSeQACVgBywJqHfRE2q6HxL1ADKZtrJP83U3Zd1oIDw=";
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];

--- a/pkgs/by-name/ro/roadrunner/package.nix
+++ b/pkgs/by-name/ro/roadrunner/package.nix
@@ -42,17 +42,6 @@ buildGoModule (finalAttrs: {
       --fish <($out/bin/rr completion fish)
   '';
 
-  postPatch = ''
-    substituteInPlace internal/rpc/client_test.go \
-      --replace "127.0.0.1:55555" "127.0.0.1:55554"
-
-    substituteInPlace internal/rpc/test/config_rpc_ok.yaml \
-      --replace "127.0.0.1:55555" "127.0.0.1:55554"
-
-    substituteInPlace internal/rpc/test/config_rpc_conn_err.yaml \
-      --replace "127.0.0.1:0" "127.0.0.1:55554"
-  '';
-
   __darwinAllowLocalNetworking = true;
 
   doInstallCheck = true;

--- a/pkgs/by-name/ro/roadrunner/package.nix
+++ b/pkgs/by-name/ro/roadrunner/package.nix
@@ -4,6 +4,7 @@
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -22,11 +23,11 @@ buildGoModule (finalAttrs: {
   ];
 
   # Flags as provided by the build automation of the project:
-  # https://github.com/roadrunner-server/roadrunner/blob/fe572d0eceae8fd05225fbd99ba50a9eb10c4393/.github/workflows/release.yml#L89
+  # https://github.com/roadrunner-server/roadrunner/blob/3853ad693522e82d53d62950e5f1315402c910f2/.github/workflows/release.yml#L82
   ldflags = [
     "-s"
-    "-X=github.com/roadrunner-server/roadrunner/v2023/internal/meta.version=${finalAttrs.version}"
-    "-X=github.com/roadrunner-server/roadrunner/v2023/internal/meta.buildTime=1970-01-01T00:00:00Z"
+    "-X=github.com/roadrunner-server/roadrunner/v${lib.versions.major finalAttrs.version}/internal/meta.version=${finalAttrs.version}"
+    "-X=github.com/roadrunner-server/roadrunner/v${lib.versions.major finalAttrs.version}/internal/meta.buildTime=1970-01-01T00:00:00Z"
   ];
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
@@ -50,6 +51,9 @@ buildGoModule (finalAttrs: {
   __darwinAllowLocalNetworking = true;
 
   vendorHash = "sha256-LSeQACVgBywJqHfRE2q6HxL1ADKZtrJP83U3Zd1oIDw=";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = {
     changelog = "https://github.com/roadrunner-server/roadrunner/blob/v${finalAttrs.version}/CHANGELOG.md";

--- a/pkgs/by-name/ro/roadrunner/package.nix
+++ b/pkgs/by-name/ro/roadrunner/package.nix
@@ -53,6 +53,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://roadrunner.dev";
     license = lib.licenses.mit;
     mainProgram = "rr";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ moraxyc ];
   };
 })


### PR DESCRIPTION
https://github.com/roadrunner-server/roadrunner/releases/tag/v2025.1.15 requires 1.26.4 go, https://github.com/NixOS/nixpkgs/pull/527289

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
