### PR TITLE
nixos/fprintd: Add separate enablePam option to fprintd service 

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -375,12 +375,18 @@ let
         };
 
         fprintAuth = lib.mkOption {
-          default = config.services.fprintd.enable;
-          defaultText = lib.literalExpression "config.services.fprintd.enable";
+          default = config.services.fprintd.enablePam;
+          defaultText = lib.literalExpression "config.services.fprintd.enablePam";
           type = lib.types.bool;
           description = ''
             If set, fingerprint reader will be used (if exists and
             your fingerprints are enrolled).
+
+            ::: {.note}
+            This setting should only be enabled for clients that can ensure
+            user attention, such as lockscreens.
+            See https://github.com/NixOS/nixpkgs/issues/442117
+            :::
           '';
         };
 

--- a/nixos/modules/services/security/fprintd.nix
+++ b/nixos/modules/services/security/fprintd.nix
@@ -21,6 +21,23 @@ in
 
       enable = lib.mkEnableOption "fprintd daemon and PAM module for fingerprint readers handling";
 
+      enablePam = lib.mkOption {
+        type = lib.types.bool;
+        default = cfg.enable;
+        defaultText = lib.literalExpression "config.services.fprintd.enable";
+        description = ''
+          When enabled, PAM services will be configured to use fprintd for authorization.
+
+          :::{.note}
+          Enabling this option will add fingerprint-based authorization to all
+          PAM services, including those which can authorize users in the background.
+          If this is undesired, you can override this setting on a per-service
+          basis through `config.security.pam.services.<name>.fprintAuth`.
+          See https://github.com/NixOS/nixpkgs/issues/442117
+          :::
+        '';
+      };
+
       package = lib.mkOption {
         type = lib.types.package;
         default = fprintdPkg;
@@ -48,6 +65,13 @@ in
   ###### implementation
 
   config = lib.mkIf cfg.enable {
+
+    assertions = [
+      {
+        assertion = cfg.enablePam -> cfg.enable;
+        message = "fprintd.enablePam depends on fprintd.enable";
+      }
+    ];
 
     services.dbus.packages = [ cfg.package ];
 


### PR DESCRIPTION
Because fprintd does not have a mechanism to ensure user attention, using it to authenticate to programs such as sudo or su is not secure.
This was assigned [CVE-2024-37408](https://nvd.nist.gov/vuln/detail/cve-2024-37408).
A comment was added to the PAM fprintAuth option to make this clear.

This commit also adds the setting `services.fprintd.enablePam`,
which is now used to control the use of the fprintd PAM authorization.

See #442117 for more details, discussion can continue there for better mitigation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [X] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
