### PR TITLE
ncro: init at 2.2.2; init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1309,6 +1309,7 @@
   ./services/networking/nbd.nix
   ./services/networking/ncdns.nix
   ./services/networking/ncps.nix
+  ./services/networking/ncro.nix
   ./services/networking/ndppd.nix
   ./services/networking/nebula-lighthouse-service.nix
   ./services/networking/nebula.nix

--- a/nixos/modules/services/networking/ncro.nix
+++ b/nixos/modules/services/networking/ncro.nix
@@ -1,0 +1,166 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  tomlFormat = pkgs.formats.toml { };
+  tomlType = tomlFormat.type;
+
+  cfg = config.services.ncro;
+  configFile = tomlFormat.generate "ncro.toml" cfg.settings;
+
+  # Normalize a ncro listen address (`:port` shorthand) to the
+  # `host:port` format expected by systemd's ListenStream.
+  toListenStream =
+    addr:
+    let
+      raw = if addr == "" then ":8080" else addr;
+    in
+    if lib.hasPrefix ":" raw then "0.0.0.0${raw}" else raw;
+
+  fallbackPublicKeys = lib.optional (cfg.settings.fallback_cache.enabled or false) (
+    cfg.settings.fallback_cache.public_key
+      or "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+  );
+
+  upstreamPublicKeys = lib.pipe ((cfg.settings.upstreams or [ ]) ++ fallbackPublicKeys) [
+    (map (upstream: if builtins.isAttrs upstream then upstream.public_key or "" else upstream))
+    (builtins.filter (key: key != ""))
+    lib.unique
+  ];
+in
+{
+  meta.maintainers = with lib.maintainers; [
+    amaanq
+    atagen
+    faukah
+    max
+    NotAShelf
+  ];
+
+  options.services.ncro = {
+    enable = lib.mkEnableOption "ncro, the Nix cache route optimizer";
+
+    addUpstreamPublicKeys = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Append non-empty upstream public_key values from {option}`services.ncro.settings`
+        to {option}`nix.settings.trusted-public-keys`.
+
+        This keeps Nix client signature validation aligned with the upstream
+        caches that ncro is allowed to route to. Disable this if you manage Nix
+        trusted public keys separately.
+      '';
+    };
+
+    socketActivation = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Enable systemd socket activation for ncro. When enabled, systemd
+        creates and holds the listening TCP socket, starting ncro on the first
+        incoming connection.
+
+        ncro signals readiness via {manpage}`sd_notify(3)`, so downstream units
+        that declare `After = ncro.service` will not start until ncro is actually
+        accepting connections.
+
+        A {manpage}`systemd.socket(5)` unit `ncro.socket` is created automatically.
+        The listen address is taken from {option}`services.ncro.settings.server.listen`
+        if set, defaulting to `:8080`.
+      '';
+    };
+
+    package = lib.mkPackageOption pkgs "nh" { };
+
+    settings = lib.mkOption {
+      type = tomlType;
+      default = { };
+      description = ''
+        ncro configuration as an attribute set.
+
+        Keys and structure match the TOML config file format; all defaults are
+        handled by the ncro binary.
+      '';
+      example = {
+        logging.level = "info";
+        server = {
+          listen = ":8080";
+          cache_priority = 20;
+        };
+
+        upstreams = [
+          {
+            url = "https://cache.nixos.org";
+            priority = 10;
+          }
+          {
+            url = "https://nix-community.cachix.org";
+            priority = 20;
+          }
+        ];
+
+        cache = {
+          ttl = "2h";
+          negative_ttl = "15m";
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    nix.settings.trusted-public-keys = lib.mkIf cfg.addUpstreamPublicKeys (
+      lib.mkAfter upstreamPublicKeys
+    );
+
+    systemd.sockets.ncro = lib.mkIf cfg.socketActivation {
+      wantedBy = [ "sockets.target" ];
+      socketConfig.ListenStream = toListenStream (cfg.settings.server.listen or "");
+    };
+
+    systemd.services.ncro = {
+      description = "Nix Cache Route Optimizer";
+      wantedBy = [ "multi-user.target" ];
+      after = if cfg.socketActivation then [ "ncro.socket" ] else [ "network.target" ];
+      requires = lib.optionals cfg.socketActivation [ "ncro.socket" ];
+      serviceConfig = {
+        ExecStart = "${lib.getExe' cfg.package "ncro"} --config ${configFile}";
+        DynamicUser = true;
+        StateDirectory = "ncro";
+        Restart = "on-failure";
+        RestartSec = "5s";
+
+        # Hardening
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ProtectProc = "invisible";
+        ProtectHostname = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectKernelLogs = true;
+        ProtectKernelTunables = true;
+        RestrictRealtime = true;
+        CapabilityBoundingSet = "";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_NETLINK" # required by mdns-sd and system resolver
+        ]
+        # sd_notify uses a Unix datagram socket to signal readiness.
+        ++ lib.optional cfg.socketActivation "AF_UNIX";
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        SystemCallFilter = [ "@system-service" ];
+        SystemCallArchitectures = "native";
+      }
+      // lib.optionalAttrs cfg.socketActivation { Type = "notify"; };
+    };
+  };
+}

--- a/pkgs/by-name/nc/ncro/package.nix
+++ b/pkgs/by-name/nc/ncro/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  cacert,
+  wild ? null,
+  clang,
+  nix-update-script,
+  versionCheckHook,
+}:
+let
+  hasWild =
+    stdenv.hostPlatform.isLinux && (stdenv.hostPlatform.isx86_64 || stdenv.hostPlatform.isAarch64);
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ncro";
+  version = "2.2.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "manic-systems";
+    repo = "ncro";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-attdCg/FjUooYxVidEDR5wVeQ8aAPAj4b6HQVL17Tng=";
+  };
+
+  cargoHash = "sha256-woqDFlQ8r/8KMVLW6K8ucrMPBNZklqmiaaAevQnzbPk=";
+
+  useNextest = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    cacert
+  ]
+  ++ (lib.optionals hasWild [
+    wild
+    clang
+  ]);
+
+  buildInputs = [
+    openssl.dev
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  env = {
+    # reqwest (rustls) needs a CA bundle to construct a TLS client, even in
+    # tests that never make network requests.
+    SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+
+    # Link nixpkgs c libs, no vendored copies.
+    OPENSSL_NO_VENDOR = 1;
+  }
+  // lib.optionalAttrs hasWild {
+    RUSTFLAGS = "-Clinker=${clang}/bin/clang -Clink-arg=--ld-path=wild";
+  };
+
+  meta = {
+    homepage = "https://github.com/manic-systems/ncro";
+    description = "Lightweight HTTP proxy, optimized for Nix binary cache routing";
+    changelog = "https://github.com/manic-systems/ncro/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.eupl12;
+    maintainers = with lib.maintainers; [
+      amaanq
+      atagen
+      faukah
+      max
+      NotAShelf
+    ];
+    mainProgram = "ncro";
+  };
+})


### PR DESCRIPTION
cc @max-privatevoid @NotAShelf @amaanq @atagen.

Adds the [ncro](https://github.com/manic-systems/ncro) package + a module for it. 
Most of the code was taken verbatim from ncro's [module](https://github.com/manic-systems/ncro/blob/main/nix/module.nix) and [package](https://github.com/manic-systems/ncro/blob/main/nix/package.nix) definitions. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
