### PR TITLE
klipper-firmware: build bossac flash binary conditionally

### DIFF
--- a/pkgs/servers/klipper/klipper-firmware.nix
+++ b/pkgs/servers/klipper/klipper-firmware.nix
@@ -20,11 +20,16 @@ args@{
 # are used by flash scripts
 # find those with `rg '\[\"lib'` inside of klipper repo
 let
+  needsBossac =
+    let
+      lines = lib.strings.splitString "\n" (builtins.readFile firmwareConfig);
+    in
+    builtins.any (line: builtins.match "[^#\r\n]*CONFIG_MACH_ATSAMD?=y.*" line != null) lines;
   flashBinaries = [
-    "lib/bossac/bin/bossac"
     "lib/hidflash/hid-flash"
     "lib/rp2040_flash/rp2040_flash"
-  ];
+  ]
+  ++ lib.optional needsBossac "lib/bossac/bin/bossac";
 in
 stdenv.mkDerivation {
   pname = "klipper-firmware-${mcu}";
@@ -41,8 +46,8 @@ stdenv.mkDerivation {
     avrdude
     stm32flash
     pkg-config
-    wxwidgets_3_2 # Required for bossac
-  ];
+  ]
+  ++ lib.optional needsBossac wxwidgets_3_2;
 
   configurePhase = ''
     cp ${firmwareConfig} ./.config


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`klipper-firmware` requires `wxwidgets_3_2` as a dependency (which is pretty heavy), but this is only actually required when building firmware for ATSAM/ATSAMD mcus. This conditionally includes `wxwidgets_3_2`, only when the `firmwareConfig` specifies one of those mcus.

(I only noticed this because I enabled the Raspberry Pi optimized packages from [`nixos-raspberry`](github.com/nvmd/nixos-raspberrypi), which caused a non-cached rebuild of `wxwidgets_3_2`, which made me wonder why (tf) this is even a dependency in the first place.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
