### PR TITLE
glitchtip: add missing dependency; python314Packages.django-async-backend: init at 6.0.7

### DIFF
--- a/pkgs/by-name/gl/glitchtip/package.nix
+++ b/pkgs/by-name/gl/glitchtip/package.nix
@@ -29,6 +29,7 @@ let
       django
       django-allauth
       django-anymail
+      django-async-backend
       django-cors-headers
       django-environ
       django-extensions

--- a/pkgs/development/python-modules/django-async-backend/default.nix
+++ b/pkgs/development/python-modules/django-async-backend/default.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  buildPythonPackage,
+  django,
+  fetchFromGitHub,
+  poetry-core,
+  postgresql,
+  postgresqlTestHook,
+  psycopg,
+  psycopg-pool,
+  pytest-django,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "django-async-backend";
+  version = "6.0.7";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Arfey";
+    repo = "django-async-backend";
+    tag = "v${version}";
+    hash = "sha256-4zaXPfHIE9RwkSbHPt1DHFInn8LP+JXiBiMJYkZeR6M=";
+  };
+
+  postPatch = ''
+    substituteInPlace tests/settings.py \
+      --replace-fail '"HOST": "localhost"' '"HOST": "/build/run/postgresql"'
+
+    substituteInPlace tests/db/backends/postgresql/test_async_backend.py \
+      --replace-fail "new_connection.get_database_version())[0], 15" "new_connection.get_database_version())[0], ${lib.versions.major postgresql.version}"
+  '';
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    django
+    psycopg
+  ];
+
+  pythonImportsCheck = [ "django_async_backend" ];
+
+  env = {
+    DJANGO_SETTINGS_MODULE = "settings";
+    PGDATABASE = "postgres";
+    PGUSER = "postgres";
+  };
+
+  preCheck = ''
+    export PYTHONPATH=$PYTHONPATH:$PWD/tests
+  '';
+
+  nativeCheckInputs = [
+    django # must come first as vtasks only works with django 6
+
+    postgresql
+    postgresqlTestHook
+    psycopg-pool
+    pytest-django
+    pytestCheckHook
+  ];
+
+  pytestFlags = [ "./tests" ];
+
+  meta = {
+    description = "Django extension providing async capabilities for database and other components";
+    homepage = "https://github.com/Arfey/django-async-backend";
+    changelog = "https://github.com/Arfey/django-async-backend/releases/tag/${src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+    broken = lib.versionOlder (lib.versions.major django.version) "6";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4138,6 +4138,8 @@ self: super: with self; {
 
   django-apscheduler = callPackage ../development/python-modules/django-apscheduler { };
 
+  django-async-backend = callPackage ../development/python-modules/django-async-backend { };
+
   django-auditlog = callPackage ../development/python-modules/django-auditlog { };
 
   django-auth-ldap = callPackage ../development/python-modules/django-auth-ldap {


### PR DESCRIPTION
Required since https://gitlab.com/glitchtip/glitchtip-backend/-/merge_requests/2343 which is contained in 6.1.7 I did not see any errors related to that, might be that it is just indirectly drawn in somewhere.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
