### PR TITLE
jenv: init at 0.6.0-unstable-2026-02-22

### DIFF
--- a/pkgs/by-name/je/jenv/package.nix
+++ b/pkgs/by-name/je/jenv/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  installShellFiles,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "jenv";
+  version = "0.6.0-unstable-2026-02-22";
+
+  src = fetchFromGitHub {
+    owner = "jenv";
+    repo = "jenv";
+    rev = "a771525269be4637e5b29d6adbba28be93953c02";
+    hash = "sha256-Mpe9r6yK39I8tKDSA8EI78/NCYd6xM3+aCgDkTlQISk=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  dontBuild = true;
+
+  postPatch = ''
+    patchShebangs bin libexec
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -d $out
+    cp -r bin libexec available-plugins fish $out/
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    installShellCompletion  \
+      --bash completions/jenv.bash  \
+      --fish completions/jenv.fish  \
+      --zsh completions/jenv.zsh
+  '';
+
+  meta = {
+    description = "Java environment manager";
+    homepage = "https://github.com/jenv/jenv";
+    mainProgram = "jenv";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ castorNova2 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds [jenv](https://github.com/jenv/jenv) which is a Java environment manager inspired by rbenv

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
