### PR TITLE
python3Packages.ament-package: 8 -> 0.19.0

### DIFF
--- a/pkgs/development/python-modules/ament-package/default.nix
+++ b/pkgs/development/python-modules/ament-package/default.nix
@@ -3,29 +3,22 @@
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
-  importlib-metadata,
-  importlib-resources,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "ament-package";
-  version = "8";
+  version = "0.19.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ament";
     repo = "ament_package";
-    tag = "release-alpha${version}";
-    hash = "sha256-KaP75+95mRmSO0bRDy0LVG+kx1Z4YDn5edsvKq+UXeE=";
+    tag = finalAttrs.version;
+    hash = "sha256-4NLrRcBM82Bu8hDufma3z5li/kJQCyJEJma0UBBBvKw=";
   };
 
   build-system = [
     setuptools
-  ];
-
-  dependencies = [
-    importlib-metadata
-    importlib-resources
   ];
 
   pythonImportsCheck = [ "ament_package" ];
@@ -33,10 +26,14 @@ buildPythonPackage rec {
   # Tests currently broken
   doCheck = false;
 
+  # The script selects tag release-alpha8
+  passthru.skipBulkUpdate = true;
+
   meta = {
+    changelog = "https://github.com/ament/ament_package/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
     description = "Parser for the manifest files in the ament buildsystem";
     homepage = "https://github.com/ament/ament_package";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ guelakais ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/ament/ament_package/compare/release-alpha8...0.19.0

Changelog: https://github.com/ament/ament_package/blob/0.19.0/CHANGELOG.rst


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
