### PR TITLE
microcad: init at version 0.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9324,6 +9324,12 @@
     github = "frectonz";
     githubId = 53809656;
   };
+  fred441a = {
+    email = "frederik@altofte.dk";
+    github = "fred441a";
+    githubId = 10808098;
+    name = "Frederik Hansen";
+  };
   fredeb = {
     email = "frederikbraendstrup@gmail.com";
     github = "FredeHoey";

--- a/pkgs/by-name/mi/microcad/package.nix
+++ b/pkgs/by-name/mi/microcad/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  fetchFromCodeberg,
+  rustPlatform,
+  pkg-config,
+  wayland,
+  cmake,
+  ninja,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "microcad";
+  version = "0.5.0";
+  __structuredAttrs = true;
+
+  src = fetchFromCodeberg {
+    owner = "microcad";
+    repo = "microcad";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2164ynL01cLv5/D1FkcZpuBXTHPMjbpeaPPEZpmrSso=";
+  };
+
+  cargoHash = "sha256-OwPAl8LirPQEQ8ytx/+9OnrdbUagLA25mGMw1z/L6V0=";
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+  ];
+  buildInputs = [ wayland ];
+  cargoBuildFlags = [
+    "-p"
+    "microcad-viewer"
+    "-p"
+    "microcad"
+    "-p"
+    "microcad-lsp"
+  ];
+
+  dontUseCmakeConfigure = true;
+  dontUseNinjaBuild = true;
+  dontUseNinjaInstall = true;
+  dontUseNinjaCheck = true;
+
+  meta = {
+    description = "Description language for modeling parameterizable geometric objects";
+    homepage = "https://microcad.xyz";
+    license = lib.licenses.agpl3Plus;
+    mainProgram = "microcad";
+    donationPage = "https://opencollective.com/microcad/donate";
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ fred441a ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added nixpkgs instructions for microcad, an opensource object description language. This build also includes microcad-viewer and microcad-lsp

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
