### PR TITLE
libmodsecurity: migrate to pcre2

### DIFF
--- a/pkgs/by-name/li/libmodsecurity/package.nix
+++ b/pkgs/by-name/li/libmodsecurity/package.nix
@@ -12,7 +12,6 @@
   libxml2,
   lmdb,
   lua,
-  pcre,
   pcre2,
   ssdeep,
   yajl,
@@ -37,6 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     flex
     pkg-config
   ];
+
   buildInputs = [
     curl
     geoip
@@ -44,7 +44,6 @@ stdenv.mkDerivation (finalAttrs: {
     libxml2
     lmdb
     lua
-    pcre
     pcre2
     ssdeep
     yajl
@@ -58,34 +57,15 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags = [
     "--enable-parser-generation"
     "--disable-doxygen-doc"
-    "--with-curl=${curl.dev}"
-    "--with-libxml=${libxml2.dev}"
-    "--with-lmdb=${lmdb.out}"
-    "--with-maxmind=${libmaxminddb}"
-    "--with-pcre=${pcre.dev}"
-    "--with-pcre2=${pcre2.out}"
+    "--disable-examples"
+    "--with-lmdb=${lmdb}"
     "--with-ssdeep=${ssdeep}"
   ];
 
   postPatch = ''
-    substituteInPlace build/lmdb.m4 \
-      --replace "\''${path}/include/lmdb.h" "${lmdb.dev}/include/lmdb.h" \
-      --replace "lmdb_inc_path=\"\''${path}/include\"" "lmdb_inc_path=\"${lmdb.dev}/include\""
-    substituteInPlace build/pcre2.m4 \
-      --replace "/usr/local/pcre2" "${pcre2.out}/lib" \
-      --replace "\''${path}/include/pcre2.h" "${pcre2.dev}/include/pcre2.h" \
-      --replace "pcre2_inc_path=\"\''${path}/include\"" "pcre2_inc_path=\"${pcre2.dev}/include\""
-    substituteInPlace build/ssdeep.m4 \
-      --replace "/usr/local/libfuzzy" "${ssdeep}/lib" \
-      --replace "\''${path}/include/fuzzy.h" "${ssdeep}/include/fuzzy.h" \
-      --replace "ssdeep_inc_path=\"\''${path}/include\"" "ssdeep_inc_path=\"${ssdeep}/include\""
-    substituteInPlace modsecurity.conf-recommended \
-      --replace "SecUnicodeMapFile unicode.mapping 20127" "SecUnicodeMapFile $out/share/modsecurity/unicode.mapping 20127"
-
     # https://github.com/owasp-modsecurity/ModSecurity/blob/v3.0.15/build.sh#L6-L25
-    cd src
-    echo "noinst_HEADERS = \\" > headers.mk
-    ls -1 \
+    echo "noinst_HEADERS = \\" > ./src/headers.mk
+    ls -1 ./src/ \
         actions/*.h \
         actions/ctl/*.h \
         actions/data/*.h \
@@ -100,8 +80,10 @@ stdenv.mkDerivation (finalAttrs: {
         utils/*.h \
         variables/*.h \
         engine/*.h \
-        *.h | tr "\012" " " >> headers.mk
-    cd ../
+        *.h | tr "\012" " " >> ./src/headers.mk
+
+    substituteInPlace modsecurity.conf-recommended \
+      --replace-fail "SecUnicodeMapFile unicode.mapping 20127" "SecUnicodeMapFile $out/share/modsecurity/unicode.mapping 20127"
   '';
 
   postInstall = ''


### PR DESCRIPTION
Migrate to pcre2 - https://github.com/NixOS/nixpkgs/issues/356387.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
