### PR TITLE
mendingwall: init at 0.3.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13572,6 +13572,11 @@
     githubId = 4611077;
     name = "Raymond Gauthier";
   };
+  jromer = {
+    github = "jelleromer";
+    githubId = 11951893;
+    name = "Jelle Römer";
+  };
   jrpotter = {
     email = "jrpotter2112@gmail.com";
     github = "jrpotter";

--- a/pkgs/by-name/me/mendingwall/package.nix
+++ b/pkgs/by-name/me/mendingwall/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  wrapGAppsHook4,
+  meson,
+  blueprint-compiler,
+  glib,
+  gtk4,
+  libadwaita,
+  gettext,
+  appstream,
+  desktop-file-utils,
+  pkg-config,
+  ninja,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mendingwall";
+  version = "0.3.8";
+
+  src = fetchFromGitHub {
+    owner = "lawmurray";
+    repo = "mendingwall";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-bt2DvbtwUaad5j2XpySA4KBfI4953tc1bHRuUUkS84M=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    meson
+    blueprint-compiler
+    gettext
+    appstream
+    desktop-file-utils
+    pkg-config
+    ninja
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    glib
+    gtk4
+    libadwaita
+  ];
+
+  meta = with lib; {
+    description = "Fix theme and menu inconsistencies when using multiple desktop environments";
+    homepage = "https://mendingwall.indii.org/";
+    changelog = "https://github.com/lawmurray/mendingwall/releases/tag/v${finalAttrs.version}";
+    license = licenses.gpl3Plus;
+    maintainers = [ maintainers.jromer ];
+    platforms = platforms.linux;
+    mainProgram = "mendingwall";
+  };
+})


### PR DESCRIPTION
> Linux distributions offer a choice of desktop environment, but installing more than one can break themes and clutter menus. Mending Wall fixes this, so you can enjoy them all.

This program seems like a perfect fit for NixOS.

[The readme advises to run this command:](https://github.com/lawmurray/mendingwall#installation)

`gdbus call --session --dest org.freedesktop.DBus --object-path /org/freedesktop/DBus --method org.freedesktop.DBus.ReloadConfig`

> The last line just ensures that newly-installed .service files in $HOME/.local/share/dbus-1/services/ are found by D-Bus, in case that directory did not exist already. If you try to launch Mending Wall from an application menu and nothing happens, running that line should fix it, and it does not hurt to run it anyway.

I don't think it's necessary on NixOS, launching from the application menu worked immediately after install.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
