### PR TITLE
qt6/kde: use scopes properly

### DIFF
--- a/pkgs/kde/default.nix
+++ b/pkgs/kde/default.nix
@@ -1,105 +1,98 @@
 {
   lib,
-  generateSplicesForMkScope,
-  makeScopeWithSplicing',
   fetchurl,
   qt6Packages,
   cmark,
-  gpgme,
   taglib,
   wayland-protocols,
   wayland,
   zxing-cpp,
 }:
+
 let
-  allPackages =
-    self:
-    let
-      frameworks = import ./frameworks { inherit (self) callPackage; };
-      gear = import ./gear { inherit (self) callPackage; };
-      plasma = import ./plasma { inherit (self) callPackage; };
+  sets = [
+    "gear"
+    "frameworks"
+    "plasma"
+  ];
 
-      sets = [
-        "gear"
-        "frameworks"
-        "plasma"
-      ];
+  frameworks = import ./frameworks;
+  gear = import ./gear;
+  plasma = import ./plasma;
 
-      loadUrls = set: lib.importJSON (./generated/sources + "/${set}.json");
-      allUrls = lib.attrsets.mergeAttrsList (map loadUrls sets);
+  loadUrls = set: lib.importJSON (./generated/sources + "/${set}.json");
+  allUrls = lib.attrsets.mergeAttrsList (map loadUrls sets);
 
-      sources = lib.mapAttrs (
-        _: v:
-        (fetchurl {
-          inherit (v) url hash;
-        })
-        // {
-          inherit (v) version;
-        }
-      ) allUrls;
-    in
-    (
-      qt6Packages
-      // frameworks
-      // gear
-      // plasma
+  allPackages = final: prev: {
+    sources = lib.mapAttrs (
+      _: v:
+      (fetchurl {
+        inherit (v) url hash;
+      })
       // {
-        # Aliases to simplify test-building entire package sets
-        inherit
-          sources
-          frameworks
-          gear
-          plasma
-          ;
-
-        mkKdeDerivation = self.callPackage (import ./lib/mk-kde-derivation.nix self) { };
-
-        # THIRD PARTY
-        inherit
-          cmark
-          taglib
-          wayland
-          wayland-protocols
-          zxing-cpp
-          ;
-
-        # Alias to match metadata
-        kquickimageeditor = self.kquickimageedit;
-
-        selenium-webdriver-at-spi = null; # Used for integration tests that we don't run, stub
-
-        alpaka = self.callPackage ./misc/alpaka { };
-        glaxnimate = self.callPackage ./misc/glaxnimate { };
-        kdiagram = self.callPackage ./misc/kdiagram { };
-        kdevelop-pg-qt = self.callPackage ./misc/kdevelop-pg-qt { };
-        kdsoap-ws-discovery-client = self.callPackage ./misc/kdsoap-ws-discovery-client { };
-        kirigami-addons = self.callPackage ./misc/kirigami-addons { };
-        kio-extras-kf5 = self.callPackage ./misc/kio-extras-kf5 { };
-        kio-fuse = self.callPackage ./misc/kio-fuse { };
-        klevernotes = self.callPackage ./misc/klevernotes { };
-        ktextaddons = self.callPackage ./misc/ktextaddons { };
-        kup = self.callPackage ./misc/kup { };
-        marknote = self.callPackage ./misc/marknote { };
-        mpvqt = self.callPackage ./misc/mpvqt { };
-        oxygen-icons = self.callPackage ./misc/oxygen-icons { };
-        phonon = self.callPackage ./misc/phonon { };
-        phonon-vlc = self.callPackage ./misc/phonon-vlc { };
-        plasma-pass = self.callPackage ./misc/plasma-pass { };
-        plasma-wayland-protocols = self.callPackage ./misc/plasma-wayland-protocols { };
-        polkit-qt-1 = self.callPackage ./misc/polkit-qt-1 { };
-        pulseaudio-qt = self.callPackage ./misc/pulseaudio-qt { };
-
-        applet-window-buttons6 = self.callPackage ./third-party/applet-window-buttons6 { };
-        dynamic-workspaces = self.callPackage ./third-party/dynamic-workspaces { };
-        karousel = self.callPackage ./third-party/karousel { };
-        koi = self.callPackage ./third-party/koi { };
-        krohnkite = self.callPackage ./third-party/krohnkite { };
-        kzones = self.callPackage ./third-party/kzones { };
-        wallpaper-engine-plugin = self.callPackage ./third-party/wallpaper-engine-plugin { };
+        inherit (v) version;
       }
-    );
+    ) allUrls;
+
+    # Aliases to simplify test-building entire package sets
+    inherit (final)
+      frameworks
+      gear
+      plasma
+      ;
+
+    mkKdeDerivation = final.callPackage (import ./lib/mk-kde-derivation.nix final) { };
+
+    # THIRD PARTY
+    inherit
+      cmark
+      taglib
+      wayland
+      wayland-protocols
+      zxing-cpp
+      ;
+
+    # Alias to match metadata
+    kquickimageeditor = final.kquickimageedit;
+
+    selenium-webdriver-at-spi = null; # Used for integration tests that we don't run, stub
+
+    alpaka = final.callPackage ./misc/alpaka { };
+    glaxnimate = final.callPackage ./misc/glaxnimate { };
+    kdiagram = final.callPackage ./misc/kdiagram { };
+    kdevelop-pg-qt = final.callPackage ./misc/kdevelop-pg-qt { };
+    kdsoap-ws-discovery-client = final.callPackage ./misc/kdsoap-ws-discovery-client { };
+    kirigami-addons = final.callPackage ./misc/kirigami-addons { };
+    kio-extras-kf5 = final.callPackage ./misc/kio-extras-kf5 { };
+    kio-fuse = final.callPackage ./misc/kio-fuse { };
+    klevernotes = final.callPackage ./misc/klevernotes { };
+    ktextaddons = final.callPackage ./misc/ktextaddons { };
+    kup = final.callPackage ./misc/kup { };
+    marknote = final.callPackage ./misc/marknote { };
+    mpvqt = final.callPackage ./misc/mpvqt { };
+    oxygen-icons = final.callPackage ./misc/oxygen-icons { };
+    phonon = final.callPackage ./misc/phonon { };
+    phonon-vlc = final.callPackage ./misc/phonon-vlc { };
+    plasma-pass = final.callPackage ./misc/plasma-pass { };
+    plasma-wayland-protocols = final.callPackage ./misc/plasma-wayland-protocols { };
+    polkit-qt-1 = final.callPackage ./misc/polkit-qt-1 { };
+    pulseaudio-qt = final.callPackage ./misc/pulseaudio-qt { };
+
+    applet-window-buttons6 = final.callPackage ./third-party/applet-window-buttons6 { };
+    dynamic-workspaces = final.callPackage ./third-party/dynamic-workspaces { };
+    karousel = final.callPackage ./third-party/karousel { };
+    koi = final.callPackage ./third-party/koi { };
+    krohnkite = final.callPackage ./third-party/krohnkite { };
+    kzones = final.callPackage ./third-party/kzones { };
+    wallpaper-engine-plugin = final.callPackage ./third-party/wallpaper-engine-plugin { };
+  };
 in
-makeScopeWithSplicing' {
-  otherSplices = generateSplicesForMkScope "kdePackages";
-  f = allPackages;
-}
+
+qt6Packages.overrideScope (
+  lib.fixedPoints.composeManyExtensions [
+    frameworks
+    gear
+    plasma
+    allPackages
+  ]
+)

--- a/pkgs/kde/frameworks/default.nix
+++ b/pkgs/kde/frameworks/default.nix
@@ -1,4 +1,7 @@
-{ callPackage }:
+final: prev:
+let
+  inherit (final) callPackage;
+in
 {
   attica = callPackage ./attica { };
   baloo = callPackage ./baloo { };

--- a/pkgs/kde/gear/default.nix
+++ b/pkgs/kde/gear/default.nix
@@ -1,4 +1,7 @@
-{ callPackage }:
+final: prev:
+let
+  inherit (final) callPackage;
+in
 {
   accessibility-inspector = callPackage ./accessibility-inspector { };
   akonadi = callPackage ./akonadi { };

--- a/pkgs/kde/plasma/default.nix
+++ b/pkgs/kde/plasma/default.nix
@@ -1,4 +1,7 @@
-{ callPackage }:
+final: prev:
+let
+  inherit (final) callPackage;
+in
 {
   aurorae = callPackage ./aurorae { };
   bluedevil = callPackage ./bluedevil { };

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -8,11 +8,9 @@
   lib,
   config,
   __splicedPackages,
-  makeScopeWithSplicing',
-  generateSplicesForMkScope,
-  stdenv,
   pkgsHostTarget,
-  kdePackages,
+  kdePackages, # TODO why tf. are we using its callPackage here??
+  ... # FIXME
 }:
 
 let
@@ -23,151 +21,139 @@ let
   qt6 = pkgsHostTarget.qt6;
 in
 
-makeScopeWithSplicing' {
-  otherSplices = generateSplicesForMkScope "qt6Packages";
-  f = (
-    self:
-    let
-      inherit (self) callPackage;
-      noExtraAttrs =
-        set:
-        lib.attrsets.removeAttrs set [
-          "extend"
-          "override"
-          "overrideScope"
-          "overrideDerivation"
-        ];
-    in
-    (noExtraAttrs qt6)
-    // {
+qt6.overrideScope (
+  final: prev:
+  let
+    inherit (final) callPackage;
+  in
+  {
 
-      # LIBRARIES
-      accounts-qt = callPackage ../development/libraries/accounts-qt { };
-      appstream-qt = callPackage ../development/libraries/appstream/qt.nix { };
+    # LIBRARIES
+    accounts-qt = callPackage ../development/libraries/accounts-qt { };
+    appstream-qt = callPackage ../development/libraries/appstream/qt.nix { };
 
-      drumstick = callPackage ../development/libraries/drumstick { };
+    drumstick = callPackage ../development/libraries/drumstick { };
 
-      fcitx5-chinese-addons = callPackage ../tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix { };
+    fcitx5-chinese-addons = callPackage ../tools/inputmethods/fcitx5/fcitx5-chinese-addons.nix { };
 
-      fcitx5-configtool = kdePackages.callPackage ../tools/inputmethods/fcitx5/fcitx5-configtool.nix { };
+    fcitx5-configtool = kdePackages.callPackage ../tools/inputmethods/fcitx5/fcitx5-configtool.nix { };
 
-      fcitx5-qt = callPackage ../tools/inputmethods/fcitx5/fcitx5-qt.nix { };
+    fcitx5-qt = callPackage ../tools/inputmethods/fcitx5/fcitx5-qt.nix { };
 
-      fcitx5-skk-qt = callPackage ../tools/inputmethods/fcitx5/fcitx5-skk.nix { enableQt = true; };
+    fcitx5-skk-qt = callPackage ../tools/inputmethods/fcitx5/fcitx5-skk.nix { enableQt = true; };
 
-      fcitx5-unikey = callPackage ../tools/inputmethods/fcitx5/fcitx5-unikey.nix { };
+    fcitx5-unikey = callPackage ../tools/inputmethods/fcitx5/fcitx5-unikey.nix { };
 
-      fcitx5-with-addons = callPackage ../tools/inputmethods/fcitx5/with-addons.nix { };
+    fcitx5-with-addons = callPackage ../tools/inputmethods/fcitx5/with-addons.nix { };
 
-      kdsoap = callPackage ../development/libraries/kdsoap { };
+    kdsoap = callPackage ../development/libraries/kdsoap { };
 
-      kcolorpicker = callPackage ../development/libraries/kcolorpicker { };
-      kimageannotator = callPackage ../development/libraries/kimageannotator { };
+    kcolorpicker = callPackage ../development/libraries/kcolorpicker { };
+    kimageannotator = callPackage ../development/libraries/kimageannotator { };
 
-      futuresql = callPackage ../development/libraries/futuresql { };
-      kquickimageedit = callPackage ../development/libraries/kquickimageedit { };
+    futuresql = callPackage ../development/libraries/futuresql { };
+    kquickimageedit = callPackage ../development/libraries/kquickimageedit { };
 
-      ktactilefeedback = kdePackages.callPackage ../development/libraries/ktactilefeedback { };
+    ktactilefeedback = kdePackages.callPackage ../development/libraries/ktactilefeedback { };
 
-      libiodata = callPackage ../development/libraries/libiodata { };
+    libiodata = callPackage ../development/libraries/libiodata { };
 
-      libqaccessibilityclient = callPackage ../development/libraries/libqaccessibilityclient { };
+    libqaccessibilityclient = callPackage ../development/libraries/libqaccessibilityclient { };
 
-      libqglviewer = callPackage ../development/libraries/libqglviewer { };
+    libqglviewer = callPackage ../development/libraries/libqglviewer { };
 
-      libqtpas = callPackage ../development/compilers/fpc/libqtpas.nix { };
+    libqtpas = callPackage ../development/compilers/fpc/libqtpas.nix { };
 
-      libqtdbusmock = callPackage ../development/libraries/libqtdbusmock {
-        inherit (pkgs.lomiri-qt6) cmake-extras;
-      };
+    libqtdbusmock = callPackage ../development/libraries/libqtdbusmock {
+      inherit (pkgs.lomiri-qt6) cmake-extras;
+    };
 
-      libqtdbustest = callPackage ../development/libraries/libqtdbustest {
-        inherit (pkgs.lomiri-qt6) cmake-extras;
-      };
+    libqtdbustest = callPackage ../development/libraries/libqtdbustest {
+      inherit (pkgs.lomiri-qt6) cmake-extras;
+    };
 
-      libquotient = callPackage ../development/libraries/libquotient { };
-      mlt = pkgs.mlt.override {
-        qt = qt6;
-      };
+    libquotient = callPackage ../development/libraries/libquotient { };
+    mlt = pkgs.mlt.override {
+      qt = qt6;
+    };
 
-      maplibre-native-qt = callPackage ../development/libraries/maplibre-native-qt { };
+    maplibre-native-qt = callPackage ../development/libraries/maplibre-native-qt { };
 
-      pyotherside = callPackage ../development/libraries/pyotherside { };
+    pyotherside = callPackage ../development/libraries/pyotherside { };
 
-      qca = callPackage ../development/libraries/qca {
-        inherit (qt6) qtbase qt5compat;
-      };
-      qcoro = callPackage ../development/libraries/qcoro { };
-      qcustomplot = callPackage ../development/libraries/qcustomplot { };
-      qgpgme = callPackage ../development/libraries/qgpgme { };
-      qhotkey = callPackage ../development/libraries/qhotkey { };
-      qmlbox2d = callPackage ../development/libraries/qmlbox2d { };
-      packagekit-qt = callPackage ../tools/package-management/packagekit/qt.nix { };
+    qca = callPackage ../development/libraries/qca {
+      inherit (qt6) qtbase qt5compat;
+    };
+    qcoro = callPackage ../development/libraries/qcoro { };
+    qcustomplot = callPackage ../development/libraries/qcustomplot { };
+    qgpgme = callPackage ../development/libraries/qgpgme { };
+    qhotkey = callPackage ../development/libraries/qhotkey { };
+    qmlbox2d = callPackage ../development/libraries/qmlbox2d { };
+    packagekit-qt = callPackage ../tools/package-management/packagekit/qt.nix { };
 
-      qodeassist-plugin = callPackage ../development/libraries/qodeassist-plugin { };
+    qodeassist-plugin = callPackage ../development/libraries/qodeassist-plugin { };
 
-      qt6ct = callPackage ../tools/misc/qt6ct { };
+    qt6ct = callPackage ../tools/misc/qt6ct { };
 
-      qt6gtk2 = callPackage ../tools/misc/qt6gtk2 { };
+    qt6gtk2 = callPackage ../tools/misc/qt6gtk2 { };
 
-      qt-color-widgets = callPackage ../development/libraries/qt-color-widgets { };
+    qt-color-widgets = callPackage ../development/libraries/qt-color-widgets { };
 
-      qtforkawesome = callPackage ../development/libraries/qtforkawesome { };
+    qtforkawesome = callPackage ../development/libraries/qtforkawesome { };
 
-      qtkeychain = callPackage ../development/libraries/qtkeychain { };
+    qtkeychain = callPackage ../development/libraries/qtkeychain { };
 
-      qtpbfimageplugin = callPackage ../development/libraries/qtpbfimageplugin { };
+    qtpbfimageplugin = callPackage ../development/libraries/qtpbfimageplugin { };
 
-      qtstyleplugin-kvantum = kdePackages.callPackage ../development/libraries/qtstyleplugin-kvantum { };
+    qtstyleplugin-kvantum = kdePackages.callPackage ../development/libraries/qtstyleplugin-kvantum { };
 
-      qtutilities = callPackage ../development/libraries/qtutilities { };
+    qtutilities = callPackage ../development/libraries/qtutilities { };
 
-      qt-jdenticon = callPackage ../development/libraries/qt-jdenticon { };
+    qt-jdenticon = callPackage ../development/libraries/qt-jdenticon { };
 
-      quazip = callPackage ../development/libraries/quazip { };
+    quazip = callPackage ../development/libraries/quazip { };
 
-      qscintilla = callPackage ../development/libraries/qscintilla { };
+    qscintilla = callPackage ../development/libraries/qscintilla { };
 
-      qtspell = callPackage ../development/libraries/qtspell { };
+    qtspell = callPackage ../development/libraries/qtspell { };
 
-      qwt = callPackage ../development/libraries/qwt/default.nix { };
+    qwt = callPackage ../development/libraries/qwt/default.nix { };
 
-      qxlsx = callPackage ../development/libraries/qxlsx { };
+    qxlsx = callPackage ../development/libraries/qxlsx { };
 
-      qzxing = callPackage ../development/libraries/qzxing { };
+    qzxing = callPackage ../development/libraries/qzxing { };
 
-      poppler = callPackage ../development/libraries/poppler {
-        lcms = pkgs.lcms2;
-        qt6Support = true;
-        suffix = "qt6";
-      };
+    poppler = callPackage ../development/libraries/poppler {
+      lcms = pkgs.lcms2;
+      qt6Support = true;
+      suffix = "qt6";
+    };
 
-      sailfish-access-control-plugin =
-        callPackage ../development/libraries/sailfish-access-control-plugin
-          { };
+    sailfish-access-control-plugin =
+      callPackage ../development/libraries/sailfish-access-control-plugin
+        { };
 
-      sddm-unwrapped = kdePackages.callPackage ../applications/display-managers/sddm/unwrapped.nix { };
-      sddm = kdePackages.callPackage ../applications/display-managers/sddm { };
+    sddm-unwrapped = kdePackages.callPackage ../applications/display-managers/sddm/unwrapped.nix { };
+    sddm = kdePackages.callPackage ../applications/display-managers/sddm { };
 
-      sierra-breeze-enhanced =
-        kdePackages.callPackage ../data/themes/kwin-decorations/sierra-breeze-enhanced
-          { };
+    sierra-breeze-enhanced =
+      kdePackages.callPackage ../data/themes/kwin-decorations/sierra-breeze-enhanced
+        { };
 
-      signond = callPackage ../development/libraries/signond { };
+    signond = callPackage ../development/libraries/signond { };
 
-      timed = callPackage ../applications/system/timed { };
+    timed = callPackage ../applications/system/timed { };
 
-      wayqt = callPackage ../development/libraries/wayqt { };
-    }
-    // lib.optionalAttrs config.allowAliases {
-      qwlroots = throw ''
-        'qt6Packages.qwlroots' has been removed because it has been merged into treeland upstream.
-        The upstream no longer provides it as a standalone development library.
-      ''; # Added 2025-02-07
-      waylib = throw ''
-        'qt6Packages.waylib' has been removed because it has been merged into treeland upstream.
-        The upstream no longer provides it as a standalone development library.
-      ''; # Added 2025-02-07
-    }
-  );
-}
+    wayqt = callPackage ../development/libraries/wayqt { };
+  }
+  // lib.optionalAttrs config.allowAliases {
+    qwlroots = throw ''
+      'qt6Packages.qwlroots' has been removed because it has been merged into treeland upstream.
+      The upstream no longer provides it as a standalone development library.
+    ''; # Added 2025-02-07
+    waylib = throw ''
+      'qt6Packages.waylib' has been removed because it has been merged into treeland upstream.
+      The upstream no longer provides it as a standalone development library.
+    ''; # Added 2025-02-07
+  }
+)

--- a/pkgs/top-level/qt6-packages.nix
+++ b/pkgs/top-level/qt6-packages.nix
@@ -8,17 +8,13 @@
   lib,
   config,
   __splicedPackages,
-  pkgsHostTarget,
   kdePackages, # TODO why tf. are we using its callPackage here??
   ... # FIXME
 }:
 
 let
-  pkgs = __splicedPackages;
-  # qt6 set should not be pre-spliced to prevent spliced packages being a part of an unspliced set
-  # 'pkgsCross.aarch64-multiplatform.pkgsBuildTarget.targetPackages.qt6Packages.qtbase' should not have a `__spliced` but if qt6 is pre-spliced then it will have one.
-  # pkgsHostTarget == pkgs
-  qt6 = pkgsHostTarget.qt6;
+  pkgs = __splicedPackages; # TODO still necessary?
+  inherit (pkgs) qt6;
 in
 
 qt6.overrideScope (


### PR DESCRIPTION
RE: https://discourse.nixos.org/t/rfc-nix-function-that-overrides-a-scope-with-automatic-inheritance-propagation/78025/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
