### PR TITLE
librewolf-unwrapped: 152.0-1 -> 152.0.1-2

### DIFF
--- a/pkgs/by-name/li/librewolf-unwrapped/src.json
+++ b/pkgs/by-name/li/librewolf-unwrapped/src.json
@@ -1,11 +1,11 @@
 {
-  "packageVersion": "152.0-1",
+  "packageVersion": "152.0.1-2",
   "source": {
-    "rev": "152.0-1",
-    "hash": "sha256-T7ZRCmHx3jnFz7zzXS8btEepP9HRtKS8CWTehxdxIlM="
+    "rev": "152.0.1-2",
+    "hash": "sha256-qr0eO+ucXguTb2QDhbsI9jjlx9fzfZVAI++87UfXcXE="
   },
   "firefox": {
-    "version": "152.0",
-    "hash": "sha512-LHrfNnAEBj7p8zheaS9hLY5cDBBmK/KUmWwRgAHkPewSyoy0/XDmeiWpA9v1rfg9IuSH8Evz+TDaKoFcgDeM6w=="
+    "version": "152.0.1",
+    "hash": "sha512-myWVFI7ZdwQOorIefW7OcPDlP6yblrMRWxE76nbq1sBCL26UsVQCg7Qw/tXo6aIndxpjV78W9W1TCn+ufcdVOg=="
   }
 }


### PR DESCRIPTION
changelog: https://www.firefox.com/en-US/firefox/152.0.1/releasenotes/
diff: https://codeberg.org/librewolf/source/compare/152.0-1...152.0.1-2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
