### PR TITLE
python3Packages.contextily: init at 1.7.0

### DIFF
--- a/pkgs/development/python-modules/contextily/default.nix
+++ b/pkgs/development/python-modules/contextily/default.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
+  geopy,
+  joblib,
+  matplotlib,
+  mercantile,
+  numpy,
+  pillow,
+  rasterio,
+  requests,
+  xyzservices,
+
+  # tests
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "contextily";
+  version = "1.7.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-ZTT6pXAribRtDYG0xTh1Ty2LPdjMKYRUsRzO36Z+c6w=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    geopy
+    joblib
+    matplotlib
+    mercantile
+    numpy
+    pillow
+    rasterio
+    requests
+    xyzservices
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTestMarks = [
+    "network"
+  ];
+
+  disabledTests = [
+    # Tries to geocode through Nominatim.
+    "test_place_with_custom_headers"
+  ];
+
+  pythonImportsCheck = [ "contextily" ];
+
+  meta = {
+    description = "Context geo-tiles in Python";
+    homepage = "https://github.com/geopandas/contextily";
+    changelog = "https://github.com/geopandas/contextily/releases/tag/v${version}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ siraben ];
+    teams = [ lib.teams.geospatial ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3232,6 +3232,8 @@ self: super: with self; {
 
   contexter = callPackage ../development/python-modules/contexter { };
 
+  contextily = callPackage ../development/python-modules/contextily { };
+
   contextlib2 = callPackage ../development/python-modules/contextlib2 { };
 
   contexttimer = callPackage ../development/python-modules/contexttimer { };


### PR DESCRIPTION
Add `python3Packages.contextily`, a Python package for retrieving and plotting contextual web tile basemaps.

Homepage: https://github.com/geopandas/contextily

Built with `nix build -L .#python3Packages.contextily` on `aarch64-darwin`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
