### PR TITLE
python3Packages.clang: rename from libclang

### DIFF
--- a/pkgs/by-name/ed/edgetx/package.nix
+++ b/pkgs/by-name/ed/edgetx/package.nix
@@ -34,7 +34,7 @@ let
       pillow
       lz4
       jinja2
-      libclang
+      clang
     ]
   );
 

--- a/pkgs/by-name/mu/mupdf/package.nix
+++ b/pkgs/by-name/mu/mupdf/package.nix
@@ -115,7 +115,7 @@ stdenv.mkDerivation rec {
   ++ lib.optionals (enableCxx || enablePython) [
     (python3.pythonOnBuildForHost.withPackages (ps: [
       ps.setuptools
-      ps.libclang
+      ps.clang
     ]))
   ]
   ++ lib.optionals enablePython [

--- a/pkgs/development/python-modules/clang/default.nix
+++ b/pkgs/development/python-modules/clang/default.nix
@@ -25,7 +25,7 @@ let
   '';
 in
 buildPythonPackage {
-  pname = "libclang";
+  pname = "clang";
   pyproject = true;
 
   inherit (libclang) version src;

--- a/pkgs/development/python-modules/hawkmoth/default.nix
+++ b/pkgs/development/python-modules/hawkmoth/default.nix
@@ -3,9 +3,9 @@
   buildPythonPackage,
   fetchFromGitHub,
   hatchling,
-  libclang,
-  sphinx,
   clang,
+  sphinx,
+  llvmPackages,
   pytestCheckHook,
   strictyaml,
 }:
@@ -25,13 +25,13 @@ buildPythonPackage rec {
   build-system = [ hatchling ];
 
   dependencies = [
-    libclang
+    clang
     sphinx
   ];
   propagatedBuildInputs = [ clang ];
 
   nativeCheckInputs = [
-    clang
+    llvmPackages.clang
     pytestCheckHook
     strictyaml
   ];

--- a/pkgs/development/python-modules/pymupdf/default.nix
+++ b/pkgs/development/python-modules/pymupdf/default.nix
@@ -7,7 +7,7 @@
   toPythonModule,
 
   # build-system
-  libclang,
+  clang,
   pipcl,
   psutil,
   setuptools,
@@ -75,7 +75,7 @@ buildPythonPackage (finalAttrs: {
   '';
 
   build-system = [
-    libclang
+    clang
     pipcl
     swig
     setuptools

--- a/pkgs/development/python-modules/pywebtransport/default.nix
+++ b/pkgs/development/python-modules/pywebtransport/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   clang,
   fetchFromGitHub,
-  libclang,
   llvmPackages,
   msgpack,
   pkg-config,
@@ -42,13 +41,13 @@ buildPythonPackage (finalAttrs: {
   ];
 
   nativeBuildInputs = [
-    clang
+    llvmPackages.clang
     llvmPackages.libclang.lib
     pkg-config
   ];
 
   env.LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
-  env.LD_LIBRARY_PATH = "${llvmPackages.libclang.lib}/lib:${lib.getLib libclang}/lib";
+  env.LD_LIBRARY_PATH = "${llvmPackages.libclang.lib}/lib:${lib.getLib clang}/lib";
 
   prePatch = ''
     # maturin can't find the file

--- a/pkgs/development/python-modules/tensorflow/bin.nix
+++ b/pkgs/development/python-modules/tensorflow/bin.nix
@@ -19,7 +19,7 @@
   google-pasta,
   grpcio,
   h5py,
-  libclang,
+  clang,
   numpy,
   opt-einsum,
   packaging,
@@ -95,7 +95,7 @@ buildPythonPackage (finalAttrs: {
     google-pasta
     grpcio
     h5py
-    libclang
+    clang
     ml-dtypes
     numpy
     opt-einsum

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -321,6 +321,7 @@ mapAliases {
   ledger-agent = throw "ledger-agent has been removed because upstream dropped Ledger support"; # Added 2026-03-11
   ledger_agent = throw "ledger-agent has been removed because upstream dropped Ledger support"; # Added 2026-03-11
   libarcus = throw "'libarcus' has been removed, as it was unmaintained in nixpkgs"; # Added 2026-05-22
+  libclang = clang; # added 2026-06-18
   libgpiod = gpiod; # added 2026-03-30
   libpyfoscam = throw "libpyfoscam was removed because Home Assistant switched to libpyfoscamcgi"; # added 2025-07-03
   line_profiler = throw "'line_profiler' has been renamed to/replaced by 'line-profiler'"; # Converted to throw 2025-10-29

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2793,7 +2793,11 @@ self: super: with self; {
 
   ckcc-protocol = callPackage ../development/python-modules/ckcc-protocol { };
 
-  ckzg = callPackage ../development/python-modules/ckzg { };
+  ckzg = callPackage ../development/python-modules/ckzg {
+    inherit (pkgs) clang;
+  };
+
+  clang = callPackage ../development/python-modules/clang { };
 
   clarabel = callPackage ../development/python-modules/clarabel { };
 
@@ -8828,8 +8832,6 @@ self: super: with self; {
 
   libbs = callPackage ../development/python-modules/libbs { };
 
-  libclang = callPackage ../development/python-modules/libclang { };
-
   libcloud = callPackage ../development/python-modules/libcloud { };
 
   libcomps = lib.pipe pkgs.libcomps [
@@ -14786,7 +14788,9 @@ self: super: with self; {
     callPackage ../development/python-modules/pyobjc-framework-libdispatch
       { };
 
-  pyobjus = callPackage ../development/python-modules/pyobjus { };
+  pyobjus = callPackage ../development/python-modules/pyobjus {
+    inherit (pkgs) clang;
+  };
 
   pyocd = callPackage ../development/python-modules/pyocd { };
 


### PR DESCRIPTION
The project name (e.g. on PyPI) is clang. The project called libclang can be found at https://github.com/sighingnow/libclang instead.

I discovered the mismatch while working on https://github.com/NixOS/nixpkgs/pull/532778.

depends on https://github.com/NixOS/nixpkgs/pull/431131

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
