### PR TITLE
nixos/litellm: warn when database mode lacks a prisma client

### DIFF
--- a/nixos/modules/services/misc/litellm.nix
+++ b/nixos/modules/services/misc/litellm.nix
@@ -162,6 +162,19 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    warnings =
+      lib.optional
+        (
+          cfg.package == pkgs.litellm
+          && ((cfg.settings.general_settings.database_url or null) != null || cfg.environment ? DATABASE_URL)
+        )
+        ''
+          services.litellm is configured with a database, but the litellm package in Nixpkgs
+          does not include a Prisma client generated against its schema, so the proxy will not
+          start (https://github.com/NixOS/nixpkgs/issues/432925). Override
+          services.litellm.package with a build that generates one.
+        '';
+
     systemd.tmpfiles.rules = [
       "d '${cfg.stateDir}/ui' 0700 - - - -"
       "d '${cfg.stateDir}/tiktoken-cache' 0700 - - - -"


### PR DESCRIPTION
The `litellm` package does not include a Prisma client generated against litellm's schema, so configuring `services.litellm` with a database (`settings.general_settings.database_url` or `environment.DATABASE_URL`) makes the proxy fail to start at runtime. See #432925.

This adds an eval-time warning gated on `cfg.package == pkgs.litellm`, so it will only fire when you don't override `services.litellm.package` with an alternative build. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
