### PR TITLE
discordchatexporter-cli: 2.43.3 -> 2.47.2

### DIFF
--- a/pkgs/by-name/di/discordchatexporter-cli/deps.json
+++ b/pkgs/by-name/di/discordchatexporter-cli/deps.json
@@ -1,92 +1,87 @@
 [
   {
     "pname": "AdvancedStringBuilder",
-    "version": "0.1.1",
-    "sha256": "1qc5b9vlh42yyw00kppkrdz0cji0cxslh97794km9nid8wcv3f54"
+    "version": "0.2.0",
+    "hash": "sha256-66bPgNGU/wLpGs9mydkBBlTEJRpvfHDwWEysUsufZJY="
   },
   {
     "pname": "AngleSharp",
-    "version": "1.1.2",
-    "sha256": "0rfild46lmqhxkfh6nhy7a9m8zzv25lj29riav5j6dmzw07l7wif"
+    "version": "1.4.0",
+    "hash": "sha256-xHpoMkhYSj7ejeMmI2e7ygef84QGZhttPjYOnLjITd0="
   },
   {
     "pname": "AsyncKeyedLock",
-    "version": "6.4.2",
-    "sha256": "1pghspgz9xis139b5v8h2y40gp14x6qfcam27zawq6cp278gnjhi"
+    "version": "8.0.2",
+    "hash": "sha256-0NKdC+oxdYxS3Uz1lak5RpdTWyKYT7C3hkCdm5T0D84="
   },
   {
     "pname": "CliFx",
-    "version": "2.3.5",
-    "sha256": "0rlbv93ssw0d8kvhnvrz2f06ka66gz4gbz1va2q135dab99cmrin"
+    "version": "3.0.0",
+    "hash": "sha256-RMHRAQ2SQB8G3GLzG5WGKNkWNJdLCwkedSoT0iKv9gk="
   },
   {
     "pname": "CSharpier.MsBuild",
-    "version": "0.28.2",
-    "sha256": "10c3v3pqv49y5wi0slswfzkwjh9q93diihpmkbfp3r7yjpv6871d"
+    "version": "1.2.6",
+    "hash": "sha256-jvY05AmHK0MO9cbSTwAvAXf4urL+6Df2ug4IKwcleDw="
   },
   {
     "pname": "Deorcify",
-    "version": "1.0.2",
-    "sha256": "0nwxyrl4rd5x621i2hs5fl3w7fxpm13lkdssxr9fd5042px2gqbm"
+    "version": "1.1.0",
+    "hash": "sha256-R3V/9z/dP0LyhMNh+SiHD5j+XGr/DxPo4qwaKB+Fbak="
   },
   {
     "pname": "Gress",
-    "version": "2.1.1",
-    "sha256": "1svz1flhyl26h3xjch0acjjinympgf6bhj5vpb188njfih3ip4ck"
+    "version": "2.2.0",
+    "hash": "sha256-2vzffEFC2NHH5KGXssvlR4rH+e1DrsFMHN+zQcOgyGI="
   },
   {
     "pname": "JsonExtensions",
     "version": "1.2.0",
-    "sha256": "0g54hibabbqqfhxjlnxwv1rxagpali5agvnpymp2w3dk8h6q66xy"
+    "hash": "sha256-vhuDDUSzDS5u9dfup0qk6j7Vc9i8Wyo7dBivpVaEpDw="
   },
   {
     "pname": "Polly",
-    "version": "8.4.0",
-    "sha256": "1zpq6590zpj3sibdhrn3fydqrm9ga43xdxvjv3rwzhigrkddg9zl"
+    "version": "8.6.6",
+    "hash": "sha256-0BrOttCw+HQYB24Y2uMy2vo0P5/txUlhELC8FlyLKps="
   },
   {
     "pname": "Polly.Core",
-    "version": "8.4.0",
-    "sha256": "1gp66r03zqvwwr4nw96n49bfv08bk54qpdbiqgxg93yhfsbsmkg8"
+    "version": "8.6.6",
+    "hash": "sha256-y6/a4OWrUlRfe0J8qdhBRmYRDi6K2y+kwhEVCIUOjvU="
+  },
+  {
+    "pname": "PowerKit",
+    "version": "1.2.0",
+    "hash": "sha256-93mls5CuiOsNRqH+E+MQ/LSV7X2W8o+jOnPP1vvgdp0="
   },
   {
     "pname": "RazorBlade",
-    "version": "0.6.0",
-    "sha256": "11k2j7d7ddb47sj4lkply8v4aqrfxl0b314cv0l4f5syi4ilfa6s"
+    "version": "1.0.0",
+    "hash": "sha256-ieuGwqM8HHtD+llYO3CdVB+fHHvQ6QnQiajttREFOXM="
   },
   {
     "pname": "Spectre.Console",
-    "version": "0.49.1",
-    "sha256": "0fhl96p3xjd5k1wwvhs80cp35rrlgnza6mw9vy0knhmf7ji9b95n"
+    "version": "0.55.2",
+    "hash": "sha256-PmvyqWWej8pT0X/J80Yr9ClMoO96zq7QlJme8AuQ6Tc="
+  },
+  {
+    "pname": "Spectre.Console.Ansi",
+    "version": "0.55.2",
+    "hash": "sha256-ha2TNW1IOgtkr1NUEs6sSlN6t+hwCEccUUiCGwEen9U="
   },
   {
     "pname": "Superpower",
-    "version": "3.0.0",
-    "sha256": "0p6riay4732j1fahc081dzgs9q4z3n2fpxrin4zfpj6q2226dhz4"
-  },
-  {
-    "pname": "System.Text.Encoding.CodePages",
-    "version": "8.0.0",
-    "sha256": "1lgdd78cik4qyvp2fggaa0kzxasw6kc9a6cjqw46siagrm0qnc3y"
-  },
-  {
-    "pname": "System.Text.Encodings.Web",
-    "version": "8.0.0",
-    "sha256": "1wbypkx0m8dgpsaqgyywz4z760xblnwalb241d5qv9kx8m128i11"
-  },
-  {
-    "pname": "System.Text.Json",
-    "version": "8.0.3",
-    "sha256": "0jkl986gnh2a39v5wbab47qyh1g9a64dgh5s67vppcay8hd42c4n"
+    "version": "3.1.0",
+    "hash": "sha256-krsT4LFDHeCjwS0BbkgpBYggpr5Nmc1RXYyOjLqRifQ="
   },
   {
     "pname": "WebMarkupMin.Core",
-    "version": "2.16.0",
-    "sha256": "0cbkgrrkam76bhygrjzd4nj4mpzpgbnsddfzwry1933rcvjlqh6m"
+    "version": "2.21.0",
+    "hash": "sha256-k51tTFcdL9Bwsg3gA51ZswGxDtdBFb22BAj9wbyZu1E="
   },
   {
     "pname": "YoutubeExplode",
-    "version": "6.3.16",
-    "sha256": "1f6d47g1qmmahx6pn2sp0fff7hsmdqwm7z09j47hs6r1yn9a7kyj"
+    "version": "6.6.0",
+    "hash": "sha256-53mPbr8IVmJH2C3euhSz56Bl6fJt5yN0CU6vCmzUs4I="
   }
 ]

--- a/pkgs/by-name/di/discordchatexporter-cli/package.nix
+++ b/pkgs/by-name/di/discordchatexporter-cli/package.nix
@@ -9,19 +9,19 @@
 
 buildDotnetModule rec {
   pname = "discordchatexporter-cli";
-  version = "2.43.3";
+  version = "2.47.2";
 
   src = fetchFromGitHub {
     owner = "tyrrrz";
     repo = "discordchatexporter";
     rev = version;
-    hash = "sha256-r9bvTgqKQY605BoUlysSz4WJMxn2ibNh3EhoMYCfV3c=";
+    hash = "sha256-2Sft+8K74vVTpNEgAJ0Y13pn+KiTUdd/5prR1aT6ET4=";
   };
 
   projectFile = "DiscordChatExporter.Cli/DiscordChatExporter.Cli.csproj";
   nugetDeps = ./deps.json;
-  dotnet-sdk = dotnetCorePackages.sdk_8_0;
-  dotnet-runtime = dotnetCorePackages.runtime_8_0;
+  dotnet-sdk = dotnetCorePackages.sdk_10_0;
+  dotnet-runtime = dotnetCorePackages.runtime_10_0;
 
   dotnetBuildFlags = [
     # workaround for https://github.com/belav/csharpier/pull/1696


### PR DESCRIPTION
## Things done

Manual update from Dotnet 8 to Dotnet 10 needed


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
