### PR TITLE
nixos/tests/hedgedoc: migrate to nspawn containers

### DIFF
--- a/nixos/tests/hedgedoc.nix
+++ b/nixos/tests/hedgedoc.nix
@@ -1,16 +1,16 @@
-{ pkgs, lib, ... }:
+{ pkgs, ... }:
 {
   name = "hedgedoc";
 
   meta.maintainers = [ ];
-  nodes = {
-    hedgedocSqlite =
+  containers = {
+    sqlite =
       { ... }:
       {
         services.hedgedoc.enable = true;
       };
 
-    hedgedocPostgresWithTCPSocket =
+    pgsqltcp =
       { ... }:
       {
         systemd.services.hedgedoc.after = [ "postgresql.target" ];
@@ -44,7 +44,7 @@
         };
       };
 
-    hedgedocPostgresWithUNIXSocket =
+    pgsqluds =
       { ... }:
       {
         systemd.services.hedgedoc.after = [ "postgresql.target" ];
@@ -78,22 +78,22 @@
     start_all()
 
     with subtest("HedgeDoc sqlite"):
-        hedgedocSqlite.wait_for_unit("hedgedoc.service")
-        hedgedocSqlite.wait_for_open_port(3000)
-        hedgedocSqlite.wait_until_succeeds("curl -sSf http://localhost:3000/new")
+        sqlite.wait_for_unit("hedgedoc.service")
+        sqlite.wait_for_open_port(3000)
+        sqlite.wait_until_succeeds("curl -sSf http://localhost:3000/new")
 
     with subtest("HedgeDoc postgres with TCP socket"):
-        hedgedocPostgresWithTCPSocket.wait_for_unit("postgresql.target")
-        hedgedocPostgresWithTCPSocket.wait_for_unit("hedgedoc.service")
-        hedgedocPostgresWithTCPSocket.wait_for_open_port(5432)
-        hedgedocPostgresWithTCPSocket.wait_for_open_port(3000)
-        hedgedocPostgresWithTCPSocket.wait_until_succeeds("curl -sSf http://localhost:3000/new")
+        pgsqltcp.wait_for_unit("postgresql.target")
+        pgsqltcp.wait_for_unit("hedgedoc.service")
+        pgsqltcp.wait_for_open_port(5432)
+        pgsqltcp.wait_for_open_port(3000)
+        pgsqltcp.wait_until_succeeds("curl -sSf http://localhost:3000/new")
 
     with subtest("HedgeDoc postgres with UNIX socket"):
-        hedgedocPostgresWithUNIXSocket.wait_for_unit("postgresql.target")
-        hedgedocPostgresWithUNIXSocket.wait_for_unit("hedgedoc.service")
-        hedgedocPostgresWithUNIXSocket.wait_for_open_port(5432)
-        hedgedocPostgresWithUNIXSocket.wait_for_open_port(3000)
-        hedgedocPostgresWithUNIXSocket.wait_until_succeeds("curl -sSf http://localhost:3000/new")
+        pgsqluds.wait_for_unit("postgresql.target")
+        pgsqluds.wait_for_unit("hedgedoc.service")
+        pgsqluds.wait_for_open_port(5432)
+        pgsqluds.wait_for_open_port(3000)
+        pgsqluds.wait_until_succeeds("curl -sSf http://localhost:3000/new")
   '';
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
