### PR TITLE
camera-streamer: init at 0.4.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -208,6 +208,11 @@
     github = "2hexed";
     githubId = 54501296;
   };
+  _30350n = {
+    name = "Max Schlecht";
+    github = "30350n";
+    githubId = 34186858;
+  };
   _360ied = {
     name = "Brian Zhu";
     email = "therealbarryplayer@gmail.com";

--- a/pkgs/by-name/ca/camera-streamer/package.nix
+++ b/pkgs/by-name/ca/camera-streamer/package.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  makeWrapper,
+  pkg-config,
+  which,
+  xxd,
+  ffmpeg,
+  libcamera,
+  live555,
+  openssl,
+  v4l-utils,
+}:
+stdenv.mkDerivation rec {
+  pname = "camera-streamer";
+  version = "0.4.2";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "ayufan";
+    repo = "camera-streamer";
+    tag = "v${version}";
+    hash = "sha256-umU8Rp8+wUvQCNK8OpgND/6gPD013SB6sdXSLy5UGAQ=";
+    fetchSubmodules = true;
+  };
+
+  # not sure why the -Werror isn't being an issue for the project maintainer
+  # my best guess is it's because the project README specifices
+  # "Debian Bookworm" as a requirement which provides gcc12 by default
+  postPatch = ''
+    sed -i 's|git submodule update.*||' Makefile
+    substituteInPlace Makefile --replace-warn "-Werror" ""
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    makeWrapper
+    pkg-config
+    which
+    xxd
+  ];
+
+  buildInputs = [
+    ffmpeg
+    libcamera
+    live555
+    openssl
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  makeFlags = [
+    "GIT_VERSION=${src.tag}"
+    "GIT_REVISION=${src.rev}"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D camera-streamer $out/bin/camera-streamer
+    wrapProgram $out/bin/camera-streamer --prefix PATH : ${lib.makeBinPath [ v4l-utils ]}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://github.com/ayufan/camera-streamer";
+    changelog = "https://github.com/ayufan/camera-streamer/releases/tag/v${version}";
+    description = "High-performance low-latency camera streamer for Raspberry PI's";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ _30350n ];
+    platforms = lib.platforms.linux;
+    mainProgram = "camera-streamer";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add [camera-streamer](https://github.com/ayufan/camera-streamer/tree/main), an alternative to ustreamer that directly supports webrtc streaming.

I'm running this on my 3D Printer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
