### PR TITLE
veracrypt: modernize, build with fuse3

### DIFF
--- a/pkgs/by-name/ve/veracrypt/package.nix
+++ b/pkgs/by-name/ve/veracrypt/package.nix
@@ -1,11 +1,11 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   pkg-config,
   makeself,
   yasm,
-  fuse,
+  fuse3,
   wxwidgets_3_2,
   lvm2,
   replaceVars,
@@ -21,9 +21,11 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "veracrypt";
   version = "1.26.29";
 
-  src = fetchurl {
-    url = "https://launchpad.net/veracrypt/trunk/${finalAttrs.version}/+download/VeraCrypt_${finalAttrs.version}_Source.tar.bz2";
-    hash = "sha256-YIJnMeKYK0vSMeOTDoWkQ5EWljhnGhsgDFGPjItGyyo=";
+  src = fetchFromGitHub {
+    owner = "veracrypt";
+    repo = "VeraCrypt";
+    tag = "VeraCrypt_${finalAttrs.version}";
+    hash = "sha256-Q+WUz8F63cP9/KlZUn9xLu2V9wO4FeY7AtErE1T9Km4=";
   };
 
   patches = [
@@ -40,7 +42,9 @@ stdenv.mkDerivation (finalAttrs: {
     ./nix-system-paths.patch
   ];
 
-  sourceRoot = "src";
+  sourceRoot = "${finalAttrs.src.name}/src";
+
+  buildFlags = [ "WITHFUSE3=1" ];
 
   nativeBuildInputs = [
     makeself
@@ -49,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
     wrapGAppsHook3
   ];
   buildInputs = [
-    fuse
+    fuse3
     lvm2
     wxwidgets_3_2
     pcsclite
@@ -70,10 +74,12 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Free Open-Source filesystem on-the-fly encryption";
     homepage = "https://www.veracrypt.fr/";
-    license = with lib.licenses; [
-      asl20 # and
-      unfree # TrueCrypt License version 3.0
-    ];
+    license =
+      with lib.licenses;
+      AND [
+        asl20 # and
+        unfree # TrueCrypt License version 3.0
+      ];
     maintainers = [ lib.maintainers.ryand56 ];
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
Related to #526161

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
