### PR TITLE
dirge: init at 0.7.7

### DIFF
--- a/pkgs/by-name/di/dirge/package.nix
+++ b/pkgs/by-name/di/dirge/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  gcc,
+  binutils,
+  sqlite,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "dirge";
+  version = "0.10.0";
+
+  src = fetchFromGitHub {
+    owner = "dirge-code";
+    repo = "dirge";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ctUTeJr+M9RrWIlRyVqPtcAeaLVOU9/0CaoYi+DLKNs=";
+  };
+
+  cargoHash = "sha256-/pux5r91yR22zAnb0VTnWQV98hBj3rMhFhddN+vh5dw=";
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+    gcc
+    binutils
+  ];
+
+  buildInputs = [
+    sqlite
+  ];
+
+  # needs both of the following to compile
+  RUSTFLAGS = "-C linker=${gcc}/bin/gcc";
+  doCheck = false;
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Dynamic Intent Resolution Grounding Engine";
+    homepage = "https://github.com/dirge-code/dirge";
+    changelog = "https://github.com/dirge-code/dirge/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ pasqui23 ];
+    mainProgram = "dirge";
+  };
+})


### PR DESCRIPTION

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
