### PR TITLE
libmirage: remove pcre, add optional dependencies

### DIFF
--- a/pkgs/by-name/li/libmirage/package.nix
+++ b/pkgs/by-name/li/libmirage/package.nix
@@ -6,12 +6,17 @@
   vala,
   glib,
   libsndfile,
+  flac,
+  libogg,
+  libvorbis,
+  libopus,
   zlib,
   bzip2,
   xz,
   libsamplerate,
+  libgcrypt,
+  libgpg-error,
   intltool,
-  pcre,
   util-linux,
   libselinux,
   libsepol,
@@ -37,10 +42,15 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     glib
     libsndfile
+    flac
+    libogg
+    libvorbis
     zlib
     bzip2
     xz
     libsamplerate
+    libgcrypt
+    libgpg-error
   ];
 
   nativeBuildInputs = [
@@ -52,7 +62,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   propagatedBuildInputs = [
-    pcre
     util-linux
     libselinux
     libsepol


### PR DESCRIPTION
- pcre hadn't been used
- we're now supporting more image formats

ref https://github.com/NixOS/nixpkgs/issues/356387

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
