### PR TITLE
libultrahdr: fix i686-linux build and unrestrict `meta.platforms`

### DIFF
--- a/pkgs/by-name/li/libultrahdr/package.nix
+++ b/pkgs/by-name/li/libultrahdr/package.nix
@@ -47,6 +47,13 @@ stdenv.mkDerivation (finalAttrs: {
     # Based on https://github.com/google/libultrahdr/pull/383
     # modified to target 1.4.0 instead of main
     ./remove-platform-and-detection-logic.patch
+
+    # fix tests on big-endian
+    # https://github.com/google/libultrahdr/pull/396
+    (fetchpatch {
+      url = "https://github.com/google/libultrahdr/commit/13a058f452d846e43d4691f6885eeeaa8b0ea8d0.patch";
+      hash = "sha256-2ZVvBMz8wQLEThuXdRJbbx5m2ouRZpxVWoH88RLmit4=";
+    })
   ];
 
   # CMake incorrect absolute include/lib paths: https://github.com/NixOS/nixpkgs/issues/144170

--- a/pkgs/by-name/li/libultrahdr/package.nix
+++ b/pkgs/by-name/li/libultrahdr/package.nix
@@ -40,6 +40,13 @@ stdenv.mkDerivation (finalAttrs: {
     (replaceVars ./gtest.patch {
       GTEST_INCLUDE_DIRS = "${lib.getDev gtest}/include";
     })
+
+    # Remove platform and architecture detection logic
+    # Also drop arch-specific compile and optimization flags to ensure
+    # packaging friendliness.
+    # Based on https://github.com/google/libultrahdr/pull/383
+    # modified to target 1.4.0 instead of main
+    ./remove-platform-and-detection-logic.patch
   ];
 
   # CMake incorrect absolute include/lib paths: https://github.com/NixOS/nixpkgs/issues/144170
@@ -52,6 +59,12 @@ stdenv.mkDerivation (finalAttrs: {
         'includedir=''${prefix}/@CMAKE_INSTALL_INCLUDEDIR@' \
         'includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@'
   '';
+
+  # use sse2 for floating point math to fix tests
+  env = lib.optionalAttrs stdenv.hostPlatform.isi686 {
+    CFLAGS = "-mfpmath=sse -msse2";
+    CXXFLAGS = "-mfpmath=sse -msse2";
+  };
 
   cmakeFlags = [
     (lib.cmakeBool "UHDR_BUILD_TESTS" true)
@@ -102,33 +115,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       yzx9
     ];
-    # CMake script rejects non-approved platform targets
-    # https://github.com/google/libultrahdr/pull/383 would get rid of that
-    platforms =
-      let
-        # Values from the "Detect system" section in /CMakeLists.txt
-        # https://github.com/google/libultrahdr/blob/d52a0d13814ca399fc8a07e23de1d2c63f0e8404/CMakeLists.txt#L34
-        oss = [
-          "linux"
-          "windows"
-          "darwin"
-        ];
-        archs = [
-          "i686"
-          "x86_64"
-          "aarch64"
-          "armv7l"
-          "riscv64"
-          "riscv32"
-          "loongarch64"
-        ];
-      in
-      lib.lists.intersectLists lib.platforms.all (
-        lib.lists.crossLists (arch: os: "${arch}-${os}") [
-          archs
-          oss
-        ]
-      );
+    platforms = lib.platforms.all;
     license = with lib.licenses; [
       asl20
     ];

--- a/pkgs/by-name/li/libultrahdr/remove-platform-and-detection-logic.patch
+++ b/pkgs/by-name/li/libultrahdr/remove-platform-and-detection-logic.patch
@@ -1,0 +1,142 @@
+From e2daed8da97d8857dcec2fd68d2f6f3326170f67 Mon Sep 17 00:00:00 2001
+From: Kleis Auke Wolthuizen <github@kleisauke.nl>
+Date: Wed, 10 Dec 2025 15:01:28 +0100
+Subject: [PATCH] Remove platform and architecture detection logic
+
+Also drop arch-specific compile and optimization flags to ensure
+packaging friendliness.
+---
+ CMakeLists.txt      | 104 +++-----------------------------------------
+ cmake/package.cmake |   3 --
+ 2 files changed, 5 insertions(+), 102 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 51283356..07ed9100 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -25,44 +25,6 @@ project(libuhdr
+         LANGUAGES C CXX
+         DESCRIPTION "Library for encoding and decoding ultrahdr images")
+ 
+-###########################################################
+-# Detect system
+-###########################################################
+-if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+-elseif(${CMAKE_SYSTEM_NAME} MATCHES "Emscripten")
+-elseif(${CMAKE_SYSTEM_NAME} MATCHES "Android")
+-elseif(WIN32)
+-elseif(APPLE)
+-else()
+-  message(FATAL_ERROR "Platform ${CMAKE_SYSTEM_NAME} not recognized")
+-endif()
+-
+-if(CMAKE_SYSTEM_PROCESSOR MATCHES "amd64.*|x86_64.*|AMD64.*")
+-  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+-    set(ARCH "amd64")
+-  else()
+-    set(ARCH "i386")
+-  endif()
+-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "i686.*|i386.*|x86.*")
+-  set(ARCH "i386")
+-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*|ARM64.*)")
+-  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+-    set(ARCH "aarch64")
+-  else()
+-    set(ARCH "arm")
+-  endif()
+-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm.*|ARM.*)")
+-  set(ARCH "arm")
+-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^riscv64")
+-  set(ARCH "riscv64")
+-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^riscv32")
+-  set(ARCH "riscv32")
+-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^loongarch64")
+-  set(ARCH "loong64")
+-else()
+-  message(FATAL_ERROR "Architecture: ${CMAKE_SYSTEM_PROCESSOR} not recognized")
+-endif()
+-
+ ###########################################################
+ # Directories
+ ###########################################################
+@@ -287,45 +228,9 @@ elseif(EMSCRIPTEN)
+                            or try 'cmake -DUHDR_BUILD_DEPS=1'")
+     endif()
+   endif()
+-else()
+-  add_compile_options(-ffunction-sections)
+-  add_compile_options(-fdata-sections)
+-  add_compile_options(-fomit-frame-pointer)
+-  add_compile_options(-ffp-contract=fast)
+-  if(ARCH STREQUAL "i386")
+-    add_compile_options(-m32)
+-    add_compile_options(-march=i386)
+-    add_compile_options(-mtune=generic)
+-  elseif(ARCH STREQUAL "amd64")
+-    add_compile_options(-m64)
+-    add_compile_options(-march=x86-64)
+-    add_compile_options(-mtune=generic)
+-  elseif(ARCH STREQUAL "arm")
+-    add_compile_options(-march=armv7-a)
+-    add_compile_options(-marm)
+-    if(NOT ANDROID_ABI)
+-      add_compile_options(-mfloat-abi=hard)
+-    endif()
+-    add_compile_options(-mfpu=neon-vfpv3)
+-    add_compile_options(-fno-lax-vector-conversions)
+-  elseif(ARCH STREQUAL "aarch64")
+-    add_compile_options(-march=armv8-a)
+-    add_compile_options(-fno-lax-vector-conversions)
+-  elseif(ARCH STREQUAL "riscv64")
+-    add_compile_options(-march=rv64gc)
+-    add_compile_options(-mabi=lp64d)
+-  elseif(ARCH STREQUAL "riscv32")
+-    add_compile_options(-march=rv32gc)
+-    add_compile_options(-mabi=ilp32d)
+-  elseif(ARCH STREQUAL "loong64")
+-    add_compile_options(-march=loongarch64)
+-    add_compile_options(-mabi=lp64d)
+-  endif()
+-
+-  if(UHDR_ENABLE_WERROR)
+-    CheckCompilerOption("-Werror" SUPPORTS_WERROR)
+-    set(UHDR_WERROR_FLAGS "-Werror")
+-  endif()
++elseif(UHDR_ENABLE_WERROR)
++  CheckCompilerOption("-Werror" SUPPORTS_WERROR)
++  set(UHDR_WERROR_FLAGS "-Werror")
+ endif()
+ 
+ ###########################################################
+@@ -585,7 +490,8 @@ set_property(DIRECTORY PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
+ ###########################################################
+ file(GLOB UHDR_CORE_SRCS_LIST "${SOURCE_DIR}/src/*.cpp")
+ if(UHDR_ENABLE_INTRINSICS)
+-  if(ARCH STREQUAL "arm" OR ARCH STREQUAL "aarch64")
++  string(TOLOWER ${CMAKE_SYSTEM_PROCESSOR} CMAKE_SYSTEM_PROCESSOR_LC)
++  if(CMAKE_SYSTEM_PROCESSOR_LC STREQUAL "aarch64" OR CMAKE_SYSTEM_PROCESSOR_LC MATCHES "^arm")
+     file(GLOB UHDR_CORE_NEON_SRCS_LIST "${SOURCE_DIR}/src/dsp/arm/*.cpp")
+     list(APPEND UHDR_CORE_SRCS_LIST ${UHDR_CORE_NEON_SRCS_LIST})
+   endif()
+diff --git a/cmake/package.cmake b/cmake/package.cmake
+index 2e3649aa..5a416c22 100644
+--- a/cmake/package.cmake
++++ b/cmake/package.cmake
+@@ -29,9 +29,7 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "")
+   message(FATAL_ERROR "Failed to determine CPACK_SYSTEM_NAME. Is CMAKE_SYSTEM_NAME set?" )
+ endif()
+ string(TOLOWER "${CMAKE_SYSTEM_NAME}" CPACK_SYSTEM_NAME)
+-set(CPACK_PACKAGE_ARCHITECTURE ${ARCH})
+ set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_SYSTEM_NAME}")
+-set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_FILE_NAME}-${CPACK_PACKAGE_ARCHITECTURE}")
+ set(CPACK_RESOURCE_FILE_LICENSE ${CMAKE_SOURCE_DIR}/LICENSE)
+ set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
+ 
+@@ -46,7 +44,6 @@ elseif(UNIX)
+     set(CPACK_DEBIAN_PACKAGE_HOMEPAGE ${CPACK_PACKAGE_HOMEPAGE_URL})
+   elseif(EXISTS "/etc/redhat-release")
+     set(CPACK_GENERATOR "RPM")
+-    set(CPACK_RPM_PACKAGE_ARCHITECTURE ${CPACK_PACKAGE_ARCHITECTURE})
+     set(CPACK_RPM_PACKAGE_RELEASE 1)
+     set(CPACK_RPM_PACKAGE_LICENSE "Apache 2.0")
+     set(CPACK_RPM_PACKAGE_URL ${CPACK_PACKAGE_HOMEPAGE_URL})


### PR DESCRIPTION
- fix i686-linux build
  - This pull request fixes the i686-linux build by adding `-mfpmath=sse -msse2` to cflags, which fixes failing tests
  - This closes issue https://github.com/NixOS/nixpkgs/issues/532626
- unrestrict `meta.platforms`
  - By applying the upstream pull request https://github.com/google/libultrahdr/pull/383, this allows for builds of arbitrary platforms.
- fix tests on big endian
  - This pull request fixes tests on big-endian by incorporating the upstream commit in https://github.com/google/libultrahdr/pull/396, as requested by @OPNA2608

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
  - [X] i686-linux
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [X] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
