### PR TITLE
vibe: init at 2.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14237,6 +14237,12 @@
     githubId = 8211181;
     name = "Kevin Kandlbinder";
   };
+  kexi = {
+    email = "kei.of.nakayama@gmail.com";
+    github = "kexi";
+    githubId = 350671;
+    name = "Kei Nakayama";
+  };
   keyruu = {
     name = "Lucas";
     email = "me@keyruu.de";

--- a/pkgs/by-name/vi/vibe/package.nix
+++ b/pkgs/by-name/vi/vibe/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  stdenv,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "vibe";
+  version = "2.0.0";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "kexi";
+    repo = "vibe";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-p3lZVlsHT+wifoqQIO81jIh0OJywwwTjt/7UbhIaw5w=";
+  };
+
+  # Cargo workspace and lockfile live in the rust/ subdirectory.
+  cargoRoot = "rust";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  cargoHash = "sha256-ZusHniKic9AbZk5USbB6eAE8OPVhM9+GMm5JKToWlsU=";
+
+  # Build only the shipped binary crate (mirrors `cargo build -p vibe`).
+  cargoBuildFlags = [
+    "-p"
+    "vibe"
+  ];
+
+  # Surface the packaging origin to build.rs. VIBE_BUILD_COMMIT is deliberately
+  # left unset: there is no git in the sandbox and build.rs already falls back to
+  # an empty commit, so the embedded version stays "2.0.0".
+  env = {
+    VIBE_BUILD_DISTRIBUTION = "nixpkgs";
+    VIBE_BUILD_ENV = "nixpkgs";
+  };
+
+  # rustls/aws-lc-rs links libgcc_s at runtime on Linux; buildRustPackage runs
+  # autoPatchelfHook there and needs the shared lib present.
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc.lib ];
+
+  # The workspace test suite needs git, a populated worktree, and filesystem
+  # fixtures unavailable in the Nix sandbox; tests run upstream in CI instead.
+  doCheck = false;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Git worktree helper CLI";
+    homepage = "https://github.com/kexi/vibe";
+    changelog = "https://github.com/kexi/vibe/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    mainProgram = "vibe";
+    maintainers = with lib.maintainers; [ kexi ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adds [vibe](https://github.com/kexi/vibe), a fast Git worktree helper CLI
(start / scratch / jump / rename / clean / trust / verify / config / upgrade),
with Copy-on-Write worktree cloning on APFS, Btrfs and XFS.

Built from source with `rustPlatform.buildRustPackage` against the upstream
`v2.0.0` release tag. The Cargo workspace lives in the `rust/` subdirectory
(`cargoRoot` / `buildAndTestSubdir`); only the shipped `vibe` binary crate is
built. The packaging origin is surfaced to the binary via the
`VIBE_BUILD_DISTRIBUTION` / `VIBE_BUILD_ENV` env vars its `build.rs` reads.

- Homepage / changelog: https://github.com/kexi/vibe/releases/tag/v2.0.0
- License: Apache-2.0
- I am the upstream author and am adding myself as maintainer (`kexi`).

## Things done

- Built on platform (aarch64-darwin locally; both Linux arches built on GCP VMs; x86_64-darwin builds/evaluates green in PR CI):
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

> **Automation/AI disclosure:** the `package.nix` and these commits were drafted
> with the assistance of Claude Code (Claude Opus 4.8); each commit carries an
> `Assisted-by:` trailer. This pull request summary was likewise drafted with that
> tool. I (the upstream author) am the responsible person in the loop and have
> reviewed everything before submission.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


