### PR TITLE
python3Packages.imgw-pib: 2.2.2 -> 2.4.0

### DIFF
--- a/pkgs/development/python-modules/aiointercept/default.nix
+++ b/pkgs/development/python-modules/aiointercept/default.nix
@@ -1,0 +1,73 @@
+{
+  aiohttp,
+  buildPythonPackage,
+  ddt,
+  fetchFromGitHub,
+  hatchling,
+  lib,
+  multidict,
+  pytest-asyncio,
+  pytestCheckHook,
+  yarl,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "aiointercept";
+  version = "0.1.7";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Polandia94";
+    repo = "aiointercept";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+tl3Cb2Lkl40FdPNs5byCNoyfm9g6wEKtR0nT1jjrx0=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    aiohttp
+    multidict
+    yarl
+  ];
+
+  pythonImportsCheck = [
+    "aiointercept"
+    "aiointercept.pytest_plugin"
+  ];
+
+  nativeCheckInputs = [
+    ddt
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # different indentation
+    "test_assert_called_with_json"
+    "test_assert_called_with_data_bytes"
+    "test_assert_called_with_data_dict"
+    "test_assert_called_with_strict_headers_fail"
+    # connect to DNS servers
+    "test_address_as_instance_of_url_combined_with_pass_through"
+    "test_pass_through_unmatched_requests"
+    "test_pass_through_with_origin_params"
+    "test_passthrough_host_is_allowed"
+    "test_passthrough_https_explicit"
+    "test_passthrough_unmatched_allows_real_requests"
+    "test_passthrough_unmatched_https_no_patterns"
+    "test_passthrough_unmatched_https_with_patterns"
+    "test_passthrough_unmatched_url_handler_unknown_path_proxied"
+    "test_passthrough_unmatched_with_pattern_proxies_unmatched"
+    "test_real_request_then_mock_same_host_ignores_stale_dns"
+    "test_shared_resolve_no_active_instances_uses_real_resolver"
+  ];
+
+  meta = {
+    changelog = "https://github.com/Polandia94/aiointercept/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    description = "Aiohttp mock library that routes requests through a real test server";
+    homepage = "https://github.com/Polandia94/aiointercept";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.dotlambda ];
+  };
+})

--- a/pkgs/development/python-modules/imgw-pib/default.nix
+++ b/pkgs/development/python-modules/imgw-pib/default.nix
@@ -1,6 +1,7 @@
 {
   aiofiles,
   aiohttp,
+  aiointercept,
   aioresponses,
   buildPythonPackage,
   fetchFromGitHub,
@@ -15,17 +16,21 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "imgw-pib";
-  version = "2.2.2";
+  version = "2.4.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "bieniu";
     repo = "imgw-pib";
     tag = finalAttrs.version;
-    hash = "sha256-LWyaTi4OIxK+Nyrwp9/Czl2hxCiRjoTeKhl0Yfw95pk=";
+    hash = "sha256-IJOzQV2WYc6ZWo6S6kkgSJLC4Y5kWbwkyMDvuFSmESU=";
   };
 
   build-system = [ setuptools ];
+
+  pythonRelaxDeps = [
+    "aiohttp"
+  ];
 
   dependencies = [
     aiofiles
@@ -36,6 +41,7 @@ buildPythonPackage (finalAttrs: {
   pythonImportsCheck = [ "imgw_pib" ];
 
   nativeCheckInputs = [
+    aiointercept
     aioresponses
     freezegun
     pytest-asyncio

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -374,6 +374,8 @@ self: super: with self; {
 
   aioimmich = callPackage ../development/python-modules/aioimmich { };
 
+  aiointercept = callPackage ../development/python-modules/aiointercept { };
+
   aioitertools = callPackage ../development/python-modules/aioitertools { };
 
   aiojellyfin = callPackage ../development/python-modules/aiojellyfin { };


### PR DESCRIPTION
Diff: https://github.com/bieniu/imgw-pib/compare/2.2.2...2.4.0

Changelog: https://github.com/bieniu/imgw-pib/releases/tag/2.4.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
