### PR TITLE
python3Packages.pydeprecate: init at 0.9.0

### DIFF
--- a/pkgs/development/python-modules/pydeprecate/default.nix
+++ b/pkgs/development/python-modules/pydeprecate/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+  wheel,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pydeprecate";
+  version = "0.9.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Borda";
+    repo = "pyDeprecate";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-M3h5m+MqUYl8902YUqKqPfLpZXF3yQjlXP8f0ehnHds=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  pythonImportsCheck = [ "deprecate" ];
+
+  meta = {
+    description = "Smoothly deprecate and redirect Python functions/classes with smart warnings and auto-routing";
+    homepage = "https://github.com/Borda/pyDeprecate";
+    changelog = "https://github.com/Borda/pyDeprecate/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mahyarmirrashed ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13912,6 +13912,8 @@ self: super: with self; {
 
   pydenticon = callPackage ../development/python-modules/pydenticon { };
 
+  pydeprecate = callPackage ../development/python-modules/pydeprecate { };
+
   pydeps = callPackage ../development/python-modules/pydeps { inherit (pkgs) graphviz; };
 
   pydes = callPackage ../development/python-modules/pydes { };


### PR DESCRIPTION
Adds https://github.com/Borda/pyDeprecate. 

It is a simple tooling for marking deprecated functions or classes and re-routing to their successors.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
