### PR TITLE
python3Packages.udtools: 0.2.7 -> 0.2.8; enable tests

### DIFF
--- a/pkgs/development/python-modules/udtools/default.nix
+++ b/pkgs/development/python-modules/udtools/default.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   python,
   setuptools,
+  pytestCheckHook,
   # dependencies
   regex,
   udapi,
@@ -12,14 +13,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "udtools";
-  version = "0.2.7";
+  version = "0.2.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "UniversalDependencies";
     repo = "tools";
     tag = "py${finalAttrs.version}";
-    hash = "sha256-P1gx6JRq1oWCXzB2uO/eCrw8ZgJ+0Y/0cvlLtj+X7SY=";
+    hash = "sha256-PeMIjxHU99HHNwT/D6UiS5HqxXj66ngRTYfA1xn9uOw=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/udtools";
@@ -31,9 +32,8 @@ buildPythonPackage (finalAttrs: {
     regex
   ];
 
-  # pycheck tests are not enabled because they try to import packages/types
-  # that I can't seem to find anywhere on the internet.
-  # https://github.com/UniversalDependencies/tools/issues/158
+  nativeCheckInputs = [ pytestCheckHook ];
+
   pythonImportsCheck = [ "udtools" ];
 
   passthru.updateScript = nix-update-script {


### PR DESCRIPTION
There's no actual changelog, but you can see the commits here: https://github.com/UniversalDependencies/tools/commits/master/udtools

This PR also enables tests as https://github.com/UniversalDependencies/tools/issues/158 has been fixed.

Tested with the now-enabled tests.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test