### PR TITLE
nodejs_24: fix riscv64-linux build

### DIFF
--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -524,6 +524,27 @@ let
               "test-esm-import-meta-main-eval"
               "test-worker-debug"
             ]
+            # These network/fetch/inspector tests fail on riscv64
+            ++ lib.optionals (majorVersion == "24" && stdenv.hostPlatform.isRiscV64) [
+              "test-fetch"
+              "test-http2-allow-http1-upgrade-ws"
+              "test-http-proxy-fetch"
+              "test-http-set-global-proxy-from-env-fetch"
+              "test-http-set-global-proxy-from-env-fetch-default"
+              "test-http-set-global-proxy-from-env-fetch-empty"
+              "test-http-set-global-proxy-from-env-fetch-no-proxy"
+              "test-http-set-global-proxy-from-env-fetch-restore"
+              "test-http-set-global-proxy-from-env-override-fetch"
+              "test-inspector-invalid-protocol"
+              "test-inspector-network-content-type"
+              "test-inspector-network-fetch"
+              "test-inspector-network-websocket"
+              "test-report-exclude-network"
+              "test-tls-set-default-ca-certificates-append-fetch"
+              "test-tls-set-default-ca-certificates-reset-fetch"
+              "test-use-env-proxy-cli-http"
+              "test-wasm-web-api"
+            ]
             # Those are annoyingly flaky, but not enough to be marked as such upstream.
             ++ lib.optional (majorVersion == "22") "test-child-process-stdout-flush-exit"
             ++ lib.optional (


### PR DESCRIPTION
Fix this issue :

```
nodejs-slim> Failed tests:
nodejs-slim> out/Release/node /build/node-v24.15.0/test/es-module/test-wasm-web-api.js
nodejs-slim> out/Release/node /build/node-v24.15.0/test/client-proxy/test-http-proxy-fetch.mjs
nodejs-slim> out/Release/node /build/node-v24.15.0/test/client-proxy/test-http-set-global-proxy-from-env-fetch-default.mjs
nodejs-slim> out/Release/node /build/node-v24.15.0/test/client-proxy/test-http-set-global-proxy-from-env-fetch-empty.mjs
nodejs-slim> out/Release/node /build/node-v24.15.0/test/client-proxy/test-http-set-global-proxy-from-env-fetch.mjs
nodejs-slim> out/Release/node /build/node-v24.15.0/test/client-proxy/test-http-set-global-proxy-from-env-fetch-no-proxy.mjs
nodejs-slim> out/Release/node /build/node-v24.15.0/test/client-proxy/test-http-set-global-proxy-from-env-fetch-restore.mjs
nodejs-slim> out/Release/node /build/node-v24.15.0/test/client-proxy/test-http-set-global-proxy-from-env-override-fetch.mjs
nodejs-slim> out/Release/node /build/node-v24.15.0/test/client-proxy/test-use-env-proxy-cli-http.mjs
nodejs-slim> out/Release/node /build/node-v24.15.0/test/parallel/test-fetch.mjs
nodejs-slim> out/Release/node --inspect=0 --experimental-network-inspection /build/node-v24.15.0/test/parallel/test-inspector-network-content-type.js
nodejs-slim> out/Release/node --inspect=0 --experimental-network-inspection --expose-internals /build/node-v24.15.0/test/parallel/test-inspector-network-fetch.js
nodejs-slim> out/Release/node --no-use-system-ca /build/node-v24.15.0/test/parallel/test-tls-set-default-ca-certificates-append-fetch.mjs
nodejs-slim> out/Release/node --no-use-system-ca /build/node-v24.15.0/test/parallel/test-tls-set-default-ca-certificates-reset-fetch.mjs
nodejs-slim> out/Release/node --expose-internals /build/node-v24.15.0/test/parallel/test-http2-allow-http1-upgrade-ws.js
nodejs-slim> out/Release/node /build/node-v24.15.0/test/parallel/test-inspector-invalid-protocol.js
nodejs-slim> out/Release/node --inspect=0 --experimental-network-inspection /build/node-v24.15.0/test/parallel/test-inspector-network-websocket.js
nodejs-slim> out/Release/node --test-reporter=./test/common/test-error-reporter.js --test-reporter-destination=stdout /build/node-v24.15.0/test/report/test-report-exclude-network.js
nodejs-slim> make: *** [Makefile:596: test-ci-js] Error 1
```

Build OK on riscv64 :

<img width="460" height="85" alt="image" src="https://github.com/user-attachments/assets/470f9a3b-13c2-40ed-b381-011d41dd1dc5" />


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
