### PR TITLE
python3Packages.trackers: init at 2.4.0

### DIFF
--- a/pkgs/development/python-modules/trackers/default.nix
+++ b/pkgs/development/python-modules/trackers/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  numpy,
+  opencv-python,
+  requests,
+  rich,
+  scipy,
+  supervision,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "trackers";
+  version = "2.4.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "roboflow";
+    repo = "trackers";
+    tag = finalAttrs.version;
+    hash = "sha256-BJsRRKz+NyjldT88ZVTkqd0pVul/rLicFA9QpUSOGDg=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    numpy
+    opencv-python
+    requests
+    rich
+    scipy
+    supervision
+  ];
+
+  # Tests require external data downloads and GPU resources.
+  doCheck = false;
+
+  pythonImportsCheck = [ "trackers" ];
+
+  meta = {
+    description = "Unified library for object tracking featuring clean room re-implementations of leading multi-object tracking algorithms";
+    homepage = "https://github.com/roboflow/trackers";
+    changelog = "https://github.com/roboflow/trackers/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ mahyarmirrashed ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20082,6 +20082,8 @@ self: super: with self; {
 
   tracerite = callPackage ../development/python-modules/tracerite { };
 
+  trackers = callPackage ../development/python-modules/trackers { };
+
   trackpy = callPackage ../development/python-modules/trackpy { };
 
   trafilatura = callPackage ../development/python-modules/trafilatura { };


### PR DESCRIPTION
Adds https://github.com/roboflow/trackers.

Trackers gives a clean, modular re-implementations of leading multi-object tracking algorithms

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
