### PR TITLE
python3Packages.py-deprecate: 0.7.0 -> 0.9.0, rename to pydeprecate

### DIFF
--- a/pkgs/development/python-modules/py-deprecate/default.nix
+++ b/pkgs/development/python-modules/py-deprecate/default.nix
@@ -2,36 +2,74 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonOlder,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  typing-extensions,
+
+  # optional-dependencies
+  # audit
+  packaging,
+  # cli
+  fire,
+  rich,
+
+  # tests
+  pytest-asyncio,
   pytestCheckHook,
   scikit-learn,
 }:
 
-let
+buildPythonPackage (finalAttrs: {
   pname = "py-deprecate";
-  version = "0.7.0";
-in
-buildPythonPackage {
-  inherit pname version;
-  format = "setuptools";
+  version = "0.9.0";
+  pyproject = true;
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "Borda";
     repo = "pyDeprecate";
-    tag = "v${version}";
-    hash = "sha256-agJTANU3WhmAxj8EjeewHtvPxF9Fr0cRHNTMZBtDFQA=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-M3h5m+MqUYl8902YUqKqPfLpZXF3yQjlXP8f0ehnHds=";
   };
 
-  nativeCheckInputs = [
-    pytestCheckHook
-    scikit-learn
+  build-system = [
+    setuptools
   ];
+
+  dependencies = lib.optionals (pythonOlder "3.13") [
+    typing-extensions
+  ];
+
+  optional-dependencies = {
+    audit = [
+      packaging
+    ];
+    cli = [
+      fire
+      rich
+    ];
+  };
 
   pythonImportsCheck = [ "deprecate" ];
 
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytestCheckHook
+    scikit-learn
+    typing-extensions
+  ]
+  ++ finalAttrs.passthru.optional-dependencies.cli;
+
   meta = {
-    description = "Module for marking deprecated functions or classes and re-routing to the new successors' instance. Used by torchmetrics";
+    description = "Module for marking deprecated functions or classes and re-routing to the new successors' instance";
     homepage = "https://borda.github.io/pyDeprecate/";
+    downloadPage = "https://github.com/Borda/pyDeprecate";
+    changelog = "https://github.com/Borda/pyDeprecate/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ SomeoneSerge ];
   };
-}
+})

--- a/pkgs/development/python-modules/pydeprecate/default.nix
+++ b/pkgs/development/python-modules/pydeprecate/default.nix
@@ -24,7 +24,7 @@
 }:
 
 buildPythonPackage (finalAttrs: {
-  pname = "py-deprecate";
+  pname = "pyDeprecate";
   version = "0.9.0";
   pyproject = true;
   __structuredAttrs = true;

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -421,6 +421,7 @@ mapAliases {
   push-receiver = throw "push-receiver has been removed since it is unmaintained for 3 years"; # added 2025-05-17
   pushbullet = throw "'pushbullet' has been renamed to/replaced by 'pushbullet-py'"; # Converted to throw 2025-10-29
   Pweave = throw "'Pweave' has been renamed to/replaced by 'pweave'"; # Converted to throw 2025-10-29
+  py-deprecate = throw "'py-deprecate' has been renamed to/replaced by 'pydeprecate'"; # Converted to throw 2026-06-19
   py-eth-sig-utils = throw "py-eth-sig-utils has been removed because it has been marked as broken since at least November 2024."; # Added 2025-10-04
   py-scrypt = scrypt; # added 2025-08-07
   py_stringmatching = throw "'py_stringmatching' has been renamed to/replaced by 'py-stringmatching'"; # Converted to throw 2025-10-29

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13415,8 +13415,6 @@ self: super: with self; {
 
   py-datastruct = callPackage ../development/python-modules/py-datastruct { };
 
-  py-deprecate = callPackage ../development/python-modules/py-deprecate { };
-
   py-desmume = callPackage ../development/python-modules/py-desmume {
     inherit (pkgs) libpcap; # Avoid confusion with python package of the same name
   };
@@ -13913,6 +13911,8 @@ self: super: with self; {
   pydemumble = callPackage ../development/python-modules/pydemumble { };
 
   pydenticon = callPackage ../development/python-modules/pydenticon { };
+
+  pydeprecate = callPackage ../development/python-modules/pydeprecate { };
 
   pydeps = callPackage ../development/python-modules/pydeps { inherit (pkgs) graphviz; };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/Borda/pyDeprecate/compare/v0.7.0...v0.9.0
Changelog: https://github.com/Borda/pyDeprecate/releases/tag/v0.9.0

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
