### PR TITLE
mbwilding packages: init dtctl, github-copilot, open-ecc, power-platform-toolbox, steam-achievement-manager

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17523,6 +17523,12 @@
     githubId = 2971615;
     name = "Marius Bergmann";
   };
+  mbwilding = {
+    email = "mbwilding@gmail.com";
+    github = "mbwilding";
+    githubId = 8856912;
+    name = "Matthew Wilding";
+  };
   mccartykim = {
     email = "mccartykim@zoho.com";
     github = "mccartykim";

--- a/pkgs/by-name/dt/dtctl/package.nix
+++ b/pkgs/by-name/dt/dtctl/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  testers,
+}:
+
+let
+  version = "0.30.3";
+
+  sources = {
+    "x86_64-linux" = {
+      url = "https://github.com/dynatrace-oss/dtctl/releases/download/v${version}/dtctl_${version}_linux_amd64.tar.gz";
+      hash = "sha256-Mg66uvyYnzm32hQS3Sxm3J5Hi3lG7w95HgoT5IhPrx8=";
+    };
+    "aarch64-linux" = {
+      url = "https://github.com/dynatrace-oss/dtctl/releases/download/v${version}/dtctl_${version}_linux_arm64.tar.gz";
+      hash = "sha256-GfhYRwIIYpvganlp/sQ7ATc130yvepVDnfUkG1iDM5I=";
+    };
+    "x86_64-darwin" = {
+      url = "https://github.com/dynatrace-oss/dtctl/releases/download/v${version}/dtctl_${version}_darwin_amd64.tar.gz";
+      hash = "sha256-FHpCfjhoLdbYmn5g43x4mffWshChXXhqdutg4CvLybk=";
+    };
+    "aarch64-darwin" = {
+      url = "https://github.com/dynatrace-oss/dtctl/releases/download/v${version}/dtctl_${version}_darwin_arm64.tar.gz";
+      hash = "sha256-PpMFacjzcQKUlc+LrYJxra5wXyV4qNGAMleC2QhmgHg=";
+    };
+  };
+
+  source =
+    sources.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dtctl";
+  version = version;
+
+  src = fetchurl {
+    inherit (source) url hash;
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  sourceRoot = ".";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 dtctl $out/bin/dtctl
+    wrapProgram $out/bin/dtctl \
+      --set DTCTL_TOKEN_STORAGE file
+    install -Dm644 completions/dtctl.bash $out/share/bash-completion/completions/dtctl
+    install -Dm644 completions/dtctl.fish $out/share/fish/vendor_completions.d/dtctl.fish
+    install -Dm644 completions/dtctl.zsh $out/share/zsh/site-functions/_dtctl
+    runHook postInstall
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "dtctl version";
+  };
+
+  meta = {
+    description = "CLI for the Dynatrace platform";
+    homepage = "https://github.com/dynatrace-oss/dtctl";
+    downloadPage = "https://github.com/dynatrace-oss/dtctl/releases";
+    license = lib.licenses.asl20;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    maintainers = with lib.maintainers; [ mbwilding ];
+    platforms = builtins.attrNames sources;
+    mainProgram = "dtctl";
+  };
+})

--- a/pkgs/by-name/gi/github-copilot/package.nix
+++ b/pkgs/by-name/gi/github-copilot/package.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  stdenv,
+  appimageTools,
+  fetchurl,
+  makeWrapper,
+}:
+
+let
+  pname = "github-copilot";
+  version = "1.0.2";
+
+  sources = {
+    "x86_64-linux" = {
+      url = "https://github.com/github/app/releases/download/v${version}/GitHub-Copilot-linux-x64.AppImage";
+      hash = "sha256-IFUhSwvI/+bBEwf3iFd4+IHOgDCF/+DBmiHME6MrSLU=";
+    };
+    "aarch64-linux" = {
+      url = "https://github.com/github/app/releases/download/v${version}/GitHub-Copilot-linux-arm64.AppImage";
+      hash = "sha256-HgMKs+1Z1HhK/+g2kZjPVrLHPxcfJ5EX6VXrRLOn7F4=";
+    };
+    "aarch64-darwin" = {
+      url = "https://github.com/github/app/releases/download/v${version}/GitHub-Copilot-darwin-arm64.tar.gz";
+      hash = "sha256-KT9uepk3yhKNbLSagFWq967FVfw0mn4r9xWf7M+l9oQ=";
+    };
+    "x86_64-darwin" = {
+      url = "https://github.com/github/app/releases/download/v${version}/GitHub-Copilot-darwin-x64.tar.gz";
+      hash = "sha256-BRyrLJGKOjeGgQ9Cp0NNSR85ugX0bK0NnMGPgYfvulE=";
+    };
+  };
+
+  source =
+    sources.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  src = fetchurl { inherit (source) url hash; };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit pname version src;
+  };
+
+  meta = {
+    description = "GitHub Copilot desktop app";
+    homepage = "https://github.com/github/app";
+    downloadPage = "https://github.com/github/app/releases";
+    license = lib.licenses.unfree;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    maintainers = with lib.maintainers; [ mbwilding ];
+    platforms = builtins.attrNames sources;
+    mainProgram = pname;
+  };
+
+  linuxPkg =
+    (appimageTools.wrapType2 {
+      inherit pname version src;
+
+      nativeBuildInputs = [ makeWrapper ];
+
+      extraInstallCommands = ''
+        install -Dm444 "${appimageContents}/GitHub Copilot.desktop" -T $out/share/applications/${pname}.desktop
+        install -Dm444 "${appimageContents}/usr/share/icons/hicolor/128x128/apps/github.png" \
+          -T $out/share/icons/hicolor/128x128/apps/${pname}.png
+
+        substituteInPlace $out/share/applications/${pname}.desktop \
+          --replace-fail 'Exec=github' "Exec=${pname}" \
+          --replace-fail 'Icon=github' "Icon=${pname}"
+
+        wrapProgram $out/bin/${pname} \
+          --set ELECTRON_OZONE_PLATFORM_HINT auto
+      '';
+
+      meta = meta;
+    }).overrideAttrs
+      {
+        strictDeps = true;
+        __structuredAttrs = true;
+      };
+
+  darwinPkg = stdenv.mkDerivation {
+    inherit pname version src;
+
+    nativeBuildInputs = [ makeWrapper ];
+
+    strictDeps = true;
+    __structuredAttrs = true;
+
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out/Applications" "$out/bin"
+      cp -r "GitHub Copilot.app" "$out/Applications/GitHub Copilot.app"
+      makeWrapper "$out/Applications/GitHub Copilot.app/Contents/MacOS/github" "$out/bin/${pname}"
+      runHook postInstall
+    '';
+
+    meta = meta;
+  };
+in
+if stdenv.hostPlatform.isLinux then linuxPkg else darwinPkg

--- a/pkgs/by-name/op/open-ecc/package.nix
+++ b/pkgs/by-name/op/open-ecc/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  testers,
+}:
+
+let
+  version = "0.0.7";
+
+  sources = {
+    "x86_64-linux" = {
+      url = "https://github.com/mbwilding/open-ecc/releases/download/v${version}/ecc-Linux-musl-x86_64.tar.gz";
+      hash = "sha256-NaSVQ8WcbN2PEpNuaz/JEex/1T5mHgz7vQWsAdPR2gc=";
+    };
+    "aarch64-linux" = {
+      url = "https://github.com/mbwilding/open-ecc/releases/download/v${version}/ecc-Linux-musl-arm64.tar.gz";
+      hash = "sha256-cRrBWgY25owmtyCaNc8wXyhfshYhsbc8vgInuw/klJE=";
+    };
+    "x86_64-freebsd" = {
+      url = "https://github.com/mbwilding/open-ecc/releases/download/v${version}/ecc-FreeBSD-x86_64.tar.gz";
+      hash = "sha256-b0XVwZpudNBw+oOGw9HGmxHCs0Wu1gAsesiyg9U07qM=";
+    };
+    "aarch64-darwin" = {
+      url = "https://github.com/mbwilding/open-ecc/releases/download/v${version}/ecc-macOS-arm64.tar.gz";
+      hash = "sha256-sepO2Ws6qfQqEqGootKoqLF9TjB2sfDhgBaiQ6Rpcm4=";
+    };
+    "x86_64-darwin" = {
+      url = "https://github.com/mbwilding/open-ecc/releases/download/v${version}/ecc-macOS-x86_64.tar.gz";
+      hash = "sha256-I33KRaVTUKaYJG5zqjFMArLW5gqcVTOZU/QaOxJtMeA=";
+    };
+  };
+
+  source =
+    sources.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "open-ecc";
+  inherit version;
+
+  src = fetchurl {
+    inherit (source) url hash;
+  };
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  sourceRoot = ".";
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 ecc $out/bin/ecc
+    runHook postInstall
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Unofficial Elgato Command Centre cross-platform CLI";
+    homepage = "https://github.com/mbwilding/open-ecc";
+    license = lib.licenses.mit;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    maintainers = with lib.maintainers; [ mbwilding ];
+    platforms = builtins.attrNames sources;
+    mainProgram = "ecc";
+  };
+})

--- a/pkgs/by-name/po/power-platform-toolbox/package.nix
+++ b/pkgs/by-name/po/power-platform-toolbox/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+  makeWrapper,
+}:
+
+let
+  pname = "power-platform-toolbox";
+  version = "1.2.2";
+
+  src = fetchurl {
+    url = "https://github.com/PowerPlatformToolBox/desktop-app/releases/download/v${version}/Power-Platform-ToolBox-${version}-x86_64-linux.AppImage";
+    hash = "sha256-Pgf6JqBmTSsThhqJZ0KC8UNuSj77s+mT2cYlVaevr+4=";
+  };
+
+  appimageContents = appimageTools.extractType1 {
+    inherit pname version src;
+  };
+in
+(appimageTools.wrapType2 {
+  inherit pname version src;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  extraInstallCommands = ''
+    install -Dm444 ${appimageContents}/powerplatform-toolbox.desktop -T $out/share/applications/${pname}.desktop
+    install -Dm444 ${appimageContents}/powerplatform-toolbox.png -T $out/share/icons/hicolor/512x512/apps/${pname}.png
+
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace-fail 'Exec=AppRun' "Exec=${pname}" \
+      --replace-fail 'Icon=powerplatform-toolbox' "Icon=${pname}"
+
+    wrapProgram $out/bin/${pname} \
+      --set ELECTRON_OZONE_PLATFORM_HINT x11
+  '';
+
+  meta = {
+    description = "Desktop app for managing Microsoft Power Platform resources";
+    homepage = "https://www.powerplatformtoolbox.com";
+    downloadPage = "https://github.com/PowerPlatformToolBox/desktop-app/releases";
+    license = lib.licenses.gpl3Only;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    maintainers = with lib.maintainers; [ mbwilding ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "power-platform-toolbox";
+  };
+}).overrideAttrs
+  {
+    strictDeps = true;
+    __structuredAttrs = true;
+  }

--- a/pkgs/by-name/st/steam-achievement-manager/package.nix
+++ b/pkgs/by-name/st/steam-achievement-manager/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  autoPatchelfHook,
+  gcc,
+  testers,
+}:
+
+let
+  version = "2.0.3";
+
+  sources = {
+    "x86_64-linux" = {
+      url = "https://github.com/mbwilding/steam-achievement-manager/releases/download/v${version}/sam-linux-x64.zip";
+      hash = "sha256-9550vfHLrsPRKCRHOdnl3+AtjDVAMMUxWrcT/6f6vyk=";
+    };
+    "aarch64-darwin" = {
+      url = "https://github.com/mbwilding/steam-achievement-manager/releases/download/v${version}/sam-mac-arm64.zip";
+      hash = "sha256-mBGib35CqQB0EiCU2pK8rSGHEpoXTHQCWj5uQ4eSaUo=";
+    };
+    "x86_64-darwin" = {
+      url = "https://github.com/mbwilding/steam-achievement-manager/releases/download/v${version}/sam-mac-x64.zip";
+      hash = "sha256-styxsf4GJWRSkLGkud2hvz0UX81A/IA05v+3GJo9iDo=";
+    };
+  };
+
+  source =
+    sources.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "steam-achievement-manager";
+  inherit version;
+
+  src = fetchzip {
+    inherit (source) url hash;
+    stripRoot = false;
+  };
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ gcc.cc.lib ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 sam $out/bin/sam
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      install -Dm644 libsteam_api.so $out/lib/libsteam_api.so
+    ''}
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+      install -Dm644 libsteam_api.dylib $out/lib/libsteam_api.dylib
+    ''}
+    runHook postInstall
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Steam Achievement Manager CLI";
+    homepage = "https://github.com/mbwilding/steam-achievement-manager";
+    license = lib.licenses.mit;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    maintainers = with lib.maintainers; [ mbwilding ];
+    platforms = builtins.attrNames sources;
+    mainProgram = "sam";
+  };
+})


### PR DESCRIPTION
> PR description and package derivations produced with AI assistance (OpenCode, claude-sonnet-4.6) and manually reviewed.

Adds 5 packages maintained by `mbwilding`, plus the maintainer entry. Each package is a separate commit for independent review.

- `dtctl` — CLI for the Dynatrace platform: https://github.com/dynatrace-oss/dtctl
- `github-copilot` — GitHub Copilot desktop app: https://github.com/github/app
- `open-ecc` — Unofficial Elgato Command Centre cross-platform CLI: https://github.com/mbwilding/open-ecc
- `power-platform-toolbox` — Desktop app for managing Microsoft Power Platform resources: https://www.powerplatformtoolbox.com
- `steam-achievement-manager` — Steam Achievement Manager CLI: https://github.com/mbwilding/steam-achievement-manager

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].