### PR TITLE
python3Packages.muon-optimizer: init at 0.1.0

### DIFF
--- a/pkgs/development/python-modules/muon-optimizer/default.nix
+++ b/pkgs/development/python-modules/muon-optimizer/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  nix-update-script,
+  torch,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "muon-optimizer";
+  version = "0.1.0";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchPypi {
+    pname = "muon_optimizer";
+    inherit (finalAttrs) version;
+    hash = "sha256-ZcUEQfKbckjlhjg9NxJi65BiZT6CCxEUPIGnoQukjac=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  pythonImportsCheck = [
+    "muon"
+  ];
+
+  dependencies = [
+    torch
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Optimizer for the hidden layers of neural networks";
+    homepage = "https://pypi.org/project/muon-optimizer";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jlesquembre ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10563,6 +10563,8 @@ self: super: with self; {
 
   munkres = callPackage ../development/python-modules/munkres { };
 
+  muon-optimizer = callPackage ../development/python-modules/muon-optimizer { };
+
   murmurhash = callPackage ../development/python-modules/murmurhash { };
 
   muscima = callPackage ../development/python-modules/muscima { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
