### PR TITLE
tinymist: 0.14.25 -> 0.15.0

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/myriad-dreamin.tinymist/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/myriad-dreamin.tinymist/default.nix
@@ -11,7 +11,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     name = "tinymist";
     publisher = "myriad-dreamin";
     inherit (tinymist) version;
-    hash = "sha256-13/qw2BZ/WG+TYNVncJ/PuFLaUhlAn63zaa27JcLITE=";
+    hash = "sha256-7kpW5EYOFsnib5i5xVcywgM82I0Ey/2mjC/LAjFy8qM=";
   };
 
   __structuredAttrs = true;

--- a/pkgs/by-name/ti/tinymist/package.nix
+++ b/pkgs/by-name/ti/tinymist/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tinymist";
   # Please update the corresponding vscode extension when updating
   # this derivation.
-  version = "0.14.25";
+  version = "0.15.0";
 
   __structuredAttrs = true;
 
@@ -23,10 +23,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "Myriad-Dreamin";
     repo = "tinymist";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-F+GDI+1n8PqhWIxHlKgdsZ8IhQo0CsyAV6g26f5ITVo=";
+    hash = "sha256-SfkyyszTmleWHa19jMgHjiOUvBOniVybDr9GBmtMVDw=";
   };
 
-  cargoHash = "sha256-JpeXrk/6FP27rcG84CzeaCn9JEMopvtu/rg7/w1TgzI=";
+  cargoHash = "sha256-ztJb2Br0Ph2qSeo9MGm9OdU66YPkep+9lBCrL2TimB4=";
 
   nativeBuildInputs = [
     installShellFiles
@@ -56,6 +56,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=references::tests::test"
     "--skip=rename::tests::test"
     "--skip=semantic_tokens_full::tests::test"
+
+    # Return "No compatible device found" when testing preview
+    "--skip=doc::tests::diff_v1_preview_frame_paints_generated_page"
+    "--skip=doc::tests::full_current_preview_frame_paints_generated_page_after_reset"
+    "--skip=doc::tests::page_canvas_exposes_synthetic_accesskit_link_nodes"
+    "--skip=doc::tests::page_canvas_exposes_synthetic_accesskit_text_runs"
+    "--skip=doc::tests::page_canvas_paints_selection_overlay_above_scene"
+    "--skip=doc::tests::page_canvas_paints_supplied_white_background"
+    "--skip=doc::tests::page_canvas_selects_and_copies_text"
+    "--skip=doc::tests::page_canvas_uses_pointer_cursor_over_links"
   ];
 
   postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (


### PR DESCRIPTION
Changelog: https://github.com/Myriad-Dreamin/tinymist/releases/tag/v0.15.0
Diff: https://github.com/Myriad-Dreamin/tinymist/compare/v0.14.25...v0.15.0

Skip preview-related tests that fail due to "No compatible device found"


This PR doesn't yet address the auto-updates to pre-release versions as I didn't find an easy solution. If you know how to let the nix-update bot filter for latest flags, please let me know or open another PR.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
