### PR TITLE
proxyauth: fix 404

### DIFF
--- a/pkgs/by-name/pr/proxyauth/package.nix
+++ b/pkgs/by-name/pr/proxyauth/package.nix
@@ -33,6 +33,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     nettle
   ];
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   nativeInstallCheckInputs = [
     versionCheckHook
   ];

--- a/pkgs/by-name/pr/proxyauth/package.nix
+++ b/pkgs/by-name/pr/proxyauth/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitHub,
+  fetchFromForgejo,
   rustPlatform,
   pkg-config,
   openssl,
@@ -13,10 +13,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "proxyauth";
   version = "0.8.0";
 
-  src = fetchFromGitHub {
+  src = fetchFromForgejo {
+    domain = "git.proxyauth.app";
     owner = "ProxyAuth";
     repo = "ProxyAuth";
-    tag = finalAttrs.version;
+    rev = "13b353e4a8b34fc1736c834cfcaa9afe06e8abf8";
+    # Tags were not replicated from GitHub to git.proxyauth.app
     hash = "sha256-cVjD91tBCGyslLsYUSP1Gy7KuMQZDVxQXU7fQkWeWyM=";
   };
 
@@ -42,7 +44,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   meta = {
     description = "Proxy Authentication Token - Fast authentication gateway for backend APIs";
-    homepage = "https://github.com/ProxyAuth/ProxyAuth";
+    homepage = "https://git.proxyauth.app/ProxyAuth/ProxyAuth";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ liberodark ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
Fix repo link.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
