### PR TITLE
tt-toplike: init at 0.6.2-unstable-2026-06-08

### DIFF
--- a/pkgs/by-name/tt/tt-toplike/package.nix
+++ b/pkgs/by-name/tt/tt-toplike/package.nix
@@ -1,0 +1,139 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  makeWrapper,
+  pkg-config,
+  tt-smi,
+  dbus,
+  fontconfig,
+  freetype,
+  libGL,
+  libx11,
+  libxcb,
+  libxcursor,
+  libxi,
+  libxkbcommon,
+  libxrandr,
+  vulkan-loader,
+  wayland,
+  withTui ? true,
+  withGui ? false,
+  withEgui ? false,
+  withApp ? false,
+}:
+
+let
+  # tt-toplike-app hosts tt-toplike-tui in a PTY, so enabling the app must
+  # also build and install the TUI binary.
+  enableTui = withTui || withApp;
+  hasGraphicalFrontend = withGui || withEgui || withApp;
+
+  frontendFeatures =
+    lib.optional enableTui "tui"
+    ++ lib.optional withGui "gui"
+    ++ lib.optional withEgui "egui"
+    ++ lib.optional withApp "app";
+
+  frontendBinaries =
+    lib.optional enableTui "tt-toplike-tui"
+    ++ lib.optional withGui "tt-toplike-gui"
+    ++ lib.optional withEgui "tt-toplike-egui"
+    ++ lib.optional withApp "tt-toplike-app";
+
+  guiLibraries = [
+    dbus
+    fontconfig
+    freetype
+    libGL
+    libx11
+    libxcb
+    libxcursor
+    libxi
+    libxkbcommon
+    libxrandr
+    vulkan-loader
+    wayland
+  ];
+
+  wrapperArgs = lib.escapeShellArgs (
+    [
+      "--prefix"
+      "PATH"
+      ":"
+      (lib.makeBinPath [ tt-smi ])
+    ]
+    ++ lib.optionals hasGraphicalFrontend [
+      "--prefix"
+      "LD_LIBRARY_PATH"
+      ":"
+      (lib.makeLibraryPath guiLibraries)
+    ]
+  );
+in
+
+assert lib.assertMsg (frontendBinaries != [ ]) "tt-toplike: at least one frontend must be enabled";
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tt-toplike";
+  version = "0.6.2-unstable-2026-06-08";
+
+  src = fetchFromGitHub {
+    owner = "tenstorrent";
+    repo = "tt-toplike";
+    rev = "487bfe5aa6236068f6a7a148529601c57a2f7648";
+    hash = "sha256-ZffI1RORPRbntYTeb8DgtpQcUMxrrYEhqzg5XPH2f+E=";
+  };
+
+  cargoHash = "sha256-puHjLwKCPFQBKGnMStzdnFxmDiALdkgJWld2W3Sd7Sc=";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = lib.optionals hasGraphicalFrontend guiLibraries;
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = [
+    "json-backend"
+    "linux-procfs"
+  ]
+  ++ frontendFeatures;
+
+  cargoBuildFlags = lib.concatMap (binary: [
+    "--bin"
+    binary
+  ]) frontendBinaries;
+
+  cargoTestFlags = [ "--lib" ];
+
+  postFixup = ''
+    for binary in ${lib.concatStringsSep " " frontendBinaries}; do
+      if [ -x "$out/bin/$binary" ]; then
+        wrapProgram "$out/bin/$binary" ${wrapperArgs}
+      fi
+    done
+  '';
+
+  passthru = {
+    inherit
+      withTui
+      withGui
+      withEgui
+      withApp
+      ;
+  };
+
+  meta = {
+    description = "Real-time hardware monitoring for Tenstorrent silicon";
+    homepage = "https://github.com/tenstorrent/tt-toplike";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers."mert-kurttutan" ];
+    mainProgram = builtins.head frontendBinaries;
+    platforms = [ "x86_64-linux" ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
