### PR TITLE
go_1_27: init at 1.27rc1

### DIFF
--- a/pkgs/development/compilers/go/1.27.nix
+++ b/pkgs/development/compilers/go/1.27.nix
@@ -1,0 +1,204 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  tzdata,
+  replaceVars,
+  iana-etc,
+  mailcap,
+  buildPackages,
+  pkgsBuildTarget,
+  targetPackages,
+  # for testing
+  buildGo127Module,
+  callPackage,
+}:
+
+let
+  goBootstrap = buildPackages.callPackage ./bootstrap124.nix { };
+
+  # We need a target compiler which is still runnable at build time,
+  # to handle the cross-building case where build != host == target
+  targetCC = pkgsBuildTarget.targetPackages.stdenv.cc;
+
+  isCross = stdenv.buildPlatform != stdenv.targetPlatform;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "go";
+  version = "1.27rc1";
+
+  src = fetchurl {
+    url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
+    hash = "sha256-M49R9VfG2xI1o+64mgk2r29ODUEWKR7zuOQRhrxlUzQ=";
+  };
+
+  strictDeps = true;
+  buildInputs =
+    [ ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.libc.out ]
+    ++ lib.optionals (stdenv.hostPlatform.libc == "glibc") [ stdenv.cc.libc.static ];
+
+  depsBuildTarget = lib.optional isCross targetCC;
+
+  depsTargetTarget = lib.optional stdenv.targetPlatform.isMinGW targetPackages.threads.package;
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  patches = [
+    (replaceVars ./iana-etc-1.25.patch {
+      iana = iana-etc;
+    })
+    # Patch the mimetype database location which is missing on NixOS.
+    # but also allow static binaries built with NixOS to run outside nix
+    (replaceVars ./mailcap-1.17.patch {
+      inherit mailcap;
+    })
+    # prepend the nix path to the zoneinfo files but also leave the original value for static binaries
+    # that run outside a nix server
+    (replaceVars ./tzdata-1.19.patch {
+      inherit tzdata;
+    })
+    ./remove-tools-1.11.patch
+    ./go_no_vendor_checks-1.27.patch
+    ./go-env-go_ldso.patch
+  ];
+
+  env = {
+    inherit (stdenv.targetPlatform.go) GOOS GOARCH GOARM;
+    # GOHOSTOS/GOHOSTARCH must match the building system, not the host system.
+    # Go will nevertheless build a for host system that we will copy over in
+    # the install phase.
+    GOHOSTOS = stdenv.buildPlatform.go.GOOS;
+    GOHOSTARCH = stdenv.buildPlatform.go.GOARCH;
+
+    GO386 = "softfloat"; # from Arch: don't assume sse2 on i686
+    # Wasi does not support CGO
+    # ppc64/linux CGO is incomplete/borked, and will likely not receive any further improvements
+    # https://github.com/golang/go/issues/8912
+    # https://github.com/golang/go/issues/13192
+    CGO_ENABLED =
+      if
+        (
+          stdenv.targetPlatform.isWasi
+          || (stdenv.targetPlatform.isPower64 && stdenv.targetPlatform.isBigEndian)
+        )
+      then
+        0
+      else
+        1;
+
+    GOROOT_BOOTSTRAP = "${goBootstrap}/share/go";
+  }
+  // lib.optionalAttrs isCross {
+    # {CC,CXX}_FOR_TARGET must be only set for cross compilation case as go expect those
+    # to be different from CC/CXX
+    CC_FOR_TARGET = "${targetCC}/bin/${targetCC.targetPrefix}cc";
+    CXX_FOR_TARGET = "${targetCC}/bin/${targetCC.targetPrefix}c++";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+    export GOCACHE=$TMPDIR/go-cache
+    if [ -f "$NIX_CC/nix-support/dynamic-linker" ]; then
+      export GO_LDSO=$(cat $NIX_CC/nix-support/dynamic-linker)
+    fi
+
+    export PATH=$(pwd)/bin:$PATH
+
+    ${lib.optionalString isCross ''
+      # Independent from host/target, CC should produce code for the building system.
+      # We only set it when cross-compiling.
+      export CC=${buildPackages.stdenv.cc}/bin/cc
+      # Prefer external linker for cross when CGO is supported, since
+      # we haven't taught go's internal linker to pick the correct ELF
+      # interpreter for cross
+      # When CGO is not supported we rely on static binaries being built
+      # since they don't need an ELF interpreter
+      export GO_EXTLINK_ENABLED=${toString finalAttrs.env.CGO_ENABLED}
+    ''}
+    ulimit -a
+
+    pushd src
+    ./make.bash
+    popd
+    runHook postBuild
+  '';
+
+  preInstall = ''
+    # Contains the wrong perl shebang when cross compiling,
+    # since it is not used for anything we can deleted as well.
+    rm src/regexp/syntax/make_perl_groups.pl
+  ''
+  + (
+    if (stdenv.buildPlatform.system != stdenv.hostPlatform.system) then
+      ''
+        mv bin/*_*/* bin
+        rmdir bin/*_*
+        ${lib.optionalString
+          (
+            !(
+              finalAttrs.env.GOHOSTARCH == finalAttrs.env.GOARCH && finalAttrs.env.GOOS == finalAttrs.env.GOHOSTOS
+            )
+          )
+          ''
+            rm -rf pkg/${finalAttrs.env.GOHOSTOS}_${finalAttrs.env.GOHOSTARCH} pkg/tool/${finalAttrs.env.GOHOSTOS}_${finalAttrs.env.GOHOSTARCH}
+          ''
+        }
+      ''
+    else
+      lib.optionalString (stdenv.hostPlatform.system != stdenv.targetPlatform.system) ''
+        rm -rf bin/*_*
+        ${lib.optionalString
+          (
+            !(
+              finalAttrs.env.GOHOSTARCH == finalAttrs.env.GOARCH && finalAttrs.env.GOOS == finalAttrs.env.GOHOSTOS
+            )
+          )
+          ''
+            rm -rf pkg/${finalAttrs.env.GOOS}_${finalAttrs.env.GOARCH} pkg/tool/${finalAttrs.env.GOOS}_${finalAttrs.env.GOARCH}
+          ''
+        }
+      ''
+  );
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/go
+    cp -a bin pkg src lib misc api doc go.env VERSION $out/share/go
+    mkdir -p $out/bin
+    ln -s $out/share/go/bin/* $out/bin
+    runHook postInstall
+  '';
+
+  disallowedReferences = [ goBootstrap ];
+
+  passthru = {
+    inherit goBootstrap;
+    tests = callPackage ./tests.nix {
+      go = finalAttrs.finalPackage;
+      buildGoModule = buildGo127Module;
+    };
+  };
+
+  __structuredAttrs = true;
+
+  meta = {
+    changelog = "https://go.dev/doc/devel/release#go${lib.versions.majorMinor finalAttrs.version}";
+    description = "Go Programming language";
+    homepage = "https://go.dev/";
+    license = lib.licenses.bsd3;
+    teams = [ lib.teams.golang ];
+    platforms =
+      lib.platforms.darwin ++ lib.platforms.linux ++ lib.platforms.wasi ++ lib.platforms.freebsd;
+    badPlatforms = [
+      # Support for big-endian POWER < 8 was dropped in 1.9, but POWER8 users have less of a reason to run in big-endian mode than pre-POWER8 ones
+      # So non-LE ppc64 is effectively unsupported, and Go SIGILLs on affordable ppc64 hardware
+      # https://github.com/golang/go/issues/19074 - Dropped support for big-endian POWER < 8, with community pushback
+      # https://github.com/golang/go/issues/73349 - upstream will not accept submissions to fix this
+      "powerpc64-linux"
+    ];
+    mainProgram = "go";
+  };
+})

--- a/pkgs/development/compilers/go/go_no_vendor_checks-1.27.patch
+++ b/pkgs/development/compilers/go/go_no_vendor_checks-1.27.patch
@@ -1,0 +1,26 @@
+diff --git a/src/cmd/go/internal/modload/import.go b/src/cmd/go/internal/modload/import.go
+index 98f17ccff15b3378c44350615e19226b5b8ee68f..964f86a6dd25ed0c25a923ae4e946da8a2eff713 100644
+--- a/src/cmd/go/internal/modload/import.go
++++ b/src/cmd/go/internal/modload/import.go
+@@ -350,7 +350,7 @@ func importFromModules(ld *Loader, ctx context.Context, path string, rs *Require
+ 				// vendor/modules.txt does not exist or the user manually added directories to the vendor directory.
+ 				// Go 1.23 and later require vendored packages to be present in modules.txt to be imported.
+ 				_, ok := vendorPkgModule[path]
+-				if ok || (gover.Compare(ld.MainModules.GoVersion(ld), gover.ExplicitModulesTxtImportVersion) < 0) {
++				if ok || (gover.Compare(ld.MainModules.GoVersion(ld), gover.ExplicitModulesTxtImportVersion) < 0) || os.Getenv("GO_NO_VENDOR_CHECKS") == "1" {
+ 					mods = append(mods, vendorPkgModule[path])
+ 					dirs = append(dirs, dir)
+ 					roots = append(roots, vendorDir)
+diff --git a/src/cmd/go/internal/modload/vendor.go b/src/cmd/go/internal/modload/vendor.go
+index 577e8f67769e0e92958ebcb684b3afa124014b64..ea7a45d90bcfb1dade2178e222b85ff52dee75b5 100644
+--- a/src/cmd/go/internal/modload/vendor.go
++++ b/src/cmd/go/internal/modload/vendor.go
+@@ -159,7 +159,7 @@ func checkVendorConsistency(ld *Loader, indexes []*modFileIndex, modFiles []*mod
+ 			panic(fmt.Errorf("not in workspace mode but number of indexes is %v, not 1", len(indexes)))
+ 		}
+ 		index := indexes[0]
+-		if gover.Compare(index.goVersion, "1.14") < 0 {
++		if gover.Compare(index.goVersion, "1.14") < 0 || (os.Getenv("GO_NO_VENDOR_CHECKS") == "1" && len(vendorMeta) == 0) {
+ 			// Go versions before 1.14 did not include enough information in
+ 			// vendor/modules.txt to check for consistency.
+ 			// If we know that we're on an earlier version, relax the consistency check.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7067,6 +7067,11 @@ with pkgs;
     go = buildPackages.go_1_26;
   };
 
+  inherit ({ go_1_27 = callPackage ../development/compilers/go/1.27.nix { }; }) go_1_27;
+  buildGo127Module = callPackage ../build-support/go/module.nix {
+    go = buildPackages.go_1_27;
+  };
+
   ### DEVELOPMENT / HARE
 
   hareHook = callPackage ../by-name/ha/hare/hook.nix { };


### PR DESCRIPTION
https://go.dev/doc/go1.27


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
