### PR TITLE
gpclient: restore gpgui.desktop for globalprotectcallback scheme handler

### DIFF
--- a/pkgs/by-name/gp/gpclient/package.nix
+++ b/pkgs/by-name/gp/gpclient/package.nix
@@ -131,6 +131,11 @@ rustPlatform.buildRustPackage {
     cp -r packaging/files/usr/lib $out/lib
     substituteInPlace $out/lib/NetworkManager/dispatcher.d/pre-down.d/gpclient.down \
       --replace-fail /usr/bin/gpclient $out/bin/gpclient
+
+    install -Dm644 packaging/files/usr/share/applications/gpgui.desktop \
+      $out/share/applications/gpgui.desktop
+    substituteInPlace $out/share/applications/gpgui.desktop \
+      --replace-fail /usr/bin/gpclient $out/bin/gpclient
   '';
 
   postFixup = ''


### PR DESCRIPTION
PR #485779 dropped the gpgui.desktop install, reasoning that all gpgui files require the proprietary gpgui binary. But the desktop file is not gpgui-only: its Exec is `gpclient launch-gui %u`, the free CLI subcommand that receives the SAML auth callback. Without it the x-scheme-handler/globalprotectcallback handler is unregistered, so external-browser SSO (`gpclient connect --browser <x>`) hangs after login. The browser opens globalprotectcallback://<data> with nothing to handle it, and the auth cookie never returns to the waiting connect process.

Reinstall the desktop file on Linux and point Exec at the gpclient in $out, matching the pre-2.5.1 behaviour.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
