### PR TITLE
zerostack: init at 1.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27742,6 +27742,12 @@
     githubId = 3512122;
     keys = [ { fingerprint = "5F29 132D EFA8 5DA0 B598  5BF2 5941 754C 1CDE 33BB"; } ];
   };
+  TheCodedKid = {
+    name = "Samuel";
+    email = "samuel.raumin@gmail.com";
+    github = "TheCodedKid";
+    githubId = 15819181;
+  };
   TheColorman = {
     name = "colorman";
     email = "nixpkgs@colorman.me";

--- a/pkgs/by-name/ze/zerostack/package.nix
+++ b/pkgs/by-name/ze/zerostack/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  mold,
+  openssl,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "zerostack";
+  version = "1.5.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "gi-dellav";
+    repo = "zerostack";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-CLBb7SaSaE4kpQqTOWdjneg9smszE5uJfvNJ8fQDmrg=";
+  };
+
+  cargoHash = "sha256-qBKvYXLmAMj42/ZAgxWHgRFZwzEYaY8biiUwqt/TEyo=";
+
+  nativeBuildInputs = [
+    pkg-config
+    mold
+  ];
+
+  buildInputs = [ openssl ];
+
+  # needs HOME for test run
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  # tests share a global TODO_LIST mutex and race under parallelism
+  dontUseCargoParallelTests = true;
+  checkFlags = [ "--test-threads=1" ];
+
+  buildFeatures = [
+    "acp"
+    "memory"
+    "multithread"
+  ];
+
+  meta = {
+    description = "Minimalistic coding agent written in Rust, optimized for memory footprint and performance";
+    homepage = "https://github.com/gi-dellav/zerostack";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ TheCodedKid ];
+    mainProgram = "zerostack";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
## Description

Adds `zerostack`, a minimalistic coding agent written in Rust, optimized for memory footprint and performance.

Homepage: https://github.com/gi-dellav/zerostack
Version: 1.5.0

Assisted-by: Claude Opus 4.8

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
