### PR TITLE
python3Packages.mdit-py-plugins: 0.5.0 -> 0.6.1

### DIFF
--- a/pkgs/development/python-modules/markdown-it-py/default.nix
+++ b/pkgs/development/python-modules/markdown-it-py/default.nix
@@ -26,14 +26,14 @@
 
 buildPythonPackage rec {
   pname = "markdown-it-py";
-  version = "4.0.0";
+  version = "4.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "executablebooks";
     repo = "markdown-it-py";
     tag = "v${version}";
-    hash = "sha256-92J9cMit2zwyjoE8G1YpwDxj+wiApQW2eUHxUOUt3as=";
+    hash = "sha256-S3xDPvnGqawsxAUcrMF/3a4jds6i+zfPLMpyvduaDpE=";
   };
 
   # fix downstrem usage of markdown-it-py[linkify]

--- a/pkgs/development/python-modules/mdit-py-plugins/default.nix
+++ b/pkgs/development/python-modules/mdit-py-plugins/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "mdit-py-plugins";
-  version = "0.5.0";
+  version = "0.6.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "executablebooks";
     repo = "mdit-py-plugins";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-MQU6u49KsWGaKeWU5v066kZidcfCoubqClxAapAZb9A=";
+    hash = "sha256-rG9l45V+qsXZmBpRGkt1zuCRJVOsEC+Z2WrplQ1oGSo=";
   };
 
   build-system = [ flit-core ];


### PR DESCRIPTION
This fixes a Markdown parsing bug in MyST that I keep having.

- https://github.com/executablebooks/mdit-py-plugins/releases/tag/v0.6.0
- https://github.com/executablebooks/mdit-py-plugins/releases/tag/v0.6.1

Also upgraded markdown-it-py to 4.2.0 to pass the tests.

- https://github.com/executablebooks/markdown-it-py/releases/tag/v4.1.0
- https://github.com/executablebooks/markdown-it-py/releases/tag/v4.2.0

Lots of packages using MyST for documentation, so I'm targeting staging.
There doesn't seem to be any breaking changes, so this can be backported.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
