### PR TITLE
infcloud: init at 0.13.1, allow for radicale to bundle it

### DIFF
--- a/pkgs/by-name/in/infcloud/package.nix
+++ b/pkgs/by-name/in/infcloud/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+}:
+stdenv.mkDerivation {
+  version = "0.13.1";
+  pname = "infcloud";
+
+  src = fetchzip {
+    url = "https://inf-it.com/open-source/download/InfCloud_0.13.1.zip";
+    hash = "sha256-OEZV1KWYua4HCVqtUMoPr1Y7a0DiO+2Lgy4tIBnQULo=";
+  };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp -r . $out/
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Open source CalDAV/CardDAV web client";
+    homepage = "https://inf-it.com/open-source/clients/infcloud/";
+    license = lib.licenses.agpl3Plus;
+    maintainers = [ lib.maintainers.erictapen ];
+  };
+}

--- a/pkgs/by-name/ra/radicale/package.nix
+++ b/pkgs/by-name/ra/radicale/package.nix
@@ -1,8 +1,9 @@
 {
-  fetchFromGitHub,
   lib,
+  fetchFromGitHub,
   nixosTests,
   python3,
+  infcloud ? null,
 }:
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
@@ -40,6 +41,12 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     pytestCheckHook
     waitress
   ];
+
+  # Since 3.5.0 Radicale allows for an optionally bundled InfCloud web client,
+  # no need for RadicaleInfcloud.
+  postInstall = lib.optionalString (infcloud != null) ''
+    ln -s '${infcloud}' $out/${python3.sitePackages}/radicale/web/internal_data/infcloud
+  '';
 
   passthru.tests = {
     inherit (nixosTests) radicale;

--- a/pkgs/by-name/ra/radicale/package.nix
+++ b/pkgs/by-name/ra/radicale/package.nix
@@ -1,8 +1,9 @@
 {
-  fetchFromGitHub,
   lib,
+  fetchFromGitHub,
   nixosTests,
   python3,
+  infcloud ? null,
 }:
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
@@ -44,6 +45,12 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   # skip tests which try to measure how long something takes; makes the build fail sometimes
   disabledTests = [ "delay" ];
+
+  # Since 3.5.0 Radicale allows for an optionally bundled InfCloud web client,
+  # no need for RadicaleInfcloud.
+  postInstall = lib.optionalString (infcloud != null) ''
+    ln -s '${infcloud}' $out/${python3.sitePackages}/radicale/web/internal_data/infcloud
+  '';
 
   passthru.tests = {
     inherit (nixosTests) radicale;


### PR DESCRIPTION
RadicaleInfcloud stopped working for me in 26.05, but since Radicale allows for bundling InfCloud now, we can just use a more elegant solution.

This makes `python3Packages.radicale-infcloud` obsolete, which I'd remove in another PR, so that this one can be backported.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
