### PR TITLE
Qrypad

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29680,6 +29680,12 @@
     githubId = 42812654;
     name = "William Underwood";
   };
+  wheelibin = {
+    email = "wheelibin@gmail.com";
+    github = "wheelibin";
+    githubId = 135223;
+    name = "Jon Wheeler";
+  };
   wheelsandmetal = {
     email = "jakob@schmutz.co.uk";
     github = "wheelsandmetal";

--- a/pkgs/by-name/qr/qrypad/package.nix
+++ b/pkgs/by-name/qr/qrypad/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+  writableTmpDirAsHomeHook,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "qrypad";
+  version = "1.8.3";
+
+  src = fetchFromGitHub {
+    owner = "wheelibin";
+    repo = "qrypad";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-vr3xH4ny/Bmz90SjpznlPBckeHQCrxh2HJhORRm2NNU=";
+  };
+
+  vendorHash = "sha256-5YBBy1kp+FNJMGzuIQHBIzxo9P7u0Z2hAepkmszcevA=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/wheelibin/qrypad/internal/constants.Version=${finalAttrs.version}"
+  ];
+
+  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terminal SQL client for Postgres, MySQL and SQLite";
+    homepage = "https://github.com/wheelibin/qrypad";
+    changelog = "https://github.com/wheelibin/qrypad/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ wheelibin ];
+    mainProgram = "qrypad";
+  };
+})


### PR DESCRIPTION
This PR add [qrypad](https://github.com/wheelibin/qrypad), a terminal SQL client for Postgres, MySQL and SQLite.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
