### PR TITLE
boomer: init at 0.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5835,6 +5835,12 @@
     githubId = 16950437;
     name = "cwyc";
   };
+  cxinu = {
+    email = "cxinu.main@protonmail.com";
+    github = "cxinu";
+    githubId = 72374438;
+    name = "cxinu";
+  };
   cybardev = {
     name = "Sheikh";
     github = "cybardev";

--- a/pkgs/by-name/bo/boomer/package.nix
+++ b/pkgs/by-name/bo/boomer/package.nix
@@ -1,0 +1,82 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  nim,
+  pkg-config,
+  makeWrapper,
+  wayland,
+  wayland-protocols,
+  libGL,
+  grim,
+}:
+
+let
+  x11-nim = fetchFromGitHub {
+    owner = "nim-lang";
+    repo = "x11";
+    rev = "1.2";
+    sha256 = "sha256-jBNsv8meDvF2ySKewbA+rF2XS+gqydZUl1xhEevD15o=";
+  };
+
+  opengl-nim = fetchFromGitHub {
+    owner = "nim-lang";
+    repo = "opengl";
+    rev = "1.2.9";
+    sha256 = "sha256-v3bMDobYQZqX0anBFIUfZx5q5/vxTHO6PDtKQlf5mgU=";
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "boomer";
+  version = "0.0.1";
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "cxinu";
+    repo = "zoomer";
+    rev = "v${version}";
+    hash = "sha256-oYDTvqUDw1UwzINQl32xQEUN8anZs3TbJ5qHvgC1k6k=";
+  };
+
+  nativeBuildInputs = [
+    nim
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    wayland
+    wayland-protocols
+    libGL
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    export HOME=$TMPDIR
+    nim -p:${x11-nim}/ -p:${opengl-nim}/src -d:release -d:wayland c src/boomer.nim
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    install -Dt $out/bin src/boomer
+    install -Dm644 LICENSE -t $out/share/licenses/${pname}/
+    install -Dm644 README.md -t $out/share/doc/${pname}/
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/boomer \
+      --prefix PATH : ${lib.makeBinPath [ grim ]}
+  '';
+
+  meta = with lib; {
+    description = "A zooming tool for Linux, Wayland port of tsoding's boomer.";
+    homepage = "https://github.com/cxinu/zoomer";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ cxinu ];
+  };
+}


### PR DESCRIPTION
[Boomer](https://github.com/cxinu/zoomer) is a Wayland port to tsoding's boomer, A Linux desktop zooming utility 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
