### PR TITLE
python3Packages.webencodings: migrate to pyproject

### DIFF
--- a/pkgs/development/python-modules/webencodings/default.nix
+++ b/pkgs/development/python-modules/webencodings/default.nix
@@ -2,18 +2,21 @@
   buildPythonPackage,
   lib,
   fetchPypi,
+  setuptools,
   pytest,
 }:
 
 buildPythonPackage rec {
   pname = "webencodings";
   version = "0.5.1";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923";
   };
+
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [ pytest ];
 

--- a/pkgs/development/python-modules/webencodings/default.nix
+++ b/pkgs/development/python-modules/webencodings/default.nix
@@ -6,14 +6,16 @@
   pytest,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "webencodings";
   version = "0.5.1";
   pyproject = true;
 
+  __structuredAttrs = true;
+
   src = fetchPypi {
-    inherit pname version;
-    sha256 = "b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923";
+    inherit (finalAttrs) pname version;
+    hash = "sha256-s2ocJF8tMEll604KgoSDeSQdwEuGWvzEqrFnSFh+GSM=";
   };
 
   build-system = [ setuptools ];
@@ -24,9 +26,11 @@ buildPythonPackage rec {
     py.test webencodings/tests.py
   '';
 
+  pythonImportsCheck = [ "webencodings" ];
+
   meta = {
     description = "Character encoding aliases for legacy web content";
     homepage = "https://github.com/SimonSapin/python-webencodings";
     license = lib.licenses.bsd3;
   };
-}
+})

--- a/pkgs/development/python-modules/webencodings/default.nix
+++ b/pkgs/development/python-modules/webencodings/default.nix
@@ -30,7 +30,7 @@ buildPythonPackage (finalAttrs: {
 
   meta = {
     description = "Character encoding aliases for legacy web content";
-    homepage = "https://github.com/SimonSapin/python-webencodings";
+    homepage = "https://github.com/gsnedders/python-webencodings";
     license = lib.licenses.bsd3;
   };
 })


### PR DESCRIPTION
- #515974 (Part Of)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
