### PR TITLE
grafana-image-renderer: 5.7.3 -> 5.8.11

### DIFF
--- a/pkgs/by-name/gr/grafana-image-renderer/package.nix
+++ b/pkgs/by-name/gr/grafana-image-renderer/package.nix
@@ -6,19 +6,19 @@
 
 buildGoModule (finalAttrs: {
   pname = "grafana-image-renderer";
-  version = "5.7.3";
+  version = "5.8.11";
 
   src = fetchFromGitHub {
     owner = "grafana";
     repo = "grafana-image-renderer";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-CrJkBx2BMGlFtqXR174A5CVTH2GIZHTVxxwJjCi68pg=";
+    hash = "sha256-qNi268XHyKQ2kvT24ovhzUEREaYMXWlGHfcuyRHjRYQ=";
   };
 
-  vendorHash = "sha256-3nd0m0PltTiJX5e1tbQ7LSgUmDRXC8nRktOVAIgHOCU=";
+  vendorHash = "sha256-QiseTdsFOBg3aDYpdmLHfXL9eFll6iJo4wSKwXvdGnM=";
 
   postPatch = ''
-    substituteInPlace go.mod --replace-fail 'go 1.26.1' 'go 1.25.7'
+    substituteInPlace go.mod --replace-fail 'go 1.26.4' 'go 1.26.3'
   '';
 
   subPackages = [ "." ];


### PR DESCRIPTION
ChangeLogs:
* https://github.com/grafana/grafana-image-renderer/releases/tag/v5.8.0
* https://github.com/grafana/grafana-image-renderer/releases/tag/v5.8.1
* https://github.com/grafana/grafana-image-renderer/releases/tag/v5.8.2
* https://github.com/grafana/grafana-image-renderer/releases/tag/v5.8.3
* https://github.com/grafana/grafana-image-renderer/releases/tag/v5.8.4
* https://github.com/grafana/grafana-image-renderer/releases/tag/v5.8.5
* https://github.com/grafana/grafana-image-renderer/releases/tag/v5.8.6
* https://github.com/grafana/grafana-image-renderer/releases/tag/v5.8.7
* https://github.com/grafana/grafana-image-renderer/releases/tag/v5.8.8
* https://github.com/grafana/grafana-image-renderer/releases/tag/v5.8.9
* https://github.com/grafana/grafana-image-renderer/releases/tag/v5.8.10
* https://github.com/grafana/grafana-image-renderer/releases/tag/v5.8.11


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
