### PR TITLE
switch-to-configuration-ng: handle transition to socket activation

### DIFF
--- a/nixos/tests/switch-test.nix
+++ b/nixos/tests/switch-test.nix
@@ -541,6 +541,12 @@ in
             systemd.services."accept-socket@".serviceConfig.X-Test = "test";
           };
 
+          socket-activated-without-socket.configuration = {
+            imports = [ simple-socket.configuration ];
+            systemd.sockets.socket-activated.enable = false;
+            systemd.services.socket-activated.wantedBy = [ "multi-user.target" ];
+          };
+
           mount.configuration = {
             systemd.mounts = [
               {
@@ -1619,6 +1625,18 @@ in
           # Socket-activation of the unit still works
           if machine.succeed("socat - UNIX-CONNECT:/run/test.sock") != "hello":
               raise Exception("Socket was not properly activated after the service was restarted")
+
+          # A service transitioning to socket activation is not started directly,
+          # it's left for the newly started socket to activate on demand
+          switch_to_specialisation("${machine}", "socket-activated-without-socket")
+          machine.succeed("systemctl is-active socket-activated.service")
+          out = switch_to_specialisation("${machine}", "simple-socket-stop-if-changed")
+          assert_contains(out, "stopping the following units: socket-activated.service\n")
+          assert_lacks(out, "\nstarting the following units:")
+          assert_contains(out, "the following new units were started: socket-activated.socket\n")
+          machine.succeed("[ -S /run/test.sock ]")
+          if machine.succeed("socat - UNIX-CONNECT:/run/test.sock") != "hello":
+              raise Exception("Socket was not properly activated after the transition")
 
       with subtest("socket-activated services with Accept=yes"):
           # Socket-activated services don't get started, just the socket

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
@@ -777,6 +777,9 @@ fn handle_modified_unit(
                     }
 
                     for socket in &sockets {
+                        let socket_in_new_config =
+                            toplevel.join(scope.etc_dir()).join(socket).exists();
+
                         if active_cur.contains_key(socket) {
                             // We can now be sure this is a socket-activated unit
 
@@ -787,7 +790,7 @@ fn handle_modified_unit(
                             }
 
                             // Only restart sockets that actually exist in new configuration:
-                            if toplevel.join(scope.etc_dir()).join(socket).exists() {
+                            if socket_in_new_config {
                                 if use_restart_as_stop_and_start {
                                     units_to_restart.insert(socket.to_string(), ());
                                     record_unit(&restart_list, socket);
@@ -798,12 +801,17 @@ fn handle_modified_unit(
 
                                 socket_activated = true;
                             }
+                        } else if socket_in_new_config {
+                            // Transitioning to socket activation; let the socket start it.
+                            socket_activated = true;
+                        } else {
+                            continue;
+                        }
 
-                            // Remove from units to reload so we don't restart and reload
-                            if units_to_reload.contains_key(unit) {
-                                units_to_reload.remove(unit);
-                                unrecord_unit(&reload_list, unit);
-                            }
+                        // Remove from units to reload so we don't restart and reload
+                        if units_to_reload.contains_key(unit) {
+                            units_to_reload.remove(unit);
+                            unrecord_unit(&reload_list, unit);
                         }
                     }
                 }

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/main.rs
@@ -743,11 +743,6 @@ fn handle_modified_unit(
                 // This unit should be restarted instead of stopped and started.
                 units_to_restart.insert(unit.to_string(), ());
                 record_unit(&restart_list, unit);
-                // Remove from units to reload so we don't restart and reload
-                if units_to_reload.contains_key(unit) {
-                    units_to_reload.remove(unit);
-                    unrecord_unit(&reload_list, unit);
-                }
             } else {
                 // If this unit is socket-activated, then stop the socket unit(s) as well, and
                 // restart the socket(s) instead of the service.
@@ -804,14 +799,6 @@ fn handle_modified_unit(
                         } else if socket_in_new_config {
                             // Transitioning to socket activation; let the socket start it.
                             socket_activated = true;
-                        } else {
-                            continue;
-                        }
-
-                        // Remove from units to reload so we don't restart and reload
-                        if units_to_reload.contains_key(unit) {
-                            units_to_reload.remove(unit);
-                            unrecord_unit(&reload_list, unit);
                         }
                     }
                 }
@@ -840,11 +827,11 @@ fn handle_modified_unit(
                 } else {
                     units_to_stop.insert(unit.to_string(), ());
                 }
-                // Remove from units to reload so we don't restart and reload
-                if units_to_reload.contains_key(unit) {
-                    units_to_reload.remove(unit);
-                    unrecord_unit(&reload_list, unit);
-                }
+            }
+
+            // Remove from units to reload so we don't restart and reload
+            if units_to_reload.remove(unit).is_some() {
+                unrecord_unit(&reload_list, unit);
             }
         }
     }


### PR DESCRIPTION
When a service gains a `.socket` unit, the socket is not yet active, so the `active_cur.contains_key(socket)` check is false and the service is queued in `units_to_start`. That races with the socket unit being started by `sockets.target`, producing "Socket service already active, refusing" or "no socket activation file descriptors found" errors.

Treat the service as socket-activated whenever the socket is absent now but present in the new configuration, leaving it to be activated on demand by the newly started socket rather than started directly.

Fixes: https://github.com/NixOS/nixpkgs/pull/510391#issuecomment-4273511176
Assisted-by: Claude:claude-opus-4-8


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
