### PR TITLE
mise: 2026.6.5 -> 2026.6.11

### DIFF
--- a/pkgs/by-name/mi/mise/package.nix
+++ b/pkgs/by-name/mi/mise/package.nix
@@ -22,16 +22,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mise";
-  version = "2026.6.5";
+  version = "2026.6.11";
 
   src = fetchFromGitHub {
     owner = "jdx";
     repo = "mise";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-z3+rGBwqTD0r22cv2Yk9EWyPj+mXJSMV6flrjG2LygA=";
+    hash = "sha256-8sC/gSgpP2A6rh8j0aZeMq8pLwbBvcSUAxhehQlTLJg=";
   };
 
-  cargoHash = "sha256-Qd57u6dTEUccTic9f5H/Kn5vQT4iZeKKnQtGUzrnP4A=";
+  cargoHash = "sha256-yya9rtEki0o0MfBeWK2/Mo16/I1Mg6aCZOQOP8aWJi0=";
 
   nativeBuildInputs = [
     installShellFiles
@@ -75,6 +75,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   checkFlags = [
     # last_modified will always be different in nix
     "--skip=tera::tests::test_last_modified"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux) [
+    # Nix's Linux sandbox rejects setting setuid bits.
+    "--skip=oci::layer::tests::preserve_metadata_dir_layer_keeps_special_permission_bits"
   ]
   ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
     # x86_64-darwin started failing mid-April 2025; aarch64 in Feb 2026


### PR DESCRIPTION
Updates mise from 2026.6.5 to 2026.6.11.

This also skips `oci::layer::tests::preserve_metadata_dir_layer_keeps_special_permission_bits` only on Linux. The upstream test sets setuid bits while checking OCI layer metadata preservation. nixpkgs-update hit `Operation not permitted` for that chmod under the Linux Nix build environment as seen in https://nixpkgs-update-logs.nix-community.org/mise/2026-06-15.log. The same test passed on Darwin so the skip is Linux-scoped instead of unconditional.

Changelog/release notes:
- https://github.com/jdx/mise/releases/tag/v2026.6.11
- https://github.com/jdx/mise/releases/tag/v2026.6.10

Automation disclosure: commit and PR were prepared with help from codex but reviewed and edited by me. The diff and verification output were reviewed in this session before submission.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

@konradmalik
