### PR TITLE
gh: 2.94.0 -> 2.95.0

### DIFF
--- a/pkgs/by-name/gh/gh/package.nix
+++ b/pkgs/by-name/gh/gh/package.nix
@@ -10,7 +10,7 @@
 
 buildGoModule (finalAttrs: {
   pname = "gh";
-  version = "2.94.0";
+  version = "2.95.0";
 
   __structuredAttrs = true;
 
@@ -18,10 +18,10 @@ buildGoModule (finalAttrs: {
     owner = "cli";
     repo = "cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-wv9hMep8dDKKpqzNI5We6KThOFX82ppzvkoGyhY21pk=";
+    hash = "sha256-Hzdod8dJuwFv3mNa4Nflqf8uy45RpoeO93sFSMq3D5E=";
   };
 
-  vendorHash = "sha256-sRpHQTJNDPVe1jaLO9zMqtIMDE6JQB3vUL7AMxlcnJA=";
+  vendorHash = "sha256-tqbo791t7phe6ip5UzBiLer0rGcKqpKGF0bqwxr3j78=";
 
   nativeBuildInputs = [
     installShellFiles


### PR DESCRIPTION
Bump `gh` from 2.94.0 to 2.95.0. Changelog: https://github.com/cli/cli/releases/tag/v2.95.0

## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [[NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests)] in [[nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)].
  - [ ] [[Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)] at `passthru.tests`.
  - [ ] Tests in [[lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests)] or [[pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [[nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [[CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)], [[pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md)], [[maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md)] and other READMEs.
- [x] Follows the [[automation/AI policy](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy)].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test