### PR TITLE
supmover: init at 2.5.1

### DIFF
--- a/pkgs/by-name/su/supmover/package.nix
+++ b/pkgs/by-name/su/supmover/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  nix-update-script,
+  fetchFromGitHub,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "supmover";
+  version = "2.5.1";
+
+  src = fetchFromGitHub {
+    owner = "MonoS";
+    repo = "SupMover";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-AqxmCl3BH9+QpGyB/rMpuafhEDaIHHNy1gHOqlal1Fw=";
+  };
+
+  installPhase = ''
+    install -Dm755 supmover $out/bin/supmover
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://github.com/MonoS/SupMover";
+    description = "Shift timings and Screen Area of PGS/Sup subtitle";
+
+    license = with lib.licenses; [
+      agpl3Only
+    ];
+
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      claraphyll
+    ];
+
+    mainProgram = "supmover";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+})


### PR DESCRIPTION
This adds [supmover](https://github.com/MonoS/SupMover), a package that allows users to move the position of subtitles in video files. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
