### PR TITLE
More vscode extensions

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/danielatanasov.todo/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/danielatanasov.todo/default.nix
@@ -1,0 +1,19 @@
+{
+  lib,
+  vscode-utils,
+}:
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "todo";
+    publisher = "danielatanasov";
+    version = "0.2.0";
+    hash = "sha256-5FNG4rNCD5OoTnnfE6ieHo26ArzonkqEK0Xaw4EJkg0=";
+  };
+  meta = {
+    description = "Hightlight TODOs in comments";
+    homepage = "https://github.com/Gismo359/todo-highlight#readme";
+    changelog = "https://github.com/Gismo359/todo-highlight/blob/master/CHANGELOG.md";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=DanielAtanasov.todo";
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -2591,6 +2591,8 @@ let
 
       jjk.jjk = callPackage ./jjk.jjk { };
 
+      joelkoz.nodeuml = callPackage ./joelkoz.nodeuml { };
+
       jkillian.custom-local-formatters = buildVscodeMarketplaceExtension {
         mktplcRef = {
           publisher = "jkillian";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1155,6 +1155,22 @@ let
         };
       };
 
+      danielatanasov.todo = buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "todo";
+          publisher = "danielatanasov";
+          version = "0.2.0";
+          hash = "sha256-5FNG4rNCD5OoTnnfE6ieHo26ArzonkqEK0Xaw4EJkg0=";
+        };
+        meta = {
+          description = "Hightlight TODOs in comments";
+          homepage = "https://github.com/Gismo359/todo-highlight#readme";
+          changelog = "https://github.com/Gismo359/todo-highlight/blob/master/CHANGELOG.md";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=DanielAtanasov.todo";
+          license = lib.licenses.mit;
+        };
+      };
+
       danielgavin.ols = buildVscodeMarketplaceExtension {
         mktplcRef = {
           publisher = "DanielGavin";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -5558,6 +5558,22 @@ let
         };
       };
 
+      zhiyuan-lin.simple-perl = vscode-utils.buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "simple-perl";
+          publisher = "zhiyuan-lin";
+          version = "0.0.4";
+          hash = "sha256-rXpAWnB6NNLfYqkxPe9TF3uog7+thnt7O7vphH4dtmA=";
+        };
+        meta = {
+          description = "Supports perltidy and perlcritic.";
+          homepage = "https://github.com/itsuki-hayashi/vscode-perl#readme";
+          changelog = "https://github.com/itsuki-hayashi/vscode-perl/blob/master/CHANGELOG.md";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=zhiyuan-lin.simple-perl";
+          license = lib.licenses.mit;
+        };
+      };
+
       zhuangtongfa.material-theme = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "material-theme";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -3854,6 +3854,22 @@ let
         };
       };
 
+      prateekmahendrakar.prettyxml = vscode-utils.buildVscodeMarketplaceExtension {
+        mktplcRef = {
+          name = "prettyxml";
+          publisher = "prateekmahendrakar";
+          version = "6.8.0";
+          hash = "sha256-QfFrWxuHPVmIHgTEdiWPG7J5j3G/Fw1mvV8RY27VpQk=";
+        };
+        meta = {
+          description = "Formats XML documents just like Visual Studio.";
+          homepage = "https://github.com/pmahend1/prettyxml#readme";
+          changelog = "https://github.com/pmahend1/prettyxml/blob/master/CHANGELOG.md";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=prateekmahendrakar.prettyxml";
+          license = lib.licenses.mit;
+        };
+      };
+
       pylyzer.pylyzer = callPackage ./pylyzer.pylyzer { };
 
       pythagoratechnologies.gpt-pilot-vs-code = buildVscodeMarketplaceExtension {

--- a/pkgs/applications/editors/vscode/extensions/joelkoz.nodeuml/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/joelkoz.nodeuml/default.nix
@@ -1,0 +1,20 @@
+{
+  lib,
+  vscode-utils,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "nodeuml";
+    publisher = "joelkoz";
+    version = "2.1.1";
+    hash = "sha256-sYVqldGk+eSqm/6gMAdEvWcN6GGn4G8xjkOUxs9fw0c=";
+  };
+  meta = {
+    description = "Create UML class diagrams and generate code with NodeMDA.";
+    homepage = "https://github.com/joelkoz/NodeUML#readme";
+    changelog = "https://github.com/joelkoz/NodeUML/blob/master/CHANGELOG.md";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=joelkoz.nodeuml";
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/prateekmahendrakar.prettyxml/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/prateekmahendrakar.prettyxml/default.nix
@@ -1,0 +1,19 @@
+{
+  lib,
+  vscode-utils,
+}:
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "prettyxml";
+    publisher = "prateekmahendrakar";
+    version = "6.8.0";
+    hash = "sha256-QfFrWxuHPVmIHgTEdiWPG7J5j3G/Fw1mvV8RY27VpQk=";
+  };
+  meta = {
+    description = "Formats XML documents just like Visual Studio.";
+    homepage = "https://github.com/pmahend1/prettyxml#readme";
+    changelog = "https://github.com/pmahend1/prettyxml/blob/master/CHANGELOG.md";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=prateekmahendrakar.prettyxml";
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/zhiyuan-lin.simple-perl/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/zhiyuan-lin.simple-perl/default.nix
@@ -1,0 +1,19 @@
+{
+  lib,
+  vscode-utils,
+}:
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "simple-perl";
+    publisher = "zhiyuan-lin";
+    version = "0.0.4";
+    hash = "sha256-rXpAWnB6NNLfYqkxPe9TF3uog7+thnt7O7vphH4dtmA=";
+  };
+  meta = {
+    description = "Supports perltidy and perlcritic.";
+    homepage = "https://github.com/itsuki-hayashi/vscode-perl#readme";
+    changelog = "https://github.com/itsuki-hayashi/vscode-perl/blob/master/CHANGELOG.md";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=zhiyuan-lin.simple-perl";
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
## Things done

I added 3 extensions that were missing from the nixpkgs : 
- danielatanasov.todo : https://github.com/Gismo359/todo-highlight#readme
- prateekmahendrakar.prettyxml : https://github.com/pmahend1/prettyxml#readme
- zhiyuan-lin.simple-perl : https://github.com/itsuki-hayashi/vscode-perl#readme

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
