### PR TITLE
xfsdump: fix buffer overflow crash

### DIFF
--- a/pkgs/by-name/xf/xfsdump/package.nix
+++ b/pkgs/by-name/xf/xfsdump/package.nix
@@ -10,6 +10,7 @@
   libtool,
   libuuid,
   libxfs,
+  fetchpatch,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -32,6 +33,17 @@ stdenv.mkDerivation (finalAttrs: {
     libuuid
     libxfs
     ncurses
+  ];
+  # xfsdump doesn't use flexible array. The old dh_name[6] causes buffer
+  # overflow crash while strcpy() in various places.
+  # See:
+  # https://github.com/NixOS/nixpkgs/pull/533325
+  # https://lore.kernel.org/linux-xfs/20260625222337.54449-1-celeste@collar.sh/T/#u
+  patches = [
+    (fetchpatch {
+      url = "https://lore.kernel.org/linux-xfs/20260625222337.54449-1-celeste@collar.sh/raw";
+      sha256 = "sha256-iOxnd9lgdeNQThinzEjMRKN90YLRcGdTuczUFU61Cm8=";
+    })
   ];
 
   postPatch = ''


### PR DESCRIPTION
The xfsdump uses old style flexible arrays. These arrays are placed after the header struct, which has last element as a pointer to that array. Source fortification adds boundary checks while copying to that pointer. This breaks strcpy() and memcpy() functions which fails at runtime with buffer overflow message.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
