### PR TITLE
qman: init at 1.5.1

### DIFF
--- a/pkgs/by-name/qm/qman/package.nix
+++ b/pkgs/by-name/qm/qman/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  runtimeShell,
+  man-db,
+  groff,
+  xdg-utils,
+  meson,
+  ninja,
+  pkg-config,
+  cmake,
+  python3Packages,
+  ncurses,
+  zlib,
+  bzip2,
+  xz,
+  cunit,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "qman";
+  version = "1.5.1";
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "plp13";
+    repo = "qman";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-z3ILbbwcCYZT8qabVaGnMCyZRag8djEI32i6G7cLL2A=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/qman_tests_list.sh \
+      --replace-fail "/usr/bin/env bash" ${runtimeShell}
+    substituteInPlace src/config_def.py \
+      --replace-fail "/usr/bin/man" ${man-db}/bin/man \
+      --replace-fail "/usr/bin/groff" ${groff}/bin/groff \
+      --replace-fail "/usr/bin/whatis" ${man-db}/bin/whatis \
+      --replace-fail "/usr/bin/apropos" ${man-db}/bin/apropos \
+      --replace-fail "/usr/bin/xdg-open" ${xdg-utils}/bin/xdg-open \
+      --replace-fail "/usr/bin/xdg-email" ${xdg-utils}/bin/xdg-email
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    cmake
+    python3Packages.cogapp
+  ];
+
+  buildInputs = [
+    ncurses
+    zlib
+    bzip2
+    xz
+    cunit
+  ];
+
+  mesonFlags = [
+    "-Dconfigdir=${placeholder "out"}/etc/xdg/qman"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A more modern man page viewer for our terminals";
+    homepage = "https://github.com/plp13/qman";
+    changelog = "https://github.com/plp13/qman/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ pborzenkov ];
+    mainProgram = "qman";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
https://github.com/plp13/qman

Assisted-by: nix-init


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
