### PR TITLE
cpat: init at 1.4.2

### DIFF
--- a/pkgs/by-name/cp/cpat/format-security.patch
+++ b/pkgs/by-name/cp/cpat/format-security.patch
@@ -1,0 +1,44 @@
+diff --git a/src/cpat.c b/src/cpat.c
+index 4bb5dec..6aeeca3 100644
+--- a/src/cpat.c
++++ b/src/cpat.c
+@@ -126,10 +126,10 @@ pager(char *title,char* text,int num_phrases, char **phrases)
+ 
+     /* Add title and header lines */
+     wattron(outer,A_UNDERLINE);
+-    mvwprintw(outer,2,4,title);
++    mvwprintw(outer,2,4,"%s",title);
+     xtermtitle(title);
+     wattroff(outer,A_UNDERLINE);
+-    for (i = 0;i < num_phrases;i++) mvwprintw(outer,4+i,4,phrases[i]);
++    for (i = 0;i < num_phrases;i++) mvwprintw(outer,4+i,4,"%s",phrases[i]);
+     wrefresh(outer);
+ 
+     /* Values for inner window */
+@@ -244,10 +244,10 @@ d                    Scroll forward half a page\n\
+ q                    Exit pager",-1,NULL);
+                     box(outer,0,0);
+                     wattron(outer,A_UNDERLINE);
+-                    mvwprintw(outer,2,4,title);
++                    mvwprintw(outer,2,4,"%s",title);
+                     xtermtitle(title);
+                     wattroff(outer,A_UNDERLINE);
+-                    for (i = 0;i < num_phrases;i++) mvwprintw(outer,4+i,4,phrases[i]);
++                    for (i = 0;i < num_phrases;i++) mvwprintw(outer,4+i,4,"%s",phrases[i]);
+                     wrefresh(outer);
+                     prev_line = -1; /* force page refresh */
+                     break;
+@@ -354,11 +354,11 @@ menu(char *title,char **queries,int num_queries,
+     box(outer, 0, 0);
+ 
+     wattron(outer,A_UNDERLINE);
+-    mvwprintw(outer,title_y,4,title);
++    mvwprintw(outer,title_y,4,"%s",title);
+     xtermtitle(title);
+     wattroff(outer,A_UNDERLINE);
+     for (i = 0;i < num_phrases;i++) 
+-        mvwprintw(outer,phrases_y+i,6,phrases[i]);
++        mvwprintw(outer,phrases_y+i,6,"%s",phrases[i]);
+     wrefresh(outer);
+ 
+     input = newwin(inner_h,inner_w,inner_y,inner_x);

--- a/pkgs/by-name/cp/cpat/package.nix
+++ b/pkgs/by-name/cp/cpat/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  ncurses,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cpat";
+  version = "1.4.2";
+
+  src = fetchurl {
+    url = "https://downloads.sourceforge.net/project/cpat/v1.4.2/cpat-${finalAttrs.version}.tar.gz";
+    hash = "sha256-viVbaU21tI4lU+0WoSzRW81aUPzCIkJKjJR/BPEFO2c=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  patches = [ ./format-security.patch ];
+
+  buildInputs = [ ncurses ];
+
+  meta = {
+    description = "A curses based card games application";
+    homepage = "https://sourceforge.net/projects/cpat/";
+    mainProgram = "cpat";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ castorNova2 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds [cpat](https://sourceforge.net/projects/cpat/) which is a terminal games consisiting of many card games like freecell, spider, etc.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
