### PR TITLE
mdfried: add pdf support

### DIFF
--- a/pkgs/by-name/md/mdfried/package.nix
+++ b/pkgs/by-name/md/mdfried/package.nix
@@ -1,10 +1,18 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
   pkg-config,
   chafa,
+  fontconfig,
   glib,
+  gnumake,
+  gperf,
+  libiconv,
+  python3,
+  unzip,
+  writeShellScriptBin,
   nix-update-script,
 }:
 
@@ -21,14 +29,38 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-jnByeBBL13DavExG2pVN7vNRr+UXGkxRY0a4MkwzRe0=";
 
+  buildFeatures = [ "pdf" ];
+
+  # Prevent updateAutotoolsGnuConfigScripts from modifying mupdf's vendored
+  # autotools files — doing so invalidates cargo's fingerprint for mupdf-sys
+  # and causes a rebuild that fails on read-only cargoArtifacts files.
+  updateAutotoolsGnuConfigScriptsPhase = "true";
+
   nativeBuildInputs = [
     pkg-config
+    rustPlatform.bindgenHook # for mupdf-sys bindgen
+    gperf # for mupdf vendored Makefile
+    python3 # for mupdf vendored Makefile
+    unzip # for mupdf vendored docx_template build
+    # mupdf-sys cp_r copies files from the read-only Nix store, preserving
+    # mode 444. make then fails to regenerate headers. Wrap make to chmod first.
+    (writeShellScriptBin "make" ''
+      chmod -R u+w . 2>/dev/null || true
+      exec ${lib.getExe gnumake} "$@"
+    '')
   ];
 
   buildInputs = [
     chafa
-    glib
+    fontconfig.dev # for font-kit (mupdf dep)
+    glib.dev # for glib-2.0.pc (mupdf needs glib.dev, chafa could do with just glib)
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    libiconv
   ];
+
+  CFLAGS_aarch64_apple_darwin = lib.optionalString stdenv.hostPlatform.isDarwin "-UTARGET_OS_MAC";
+  CXXFLAGS_aarch64_apple_darwin = lib.optionalString stdenv.hostPlatform.isDarwin "-UTARGET_OS_MAC";
 
   doCheck = true;
 


### PR DESCRIPTION
Add pdf support to mdfried, same strategy as the project's flake.nix

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
