### PR TITLE
ocamlPackages.windtrap: init at 0.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/windtrap/default.nix
+++ b/pkgs/development/ocaml-modules/windtrap/default.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  fetchurl,
+  buildDunePackage,
+}:
+
+buildDunePackage {
+  pname = "windtrap";
+  version = "0.1.0";
+  minimalOCamlVersion = "5.0";
+
+  src = fetchurl {
+    url = "https://github.com/invariant-hq/windtrap/releases/download/0.1.0/windtrap-0.1.0.tbz";
+    hash = "sha256-IkGylLJO1dVuqLg00pbm+rxdvdkkqJ9RwUsA2mbFCiU=";
+  };
+
+  doCheck = true;
+
+  # this force to skip "collapse_home" tests, because $HOME != getpwuid in the
+  # sandbox
+  preCheck = ''
+    unset HOME
+  '';
+
+  meta = {
+    description = "Unit tests, property-based tests, snapshot tests, and expect tests in a single package with one API.";
+    homepage = "https://ocaml.org/p/windtrap";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.joblade ];
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2261,6 +2261,8 @@ let
 
         webmachine = callPackage ../development/ocaml-modules/webmachine { };
 
+        windtrap = callPackage ../development/ocaml-modules/windtrap { };
+
         wtf8 = callPackage ../development/ocaml-modules/wtf8 { };
 
         ### X ###


### PR DESCRIPTION
https://ocaml.org/p/windtrap/0.1.0

Among other packages, this is a requirement for [ocaml-raven](https://raven-ml.dev/) I would like to package in a separate MR.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
