### PR TITLE
headscale: make headscale module compatible with headplane

### DIFF
--- a/nixos/modules/services/networking/headscale.nix
+++ b/nixos/modules/services/networking/headscale.nix
@@ -36,8 +36,10 @@ in
       configFile = lib.mkOption {
         type = lib.types.path;
         readOnly = true;
-        default = settingsFormat.generate "headscale.yaml" cfg.settings;
-        defaultText = lib.literalExpression ''(pkgs.formats.yaml { }).generate "headscale.yaml" config.services.headscale.settings'';
+        default = settingsFormat.generate "headscale.yaml" (
+          lib.filterAttrsRecursive (n: v: v != null) cfg.settings
+        );
+        defaultText = lib.literalExpression ''(pkgs.formats.yaml { }).generate "headscale.yaml" (lib.filterAttrsRecursive (n: v: v != null) config.services.headscale.settings)'';
         description = ''
           Path to the configuration file of headscale.
         '';
@@ -398,6 +400,16 @@ in
                 '';
               };
 
+              extra_records_path = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+                description = ''
+                  Path to a JSON file containing extra DNS records.
+                  This is mutually exclusive with {option}`extra_records`.
+                '';
+                example = "/run/headscale/records.json";
+              };
+
               search_domains = lib.mkOption {
                 type = lib.types.listOf lib.types.str;
                 default = [ ];
@@ -656,6 +668,10 @@ in
       {
         assertion = with cfg.settings; dns.override_local_dns -> dns.nameservers.global != [ ];
         message = "dns.nameservers.global must be set when overriding local DNS";
+      }
+      {
+        assertion = with cfg.settings; dns.extra_records_path == null || dns.extra_records == null;
+        message = "dns.extra_records and dns.extra_records_path are mutually exclusive";
       }
       (assertRemovedOption [ "settings" "acl_policy_path" ] "Use `policy.path` instead.")
       (assertRemovedOption [ "settings" "db_host" ] "Use `database.postgres.host` instead.")


### PR DESCRIPTION
- adds option to manages dns records using external file.
- removes fields set to null completely
- adds an assertion to ensure no conflicts

The outcome is that the dns page on headplane works. This is not only beneficial for headplane but also for any production environment that needs to change dns records without nixos-rebuild.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
