### PR TITLE
ocamlPackages.raven: init at 1.0.0_alpha3

### DIFF
--- a/pkgs/development/ocaml-modules/raven/default.nix
+++ b/pkgs/development/ocaml-modules/raven/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  raven-fehu,
+  raven-hugin,
+  raven-kaun,
+  raven-nx,
+  raven-rune,
+  raven-sowilo,
+  raven-talon,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "raven";
+  version = "1.0.0_alpha3";
+
+  src = fetchFromGitHub {
+    owner = "raven-ml";
+    repo = "raven";
+    tag = finalAttrs.version;
+    hash = "sha256-7YUpbjrh3O6isWF3R1orfGi/C5FLg2b8YpB1ON4s3p4=";
+  };
+
+  # remove docs to prevent pulling unnecessary dependencies during check phase
+  postUnpack = ''
+    rm -r $sourceRoot/{doc,www}
+  '';
+
+  propagatedBuildInputs = [
+    raven-fehu
+    raven-hugin
+    raven-kaun
+    raven-nx
+    raven-rune
+    raven-sowilo
+    raven-talon
+  ];
+
+  meta = {
+    description = "Meta package for the Raven ML ecosystem";
+    longDescription = ''
+      Raven is a comprehensive machine learning ecosystem for OCaml.
+      This meta package installs all Raven components including
+      Nx (tensors), Hugin (plotting), Quill (notebooks),
+      Rune (autodiff), Kaun (neural networks), and Sowilo (computer vision).
+    '';
+    homepage = "https://raven-ml.dev";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.stepbrobd ];
+  };
+})

--- a/pkgs/development/ocaml-modules/raven/fehu.nix
+++ b/pkgs/development/ocaml-modules/raven/fehu.nix
@@ -1,0 +1,38 @@
+{
+  buildDunePackage,
+  windtrap,
+  raven,
+  raven-nx,
+  mdx,
+  logs,
+}:
+
+buildDunePackage {
+  pname = "fehu";
+
+  inherit (raven) version src postUnpack;
+
+  propagatedBuildInputs = [
+    raven-nx
+  ];
+
+  doCheck = true;
+
+  nativeCheckInputs = [
+    mdx.bin
+    (mdx.override { inherit logs; })
+  ];
+
+  checkInputs = [
+    windtrap
+    mdx
+  ];
+
+  meta = raven.meta // {
+    description = "Reinforcement learning framework for OCaml";
+    longDescription = ''
+      Fehu is a reinforcement learning framework built on Raven's ecosystem,
+      providing environments, algorithms, and training utilities
+    '';
+  };
+}

--- a/pkgs/development/ocaml-modules/raven/hugin.nix
+++ b/pkgs/development/ocaml-modules/raven/hugin.nix
@@ -1,0 +1,44 @@
+{
+  buildDunePackage,
+  SDL2,
+  cairo,
+  dune-configurator,
+  pkg-config,
+  raven,
+  raven-nx,
+  windtrap,
+}:
+
+buildDunePackage {
+  pname = "hugin";
+
+  inherit (raven) version src postUnpack;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    dune-configurator
+    SDL2
+  ];
+
+  propagatedBuildInputs = [
+    cairo
+    raven-nx
+  ];
+
+  doCheck = true;
+
+  checkInputs = [
+    windtrap
+  ];
+
+  meta = raven.meta // {
+    description = "Visualization library for OCaml";
+    longDescription = ''
+      Hugin is a powerful visualization library for OCaml that produces publication-quality plots and charts.
+      It integrates with the Raven ecosystem to provide visualization of Nx data.
+    '';
+  };
+}

--- a/pkgs/development/ocaml-modules/raven/kaun.nix
+++ b/pkgs/development/ocaml-modules/raven/kaun.nix
@@ -1,0 +1,46 @@
+{
+  buildDunePackage,
+  raven,
+  bytesrw,
+  jsont,
+  raven-nx,
+  raven-rune,
+  windtrap,
+  mdx,
+  logs,
+}:
+
+buildDunePackage {
+  pname = "kaun";
+
+  inherit (raven) version src postUnpack;
+
+  propagatedBuildInputs = [
+    bytesrw
+    jsont
+    raven-nx
+    raven-rune
+  ];
+
+  doCheck = true;
+
+  nativeCheckInputs = [
+    mdx.bin
+    (mdx.override { inherit logs; })
+  ];
+
+  checkInputs = [
+    windtrap
+    mdx
+  ];
+
+  meta = raven.meta // {
+    description = "Flax-inspired neural network library for OCaml";
+    longDescription = ''
+      Kaun brings modern deep learning to OCaml with a flexible,
+      type-safe API for building and training neural networks.
+      It leverages Rune for automatic differentiation and computation graph optimization
+      while maintaining OCaml's functional programming advantages.
+    '';
+  };
+}

--- a/pkgs/development/ocaml-modules/raven/nx.nix
+++ b/pkgs/development/ocaml-modules/raven/nx.nix
@@ -1,0 +1,50 @@
+{
+  buildDunePackage,
+  raven,
+  dune-configurator,
+  pkg-config,
+  openblas,
+  zlib,
+  windtrap,
+  mdx,
+  logs,
+}:
+
+buildDunePackage {
+  pname = "nx";
+
+  inherit (raven) version src postUnpack;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    dune-configurator
+  ];
+
+  propagatedBuildInputs = [
+    openblas.dev
+    zlib
+  ];
+
+  doCheck = true;
+
+  nativeCheckInputs = [
+    mdx.bin
+    (mdx.override { inherit logs; })
+  ];
+
+  checkInputs = [
+    windtrap
+    mdx
+  ];
+
+  meta = raven.meta // {
+    description = "High-performance N-dimensional array library for OCaml";
+    longDescription = ''
+      Nx is the core component of the Raven ecosystem providing efficient numerical computation with multi-device support.
+      It offers NumPy-like functionality with the benefits of OCaml's type system.
+    '';
+  };
+}

--- a/pkgs/development/ocaml-modules/raven/rune.nix
+++ b/pkgs/development/ocaml-modules/raven/rune.nix
@@ -1,0 +1,54 @@
+{
+  buildDunePackage,
+  raven,
+  lib,
+  stdenv,
+  dune-configurator,
+  raven-nx,
+  windtrap,
+  mdx,
+  logs,
+}:
+
+buildDunePackage {
+  pname = "rune";
+
+  inherit (raven) version src postUnpack;
+
+  sandboxProfile = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    (allow iokit-open)
+    (allow file-read* (subpath "/System/Library/Extensions"))
+    (allow mach-lookup (global-name "com.apple.MTLCompilerService"))
+  '';
+
+  buildInputs = [
+    dune-configurator
+  ];
+
+  propagatedBuildInputs = [
+    raven-nx
+  ];
+
+  doCheck = true;
+
+  nativeCheckInputs = [
+    mdx.bin
+    (mdx.override { inherit logs; })
+  ];
+
+  checkInputs = [
+    windtrap
+    mdx
+  ];
+
+  meta = raven.meta // {
+    description = "Automatic differentiation and JIT compilation for OCaml";
+    longDescription = ''
+      Rune provides automatic differentiation capabilities and
+      experimental JIT compilation for the Raven ecosystem.
+      It enables gradient-based optimization and supports
+      functional transformations like grad, value_and_grad,
+      and vmap, making it the foundation for deep learning in OCaml.
+    '';
+  };
+}

--- a/pkgs/development/ocaml-modules/raven/sowilo.nix
+++ b/pkgs/development/ocaml-modules/raven/sowilo.nix
@@ -1,0 +1,38 @@
+{
+  buildDunePackage,
+  raven,
+  raven-rune,
+  windtrap,
+  mdx,
+  logs,
+}:
+
+buildDunePackage {
+  pname = "sowilo";
+
+  inherit (raven) version src postUnpack;
+
+  propagatedBuildInputs = [
+    raven-rune
+  ];
+
+  doCheck = true;
+
+  nativeCheckInputs = [
+    mdx.bin
+    (mdx.override { inherit logs; })
+  ];
+
+  checkInputs = [
+    windtrap
+    mdx
+  ];
+
+  meta = raven.meta // {
+    description = "Computer vision extensions for Rune";
+    longDescription = ''
+      Computer vision operations and algorithms built on top of the Rune library.
+      Provides image processing, feature extraction, and other vision-related functionality.
+    '';
+  };
+}

--- a/pkgs/development/ocaml-modules/raven/talon.nix
+++ b/pkgs/development/ocaml-modules/raven/talon.nix
@@ -1,0 +1,38 @@
+{
+  buildDunePackage,
+  raven,
+  raven-nx,
+  windtrap,
+  mdx,
+  logs,
+}:
+
+buildDunePackage {
+  pname = "talon";
+
+  inherit (raven) version src postUnpack;
+
+  propagatedBuildInputs = [
+    raven-nx
+  ];
+
+  doCheck = true;
+
+  nativeCheckInputs = [
+    mdx.bin
+    (mdx.override { inherit logs; })
+  ];
+
+  checkInputs = [
+    windtrap
+    mdx
+  ];
+
+  meta = raven.meta // {
+    description = "A dataframe library for OCaml";
+    longDescription = ''
+      Talon provides efficient tabular data manipulation with
+      heterogeneous column types, inspired by pandas and polars.
+    '';
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1916,6 +1916,22 @@ let
 
         randomconv = callPackage ../development/ocaml-modules/randomconv { };
 
+        raven = callPackage ../development/ocaml-modules/raven { };
+
+        raven-fehu = callPackage ../development/ocaml-modules/raven/fehu.nix { };
+
+        raven-hugin = callPackage ../development/ocaml-modules/raven/hugin.nix { };
+
+        raven-kaun = callPackage ../development/ocaml-modules/raven/kaun.nix { };
+
+        raven-nx = callPackage ../development/ocaml-modules/raven/nx.nix { };
+
+        raven-rune = callPackage ../development/ocaml-modules/raven/rune.nix { };
+
+        raven-sowilo = callPackage ../development/ocaml-modules/raven/sowilo.nix { };
+
+        raven-talon = callPackage ../development/ocaml-modules/raven/talon.nix { };
+
         raylib = callPackage ../development/ocaml-modules/raylib { };
 
         raygui = callPackage ../development/ocaml-modules/raylib/raygui.nix { };


### PR DESCRIPTION
https://github.com/raven-ml/raven

This is another try to package ocaml-raven, but with the new alpha3. Initial work is #445206

This package depends on windtrap that I packaged in a separate MR: #533330

I used the same workaround as #364047 to fix mdx lib causing some warnings/build errors

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [ ] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
