### PR TITLE
datadog-pup: init at 1.8.0

### DIFF
--- a/pkgs/by-name/da/datadog-pup/package.nix
+++ b/pkgs/by-name/da/datadog-pup/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  cacert,
+  fetchFromGitHub,
+  nix-update-script,
+  rustPlatform,
+  stdenv,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "datadog-pup";
+  version = "1.8.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "DataDog";
+    repo = "pup";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8leLUaoce3i4i2asd0tzhbM4mXAOkn/rdNIaGLLCfko=";
+  };
+
+  cargoHash = "sha256-+F5P2tOLGSjABD4B0MG84x1uVI4o06Kl1nZfOS7tP1Y=";
+
+  checkType = "debug";
+  dontUseCargoParallelTests = true;
+  __darwinAllowLocalNetworking = true;
+
+  checkFlags = lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+    # This test is missing a case for aarch64-linux
+    "--skip=extensions::install::tests::test_find_platform_asset_found"
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  doInstallCheck = true;
+
+  preCheck = ''
+    export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI for Datadog's observability platform";
+    homepage = "https://github.com/DataDog/pup";
+    changelog = "https://github.com/DataDog/pup/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    mainProgram = "pup";
+    maintainers = with lib.maintainers; [ deejayem ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Add datadog-pup (https://github.com/DataDog/pup). The upstream package (and the binary) are just called pup, but there's already a package in nixpkgs called that.

Here's an example of it being used (filtering most of the long list):
```
❯ pup metrics query --query "avg:system.cpu.user{*}" --from 1h | jq '.series[].pointlist |= .[:2]'
{
  "from_date": 1784643679000,
  "group_by": [],
  "message": "",
  "query": "avg:system.cpu.user{*}",
  "res_type": "time_series",
  "resp_version": 1,
  "series": [
    {
      "aggr": "avg",
      "attributes": {},
      "display_name": "system.cpu.user",
      "end": 1784647279000,
      "expression": "avg:system.cpu.user{*}",
      "interval": 20,
      "length": 180,
      "metric": "system.cpu.user",
      "pointlist": [
        [
          1784643680000.0,
          8.966297855328193
        ],
        [
          1784643700000.0,
          8.65768472250115
        ]
      ],
      "query_index": 0,
      "scope": "*",
      "start": 1784643680000,
      "tag_set": [],
      "unit": [
        {
          "family": "percentage",
          "id": 17,
          "name": "percent",
          "plural": "percent",
          "scale_factor": 1.0,
          "short_name": "%"
        },
        null
      ]
    }
  ],
  "status": "ok",
  "times": [],
  "to_date": 1784647279000,
  "values": []
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
