### PR TITLE
nixos/run0: add options for persistent authentication

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -50,6 +50,8 @@
 
 - `security.run0.enableSudoAlias` now uses the `run0-sudo-shim` instead of a shell-script to improve compatibility.
 
+- `security.run0.persistentAuth` options have been added to support persistent Authentication of session. Timeout configurable via `security.polkit.settings.Polkitd.ExpirationSeconds`.
+
 - `boot.loader.systemd-boot` gained support for [Automatic Boot Assessment](https://systemd.io/AUTOMATIC_BOOT_ASSESSMENT/) via the new [`boot.loader.systemd-boot.bootCounting`](#opt-boot.loader.systemd-boot.bootCounting.enable) options, allowing automatic detection of and recovery from bad NixOS generations. As part of this change, boot loader entries on the ESP/XBOOTLDR partition are now named `nixos-<content-hash>.conf` instead of `nixos-generation-<n>.conf`; existing entries are migrated automatically on the next `nixos-rebuild boot`/`switch`.
 
 - The `newuidmap` and `newgidmap` security wrappers are now installed with `cap_setuid`/`cap_setgid` file capabilities instead of the setuid-root bit, matching shadow's `--with-fcaps` install mode and other major distributions. Rootless containers (podman, docker-rootless, unprivileged user namespaces) are unaffected. The only behavioural change is that mapping host uid 0 via `/etc/subuid` (which NixOS never configures by default) additionally requires `cap_setfcap`; users who explicitly grant uid 0 in a subuid range can restore the previous behaviour with `security.wrappers.newuidmap.capabilities = lib.mkForce "cap_setuid,cap_setfcap+ep";`.

--- a/nixos/modules/security/run0.nix
+++ b/nixos/modules/security/run0.nix
@@ -13,6 +13,7 @@ let
     mkOption
     mkPackageOption
     mkAliasOptionModule
+    optionalString
     ;
 
   cfg = config.security.run0;
@@ -20,6 +21,12 @@ in
 {
   options.security.run0 = {
     enable = mkEnableOption "support for run0";
+
+    persistentAuth.enable = mkEnableOption ''
+      persistent authentication for sessions.
+      Timeout configurable via {option}`security.polkit.settings.Polkitd.ExpirationSeconds`
+    '';
+    persistentAuth.enableRemote = mkEnableOption "persistent authentication for remote sessions";
 
     wheelNeedsPassword = mkOption {
       type = lib.types.bool;
@@ -67,13 +74,24 @@ in
 
       security.polkit = {
         enable = true;
-        extraConfig = mkIf (!cfg.wheelNeedsPassword) ''
-          polkit.addRule(function(action, subject) {
-            if (action.id == "org.freedesktop.systemd1.manage-units" && subject.isInGroup("wheel")) {
-              return polkit.Result.YES;
-            }
-          });
-        '';
+        extraConfig = lib.concatLines [
+          (optionalString (!cfg.wheelNeedsPassword) ''
+            polkit.addRule(function(action, subject) {
+              if (action.id == "org.freedesktop.systemd1.manage-units" && subject.isInGroup("wheel")) {
+                return polkit.Result.YES;
+              }
+            });
+          '')
+          (optionalString cfg.persistentAuth.enable ''
+            polkit.addRule(function(action, subject) {
+              if (action.id == "org.freedesktop.systemd1.manage-units" && subject.active ${
+                optionalString (!cfg.persistentAuth.enableRemote) "&& subject.local"
+              }) {
+                return polkit.Result.AUTH_ADMIN_KEEP;
+              }
+            });
+          '')
+        ];
       };
 
       environment.systemPackages = lib.optional cfg.sudo-shim.enable cfg.sudo-shim.package;


### PR DESCRIPTION
Assisted-by: languagetool 6.6

The polkit rule originated from the [run0-sudo-shim](https://github.com/LordGrimmauld/run0-sudo-shim/blob/main/flake.nix#L205) flake. This should bring the UX pretty much to sudo's for most users and makes the use of the upstream module unnecessary. 

Soft-depends on #532954 for configuring the timeout, otherwise its 5 minutes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
