### PR TITLE
ci: don't use the default problems handler in ci

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -244,6 +244,15 @@ jobs:
             --argstr evalSystem "$MATRIX_SYSTEM" \
             --out-link diff
 
+      - name: Check new packages for depreacted features
+        env:
+          MATRIX_SYSTEM: ${{ matrix.system }}
+        run: |
+          nix-build nixpkgs/untrusted/ci --arg nixpkgs ./nixpkgs/untrusted-pinned -A eval.checkNewPackages \
+            --arg diffDir ./diff \
+            --argstr evalSystem "$MATRIX_SYSTEM" \
+            --out-link checked
+
       - name: Upload outpaths diff and stats
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -92,6 +92,7 @@ let
       evalSystem ? builtins.currentSystem,
       # The path to the `paths.json` file from `attrpathsSuperset`
       attrpathFile ? "${attrpathsSuperset { inherit evalSystem; }}/paths.json",
+      extraNixpkgsConfig' ? extraNixpkgsConfig,
     }:
     let
       singleChunk = writeShellScript "single-chunk" ''
@@ -124,7 +125,7 @@ let
           --arg attrpathFile "${attrpathFile}" \
           --arg systems "[ \"$system\" ]" \
           --arg includeBroken ${lib.boolToString includeBroken} \
-          --argstr extraNixpkgsConfigJson ${lib.escapeShellArg (builtins.toJSON extraNixpkgsConfig)} \
+          --argstr extraNixpkgsConfigJson ${lib.escapeShellArg (builtins.toJSON extraNixpkgsConfig')} \
           -I ${nixpkgs} \
           -I ${attrpathFile} \
           > "$outputDir/result/$myChunk" \
@@ -216,6 +217,38 @@ let
       '';
 
   diff = callPackage ./diff.nix { };
+
+  checkNewPackages = {
+    # The system to evaluate.
+    # Note that this is intentionally not called `system`,
+    # because `--argstr system` would only be passed to the ci/default.nix file!
+    evalSystem ? builtins.currentSystem,
+    diffDir,
+  }: let
+      attrpathFile = "${runCommand "attrpathFile" {
+        # Don't depend on -dev outputs to reduce closure size for CI.
+        nativeBuildInputs = map lib.getBin [
+          jq
+        ];
+      } ''
+        mkdir -p $out
+        cat ${diffDir}/*/diff.json | jq '.added' > $out/${evalSystem}.json
+      ''}/${evalSystem}.json";
+     in
+      singleSystem {
+       inherit evalSystem attrpathFile;
+       extraNixpkgsConfig' = {
+            # List of problems that should fail for new packages
+            problems.matchers = lib.mkForce (
+              lib.optionals (!includeBroken) [
+                {
+                  kind = "broken";
+                  handler = "error";
+                }
+              ]
+            );
+       } // extraNixpkgsConfig;
+    };
 
   combine =
     {
@@ -319,6 +352,7 @@ in
     attrpathsSuperset
     singleSystem
     diff
+    checkNewPackages
     combine
     compare
     # The above three are used by separate VMs in a GitHub workflow,

--- a/ci/eval/outpaths.nix
+++ b/ci/eval/outpaths.nix
@@ -38,6 +38,16 @@ let
             # Silence the `x86_64-darwin` deprecation warning.
             allowDeprecatedx86_64Darwin = true;
 
+            # List of problems that should fail the CI
+            problems.matchers = lib.mkForce (
+              lib.optionals (!includeBroken) [
+                {
+                  kind = "broken";
+                  handler = "error";
+                }
+              ]
+            );
+
             handleEvalIssue =
               reason: errormsg:
               let


### PR DESCRIPTION
This makes it possible to use a custom broken massage or to mark a package as slated for removal without triggering the CI.

closes #523712
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
