### PR TITLE
interval-tree: init at 3.1.1

### DIFF
--- a/pkgs/by-name/in/interval-tree/package.nix
+++ b/pkgs/by-name/in/interval-tree/package.nix
@@ -1,0 +1,43 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "interval-tree";
+  version = "3.1.1";
+
+  src = fetchFromGitHub {
+    owner = "5cript";
+    repo = "interval-tree";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-bSZ56EzzNy6gHgs8OptT/iBlf56RJz+09BE4WGGJpog=";
+  };
+
+  # interval-tree is a header only library
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/
+    cp -r $src/include/ $out/
+
+    runHook postInstall
+  '';
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "C++ header only interval tree implementation";
+    maintainers = with lib.maintainers; [ aiyion ];
+    homepage = "https://github.com/5cript/interval-tree";
+    license = lib.licenses.cc0;
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
https://github.com/5cript/interval-tree

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all ~binary~ include files, ~usually in `./result/bin/`.~
- Nixpkgs Release Notes
  - ~Package update: when the change is major or breaking.~
- NixOS Release Notes
  - ~Module addition: when adding a new NixOS module.~
  - ~Module update: when the change is significant.~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
