### PR TITLE
python3Packages.rich-toolkit: 0.17.1 -> 0.20.1

### DIFF
--- a/pkgs/development/python-modules/rich-toolkit/default.nix
+++ b/pkgs/development/python-modules/rich-toolkit/default.nix
@@ -17,17 +17,22 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "rich-toolkit";
-  version = "0.17.1";
+  version = "0.20.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "patrick91";
     repo = "rich-toolkit";
-    tag = version;
-    hash = "sha256-69x760lnMdwrNFUL1g9PBlTRGz34Ur2CHWbJq7PqBmk=";
+    tag = finalAttrs.version;
+    hash = "sha256-XYSksCMCCxO6wzsEEJ6X340iT32hU5n/EikKLZ2m7A0=";
   };
+
+  postPatch = ''
+    # the commit updating the version happens only after tagging
+    sed -i 's/version = ".*"/version = "${finalAttrs.version}"/' pyproject.toml
+  '';
 
   build-system = [ hatchling ];
 
@@ -46,10 +51,10 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "rich_toolkit" ];
 
   meta = {
-    changelog = "https://github.com/patrick91/rich-toolkit/releases/tag/${src.tag}";
+    changelog = "https://github.com/patrick91/rich-toolkit/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "Rich toolkit for building command-line applications";
     homepage = "https://github.com/patrick91/rich-toolkit/";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/patrick91/rich-toolkit/compare/0.17.1...0.20.1

Changelog: https://github.com/patrick91/rich-toolkit/blob/0.20.1/CHANGELOG.md

relevant for https://github.com/NixOS/nixpkgs/pull/532778
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
