### PR TITLE
viber: fix missing deps and libxml2 valuePush compat for 27.3.0.2

### DIFF
--- a/pkgs/by-name/vi/viber/package.nix
+++ b/pkgs/by-name/vi/viber/package.nix
@@ -40,6 +40,9 @@
   libxkbcommon,
   libxkbfile,
   libxml2,
+  libxshmfence,
+  libxcb-cursor,
+  libxcb-util,
   libxslt,
   mtdev,
   nspr,
@@ -96,6 +99,10 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
   ];
 
+  buildInputs = [
+    libxml2.dev
+  ];
+
   libPath = lib.makeLibraryPath [
     alsa-lib
     brotli
@@ -135,6 +142,9 @@ stdenv.mkDerivation (finalAttrs: {
     libxkbcommon
     libxkbfile
     libxml2
+    libxshmfence
+    libxcb-cursor
+    libxcb-util
     libxslt
     mtdev
     nspr
@@ -185,6 +195,32 @@ stdenv.mkDerivation (finalAttrs: {
       patchelf --set-rpath ${finalAttrs.libPath}:$out/opt/viber/lib $file || true
     done
 
+    # Build a shim that re-exports valuePush/valuePop with the old LIBXML2_2.4.30
+    # version tag. Qt6WebEngine in Viber was compiled against libxml2 < 2.13 where
+    # these were public API; 2.13+ renamed them to xmlXPathValuePush/Pop and dropped
+    # the old versioned exports.
+    cat > libxml2-compat.c << 'EOF'
+#include <libxml/xpathInternals.h>
+#undef valuePush
+#undef valuePop
+int valuePush(xmlXPathParserContextPtr ctxt, xmlXPathObjectPtr value) {
+    return xmlXPathValuePush(ctxt, value);
+}
+xmlXPathObjectPtr valuePop(xmlXPathParserContextPtr ctxt) {
+    return xmlXPathValuePop(ctxt);
+}
+EOF
+    cat > libxml2-compat.map << 'EOF'
+LIBXML2_2.4.30 {
+  global: valuePush; valuePop;
+  local: *;
+};
+EOF
+    $CC -shared -fPIC -o $out/opt/viber/lib/libxml2-compat.so libxml2-compat.c \
+      -I${libxml2.dev}/include/libxml2 \
+      -L${lib.getLib libxml2}/lib -lxml2 \
+      -Wl,--version-script=libxml2-compat.map
+
     mkdir $out/bin
     # qt.conf is not working, so override everything using environment variables
     makeWrapper $out/opt/viber/Viber $out/bin/viber \
@@ -192,7 +228,8 @@ stdenv.mkDerivation (finalAttrs: {
       --set QT_PLUGIN_PATH "$out/opt/viber/plugins" \
       --set QT_XKB_CONFIG_ROOT "${xkeyboard-config}/share/X11/xkb" \
       --set QTCOMPOSE "${libx11.out}/share/X11/locale" \
-      --set QML2_IMPORT_PATH "$out/opt/viber/qml"
+      --set QML2_IMPORT_PATH "$out/opt/viber/qml" \
+      --prefix LD_PRELOAD : "$out/opt/viber/lib/libxml2-compat.so"
 
     mv $out/usr/share $out/share
     rm -rf $out/usr

--- a/pkgs/by-name/vi/viber/package.nix
+++ b/pkgs/by-name/vi/viber/package.nix
@@ -186,60 +186,60 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   installPhase = ''
-    runHook preInstall
+        runHook preInstall
 
-    cp -r . $out
+        cp -r . $out
 
-    for file in $(find $out -type f \( -perm /0111 -o -name \*.so\* \) ); do
-      patchelf --set-interpreter ${bintools.dynamicLinker} "$file" || true
-      patchelf --set-rpath ${finalAttrs.libPath}:$out/opt/viber/lib $file || true
-    done
+        for file in $(find $out -type f \( -perm /0111 -o -name \*.so\* \) ); do
+          patchelf --set-interpreter ${bintools.dynamicLinker} "$file" || true
+          patchelf --set-rpath ${finalAttrs.libPath}:$out/opt/viber/lib $file || true
+        done
 
-    # Build a shim that re-exports valuePush/valuePop with the old LIBXML2_2.4.30
-    # version tag. Qt6WebEngine in Viber was compiled against libxml2 < 2.13 where
-    # these were public API; 2.13+ renamed them to xmlXPathValuePush/Pop and dropped
-    # the old versioned exports.
-    cat > libxml2-compat.c << 'EOF'
-#include <libxml/xpathInternals.h>
-#undef valuePush
-#undef valuePop
-int valuePush(xmlXPathParserContextPtr ctxt, xmlXPathObjectPtr value) {
-    return xmlXPathValuePush(ctxt, value);
-}
-xmlXPathObjectPtr valuePop(xmlXPathParserContextPtr ctxt) {
-    return xmlXPathValuePop(ctxt);
-}
-EOF
-    cat > libxml2-compat.map << 'EOF'
-LIBXML2_2.4.30 {
-  global: valuePush; valuePop;
-  local: *;
-};
-EOF
-    $CC -shared -fPIC -o $out/opt/viber/lib/libxml2-compat.so libxml2-compat.c \
-      -I${libxml2.dev}/include/libxml2 \
-      -L${lib.getLib libxml2}/lib -lxml2 \
-      -Wl,--version-script=libxml2-compat.map
+        # Build a shim that re-exports valuePush/valuePop with the old LIBXML2_2.4.30
+        # version tag. Qt6WebEngine in Viber was compiled against libxml2 < 2.13 where
+        # these were public API; 2.13+ renamed them to xmlXPathValuePush/Pop and dropped
+        # the old versioned exports.
+        cat > libxml2-compat.c << 'EOF'
+    #include <libxml/xpathInternals.h>
+    #undef valuePush
+    #undef valuePop
+    int valuePush(xmlXPathParserContextPtr ctxt, xmlXPathObjectPtr value) {
+        return xmlXPathValuePush(ctxt, value);
+    }
+    xmlXPathObjectPtr valuePop(xmlXPathParserContextPtr ctxt) {
+        return xmlXPathValuePop(ctxt);
+    }
+    EOF
+        cat > libxml2-compat.map << 'EOF'
+    LIBXML2_2.4.30 {
+      global: valuePush; valuePop;
+      local: *;
+    };
+    EOF
+        $CC -shared -fPIC -o $out/opt/viber/lib/libxml2-compat.so libxml2-compat.c \
+          -I${libxml2.dev}/include/libxml2 \
+          -L${lib.getLib libxml2}/lib -lxml2 \
+          -Wl,--version-script=libxml2-compat.map
 
-    mkdir $out/bin
-    # qt.conf is not working, so override everything using environment variables
-    makeWrapper $out/opt/viber/Viber $out/bin/viber \
-      --set QT_QPA_PLATFORM "xcb" \
-      --set QT_PLUGIN_PATH "$out/opt/viber/plugins" \
-      --set QT_XKB_CONFIG_ROOT "${xkeyboard-config}/share/X11/xkb" \
-      --set QTCOMPOSE "${libx11.out}/share/X11/locale" \
-      --set QML2_IMPORT_PATH "$out/opt/viber/qml" \
-      --prefix LD_PRELOAD : "$out/opt/viber/lib/libxml2-compat.so"
+        mkdir $out/bin
+        # qt.conf is not working, so override everything using environment variables
+        makeWrapper $out/opt/viber/Viber $out/bin/viber \
+          --set QT_QPA_PLATFORM "xcb" \
+          --set QT_PLUGIN_PATH "$out/opt/viber/plugins" \
+          --set QT_XKB_CONFIG_ROOT "${xkeyboard-config}/share/X11/xkb" \
+          --set QTCOMPOSE "${libx11.out}/share/X11/locale" \
+          --set QML2_IMPORT_PATH "$out/opt/viber/qml" \
+          --prefix LD_PRELOAD : "$out/opt/viber/lib/libxml2-compat.so"
 
-    mv $out/usr/share $out/share
-    rm -rf $out/usr
-    # Fix the desktop link
-    substituteInPlace $out/share/applications/viber.desktop \
-      --replace-fail "/opt/viber/" "$out/opt/viber/"
-    # Fix libxml2 breakage. See https://github.com/NixOS/nixpkgs/pull/396195#issuecomment-2881757108
-    ln -s "${lib.getLib libxml2}/lib/libxml2.so" "$out/opt/viber/lib/libxml2.so.2"
+        mv $out/usr/share $out/share
+        rm -rf $out/usr
+        # Fix the desktop link
+        substituteInPlace $out/share/applications/viber.desktop \
+          --replace-fail "/opt/viber/" "$out/opt/viber/"
+        # Fix libxml2 breakage. See https://github.com/NixOS/nixpkgs/pull/396195#issuecomment-2881757108
+        ln -s "${lib.getLib libxml2}/lib/libxml2.so" "$out/opt/viber/lib/libxml2.so.2"
 
-    runHook postInstall
+        runHook postInstall
   '';
 
   dontStrip = true;


### PR DESCRIPTION
Viber 27.3.0.2 fails to start on current nixos-unstable due to several missing dependencies and a libxml2 ABI incompatibility.

Fixes:
  - Add libxshmfence to libPath (missing, causes immediate crash on launch)
  - Add libxcb-cursor and libxcb-util to libPath (required by the Qt xcb platform plugin since Qt 6.5)
  - Build a libxml2-compat.so shim and inject it via LD_PRELOAD to re-export valuePush/valuePop with the LIBXML2_2.4.30 version tag — Qt6WebEngine bundled in Viber 27.x was compiled against libxml2 < 2.13 where these were public API; libxml2 2.13+ renamed them to xmlXPathValuePush / xmlXPathValuePop and dropped the old versioned exports

Tested on: NixOS unstable (nixos-unstable 567a49d), x86_64-linux