### PR TITLE
keyroost: init at 0.6.0

### DIFF
--- a/pkgs/by-name/ke/keyroost/package.nix
+++ b/pkgs/by-name/ke/keyroost/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  hidapi,
+  pcsclite,
+  libxkbcommon,
+  libx11,
+  libxcursor,
+  libxi,
+  libxrandr,
+  wayland,
+  libGL,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "keyroost";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "framefilter";
+    repo = "keyroost";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-ArLDhyuK04eq/1RYsBHNm3U7AzaGsYZWhH+q0Q+9gIg=";
+  };
+
+  __structuredAttrs = true;
+
+  cargoHash = "sha256-zktnXrLGj2WUQlTtqOsIXD0QhdPPVbnw37+zSuuj0qg=";
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    hidapi
+    pcsclite
+    libxkbcommon
+    libx11
+    libxcursor
+    libxi
+    libxrandr
+    wayland
+    libGL
+  ];
+
+  # egui dynamically loads Wayland, libxkbcommon, and OpenGL at runtime
+  postFixup = ''
+    patchelf --add-rpath "${
+      lib.makeLibraryPath [
+        wayland
+        libxkbcommon
+        libGL
+      ]
+    }" $out/bin/keyroost
+  '';
+
+  postInstall = ''
+    install -Dm444 -t $out/lib/udev/rules.d udev/*
+  '';
+
+  meta = {
+    description = "Hardware security key management supporting FIDO2, OATH, OpenPGP, and PIV over PC/SC and USB HID";
+    homepage = "https://github.com/framefilter/keyroost";
+    changelog = "https://github.com/framefilter/keyroost/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.OR [
+      lib.licenses.mit
+      lib.licenses.asl20
+    ];
+    maintainers = with lib.maintainers; [ io12 ];
+    mainProgram = "keyroost";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add package for [keyroost](https://github.com/framefilter/keyroost).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
