### PR TITLE
stoat-desktop:  1.3.0 -> 1.4.0

### DIFF
--- a/pkgs/by-name/st/stoat-desktop/package.nix
+++ b/pkgs/by-name/st/stoat-desktop/package.nix
@@ -11,23 +11,23 @@
   copyDesktopItems,
   pnpm_10,
   nodejs,
-  electron_38,
+  electron_42,
   zip,
 }:
 let
-  electron = electron_38;
+  electron = electron_42;
   stdenv = stdenvNoCC;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "stoat-desktop";
-  version = "1.3.0";
+  version = "1.4.0";
 
   src = fetchFromGitHub {
     owner = "stoatchat";
     repo = "for-desktop";
     tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-vMXnBniA0wyoK7Pe13h/yHtf8ky59ts4VQb9k7KuUCE=";
+    hash = "sha256-l4kxlPwohaxserVyNAb3Dp4f5XhnPUKeuRJwrOl9EWc=";
   };
 
   postPatch = ''
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
     inherit (finalAttrs) pname version src;
     fetcherVersion = 3;
     pnpm = pnpm_10;
-    hash = "sha256-m0EuM8qTCFLxxO0RNze5WgMkuHZXeIi+U/Jiuv91eCg=";
+    hash = "sha256-bIDwEmt/8URBMx7XIQ1EP4SucwMuyGZE1hlQM0rxDnw=";
   };
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";


### PR DESCRIPTION
Electron 38 has reached end-of-life and is marked as insecure in Nixpkgs, causing evaluation failures when building systems that include `stoat-desktop`.

Update the package to Electron 42, which is currently supported upstream. This restores buildability on current Nixpkgs revisions and ensures the application receives security fixes from the Electron project.

Closes #504379

## Things done

* Built on platform:

  * [x] x86_64-linux
  * [ ] aarch64-linux
  * [ ] x86_64-darwin
  * [ ] aarch64-darwin
* Tested, as applicable:

  * [ ] NixOS tests in nixos/tests.
  * [ ] Package tests at `passthru.tests`.
  * [ ] Tests in lib/tests or pkgs/test for functions and core functionality.
* [ ] Ran `nixpkgs-review` on this PR.
* [x] Tested basic functionality of the package.
* Nixpkgs Release Notes

  * [ ] Package update: when the change is major or breaking.
* NixOS Release Notes

  * [ ] Module addition: when adding a new NixOS module.
  * [ ] Module update: when the change is significant.
* [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.
* [ ] Follows the automation/AI policy.
